### PR TITLE
Fix haptics bug for durations shorter than 1 second

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/HapticsExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/HapticsExtensions.cs
@@ -50,7 +50,7 @@ namespace HoloToolkit.Unity
                                 }
                                 else
                                 {
-                                    simpleHapticsController.SendHapticFeedbackForDuration(hapticsFeedback, intensity, new TimeSpan(Convert.ToInt64(durationInSeconds) * TimeSpan.TicksPerSecond));
+                                    simpleHapticsController.SendHapticFeedbackForDuration(hapticsFeedback, intensity, TimeSpan.FromSeconds(durationInSeconds));
                                 }
                                 return;
                             }


### PR DESCRIPTION
Turns out there's an easier way to convert seconds into a TimeSpan :)