### PR TITLE
Revert "Instance isn't found if class is on a disabled GameObject."

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/SingleInstance.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SingleInstance.cs
@@ -18,7 +18,7 @@ namespace HoloToolkit.Unity
             {
                 if (_Instance == null)
                 {
-                    T[] objects = Resources.FindObjectsOfTypeAll<T>();
+                    T[] objects = FindObjectsOfType<T>();
                     if (objects.Length != 1)
                     {
                         Debug.LogErrorFormat("Expected exactly 1 {0} but found {1}", typeof(T).ToString(), objects.Length);


### PR DESCRIPTION
Reverts Microsoft/MixedRealityToolkit-Unity#1033
This change completely blows up in the editor.
Need to find a better way to filter out what's actually in the scene vs. on disk.
