### PR TITLE
Added a note to capabilities RE: Remote Profiler

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/CapabilitySettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/CapabilitySettingsWindow.cs
@@ -143,7 +143,8 @@ namespace HoloToolkit.Unity
             Descriptions[PlayerSettings.WSACapability.PrivateNetworkClientServer] = "The Private Network Client Server capability provides inbound and outbound access to home and " +
                                                                                     "work networks through the firewall. This capability is typically used for games that " +
                                                                                     "communicate across the local area network (LAN), and for apps that share data across a variety " +
-                                                                                    "of local devices.\n\nNote: On Windows, this capability does not provide access to the Internet.";
+                                                                                    "of local devices.\n\nRequired when connecting the Unity Profiler to your app on the HoloLens" +
+                                                                                    "\n\nNote: On Windows, this capability does not provide access to the Internet.";
         }
 
         protected override void OnEnable()


### PR DESCRIPTION
Only just found this one, you need Private Network Client Server enabled in order to use the Unity Remote Profiler with Hololens.

Wording may need tweaking, or perhaps it would be best moved into a separate menu option for "Enable Remote Profiler" that pops up a window saying "This will enable the 'Private Network Client Server' capability, are you sure?" instead.