### PR TITLE
Added a Cursor Offset to the TapToPlace script

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -49,7 +49,8 @@ namespace HoloToolkit.Unity.InputModule
         private const int IgnoreRaycastLayer = 2;
 
         private Dictionary<GameObject, int> layerCache = new Dictionary<GameObject, int>();
-        public Vector3 PlacementPosOffset;
+
+        private Vector3 PlacementPosOffset;
 
         protected virtual void Start()
         {
@@ -197,7 +198,7 @@ namespace HoloToolkit.Unity.InputModule
 
         public void CalculateColliderOffset()
         {
-            Collider[] colliders = GetComponentsInChildren<Collider>();
+            Collider[] colliders = GetComponents<Collider>();
             Bounds bounds = colliders[0].bounds;
 
             for (int i = 0; i < colliders.Length; i++)

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -38,8 +38,9 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("Setting this to true will allow this behavior to control the DrawMesh property on the spatial mapping.")]
         public bool AllowMeshVisualizationControl = true;
 
+        public enum PlacePositionCenter { GameObjectTransform, GameObjectCollider, GameObjectAndChildrenColliders };
         [Tooltip("Should the center of the Collider be used instead of the gameObjects world transform.")]
-        public bool UseColliderCenter;
+        public PlacePositionCenter PlacementPositionCenter;
 
         private Interpolator interpolator;
 
@@ -107,7 +108,8 @@ namespace HoloToolkit.Unity.InputModule
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
 
-            if (UseColliderCenter)
+            if (PlacementPositionCenter == PlacePositionCenter.GameObjectAndChildrenColliders ||
+                PlacementPositionCenter == PlacePositionCenter.GameObjectCollider)
             {
                 placementPosition += PlacementPosOffset;
             }
@@ -198,7 +200,17 @@ namespace HoloToolkit.Unity.InputModule
 
         public void CalculateColliderOffset()
         {
-            Collider[] colliders = GetComponents<Collider>();
+            Collider[] colliders;
+            if (PlacementPositionCenter == PlacePositionCenter.GameObjectAndChildrenColliders)
+            {
+                colliders = GetComponentsInChildren<Collider>();
+
+            }
+            else
+            {
+                colliders = GetComponents<Collider>();
+
+            }
             Bounds bounds = colliders[0].bounds;
 
             for (int i = 0; i < colliders.Length; i++)

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -49,7 +49,7 @@ namespace HoloToolkit.Unity.InputModule
         private const int IgnoreRaycastLayer = 2;
 
         private Dictionary<GameObject, int> layerCache = new Dictionary<GameObject, int>();
-        private Vector3 PlacementPosOffset;
+        public Vector3 PlacementPosOffset;
 
         protected virtual void Start()
         {
@@ -195,7 +195,7 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
-        private void CalculateColliderOffset()
+        public void CalculateColliderOffset()
         {
             Collider[] colliders = GetComponentsInChildren<Collider>();
             Bounds bounds = colliders[0].bounds;

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -73,7 +73,8 @@ namespace HoloToolkit.Unity.InputModule
 
         private void OnEnable()
         {
-            CalculateColliderOffset();
+            Bounds bounds = transform.GetColliderBounds();
+            PlacementPosOffset = transform.position - bounds.center;
         }
 
         /// <summary>
@@ -193,18 +194,6 @@ namespace HoloToolkit.Unity.InputModule
             {
                 SpatialMappingManager.Instance.DrawVisualMeshes = IsBeingPlaced;
             }
-        }
-
-        public void CalculateColliderOffset()
-        {
-            Collider[] colliders = GetComponentsInChildren<Collider>();
-            Bounds bounds = colliders[0].bounds;
-
-            for (int i = 1; i < colliders.Length; i++)
-            {
-                bounds.Encapsulate(colliders[i].bounds);
-            }
-            PlacementPosOffset = transform.position - bounds.center;
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -38,9 +38,8 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("Setting this to true will allow this behavior to control the DrawMesh property on the spatial mapping.")]
         public bool AllowMeshVisualizationControl = true;
 
-        public enum PlacePositionCenter { GameObjectTransform, GameObjectCollider, GameObjectAndChildrenColliders };
         [Tooltip("Should the center of the Collider be used instead of the gameObjects world transform.")]
-        public PlacePositionCenter PlacementPositionCenter;
+        public bool UseColliderCenter;
 
         private Interpolator interpolator;
 
@@ -50,7 +49,6 @@ namespace HoloToolkit.Unity.InputModule
         private const int IgnoreRaycastLayer = 2;
 
         private Dictionary<GameObject, int> layerCache = new Dictionary<GameObject, int>();
-
         private Vector3 PlacementPosOffset;
 
         protected virtual void Start()
@@ -108,8 +106,7 @@ namespace HoloToolkit.Unity.InputModule
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
 
-            if (PlacementPositionCenter == PlacePositionCenter.GameObjectAndChildrenColliders ||
-                PlacementPositionCenter == PlacePositionCenter.GameObjectCollider)
+            if (UseColliderCenter)
             {
                 placementPosition += PlacementPosOffset;
             }
@@ -200,17 +197,7 @@ namespace HoloToolkit.Unity.InputModule
 
         public void CalculateColliderOffset()
         {
-            Collider[] colliders;
-            if (PlacementPositionCenter == PlacePositionCenter.GameObjectAndChildrenColliders)
-            {
-                colliders = GetComponentsInChildren<Collider>();
-
-            }
-            else
-            {
-                colliders = GetComponents<Collider>();
-
-            }
+            Collider[] colliders = GetComponentsInChildren<Collider>();
             Bounds bounds = colliders[0].bounds;
 
             for (int i = 0; i < colliders.Length; i++)

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -38,6 +38,9 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("Setting this to true will allow this behavior to control the DrawMesh property on the spatial mapping.")]
         public bool AllowMeshVisualizationControl = true;
 
+        [Tooltip("Amount model should be offset from the placement position.")]
+        public Vector3 centerOffset;
+
         private Interpolator interpolator;
 
         /// <summary>
@@ -96,6 +99,7 @@ namespace HoloToolkit.Unity.InputModule
             Transform cameraTransform = CameraCache.Main.transform;
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
+            placementPosition += centerOffset;
 
             // Here is where you might consider adding intelligence
             // to how the object is placed.  For example, consider

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -200,7 +200,7 @@ namespace HoloToolkit.Unity.InputModule
             Collider[] colliders = GetComponentsInChildren<Collider>();
             Bounds bounds = colliders[0].bounds;
 
-            for (int i = 0; i < colliders.Length; i++)
+            for (int i = 1; i < colliders.Length; i++)
             {
                 bounds.Encapsulate(colliders[i].bounds);
             }

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -49,7 +49,7 @@ namespace HoloToolkit.Unity.InputModule
         private const int IgnoreRaycastLayer = 2;
 
         private Dictionary<GameObject, int> layerCache = new Dictionary<GameObject, int>();
-
+        private Vector3 PlacementPosOffset;
 
         protected virtual void Start()
         {
@@ -69,6 +69,11 @@ namespace HoloToolkit.Unity.InputModule
             {
                 AttachWorldAnchor();
             }
+        }
+
+        private void OnEnable()
+        {
+            CalculateColliderOffset();
         }
 
         /// <summary>
@@ -100,10 +105,10 @@ namespace HoloToolkit.Unity.InputModule
             Transform cameraTransform = CameraCache.Main.transform;
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
+
             if (UseColliderCenter)
             {
-                Bounds bounds = CalculateAllColliderBounds();
-                placementPosition += (transform.position - bounds.center);
+                placementPosition += PlacementPosOffset;
             }
 
             // Here is where you might consider adding intelligence
@@ -190,7 +195,7 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
-        private Bounds CalculateAllColliderBounds()
+        private void CalculateColliderOffset()
         {
             Collider[] colliders = GetComponentsInChildren<Collider>();
             Bounds bounds = colliders[0].bounds;
@@ -199,7 +204,7 @@ namespace HoloToolkit.Unity.InputModule
             {
                 bounds.Encapsulate(colliders[i].bounds);
             }
-            return bounds;
+            PlacementPosOffset = transform.position - bounds.center;
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
@@ -86,5 +86,22 @@ namespace HoloToolkit.Unity
                 yield return parentTransform;
             }
         }
+
+        /// <summary>
+        /// Calculates the bounds of all the colliders attached to this gameObject and all it's children
+        /// </summary>
+        /// <param name="transform">Transform of root GameObject the colliders are attached to </param>
+        /// <returns></returns>
+        public static Bounds GetColliderBounds(this Transform transform)
+        {
+            Collider[] colliders = transform.GetComponentsInChildren<Collider>();
+            Bounds bounds = colliders[0].bounds;
+
+            for (int i = 1; i < colliders.Length; i++)
+            {
+                bounds.Encapsulate(colliders[i].bounds);
+            }
+            return bounds;
+        }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
@@ -88,10 +88,10 @@ namespace HoloToolkit.Unity
         }
 
         /// <summary>
-        /// Calculates the bounds of all the colliders attached to this game object and all it's children
+        /// Calculates the bounds of all the colliders attached to this GameObject and all it's children
         /// </summary>
         /// <param name="transform">Transform of root GameObject the colliders are attached to </param>
-        /// <returns>The total bounds of all colliders attached to this game object. 
+        /// <returns>The total bounds of all colliders attached to this GameObject. 
         /// If no colliders attached, returns a bounds of center and extents 0</returns>
         public static Bounds GetColliderBounds(this Transform transform)
         {

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
@@ -88,20 +88,29 @@ namespace HoloToolkit.Unity
         }
 
         /// <summary>
-        /// Calculates the bounds of all the colliders attached to this gameObject and all it's children
+        /// Calculates the bounds of all the colliders attached to this game object and all it's children
         /// </summary>
         /// <param name="transform">Transform of root GameObject the colliders are attached to </param>
-        /// <returns></returns>
+        /// <returns>The total bounds of all colliders attached to this game object. 
+        /// If no colliders attached, returns a bounds of center and extents 0</returns>
         public static Bounds GetColliderBounds(this Transform transform)
         {
             Collider[] colliders = transform.GetComponentsInChildren<Collider>();
-            Bounds bounds = colliders[0].bounds;
-
-            for (int i = 1; i < colliders.Length; i++)
+            if (colliders.Length != 0)
             {
-                bounds.Encapsulate(colliders[i].bounds);
+                Bounds bounds = colliders[0].bounds;
+
+                for (int i = 1; i < colliders.Length; i++)
+                {
+                    bounds.Encapsulate(colliders[i].bounds);
+                }
+                return bounds;
             }
-            return bounds;
+            else
+            {
+                Debug.LogWarningFormat("No Colliders attached to '{0}'", transform.name);
+                return new Bounds();
+            }
         }
     }
 }


### PR DESCRIPTION
Adds an offset to the placement position for situations where the centre of a mesh is not the same as the centre of the GameObject.

(Should I have opened an Issue first btw? Wasn't sure if it mattered since it's such a small feature)