### PR TITLE
Fixed XboxController update regressions

### DIFF
--- a/Assets/HoloToolkit-Examples/GamePad/Scenes/XboxControllerExample.unity
+++ b/Assets/HoloToolkit-Examples/GamePad/Scenes/XboxControllerExample.unity
@@ -701,10 +701,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   DeviceRefreshInterval: 3
-  horizontalAxis: 4
-  verticalAxis: 5
-  submitButton: 9
-  cancelButton: 10
+  horizontalAxis: 3
+  verticalAxis: 4
+  submitButton: 10
+  cancelButton: 11
   mapping:
   - Type: 0
     Value: 

--- a/Assets/HoloToolkit-Examples/GamePad/Scenes/XboxControllerExample.unity
+++ b/Assets/HoloToolkit-Examples/GamePad/Scenes/XboxControllerExample.unity
@@ -744,3 +744,5 @@ MonoBehaviour:
     Value: 
   - Type: 18
     Value: 
+  - Type: 19
+    Value: 

--- a/Assets/HoloToolkit/Input/Scripts/GamePad/XboxControllerMapping.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GamePad/XboxControllerMapping.cs
@@ -34,6 +34,8 @@ namespace HoloToolkit.Unity.InputModule
         {
             switch (type)
             {
+                case XboxControllerMappingTypes.None:
+                    return string.Empty;
                 case XboxControllerMappingTypes.XboxLeftStickHorizontal:
                     return XboxLeftStickHorizontal;
                 case XboxControllerMappingTypes.XboxLeftStickVertical:
@@ -81,6 +83,8 @@ namespace HoloToolkit.Unity.InputModule
         {
             switch (type)
             {
+                case XboxControllerMappingTypes.None:
+                    return;
                 case XboxControllerMappingTypes.XboxLeftStickHorizontal:
                     XboxLeftStickHorizontal = string.IsNullOrEmpty(value) ? "XBOX_LEFT_STICK_HORIZONTAL" : value;
                     break;

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/XboxControllerInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/XboxControllerInputSource.cs
@@ -18,7 +18,7 @@ namespace HoloToolkit.Unity.InputModule
         [Serializable]
         private class MappingEntry
         {
-            public XboxControllerMappingTypes Type = 0;
+            public XboxControllerMappingTypes Type = XboxControllerMappingTypes.None;
             public string Value = string.Empty;
         }
 


### PR DESCRIPTION
Regression from #994 

- Event System Overrides were mapped incorrectly.
- `XboxControllerMappingTypes.None` was not handled when getting and setting the mapping types.