### PR TITLE
Fix null coalescing causing errors

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -138,8 +138,12 @@ namespace HoloToolkit.Unity.InputModule
 
         private bool FindGazeTransform()
         {
-            GazeTransform = GazeTransform ?? CameraCache.Main.transform;
-            if (GazeTransform != null) return true;
+            if (GazeTransform != null) { return true; }
+            if (CameraCache.Main != null)
+            {
+                GazeTransform = CameraCache.Main.transform;
+                return true;
+            }
 
             Debug.LogError("Gaze Manager was not given a GazeTransform and no main camera exists to default to.");
             return false;

--- a/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/CameraCache.cs
@@ -20,7 +20,11 @@ namespace HoloToolkit.Unity
         {
             get
             {
-                return cachedCamera ?? Refresh(Camera.main);
+                if (cachedCamera == null)
+                {
+                    return Refresh(Camera.main);
+                }
+                return cachedCamera;
             }
         }
 


### PR DESCRIPTION
Reverted the gaze manager code to what it was before. Also removed the other occurrence in the CameraCache class for good measure, although that one seemed to work.