### PR TITLE
Reverted removal of SpeechKeyworkRecognizedEventData

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/InputEventData/SpeechKeywordRecognizedEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEventData/SpeechKeywordRecognizedEventData.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine.EventSystems;
+
+namespace HoloToolkit.Unity.InputModule
+{
+    /// <summary>
+    /// Describes an input event that involves keyword recognition.
+    /// </summary>
+    [Obsolete("Please use SpeechEventData")]
+    public class SpeechKeywordRecognizedEventData : SpeechEventData
+    {
+        public SpeechKeywordRecognizedEventData(EventSystem eventSystem) : base(eventSystem) { }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/InputEventData/SpeechKeywordRecognizedEventData.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/InputEventData/SpeechKeywordRecognizedEventData.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 67b2f86e6c05d484f8c74c5e4db84fdf
+timeCreated: 1479913151
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added `SpeechKeyworkRecognizedEventData` back into project to help devs update instead of ripping it out.

Now properly uses `obsolete` attribute.