### PR TITLE
Fixing glTF controller emission & normal mappings and override animations

### DIFF
--- a/Assets/HoloToolkit/Input/Materials/ControllerMaterial.mat
+++ b/Assets/HoloToolkit/Input/Materials/ControllerMaterial.mat
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: ControllerMaterial
+  m_Shader: {fileID: 45, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: EMISSION_MAP_ON OCC_METAL_ROUGH_ON _EMISSION _NORMALMAP
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 10305, guid: 0000000000000000f000000000000000, type: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 1
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
+    - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}

--- a/Assets/HoloToolkit/Input/Materials/ControllerMaterial.mat.meta
+++ b/Assets/HoloToolkit/Input/Materials/ControllerMaterial.mat.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2ac78523d661e954c83d799f582b22e8
+timeCreated: 1504991298
+licenseType: Pro
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Prefabs/Controllers.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/Controllers.prefab
@@ -51,7 +51,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03314f8008ae1ed4fbd45c95a7ed5182, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AnimateControllerModel: 1
   LeftControllerOverride: {fileID: 0}
   RightControllerOverride: {fileID: 0}
   TouchpadTouchedOverride: {fileID: 0}
-  GLTFShader: {fileID: 4800000, guid: 30a212a88e1063a428c85e50b1e427f2, type: 3}
+  GLTFMaterial: {fileID: 2100000, guid: 2ac78523d661e954c83d799f582b22e8, type: 2}

--- a/Assets/HoloToolkit/Input/Prefabs/MixedRealityCamera.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/MixedRealityCamera.prefab
@@ -20,7 +20,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4543495872665798}
   - component: {fileID: 20398397884145480}
-  - component: {fileID: 92627437589219448}
   - component: {fileID: 124268468487872672}
   - component: {fileID: 81159208133050278}
   - component: {fileID: 114065736676316334}
@@ -404,12 +403,11 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
-  m_AllowMSAA: 1
+  m_AllowMSAA: 0
   m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!81 &81159208133050278
 AudioListener:
   m_ObjectHideFlags: 1
@@ -417,13 +415,7 @@ AudioListener:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1208988342737728}
   m_Enabled: 1
---- !u!92 &92627437589219448
-Behaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1208988342737728}
-  m_Enabled: 1
+  m_ExtensionPropertyValues: []
 --- !u!114 &114065736676316334
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -519,7 +511,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e09147e2b1429c9428010f6aa89f91c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NearClipPlane_OpaqueDisplay: 0.3
+  NearClipPlane_OpaqueDisplay: 0.1
   CameraClearFlags_OpaqueDisplay: 1
   OpaqueQualityLevel: 5
   NearClipPlane_TransparentDisplay: 0.85

--- a/Assets/HoloToolkit/Input/Prefabs/MixedRealityCameraParent.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/MixedRealityCameraParent.prefab
@@ -530,7 +530,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!23 &23322403167181422
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -739,7 +738,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e09147e2b1429c9428010f6aa89f91c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NearClipPlane_OpaqueDisplay: 0.3
+  NearClipPlane_OpaqueDisplay: 0.1
   CameraClearFlags_OpaqueDisplay: 1
   OpaqueQualityLevel: 5
   NearClipPlane_TransparentDisplay: 0.85
@@ -777,10 +776,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03314f8008ae1ed4fbd45c95a7ed5182, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  AnimateControllerModel: 1
   LeftControllerOverride: {fileID: 0}
   RightControllerOverride: {fileID: 0}
   TouchpadTouchedOverride: {fileID: 0}
-  GLTFShader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  GLTFMaterial: {fileID: 2100000, guid: 2ac78523d661e954c83d799f582b22e8, type: 2}
 --- !u!114 &114755176645041546
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/HoloToolkit/Input/Scripts/ControllerInfo.cs
+++ b/Assets/HoloToolkit/Input/Scripts/ControllerInfo.cs
@@ -301,5 +301,15 @@ namespace HoloToolkit.Unity.InputModule
             buttonGameObject.transform.localPosition = newTransform.localPosition;
             buttonGameObject.transform.localRotation = newTransform.localRotation;
         }
+
+        private void OnDestroy()
+        {
+            if (touchpadTouchVisualizer != null)
+            {
+                Destroy(touchpadTouchVisualizer.GetComponent<Renderer>().material);
+            }
+
+            Destroy(gameObject);
+        }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/ControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/ControllerVisualizer.cs
@@ -233,7 +233,7 @@ namespace HoloToolkit.Unity.InputModule
                 ControllerInfo controller;
                 if (controllerDictionary != null && controllerDictionary.TryGetValue(source.id, out controller))
                 {
-                    Destroy(controller.gameObject);
+                    Destroy(controller);
 
                     // After destruction, the reference can be removed from the dictionary.
                     controllerDictionary.Remove(source.id);
@@ -244,7 +244,7 @@ namespace HoloToolkit.Unity.InputModule
         private void InteractionManager_InteractionSourceUpdated(InteractionSourceUpdatedEventArgs obj)
         {
             ControllerInfo currentController;
-            if (controllerDictionary != null && controllerDictionary.TryGetValue(obj.state.source.id, out currentController))
+            if (AnimateControllerModel && controllerDictionary != null && controllerDictionary.TryGetValue(obj.state.source.id, out currentController))
             {
                 currentController.AnimateSelect(obj.state.selectPressedAmount);
 

--- a/Assets/HoloToolkit/Input/Tests/Scenes/MotionControllerTest.unity
+++ b/Assets/HoloToolkit/Input/Tests/Scenes/MotionControllerTest.unity
@@ -484,6 +484,33 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1662233528}
   m_Script: {fileID: 11500000, guid: afa1ae235bc6cfa43addd1435e2fd822, type: 3}
+--- !u!1 &1738618829 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1493965172262900, guid: d29bc40b7f3df26479d6a0aac211c355,
+    type: 2}
+  m_PrefabInternal: {fileID: 1996766209}
+--- !u!114 &1738618830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1738618829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f70d42c5aa30ffb4e9cd9116a13bd2b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1738618831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1738618829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cae8f3c88e9704a4393cb8d904b62372, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1873443075
 Prefab:
   m_ObjectHideFlags: 0
@@ -583,30 +610,3 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &1996766210 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1493965172262900, guid: d29bc40b7f3df26479d6a0aac211c355,
-    type: 2}
-  m_PrefabInternal: {fileID: 1996766209}
---- !u!114 &1996766211
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1996766210}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f70d42c5aa30ffb4e9cd9116a13bd2b8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1996766212
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1996766210}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cae8f3c88e9704a4393cb8d904b62372, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/HoloToolkit/Utilities/Scripts/GLTFComponentStreamingAssets.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/GLTFComponentStreamingAssets.cs
@@ -12,8 +12,8 @@ namespace GLTF
 
         public int MaximumLod = 300;
 
-        public Shader GLTFStandard;
-        public Shader GLTFConstant;
+        public UnityEngine.Material ColorMaterial;
+        public UnityEngine.Material NoColorMaterial;
 
         [HideInInspector]
         public byte[] GLTFData;
@@ -40,8 +40,8 @@ namespace GLTF
                 GLTFData,
                 gameObject.transform
             );
-            loader.SetShaderForMaterialType(GLTFLoader.MaterialType.PbrMetallicRoughness, GLTFStandard);
-            loader.SetShaderForMaterialType(GLTFLoader.MaterialType.CommonConstant, GLTFConstant);
+            loader.ColorMaterial = ColorMaterial;
+            loader.NoColorMaterial = NoColorMaterial;
             loader.Multithreaded = Multithreaded;
             loader.MaximumLod = MaximumLod;
             yield return loader.Load();


### PR DESCRIPTION
Making glTF loading take in a material instead of a shader, since Unity doesn't build unused shader configurations.

Also, refactored controller animation to be dependent on developer preference instead of override/non-override, to allow for specialized overrides to be animated.