### PR TITLE
Ensure that rotation is smoothed when SmoothLerpToTarget is True.

### DIFF
--- a/Assets/HoloToolkit/Utilities/Interpolator.cs
+++ b/Assets/HoloToolkit/Utilities/Interpolator.cs
@@ -303,7 +303,7 @@ namespace HoloToolkit.Unity
                 else
                 {
                     // Only lerp rotation here, as ratio is NaN if angleDiff is 0.0f
-                    transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, ratio);
+                    transform.rotation = Quaternion.Slerp(transform.rotation, lerpTargetRotation, ratio);
                     interpOccuredThisFrame = true;
                 }
             }
@@ -329,7 +329,7 @@ namespace HoloToolkit.Unity
                 else
                 {
                     // Only lerp rotation here, as ratio is NaN if angleDiff is 0.0f
-                    transform.localRotation = Quaternion.Slerp(transform.localRotation, targetLocalRotation, ratio);
+                    transform.localRotation = Quaternion.Slerp(transform.localRotation, lerpTargetLocalRotation, ratio);
                     interpOccuredThisFrame = true;
                 }
             }


### PR DESCRIPTION
When SmoothLerpToTarget is true, the target value that we are
interpolating to should be lerpTargetLocalRotation. For example, on line
320 we compute angleDiff assuming the new angle we are going to is
lerpTargetLocalRotation.

However, when performing the actual Quaternion.Slerp computation, we are
currently setting the target as targetRotation. Fix this by setting the
target in the Quaternion.Slerp call to lerpTargetRotation and
lerpTargetLocalRotation.
