### PR TITLE
Fixes build discovery

### DIFF
--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
@@ -927,10 +927,10 @@ namespace HoloToolkit.Unity
             try
             {
                 var appPackageDirectories = new List<string>();
-                string[] buildList = Directory.GetDirectories(BuildDeployPrefs.AbsoluteBuildDirectory);
+                string[] buildList = Directory.GetDirectories(Path.Combine(BuildDeployPrefs.AbsoluteBuildDirectory, "AppPackages"));
                 foreach (string appBuild in buildList)
                 {
-                    string appPackageDirectory = appBuild + @"\AppPackages";
+                    string appPackageDirectory = appBuild;
                     if (Directory.Exists(appPackageDirectory))
                     {
                         appPackageDirectories.AddRange(Directory.GetDirectories(appPackageDirectory));


### PR DESCRIPTION
I may be totally missing something here, but I'm just going off what the build window generates for me (that is, it builds to the build folder directory, it doesn't build to incremental subfolders or anything like that)

Currently, it will search the build folder for folders, then search those folders for an `AppPackages` folder and use that to identify it's a build. But this isn't how builds are generated by the build tools. The `AppPackages` folder is in the root of the build folder, so what should actually be iterated through is the contents of the `AppPackages` folder in the root of the build folder. _Those_ are the individual builds.