### PR TITLE
Handle a null switch and gracefully stop searching

### DIFF
--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/XdeGuestLocator.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/XdeGuestLocator.cs
@@ -54,7 +54,13 @@ namespace HoloToolkit.Unity
                 HasData = false;
                 GuestIpAddress = IPAddress.None;
 
-                var internalSwitchAddressInfo = GetInternalSwitchAddressInfo();
+                var internalSwitchAddressInfo = null;
+                try {
+                    internalSwitchAddressInfo = GetInternalSwitchAddressInfo();
+                } catch(Exception e) {
+                    UnityEngine.Debug.LogError("Failed to locate internal switch adapter");
+                }
+                
                 if (internalSwitchAddressInfo != null)
                 {
                     using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))


### PR DESCRIPTION
This resolves an issue when calling `GetInternalSwitchAddressInfo()` where when failing to locate the adapter, it would throw a silent exception and never stop searching - giving the impression that it's still trying to find something when it never gets to line 58 to check if it's null.