### PR TITLE
Properly supports Hand position and Fixed HandDraggable

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
@@ -622,7 +622,7 @@ namespace HoloToolkit.Unity.InputModule
 #if UNITY_2017_2_OR_NEWER
                 interactionSourceState.sourcePose.TryGetPosition(out newPointerPosition, InteractionSourceNode.Pointer);
 #else
-                false;
+                interactionSourceState.properties.location.TryGetPosition(out newPointerPosition);
 #endif
             // Using a heuristic for IsSupported, since the APIs don't yet support querying this capability directly.
             sourceData.PointerPosition.IsSupported |= sourceData.PointerPosition.IsAvailable;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -118,7 +118,7 @@ namespace HoloToolkit.Unity.InputModule
 
             Transform cameraTransform = CameraCache.Main.transform;
             Vector3 handPosition;
-            currentInputSource.TryGetGripPosition(currentInputSourceId, out handPosition);
+            currentInputSource.TryGetPointerPosition(currentInputSourceId, out handPosition);
 
             Vector3 pivotPosition = GetHandPivotPosition(cameraTransform);
             handRefDistance = Vector3.Magnitude(handPosition - pivotPosition);
@@ -183,7 +183,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             Vector3 newHandPosition;
             Transform cameraTransform = CameraCache.Main.transform;
-            currentInputSource.TryGetGripPosition(currentInputSourceId, out newHandPosition);
+            currentInputSource.TryGetPointerPosition(currentInputSourceId, out newHandPosition);
 
             Vector3 pivotPosition = GetHandPivotPosition(cameraTransform);
 


### PR DESCRIPTION
Fixes #1176

To test, build and run the `InputManagerTest` scene on the HoloLens and drag around the objects.