### PR TITLE
Fixed VR enabling on build target group in Project wizard.

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/ProjectSettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/ProjectSettingsWindow.cs
@@ -244,7 +244,7 @@ namespace HoloToolkit.Unity
                 if (!Values[ProjectSetting.TargetOccludedDevices])
                 {
                     EditorUserBuildSettings.wsaSubtarget = WSASubtarget.HoloLens;
-                    UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.WSA, new[] { "HoloLens" });
+                    UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.WSA, new[] { "WindowsMR" });
                     PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.HumanInterfaceDevice, Values[ProjectSetting.XboxControllerSupport]);
                     BuildDeployPrefs.BuildPlatform = "x86";
 
@@ -256,7 +256,7 @@ namespace HoloToolkit.Unity
                 else
                 {
                     EditorUserBuildSettings.wsaSubtarget = WSASubtarget.PC;
-                    UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.WSA, new[] { "stereo" });
+                    UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.WSA, new[] { "WindowsMR" });
                     PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.HumanInterfaceDevice, false);
                     BuildDeployPrefs.BuildPlatform = "x64";
 


### PR DESCRIPTION
Incorrectly changed it to `stereo` instead of `WindowsMR`

Updated `HoloLens` to `WindowsMR`

No changes needed to master branch, because the SDK names did not change, and there's no way to enable occluded devices.