### PR TITLE
Fix for mismatched Mic network stream

### DIFF
--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
@@ -248,16 +248,16 @@ namespace HoloToolkit.Sharing.VoiceChat
                     float averageAmplitude = message.ReadFloat();
                     UInt32 hrtfSourceID = (UInt32)message.ReadInt32();
                     Vector3 hrtfPosition = new Vector3();
-                    //Vector3 hrtfDirection = new Vector3();
+                    Vector3 hrtfDirection = new Vector3();
                     if (hrtfSourceID != 0)
                     {
                         hrtfPosition.x = message.ReadFloat();
                         hrtfPosition.y = message.ReadFloat();
                         hrtfPosition.z = message.ReadFloat();
 
-                        //hrtfDirection.x = message.ReadFloat();
-                        //hrtfDirection.y = message.ReadFloat();
-                        //hrtfDirection.z = message.ReadFloat();
+                        hrtfDirection.x = message.ReadFloat();
+                        hrtfDirection.y = message.ReadFloat();
+                        hrtfDirection.z = message.ReadFloat();
 
                         Vector3 cameraPosRelativeToGlobalAnchor = Vector3.zero;
                         Vector3 cameraDirectionRelativeToGlobalAnchor = Vector3.zero;

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneReceiver.cs
@@ -329,7 +329,7 @@ namespace HoloToolkit.Sharing.VoiceChat
 
                         if (hrtfSourceID > 0)
                         {
-                            // hrtf processing here
+                            // TODO hrtf processing here
                         }
 
                         circularBuffer.Write(networkPacketBufferBytes, 0, networkPacketBufferBytes.Length);

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
@@ -271,9 +271,9 @@ namespace HoloToolkit.Sharing.VoiceChat
             msg.Write(cameraPosRelativeToGlobalAnchor.z);
 
             // HRTF direction bits
-            msg.Write(cameraDirectionRelativeToGlobalAnchor.x);
-            msg.Write(cameraDirectionRelativeToGlobalAnchor.y);
-            msg.Write(cameraDirectionRelativeToGlobalAnchor.z);
+            //msg.Write(cameraDirectionRelativeToGlobalAnchor.x);
+            //msg.Write(cameraDirectionRelativeToGlobalAnchor.y);
+            //msg.Write(cameraDirectionRelativeToGlobalAnchor.z);
 
             msg.WriteArray(data, (uint)dataCountFloats * 4);
 

--- a/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/VoiceChat/MicrophoneTransmitter.cs
@@ -271,9 +271,9 @@ namespace HoloToolkit.Sharing.VoiceChat
             msg.Write(cameraPosRelativeToGlobalAnchor.z);
 
             // HRTF direction bits
-            //msg.Write(cameraDirectionRelativeToGlobalAnchor.x);
-            //msg.Write(cameraDirectionRelativeToGlobalAnchor.y);
-            //msg.Write(cameraDirectionRelativeToGlobalAnchor.z);
+            msg.Write(cameraDirectionRelativeToGlobalAnchor.x);
+            msg.Write(cameraDirectionRelativeToGlobalAnchor.y);
+            msg.Write(cameraDirectionRelativeToGlobalAnchor.z);
 
             msg.WriteArray(data, (uint)dataCountFloats * 4);
 


### PR DESCRIPTION
Fixes #786 
- Added HTRF bits to be read from the stream to prevent mismatch on receiving end.