### PR TITLE
Prevent Stack exception on InputManager.PopModalInputHandler

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
@@ -89,7 +89,11 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         public void PopModalInputHandler()
         {
-            modalInputStack.Pop();
+            if (modalInputStack.Count>0)
+            {
+                modalInputStack.Pop();
+
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Maybe a nit, but if there are no input handlers on the stack, the InputManager throws an exception. Added a check for empty stack to prevent exception being thrown.