### PR TITLE
Updating input tests with FocusManager and new InputManager checks

### DIFF
--- a/Assets/HoloToolkit-UnitTests/Input/TestEventHandler.cs
+++ b/Assets/HoloToolkit-UnitTests/Input/TestEventHandler.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using HoloToolkit.Unity.InputModule;
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -10,7 +10,7 @@ namespace HoloToolkit.Unity.Tests
 {
     public interface ITestEventSystemHandler : IEventSystemHandler
     {
-        void OnTest();
+        void OnTest(BaseEventData eventData);
     }
 
     public class TestEventHandler : MonoBehaviour, ITestEventSystemHandler, IFocusable
@@ -18,25 +18,24 @@ namespace HoloToolkit.Unity.Tests
         public static readonly ExecuteEvents.EventFunction<ITestEventSystemHandler> OnTestHandler =
         delegate (ITestEventSystemHandler handler, BaseEventData eventData)
         {
-            handler.OnTest();
+            handler.OnTest(eventData);
         };
 
+        public Action<GameObject, BaseEventData> EventFiredCallback;
 
-        public Action<GameObject> EventFiredCallback;
-
-        public void OnTest()
+        public void OnTest(BaseEventData eventData)
         {
-            EventFiredCallback(gameObject);
+            EventFiredCallback(gameObject, eventData);
         }
 
         public void OnFocusEnter()
         {
-            EventFiredCallback(gameObject);
+            EventFiredCallback(gameObject, null);
         }
 
         public void OnFocusExit()
         {
-            EventFiredCallback(gameObject);
+            EventFiredCallback(gameObject, null);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -205,6 +205,14 @@ namespace HoloToolkit.Unity.InputModule
             InitializeEventDatas();
         }
 
+        private void Start()
+        {
+            if (!FocusManager.IsInitialized)
+            {
+                Debug.LogError("InputManager requires an active FocusManager in the scene");
+            }
+        }
+
         private void InitializeEventDatas()
         {
             inputEventData = new InputEventData(EventSystem.current);


### PR DESCRIPTION
Fixes #1022

The InputManager changes mean that it now takes into account whether the eventdata was actually used versus an event firing.