### PR TITLE
Fix glTF loader rotation calculation.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/ControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/ControllerVisualizer.cs
@@ -121,15 +121,15 @@ namespace HoloToolkit.Unity.InputModule
             bool isOverride;
             if (controllerDictionary != null && !controllerDictionary.ContainsKey(source.Id))
             {
-                GameObject controllerModelGO;
+                GameObject controllerModelGameObject;
                 if (source.Handedness == SpatialInteractionSourceHandedness.Left && LeftControllerOverride != null)
                 {
-                    controllerModelGO = Instantiate(LeftControllerOverride);
+                    controllerModelGameObject = Instantiate(LeftControllerOverride);
                     isOverride = true;
                 }
                 else if (source.Handedness == SpatialInteractionSourceHandedness.Right && RightControllerOverride != null)
                 {
-                    controllerModelGO = Instantiate(RightControllerOverride);
+                    controllerModelGameObject = Instantiate(RightControllerOverride);
                     isOverride = true;
                 }
                 else
@@ -182,15 +182,16 @@ namespace HoloToolkit.Unity.InputModule
                         reader.ReadBytes(fileBytes);
                     }
 
-                    controllerModelGO = new GameObject();
-                    GLTFComponentStreamingAssets gltfScript = controllerModelGO.AddComponent<GLTFComponentStreamingAssets>();
+                    controllerModelGameObject = new GameObject();
+                    GLTFComponentStreamingAssets gltfScript = controllerModelGameObject.AddComponent<GLTFComponentStreamingAssets>();
                     gltfScript.GLTFStandard = GLTFShader;
                     gltfScript.GLTFData = fileBytes;
+
                     yield return gltfScript.LoadModel();
                     isOverride = false;
                 }
 
-                FinishControllerSetup(controllerModelGO, isOverride, source.Handedness.ToString(), source.Id);
+                FinishControllerSetup(controllerModelGameObject, isOverride, source.Handedness.ToString(), source.Id);
             }
         }
 #endif
@@ -267,13 +268,13 @@ namespace HoloToolkit.Unity.InputModule
                 }
 
                 Vector3 newPosition;
-                if (obj.state.sourcePose.TryGetPosition(out newPosition, InteractionSourceNode.Pointer))
+                if (obj.state.sourcePose.TryGetPosition(out newPosition, InteractionSourceNode.Grip))
                 {
                     currentController.gameObject.transform.localPosition = newPosition;
                 }
 
                 Quaternion newRotation;
-                if (obj.state.sourcePose.TryGetRotation(out newRotation, InteractionSourceNode.Pointer))
+                if (obj.state.sourcePose.TryGetRotation(out newRotation, InteractionSourceNode.Grip))
                 {
                     currentController.gameObject.transform.localRotation = newRotation;
                 }

--- a/Assets/HoloToolkit/Utilities/Scripts/GLTF/Scripts/Schema/Node.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/GLTF/Scripts/Schema/Node.cs
@@ -108,17 +108,7 @@ namespace GLTF
 				mat.GetColumn(2).magnitude
 			);
 
-			var w = Mathf.Sqrt(1.0f + mat.m00 + mat.m11 + mat.m22) / 2.0f;
-			var w4 = 4.0f * w;
-			var x = (mat.m21 - mat.m12) / w4;
-			var y = (mat.m02 - mat.m20) / w4;
-			var z = (mat.m10 - mat.m01) / w4;
-
-			x = float.IsNaN(x) ? 0 : x;
-			y = float.IsNaN(y) ? 0 : y;
-			z = float.IsNaN(z) ? 0 : z;
-
-			rotation = new Quaternion(x, y, z, w);
+			rotation = mat.rotation;
 		}
 
 		public static Node Deserialize(GLTFRoot root, JsonReader reader)


### PR DESCRIPTION
Removed a workaround for Grip/Position rotation returning incorrect values. Removing a manual calculation (which wasn't working properly with the provided glTF models) in favor of Unity's built in rotation matrix.