### PR TITLE
Add a null-check of TeleportMarker before instantiating the object.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityTeleport.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityTeleport.cs
@@ -66,13 +66,16 @@ namespace HoloToolkit.Unity.InputModule
                 return;
             }
 
-            teleportMarker = Instantiate(TeleportMarker);
-            teleportMarker.SetActive(false);
-
-            animationController = teleportMarker.GetComponentInChildren<Animator>();
-            if (animationController != null)
+            if (TeleportMarker != null)
             {
-                animationController.StopPlayback();
+                teleportMarker = Instantiate(TeleportMarker);
+                teleportMarker.SetActive(false);
+
+                animationController = teleportMarker.GetComponentInChildren<Animator>();
+                if (animationController != null)
+                {
+                    animationController.StopPlayback();
+                }
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/FadeScript.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FadeScript.cs
@@ -9,6 +9,8 @@ namespace HoloToolkit.Unity
 {
     public class FadeScript : SingleInstance<FadeScript>
     {
+        [Tooltip("If true, the FadeScript will update the shared material. Useful for fading multiple cameras that each render different layers.")]
+        public bool FadeSharedMaterial = false;
         Material fadeMaterial;
         Color fadeColor = Color.black;
 
@@ -46,7 +48,14 @@ namespace HoloToolkit.Unity
 #endif
 
             currentState = FadeState.idle;
-            fadeMaterial = GetComponentInChildren<MeshRenderer>().material;
+            if (FadeSharedMaterial)
+            {
+                fadeMaterial = GetComponentInChildren<MeshRenderer>().sharedMaterial;
+            }
+            else
+            {
+                fadeMaterial = GetComponentInChildren<MeshRenderer>().material;
+            }
         }
 
         void Update()
@@ -90,7 +99,7 @@ namespace HoloToolkit.Unity
 
         protected override void OnDestroy()
         {
-            if (fadeMaterial != null)
+            if (fadeMaterial != null && !FadeSharedMaterial)
             {
                 Destroy(fadeMaterial);
             }


### PR DESCRIPTION
Fixes #1112 Added a null-check of TeleportMarker before instantitiating the object.
Fixes #1113 Add an option to use sharedMaterial when fading.