### PR TITLE
Implement camera cache utility class 

### DIFF
--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
@@ -30,7 +30,7 @@ namespace HoloToolkit.Examples.GazeRuler
             if (lastPoint != null && lastPoint.IsStart)
             {
                 Vector3 centerPos = (lastPoint.Position + hitPoint) * 0.5f;
-                Transform cameraTransform = CameraCache.main.transform;
+                Transform cameraTransform = CameraCache.Main.transform;
                 Vector3 directionFromCamera = centerPos - cameraTransform.position;
 
                 float distanceA = Vector3.Distance(lastPoint.Position, cameraTransform.position);

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
@@ -30,11 +30,11 @@ namespace HoloToolkit.Examples.GazeRuler
             if (lastPoint != null && lastPoint.IsStart)
             {
                 Vector3 centerPos = (lastPoint.Position + hitPoint) * 0.5f;
+                Transform cameraTransform = CameraCache.main.transform;
+                Vector3 directionFromCamera = centerPos - cameraTransform.position;
 
-                Vector3 directionFromCamera = centerPos - Camera.main.transform.position;
-
-                float distanceA = Vector3.Distance(lastPoint.Position, Camera.main.transform.position);
-                float distanceB = Vector3.Distance(hitPoint, Camera.main.transform.position);
+                float distanceA = Vector3.Distance(lastPoint.Position, cameraTransform.position);
+                float distanceB = Vector3.Distance(hitPoint, cameraTransform.position);
 
                 Debug.Log("A: " + distanceA + ",B: " + distanceB);
                 Vector3 direction;

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
@@ -30,11 +30,11 @@ namespace HoloToolkit.Examples.GazeRuler
             if (lastPoint != null && lastPoint.IsStart)
             {
                 Vector3 centerPos = (lastPoint.Position + hitPoint) * 0.5f;
-                Transform cameraTransform = CameraCache.Main.transform;
-                Vector3 directionFromCamera = centerPos - cameraTransform.position;
+                Vector3 cameraPosition = CameraCache.Main.transform.position;
+                Vector3 directionFromCamera = centerPos - cameraPosition;
 
-                float distanceA = Vector3.Distance(lastPoint.Position, cameraTransform.position);
-                float distanceB = Vector3.Distance(hitPoint, cameraTransform.position);
+                float distanceA = Vector3.Distance(lastPoint.Position, cameraPosition);
+                float distanceB = Vector3.Distance(hitPoint, cameraPosition);
 
                 Debug.Log("A: " + distanceA + ",B: " + distanceB);
                 Vector3 direction;

--- a/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractive.cs
+++ b/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractive.cs
@@ -139,7 +139,7 @@ namespace HoloToolkit.Examples.InteractiveElements
             mCurrentInputSource = mTempInputSource;
             mCurrentInputSourceId = mTempInputSourceId;
 
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             mStartHeadPosition = cameraTransform.position;
             mStartHeadRay = cameraTransform.forward;
 

--- a/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractive.cs
+++ b/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractive.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections;
+using HoloToolkit.Unity;
 using HoloToolkit.Unity.InputModule;
 using UnityEngine;
 using Cursor = HoloToolkit.Unity.InputModule.Cursor;
@@ -138,8 +139,9 @@ namespace HoloToolkit.Examples.InteractiveElements
             mCurrentInputSource = mTempInputSource;
             mCurrentInputSourceId = mTempInputSourceId;
 
-            mStartHeadPosition = Camera.main.transform.position;
-            mStartHeadRay = Camera.main.transform.forward;
+            Transform cameraTransform = CameraCache.main.transform;
+            mStartHeadPosition = cameraTransform.position;
+            mStartHeadRay = cameraTransform.forward;
 
             Vector3 handPosition;
             mCurrentInputSource.TryGetPosition(mCurrentInputSourceId, out handPosition);

--- a/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractive.cs
+++ b/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractive.cs
@@ -139,9 +139,8 @@ namespace HoloToolkit.Examples.InteractiveElements
             mCurrentInputSource = mTempInputSource;
             mCurrentInputSourceId = mTempInputSourceId;
 
-            Transform cameraTransform = CameraCache.Main.transform;
-            mStartHeadPosition = cameraTransform.position;
-            mStartHeadRay = cameraTransform.forward;
+            mStartHeadPosition = CameraCache.Main.transform.position;
+            mStartHeadRay = CameraCache.Main.transform.forward;
 
             Vector3 handPosition;
             mCurrentInputSource.TryGetPosition(mCurrentInputSourceId, out handPosition);

--- a/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractiveControl.cs
+++ b/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractiveControl.cs
@@ -87,7 +87,7 @@ namespace HoloToolkit.Examples.InteractiveElements
         /// <summary>
         /// Camera reference
         /// </summary>
-        protected Camera MainCamera { get { return CameraCache.main; } }
+        protected Camera MainCamera { get { return CameraCache.Main; } }
 
         /// <summary>
         /// Orientation based on the user facing direction.

--- a/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractiveControl.cs
+++ b/Assets/HoloToolkit-Examples/InteractiveElements/Scripts/GestureInteractiveControl.cs
@@ -3,6 +3,7 @@
 
 using UnityEngine;
 using System.Collections;
+using HoloToolkit.Unity;
 
 namespace HoloToolkit.Examples.InteractiveElements
 {
@@ -86,7 +87,7 @@ namespace HoloToolkit.Examples.InteractiveElements
         /// <summary>
         /// Camera reference
         /// </summary>
-        protected Camera MainCamera { get { return Camera.main; } }
+        protected Camera MainCamera { get { return CameraCache.main; } }
 
         /// <summary>
         /// Orientation based on the user facing direction.
@@ -385,7 +386,7 @@ namespace HoloToolkit.Examples.InteractiveElements
         protected float FlipDistanceOnFacingControl(float toFlip, Vector3 controlPosition, Vector3 controlForward)
         {
             Vector3 cameraRay = StartHeadPosition - controlPosition;
-            bool facingForward = Vector3.Dot(Camera.main.transform.forward, StartHeadRay) >= 0;
+            bool facingForward = Vector3.Dot(MainCamera.transform.forward, StartHeadRay) >= 0;
             bool facingControl = Vector3.Dot(cameraRay, controlForward) >= 0;
 
             if (!facingForward)

--- a/Assets/HoloToolkit-Examples/Medical/Scripts/TapToPlaceScene.cs
+++ b/Assets/HoloToolkit-Examples/Medical/Scripts/TapToPlaceScene.cs
@@ -31,7 +31,7 @@ namespace HoloToolkit.Unity
         {
             if (Placing)
             {
-                var cameraTransform = CameraCache.main.transform;
+                var cameraTransform = CameraCache.Main.transform;
                 var headPosition = cameraTransform.position;
                 var forward = cameraTransform.forward;
                 var scenePosition = headPosition + DistanceFromHead * forward;

--- a/Assets/HoloToolkit-Examples/Medical/Scripts/TapToPlaceScene.cs
+++ b/Assets/HoloToolkit-Examples/Medical/Scripts/TapToPlaceScene.cs
@@ -31,11 +31,12 @@ namespace HoloToolkit.Unity
         {
             if (Placing)
             {
-                var headPosition = Camera.main.transform.position;
-                var forward = Camera.main.transform.forward;
+                var cameraTransform = CameraCache.main.transform;
+                var headPosition = cameraTransform.position;
+                var forward = cameraTransform.forward;
                 var scenePosition = headPosition + DistanceFromHead * forward;
 
-                var facingRotation = Camera.main.transform.localRotation * this.initialRotation;
+                var facingRotation = cameraTransform.localRotation * this.initialRotation;
                 //only yaw
                 facingRotation.x = 0;
                 facingRotation.z = 0;

--- a/Assets/HoloToolkit-Examples/Prototyping/Scripts/MoveWithObject.cs
+++ b/Assets/HoloToolkit-Examples/Prototyping/Scripts/MoveWithObject.cs
@@ -83,7 +83,7 @@ namespace HoloToolkit.Examples.Prototyping
         {
             if (ReferenceObject == null)
             {
-                ReferenceObject = CameraCache.main.gameObject;
+                ReferenceObject = CameraCache.Main.gameObject;
             }
         }
 
@@ -92,7 +92,7 @@ namespace HoloToolkit.Examples.Prototyping
         {
 
             if (ReferenceObject == null)
-                ReferenceObject = CameraCache.main.gameObject;
+                ReferenceObject = CameraCache.Main.gameObject;
 
             mOffsetDirection = this.transform.position - ReferenceObject.transform.position;
             mOffsetDistance = mOffsetDirection.magnitude;

--- a/Assets/HoloToolkit-Examples/Prototyping/Scripts/MoveWithObject.cs
+++ b/Assets/HoloToolkit-Examples/Prototyping/Scripts/MoveWithObject.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using HoloToolkit.Unity.InputModule;
-using System.Collections;
-using System.Collections.Generic;
+using HoloToolkit.Unity;
 using UnityEngine;
-using UnityEngine.Networking;
 
 namespace HoloToolkit.Examples.Prototyping
 {
@@ -85,7 +83,7 @@ namespace HoloToolkit.Examples.Prototyping
         {
             if (ReferenceObject == null)
             {
-                ReferenceObject = Camera.main.gameObject;
+                ReferenceObject = CameraCache.main.gameObject;
             }
         }
 
@@ -94,7 +92,7 @@ namespace HoloToolkit.Examples.Prototyping
         {
 
             if (ReferenceObject == null)
-                ReferenceObject = Camera.main.gameObject;
+                ReferenceObject = CameraCache.main.gameObject;
 
             mOffsetDirection = this.transform.position - ReferenceObject.transform.position;
             mOffsetDistance = mOffsetDirection.magnitude;

--- a/Assets/HoloToolkit-Examples/Prototyping/Scripts/ScaleByDistance.cs
+++ b/Assets/HoloToolkit-Examples/Prototyping/Scripts/ScaleByDistance.cs
@@ -55,7 +55,7 @@ namespace HoloToolkit.Examples.Prototyping
 
             if (RefernceObject == null)
             {
-                RefernceObject = CameraCache.main.gameObject;
+                RefernceObject = CameraCache.Main.gameObject;
             }
         }
         

--- a/Assets/HoloToolkit-Examples/Prototyping/Scripts/ScaleByDistance.cs
+++ b/Assets/HoloToolkit-Examples/Prototyping/Scripts/ScaleByDistance.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using HoloToolkit.Unity.InputModule;
-using System.Collections;
-using System.Collections.Generic;
+using HoloToolkit.Unity;
 using UnityEngine;
-using UnityEngine.Networking;
 
 namespace HoloToolkit.Examples.Prototyping
 {
@@ -57,7 +55,7 @@ namespace HoloToolkit.Examples.Prototyping
 
             if (RefernceObject == null)
             {
-                RefernceObject = Camera.main.gameObject;
+                RefernceObject = CameraCache.main.gameObject;
             }
         }
         

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
@@ -100,9 +100,8 @@ namespace HoloToolkit.Examples.SharingWithUNET
 
             // if we are the remote player then we need to update our worldPosition and then set our 
             // local (to the shared world anchor) position for other clients to update our position in their world.
-            Transform cameraTransform = CameraCache.Main.transform;
-            transform.position = cameraTransform.position;
-            transform.rotation = cameraTransform.rotation;
+            transform.position = CameraCache.Main.transform.position;
+            transform.rotation = CameraCache.Main.transform.rotation;
 
             // Depending on if you are host or client, either setting the SyncVar (client) 
             // or calling the Cmd (host) will update the other users in the session.

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using HoloToolkit.Unity;
 using UnityEngine;
 using UnityEngine.Networking;
 using HoloToolkit.Unity.InputModule;
@@ -99,8 +100,9 @@ namespace HoloToolkit.Examples.SharingWithUNET
 
             // if we are the remote player then we need to update our worldPosition and then set our 
             // local (to the shared world anchor) position for other clients to update our position in their world.
-            transform.position = Camera.main.transform.position;
-            transform.rotation = Camera.main.transform.rotation;
+            Transform cameraTransform = CameraCache.main.transform;
+            transform.position = cameraTransform.position;
+            transform.rotation = cameraTransform.rotation;
 
             // Depending on if you are host or client, either setting the SyncVar (client) 
             // or calling the Cmd (host) will update the other users in the session.

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
@@ -100,7 +100,7 @@ namespace HoloToolkit.Examples.SharingWithUNET
 
             // if we are the remote player then we need to update our worldPosition and then set our 
             // local (to the shared world anchor) position for other clients to update our position in their world.
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             transform.position = cameraTransform.position;
             transform.rotation = cameraTransform.rotation;
 

--- a/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
+++ b/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using HoloToolkit.Unity;
 using UnityEngine;
 
 #if UNITY_EDITOR || UNITY_WSA
@@ -32,9 +33,10 @@ namespace HoloToolkit.Examples.SpatialMappingComponent
 
         private void Recognizer_TappedEvent(InteractionSourceKind source, int tapCount, Ray headRay)
         {
+            Transform cameraTransform = CameraCache.main.transform;
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube); // Create a cube
             cube.transform.localScale = Vector3.one * 0.3f; // Make the cube smaller
-            cube.transform.position = Camera.main.transform.position + Camera.main.transform.forward; // Start to drop it in front of the camera
+            cube.transform.position = cameraTransform.position + cameraTransform.forward; // Start to drop it in front of the camera
             cube.AddComponent<Rigidbody>(); // Apply physics
         }
 #endif

--- a/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
+++ b/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
@@ -33,11 +33,14 @@ namespace HoloToolkit.Examples.SpatialMappingComponent
 
         private void Recognizer_TappedEvent(InteractionSourceKind source, int tapCount, Ray headRay)
         {
-            Transform cameraTransform = CameraCache.Main.transform;
-            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube); // Create a cube
-            cube.transform.localScale = Vector3.one * 0.3f; // Make the cube smaller
-            cube.transform.position = cameraTransform.position + cameraTransform.forward; // Start to drop it in front of the camera
-            cube.AddComponent<Rigidbody>(); // Apply physics
+            // Create a cube
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            // Make the cube smaller
+            cube.transform.localScale = Vector3.one * 0.3f;
+            // Start to drop it in front of the camera
+            cube.transform.position = CameraCache.Main.transform.position + CameraCache.Main.transform.forward;
+            // Apply physics
+            cube.AddComponent<Rigidbody>(); 
         }
 #endif
     }

--- a/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
+++ b/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
@@ -33,7 +33,7 @@ namespace HoloToolkit.Examples.SpatialMappingComponent
 
         private void Recognizer_TappedEvent(InteractionSourceKind source, int tapCount, Ray headRay)
         {
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube); // Create a cube
             cube.transform.localScale = Vector3.one * 0.3f; // Make the cube smaller
             cube.transform.position = cameraTransform.position + cameraTransform.forward; // Start to drop it in front of the camera

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/AppState.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/AppState.cs
@@ -202,7 +202,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
         private void Start()
         {
             // Default the scene & the HoloToolkit objects to the camera
-            Vector3 sceneOrigin = CameraCache.main.transform.position;
+            Vector3 sceneOrigin = CameraCache.Main.transform.position;
             Parent_Scene.transform.position = sceneOrigin;
             MappingObserver.SetObserverOrigin(sceneOrigin);
             InputManager.Instance.AddGlobalListener(gameObject);

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/AppState.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/AppState.cs
@@ -202,7 +202,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
         private void Start()
         {
             // Default the scene & the HoloToolkit objects to the camera
-            Vector3 sceneOrigin = Camera.main.transform.position;
+            Vector3 sceneOrigin = CameraCache.main.transform.position;
             Parent_Scene.transform.position = sceneOrigin;
             MappingObserver.SetObserverOrigin(sceneOrigin);
             InputManager.Instance.AddGlobalListener(gameObject);

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LevelSolver.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LevelSolver.cs
@@ -361,7 +361,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                     new PlacementQuery(SpatialUnderstandingDllObjectPlacement.ObjectPlacementDefinition.Create_RandomInAir(new Vector3(halfDimSize, halfDimSize, halfDimSize)),
                                         new List<SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule>() {
                                             SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromOtherObjects(halfDimSize * 3.0f),
-                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(Camera.main.transform.position, 2.5f),
+                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(CameraCache.main.transform.position, 2.5f),
                                         }));
             }
             PlaceObjectAsync("RandomInAir - AwayFromMe", placementQuery);
@@ -395,7 +395,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 placementQuery.Add(
                     new PlacementQuery(SpatialUnderstandingDllObjectPlacement.ObjectPlacementDefinition.Create_OnFloor(new Vector3(halfDimSize, halfDimSize, halfDimSize)),
                                        new List<SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule>() {
-                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(Camera.main.transform.position, 2.0f),
+                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(CameraCache.main.transform.position, 2.0f),
                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromOtherObjects(halfDimSize * 3.0f),
                                        }));
             }
@@ -414,7 +414,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromOtherObjects(halfDimSize * 3.0f),
                                        },
                                        new List<SpatialUnderstandingDllObjectPlacement.ObjectPlacementConstraint>() {
-                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementConstraint.Create_NearPoint(Camera.main.transform.position, 0.5f, 2.0f)
+                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementConstraint.Create_NearPoint(CameraCache.main.transform.position, 0.5f, 2.0f)
                                        }));
             }
             PlaceObjectAsync("OnFloor - NearMe", placementQuery);

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LevelSolver.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LevelSolver.cs
@@ -361,7 +361,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                     new PlacementQuery(SpatialUnderstandingDllObjectPlacement.ObjectPlacementDefinition.Create_RandomInAir(new Vector3(halfDimSize, halfDimSize, halfDimSize)),
                                         new List<SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule>() {
                                             SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromOtherObjects(halfDimSize * 3.0f),
-                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(CameraCache.main.transform.position, 2.5f),
+                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(CameraCache.Main.transform.position, 2.5f),
                                         }));
             }
             PlaceObjectAsync("RandomInAir - AwayFromMe", placementQuery);
@@ -395,7 +395,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 placementQuery.Add(
                     new PlacementQuery(SpatialUnderstandingDllObjectPlacement.ObjectPlacementDefinition.Create_OnFloor(new Vector3(halfDimSize, halfDimSize, halfDimSize)),
                                        new List<SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule>() {
-                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(CameraCache.main.transform.position, 2.0f),
+                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromPosition(CameraCache.Main.transform.position, 2.0f),
                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromOtherObjects(halfDimSize * 3.0f),
                                        }));
             }
@@ -414,7 +414,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                                            SpatialUnderstandingDllObjectPlacement.ObjectPlacementRule.Create_AwayFromOtherObjects(halfDimSize * 3.0f),
                                        },
                                        new List<SpatialUnderstandingDllObjectPlacement.ObjectPlacementConstraint>() {
-                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementConstraint.Create_NearPoint(CameraCache.main.transform.position, 0.5f, 2.0f)
+                                           SpatialUnderstandingDllObjectPlacement.ObjectPlacementConstraint.Create_NearPoint(CameraCache.Main.transform.position, 0.5f, 2.0f)
                                        }));
             }
             PlaceObjectAsync("OnFloor - NearMe", placementQuery);

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
@@ -128,9 +128,8 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 }
 
                 // Calc the forward distance for the animation start point
-                Transform cameraTransform = CameraCache.Main.transform;
-                Vector3 rayPos = cameraTransform.position;
-                Vector3 rayVec = cameraTransform.forward * InitialPositionForwardMaxDistance;
+                Vector3 rayPos = CameraCache.Main.transform.position;
+                Vector3 rayVec = CameraCache.Main.transform.forward * InitialPositionForwardMaxDistance;
                 IntPtr raycastResultPtr = HoloToolkit.Unity.SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticRaycastResultPtr();
                 HoloToolkit.Unity.SpatialUnderstandingDll.Imports.PlayspaceRaycast(
                     rayPos.x, rayPos.y, rayPos.z, rayVec.x, rayVec.y, rayVec.z,

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
@@ -128,7 +128,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 }
 
                 // Calc the forward distance for the animation start point
-                Transform cameraTransform = CameraCache.main.transform;
+                Transform cameraTransform = CameraCache.Main.transform;
                 Vector3 rayPos = cameraTransform.position;
                 Vector3 rayVec = cameraTransform.forward * InitialPositionForwardMaxDistance;
                 IntPtr raycastResultPtr = HoloToolkit.Unity.SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticRaycastResultPtr();

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
@@ -128,8 +128,9 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 }
 
                 // Calc the forward distance for the animation start point
-                Vector3 rayPos = Camera.main.transform.position;
-                Vector3 rayVec = Camera.main.transform.forward * InitialPositionForwardMaxDistance;
+                Transform cameraTransform = CameraCache.main.transform;
+                Vector3 rayPos = cameraTransform.position;
+                Vector3 rayVec = cameraTransform.forward * InitialPositionForwardMaxDistance;
                 IntPtr raycastResultPtr = HoloToolkit.Unity.SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticRaycastResultPtr();
                 HoloToolkit.Unity.SpatialUnderstandingDll.Imports.PlayspaceRaycast(
                     rayPos.x, rayPos.y, rayPos.z, rayVec.x, rayVec.y, rayVec.z,

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
@@ -32,8 +32,9 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
             if (SpatialUnderstanding.Instance.AllowSpatialUnderstanding &&
                 SpatialUnderstanding.Instance.ScanState == SpatialUnderstanding.ScanStates.Done)
             {
-                Vector3 rayPos = Camera.main.transform.position;
-                Vector3 rayVec = Camera.main.transform.forward * RayCastLength;
+                Transform cameraTransform = CameraCache.main.transform;
+                Vector3 rayPos = cameraTransform.position;
+                Vector3 rayVec = cameraTransform.forward * RayCastLength;
                 IntPtr raycastResultPtr = SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticRaycastResultPtr();
                 SpatialUnderstandingDll.Imports.PlayspaceRaycast(
                     rayPos.x, rayPos.y, rayPos.z,
@@ -68,8 +69,9 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
 
             // Do the raycast
             RaycastHit hitInfo;
-            Vector3 uiRayCastOrigin = Camera.main.transform.position;
-            Vector3 uiRayCastDirection = Camera.main.transform.forward;
+            Transform cameraTransform = CameraCache.main.transform;
+            Vector3 uiRayCastOrigin = cameraTransform.position;
+            Vector3 uiRayCastDirection = cameraTransform.forward;
             if (Physics.Raycast(uiRayCastOrigin, uiRayCastDirection, out hitInfo, RayCastLength, UILayerMask))
             {
                 Canvas canvas = hitInfo.collider.gameObject.GetComponent<Canvas>();
@@ -135,8 +137,9 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 CursorText.gameObject.SetActive(true);
                 CursorText.text = rayCastResult.SurfaceType.ToString();
 
-                CursorText.transform.rotation = Quaternion.LookRotation(Camera.main.transform.forward, Vector3.up);
-                CursorText.transform.position = transform.position + Camera.main.transform.right * 0.05f;
+                Transform cameraTransform = CameraCache.main.transform;
+                CursorText.transform.rotation = Quaternion.LookRotation(cameraTransform.forward, Vector3.up);
+                CursorText.transform.position = transform.position + cameraTransform.right * 0.05f;
             }
             else
             {

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
@@ -32,7 +32,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
             if (SpatialUnderstanding.Instance.AllowSpatialUnderstanding &&
                 SpatialUnderstanding.Instance.ScanState == SpatialUnderstanding.ScanStates.Done)
             {
-                Transform cameraTransform = CameraCache.main.transform;
+                Transform cameraTransform = CameraCache.Main.transform;
                 Vector3 rayPos = cameraTransform.position;
                 Vector3 rayVec = cameraTransform.forward * RayCastLength;
                 IntPtr raycastResultPtr = SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticRaycastResultPtr();
@@ -69,7 +69,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
 
             // Do the raycast
             RaycastHit hitInfo;
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             Vector3 uiRayCastOrigin = cameraTransform.position;
             Vector3 uiRayCastDirection = cameraTransform.forward;
             if (Physics.Raycast(uiRayCastOrigin, uiRayCastDirection, out hitInfo, RayCastLength, UILayerMask))
@@ -137,7 +137,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 CursorText.gameObject.SetActive(true);
                 CursorText.text = rayCastResult.SurfaceType.ToString();
 
-                Transform cameraTransform = CameraCache.main.transform;
+                Transform cameraTransform = CameraCache.Main.transform;
                 CursorText.transform.rotation = Quaternion.LookRotation(cameraTransform.forward, Vector3.up);
                 CursorText.transform.position = transform.position + cameraTransform.right * 0.05f;
             }

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
@@ -32,9 +32,8 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
             if (SpatialUnderstanding.Instance.AllowSpatialUnderstanding &&
                 SpatialUnderstanding.Instance.ScanState == SpatialUnderstanding.ScanStates.Done)
             {
-                Transform cameraTransform = CameraCache.Main.transform;
-                Vector3 rayPos = cameraTransform.position;
-                Vector3 rayVec = cameraTransform.forward * RayCastLength;
+                Vector3 rayPos = CameraCache.Main.transform.position;
+                Vector3 rayVec = CameraCache.Main.transform.forward * RayCastLength;
                 IntPtr raycastResultPtr = SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticRaycastResultPtr();
                 SpatialUnderstandingDll.Imports.PlayspaceRaycast(
                     rayPos.x, rayPos.y, rayPos.z,
@@ -69,9 +68,8 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
 
             // Do the raycast
             RaycastHit hitInfo;
-            Transform cameraTransform = CameraCache.Main.transform;
-            Vector3 uiRayCastOrigin = cameraTransform.position;
-            Vector3 uiRayCastDirection = cameraTransform.forward;
+            Vector3 uiRayCastOrigin = CameraCache.Main.transform.position;
+            Vector3 uiRayCastDirection = CameraCache.Main.transform.forward;
             if (Physics.Raycast(uiRayCastOrigin, uiRayCastDirection, out hitInfo, RayCastLength, UILayerMask))
             {
                 Canvas canvas = hitInfo.collider.gameObject.GetComponent<Canvas>();
@@ -137,9 +135,8 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 CursorText.gameObject.SetActive(true);
                 CursorText.text = rayCastResult.SurfaceType.ToString();
 
-                Transform cameraTransform = CameraCache.Main.transform;
-                CursorText.transform.rotation = Quaternion.LookRotation(cameraTransform.forward, Vector3.up);
-                CursorText.transform.position = transform.position + cameraTransform.right * 0.05f;
+                CursorText.transform.rotation = Quaternion.LookRotation(CameraCache.Main.transform.forward, Vector3.up);
+                CursorText.transform.position = transform.position + CameraCache.Main.transform.right * 0.05f;
             }
             else
             {

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/UI.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/UI.cs
@@ -145,6 +145,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
             // Wait a frame
             yield return null;
 
+            Transform cameraTransform = CameraCache.main.transform;
             // Fallback, place floor (add a facing, if so)
             int locationCount = SpatialUnderstandingDllTopology.QueryTopology_FindLargestPositionsOnFloor(
                 resultsTopology.Length, resultsTopologyPtr);
@@ -153,7 +154,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 Debug.Log("PlaceMenu - LargestPositionsOnFloor");
                 SpatialUnderstandingDllTopology.TopologyResult menuLocation = resultsTopology[0];
                 Vector3 menuPosition = menuLocation.position + Vector3.up * MenuHeight;
-                Vector3 menuLookVector = Camera.main.transform.position - menuPosition;
+                Vector3 menuLookVector = cameraTransform.position - menuPosition;
                 PlaceMenu(menuPosition, (new Vector3(menuLookVector.x, 0.0f, menuLookVector.z)).normalized, true);
                 yield break;
             }
@@ -161,8 +162,8 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
             // Final fallback just in front of the user
             SpatialUnderstandingDll.Imports.QueryPlayspaceAlignment(SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticPlayspaceAlignmentPtr());
             SpatialUnderstandingDll.Imports.PlayspaceAlignment alignment = SpatialUnderstanding.Instance.UnderstandingDLL.GetStaticPlayspaceAlignment();
-            Vector3 defaultPosition = Camera.main.transform.position + Camera.main.transform.forward * 2.0f;
-            PlaceMenu(new Vector3(defaultPosition.x, Math.Max(defaultPosition.y, alignment.FloorYValue + 1.5f), defaultPosition.z), (new Vector3(Camera.main.transform.forward.x, 0.0f, Camera.main.transform.forward.z)).normalized, true);
+            Vector3 defaultPosition = cameraTransform.position + cameraTransform.forward * 2.0f;
+            PlaceMenu(new Vector3(defaultPosition.x, Math.Max(defaultPosition.y, alignment.FloorYValue + 1.5f), defaultPosition.z), (new Vector3(cameraTransform.forward.x, 0.0f, cameraTransform.forward.z)).normalized, true);
             Debug.Log("PlaceMenu - InFrontOfUser");
         }
 
@@ -307,7 +308,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 {
                     // Rotate to face the user
                     transform.position = MenuAnimatedBox.AnimPosition.Evaluate(MenuAnimatedBox.Time);
-                    Vector3 lookDirTarget = Camera.main.transform.position - transform.position;
+                    Vector3 lookDirTarget = CameraCache.main.transform.position - transform.position;
                     lookDirTarget = (new Vector3(lookDirTarget.x, 0.0f, lookDirTarget.z)).normalized;
                     transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(-lookDirTarget), Time.deltaTime * 10.0f);
                 }

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/UI.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/UI.cs
@@ -145,7 +145,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
             // Wait a frame
             yield return null;
 
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             // Fallback, place floor (add a facing, if so)
             int locationCount = SpatialUnderstandingDllTopology.QueryTopology_FindLargestPositionsOnFloor(
                 resultsTopology.Length, resultsTopologyPtr);
@@ -308,7 +308,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
                 {
                     // Rotate to face the user
                     transform.position = MenuAnimatedBox.AnimPosition.Evaluate(MenuAnimatedBox.Time);
-                    Vector3 lookDirTarget = CameraCache.main.transform.position - transform.position;
+                    Vector3 lookDirTarget = CameraCache.Main.transform.position - transform.position;
                     lookDirTarget = (new Vector3(lookDirTarget.x, 0.0f, lookDirTarget.z)).normalized;
                     transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(-lookDirTarget), Time.deltaTime * 10.0f);
                 }

--- a/Assets/HoloToolkit-Tests/Sharing/Scripts/RemoteHeadManager.cs
+++ b/Assets/HoloToolkit-Tests/Sharing/Scripts/RemoteHeadManager.cs
@@ -52,7 +52,7 @@ namespace HoloToolkit.Sharing.Tests
         private void Update()
         {
             // Grab the current head transform and broadcast it to all the other users in the session
-            Transform headTransform = CameraCache.main.transform;
+            Transform headTransform = CameraCache.Main.transform;
 
             // Transform the head position and rotation from world space into local space
             Vector3 headPosition = transform.InverseTransformPoint(headTransform.position);

--- a/Assets/HoloToolkit-Tests/Sharing/Scripts/RemoteHeadManager.cs
+++ b/Assets/HoloToolkit-Tests/Sharing/Scripts/RemoteHeadManager.cs
@@ -52,7 +52,7 @@ namespace HoloToolkit.Sharing.Tests
         private void Update()
         {
             // Grab the current head transform and broadcast it to all the other users in the session
-            Transform headTransform = Camera.main.transform;
+            Transform headTransform = CameraCache.main.transform;
 
             // Transform the head position and rotation from world space into local space
             Vector3 headPosition = transform.InverseTransformPoint(headTransform.position);

--- a/Assets/HoloToolkit-Tests/Utilities/Scripts/PlaneTargetGroupPicker.cs
+++ b/Assets/HoloToolkit-Tests/Utilities/Scripts/PlaneTargetGroupPicker.cs
@@ -22,7 +22,7 @@ namespace HoloToolkit.Unity.Tests
         {
             PlaneTargetGroup newGroup = null;
             float smallestAngle = float.PositiveInfinity;
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             // Figure out which group we're looking at
             foreach (PlaneTargetGroup group in Groups)
             {

--- a/Assets/HoloToolkit-Tests/Utilities/Scripts/PlaneTargetGroupPicker.cs
+++ b/Assets/HoloToolkit-Tests/Utilities/Scripts/PlaneTargetGroupPicker.cs
@@ -22,12 +22,12 @@ namespace HoloToolkit.Unity.Tests
         {
             PlaneTargetGroup newGroup = null;
             float smallestAngle = float.PositiveInfinity;
-
+            Transform cameraTransform = CameraCache.main.transform;
             // Figure out which group we're looking at
             foreach (PlaneTargetGroup group in Groups)
             {
-                Vector3 camToGroup = group.transform.position - Camera.main.transform.position;
-                float gazeObjectAngle = Vector3.Angle(camToGroup, Camera.main.transform.forward);
+                Vector3 camToGroup = group.transform.position - cameraTransform.position;
+                float gazeObjectAngle = Vector3.Angle(camToGroup, cameraTransform.forward);
                 if (group.Targets.Length > 0 && gazeObjectAngle < AngleOfAcceptance && gazeObjectAngle < smallestAngle)
                 {
                     smallestAngle = gazeObjectAngle;

--- a/Assets/HoloToolkit/Input/Scripts/GameControllerManipulator.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GameControllerManipulator.cs
@@ -73,7 +73,7 @@ namespace HoloToolkit.Unity.InputModule
                 return;
             }
 
-            var cameraTransform = CameraCache.main.transform;
+            var cameraTransform = CameraCache.Main.transform;
 
             //Rotate
             var noRotateModifier = string.IsNullOrEmpty(RotateModifierButtonName);

--- a/Assets/HoloToolkit/Input/Scripts/GameControllerManipulator.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GameControllerManipulator.cs
@@ -73,7 +73,7 @@ namespace HoloToolkit.Unity.InputModule
                 return;
             }
 
-            var cameraTransform = Camera.main.transform;
+            var cameraTransform = CameraCache.main.transform;
 
             //Rotate
             var noRotateModifier = string.IsNullOrEmpty(RotateModifierButtonName);

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -138,7 +138,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private bool FindGazeTransform()
         {
-            GazeTransform = GazeTransform ?? CameraCache.main.transform;
+            GazeTransform = GazeTransform ?? CameraCache.Main.transform;
             if (GazeTransform != null) return true;
 
             Debug.LogError("Gaze Manager was not given a GazeTransform and no main camera exists to default to.");
@@ -210,7 +210,7 @@ namespace HoloToolkit.Unity.InputModule
             {
                 UnityUIPointerEvent = new PointerEventData(EventSystem.current);
             }
-            Camera mainCamera = CameraCache.main;
+            Camera mainCamera = CameraCache.Main;
 
             // 2D cursor position
             Vector2 cursorScreenPos = mainCamera.WorldToScreenPoint(HitPosition);

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -138,13 +138,8 @@ namespace HoloToolkit.Unity.InputModule
 
         private bool FindGazeTransform()
         {
-            if (GazeTransform != null) { return true; }
-
-            if (Camera.main != null)
-            {
-                GazeTransform = Camera.main.transform;
-                return true;
-            }
+            GazeTransform = GazeTransform ?? CameraCache.main.transform;
+            if (GazeTransform != null) return true;
 
             Debug.LogError("Gaze Manager was not given a GazeTransform and no main camera exists to default to.");
             return false;
@@ -181,8 +176,7 @@ namespace HoloToolkit.Unity.InputModule
             if (RaycastLayerMasks.Length == 1)
             {
                 IsGazingAtObject = Physics.Raycast(GazeOrigin, GazeNormal, out hitInfo, MaxGazeCollisionDistance, RaycastLayerMasks[0]);
-            }
-            else
+            } else
             {
                 // Raycast across all layers and prioritize
                 RaycastHit? hit = PrioritizeHits(Physics.RaycastAll(new Ray(GazeOrigin, GazeNormal), MaxGazeCollisionDistance, -1));
@@ -199,8 +193,7 @@ namespace HoloToolkit.Unity.InputModule
                 HitObject = HitInfo.collider.gameObject;
                 HitPosition = HitInfo.point;
                 lastHitDistance = HitInfo.distance;
-            }
-            else
+            } else
             {
                 HitObject = null;
                 HitPosition = GazeOrigin + (GazeNormal * lastHitDistance);
@@ -217,9 +210,10 @@ namespace HoloToolkit.Unity.InputModule
             {
                 UnityUIPointerEvent = new PointerEventData(EventSystem.current);
             }
+            Camera mainCamera = CameraCache.main;
 
             // 2D cursor position
-            Vector2 cursorScreenPos = Camera.main.WorldToScreenPoint(HitPosition);
+            Vector2 cursorScreenPos = mainCamera.WorldToScreenPoint(HitPosition);
             UnityUIPointerEvent.delta = cursorScreenPos - UnityUIPointerEvent.position;
             UnityUIPointerEvent.position = cursorScreenPos;
 
@@ -245,16 +239,14 @@ namespace HoloToolkit.Unity.InputModule
                         if (threeDLayerIndex > uiLayerIndex)
                         {
                             superseded3DObject = true;
-                        }
-                        else if (threeDLayerIndex == uiLayerIndex)
+                        } else if (threeDLayerIndex == uiLayerIndex)
                         {
                             if (hitInfo.distance > uiRaycastResult.distance)
                             {
                                 superseded3DObject = true;
                             }
                         }
-                    }
-                    else
+                    } else
                     {
                         if (hitInfo.distance > uiRaycastResult.distance)
                         {
@@ -267,11 +259,10 @@ namespace HoloToolkit.Unity.InputModule
                 if (!IsGazingAtObject || superseded3DObject)
                 {
                     IsGazingAtObject = true;
-                    Vector3 worldPos = Camera.main.ScreenToWorldPoint(new Vector3(uiRaycastResult.screenPosition.x, uiRaycastResult.screenPosition.y, uiRaycastResult.distance));
-                    hitInfo = new RaycastHit
-                    {
+                    Vector3 worldPos = mainCamera.ScreenToWorldPoint(new Vector3(uiRaycastResult.screenPosition.x, uiRaycastResult.screenPosition.y, uiRaycastResult.distance));
+                    hitInfo = new RaycastHit {
                         distance = uiRaycastResult.distance,
-                        normal = -Camera.main.transform.forward,
+                        normal = -mainCamera.transform.forward,
                         point = worldPos
                     };
 

--- a/Assets/HoloToolkit/Input/Scripts/HandGuidance.cs
+++ b/Assets/HoloToolkit/Input/Scripts/HandGuidance.cs
@@ -105,7 +105,7 @@ namespace HoloToolkit.Unity.InputModule
 
             // Subtract direction from origin so that the indicator is between the hand and the origin.
             position = Cursor.transform.position - hand.properties.sourceLossMitigationDirection * distanceFromCenter;
-            rotation = Quaternion.LookRotation(Camera.main.transform.forward, hand.properties.sourceLossMitigationDirection);
+            rotation = Quaternion.LookRotation(CameraCache.main.transform.forward, hand.properties.sourceLossMitigationDirection);
         }
 
         private void InteractionManager_SourceUpdated(InteractionSourceState hand)

--- a/Assets/HoloToolkit/Input/Scripts/HandGuidance.cs
+++ b/Assets/HoloToolkit/Input/Scripts/HandGuidance.cs
@@ -105,7 +105,7 @@ namespace HoloToolkit.Unity.InputModule
 
             // Subtract direction from origin so that the indicator is between the hand and the origin.
             position = Cursor.transform.position - hand.properties.sourceLossMitigationDirection * distanceFromCenter;
-            rotation = Quaternion.LookRotation(CameraCache.main.transform.forward, hand.properties.sourceLossMitigationDirection);
+            rotation = Quaternion.LookRotation(CameraCache.Main.transform.forward, hand.properties.sourceLossMitigationDirection);
         }
 
         private void InteractionManager_SourceUpdated(InteractionSourceState hand)

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -49,7 +49,6 @@ namespace HoloToolkit.Unity.InputModule
 
         public bool IsDraggingEnabled = true;
 
-        private Camera mainCamera;
         private bool isDragging;
         private bool isGazed;
         private Vector3 objRefForward;
@@ -71,8 +70,6 @@ namespace HoloToolkit.Unity.InputModule
             {
                 HostTransform = transform;
             }
-
-            mainCamera = Camera.main;
         }
 
         private void OnDestroy()
@@ -117,26 +114,26 @@ namespace HoloToolkit.Unity.InputModule
             isDragging = true;
 
             Vector3 gazeHitPosition = GazeManager.Instance.HitInfo.point;
+            Transform cameraTransform = CameraCache.main.transform;
             Vector3 handPosition;
             currentInputSource.TryGetPosition(currentInputSourceId, out handPosition);
 
-            Vector3 pivotPosition = GetHandPivotPosition();
+            Vector3 pivotPosition = GetHandPivotPosition(cameraTransform);
             handRefDistance = Vector3.Magnitude(handPosition - pivotPosition);
             objRefDistance = Vector3.Magnitude(gazeHitPosition - pivotPosition);
 
             Vector3 objForward = HostTransform.forward;
             Vector3 objUp = HostTransform.up;
-
             // Store where the object was grabbed from
-            objRefGrabPoint = mainCamera.transform.InverseTransformDirection(HostTransform.position - gazeHitPosition);
+            objRefGrabPoint = cameraTransform.InverseTransformDirection(HostTransform.position - gazeHitPosition);
 
             Vector3 objDirection = Vector3.Normalize(gazeHitPosition - pivotPosition);
             Vector3 handDirection = Vector3.Normalize(handPosition - pivotPosition);
 
-            objForward = mainCamera.transform.InverseTransformDirection(objForward);       // in camera space
-            objUp = mainCamera.transform.InverseTransformDirection(objUp);                 // in camera space
-            objDirection = mainCamera.transform.InverseTransformDirection(objDirection);   // in camera space
-            handDirection = mainCamera.transform.InverseTransformDirection(handDirection); // in camera space
+            objForward = cameraTransform.InverseTransformDirection(objForward);       // in camera space
+            objUp = cameraTransform.InverseTransformDirection(objUp);                 // in camera space
+            objDirection = cameraTransform.InverseTransformDirection(objDirection);   // in camera space
+            handDirection = cameraTransform.InverseTransformDirection(handDirection); // in camera space
 
             objRefForward = objForward;
             objRefUp = objUp;
@@ -152,9 +149,9 @@ namespace HoloToolkit.Unity.InputModule
         /// Gets the pivot position for the hand, which is approximated to the base of the neck.
         /// </summary>
         /// <returns>Pivot position for the hand.</returns>
-        private Vector3 GetHandPivotPosition()
+        private Vector3 GetHandPivotPosition(Transform cameraTransform)
         {
-            Vector3 pivot = Camera.main.transform.position + new Vector3(0, -0.2f, 0) - Camera.main.transform.forward * 0.2f; // a bit lower and behind
+            Vector3 pivot = cameraTransform.position + new Vector3(0, -0.2f, 0) - cameraTransform.forward * 0.2f; // a bit lower and behind
             return pivot;
         }
 
@@ -183,15 +180,16 @@ namespace HoloToolkit.Unity.InputModule
         private void UpdateDragging()
         {
             Vector3 newHandPosition;
+            Transform cameraTransform = CameraCache.main.transform;
             currentInputSource.TryGetPosition(currentInputSourceId, out newHandPosition);
 
-            Vector3 pivotPosition = GetHandPivotPosition();
+            Vector3 pivotPosition = GetHandPivotPosition(cameraTransform);
 
             Vector3 newHandDirection = Vector3.Normalize(newHandPosition - pivotPosition);
 
-            newHandDirection = mainCamera.transform.InverseTransformDirection(newHandDirection); // in camera space
+            newHandDirection = cameraTransform.InverseTransformDirection(newHandDirection); // in camera space
             Vector3 targetDirection = Vector3.Normalize(gazeAngularOffset * newHandDirection);
-            targetDirection = mainCamera.transform.TransformDirection(targetDirection); // back to world space
+            targetDirection = cameraTransform.TransformDirection(targetDirection); // back to world space
 
             float currentHandDistance = Vector3.Magnitude(newHandPosition - pivotPosition);
 
@@ -211,13 +209,13 @@ namespace HoloToolkit.Unity.InputModule
             }
             else // RotationModeEnum.Default
             {
-                Vector3 objForward = mainCamera.transform.TransformDirection(objRefForward); // in world space
-                Vector3 objUp = mainCamera.transform.TransformDirection(objRefUp);   // in world space
+                Vector3 objForward = cameraTransform.TransformDirection(objRefForward); // in world space
+                Vector3 objUp = cameraTransform.TransformDirection(objRefUp);   // in world space
                 draggingRotation = Quaternion.LookRotation(objForward, objUp);
             }
 
             // Apply Final Position
-            HostTransform.position = Vector3.Lerp(HostTransform.position, draggingPosition + mainCamera.transform.TransformDirection(objRefGrabPoint), PositionLerpSpeed);
+            HostTransform.position = Vector3.Lerp(HostTransform.position, draggingPosition + cameraTransform.TransformDirection(objRefGrabPoint), PositionLerpSpeed);
             // Apply Final Rotation
             HostTransform.rotation = Quaternion.Lerp(HostTransform.rotation, draggingRotation, RotationLerpSpeed);
 

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -114,7 +114,7 @@ namespace HoloToolkit.Unity.InputModule
             isDragging = true;
 
             Vector3 gazeHitPosition = GazeManager.Instance.HitInfo.point;
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             Vector3 handPosition;
             currentInputSource.TryGetPosition(currentInputSourceId, out handPosition);
 
@@ -180,7 +180,7 @@ namespace HoloToolkit.Unity.InputModule
         private void UpdateDragging()
         {
             Vector3 newHandPosition;
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             currentInputSource.TryGetPosition(currentInputSourceId, out newHandPosition);
 
             Vector3 pivotPosition = GetHandPivotPosition(cameraTransform);

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -82,7 +82,7 @@ namespace HoloToolkit.Unity.InputModule
         protected virtual void Update()
         {
             if (!IsBeingPlaced) { return; }
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             Vector3 headPosition = cameraTransform.position;
             Vector3 gazeDirection = cameraTransform.forward;
 

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -82,9 +82,9 @@ namespace HoloToolkit.Unity.InputModule
         protected virtual void Update()
         {
             if (!IsBeingPlaced) { return; }
-
-            Vector3 headPosition = Camera.main.transform.position;
-            Vector3 gazeDirection = Camera.main.transform.forward;
+            Transform cameraTransform = CameraCache.main.transform;
+            Vector3 headPosition = cameraTransform.position;
+            Vector3 gazeDirection = cameraTransform.forward;
 
             // If we're using the spatial mapping, check to see if we got a hit, else use the gaze position.
             RaycastHit hitInfo;
@@ -109,7 +109,7 @@ namespace HoloToolkit.Unity.InputModule
             interpolator.SetTargetPosition(placementPosition);
 
             // Rotate this object to face the user.
-            interpolator.SetTargetRotation(Quaternion.Euler(0, Camera.main.transform.localEulerAngles.y, 0));
+            interpolator.SetTargetRotation(Quaternion.Euler(0, cameraTransform.localEulerAngles.y, 0));
         }
 
         public virtual void OnInputClicked(InputClickedEventData eventData)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
@@ -168,7 +168,7 @@ namespace HoloToolkit.Unity.InputModule
         private void Update()
         {
             UpdateHandVisualization();
-
+            Transform cameraTransform = CameraCache.main.transform;
             float deltaTime = UseUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;
@@ -219,10 +219,10 @@ namespace HoloToolkit.Unity.InputModule
                 }
 
                 leftHandLocalPosition += translate;
-                LeftHandSourceState.Properties.Location.Position = Camera.main.transform.position + Camera.main.transform.TransformVector(leftHandLocalPosition);
+                LeftHandSourceState.Properties.Location.Position = cameraTransform.position + cameraTransform.TransformVector(leftHandLocalPosition);
 
                 LeftHandVisualizer.transform.position = LeftHandSourceState.Properties.Location.Position;
-                LeftHandVisualizer.transform.forward = Camera.main.transform.forward;
+                LeftHandVisualizer.transform.forward = cameraTransform.forward;
 
                 leftHandVisualPropertyBlock.SetTexture(mainTexID, LeftHandSourceState.Pressed ? HandDownTexture : HandUpTexture);
                 leftHandVisualRenderer.SetPropertyBlock(leftHandVisualPropertyBlock);
@@ -253,10 +253,10 @@ namespace HoloToolkit.Unity.InputModule
                 }
 
                 rightHandLocalPosition += translate;
-                RightHandSourceState.Properties.Location.Position = Camera.main.transform.position + Camera.main.transform.TransformVector(rightHandLocalPosition);
+                RightHandSourceState.Properties.Location.Position = cameraTransform.position + cameraTransform.TransformVector(rightHandLocalPosition);
 
                 RightHandVisualizer.transform.position = RightHandSourceState.Properties.Location.Position;
-                RightHandVisualizer.transform.forward = Camera.main.transform.forward;
+                RightHandVisualizer.transform.forward = cameraTransform.forward;
                 rightHandVisualPropertyBlock.SetTexture(mainTexID, RightHandSourceState.Pressed ? HandDownTexture : HandUpTexture);
                 rightHandVisualRenderer.SetPropertyBlock(rightHandVisualPropertyBlock);
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
@@ -168,7 +168,7 @@ namespace HoloToolkit.Unity.InputModule
         private void Update()
         {
             UpdateHandVisualization();
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             float deltaTime = UseUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
@@ -264,14 +264,15 @@ namespace HoloToolkit.Sharing.VoiceChat
 
                         if (GlobalAnchorTransform != null)
                         {
+                            Vector3 cameraPos = CameraCache.main.transform.position;
                             cameraPosRelativeToGlobalAnchor = MathUtils.TransformPointFromTo(
                                 null,
                                 GlobalAnchorTransform,
-                                Camera.main.transform.position);
+                                cameraPos);
                             cameraDirectionRelativeToGlobalAnchor = MathUtils.TransformDirectionFromTo(
                                 null,
                                 GlobalAnchorTransform,
-                                Camera.main.transform.position);
+                                cameraPos);
 
                         }
 

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
@@ -264,7 +264,7 @@ namespace HoloToolkit.Sharing.VoiceChat
 
                         if (GlobalAnchorTransform != null)
                         {
-                            Vector3 cameraPos = CameraCache.main.transform.position;
+                            Vector3 cameraPos = CameraCache.Main.transform.position;
                             cameraPosRelativeToGlobalAnchor = MathUtils.TransformPointFromTo(
                                 null,
                                 GlobalAnchorTransform,

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
@@ -264,16 +264,14 @@ namespace HoloToolkit.Sharing.VoiceChat
 
                         if (GlobalAnchorTransform != null)
                         {
-                            Vector3 cameraPos = CameraCache.Main.transform.position;
                             cameraPosRelativeToGlobalAnchor = MathUtils.TransformPointFromTo(
                                 null,
                                 GlobalAnchorTransform,
-                                cameraPos);
+                                CameraCache.Main.transform.position);
                             cameraDirectionRelativeToGlobalAnchor = MathUtils.TransformDirectionFromTo(
                                 null,
                                 GlobalAnchorTransform,
-                                cameraPos);
-
+                                CameraCache.Main.transform.position);
                         }
 
                         cameraPosRelativeToGlobalAnchor.Normalize();

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
@@ -251,7 +251,7 @@ namespace HoloToolkit.Sharing.VoiceChat
 
             if (GlobalAnchorTransform != null)
             {
-                Vector3 cameraPos = CameraCache.main.transform.position;
+                Vector3 cameraPos = CameraCache.Main.transform.position;
                 cameraPosRelativeToGlobalAnchor = MathUtils.TransformPointFromTo(
                     null,
                     GlobalAnchorTransform,

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
@@ -251,16 +251,15 @@ namespace HoloToolkit.Sharing.VoiceChat
 
             if (GlobalAnchorTransform != null)
             {
-                Vector3 cameraPos = CameraCache.Main.transform.position;
                 cameraPosRelativeToGlobalAnchor = MathUtils.TransformPointFromTo(
                     null,
                     GlobalAnchorTransform,
-                    cameraPos);
+                    CameraCache.Main.transform.position);
 
                 cameraDirectionRelativeToGlobalAnchor = MathUtils.TransformDirectionFromTo(
                     null,
                     GlobalAnchorTransform,
-                    cameraPos);
+                    CameraCache.Main.transform.position);
             }
 
             cameraPosRelativeToGlobalAnchor.Normalize();

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
@@ -251,15 +251,16 @@ namespace HoloToolkit.Sharing.VoiceChat
 
             if (GlobalAnchorTransform != null)
             {
+                Vector3 cameraPos = CameraCache.main.transform.position;
                 cameraPosRelativeToGlobalAnchor = MathUtils.TransformPointFromTo(
-                     null,
-                     GlobalAnchorTransform,
-                     Camera.main.transform.position);
+                    null,
+                    GlobalAnchorTransform,
+                    cameraPos);
 
                 cameraDirectionRelativeToGlobalAnchor = MathUtils.TransformDirectionFromTo(
                     null,
                     GlobalAnchorTransform,
-                    Camera.main.transform.position);
+                    cameraPos);
             }
 
             cameraPosRelativeToGlobalAnchor.Normalize();

--- a/Assets/HoloToolkit/SpatialSound/Scripts/AudioEmitter.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/AudioEmitter.cs
@@ -111,13 +111,13 @@ namespace HoloToolkit.Unity
         private List<IAudioInfluencer> GetInfluencers()
         {
             List<IAudioInfluencer> influencers = new List<IAudioInfluencer>();
-
+            Transform cameraTransform = CameraCache.main.transform;
             // For influencers that take effect only when between the emitter and the user, perform a raycast
             // from the user toward the object.
-            Vector3 direction = (gameObject.transform.position - Camera.main.transform.position).normalized;
-            float distance = Vector3.Distance(Camera.main.transform.position, gameObject.transform.position);
+            Vector3 direction = (gameObject.transform.position - cameraTransform.position).normalized;
+            float distance = Vector3.Distance(cameraTransform.position, gameObject.transform.position);
 
-            int count = Physics.RaycastNonAlloc(Camera.main.transform.position,
+            int count = Physics.RaycastNonAlloc(cameraTransform.position,
                                                 direction,
                                                 hits,
                                                 distance,

--- a/Assets/HoloToolkit/SpatialSound/Scripts/AudioEmitter.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/AudioEmitter.cs
@@ -111,7 +111,7 @@ namespace HoloToolkit.Unity
         private List<IAudioInfluencer> GetInfluencers()
         {
             List<IAudioInfluencer> influencers = new List<IAudioInfluencer>();
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             // For influencers that take effect only when between the emitter and the user, perform a raycast
             // from the user toward the object.
             Vector3 direction = (gameObject.transform.position - cameraTransform.position).normalized;

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstanding.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstanding.cs
@@ -215,7 +215,7 @@ namespace HoloToolkit.Unity
                 (AllowSpatialUnderstanding))
             {
                 // Camera
-                Transform cameraTransform = CameraCache.main.transform;
+                Transform cameraTransform = CameraCache.Main.transform;
                 Vector3 camPos = cameraTransform.position;
                 Vector3 camFwd = cameraTransform.forward;
                 Vector3 camUp = cameraTransform.up;

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstanding.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstanding.cs
@@ -215,9 +215,10 @@ namespace HoloToolkit.Unity
                 (AllowSpatialUnderstanding))
             {
                 // Camera
-                Vector3 camPos = Camera.main.transform.position;
-                Vector3 camFwd = Camera.main.transform.forward;
-                Vector3 camUp = Camera.main.transform.up;
+                Transform cameraTransform = CameraCache.main.transform;
+                Vector3 camPos = cameraTransform.position;
+                Vector3 camFwd = cameraTransform.forward;
+                Vector3 camUp = cameraTransform.up;
 
                 // If not yet initialized, do that now
                 if (ScanState == ScanStates.ReadyToScan)

--- a/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
@@ -361,9 +361,8 @@ namespace HoloToolkit.UI.Keyboard
         public void RepositionKeyboard(Vector3 kbPos, float verticalOffset = 0.0f)
         {
             transform.position = kbPos;
-            Vector3 cameraPos = CameraCache.Main.transform.position;
-            ScaleToSize(cameraPos);
-            LookAtTargetOrigin(cameraPos);
+            ScaleToSize();
+            LookAtTargetOrigin();
         }
 
         /// <summary>
@@ -387,18 +386,16 @@ namespace HoloToolkit.UI.Keyboard
                 transform.Translate(0.0f, yTranslation, -0.6f, objectTransform);
             }
 
-            Vector3 cameraPos = CameraCache.Main.transform.position;
-            ScaleToSize(cameraPos);
-            LookAtTargetOrigin(cameraPos);
+            ScaleToSize();
+            LookAtTargetOrigin();
         }
 
         /// <summary>
         /// Function to scale keyboard to the appropriate size based on distance
         /// </summary>
-        /// <param name="cameraPos">Position of the camera</param>
-        private void ScaleToSize(Vector3 cameraPos)
+        private void ScaleToSize()
         {
-            float distance = (transform.position - cameraPos).magnitude;
+            float distance = (transform.position - CameraCache.Main.transform.position).magnitude;
             float distancePercent = (distance - m_MinDistance) / (m_MaxDistance - m_MinDistance);
             float scale = m_MinScale + (m_MaxScale - m_MinScale) * distancePercent;
 
@@ -411,10 +408,9 @@ namespace HoloToolkit.UI.Keyboard
         /// <summary>
         /// Look at function to have the keyboard face the user
         /// </summary>
-        /// <param name="cameraPos">Position of the camera</param>
-        private void LookAtTargetOrigin(Vector3 cameraPos)
+        private void LookAtTargetOrigin()
         {
-            transform.LookAt(cameraPos);
+            transform.LookAt(CameraCache.Main.transform.position);
             transform.Rotate(Vector3.up, 180.0f);
         }
 

--- a/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
@@ -252,7 +252,7 @@ namespace HoloToolkit.UI.Keyboard
             // Axis Slider
             if (SliderEnabled)
             {
-                Vector3 nearPoint = Vector3.ProjectOnPlane(CameraCache.main.transform.forward, transform.forward);
+                Vector3 nearPoint = Vector3.ProjectOnPlane(CameraCache.Main.transform.forward, transform.forward);
                 Vector3 relPos = transform.InverseTransformPoint(nearPoint);
                 InputFieldSlide.TargetPoint = relPos;
             }
@@ -361,7 +361,7 @@ namespace HoloToolkit.UI.Keyboard
         public void RepositionKeyboard(Vector3 kbPos, float verticalOffset = 0.0f)
         {
             transform.position = kbPos;
-            Vector3 cameraPos = CameraCache.main.transform.position;
+            Vector3 cameraPos = CameraCache.Main.transform.position;
             ScaleToSize(cameraPos);
             LookAtTargetOrigin(cameraPos);
         }
@@ -387,7 +387,7 @@ namespace HoloToolkit.UI.Keyboard
                 transform.Translate(0.0f, yTranslation, -0.6f, objectTransform);
             }
 
-            Vector3 cameraPos = CameraCache.main.transform.position;
+            Vector3 cameraPos = CameraCache.Main.transform.position;
             ScaleToSize(cameraPos);
             LookAtTargetOrigin(cameraPos);
         }

--- a/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
@@ -252,7 +252,7 @@ namespace HoloToolkit.UI.Keyboard
             // Axis Slider
             if (SliderEnabled)
             {
-                Vector3 nearPoint = Vector3.ProjectOnPlane(Camera.main.transform.forward, transform.forward);
+                Vector3 nearPoint = Vector3.ProjectOnPlane(CameraCache.main.transform.forward, transform.forward);
                 Vector3 relPos = transform.InverseTransformPoint(nearPoint);
                 InputFieldSlide.TargetPoint = relPos;
             }
@@ -361,8 +361,9 @@ namespace HoloToolkit.UI.Keyboard
         public void RepositionKeyboard(Vector3 kbPos, float verticalOffset = 0.0f)
         {
             transform.position = kbPos;
-            ScaleToSize();
-            LookAtTargetOrigin();
+            Vector3 cameraPos = CameraCache.main.transform.position;
+            ScaleToSize(cameraPos);
+            LookAtTargetOrigin(cameraPos);
         }
 
         /// <summary>
@@ -386,18 +387,18 @@ namespace HoloToolkit.UI.Keyboard
                 transform.Translate(0.0f, yTranslation, -0.6f, objectTransform);
             }
 
-
-            ScaleToSize();
-
-            LookAtTargetOrigin();
+            Vector3 cameraPos = CameraCache.main.transform.position;
+            ScaleToSize(cameraPos);
+            LookAtTargetOrigin(cameraPos);
         }
 
         /// <summary>
         /// Function to scale keyboard to the appropriate size based on distance
         /// </summary>
-        private void ScaleToSize()
+        /// <param name="cameraPos">Position of the camera</param>
+        private void ScaleToSize(Vector3 cameraPos)
         {
-            float distance = (transform.position - Camera.main.transform.position).magnitude;
+            float distance = (transform.position - cameraPos).magnitude;
             float distancePercent = (distance - m_MinDistance) / (m_MaxDistance - m_MinDistance);
             float scale = m_MinScale + (m_MaxScale - m_MinScale) * distancePercent;
 
@@ -410,9 +411,10 @@ namespace HoloToolkit.UI.Keyboard
         /// <summary>
         /// Look at function to have the keyboard face the user
         /// </summary>
-        private void LookAtTargetOrigin()
+        /// <param name="cameraPos">Position of the camera</param>
+        private void LookAtTargetOrigin(Vector3 cameraPos)
         {
-            transform.LookAt(Camera.main.transform.position);
+            transform.LookAt(cameraPos);
             transform.Rotate(Vector3.up, 180.0f);
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
@@ -31,7 +31,7 @@ namespace HoloToolkit.Unity
         {
             if (TargetTransform == null)
             {
-                TargetTransform = Camera.main.transform;
+                TargetTransform = CameraCache.main.transform;
             }
 
             Update();

--- a/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
@@ -31,7 +31,7 @@ namespace HoloToolkit.Unity
         {
             if (TargetTransform == null)
             {
-                TargetTransform = CameraCache.main.transform;
+                TargetTransform = CameraCache.Main.transform;
             }
 
             Update();

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity
 {

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
@@ -5,6 +5,10 @@ using UnityEngine;
 
 namespace HoloToolkit.Unity
 {
+    /// <summary>
+    /// The purpose of this class is to provide a cached reference to the main camera. Calling Camera.main
+    /// executes a FindByTag on the scene, which will get worse and worse with more tagged objects.
+    /// </summary>
     public static class CameraCache
     {
         private static Camera cachedCamera;
@@ -24,7 +28,6 @@ namespace HoloToolkit.Unity
         /// Set the cached camera to a new reference and return it
         /// </summary>
         /// <param name="newMain">New main camera to cache</param>
-        /// <returns></returns>
         public static Camera Refresh(Camera newMain)
         {
             return cachedCamera = newMain;

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
@@ -9,7 +9,7 @@ namespace HoloToolkit.Unity
         /// <summary>
         /// Returns a cached reference to the main camera and uses Camera.main if it hasn't been cached yet.
         /// </summary>
-        public static Camera main
+        public static Camera Main
         {
             get
             {

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    public static class CameraCache
+    {
+        private static Camera cachedCamera;
+
+        /// <summary>
+        /// Returns a cached reference to the main camera and uses Camera.main if it hasn't been cached yet.
+        /// </summary>
+        public static Camera main
+        {
+            get
+            {
+                return cachedCamera ?? CacheMain(Camera.main);
+            }
+        }
+
+        /// <summary>
+        /// Set the cached camera to a new reference and return it
+        /// </summary>
+        /// <param name="newMain">New main camera to cache</param>
+        /// <returns></returns>
+        private static Camera CacheMain(Camera newMain)
+        {
+            return cachedCamera = newMain;
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
@@ -13,7 +13,7 @@ namespace HoloToolkit.Unity
         {
             get
             {
-                return cachedCamera ?? CacheMain(Camera.main);
+                return cachedCamera ?? Refresh(Camera.main);
             }
         }
 
@@ -22,7 +22,7 @@ namespace HoloToolkit.Unity
         /// </summary>
         /// <param name="newMain">New main camera to cache</param>
         /// <returns></returns>
-        private static Camera CacheMain(Camera newMain)
+        public static Camera Refresh(Camera newMain)
         {
             return cachedCamera = newMain;
         }

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4cd3a62141af0a8489bb67bb8a179308
+timeCreated: 1502535623
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
@@ -107,7 +107,7 @@ namespace HoloToolkit.Unity
             {
                 return;
             }
-            Camera mainCamera = CameraCache.main;
+            Camera mainCamera = CameraCache.Main;
             // Direction from the Main Camera to this script's parent gameObject.
             Vector3 camToObjectDirection = gameObject.transform.position - mainCamera.transform.position;
             camToObjectDirection.Normalize();

--- a/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
@@ -107,13 +107,13 @@ namespace HoloToolkit.Unity
             {
                 return;
             }
-
+            Camera mainCamera = CameraCache.main;
             // Direction from the Main Camera to this script's parent gameObject.
-            Vector3 camToObjectDirection = gameObject.transform.position - Camera.main.transform.position;
+            Vector3 camToObjectDirection = gameObject.transform.position - mainCamera.transform.position;
             camToObjectDirection.Normalize();
 
             // The cursor indicator should only be visible if the target is not visible.
-            isDirectionIndicatorVisible = !IsTargetVisible();
+            isDirectionIndicatorVisible = !IsTargetVisible(mainCamera);
             directionIndicatorRenderer.enabled = isDirectionIndicatorVisible;
 
             if (isDirectionIndicatorVisible)
@@ -122,6 +122,7 @@ namespace HoloToolkit.Unity
                 Quaternion rotation;
                 GetDirectionIndicatorPositionAndRotation(
                     camToObjectDirection,
+                    mainCamera.transform,
                     out position,
                     out rotation);
 
@@ -130,37 +131,36 @@ namespace HoloToolkit.Unity
             }
         }
 
-        private bool IsTargetVisible()
+        private bool IsTargetVisible(Camera mainCamera)
         {
             // This will return true if the target's mesh is within the Main Camera's view frustums.
-            Vector3 targetViewportPosition = Camera.main.WorldToViewportPoint(gameObject.transform.position);
+            Vector3 targetViewportPosition = mainCamera.WorldToViewportPoint(gameObject.transform.position);
             return (targetViewportPosition.x > VisibilitySafeFactor && targetViewportPosition.x < 1 - VisibilitySafeFactor &&
                     targetViewportPosition.y > VisibilitySafeFactor && targetViewportPosition.y < 1 - VisibilitySafeFactor &&
                     targetViewportPosition.z > 0);
         }
 
-        private void GetDirectionIndicatorPositionAndRotation(Vector3 camToObjectDirection, out Vector3 position, out Quaternion rotation)
+        private void GetDirectionIndicatorPositionAndRotation(Vector3 camToObjectDirection, Transform cameraTransform, out Vector3 position, out Quaternion rotation)
         {
             // Find position:
             // Save the cursor transform position in a variable.
             Vector3 origin = Cursor.transform.position;
-
             // Project the camera to target direction onto the screen plane.
-            Vector3 cursorIndicatorDirection = Vector3.ProjectOnPlane(camToObjectDirection, -1 * Camera.main.transform.forward);
+            Vector3 cursorIndicatorDirection = Vector3.ProjectOnPlane(camToObjectDirection, -1 * cameraTransform.forward);
             cursorIndicatorDirection.Normalize();
 
             // If the direction is 0, set the direction to the right.
             // This will only happen if the camera is facing directly away from the target.
             if (cursorIndicatorDirection == Vector3.zero)
             {
-                cursorIndicatorDirection = Camera.main.transform.right;
+                cursorIndicatorDirection = cameraTransform.right;
             }
 
             // The final position is translated from the center of the screen along this direction vector.
             position = origin + cursorIndicatorDirection * MetersFromCursor;
 
             // Find the rotation from the facing direction to the target object.
-            rotation = Quaternion.LookRotation(Camera.main.transform.forward, cursorIndicatorDirection) * directionIndicatorDefaultRotation;
+            rotation = Quaternion.LookRotation(cameraTransform.forward, cursorIndicatorDirection) * directionIndicatorDefaultRotation;
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SceneSettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SceneSettingsWindow.cs
@@ -23,8 +23,9 @@ namespace HoloToolkit.Unity
         #region Overrides / Event Handlers
         protected override void ApplySettings()
         {
+            Camera mainCamera = CameraCache.main;
             // Ensure we have a camera
-            if (Camera.main == null)
+            if (mainCamera == null)
             {
                 Debug.LogWarning(@"Could not apply settings - no camera tagged with ""MainCamera""");
                 return;
@@ -33,20 +34,20 @@ namespace HoloToolkit.Unity
             // Apply individual settings
             if (Values[SceneSetting.CameraToOrigin])
             {
-                Camera.main.transform.position = Vector3.zero;
+                mainCamera.transform.position = Vector3.zero;
             }
             if (Values[SceneSetting.CameraClearBlack])
             {
-                Camera.main.clearFlags = CameraClearFlags.SolidColor;
-                Camera.main.backgroundColor = Color.clear;
+                mainCamera.clearFlags = CameraClearFlags.SolidColor;
+                mainCamera.backgroundColor = Color.clear;
             }
             if (Values[SceneSetting.NearClipPlane])
             {
-                Camera.main.nearClipPlane = 0.85f;
+                mainCamera.nearClipPlane = 0.85f;
             }
             if (Values[SceneSetting.FieldOfView])
             {
-                Camera.main.fieldOfView = 16.0f;
+                mainCamera.fieldOfView = 16.0f;
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SceneSettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SceneSettingsWindow.cs
@@ -23,7 +23,7 @@ namespace HoloToolkit.Unity
         #region Overrides / Event Handlers
         protected override void ApplySettings()
         {
-            Camera mainCamera = CameraCache.main;
+            Camera mainCamera = CameraCache.Main;
             // Ensure we have a camera
             if (mainCamera == null)
             {

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    public static class CameraExtensions
+    {
+        /// <summary>
+        /// Get the horizontal FOV from the stereo camera
+        /// </summary>
+        /// <returns></returns>
+        public static float GetHorizontalFieldOfViewRadians(this Camera camera)
+        {
+            float horizontalFovRadians = 2 * Mathf.Atan(Mathf.Tan((camera.fieldOfView * Mathf.Deg2Rad) / 2) * camera.aspect);
+            return horizontalFovRadians;
+        }
+
+        /// <summary>
+        /// Returns if a point will be rendered on the screen in either eye
+        /// </summary>
+        /// <param name="position"></param>
+        /// <returns></returns>
+        public static bool IsInFOV(this Camera camera, Vector3 position)
+        {
+            float verticalFovHalf = camera.fieldOfView / 2;
+            float horizontalFovHalf = camera.GetHorizontalFieldOfViewRadians() * Mathf.Rad2Deg / 2;
+
+            Vector3 deltaPos = position - camera.transform.position;
+            Vector3 headDeltaPos = MathUtils.TransformDirectionFromTo(null, camera.transform, deltaPos).normalized;
+
+            float yaw = Mathf.Asin(headDeltaPos.x) * Mathf.Rad2Deg;
+            float pitch = Mathf.Asin(headDeltaPos.y) * Mathf.Rad2Deg;
+
+            return (Mathf.Abs(yaw) < horizontalFovHalf && Mathf.Abs(pitch) < verticalFovHalf);
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
@@ -10,7 +10,7 @@ namespace HoloToolkit.Unity
         /// <returns></returns>
         public static float GetHorizontalFieldOfViewRadians(this Camera camera)
         {
-            float horizontalFovRadians = 2 * Mathf.Atan(Mathf.Tan((camera.fieldOfView * Mathf.Deg2Rad) / 2) * camera.aspect);
+            float horizontalFovRadians = 2f * Mathf.Atan(Mathf.Tan(camera.fieldOfView * Mathf.Deg2Rad * 0.5f) * camera.aspect);
             return horizontalFovRadians;
         }
 
@@ -21,8 +21,8 @@ namespace HoloToolkit.Unity
         /// <returns></returns>
         public static bool IsInFOV(this Camera camera, Vector3 position)
         {
-            float verticalFovHalf = camera.fieldOfView / 2;
-            float horizontalFovHalf = camera.GetHorizontalFieldOfViewRadians() * Mathf.Rad2Deg / 2;
+            float verticalFovHalf = camera.fieldOfView * 0.5f;
+            float horizontalFovHalf = camera.GetHorizontalFieldOfViewRadians() * Mathf.Rad2Deg * 0.5f;
 
             Vector3 deltaPos = position - camera.transform.position;
             Vector3 headDeltaPos = MathUtils.TransformDirectionFromTo(null, camera.transform, deltaPos).normalized;

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity
 {

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
@@ -20,6 +20,7 @@ namespace HoloToolkit.Unity
         /// <summary>
         /// Returns if a point will be rendered on the screen in either eye
         /// </summary>
+        /// <param name="camera">The camera to check the point against</param>
         /// <param name="position"></param>
         /// <returns></returns>
         public static bool IsInFOV(this Camera camera, Vector3 position)

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 52cb4f975029f124f98204e36c311c8c
+timeCreated: 1502551993
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -24,7 +24,7 @@ namespace HoloToolkit.Unity
         {
             // Calculate the XYZ ratios for the transform's localScale over its
             // initial distance from the camera.
-            startingDistance = Vector3.Distance(CameraCache.main.transform.position, transform.position);
+            startingDistance = Vector3.Distance(CameraCache.Main.transform.position, transform.position);
             startingScale = transform.localScale;
 
             SetSizeRatio(SizeRatio);
@@ -63,7 +63,7 @@ namespace HoloToolkit.Unity
 
         private void Update()
         {
-            float distanceToHologram = Vector3.Distance(CameraCache.main.transform.position, transform.position);
+            float distanceToHologram = Vector3.Distance(CameraCache.Main.transform.position, transform.position);
             // create an offset ratio based on the starting position. This value creates a new angle that pivots
             // on the starting position that is more or less drastic than the normal scale ratio.
             float curvedRatio = 1 - startingDistance * SizeRatio;

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -24,7 +24,7 @@ namespace HoloToolkit.Unity
         {
             // Calculate the XYZ ratios for the transform's localScale over its
             // initial distance from the camera.
-            startingDistance = Vector3.Distance(Camera.main.transform.position, transform.position);
+            startingDistance = Vector3.Distance(CameraCache.main.transform.position, transform.position);
             startingScale = transform.localScale;
 
             SetSizeRatio(SizeRatio);
@@ -63,7 +63,7 @@ namespace HoloToolkit.Unity
 
         private void Update()
         {
-            float distanceToHologram = Vector3.Distance(Camera.main.transform.position, transform.position);
+            float distanceToHologram = Vector3.Distance(CameraCache.main.transform.position, transform.position);
             // create an offset ratio based on the starting position. This value creates a new angle that pivots
             // on the starting position that is more or less drastic than the normal scale ratio.
             float curvedRatio = 1 - startingDistance * SizeRatio;

--- a/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
@@ -61,7 +61,7 @@ namespace HoloToolkit.Unity
 
         private void Start()
         {
-            Camera mainCamera = CameraCache.main;
+            Camera mainCamera = CameraCache.Main;
             Depth = Mathf.Clamp(Depth, mainCamera.nearClipPlane, mainCamera.farClipPlane);
 
             if (PointerPrefab == null)
@@ -101,7 +101,7 @@ namespace HoloToolkit.Unity
             }
             else
             {
-                Camera mainCamera = CameraCache.main;
+                Camera mainCamera = CameraCache.Main;
                 int currentFrameCount = UnityEngine.Time.frameCount;
                 if (currentFrameCount != frustumLastUpdated)
                 {

--- a/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
@@ -92,7 +92,7 @@ namespace HoloToolkit.Unity
         // Update the direction indicator's position and orientation every frame.
         private void Update()
         {
-            if (!HasObjectsToTrack()) return;
+            if (!HasObjectsToTrack()) { return; }
 
             int currentFrameCount = Time.frameCount;
             if (currentFrameCount != frustumLastUpdated)

--- a/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
@@ -61,8 +61,7 @@ namespace HoloToolkit.Unity
 
         private void Start()
         {
-            Camera mainCamera = CameraCache.Main;
-            Depth = Mathf.Clamp(Depth, mainCamera.nearClipPlane, mainCamera.farClipPlane);
+            Depth = Mathf.Clamp(Depth, CameraCache.Main.nearClipPlane, CameraCache.Main.farClipPlane);
 
             if (PointerPrefab == null)
             {
@@ -93,26 +92,23 @@ namespace HoloToolkit.Unity
         // Update the direction indicator's position and orientation every frame.
         private void Update()
         {
-            // No object to track?
-            if (TargetObject == null || pointer == null)
-            {
-                // bail out early.
-                return;
-            }
-            else
-            {
-                Camera mainCamera = CameraCache.Main;
-                int currentFrameCount = UnityEngine.Time.frameCount;
-                if (currentFrameCount != frustumLastUpdated)
-                {
-                    // Collect the updated camera information for the current frame
-                    CacheCameraTransform(mainCamera);
+            if (!HasObjectsToTrack()) return;
 
-                    frustumLastUpdated = currentFrameCount;
-                }
+            int currentFrameCount = Time.frameCount;
+            if (currentFrameCount != frustumLastUpdated)
+            {
+                // Collect the updated camera information for the current frame
+                CacheCameraTransform(CameraCache.Main);
 
-                UpdatePointerTransform(mainCamera, indicatorVolume, TargetObject.transform.position);
+                frustumLastUpdated = currentFrameCount;
             }
+
+            UpdatePointerTransform(CameraCache.Main, indicatorVolume, TargetObject.transform.position);
+        }
+
+        private bool HasObjectsToTrack()
+        {
+            return TargetObject != null && pointer != null;
         }
 
         // Cache data from the camera state that are costly to retrieve.
@@ -213,25 +209,22 @@ namespace HoloToolkit.Unity
                 if (eDistance > 0.0f)
                 {
                     return FrustumPlanes.Left;
-                }
-                else
+                } else
                 {
                     return FrustumPlanes.Bottom;
                 }
-            }
-            else
+            } else
             {
                 if (eDistance > 0.0f)
                 {
                     return FrustumPlanes.Top;
-                }
-                else
+                } else
                 {
                     return FrustumPlanes.Right;
                 }
             }
         }
- 
+
         // given a frustum wall we wish to snap the pointer to, this function returns a ray
         // along which the pointer should be placed to appear at the appropiate point along
         // the edge of the indicator field.
@@ -270,8 +263,7 @@ namespace HoloToolkit.Unity
                     (Vector3.Cross(p.normal, rNormal) * q.distance)) / det;
                 intersection = new Ray(rPoint, rNormal);
                 return true;
-            }
-            else
+            } else
             {
                 intersection = new Ray();
                 return false;
@@ -301,7 +293,7 @@ namespace HoloToolkit.Unity
                     break;
                 }
             }
-            
+
             // if the target object appears outside the indicator area...
             if (pointNotInsideIndicatorField)
             {

--- a/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
@@ -61,7 +61,8 @@ namespace HoloToolkit.Unity
 
         private void Start()
         {
-            Depth = Mathf.Clamp(Depth, Camera.main.nearClipPlane, Camera.main.farClipPlane);
+            Camera mainCamera = CameraCache.main;
+            Depth = Mathf.Clamp(Depth, mainCamera.nearClipPlane, mainCamera.farClipPlane);
 
             if (PointerPrefab == null)
             {
@@ -100,16 +101,17 @@ namespace HoloToolkit.Unity
             }
             else
             {
+                Camera mainCamera = CameraCache.main;
                 int currentFrameCount = UnityEngine.Time.frameCount;
                 if (currentFrameCount != frustumLastUpdated)
                 {
                     // Collect the updated camera information for the current frame
-                    CacheCameraTransform(Camera.main);
+                    CacheCameraTransform(mainCamera);
 
                     frustumLastUpdated = currentFrameCount;
                 }
 
-                UpdatePointerTransform(Camera.main, indicatorVolume, TargetObject.transform.position);
+                UpdatePointerTransform(mainCamera, indicatorVolume, TargetObject.transform.position);
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/MathUtils.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/MathUtils.cs
@@ -16,10 +16,10 @@ namespace HoloToolkit.Unity
         /// Get the horizontal FOV from the stereo camera
         /// </summary>
         /// <returns></returns>
+        [System.Obsolete("Use CameraExtensions.GetHorizontalFieldOfViewRadians(Camera camera) instead.")]
         public static float GetHorizontalFieldOfViewRadians()
         {
-            float horizontalFovRadians = 2 * Mathf.Atan(Mathf.Tan((Camera.main.fieldOfView * Mathf.Deg2Rad) / 2) * Camera.main.aspect);
-            return horizontalFovRadians;
+            return CameraCache.main.GetHorizontalFieldOfViewRadians();
         }
 
         /// <summary>
@@ -27,18 +27,10 @@ namespace HoloToolkit.Unity
         /// </summary>
         /// <param name="position"></param>
         /// <returns></returns>
+        [System.Obsolete("Use CameraExtensions.IsInFOV(Camera camera, Vector3 position) instead.")]
         public static bool IsInFOV(Vector3 position)
         {
-            float verticalFovHalf = Camera.main.fieldOfView / 2;
-            float horizontalFovHalf = GetHorizontalFieldOfViewRadians() * Mathf.Rad2Deg / 2;
-
-            Vector3 deltaPos = position - Camera.main.transform.position;
-            Vector3 headDeltaPos = TransformDirectionFromTo(null, Camera.main.transform, deltaPos).normalized;
-
-            float yaw = Mathf.Asin(headDeltaPos.x) * Mathf.Rad2Deg;
-            float pitch = Mathf.Asin(headDeltaPos.y) * Mathf.Rad2Deg;
-
-            return (Mathf.Abs(yaw) < horizontalFovHalf && Mathf.Abs(pitch) < verticalFovHalf);
+            return CameraCache.main.IsInFOV(position);
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Utilities/Scripts/MathUtils.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/MathUtils.cs
@@ -19,7 +19,7 @@ namespace HoloToolkit.Unity
         [System.Obsolete("Use CameraExtensions.GetHorizontalFieldOfViewRadians(Camera camera) instead.")]
         public static float GetHorizontalFieldOfViewRadians()
         {
-            return CameraCache.main.GetHorizontalFieldOfViewRadians();
+            return CameraCache.Main.GetHorizontalFieldOfViewRadians();
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace HoloToolkit.Unity
         [System.Obsolete("Use CameraExtensions.IsInFOV(Camera camera, Vector3 position) instead.")]
         public static bool IsInFOV(Vector3 position)
         {
-            return CameraCache.main.IsInFOV(position);
+            return CameraCache.Main.IsInFOV(position);
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Utilities/Scripts/SimpleTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SimpleTagalong.cs
@@ -57,7 +57,7 @@ namespace HoloToolkit.Unity
 
         protected virtual void Update()
         {
-            Camera mainCamera = CameraCache.main;
+            Camera mainCamera = CameraCache.Main;
             // Retrieve the frustum planes from the camera.
             frustumPlanes = GeometryUtility.CalculateFrustumPlanes(mainCamera);
 
@@ -96,7 +96,7 @@ namespace HoloToolkit.Unity
             // inside the camera's view frustum. Note, the bounds used are an Axis
             // Aligned Bounding Box (AABB).
             bool needsToMove = !GeometryUtility.TestPlanesAABB(frustumPlanes, tagalongCollider.bounds);
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
 
             // If we already know we don't need to move, bail out early.
             if (!needsToMove)

--- a/Assets/HoloToolkit/Utilities/Scripts/SimpleTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SimpleTagalong.cs
@@ -57,8 +57,9 @@ namespace HoloToolkit.Unity
 
         protected virtual void Update()
         {
+            Camera mainCamera = CameraCache.main;
             // Retrieve the frustum planes from the camera.
-            frustumPlanes = GeometryUtility.CalculateFrustumPlanes(Camera.main);
+            frustumPlanes = GeometryUtility.CalculateFrustumPlanes(mainCamera);
 
             // Determine if the Tagalong needs to move based on whether its
             // BoxCollider is in or out of the camera's view frustum.
@@ -77,7 +78,7 @@ namespace HoloToolkit.Unity
                 // If the Tagalong is inside the camera's view frustum, and it is
                 // supposed to stay a fixed distance from the camera, force the
                 // tagalong to that location (without using the Interpolator).
-                Ray ray = new Ray(Camera.main.transform.position, transform.position - Camera.main.transform.position);
+                Ray ray = new Ray(mainCamera.transform.position, transform.position - mainCamera.transform.position);
                 transform.position = ray.GetPoint(TagalongDistance);
             }
         }
@@ -95,6 +96,7 @@ namespace HoloToolkit.Unity
             // inside the camera's view frustum. Note, the bounds used are an Axis
             // Aligned Bounding Box (AABB).
             bool needsToMove = !GeometryUtility.TestPlanesAABB(frustumPlanes, tagalongCollider.bounds);
+            Transform cameraTransform = CameraCache.main.transform;
 
             // If we already know we don't need to move, bail out early.
             if (!needsToMove)
@@ -105,7 +107,7 @@ namespace HoloToolkit.Unity
 
             // Calculate a default position where the Tagalong should go. In this
             // case TagalongDistance from the camera along the gaze vector.
-            toPosition = Camera.main.transform.position + Camera.main.transform.forward * TagalongDistance;
+            toPosition = cameraTransform.position + cameraTransform.forward * TagalongDistance;
 
             // Create a Ray and set it's origin to be the default toPosition that
             // was calculated above.
@@ -125,14 +127,14 @@ namespace HoloToolkit.Unity
                 // our Ray's direction to point towards that plane (remember the
                 // Ray's origin is already inside the view frustum.
                 plane = frustumPlanes[frustumLeft];
-                ray.direction = -Camera.main.transform.right;
+                ray.direction = -cameraTransform.right;
             }
             else if (moveLeft)
             {
                 // Apply similar logic to above for the case where the Tagalong
                 // needs to move to the left.
                 plane = frustumPlanes[frustumRight];
-                ray.direction = Camera.main.transform.right;
+                ray.direction = cameraTransform.right;
             }
             if (moveRight || moveLeft)
             {
@@ -152,12 +154,12 @@ namespace HoloToolkit.Unity
             if (moveDown)
             {
                 plane = frustumPlanes[frustumTop];
-                ray.direction = Camera.main.transform.up;
+                ray.direction = cameraTransform.up;
             }
             else if (moveUp)
             {
                 plane = frustumPlanes[frustumBottom];
-                ray.direction = -Camera.main.transform.up;
+                ray.direction = -cameraTransform.up;
             }
             if (moveUp || moveDown)
             {
@@ -167,7 +169,7 @@ namespace HoloToolkit.Unity
 
             // Create a ray that starts at the camera and points in the direction
             // of the calculated toPosition.
-            ray = new Ray(Camera.main.transform.position, toPosition - Camera.main.transform.position);
+            ray = new Ray(cameraTransform.position, toPosition - cameraTransform.position);
 
             // Find the point along that ray that is the right distance away and
             // update the calculated toPosition to be that point.

--- a/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
@@ -37,8 +37,7 @@ namespace HoloToolkit.Unity
 
         void Update()
         {
-            Transform cameraTransform = CameraCache.Main.transform;
-            optimalPosition = cameraTransform.position + cameraTransform.forward * initialDistanceToCamera;
+            optimalPosition = CameraCache.Main.transform.position + CameraCache.Main.transform.forward * initialDistanceToCamera;
 
             Vector3 offsetDir = this.transform.position - optimalPosition;
             if (offsetDir.magnitude > SphereRadius)

--- a/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
@@ -32,12 +32,13 @@ namespace HoloToolkit.Unity
 
         void Start()
         {
-            initialDistanceToCamera = Vector3.Distance(this.transform.position, Camera.main.transform.position);
+            initialDistanceToCamera = Vector3.Distance(this.transform.position, CameraCache.main.transform.position);
         }
 
         void Update()
         {
-            optimalPosition = Camera.main.transform.position + Camera.main.transform.forward * initialDistanceToCamera;
+            Transform cameraTransform = CameraCache.main.transform;
+            optimalPosition = cameraTransform.position + cameraTransform.forward * initialDistanceToCamera;
 
             Vector3 offsetDir = this.transform.position - optimalPosition;
             if (offsetDir.magnitude > SphereRadius)

--- a/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
@@ -32,12 +32,12 @@ namespace HoloToolkit.Unity
 
         void Start()
         {
-            initialDistanceToCamera = Vector3.Distance(this.transform.position, CameraCache.main.transform.position);
+            initialDistanceToCamera = Vector3.Distance(this.transform.position, CameraCache.Main.transform.position);
         }
 
         void Update()
         {
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             optimalPosition = cameraTransform.position + cameraTransform.forward * initialDistanceToCamera;
 
             Vector3 offsetDir = this.transform.position - optimalPosition;

--- a/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
@@ -138,7 +138,7 @@ namespace HoloToolkit.Unity
                 {
                     return GazeManager.Instance.GazeOrigin;
                 }
-                return Camera.main.transform.position;
+                return CameraCache.main.transform.position;
             }
         }
 
@@ -153,7 +153,7 @@ namespace HoloToolkit.Unity
                 {
                     return GazeManager.Instance.GazeNormal;
                 }
-                return Camera.main.transform.forward;
+                return CameraCache.main.transform.forward;
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
@@ -138,7 +138,7 @@ namespace HoloToolkit.Unity
                 {
                     return GazeManager.Instance.GazeOrigin;
                 }
-                return CameraCache.main.transform.position;
+                return CameraCache.Main.transform.position;
             }
         }
 
@@ -153,7 +153,7 @@ namespace HoloToolkit.Unity
                 {
                     return GazeManager.Instance.GazeNormal;
                 }
-                return CameraCache.main.transform.forward;
+                return CameraCache.Main.transform.forward;
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
@@ -58,10 +58,9 @@ namespace HoloToolkit.Unity
             // If the specified minimum distance for the tagalong would be within the
             // camera's near clipping plane, adjust it to be 10% beyond the near
             // clipping plane.
-            Camera mainCamera = CameraCache.Main;
-            if (mainCamera.nearClipPlane > MinimumTagalongDistance)
+            if (CameraCache.Main.nearClipPlane > MinimumTagalongDistance)
             {
-                MinimumTagalongDistance = mainCamera.nearClipPlane * 1.1f;
+                MinimumTagalongDistance = CameraCache.Main.nearClipPlane * 1.1f;
             }
 
             // The EnforceDistance functionality of the SimmpleTagalong has a
@@ -86,12 +85,11 @@ namespace HoloToolkit.Unity
                 // we need to update the Tagalong's position because it is behind
                 // some other hologram or the Spatial Mapping mesh.
                 Vector3 newPosition;
-                Vector3 cameraPosition = CameraCache.Main.transform.position;
-                if (AdjustTagalongDistance(cameraPosition, out newPosition))
+                if (AdjustTagalongDistance(CameraCache.Main.transform.position, out newPosition))
                 {
                     interpolator.PositionPerSecond = DepthUpdateSpeed;
                     interpolator.SetTargetPosition(newPosition);
-                    TagalongDistance = Mathf.Min(defaultTagalongDistance, Vector3.Distance(cameraPosition, newPosition));
+                    TagalongDistance = Mathf.Min(defaultTagalongDistance, Vector3.Distance(CameraCache.Main.transform.position, newPosition));
                 }
             }
         }

--- a/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
@@ -58,9 +58,10 @@ namespace HoloToolkit.Unity
             // If the specified minimum distance for the tagalong would be within the
             // camera's near clipping plane, adjust it to be 10% beyond the near
             // clipping plane.
-            if (Camera.main.nearClipPlane > MinimumTagalongDistance)
+            Camera mainCamera = CameraCache.main;
+            if (mainCamera.nearClipPlane > MinimumTagalongDistance)
             {
-                MinimumTagalongDistance = Camera.main.nearClipPlane * 1.1f;
+                MinimumTagalongDistance = mainCamera.nearClipPlane * 1.1f;
             }
 
             // The EnforceDistance functionality of the SimmpleTagalong has a
@@ -85,11 +86,12 @@ namespace HoloToolkit.Unity
                 // we need to update the Tagalong's position because it is behind
                 // some other hologram or the Spatial Mapping mesh.
                 Vector3 newPosition;
-                if (AdjustTagalongDistance(out newPosition))
+                Vector3 cameraPosition = CameraCache.main.transform.position;
+                if (AdjustTagalongDistance(cameraPosition, out newPosition))
                 {
                     interpolator.PositionPerSecond = DepthUpdateSpeed;
                     interpolator.SetTargetPosition(newPosition);
-                    TagalongDistance = Mathf.Min(defaultTagalongDistance, Vector3.Distance(Camera.main.transform.position, newPosition));
+                    TagalongDistance = Mathf.Min(defaultTagalongDistance, Vector3.Distance(cameraPosition, newPosition));
                 }
             }
         }
@@ -101,7 +103,7 @@ namespace HoloToolkit.Unity
             toPosition = fromPosition;
 
             // Cache some things that we will need later.
-            Transform cameraTransform = Camera.main.transform;
+            Transform cameraTransform = CameraCache.main.transform;
             Vector3 cameraPosition = cameraTransform.position;
 
             // Get the bounds of the Tagalong's collider.
@@ -209,7 +211,7 @@ namespace HoloToolkit.Unity
         private Vector3 CalculateTargetPosition(bool isHorizontal, Vector3 centermostEdge, Vector3 vectorTowardCenter, float width,
             Vector3 center, Plane frustumPlane, bool invertAngle)
         {
-            Transform cameraTransform = Camera.main.transform;
+            Transform cameraTransform = CameraCache.main.transform;
             Vector3 cameraPosition = cameraTransform.position;
 
             // The target overlap can't be less than the minimum overlap. Pick
@@ -254,15 +256,13 @@ namespace HoloToolkit.Unity
             return newCalculatedTargetPosition;
         }
 
-        private bool AdjustTagalongDistance(out Vector3 newPosition)
+        private bool AdjustTagalongDistance(Vector3 cameraPosition, out Vector3 newPosition)
         {
             bool needsUpdating = false;
 
             // Get the actual width and height of the Tagalong's BoxCollider.
             float width = tagalongCollider.size.x * transform.lossyScale.x;
             float height = tagalongCollider.size.y * transform.lossyScale.y;
-
-            Vector3 cameraPosition = Camera.main.transform.position;
 
             // Find the lower-left corner of the Tagalong's BoxCollider.
             Vector3 lowerLeftCorner = transform.position - (transform.right * (width / 2)) - (transform.up * (height / 2));

--- a/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
@@ -58,7 +58,7 @@ namespace HoloToolkit.Unity
             // If the specified minimum distance for the tagalong would be within the
             // camera's near clipping plane, adjust it to be 10% beyond the near
             // clipping plane.
-            Camera mainCamera = CameraCache.main;
+            Camera mainCamera = CameraCache.Main;
             if (mainCamera.nearClipPlane > MinimumTagalongDistance)
             {
                 MinimumTagalongDistance = mainCamera.nearClipPlane * 1.1f;
@@ -86,7 +86,7 @@ namespace HoloToolkit.Unity
                 // we need to update the Tagalong's position because it is behind
                 // some other hologram or the Spatial Mapping mesh.
                 Vector3 newPosition;
-                Vector3 cameraPosition = CameraCache.main.transform.position;
+                Vector3 cameraPosition = CameraCache.Main.transform.position;
                 if (AdjustTagalongDistance(cameraPosition, out newPosition))
                 {
                     interpolator.PositionPerSecond = DepthUpdateSpeed;
@@ -103,7 +103,7 @@ namespace HoloToolkit.Unity
             toPosition = fromPosition;
 
             // Cache some things that we will need later.
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             Vector3 cameraPosition = cameraTransform.position;
 
             // Get the bounds of the Tagalong's collider.
@@ -211,7 +211,7 @@ namespace HoloToolkit.Unity
         private Vector3 CalculateTargetPosition(bool isHorizontal, Vector3 centermostEdge, Vector3 vectorTowardCenter, float width,
             Vector3 center, Plane frustumPlane, bool invertAngle)
         {
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             Vector3 cameraPosition = cameraTransform.position;
 
             // The target overlap can't be less than the minimum overlap. Pick

--- a/Assets/HoloToolkit/Utilities/Scripts/Utils.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Utils.cs
@@ -64,9 +64,8 @@ namespace HoloToolkit.Unity
         public static void MoveObjectInFrontOfUser(Transform stageTransform, Transform tran, Vector3 offset, float yawOffset)
         {
             // have obj track head position with translation offset
-            Transform cameraTransform = CameraCache.Main.transform;
-            Vector3 stageHeadPos = MathUtils.TransformPointFromTo(null, stageTransform, cameraTransform.position);
-            Vector3 stageHeadDir = MathUtils.TransformDirectionFromTo(null, stageTransform, cameraTransform.forward);
+            Vector3 stageHeadPos = MathUtils.TransformPointFromTo(null, stageTransform, CameraCache.Main.transform.position);
+            Vector3 stageHeadDir = MathUtils.TransformDirectionFromTo(null, stageTransform, CameraCache.Main.transform.forward);
             stageHeadDir.y = 0.0f; // ignore head pitch - use head position to set height
             stageHeadDir.Normalize();
             Vector3 sideDir = Vector3.Cross(stageHeadDir, Vector3.up).normalized;

--- a/Assets/HoloToolkit/Utilities/Scripts/Utils.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Utils.cs
@@ -64,8 +64,9 @@ namespace HoloToolkit.Unity
         public static void MoveObjectInFrontOfUser(Transform stageTransform, Transform tran, Vector3 offset, float yawOffset)
         {
             // have obj track head position with translation offset
-            Vector3 stageHeadPos = MathUtils.TransformPointFromTo(null, stageTransform, Camera.main.transform.transform.position);
-            Vector3 stageHeadDir = MathUtils.TransformDirectionFromTo(null, stageTransform, Camera.main.transform.transform.forward);
+            Transform cameraTransform = CameraCache.main.transform;
+            Vector3 stageHeadPos = MathUtils.TransformPointFromTo(null, stageTransform, cameraTransform.position);
+            Vector3 stageHeadDir = MathUtils.TransformDirectionFromTo(null, stageTransform, cameraTransform.forward);
             stageHeadDir.y = 0.0f; // ignore head pitch - use head position to set height
             stageHeadDir.Normalize();
             Vector3 sideDir = Vector3.Cross(stageHeadDir, Vector3.up).normalized;

--- a/Assets/HoloToolkit/Utilities/Scripts/Utils.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Utils.cs
@@ -64,7 +64,7 @@ namespace HoloToolkit.Unity
         public static void MoveObjectInFrontOfUser(Transform stageTransform, Transform tran, Vector3 offset, float yawOffset)
         {
             // have obj track head position with translation offset
-            Transform cameraTransform = CameraCache.main.transform;
+            Transform cameraTransform = CameraCache.Main.transform;
             Vector3 stageHeadPos = MathUtils.TransformPointFromTo(null, stageTransform, cameraTransform.position);
             Vector3 stageHeadDir = MathUtils.TransformDirectionFromTo(null, stageTransform, cameraTransform.forward);
             stageHeadDir.y = 0.0f; // ignore head pitch - use head position to set height


### PR DESCRIPTION
Fixes #848 

This adds a new Utility class that allows the use a cached reference to the main camera via `CameraCache.main`. Additionally, a method to refresh the reference is provided with `CameraCache.Refresh(camera)`. On the first call where the cached camera is null, `Refresh(Camera.main)` is called to initialize. Should I add this to documentation somewhere? What do you think of the names?

I moved `MathUtils.GetHorizontalFieldOfViewRadians` and `MathUtils.IsInFov` to a new `CameraExtensions` since they were both relying on and using `Camera.main`. Both Methods are not marked as obsolete and use the new extension with the cached camera instead. There was another method in `Utils.MoveObjectInFrontOfUser` that also uses the camera but I didn't move that one into Camera because I thought it didn't fit as well. But maybe `camera.MoveObjectInFront` might not be so bad.

Most scripts were simple replacements from `Camera.main` to `CameraCache.main` where I also added a local variable in some cases where it's used more than once. 

2 Scripts cache the reference to the camera once on start: `ScaleByDistance`, `MoveWithObject`. Not sure how to deal with those. Maybe do it like the GazeManager that checks for the GazeTransform on every update?

Lastly `GestureInteractiveData`  does this: 
```csharp
 protected Camera MainCamera { get { return Camera.main; } }
```
I changed it to use `CameraCache` but wasn't comfortable to just completely remove it and use local variables where it's used.