### PR TITLE
MRDL->MRTK: Multi-step pointer sources

### DIFF
--- a/Assets/HoloToolkit-Examples/ColorPicker/ColorPickerExample.unity
+++ b/Assets/HoloToolkit-Examples/ColorPicker/ColorPickerExample.unity
@@ -188,7 +188,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 1596720591}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -701,3 +701,8 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &1596720591 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 1596720590}

--- a/Assets/HoloToolkit-Examples/Input/Scenes/CanvasUiRaycasts.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/CanvasUiRaycasts.unity
@@ -274,6 +274,11 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &41258885 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 41258884}
 --- !u!1 &47967669
 GameObject:
   m_ObjectHideFlags: 0
@@ -408,7 +413,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 41258885}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -436,7 +441,7 @@ RectTransform:
   - {fileID: 1577322405}
   - {fileID: 1354349145}
   m_Father: {fileID: 603432406}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -862,8 +867,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 160117912}
   - {fileID: 1748863526}
+  - {fileID: 160117912}
   - {fileID: 1985735395}
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -2205,7 +2210,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 41258885}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -2233,7 +2238,7 @@ RectTransform:
   - {fileID: 576869519}
   - {fileID: 1825249308}
   m_Father: {fileID: 603432406}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2719,7 +2724,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 41258885}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1

--- a/Assets/HoloToolkit-Examples/Input/Scenes/InputManagerTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/InputManagerTest.unity
@@ -1397,7 +1397,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 485146271}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -1650,9 +1650,19 @@ Prefab:
       propertyPath: Cursor
       value: 
       objectReference: {fileID: 759629491}
+    - target: {fileID: 114950568511066590, guid: 3eddd1c29199313478dd3f912bfab2ab,
+        type: 2}
+      propertyPath: simulateHandsInEditor
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &485146271 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 485146270}
 --- !u!1 &502235477
 GameObject:
   m_ObjectHideFlags: 0
@@ -3147,6 +3157,11 @@ Prefab:
         type: 2}
       propertyPath: ShapeModule.radius.value
       value: 0.02237308
+      objectReference: {fileID: 0}
+    - target: {fileID: 199000010866415596, guid: 31ed45da60c98354380578a9bde4814d,
+        type: 2}
+      propertyPath: m_SelectedEditorRenderState
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 31ed45da60c98354380578a9bde4814d, type: 2}

--- a/Assets/HoloToolkit-Examples/Input/Scenes/KeyboardTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/KeyboardTest.unity
@@ -656,6 +656,10 @@ Prefab:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 22335612, guid: c4e389e44d96da64ea974ab237ce1a9a, type: 2}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1003701765}
     m_RemovedComponents:
     - {fileID: 114513796278864976, guid: c4e389e44d96da64ea974ab237ce1a9a, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: c4e389e44d96da64ea974ab237ce1a9a, type: 2}
@@ -707,6 +711,11 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &1003701765 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 1003701764}
 --- !u!1 &1083211976
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,11 +977,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1483467051}
---- !u!20 &1532151206 stripped
-Camera:
-  m_PrefabParentObject: {fileID: 20770519707920992, guid: d29bc40b7f3df26479d6a0aac211c355,
-    type: 2}
-  m_PrefabInternal: {fileID: 1571667773}
 --- !u!1 &1555344818
 GameObject:
   m_ObjectHideFlags: 0
@@ -1172,7 +1176,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 1532151206}
+  m_Camera: {fileID: 1003701765}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1

--- a/Assets/HoloToolkit-Examples/Input/Scenes/XboxControllerExample.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/XboxControllerExample.unity
@@ -508,6 +508,11 @@ Prefab:
       propertyPath: m_FontData.m_HorizontalOverflow
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 223000013180475572, guid: 022450106439a8946ae18a9e20cc92d8,
+        type: 2}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1635556076}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 022450106439a8946ae18a9e20cc92d8, type: 2}
   m_IsPrefabParent: 0
@@ -607,6 +612,11 @@ Prefab:
 --- !u!4 &1635556075 stripped
 Transform:
   m_PrefabParentObject: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 1635556074}
+--- !u!20 &1635556076 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
     type: 2}
   m_PrefabInternal: {fileID: 1635556074}
 --- !u!1001 &1763047398

--- a/Assets/HoloToolkit-Examples/Input/Scripts/InputTest.cs
+++ b/Assets/HoloToolkit-Examples/Input/Scripts/InputTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
@@ -9,7 +10,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// Test behaviour that simply prints out a message very time a supported event is received from the input module.
     /// This is used to make sure that the input module routes events appropriately to game objects.
     /// </summary>
-    public class InputTest : MonoBehaviour, IInputHandler, IInputClickHandler, IFocusable, ISourceStateHandler, IHoldHandler, IManipulationHandler, INavigationHandler
+    public class InputTest : MonoBehaviour, IInputHandler, IInputClickHandler, IFocusable, ISourceStateHandler, IHoldHandler, IManipulationHandler, INavigationHandler, IPointerClickHandler
     {
         [Tooltip("Set to true if gestures update (ManipulationUpdated, NavigationUpdated) should be logged. Note that this can impact performance.")]
         public bool LogGesturesUpdateEvents = false;
@@ -30,6 +31,14 @@ namespace HoloToolkit.Unity.InputModule.Tests
         {
             Debug.LogFormat("OnInputClicked\r\nSource: {0}  SourceId: {1}  InteractionPressKind: {2}  TapCount: {3}", eventData.InputSource, eventData.SourceId, eventData.PressType, eventData.TapCount);
             eventData.Use(); // Mark the event as used, so it doesn't fall through to other handlers.
+        }
+
+        /// <summary>
+        /// Just a public method called by the Unity OnClick Event.
+        /// </summary>
+        public void OnPointerClick(PointerEventData pointerEventData)
+        {
+            Debug.Log("OnPointerClick: " + pointerEventData.pointerId);
         }
 
         public void OnFocusEnter()
@@ -74,7 +83,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
         public void OnManipulationStarted(ManipulationEventData eventData)
         {
-            Debug.LogFormat("OnManipulationStarted\r\nSource: {0}  SourceId: {1}\r\nCumulativeDelta: {2} {3} {4}", 
+            Debug.LogFormat("OnManipulationStarted\r\nSource: {0}  SourceId: {1}\r\nCumulativeDelta: {2} {3} {4}",
                 eventData.InputSource,
                 eventData.SourceId,
                 eventData.CumulativeDelta.x,

--- a/Assets/HoloToolkit-Examples/Medical/Scenes/MedicalExample.unity
+++ b/Assets/HoloToolkit-Examples/Medical/Scenes/MedicalExample.unity
@@ -402,6 +402,11 @@ Transform:
   m_PrefabParentObject: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab,
     type: 2}
   m_PrefabInternal: {fileID: 357232768}
+--- !u!20 &357232770 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 357232768}
 --- !u!1 &512838807
 GameObject:
   m_ObjectHideFlags: 0
@@ -1381,7 +1386,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 357232770}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1

--- a/Assets/HoloToolkit-Examples/Prototyping/Scenes/PanelLayout.unity
+++ b/Assets/HoloToolkit-Examples/Prototyping/Scenes/PanelLayout.unity
@@ -4668,7 +4668,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 2076036018}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -12296,7 +12296,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 2076036018}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -13818,6 +13818,11 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &2076036018 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 2076036017}
 --- !u!1 &2091594862
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit-Examples/Sharing/SharingService/Scenes/SharingTest.unity
+++ b/Assets/HoloToolkit-Examples/Sharing/SharingService/Scenes/SharingTest.unity
@@ -395,6 +395,11 @@ Prefab:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 223417620871411940, guid: 9a2f56337670a294baaf9bba300b1c1c,
+        type: 2}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1376606041}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 9a2f56337670a294baaf9bba300b1c1c, type: 2}
   m_IsPrefabParent: 0
@@ -600,6 +605,11 @@ Prefab:
 --- !u!4 &1376606040 stripped
 Transform:
   m_PrefabParentObject: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 1376606039}
+--- !u!20 &1376606041 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
     type: 2}
   m_PrefabInternal: {fileID: 1376606039}
 --- !u!1001 &1703234099

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/Scenes/SpatialUnderstandingExample.unity
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/Scenes/SpatialUnderstandingExample.unity
@@ -164,6 +164,11 @@ Transform:
   m_PrefabParentObject: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab,
     type: 2}
   m_PrefabInternal: {fileID: 14992882}
+--- !u!20 &14992884 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 14992882}
 --- !u!1001 &54805934
 Prefab:
   m_ObjectHideFlags: 0
@@ -2266,7 +2271,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 14992884}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1

--- a/Assets/HoloToolkit-Examples/UX/Materials/LineMeshesMaterial.mat
+++ b/Assets/HoloToolkit-Examples/UX/Materials/LineMeshesMaterial.mat
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: LineMeshesMaterial
+  m_Shader: {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _FORCEPERPIXEL_ON _SHADE4_ON _SPECULARHIGHLIGHTS_ON _USEAMBIENT_ON
+    _USEDIFFUSE_ON _USEMAINCOLOR_ON _USEVERTEXCOLOR_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CubeMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _GlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaTest: 0
+    - _BlendOp: 0
+    - _BumpScale: 1
+    - _CalibrationSpaceReflections: 0
+    - _ColorWriteMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _ForcePerPixel: 1
+    - _Gloss: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _ReflectionScale: 2
+    - _RimPower: 0.7
+    - _Shade4: 1
+    - _SmoothnessTextureChannel: 0
+    - _Specular: 10
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _UseAmbient: 1
+    - _UseBumpMap: 0
+    - _UseDiffuse: 1
+    - _UseEmissionColor: 0
+    - _UseEmissionMap: 0
+    - _UseGlossMap: 0
+    - _UseMainColor: 1
+    - _UseMainTex: 0
+    - _UseOcclusionMap: 0
+    - _UseReflections: 0
+    - _UseRimLighting: 0
+    - _UseSpecularMap: 0
+    - _UseVertexColor: 1
+    - _ZTest: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _RimColor: {r: 1, g: 1, b: 1, a: 1}
+    - _SpecColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _TextureScaleOffset: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/HoloToolkit-Examples/UX/Materials/LineMeshesMaterial.mat.meta
+++ b/Assets/HoloToolkit-Examples/UX/Materials/LineMeshesMaterial.mat.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 20978cf8cb27a50459a532d464f4fece
-folderAsset: yes
-timeCreated: 1509728667
+guid: 443e485ee15910c489d44ce79e71d700
+timeCreated: 1510008475
 licenseType: Free
-DefaultImporter:
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 2100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/HoloToolkit-Examples/UX/Materials/LineStripMeshMaterial.mat
+++ b/Assets/HoloToolkit-Examples/UX/Materials/LineStripMeshMaterial.mat
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: LineStripMeshMaterial
+  m_Shader: {fileID: 4800000, guid: f1f3948b20c230044bda31b620ddd37f, type: 3}
+  m_ShaderKeywords: _SHADE4_ON _USEAMBIENT_ON _USEDIFFUSE_ON _USEVERTEXCOLOR_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CubeMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _GlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaTest: 0
+    - _BlendOp: 0
+    - _BumpScale: 1
+    - _CalibrationSpaceReflections: 0
+    - _ColorWriteMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _ForcePerPixel: 0
+    - _Gloss: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 2
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _ReflectionScale: 2
+    - _RimPower: 0.7
+    - _Shade4: 1
+    - _SmoothnessTextureChannel: 0
+    - _Specular: 10
+    - _SpecularHighlights: 0
+    - _SrcBlend: 5
+    - _UVSec: 0
+    - _UseAmbient: 1
+    - _UseBumpMap: 0
+    - _UseDiffuse: 1
+    - _UseEmissionColor: 0
+    - _UseEmissionMap: 0
+    - _UseGlossMap: 0
+    - _UseMainColor: 0
+    - _UseMainTex: 0
+    - _UseOcclusionMap: 0
+    - _UseReflections: 0
+    - _UseRimLighting: 0
+    - _UseSpecularMap: 0
+    - _UseVertexColor: 1
+    - _ZTest: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _RimColor: {r: 1, g: 1, b: 1, a: 1}
+    - _SpecColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _TextureScaleOffset: {r: 1, g: 1, b: 0, a: 0}

--- a/Assets/HoloToolkit-Examples/UX/Materials/LineStripMeshMaterial.mat.meta
+++ b/Assets/HoloToolkit-Examples/UX/Materials/LineStripMeshMaterial.mat.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 20978cf8cb27a50459a532d464f4fece
-folderAsset: yes
-timeCreated: 1509728667
+guid: 864835bfd01299a49a9753a589ee4e01
+timeCreated: 1510008475
 licenseType: Free
-DefaultImporter:
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 2100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/HoloToolkit-Examples/UX/Scenes/LineExamples.unity
+++ b/Assets/HoloToolkit-Examples/UX/Scenes/LineExamples.unity
@@ -1,0 +1,1861 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 9
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &68185232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 68185233}
+  - component: {fileID: 68185235}
+  - component: {fileID: 68185234}
+  m_Layer: 0
+  m_Name: Spline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &68185233
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 68185232}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.21, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319818677}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &68185234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 68185232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b26c15dcaf594844ca59863543510699, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0.088
+  ManualUpVectors:
+  - {x: 0.11623266, y: 0.97558594, z: 0.1863387}
+  - {x: 0.10851363, y: 0.85639536, z: 0.50478876}
+  - {x: -0.44176802, y: 0.8753696, z: -0.19639021}
+  - {x: -0.30579388, y: 0.2691561, z: -0.9132607}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  points:
+  - Point: {x: 1.4592714, y: -2.0016334, z: -0.70751154}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -0.36896706, y: -1.374608, z: -1.7523116}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.499701, y: 0.5669091, z: -1.6824303}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.330956, y: 2.0922124, z: -0.8414527}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.1395226, y: 3.8225985, z: 0.112597406}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: 0.7535181, y: 2.9743414, z: 1.264758}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: 1.343995, y: 1.5389963, z: 1.0447944}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: 1.9680669, y: 0.021987557, z: 0.81231606}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -0.34781408, y: -1.2348026, z: -0.924934}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.572679, y: -1.8808163, z: 1.1909236}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  alignControlPoints: 1
+--- !u!114 &68185235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 68185232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9a4d6e2d0d55194788e9a2df9c0261f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 68185234}
+  LineColor:
+    serializedVersion: 2
+    key0: {r: 1, g: 0, b: 0, a: 1}
+    key1: {r: 0.32413816, g: 0, b: 1, a: 1}
+    key2: {r: 0, g: 0, b: 0, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 65535
+    ctime2: 0
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 2
+    m_NumAlphaKeys: 2
+  LineWidth:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  WidthMultiplier: 5
+  ColorOffset: 0
+  WidthOffset: 0
+  RotationOffset: 0
+  StepMode: 0
+  NumLineSteps: 32
+  InterpolationMode: 1
+  StepLength: 0.05
+  MaxLineSteps: 2048
+  StepLengthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: -0.5
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.5
+      inSlope: -0.5
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  LineMaterial: {fileID: 0}
+  RoundedEdges: 1
+  RoundedCaps: 1
+  lineRenderer: {fileID: 0}
+--- !u!1 &257019345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 257019346}
+  - component: {fileID: 257019348}
+  - component: {fileID: 257019347}
+  m_Layer: 0
+  m_Name: Ellipse
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &257019346
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 257019345}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.93, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319818677}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &257019347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 257019345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de408bb391ea251449125ebbb50d896c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 1
+  Resolution: 36
+  Radius: {x: 1, y: 0.5}
+--- !u!114 &257019348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 257019345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9a4d6e2d0d55194788e9a2df9c0261f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 257019347}
+  LineColor:
+    serializedVersion: 2
+    key0: {r: 0, g: 0.3372549, b: 1, a: 1}
+    key1: {r: 0.6336713, g: 0.62058824, b: 1, a: 1}
+    key2: {r: 0, g: 0.33793116, b: 1, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 33539
+    ctime2: 65535
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 3
+    m_NumAlphaKeys: 2
+  LineWidth:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  WidthMultiplier: 2
+  ColorOffset: 0
+  WidthOffset: 0
+  RotationOffset: 0
+  StepMode: 0
+  NumLineSteps: 16
+  InterpolationMode: 1
+  StepLength: 0.05
+  MaxLineSteps: 2048
+  StepLengthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: -0.5
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.5
+      inSlope: -0.5
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  LineMaterial: {fileID: 0}
+  RoundedEdges: 0
+  RoundedCaps: 0
+  lineRenderer: {fileID: 0}
+--- !u!1 &319818676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 319818677}
+  m_Layer: 0
+  m_Name: RenderedLines
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &319818677
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 319818676}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 68185233}
+  - {fileID: 479148581}
+  - {fileID: 257019346}
+  - {fileID: 459881475}
+  - {fileID: 466643704}
+  - {fileID: 1545707155}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &345617693
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 345617695}
+  - component: {fileID: 345617694}
+  m_Layer: 0
+  m_Name: Bezeir
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &345617694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 345617693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 692d8c30071cdf64a8e7bacd05759787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: -0.14835319, y: 0.6383629, z: 0.25319785}
+  - {x: -0.05724616, y: 0.6049619, z: 0.35267943}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  points:
+    Point1: {x: -0.4064849, y: -1.7324481, z: -4.8246646}
+    Point2: {x: 1.0307146, y: -0.86579084, z: -5.1624217}
+    Point3: {x: -1.9511347, y: 0.015818596, z: -5.4449763}
+    Point4: {x: -0.5034891, y: 0.98957634, z: -4.850485}
+--- !u!4 &345617695
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 345617693}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.106, y: 0, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 743511469}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &347587352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 347587354}
+  - component: {fileID: 347587353}
+  m_Layer: 0
+  m_Name: Rectangle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &347587353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 347587352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b92ef91b40f8354ca95d136161548ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 1
+  points:
+  - {x: -0.25, y: 0.5, z: 0}
+  - {x: 0, y: 0.5, z: 0}
+  - {x: 0.25, y: 0.5, z: 0}
+  - {x: 0.25, y: 0, z: 0}
+  - {x: 0.25, y: -0.5, z: 0}
+  - {x: 0, y: -0.5, z: 0}
+  - {x: -0.25, y: -0.5, z: 0}
+  - {x: -0.25, y: 0, z: 0}
+  xSize: 0.5
+  ySize: 1
+  zOffset: 0
+--- !u!4 &347587354
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 347587352}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 4.08, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 743511469}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &357511914
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 357511916}
+  - component: {fileID: 357511915}
+  m_Layer: 0
+  m_Name: Spline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &357511915
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 357511914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b26c15dcaf594844ca59863543510699, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0.088
+  ManualUpVectors:
+  - {x: 0.11623266, y: 0.97558594, z: 0.1863387}
+  - {x: 0.10851363, y: 0.85639536, z: 0.50478876}
+  - {x: -0.44176802, y: 0.8753696, z: -0.19639021}
+  - {x: -0.30579388, y: 0.2691561, z: -0.9132607}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  points:
+  - Point: {x: 1.4592714, y: -2.0016336, z: -0.70751154}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -0.36896706, y: -1.374608, z: -1.7523116}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.4997011, y: 0.56690884, z: -1.6824303}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.330956, y: 2.0922127, z: -0.8414527}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.1395226, y: 3.8225985, z: 0.11259693}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: 0.75351804, y: 2.9743423, z: 1.264758}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: 1.343995, y: 1.5389967, z: 1.0447944}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: 1.9680667, y: 0.021987915, z: 0.8123162}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -0.34781408, y: -1.2348027, z: -0.924934}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  - Point: {x: -1.572679, y: -1.8808165, z: 1.1909236}
+    Rotation: {x: 0, y: 0, z: 0, w: 0}
+  alignControlPoints: 1
+--- !u!4 &357511916
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 357511914}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.21, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 743511469}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &392644433
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 392644435}
+  - component: {fileID: 392644434}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &392644434
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 392644433}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &392644435
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 392644433}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &459881474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 459881475}
+  - component: {fileID: 459881477}
+  - component: {fileID: 459881476}
+  m_Layer: 0
+  m_Name: Rectangle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &459881475
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 459881474}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 4.08, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319818677}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &459881476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 459881474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b92ef91b40f8354ca95d136161548ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 1
+  points:
+  - {x: -0.25, y: 0.5, z: 0}
+  - {x: 0, y: 0.5, z: 0}
+  - {x: 0.25, y: 0.5, z: 0}
+  - {x: 0.25, y: 0, z: 0}
+  - {x: 0.25, y: -0.5, z: 0}
+  - {x: 0, y: -0.5, z: 0}
+  - {x: -0.25, y: -0.5, z: 0}
+  - {x: -0.25, y: 0, z: 0}
+  xSize: 0.5
+  ySize: 1
+  zOffset: 0
+--- !u!114 &459881477
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 459881474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9a4d6e2d0d55194788e9a2df9c0261f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 459881476}
+  LineColor:
+    serializedVersion: 2
+    key0: {r: 0, g: 1, b: 0.5862069, a: 1}
+    key1: {r: 0, g: 1, b: 0.58431375, a: 1}
+    key2: {r: 0, g: 0, b: 0, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 65535
+    ctime2: 0
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 2
+    m_NumAlphaKeys: 2
+  LineWidth:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  WidthMultiplier: 1
+  ColorOffset: 0
+  WidthOffset: 0
+  RotationOffset: 0
+  StepMode: 1
+  NumLineSteps: 10
+  InterpolationMode: 1
+  StepLength: 0.05
+  MaxLineSteps: 2048
+  StepLengthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: -0.5
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.5
+      inSlope: -0.5
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  LineMaterial: {fileID: 0}
+  RoundedEdges: 0
+  RoundedCaps: 0
+  lineRenderer: {fileID: 0}
+--- !u!1 &466643703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 466643704}
+  - component: {fileID: 466643706}
+  - component: {fileID: 466643705}
+  m_Layer: 0
+  m_Name: Line
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &466643704
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 466643703}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.05, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319818677}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &466643705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 466643703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bec4b46028f8fb94c9b03b88fca37bd6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  Start: {x: 0, y: 0, z: 0}
+  End: {x: 1.3511839, y: 0.416502, z: -0.31054688}
+--- !u!114 &466643706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 466643703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a32e3ee1459c3d46b0d52d9185d20f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 466643705}
+  LineColor:
+    serializedVersion: 2
+    key0: {r: 0.034482475, g: 0, b: 1, a: 1}
+    key1: {r: 1, g: 1, b: 1, a: 1}
+    key2: {r: 0, g: 0.6275863, b: 1, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 30069
+    ctime2: 65535
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 3
+    m_NumAlphaKeys: 2
+  LineWidth:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0.0008606387
+      value: 0.00032000523
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 0.49876612
+      value: 0.054248333
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1.0099163
+      value: 0.000045347027
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  WidthMultiplier: 2
+  ColorOffset: 0
+  WidthOffset: 0
+  RotationOffset: 0
+  StepMode: 0
+  NumLineSteps: 12
+  InterpolationMode: 1
+  StepLength: 0.05
+  MaxLineSteps: 2048
+  StepLengthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: -0.5
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.5
+      inSlope: -0.5
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  LineMesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+  LineMaterial: {fileID: 2100000, guid: 443e485ee15910c489d44ce79e71d700, type: 2}
+  ColorProp: _Color
+--- !u!1 &479148580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 479148581}
+  - component: {fileID: 479148583}
+  - component: {fileID: 479148582}
+  m_Layer: 0
+  m_Name: Bezeir
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &479148581
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 479148580}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.106, y: 0, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319818677}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &479148582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 479148580}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 692d8c30071cdf64a8e7bacd05759787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: -0.14835319, y: 0.6383629, z: 0.25319785}
+  - {x: -0.05724616, y: 0.6049619, z: 0.35267943}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  points:
+    Point1: {x: -0.4064849, y: -1.732448, z: -4.8246646}
+    Point2: {x: 1.0307146, y: -0.865791, z: -5.1624217}
+    Point3: {x: -1.9511347, y: 0.015818872, z: -5.4449763}
+    Point4: {x: -0.5034891, y: 0.9895762, z: -4.850485}
+--- !u!114 &479148583
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 479148580}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9a4d6e2d0d55194788e9a2df9c0261f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 479148582}
+  LineColor:
+    serializedVersion: 2
+    key0: {r: 0, g: 0.37931037, b: 1, a: 1}
+    key1: {r: 0.19999993, g: 1, b: 0, a: 1}
+    key2: {r: 0, g: 0, b: 0, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 193
+    ctime1: 65535
+    ctime2: 0
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 2
+    m_NumAlphaKeys: 2
+  LineWidth:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 0.5146119
+      value: 0.11853409
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  WidthMultiplier: 4
+  ColorOffset: 0
+  WidthOffset: 0
+  RotationOffset: 0
+  StepMode: 0
+  NumLineSteps: 10
+  InterpolationMode: 1
+  StepLength: 0.05
+  MaxLineSteps: 2048
+  StepLengthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: -0.5
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.5
+      inSlope: -0.5
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  LineMaterial: {fileID: 0}
+  RoundedEdges: 1
+  RoundedCaps: 1
+  lineRenderer: {fileID: 0}
+--- !u!1 &513206123
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 513206124}
+  - component: {fileID: 513206125}
+  m_Layer: 0
+  m_Name: Parabola
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &513206124
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513206123}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 8.23, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 743511469}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &513206125
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513206123}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 080153f9f59bd554bad10c8b12d0441b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 2
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  Start: {x: 0, y: 0, z: 0}
+  End: {x: -0.06714821, y: -0.6343212, z: -2.5837512}
+  UpDirection: {x: 0, y: 1, z: 0}
+  Height: 1.5928516
+--- !u!1 &612022513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 612022515}
+  - component: {fileID: 612022514}
+  m_Layer: 0
+  m_Name: Line
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &612022514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 612022513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bec4b46028f8fb94c9b03b88fca37bd6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  Start: {x: 0, y: 0, z: 0}
+  End: {x: 1.3511839, y: 0.416502, z: -0.31054688}
+--- !u!4 &612022515
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 612022513}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.05, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 743511469}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &743511468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 743511469}
+  m_Layer: 0
+  m_Name: EmptyLines
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &743511469
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 743511468}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 357511916}
+  - {fileID: 345617695}
+  - {fileID: 1597375028}
+  - {fileID: 347587354}
+  - {fileID: 612022515}
+  - {fileID: 513206124}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1545707154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1545707155}
+  - component: {fileID: 1545707156}
+  - component: {fileID: 1545707157}
+  m_Layer: 0
+  m_Name: Parabola
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1545707155
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1545707154}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 8.23, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319818677}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1545707156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1545707154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f751061e95bd99d4eb0a74afe2692c60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 1545707157}
+  LineColor:
+    serializedVersion: 2
+    key0: {r: 1, g: 0, b: 0, a: 0}
+    key1: {r: 1, g: 0.6827586, b: 0, a: 1}
+    key2: {r: 0, g: 0, b: 0, a: 1}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 65535
+    ctime2: 0
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 13493
+    atime2: 54741
+    atime3: 65535
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 2
+    m_NumAlphaKeys: 4
+  LineWidth:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.05
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  WidthMultiplier: 2.3
+  ColorOffset: 0
+  WidthOffset: 0
+  RotationOffset: 0
+  StepMode: 0
+  NumLineSteps: 10
+  InterpolationMode: 1
+  StepLength: 0.05
+  MaxLineSteps: 2048
+  StepLengthCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: -0.5
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 0.5
+      inSlope: -0.5
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  LineMaterial: {fileID: 2100000, guid: 864835bfd01299a49a9753a589ee4e01, type: 2}
+  Forward: {x: 0, y: 0, z: 0}
+  uvOffset: 0
+--- !u!114 &1545707157
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1545707154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 080153f9f59bd554bad10c8b12d0441b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 2
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  - {x: 0, y: 1, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  Start: {x: 0, y: 0, z: 0}
+  End: {x: -0.06714821, y: -0.63432145, z: -2.5837512}
+  UpDirection: {x: 0, y: 1, z: 0}
+  Height: 1.5928516
+--- !u!1 &1597375026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1597375028}
+  - component: {fileID: 1597375027}
+  m_Layer: 0
+  m_Name: Ellipse
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1597375027
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1597375026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de408bb391ea251449125ebbb50d896c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LineStartClamp: 0
+  LineEndClamp: 1
+  RotationType: 1
+  FlipUpVector: 0
+  OriginOffset: {x: 0, y: 0, z: 0}
+  ManualUpVectorBlend: 0
+  ManualUpVectors:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}
+  VelocitySearchRange: 0.02
+  VelocityBlend: 0.5
+  DistortionType: 0
+  DistortionStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  UniformDistortionStrength: 1
+  distorters: []
+  loops: 0
+  Resolution: 36
+  Radius: {x: 1, y: 0.5}
+--- !u!4 &1597375028
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1597375026}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.93, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 743511469}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2024796189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2024796193}
+  - component: {fileID: 2024796192}
+  - component: {fileID: 2024796191}
+  - component: {fileID: 2024796190}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2024796190
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2024796189}
+  m_Enabled: 1
+--- !u!124 &2024796191
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2024796189}
+  m_Enabled: 1
+--- !u!20 &2024796192
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2024796189}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2024796193
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2024796189}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/HoloToolkit-Examples/UX/Scenes/LineExamples.unity.meta
+++ b/Assets/HoloToolkit-Examples/UX/Scenes/LineExamples.unity.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 20978cf8cb27a50459a532d464f4fece
-folderAsset: yes
-timeCreated: 1509728667
+guid: 99ef5a9e6d2236e47966a07ac01be657
+timeCreated: 1510002000
 licenseType: Free
 DefaultImporter:
   externalObjects: {}

--- a/Assets/HoloToolkit-Examples/UX/Scenes/TextPrefabSamplesTest.unity
+++ b/Assets/HoloToolkit-Examples/UX/Scenes/TextPrefabSamplesTest.unity
@@ -209,6 +209,11 @@ Prefab:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 223000011899940670, guid: 72ede623ddd22404eab348f24dab8757,
+        type: 2}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1206782514}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 72ede623ddd22404eab348f24dab8757, type: 2}
   m_IsPrefabParent: 0
@@ -508,3 +513,8 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &1206782514 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 1206782513}

--- a/Assets/HoloToolkit-Examples/Utilities/Scenes/TextToSpeechManager.unity
+++ b/Assets/HoloToolkit-Examples/Utilities/Scenes/TextToSpeechManager.unity
@@ -643,6 +643,11 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!20 &994161603 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20049547090947856, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    type: 2}
+  m_PrefabInternal: {fileID: 994161602}
 --- !u!1001 &1220876088
 Prefab:
   m_ObjectHideFlags: 0
@@ -1215,7 +1220,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 994161603}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1

--- a/Assets/HoloToolkit/Input/Prefabs/InputManager.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/InputManager.prefab
@@ -64,6 +64,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1715063577476300
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4977849313536866}
+  - component: {fileID: 20049547090947856}
+  m_Layer: 0
+  m_Name: RaycastCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1734860659464010
 GameObject:
   m_ObjectHideFlags: 0
@@ -149,7 +165,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 4977849313536866}
   m_Father: {fileID: 4000011656901714}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -166,6 +183,54 @@ Transform:
   m_Father: {fileID: 4000011656901714}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4977849313536866
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1715063577476300}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4521646291090770}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &20049547090947856
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1715063577476300}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 3
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 0.5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967291
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!114 &114000011980027866
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -289,6 +354,7 @@ MonoBehaviour:
   autoRegisterGazePointerIfNoPointersRegistered: 1
   debugDrawPointingRays: 0
   debugDrawPointingRayColors: []
+  uiRaycastCamera: {fileID: 20049547090947856}
 --- !u!114 &114742747811649402
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -290,7 +290,8 @@ namespace HoloToolkit.Unity.InputModule
             GameObject newTargetedObject = focusDetails.Object;
 
             // Get the forward vector looking back along the pointing ray.
-            Vector3 lookForward = -Pointer.Ray.direction;
+            RayStep lastStep = Pointer.Rays[Pointer.Rays.Length - 1];
+            Vector3 lookForward = -lastStep.direction;
 
             // Normalize scale on before update
             targetScale = Vector3.one;
@@ -300,7 +301,7 @@ namespace HoloToolkit.Unity.InputModule
             {
                 TargetedObject = null;
                 TargetedCursorModifier = null;
-                targetPosition = Pointer.Ray.origin + Pointer.Ray.direction * DefaultCursorDistance;
+                targetPosition = lastStep.terminus;
                 targetRotation = lookForward.magnitude > 0 ? Quaternion.LookRotation(lookForward, Vector3.up) : transform.rotation;
             }
             else

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/CursorModifier.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/CursorModifier.cs
@@ -78,7 +78,8 @@ namespace HoloToolkit.Unity.InputModule
         {
             Quaternion rotation;
 
-            Vector3 forward = UseGazeBasedNormal ? -cursor.Pointer.Ray.direction : HostTransform.rotation * CursorNormal;
+            RayStep lastStep = cursor.Pointer.Rays[cursor.Pointer.Rays.Length - 1];
+            Vector3 forward = UseGazeBasedNormal ? -lastStep.direction : HostTransform.rotation * CursorNormal;
 
             // Determine the cursor forward
             if (forward.magnitude > 0)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusDetails.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusDetails.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
@@ -9,6 +10,7 @@ namespace HoloToolkit.Unity.InputModule
     /// FocusDetails struct contains information about which game object has the focus currently.
     /// Also contains information about the normal of that point.
     /// </summary>
+    [Serializable]
     public struct FocusDetails
     {
         public Vector3 Point;

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -151,7 +151,7 @@ namespace HoloToolkit.Unity.InputModule
                 PointingSource = pointingSource;
             }
 
-            [Obsolete]
+            [Obsolete ("Use UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex) or UpdateHit (float extent)")]
             public void UpdateHit(RaycastHit hit)
             {
                 throw new NotImplementedException();
@@ -497,8 +497,10 @@ namespace HoloToolkit.Unity.InputModule
 
         private void UpdatePointer(PointerData pointer)
         {
-            // Call the pointer's update function first
-            pointer.PointingSource.UpdatePointer();
+            // Call the pointer's OnPreRaycast function
+            // This will give it a chance to prepare itself for raycasts
+            // eg, by building its Rays array
+            pointer.PointingSource.OnPreRaycast();
 
             // If pointer interaction isn't enabled, clear its result object and return
             if (!pointer.PointingSource.InteractionEnabled)
@@ -523,6 +525,11 @@ namespace HoloToolkit.Unity.InputModule
 
             // Set the pointer's result last
             pointer.PointingSource.Result = pointer;
+
+            // Call the pointer's OnPostRaycast function
+            // This will give it a chance to respond to raycast results
+            // eg by updating its appearance
+            pointer.PointingSource.OnPostRaycast();
         }
 
         /// <summary>
@@ -627,8 +634,8 @@ namespace HoloToolkit.Unity.InputModule
         private bool RaycastUnityUIStep(PointerData pointer, RayStep step, LayerMask[] prioritizedLayerMasks, out bool overridePhysicsRaycast, out RaycastResult uiRaycastResult)
         {
             // Move the uiRaycast camera to the the current pointer's position.
-            UIRaycastCamera.transform.position = pointer.PointingSource.Ray.origin;
-            UIRaycastCamera.transform.forward = pointer.PointingSource.Ray.direction;
+            UIRaycastCamera.transform.position = step.origin;
+            UIRaycastCamera.transform.forward = step.direction;
 
             // We always raycast from the center of the camera.
             pointer.UnityUIPointerData.position = new Vector2(UIRaycastCamera.pixelWidth * 0.5f, UIRaycastCamera.pixelHeight * 0.5f);

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -141,11 +141,11 @@ namespace HoloToolkit.Unity.InputModule
                     {
                         pointerData = new PointerInputEventData(EventSystem.current);
                     }
-
+                    
                     return pointerData;
                 }
             }
-
+            
             public PointerData(IPointingSource pointingSource)
             {
                 PointingSource = pointingSource;

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -158,8 +158,14 @@ namespace HoloToolkit.Unity.InputModule
             {
                 PointingSource = pointingSource;
             }
-
+			
+			[Obsolete]
             public void UpdateHit(RaycastHit hit)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex)
             {
                 LastRaycastHit = hit;
                 PreviousEndObject = End.Object;
@@ -199,10 +205,14 @@ namespace HoloToolkit.Unity.InputModule
                     Object = null
                 };
             }
-
-            public void ResetFocusedObjects()
+           
+            public void ResetFocusedObjects(bool clearPreviousObject = true)
             {
-                PreviousEndObject = null;
+                if (clearPreviousObject)
+                {
+                    PreviousEndObject = null;
+                }
+
                 End = new FocusDetails
                 {
                     Point = End.Point,

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -131,7 +131,7 @@ namespace HoloToolkit.Unity.InputModule
         private class PointerData : PointerResult
         {
             public readonly IPointingSource PointingSource;
-            
+
             private PointerInputEventData pointerData;
             public PointerInputEventData UnityUIPointerData
             {
@@ -141,17 +141,17 @@ namespace HoloToolkit.Unity.InputModule
                     {
                         pointerData = new PointerInputEventData(EventSystem.current);
                     }
-                    
+
                     return pointerData;
                 }
             }
-            
+
             public PointerData(IPointingSource pointingSource)
             {
                 PointingSource = pointingSource;
             }
 
-            [Obsolete ("Use UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex) or UpdateHit (float extent)")]
+            [Obsolete("Use UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex) or UpdateHit (float extent)")]
             public void UpdateHit(RaycastHit hit)
             {
                 throw new NotImplementedException();
@@ -203,7 +203,7 @@ namespace HoloToolkit.Unity.InputModule
                     Object = null
                 };
             }
-           
+
             public void ResetFocusedObjects(bool clearPreviousObject = true)
             {
                 if (clearPreviousObject)
@@ -579,7 +579,7 @@ namespace HoloToolkit.Unity.InputModule
             else
             {
                 // Raycast across all layers and prioritize
-                RaycastHit? hit = PrioritizeHits(Physics.RaycastAll(step.origin, step.direction, step.length, /*All layers*/ -1), prioritizedLayerMasks);
+                RaycastHit? hit = PrioritizeHits(Physics.RaycastAll(step.origin, step.direction, step.length, Physics.AllLayers), prioritizedLayerMasks);
                 isHit = hit.HasValue;
 
                 if (isHit)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -11,7 +12,10 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IPointingSource
     {
+        [Obsolete]
         Ray Ray { get; }
+
+        RayStep[] Rays { get; }
 
         float? ExtentOverride { get; }
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -16,7 +16,7 @@ namespace HoloToolkit.Unity.InputModule
 
         float? ExtentOverride { get; }
 
-        [Obsolete("Will be removed in a later version. For equivalent behavior return a RayStep array with a single element.")]
+        [Obsolete("Will be removed in a later version. For equivalent behavior have Rays return a RayStep array with a single element.")]
         Ray Ray { get; }
 
         RayStep[] Rays { get; }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -12,14 +12,18 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IPointingSource
     {
+        bool InteractionEnabled { get; }
+
+        float? ExtentOverride { get; }
+
         [Obsolete]
         Ray Ray { get; }
 
         RayStep[] Rays { get; }
 
-        float? ExtentOverride { get; }
-
         LayerMask[] PrioritizedLayerMasksOverride { get; }
+
+        PointerResult Result { get; set; }
 
         void UpdatePointer();
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -16,7 +16,7 @@ namespace HoloToolkit.Unity.InputModule
 
         float? ExtentOverride { get; }
 
-        [Obsolete]
+        [Obsolete("Will be removed in a later version. For equivalent behavior return a RayStep array with a single element.")]
         Ray Ray { get; }
 
         RayStep[] Rays { get; }
@@ -25,7 +25,9 @@ namespace HoloToolkit.Unity.InputModule
 
         PointerResult Result { get; set; }
 
-        void UpdatePointer();
+        void OnPreRaycast();
+
+        void OnPostRaycast();
 
         bool OwnsInput(BaseEventData eventData);
     }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -20,39 +20,54 @@ namespace HoloToolkit.Unity.InputModule
         public BaseRayStabilizer RayStabilizer { get; set; }
 
         public bool OwnAllInput { get; set; }
-        
+
         [Obsolete]
         public Ray Ray { get { return Rays[0]; } }
 
         public RayStep[] Rays {
             get
             {
-                return new RayStep(rawRay.origin, rawRay.origin + rawRay.direction);
+                return rays;
             }
         }
+
+        public PointerResult Result { get; set; }
 
         public float? ExtentOverride { get; set; }
 
         public LayerMask[] PrioritizedLayerMasksOverride { get; set; }
 
-        private Ray rawRay = default(Ray);
+        public bool InteractionEnabled
+        {
+            get
+            {
+                return true;
+            }
+        }
 
+        private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.forward) };
+        
         public void UpdatePointer()
         {
             if (InputSource == null)
             {
-                rawRay = default(Ray);
+                rays[0] = default(RayStep);
             }
             else
             {
                 Debug.Assert(InputSource.SupportsInputInfo(InputSourceId, SupportedInputInfo.Pointing));
 
-                InputSource.TryGetPointingRay(InputSourceId, out rawRay);
+                Ray pointingRay = default(Ray);
+                if (InputSource.TryGetPointingRay(InputSourceId, out pointingRay))
+                {
+                    rays[0].CopyRay(pointingRay, FocusManager.Instance.GetPointingExtent (this));
+                }
             }
 
             if (RayStabilizer != null)
             {
-                RayStabilizer.UpdateStability(rawRay.origin, rawRay.direction);
+                RayStabilizer.UpdateStability(rays[0].origin, rays[0].direction);
+                rays[0].CopyRay(RayStabilizer.StableRay, FocusManager.Instance.GetPointingExtent(this));
             }
         }
 
@@ -68,6 +83,6 @@ namespace HoloToolkit.Unity.InputModule
             return (inputData != null)
                 && (inputData.InputSource == InputSource)
                 && (inputData.SourceId == InputSourceId);
-        }
+        }    
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -21,7 +21,7 @@ namespace HoloToolkit.Unity.InputModule
 
         public bool OwnAllInput { get; set; }
 
-        [Obsolete]
+        [Obsolete("Will be removed in a later version. Use Rays instead.")]
         public Ray Ray { get { return Rays[0]; } }
 
         public RayStep[] Rays {
@@ -47,7 +47,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.forward) };
         
-        public void UpdatePointer()
+        public void OnPreRaycast()
         {
             if (InputSource == null)
             {
@@ -69,6 +69,11 @@ namespace HoloToolkit.Unity.InputModule
                 RayStabilizer.UpdateStability(rays[0].origin, rays[0].direction);
                 rays[0].CopyRay(RayStabilizer.StableRay, FocusManager.Instance.GetPointingExtent(this));
             }
+        }
+
+        public void OnPostRaycast()
+        {
+            // Nothing needed
         }
 
         public bool OwnsInput(BaseEventData eventData)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -19,14 +20,14 @@ namespace HoloToolkit.Unity.InputModule
         public BaseRayStabilizer RayStabilizer { get; set; }
 
         public bool OwnAllInput { get; set; }
+        
+        [Obsolete]
+        public Ray Ray { get { return Rays[0]; } }
 
-        public Ray Ray
-        {
+        public RayStep[] Rays {
             get
             {
-                return (RayStabilizer == null)
-                    ? rawRay
-                    : RayStabilizer.StableRay;
+                return new RayStep(rawRay.origin, rawRay.origin + rawRay.direction);
             }
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.InputModule
+{
+    [Serializable]
+    public class PointerResult
+    {
+        public Vector3 StartPoint { get; protected set; }
+
+        public FocusDetails End { get; protected set; }
+
+        public GameObject PreviousEndObject { get; protected set; }
+
+        public RaycastHit LastRaycastHit { get; protected set; }
+
+        /// <summary>
+        /// The index of the step that produced the last raycast hit
+        /// 0 when no raycast hit
+        /// </summary>
+        public int RayStepIndex { get; protected set; }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: b87b365aaff84aa4a9f18f6323d917e5
+timeCreated: 1510163952
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    [Serializable]
+    public struct RayStep
+    {
+        public RayStep(Vector3 origin, Vector3 terminus)
+        {
+            this.origin = origin;
+            this.terminus = terminus;
+            length = Vector3.Distance(origin, terminus);
+            direction = (this.terminus - this.origin).normalized;
+        }
+
+        public Vector3 origin { get; private set; }
+        public Vector3 terminus { get; private set; }
+        public Vector3 direction { get; private set; }
+        public float length { get; private set; }
+
+        public Vector3 GetPoint(float distance)
+        {
+            return Vector3.MoveTowards(origin, terminus, distance);
+        }
+
+        public void CopyRay (Ray ray, float rayLength)
+        {
+            length = rayLength;
+            origin = ray.origin;
+            direction = ray.direction;
+            terminus = origin + (direction * length);
+        }
+
+        public static implicit operator Ray(RayStep r)
+        {
+            return new Ray(r.origin, r.direction);
+        }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
@@ -24,6 +24,14 @@ namespace HoloToolkit.Unity
             return Vector3.MoveTowards(origin, terminus, distance);
         }
 
+        public void UpdateRaystep(Vector3 newOrigin, Vector3 newTerminus)
+        {
+            origin = origin;
+            terminus = terminus;
+            length = Vector3.Distance(origin, terminus);
+            direction = (this.terminus - this.origin).normalized;
+        }
+
         public void CopyRay (Ray ray, float rayLength)
         {
             length = rayLength;

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
@@ -24,10 +24,10 @@ namespace HoloToolkit.Unity
             return Vector3.MoveTowards(origin, terminus, distance);
         }
 
-        public void UpdateRaystep(Vector3 newOrigin, Vector3 newTerminus)
+        public void UpdateRayStep(Vector3 origin, Vector3 terminus)
         {
-            origin = origin;
-            terminus = terminus;
+            this.origin = origin;
+            this.terminus = terminus;
             length = Vector3.Distance(origin, terminus);
             direction = (this.terminus - this.origin).normalized;
         }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d4f2bb3817435f84a8471a990b4820c2
+timeCreated: 1509375252
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -29,6 +29,7 @@ namespace HoloToolkit.Unity.InputModule
         #region Data
 
         private bool started;
+        private bool pointerWasChanged;
 
         private bool addedInputManagerListener;
         private IPointingSource currentPointer;
@@ -86,7 +87,7 @@ namespace HoloToolkit.Unity.InputModule
 
         void IInputHandler.OnInputUp(InputEventData eventData)
         {
-            // Nothing to do on input up.
+            // Let the input fall to the next interactable object.
         }
 
         void IInputHandler.OnInputDown(InputEventData eventData)
@@ -177,12 +178,13 @@ namespace HoloToolkit.Unity.InputModule
         private void ConnectBestAvailablePointer()
         {
             IPointingSource bestPointer = null;
+            var inputSources = InputManager.Instance.DetectedInputSources;
 
-            foreach (var detectedSource in InputManager.Instance.DetectedInputSources)
+            for (var i = 0; i < inputSources.Count; i++)
             {
-                if (SupportsPointingRay(detectedSource))
+                if (SupportsPointingRay(inputSources[i]))
                 {
-                    AttachInputSourcePointer(detectedSource);
+                    AttachInputSourcePointer(inputSources[i]);
                     bestPointer = inputSourcePointer;
                     break;
                 }
@@ -201,8 +203,6 @@ namespace HoloToolkit.Unity.InputModule
             // TODO: robertes: Investigate how this feels. Since "Down" will often be followed by "Click", is
             //       marking the event as used actually effective in preventing unintended app input during a
             //       pointer change?
-
-            bool pointerWasChanged;
 
             if (SupportsPointingRay(eventData))
             {

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -65,7 +65,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         public Vector3 GazeOrigin
         {
-            get { return Ray.origin; }
+            get { return FirstRay.origin; }
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         public Vector3 GazeNormal
         {
-            get { return Ray.direction; }
+            get { return FirstRay.direction; }
         }
 
         /// <summary>
@@ -112,6 +112,7 @@ namespace HoloToolkit.Unity.InputModule
 
         [Tooltip("True to draw a debug view of the ray.")]
         public bool DebugDrawRay;
+        public PointerResult Result { get; set; }
 
         [Obsolete]
         public Ray Ray { get { return Rays[0]; } }
@@ -130,6 +131,14 @@ namespace HoloToolkit.Unity.InputModule
         public LayerMask[] PrioritizedLayerMasksOverride
         {
             get { return RaycastLayerMasks; }
+        }
+
+        public bool InteractionEnabled
+        {
+            get
+            {
+                return true;
+            }
         }
 
         private float lastHitDistance = 2.0f;
@@ -181,7 +190,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (GazeTransform == null)
             {
-                Ray = default(Ray);
+                FirstRay = default(RayStep);
             }
             else
             {
@@ -196,7 +205,7 @@ namespace HoloToolkit.Unity.InputModule
                     newGazeNormal = Stabilizer.StableRay.direction;
                 }
 
-                Ray = new Ray(newGazeOrigin, newGazeNormal);
+                FirstRay = new RayStep(newGazeOrigin, newGazeOrigin + newGazeNormal);
             }
 
             UpdateHitPosition();
@@ -228,7 +237,7 @@ namespace HoloToolkit.Unity.InputModule
 
             if (focusDetails.Object != null)
             {
-                lastHitDistance = (focusDetails.Point - Ray.origin).magnitude;
+                lastHitDistance = (focusDetails.Point - FirstRay.origin).magnitude;
                 UpdateHitPosition();
                 HitNormal = focusDetails.Normal;
             }
@@ -236,7 +245,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private void UpdateHitPosition()
         {
-            HitPosition = (Ray.origin + (lastHitDistance * Ray.direction));
+            HitPosition = (FirstRay.origin + (lastHitDistance * FirstRay.direction));
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -205,7 +205,7 @@ namespace HoloToolkit.Unity.InputModule
                     newGazeNormal = Stabilizer.StableRay.direction;
                 }
 
-                FirstRay = new RayStep(newGazeOrigin, newGazeOrigin + newGazeNormal);
+                FirstRay.UpdateRaystep(newGazeOrigin, newGazeOrigin + newGazeNormal);
             }
 
             UpdateHitPosition();

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -113,10 +113,10 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("True to draw a debug view of the ray.")]
         public bool DebugDrawRay;
         public PointerResult Result { get; set; }
-
+        
         [Obsolete]
         public Ray Ray { get { return Rays[0]; } }
-
+        
         public RayStep[] Rays { get { return rays; } }
 
         private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.zero) };

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -113,8 +113,15 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("True to draw a debug view of the ray.")]
         public bool DebugDrawRay;
 
-        public Ray Ray { get; private set; }
+        [Obsolete]
+        public Ray Ray { get { return Rays[0]; } }
 
+        public RayStep[] Rays { get { return rays; } }
+
+        private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.zero) };
+
+        private RayStep FirstRay { get { return rays[0]; } set { rays[0] = value; } }
+ 
         public float? ExtentOverride
         {
             get { return MaxGazeCollisionDistance; }

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -65,7 +65,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         public Vector3 GazeOrigin
         {
-            get { return FirstRay.origin; }
+            get { return Rays[0].origin; }
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         public Vector3 GazeNormal
         {
-            get { return FirstRay.direction; }
+            get { return Rays[0].direction; }
         }
 
         /// <summary>
@@ -120,8 +120,6 @@ namespace HoloToolkit.Unity.InputModule
         public RayStep[] Rays { get { return rays; } }
 
         private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.zero) };
-
-        private RayStep FirstRay { get { return rays[0]; } set { rays[0] = value; } }
  
         public float? ExtentOverride
         {
@@ -190,7 +188,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (GazeTransform == null)
             {
-                FirstRay = default(RayStep);
+                Rays[0] = default(RayStep);
             }
             else
             {
@@ -205,7 +203,7 @@ namespace HoloToolkit.Unity.InputModule
                     newGazeNormal = Stabilizer.StableRay.direction;
                 }
 
-                FirstRay.UpdateRaystep(newGazeOrigin, newGazeOrigin + newGazeNormal);
+                Rays[0].UpdateRayStep(newGazeOrigin, newGazeOrigin + (newGazeNormal * FocusManager.Instance.GetPointingExtent (this)));
             }
 
             UpdateHitPosition();
@@ -242,7 +240,7 @@ namespace HoloToolkit.Unity.InputModule
 
             if (focusDetails.Object != null)
             {
-                lastHitDistance = (focusDetails.Point - FirstRay.origin).magnitude;
+                lastHitDistance = (focusDetails.Point - Rays[0].origin).magnitude;
                 UpdateHitPosition();
                 HitNormal = focusDetails.Normal;
             }
@@ -250,7 +248,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private void UpdateHitPosition()
         {
-            HitPosition = (FirstRay.origin + (lastHitDistance * FirstRay.direction));
+            HitPosition = (Rays[0].origin + (lastHitDistance * Rays[0].direction));
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -114,7 +114,7 @@ namespace HoloToolkit.Unity.InputModule
         public bool DebugDrawRay;
         public PointerResult Result { get; set; }
         
-        [Obsolete]
+        [Obsolete("Will be removed in a later version. Use Rays instead.")]
         public Ray Ray { get { return Rays[0]; } }
         
         public RayStep[] Rays { get { return rays; } }
@@ -211,9 +211,14 @@ namespace HoloToolkit.Unity.InputModule
             UpdateHitPosition();
         }
 
-        public void UpdatePointer()
+        public void OnPreRaycast()
         {
             UpdateGazeInfo();
+        }
+
+        public void OnPostRaycast()
+        {
+            // Nothing needed
         }
 
         public bool OwnsInput(BaseEventData eventData)

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
@@ -909,12 +909,26 @@ namespace HoloToolkit.Unity.InputModule
 
         private void InteractionManager_InteractionSourceReleased(InteractionSourceReleasedEventArgs args)
         {
-            InputManager.Instance.RaiseSourceUp(this, args.state.source.id, (InteractionSourcePressInfo)args.pressType);
+            var pressType = (InteractionSourcePressInfo)args.pressType;
+            // HACK: If we're not dealing with a spatial controller we may not get Select called properly
+            if (args.state.source.kind != InteractionSourceKind.Controller)
+            {
+                pressType = InteractionSourcePressInfo.Select;
+            }
+
+            InputManager.Instance.RaiseSourceUp(this, args.state.source.id, pressType);
         }
 
         private void InteractionManager_InteractionSourcePressed(InteractionSourcePressedEventArgs args)
         {
-            InputManager.Instance.RaiseSourceDown(this, args.state.source.id, (InteractionSourcePressInfo)args.pressType);
+            var pressType = (InteractionSourcePressInfo)args.pressType;
+            // HACK: If we're not dealing with a spatial controller we may not get Select called properly
+            if (args.state.source.kind != InteractionSourceKind.Controller)
+            {
+                pressType = InteractionSourcePressInfo.Select;
+            }
+
+            InputManager.Instance.RaiseSourceDown(this, args.state.source.id, pressType);
         }
 
         private void InteractionManager_InteractionSourceLost(InteractionSourceLostEventArgs args)
@@ -1052,22 +1066,12 @@ namespace HoloToolkit.Unity.InputModule
 
         private void InteractionManager_InteractionSourceReleased(InteractionSourceState state)
         {
-            InputManager.Instance.RaiseSourceUp(this, state.source.id,
-#if UNITY_2017_2_OR_NEWER
-                (InteractionSourcePressInfo)args.pressType);
-#else
-                InteractionSourcePressInfo.Select);
-#endif
+            InputManager.Instance.RaiseSourceUp(this, state.source.id, InteractionSourcePressInfo.Select);
         }
 
         private void InteractionManager_InteractionSourcePressed(InteractionSourceState state)
         {
-            InputManager.Instance.RaiseSourceDown(this, state.source.id,
-#if UNITY_2017_2_OR_NEWER
-                (InteractionSourcePressInfo)args.pressType);
-#else
-                InteractionSourcePressInfo.Select);
-#endif
+            InputManager.Instance.RaiseSourceDown(this, state.source.id, InteractionSourcePressInfo.Select);
         }
 
         private void InteractionManager_InteractionSourceLost(InteractionSourceState state)

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/SpeechInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/SpeechInputSource.cs
@@ -54,7 +54,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (PersistentKeywords)
             {
-                DontDestroyOnLoad(gameObject);
+                gameObject.DontDestroyOnLoad();
             }
 
             int keywordCount = Keywords.Length;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/CustomInputSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/CustomInputSelector.cs
@@ -54,11 +54,11 @@ namespace HoloToolkit.Unity.InputModule
             bool spawnControllers = false;
 
 #if UNITY_2017_2_OR_NEWER
-            spawnControllers = !XRDevice.isPresent;
+            spawnControllers = (!XRDevice.isPresent && XRSettings.enabled || Application.isEditor) && simulateHandsInEditor;
 #else
             spawnControllers = !VRDevice.isPresent;
 #endif
-            if (spawnControllers && Application.isEditor && simulateHandsInEditor)
+            if (spawnControllers)
             {
                 sourceType = InputSourceType.Hand;
                 sourceNumber = InputSourceNumber.Two;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
@@ -72,7 +72,8 @@ namespace HoloToolkit.Unity.InputModule
         /// <summary>
         /// Should the Unity UI events be fired?
         /// </summary>
-        public bool ShouldSendUnityUiEvents { get { return FocusManager.Instance.UnityUIPointerEvent != null && EventSystem.current != null; } }
+        [Obsolete("Will be removed in a future release.  If you need to know if a specific pointer should send Unity UI Events use FocusManager.Instance.GetSpecificPointerEventData()!=null")]
+        public bool ShouldSendUnityUiEvents { get { return FocusManager.Instance.GetGazePointerEventData() != null && EventSystem.current != null; } }
 
         /// <summary>
         /// Push a game object into the modal input stack. Any input handlers
@@ -89,7 +90,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         public void PopModalInputHandler()
         {
-            if (modalInputStack.Count>0)
+            if (modalInputStack.Count > 0)
             {
                 modalInputStack.Pop();
 
@@ -232,57 +233,6 @@ namespace HoloToolkit.Unity.InputModule
 
         #endregion // Unity APIs
 
-        /// <summary>
-        /// Raise the event OnFocusEnter to the game object when focus enters it.
-        /// </summary>
-        /// <param name="focusedObject"></param>
-        public void RaiseFocusEnter(GameObject focusedObject)
-        {
-            ExecuteEvents.ExecuteHierarchy(focusedObject, null, OnFocusEnterEventHandler);
-
-            if (ShouldSendUnityUiEvents)
-            {
-                PointerInputEventData pointerInputEventData = FocusManager.Instance.GetPointerEventData();
-                ExecuteEvents.ExecuteHierarchy(focusedObject, pointerInputEventData, ExecuteEvents.pointerEnterHandler);
-            }
-        }
-
-        /// <summary>
-        /// Raise the event OnFocusExit to the game object when focus exists it.
-        /// </summary>
-        /// <param name="deFocusedObject"></param>
-        public void RaiseFocusExit(GameObject deFocusedObject)
-        {
-            ExecuteEvents.ExecuteHierarchy(deFocusedObject, null, OnFocusExitEventHandler);
-
-            if (ShouldSendUnityUiEvents)
-            {
-                PointerInputEventData pointerInputEventData = FocusManager.Instance.GetPointerEventData();
-                ExecuteEvents.ExecuteHierarchy(deFocusedObject, pointerInputEventData, ExecuteEvents.pointerExitHandler);
-            }
-        }
-
-        /// <summary>
-        /// Raise focus enter and exit events for when a motion controller that supports pointing points to a game object.
-        /// </summary>
-        /// <param name="pointer"></param>
-        /// <param name="oldFocusedObject"></param>
-        /// <param name="newFocusedObject"></param>
-        public void RaisePointerSpecificFocusChangedEvents(IPointingSource pointer, GameObject oldFocusedObject, GameObject newFocusedObject)
-        {
-            if (oldFocusedObject != null)
-            {
-                pointerSpecificEventData.Initialize(pointer);
-                ExecuteEvents.ExecuteHierarchy(oldFocusedObject, pointerSpecificEventData, OnPointerSpecificFocusExitEventHandler);
-            }
-
-            if (newFocusedObject != null)
-            {
-                pointerSpecificEventData.Initialize(pointer);
-                ExecuteEvents.ExecuteHierarchy(newFocusedObject, pointerSpecificEventData, OnPointerSpecificFocusEnterEventHandler);
-            }
-        }
-
         public void HandleEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
         {
             if (!Instance.enabled || disabledRefCount > 0)
@@ -364,11 +314,43 @@ namespace HoloToolkit.Unity.InputModule
                 handler.OnFocusEnter();
             };
 
+        /// <summary>
+        /// Raise the event OnFocusEnter to the game object when focus enters it.
+        /// </summary>
+        /// <param name="focusedObject">The object that is focused.</param>
+        public void RaiseFocusEnter(GameObject focusedObject)
+        {
+            ExecuteEvents.ExecuteHierarchy(focusedObject, null, OnFocusEnterEventHandler);
+
+            PointerInputEventData pointerInputEventData = FocusManager.Instance.GetGazePointerEventData();
+
+            if (pointerInputEventData != null)
+            {
+                ExecuteEvents.ExecuteHierarchy(focusedObject, pointerInputEventData, ExecuteEvents.pointerEnterHandler);
+            }
+        }
+
         private static readonly ExecuteEvents.EventFunction<IFocusable> OnFocusExitEventHandler =
             delegate (IFocusable handler, BaseEventData eventData)
             {
                 handler.OnFocusExit();
             };
+
+        /// <summary>
+        /// Raise the event OnFocusExit to the game object when focus exists it.
+        /// </summary>
+        /// <param name="deFocusedObject">The object that is deFocused.</param>
+        public void RaiseFocusExit(GameObject deFocusedObject)
+        {
+            ExecuteEvents.ExecuteHierarchy(deFocusedObject, null, OnFocusExitEventHandler);
+
+            PointerInputEventData pointerInputEventData = FocusManager.Instance.GetGazePointerEventData();
+
+            if (pointerInputEventData != null)
+            {
+                ExecuteEvents.ExecuteHierarchy(deFocusedObject, pointerInputEventData, ExecuteEvents.pointerExitHandler);
+            }
+        }
 
         private static readonly ExecuteEvents.EventFunction<IPointerSpecificFocusable> OnPointerSpecificFocusEnterEventHandler =
             delegate (IPointerSpecificFocusable handler, BaseEventData eventData)
@@ -383,6 +365,27 @@ namespace HoloToolkit.Unity.InputModule
                 PointerSpecificEventData casted = ExecuteEvents.ValidateEventData<PointerSpecificEventData>(eventData);
                 handler.OnFocusExit(casted);
             };
+
+        /// <summary>
+        /// Raise focus enter and exit events for when an input (that supports pointing) points to a game object.
+        /// </summary>
+        /// <param name="pointer"></param>
+        /// <param name="oldFocusedObject"></param>
+        /// <param name="newFocusedObject"></param>
+        public void RaisePointerSpecificFocusChangedEvents(IPointingSource pointer, GameObject oldFocusedObject, GameObject newFocusedObject)
+        {
+            if (oldFocusedObject != null)
+            {
+                pointerSpecificEventData.Initialize(pointer);
+                ExecuteEvents.ExecuteHierarchy(oldFocusedObject, pointerSpecificEventData, OnPointerSpecificFocusExitEventHandler);
+            }
+
+            if (newFocusedObject != null)
+            {
+                pointerSpecificEventData.Initialize(pointer);
+                ExecuteEvents.ExecuteHierarchy(newFocusedObject, pointerSpecificEventData, OnPointerSpecificFocusEnterEventHandler);
+            }
+        }
 
         #endregion // Focus Events
 
@@ -422,14 +425,17 @@ namespace HoloToolkit.Unity.InputModule
             HandleEvent(inputEventData, OnSourceUpEventHandler);
 
             // UI events
-            if (ShouldSendUnityUiEvents && pressType == InteractionSourcePressInfo.Select)
+            IPointingSource pointingSource;
+            FocusManager.Instance.TryGetPointingSource(inputEventData, out pointingSource);
+            PointerInputEventData pointerInputEventData = FocusManager.Instance.GetSpecificPointerEventData(pointingSource);
+            if (pointerInputEventData != null && pressType == InteractionSourcePressInfo.Select)
             {
-                PointerInputEventData pointerInputEventData = FocusManager.Instance.GetPointerEventData();
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
 
-                HandleEvent(pointerInputEventData, ExecuteEvents.pointerUpHandler);
-                HandleEvent(pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
+                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                pointerInputEventData.Clear();
             }
         }
 
@@ -449,11 +455,14 @@ namespace HoloToolkit.Unity.InputModule
             HandleEvent(inputEventData, OnSourceDownEventHandler);
 
             // UI events
-            if (ShouldSendUnityUiEvents && pressType == InteractionSourcePressInfo.Select)
+            IPointingSource pointingSource;
+            FocusManager.Instance.TryGetPointingSource(inputEventData, out pointingSource);
+            PointerInputEventData pointerInputEventData = FocusManager.Instance.GetSpecificPointerEventData(pointingSource);
+            if (pointerInputEventData != null && pressType == InteractionSourcePressInfo.Select)
             {
-                PointerInputEventData pointerInputEventData = FocusManager.Instance.GetPointerEventData();
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
+                pointerInputEventData.pointerId = (int)sourceId;
 
                 pointerInputEventData.eligibleForClick = true;
                 pointerInputEventData.delta = Vector2.zero;
@@ -462,7 +471,7 @@ namespace HoloToolkit.Unity.InputModule
                 pointerInputEventData.pressPosition = pointerInputEventData.position;
                 pointerInputEventData.pointerPressRaycast = pointerInputEventData.pointerCurrentRaycast;
 
-                HandleEvent(pointerInputEventData, ExecuteEvents.pointerDownHandler);
+                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
             }
         }
 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: 20978cf8cb27a50459a532d464f4fece
+guid: c5c492755d7b1c24584880a3f151cbc6
 folderAsset: yes
-timeCreated: 1509728667
+timeCreated: 1509729124
 licenseType: Free
 DefaultImporter:
   externalObjects: {}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/Distorter.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/Distorter.cs
@@ -1,0 +1,107 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+using System;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public abstract class Distorter : MonoBehaviour, IComparable<Distorter>
+    {
+        [SerializeField]
+        [Range(0, 10)]
+        protected int distortOrder = 0;
+        [SerializeField]
+        [Range(0, 1)]
+        protected float distortStrength = 1f;
+
+        public int CompareTo(Distorter other)
+        {
+            if (other == null) {
+                return 0;
+            }
+            
+            return DistortOrder.CompareTo(other.DistortOrder);
+        }
+
+        /// <summary>
+        /// Distorts a world-space point
+        /// Automatically applies DistortStrength and ensures that strength never exceeds 1
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="strength"></param>
+        /// <returns></returns>
+        public Vector3 DistortPoint (Vector3 point, float strength = 1f)
+        {
+            if (!isActiveAndEnabled) {
+                return point;
+            }
+
+            strength = Mathf.Clamp01 (strength * DistortStrength);
+
+            if (strength <= 0)
+            {
+                return point;
+            }
+
+            return DistortPointInternal(point, strength);
+        }
+
+        /// <summary>
+        /// Distorts a world-space scale
+        /// Automatically applies DistortStrength and ensures that strength never exceeds 1
+        /// </summary>
+        /// <param name="scale"></param>
+        /// <param name="strength"></param>
+        /// <returns></returns>
+        public Vector3 DistortScale(Vector3 scale, float strength = 1f)
+        {
+            if (!isActiveAndEnabled) {
+                return scale;
+            }
+
+            strength = Mathf.Clamp01(strength * DistortStrength);
+
+            return DistortScaleInternal(scale, strength);
+        }
+
+        /// <summary>
+        /// Internal function where position distortion is done
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="strength"></param>
+        /// <returns></returns>
+        protected abstract Vector3 DistortPointInternal(Vector3 point, float strength);
+
+        /// <summary>
+        /// Internal function where scale distortion is done
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="strength"></param>
+        /// <returns></returns>
+        protected abstract Vector3 DistortScaleInternal(Vector3 point, float strength);
+
+        protected virtual void OnEnable()
+        {
+            // Makes script enableable in editor
+        }
+
+        protected virtual void OnDisable()
+        {
+            // Makes script enableable in editor            
+        }
+
+        public float DistortStrength
+        {
+            get { return distortStrength; }
+            set { distortStrength = Mathf.Clamp01(value); }
+        }
+
+        public int DistortOrder
+        {
+            get { return distortOrder; }
+            set { distortOrder = value; } // TODO implement auto-sort
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/Distorter.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/Distorter.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 58c43d53a74609f4a8df3b57e48ec65f
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterBulge.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterBulge.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class DistorterBulge : Distorter
+    {
+        public Vector3 BulgeCenter
+        {
+            get
+            {
+                return transform.TransformPoint(bulgeCenter);
+            }
+            set
+            {
+                bulgeCenter = transform.InverseTransformPoint(value);
+            }
+        }
+
+        [SerializeField]
+        private Vector3 bulgeCenter = Vector3.zero;
+        [SerializeField]
+        private AnimationCurve bulgeFalloff = new AnimationCurve();
+        [SerializeField]
+        private float bulgeRadius = 1f;
+        [SerializeField]
+        private float scaleDistort = 2f;
+        [SerializeField]
+        private float bulgeStrength = 1f;
+
+        protected override Vector3 DistortPointInternal (Vector3 point, float strength)
+        {
+            float distanceToCenter = Vector3.Distance(point, BulgeCenter);
+            if (distanceToCenter < bulgeRadius)
+            {
+                float distortion = (1f - (bulgeFalloff.Evaluate(distanceToCenter / bulgeRadius))) * bulgeStrength;
+                Vector3 direction = (point - BulgeCenter).normalized;
+                point = point + (direction * distortion * bulgeStrength);
+            }
+            return point;
+        }
+
+        protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
+        {
+            float distanceToCenter = Vector3.Distance(point, BulgeCenter);
+            if (distanceToCenter < bulgeRadius)
+            {
+                float distortion = (1f - (bulgeFalloff.Evaluate(distanceToCenter / bulgeRadius))) * bulgeStrength;
+                return Vector3.one + (Vector3.one * distortion * scaleDistort);
+            }
+            return Vector3.one;
+        }
+
+        private void OnDrawGizmos()
+        {
+            Vector3 bulgePoint = transform.TransformPoint(bulgeCenter);
+            Color gColor = Color.red;
+            gColor.a = 0.5f;
+            Gizmos.color = gColor;
+            Gizmos.DrawWireSphere(bulgePoint, bulgeRadius);
+            int steps = 8;
+            for (int i = 0; i < steps; i++)
+            {
+                float normalizedStep = (1f / steps) * i;
+                gColor.a = (1f - bulgeFalloff.Evaluate(normalizedStep)) * 0.5f;
+                Gizmos.color = gColor;
+                Gizmos.DrawSphere(bulgePoint, bulgeRadius * bulgeFalloff.Evaluate(normalizedStep));
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterBulge.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterBulge.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: a0db0b738d5618c49845f96cc0361ba0
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterGravity.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterGravity.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class DistorterGravity : Distorter
+    {
+        public Vector3 WorldCenterOfGravity
+        {
+            get
+            {
+                return transform.TransformPoint(LocalCenterOfGravity);
+            }
+            set
+            {
+                LocalCenterOfGravity = transform.InverseTransformPoint(value);
+            }
+        }
+
+        public Vector3 LocalCenterOfGravity;
+        public Vector3 AxisStrength = Vector3.one;
+        [Range(0f, 10f)]
+        public float Radius = 0.5f;
+        public AnimationCurve GravityStrength = AnimationCurve.EaseInOut(0, 0, 1, 1);
+        
+        protected override Vector3 DistortPointInternal(Vector3 point, float strength)
+        {
+            Vector3 target = WorldCenterOfGravity;
+
+            float normalizedDistance = 1f - Mathf.Clamp01 (Vector3.Distance(point, target) / Radius);
+
+            strength *= GravityStrength.Evaluate (normalizedDistance);
+
+            point.x = Mathf.Lerp(point.x, target.x, Mathf.Clamp01(strength * AxisStrength.x));
+            point.y = Mathf.Lerp(point.y, target.y, Mathf.Clamp01(strength * AxisStrength.y));
+            point.z = Mathf.Lerp(point.z, target.z, Mathf.Clamp01(strength * AxisStrength.z));
+
+            return point;
+        }
+
+        protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
+        {
+            return point;
+        }
+
+        public void OnDrawGizmos()
+        {
+            Gizmos.color = Color.red;
+            Gizmos.DrawSphere(WorldCenterOfGravity, 0.05f);
+            Gizmos.DrawWireSphere(WorldCenterOfGravity, Radius);
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterGravity.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterGravity.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 3be3fb966fbcc0f44add9a39d15cd3d0
+timeCreated: 1509470816
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSimplex.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSimplex.cs
@@ -1,0 +1,46 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class DistorterSimplex : Distorter
+    {
+        public float ScaleMultiplier = 10f;
+        public float SpeedMultiplier = 1f;
+        public float StrengthMultiplier = 0.5f;
+        public Vector3 AxisStrength = Vector3.one;
+        public Vector3 AxisSpeed = Vector3.one;
+        public Vector3 AxisOffset = Vector3.zero;
+        public float ScaleDistort = 2f;
+        public bool UniformScaleDistort = true;
+
+        protected override Vector3 DistortPointInternal(Vector3 point, float strength)
+        {
+            Vector3 scaledPoint = (point * ScaleMultiplier) + AxisOffset;
+
+            point.x = (float)(point.x + (noise.Evaluate(scaledPoint.x, scaledPoint.y, scaledPoint.z, Time.unscaledTime * AxisSpeed.x)) * AxisStrength.x * StrengthMultiplier);
+            point.y = (float)(point.y + (noise.Evaluate(scaledPoint.x, scaledPoint.y, scaledPoint.z, Time.unscaledTime * AxisSpeed.y)) * AxisStrength.y * StrengthMultiplier);
+            point.z = (float)(point.z + (noise.Evaluate(scaledPoint.x, scaledPoint.y, scaledPoint.z, Time.unscaledTime * AxisSpeed.z)) * AxisStrength.z * StrengthMultiplier);
+            return point;
+        }
+
+        protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
+        {
+            if (UniformScaleDistort)
+            {
+                float scale = (float)(noise.Evaluate(point.x, point.y, point.z, Time.unscaledTime));
+                return Vector3.one  + (Vector3.one * (scale * ScaleDistort));
+            }
+            else
+            {
+                point = DistortPointInternal(point, strength);
+                return Vector3.Lerp (Vector3.one, Vector3.Scale(Vector3.one, Vector3.one + (point * ScaleDistort)), strength);
+            }
+        }
+
+        private FastSimplexNoise noise = new FastSimplexNoise();
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSimplex.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSimplex.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d19b3492750963c4f8838b327deb2355
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSphere.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSphere.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class DistorterSphere : Distorter
+    {
+        public Vector3 SphereCenter
+        {
+            get
+            {
+                return transform.TransformPoint(sphereCenter);
+            }
+            set
+            {
+                sphereCenter = transform.InverseTransformPoint(value);
+            }
+        }
+
+        [SerializeField]
+        private Vector3 sphereCenter;
+        [SerializeField]
+        private float radius = 2f;
+
+        protected override Vector3 DistortPointInternal(Vector3 point, float strength)
+        {
+            Vector3 direction = (point - SphereCenter).normalized;
+            return Vector3.Lerp(point, SphereCenter + (direction * radius), strength);
+        }
+
+        protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
+        {
+            return Vector3.one;
+        }
+
+        private void OnDrawGizmos()
+        {
+            Gizmos.color = Color.red;
+            Gizmos.DrawWireSphere(SphereCenter, radius);
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSphere.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSphere.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 5f8d661c4e265a246b1e1579f9577cac
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterWiggly.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterWiggly.cs
@@ -1,0 +1,50 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class DistorterWiggly : Distorter
+    {
+        public const float MinScaleMultiplier = 0.05f;
+        public const float MaxScaleMultiplier = 1f;
+        public const float MinSpeedMultiplier = -25f;
+        public const float MaxSpeedMultiplier = 25f;
+        public const float MinStrengthMultiplier = 0.00001f;
+        public const float MaxStrengthMultiplier = 1f;
+
+        const float GlobalScale = 0.1f;
+        
+        [Range(MinScaleMultiplier, MaxScaleMultiplier)]
+        public float ScaleMultiplier = 0.1f;
+        [Range(MinSpeedMultiplier, MaxSpeedMultiplier)]
+        public float SpeedMultiplier = 3f;
+        [Range(MinStrengthMultiplier, MaxStrengthMultiplier)]
+        public float StrengthMultiplier = 0.01f;
+        public Vector3 AxisStrength = new Vector3(0.5f, 0.1f, 0.5f);
+        public Vector3 AxisSpeed = new Vector3(0.2f, 0.5f, 0.7f);
+        public Vector3 AxisOffset = new Vector3(0.2f, 0.5f, 0.7f);
+
+        protected override Vector3 DistortPointInternal(Vector3 point, float strength)
+        {
+            Vector3 wiggly = point;           
+            float scale = ScaleMultiplier * GlobalScale;
+            wiggly.x = Wiggle(AxisSpeed.x * SpeedMultiplier, (wiggly.x + AxisOffset.x) / scale, AxisStrength.x * StrengthMultiplier);
+            wiggly.y = Wiggle(AxisSpeed.y * SpeedMultiplier, (wiggly.y + AxisOffset.y) / scale, AxisStrength.y * StrengthMultiplier);
+            wiggly.z = Wiggle(AxisSpeed.z * SpeedMultiplier, (wiggly.z + AxisOffset.z) / scale, AxisStrength.z * StrengthMultiplier);
+            return point + (wiggly * strength);
+        }
+
+        protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
+        {
+            return point;
+        }
+
+        private float Wiggle(float speed, float offset, float strength)
+        {
+            return Mathf.Sin((Time.unscaledTime * speed) + offset) * strength;
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterWiggly.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterWiggly.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 2a0f1121767d06f458f9d5f9624922ea
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/FastSimplexNoise.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/FastSimplexNoise.cs
@@ -1,0 +1,448 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+using System;
+
+/// <summary>
+/// A conglimeration of open-source simplex libraries in C# with an emphasis on performance
+/// </summary>
+public class FastSimplexNoise
+{
+    private const double STRETCH_2D = -1.0 / 4.73205;
+    private const double STRETCH_3D = -1.0 / 6.0;
+    private const double STRETCH_4D = -1.0 / 7.23607;
+    private const double SQUISH_2D = 1.0 / 2.73205;
+    private const double SQUISH_3D = 1.0 / 3.0;
+    private const double SQUISH_4D = 1.0 / 7.23607;
+    private const double NORM_2D = 1.0 / 47.0;
+    private const double NORM_3D = 1.0 / 103.0;
+    private const double NORM_4D = 1.0 / 30.0;
+
+    private const Int64 SEEDVAL_1 = 6364136223846793005L;
+    private const Int64 SEEDVAL_2 = 1442695040888963407L;
+
+    private byte[] perm;
+    private byte[] perm2D;
+    private byte[] perm3D;
+    private byte[] perm4D;
+
+    private static double[] gradients2D = new double[]
+    {
+             5,  2,    2,  5,
+            -5,  2,   -2,  5,
+             5, -2,    2, -5,
+            -5, -2,   -2, -5,
+    };
+
+    private static double[] gradients3D =
+    {
+            -11,  4,  4,     -4,  11,  4,    -4,  4,  11,
+             11,  4,  4,      4,  11,  4,     4,  4,  11,
+            -11, -4,  4,     -4, -11,  4,    -4, -4,  11,
+             11, -4,  4,      4, -11,  4,     4, -4,  11,
+            -11,  4, -4,     -4,  11, -4,    -4,  4, -11,
+             11,  4, -4,      4,  11, -4,     4,  4, -11,
+            -11, -4, -4,     -4, -11, -4,    -4, -4, -11,
+             11, -4, -4,      4, -11, -4,     4, -4, -11,
+        };
+
+    private static double[] gradients4D =
+    {
+             3,  1,  1,  1,      1,  3,  1,  1,      1,  1,  3,  1,      1,  1,  1,  3,
+            -3,  1,  1,  1,     -1,  3,  1,  1,     -1,  1,  3,  1,     -1,  1,  1,  3,
+             3, -1,  1,  1,      1, -3,  1,  1,      1, -1,  3,  1,      1, -1,  1,  3,
+            -3, -1,  1,  1,     -1, -3,  1,  1,     -1, -1,  3,  1,     -1, -1,  1,  3,
+             3,  1, -1,  1,      1,  3, -1,  1,      1,  1, -3,  1,      1,  1, -1,  3,
+            -3,  1, -1,  1,     -1,  3, -1,  1,     -1,  1, -3,  1,     -1,  1, -1,  3,
+             3, -1, -1,  1,      1, -3, -1,  1,      1, -1, -3,  1,      1, -1, -1,  3,
+            -3, -1, -1,  1,     -1, -3, -1,  1,     -1, -1, -3,  1,     -1, -1, -1,  3,
+             3,  1,  1, -1,      1,  3,  1, -1,      1,  1,  3, -1,      1,  1,  1, -3,
+            -3,  1,  1, -1,     -1,  3,  1, -1,     -1,  1,  3, -1,     -1,  1,  1, -3,
+             3, -1,  1, -1,      1, -3,  1, -1,      1, -1,  3, -1,      1, -1,  1, -3,
+            -3, -1,  1, -1,     -1, -3,  1, -1,     -1, -1,  3, -1,     -1, -1,  1, -3,
+             3,  1, -1, -1,      1,  3, -1, -1,      1,  1, -3, -1,      1,  1, -1, -3,
+            -3,  1, -1, -1,     -1,  3, -1, -1,     -1,  1, -3, -1,     -1,  1, -1, -3,
+             3, -1, -1, -1,      1, -3, -1, -1,      1, -1, -3, -1,      1, -1, -1, -3,
+            -3, -1, -1, -1,     -1, -3, -1, -1,     -1, -1, -3, -1,     -1, -1, -1, -3,
+        };
+
+    private static int[] p2D = new int[] { 0, 0, 1, -1, 0, 0, -1, 1, 0, 2, 1, 1, 1, 2, 2, 0, 1, 2, 0, 2, 1, 0, 0, 0 };
+    private static int[] p3D = new int[] { 0, 0, 1, -1, 0, 0, 1, 0, -1, 0, 0, -1, 1, 0, 0, 0, 1, -1, 0, 0, -1, 0, 1, 0, 0, -1, 1, 0, 2, 1, 1, 0, 1, 1, 1, -1, 0, 2, 1, 0, 1, 1, 1, -1, 1, 0, 2, 0, 1, 1, 1, -1, 1, 1, 1, 3, 2, 1, 0, 3, 1, 2, 0, 1, 3, 2, 0, 1, 3, 1, 0, 2, 1, 3, 0, 2, 1, 3, 0, 1, 2, 1, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 0, 1, 0, 2, 0, 2, 0, 1, 1, 0, 0, 1, 2, 0, 0, 2, 2, 0, 0, 0, 0, 1, 1, -1, 1, 2, 0, 0, 0, 0, 1, -1, 1, 1, 2, 0, 0, 0, 0, 1, 1, 1, -1, 2, 3, 1, 1, 1, 2, 0, 0, 2, 2, 3, 1, 1, 1, 2, 2, 0, 0, 2, 3, 1, 1, 1, 2, 0, 2, 0, 2, 1, 1, -1, 1, 2, 0, 0, 2, 2, 1, 1, -1, 1, 2, 2, 0, 0, 2, 1, -1, 1, 1, 2, 0, 0, 2, 2, 1, -1, 1, 1, 2, 0, 2, 0, 2, 1, 1, 1, -1, 2, 2, 0, 0, 2, 1, 1, 1, -1, 2, 0, 2, 0 };
+    private static int[] p4D = new int[] { 0, 0, 1, -1, 0, 0, 0, 1, 0, -1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 1, 0, 0, 0, 0, 1, -1, 0, 0, 0, 1, 0, -1, 0, 0, -1, 0, 1, 0, 0, 0, -1, 1, 0, 0, 0, 0, 1, -1, 0, 0, -1, 0, 0, 1, 0, 0, -1, 0, 1, 0, 0, 0, -1, 1, 0, 2, 1, 1, 0, 0, 1, 1, 1, -1, 0, 1, 1, 1, 0, -1, 0, 2, 1, 0, 1, 0, 1, 1, -1, 1, 0, 1, 1, 0, 1, -1, 0, 2, 0, 1, 1, 0, 1, -1, 1, 1, 0, 1, 0, 1, 1, -1, 0, 2, 1, 0, 0, 1, 1, 1, -1, 0, 1, 1, 1, 0, -1, 1, 0, 2, 0, 1, 0, 1, 1, -1, 1, 0, 1, 1, 0, 1, -1, 1, 0, 2, 0, 0, 1, 1, 1, -1, 0, 1, 1, 1, 0, -1, 1, 1, 1, 4, 2, 1, 1, 0, 4, 1, 2, 1, 0, 4, 1, 1, 2, 0, 1, 4, 2, 1, 0, 1, 4, 1, 2, 0, 1, 4, 1, 1, 0, 2, 1, 4, 2, 0, 1, 1, 4, 1, 0, 2, 1, 4, 1, 0, 1, 2, 1, 4, 0, 2, 1, 1, 4, 0, 1, 2, 1, 4, 0, 1, 1, 2, 1, 2, 1, 1, 0, 0, 3, 2, 1, 0, 0, 3, 1, 2, 0, 0, 1, 2, 1, 0, 1, 0, 3, 2, 0, 1, 0, 3, 1, 0, 2, 0, 1, 2, 0, 1, 1, 0, 3, 0, 2, 1, 0, 3, 0, 1, 2, 0, 1, 2, 1, 0, 0, 1, 3, 2, 0, 0, 1, 3, 1, 0, 0, 2, 1, 2, 0, 1, 0, 1, 3, 0, 2, 0, 1, 3, 0, 1, 0, 2, 1, 2, 0, 0, 1, 1, 3, 0, 0, 2, 1, 3, 0, 0, 1, 2, 2, 3, 1, 1, 1, 0, 2, 1, 1, 1, -1, 2, 2, 0, 0, 0, 2, 3, 1, 1, 0, 1, 2, 1, 1, -1, 1, 2, 2, 0, 0, 0, 2, 3, 1, 0, 1, 1, 2, 1, -1, 1, 1, 2, 2, 0, 0, 0, 2, 3, 1, 1, 1, 0, 2, 1, 1, 1, -1, 2, 0, 2, 0, 0, 2, 3, 1, 1, 0, 1, 2, 1, 1, -1, 1, 2, 0, 2, 0, 0, 2, 3, 0, 1, 1, 1, 2, -1, 1, 1, 1, 2, 0, 2, 0, 0, 2, 3, 1, 1, 1, 0, 2, 1, 1, 1, -1, 2, 0, 0, 2, 0, 2, 3, 1, 0, 1, 1, 2, 1, -1, 1, 1, 2, 0, 0, 2, 0, 2, 3, 0, 1, 1, 1, 2, -1, 1, 1, 1, 2, 0, 0, 2, 0, 2, 3, 1, 1, 0, 1, 2, 1, 1, -1, 1, 2, 0, 0, 0, 2, 2, 3, 1, 0, 1, 1, 2, 1, -1, 1, 1, 2, 0, 0, 0, 2, 2, 3, 0, 1, 1, 1, 2, -1, 1, 1, 1, 2, 0, 0, 0, 2, 2, 1, 1, 1, -1, 0, 1, 1, 1, 0, -1, 0, 0, 0, 0, 0, 2, 1, 1, -1, 1, 0, 1, 1, 0, 1, -1, 0, 0, 0, 0, 0, 2, 1, -1, 1, 1, 0, 1, 0, 1, 1, -1, 0, 0, 0, 0, 0, 2, 1, 1, -1, 0, 1, 1, 1, 0, -1, 1, 0, 0, 0, 0, 0, 2, 1, -1, 1, 0, 1, 1, 0, 1, -1, 1, 0, 0, 0, 0, 0, 2, 1, -1, 0, 1, 1, 1, 0, -1, 1, 1, 0, 0, 0, 0, 0, 2, 1, 1, 1, -1, 0, 1, 1, 1, 0, -1, 2, 2, 0, 0, 0, 2, 1, 1, -1, 1, 0, 1, 1, 0, 1, -1, 2, 2, 0, 0, 0, 2, 1, 1, -1, 0, 1, 1, 1, 0, -1, 1, 2, 2, 0, 0, 0, 2, 1, 1, 1, -1, 0, 1, 1, 1, 0, -1, 2, 0, 2, 0, 0, 2, 1, -1, 1, 1, 0, 1, 0, 1, 1, -1, 2, 0, 2, 0, 0, 2, 1, -1, 1, 0, 1, 1, 0, 1, -1, 1, 2, 0, 2, 0, 0, 2, 1, 1, -1, 1, 0, 1, 1, 0, 1, -1, 2, 0, 0, 2, 0, 2, 1, -1, 1, 1, 0, 1, 0, 1, 1, -1, 2, 0, 0, 2, 0, 2, 1, -1, 0, 1, 1, 1, 0, -1, 1, 1, 2, 0, 0, 2, 0, 2, 1, 1, -1, 0, 1, 1, 1, 0, -1, 1, 2, 0, 0, 0, 2, 2, 1, -1, 1, 0, 1, 1, 0, 1, -1, 1, 2, 0, 0, 0, 2, 2, 1, -1, 0, 1, 1, 1, 0, -1, 1, 1, 2, 0, 0, 0, 2, 3, 1, 1, 0, 0, 0, 2, 2, 0, 0, 0, 2, 1, 1, 1, -1, 3, 1, 0, 1, 0, 0, 2, 0, 2, 0, 0, 2, 1, 1, 1, -1, 3, 1, 0, 0, 1, 0, 2, 0, 0, 2, 0, 2, 1, 1, 1, -1, 3, 1, 1, 0, 0, 0, 2, 2, 0, 0, 0, 2, 1, 1, -1, 1, 3, 1, 0, 1, 0, 0, 2, 0, 2, 0, 0, 2, 1, 1, -1, 1, 3, 1, 0, 0, 0, 1, 2, 0, 0, 0, 2, 2, 1, 1, -1, 1, 3, 1, 1, 0, 0, 0, 2, 2, 0, 0, 0, 2, 1, -1, 1, 1, 3, 1, 0, 0, 1, 0, 2, 0, 0, 2, 0, 2, 1, -1, 1, 1, 3, 1, 0, 0, 0, 1, 2, 0, 0, 0, 2, 2, 1, -1, 1, 1, 3, 1, 0, 1, 0, 0, 2, 0, 2, 0, 0, 2, -1, 1, 1, 1, 3, 1, 0, 0, 1, 0, 2, 0, 0, 2, 0, 2, -1, 1, 1, 1, 3, 1, 0, 0, 0, 1, 2, 0, 0, 0, 2, 2, -1, 1, 1, 1, 3, 3, 2, 1, 0, 0, 3, 1, 2, 0, 0, 4, 1, 1, 1, 1, 3, 3, 2, 0, 1, 0, 3, 1, 0, 2, 0, 4, 1, 1, 1, 1, 3, 3, 0, 2, 1, 0, 3, 0, 1, 2, 0, 4, 1, 1, 1, 1, 3, 3, 2, 0, 0, 1, 3, 1, 0, 0, 2, 4, 1, 1, 1, 1, 3, 3, 0, 2, 0, 1, 3, 0, 1, 0, 2, 4, 1, 1, 1, 1, 3, 3, 0, 0, 2, 1, 3, 0, 0, 1, 2, 4, 1, 1, 1, 1, 3, 3, 2, 1, 0, 0, 3, 1, 2, 0, 0, 2, 1, 1, 1, -1, 3, 3, 2, 0, 1, 0, 3, 1, 0, 2, 0, 2, 1, 1, 1, -1, 3, 3, 0, 2, 1, 0, 3, 0, 1, 2, 0, 2, 1, 1, 1, -1, 3, 3, 2, 1, 0, 0, 3, 1, 2, 0, 0, 2, 1, 1, -1, 1, 3, 3, 2, 0, 0, 1, 3, 1, 0, 0, 2, 2, 1, 1, -1, 1, 3, 3, 0, 2, 0, 1, 3, 0, 1, 0, 2, 2, 1, 1, -1, 1, 3, 3, 2, 0, 1, 0, 3, 1, 0, 2, 0, 2, 1, -1, 1, 1, 3, 3, 2, 0, 0, 1, 3, 1, 0, 0, 2, 2, 1, -1, 1, 1, 3, 3, 0, 0, 2, 1, 3, 0, 0, 1, 2, 2, 1, -1, 1, 1, 3, 3, 0, 2, 1, 0, 3, 0, 1, 2, 0, 2, -1, 1, 1, 1, 3, 3, 0, 2, 0, 1, 3, 0, 1, 0, 2, 2, -1, 1, 1, 1, 3, 3, 0, 0, 2, 1, 3, 0, 0, 1, 2, 2, -1, 1, 1, 1 };
+    private static int[] lookupPairs2D = new int[] { 0, 1, 1, 0, 4, 1, 17, 0, 20, 2, 21, 2, 22, 5, 23, 5, 26, 4, 39, 3, 42, 4, 43, 3 };
+    private static int[] lookupPairs3D = new int[] { 0, 2, 1, 1, 2, 2, 5, 1, 6, 0, 7, 0, 32, 2, 34, 2, 129, 1, 133, 1, 160, 5, 161, 5, 518, 0, 519, 0, 546, 4, 550, 4, 645, 3, 647, 3, 672, 5, 673, 5, 674, 4, 677, 3, 678, 4, 679, 3, 680, 13, 681, 13, 682, 12, 685, 14, 686, 12, 687, 14, 712, 20, 714, 18, 809, 21, 813, 23, 840, 20, 841, 21, 1198, 19, 1199, 22, 1226, 18, 1230, 19, 1325, 23, 1327, 22, 1352, 15, 1353, 17, 1354, 15, 1357, 17, 1358, 16, 1359, 16, 1360, 11, 1361, 10, 1362, 11, 1365, 10, 1366, 9, 1367, 9, 1392, 11, 1394, 11, 1489, 10, 1493, 10, 1520, 8, 1521, 8, 1878, 9, 1879, 9, 1906, 7, 1910, 7, 2005, 6, 2007, 6, 2032, 8, 2033, 8, 2034, 7, 2037, 6, 2038, 7, 2039, 6 };
+    private static int[] lookupPairs4D = new int[] { 0, 3, 1, 2, 2, 3, 5, 2, 6, 1, 7, 1, 8, 3, 9, 2, 10, 3, 13, 2, 16, 3, 18, 3, 22, 1, 23, 1, 24, 3, 26, 3, 33, 2, 37, 2, 38, 1, 39, 1, 41, 2, 45, 2, 54, 1, 55, 1, 56, 0, 57, 0, 58, 0, 59, 0, 60, 0, 61, 0, 62, 0, 63, 0, 256, 3, 258, 3, 264, 3, 266, 3, 272, 3, 274, 3, 280, 3, 282, 3, 2049, 2, 2053, 2, 2057, 2, 2061, 2, 2081, 2, 2085, 2, 2089, 2, 2093, 2, 2304, 9, 2305, 9, 2312, 9, 2313, 9, 16390, 1, 16391, 1, 16406, 1, 16407, 1, 16422, 1, 16423, 1, 16438, 1, 16439, 1, 16642, 8, 16646, 8, 16658, 8, 16662, 8, 18437, 6, 18439, 6, 18469, 6, 18471, 6, 18688, 9, 18689, 9, 18690, 8, 18693, 6, 18694, 8, 18695, 6, 18696, 9, 18697, 9, 18706, 8, 18710, 8, 18725, 6, 18727, 6, 131128, 0, 131129, 0, 131130, 0, 131131, 0, 131132, 0, 131133, 0, 131134, 0, 131135, 0, 131352, 7, 131354, 7, 131384, 7, 131386, 7, 133161, 5, 133165, 5, 133177, 5, 133181, 5, 133376, 9, 133377, 9, 133384, 9, 133385, 9, 133400, 7, 133402, 7, 133417, 5, 133421, 5, 133432, 7, 133433, 5, 133434, 7, 133437, 5, 147510, 4, 147511, 4, 147518, 4, 147519, 4, 147714, 8, 147718, 8, 147730, 8, 147734, 8, 147736, 7, 147738, 7, 147766, 4, 147767, 4, 147768, 7, 147770, 7, 147774, 4, 147775, 4, 149509, 6, 149511, 6, 149541, 6, 149543, 6, 149545, 5, 149549, 5, 149558, 4, 149559, 4, 149561, 5, 149565, 5, 149566, 4, 149567, 4, 149760, 9, 149761, 9, 149762, 8, 149765, 6, 149766, 8, 149767, 6, 149768, 9, 149769, 9, 149778, 8, 149782, 8, 149784, 7, 149786, 7, 149797, 6, 149799, 6, 149801, 5, 149805, 5, 149814, 4, 149815, 4, 149816, 7, 149817, 5, 149818, 7, 149821, 5, 149822, 4, 149823, 4, 149824, 37, 149825, 37, 149826, 36, 149829, 34, 149830, 36, 149831, 34, 149832, 37, 149833, 37, 149842, 36, 149846, 36, 149848, 35, 149850, 35, 149861, 34, 149863, 34, 149865, 33, 149869, 33, 149878, 32, 149879, 32, 149880, 35, 149881, 33, 149882, 35, 149885, 33, 149886, 32, 149887, 32, 150080, 49, 150082, 48, 150088, 49, 150098, 48, 150104, 47, 150106, 47, 151873, 46, 151877, 45, 151881, 46, 151909, 45, 151913, 44, 151917, 44, 152128, 49, 152129, 46, 152136, 49, 152137, 46, 166214, 43, 166215, 42, 166230, 43, 166247, 42, 166262, 41, 166263, 41, 166466, 48, 166470, 43, 166482, 48, 166486, 43, 168261, 45, 168263, 42, 168293, 45, 168295, 42, 168512, 31, 168513, 28, 168514, 31, 168517, 28, 168518, 25, 168519, 25, 280952, 40, 280953, 39, 280954, 40, 280957, 39, 280958, 38, 280959, 38, 281176, 47, 281178, 47, 281208, 40, 281210, 40, 282985, 44, 282989, 44, 283001, 39, 283005, 39, 283208, 30, 283209, 27, 283224, 30, 283241, 27, 283256, 22, 283257, 22, 297334, 41, 297335, 41, 297342, 38, 297343, 38, 297554, 29, 297558, 24, 297562, 29, 297590, 24, 297594, 21, 297598, 21, 299365, 26, 299367, 23, 299373, 26, 299383, 23, 299389, 20, 299391, 20, 299584, 31, 299585, 28, 299586, 31, 299589, 28, 299590, 25, 299591, 25, 299592, 30, 299593, 27, 299602, 29, 299606, 24, 299608, 30, 299610, 29, 299621, 26, 299623, 23, 299625, 27, 299629, 26, 299638, 24, 299639, 23, 299640, 22, 299641, 22, 299642, 21, 299645, 20, 299646, 21, 299647, 20, 299648, 61, 299649, 60, 299650, 61, 299653, 60, 299654, 59, 299655, 59, 299656, 58, 299657, 57, 299666, 55, 299670, 54, 299672, 58, 299674, 55, 299685, 52, 299687, 51, 299689, 57, 299693, 52, 299702, 54, 299703, 51, 299704, 56, 299705, 56, 299706, 53, 299709, 50, 299710, 53, 299711, 50, 299904, 61, 299906, 61, 299912, 58, 299922, 55, 299928, 58, 299930, 55, 301697, 60, 301701, 60, 301705, 57, 301733, 52, 301737, 57, 301741, 52, 301952, 79, 301953, 79, 301960, 76, 301961, 76, 316038, 59, 316039, 59, 316054, 54, 316071, 51, 316086, 54, 316087, 51, 316290, 78, 316294, 78, 316306, 73, 316310, 73, 318085, 77, 318087, 77, 318117, 70, 318119, 70, 318336, 79, 318337, 79, 318338, 78, 318341, 77, 318342, 78, 318343, 77, 430776, 56, 430777, 56, 430778, 53, 430781, 50, 430782, 53, 430783, 50, 431000, 75, 431002, 72, 431032, 75, 431034, 72, 432809, 74, 432813, 69, 432825, 74, 432829, 69, 433032, 76, 433033, 76, 433048, 75, 433065, 74, 433080, 75, 433081, 74, 447158, 71, 447159, 68, 447166, 71, 447167, 68, 447378, 73, 447382, 73, 447386, 72, 447414, 71, 447418, 72, 447422, 71, 449189, 70, 449191, 70, 449197, 69, 449207, 68, 449213, 69, 449215, 68, 449408, 67, 449409, 67, 449410, 66, 449413, 64, 449414, 66, 449415, 64, 449416, 67, 449417, 67, 449426, 66, 449430, 66, 449432, 65, 449434, 65, 449445, 64, 449447, 64, 449449, 63, 449453, 63, 449462, 62, 449463, 62, 449464, 65, 449465, 63, 449466, 65, 449469, 63, 449470, 62, 449471, 62, 449472, 19, 449473, 19, 449474, 18, 449477, 16, 449478, 18, 449479, 16, 449480, 19, 449481, 19, 449490, 18, 449494, 18, 449496, 17, 449498, 17, 449509, 16, 449511, 16, 449513, 15, 449517, 15, 449526, 14, 449527, 14, 449528, 17, 449529, 15, 449530, 17, 449533, 15, 449534, 14, 449535, 14, 449728, 19, 449729, 19, 449730, 18, 449734, 18, 449736, 19, 449737, 19, 449746, 18, 449750, 18, 449752, 17, 449754, 17, 449784, 17, 449786, 17, 451520, 19, 451521, 19, 451525, 16, 451527, 16, 451528, 19, 451529, 19, 451557, 16, 451559, 16, 451561, 15, 451565, 15, 451577, 15, 451581, 15, 451776, 19, 451777, 19, 451784, 19, 451785, 19, 465858, 18, 465861, 16, 465862, 18, 465863, 16, 465874, 18, 465878, 18, 465893, 16, 465895, 16, 465910, 14, 465911, 14, 465918, 14, 465919, 14, 466114, 18, 466118, 18, 466130, 18, 466134, 18, 467909, 16, 467911, 16, 467941, 16, 467943, 16, 468160, 13, 468161, 13, 468162, 13, 468163, 13, 468164, 13, 468165, 13, 468166, 13, 468167, 13, 580568, 17, 580570, 17, 580585, 15, 580589, 15, 580598, 14, 580599, 14, 580600, 17, 580601, 15, 580602, 17, 580605, 15, 580606, 14, 580607, 14, 580824, 17, 580826, 17, 580856, 17, 580858, 17, 582633, 15, 582637, 15, 582649, 15, 582653, 15, 582856, 12, 582857, 12, 582872, 12, 582873, 12, 582888, 12, 582889, 12, 582904, 12, 582905, 12, 596982, 14, 596983, 14, 596990, 14, 596991, 14, 597202, 11, 597206, 11, 597210, 11, 597214, 11, 597234, 11, 597238, 11, 597242, 11, 597246, 11, 599013, 10, 599015, 10, 599021, 10, 599023, 10, 599029, 10, 599031, 10, 599037, 10, 599039, 10, 599232, 13, 599233, 13, 599234, 13, 599235, 13, 599236, 13, 599237, 13, 599238, 13, 599239, 13, 599240, 12, 599241, 12, 599250, 11, 599254, 11, 599256, 12, 599257, 12, 599258, 11, 599262, 11, 599269, 10, 599271, 10, 599272, 12, 599273, 12, 599277, 10, 599279, 10, 599282, 11, 599285, 10, 599286, 11, 599287, 10, 599288, 12, 599289, 12, 599290, 11, 599293, 10, 599294, 11, 599295, 10 };
+    private static int[][] base2D = new int[][]
+    {
+        new int[] { 1, 1, 0, 1, 0, 1, 0, 0, 0 },
+        new int[] { 1, 1, 0, 1, 0, 1, 2, 1, 1 }
+    };
+    private static int[][] base3D = new int[][]
+    {
+        new int[] { 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1 },
+        new int[] { 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1, 3, 1, 1, 1 },
+        new int[] { 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1 }
+    };
+    private static int[][] base4D = new int[][]
+    {
+        new int[] { 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1 },
+        new int[] { 3, 1, 1, 1, 0, 3, 1, 1, 0, 1, 3, 1, 0, 1, 1, 3, 0, 1, 1, 1, 4, 1, 1, 1, 1 },
+        new int[] { 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 2, 1, 1, 0, 0, 2, 1, 0, 1, 0, 2, 1, 0, 0, 1, 2, 0, 1, 1, 0, 2, 0, 1, 0, 1, 2, 0, 0, 1, 1 },
+        new int[] { 3, 1, 1, 1, 0, 3, 1, 1, 0, 1, 3, 1, 0, 1, 1, 3, 0, 1, 1, 1, 2, 1, 1, 0, 0, 2, 1, 0, 1, 0, 2, 1, 0, 0, 1, 2, 0, 1, 1, 0, 2, 0, 1, 0, 1, 2, 0, 0, 1, 1 }
+    };   
+
+    private static Contribution2[] lookup2D;
+    private static Contribution3[] lookup3D;
+    private static Contribution4[] lookup4D;
+
+    static FastSimplexNoise()
+    {
+        var contributions2D = new Contribution2[p2D.Length / 4];
+        for (int i = 0; i < p2D.Length; i += 4)
+        {
+            var baseSet = base2D[p2D[i]];
+            Contribution2 previous = null, current = null;
+            for (int k = 0; k < baseSet.Length; k += 3)
+            {
+                current = new Contribution2(baseSet[k], baseSet[k + 1], baseSet[k + 2]);
+                if (previous == null)
+                {
+                    contributions2D[i / 4] = current;
+                }
+                else
+                {
+                    previous.Next = current;
+                }
+                previous = current;
+            }
+            current.Next = new Contribution2(p2D[i + 1], p2D[i + 2], p2D[i + 3]);
+        }
+
+        lookup2D = new Contribution2[64];
+        for (var i = 0; i < lookupPairs2D.Length; i += 2)
+        {
+            lookup2D[lookupPairs2D[i]] = contributions2D[lookupPairs2D[i + 1]];
+        }
+
+        var contributions3D = new Contribution3[p3D.Length / 9];
+        for (int i = 0; i < p3D.Length; i += 9)
+        {
+            var baseSet = base3D[p3D[i]];
+            Contribution3 previous = null, current = null;
+            for (int k = 0; k < baseSet.Length; k += 4)
+            {
+                current = new Contribution3(baseSet[k], baseSet[k + 1], baseSet[k + 2], baseSet[k + 3]);
+                if (previous == null)
+                {
+                    contributions3D[i / 9] = current;
+                }
+                else
+                {
+                    previous.Next = current;
+                }
+                previous = current;
+            }
+            current.Next = new Contribution3(p3D[i + 1], p3D[i + 2], p3D[i + 3], p3D[i + 4]);
+            current.Next.Next = new Contribution3(p3D[i + 5], p3D[i + 6], p3D[i + 7], p3D[i + 8]);
+        }
+
+        lookup3D = new Contribution3[2048];
+        for (var i = 0; i < lookupPairs3D.Length; i += 2)
+        {
+            lookup3D[lookupPairs3D[i]] = contributions3D[lookupPairs3D[i + 1]];
+        }
+
+        var contributions4D = new Contribution4[p4D.Length / 16];
+        for (int i = 0; i < p4D.Length; i += 16)
+        {
+            var baseSet = base4D[p4D[i]];
+            Contribution4 previous = null, current = null;
+            for (int k = 0; k < baseSet.Length; k += 5)
+            {
+                current = new Contribution4(baseSet[k], baseSet[k + 1], baseSet[k + 2], baseSet[k + 3], baseSet[k + 4]);
+                if (previous == null)
+                {
+                    contributions4D[i / 16] = current;
+                }
+                else
+                {
+                    previous.Next = current;
+                }
+                previous = current;
+            }
+            current.Next = new Contribution4(p4D[i + 1], p4D[i + 2], p4D[i + 3], p4D[i + 4], p4D[i + 5]);
+            current.Next.Next = new Contribution4(p4D[i + 6], p4D[i + 7], p4D[i + 8], p4D[i + 9], p4D[i + 10]);
+            current.Next.Next.Next = new Contribution4(p4D[i + 11], p4D[i + 12], p4D[i + 13], p4D[i + 14], p4D[i + 15]);
+        }
+
+        lookup4D = new Contribution4[1048576];
+        for (var i = 0; i < lookupPairs4D.Length; i += 2)
+        {
+            lookup4D[lookupPairs4D[i]] = contributions4D[lookupPairs4D[i + 1]];
+        }
+    }
+
+    private static int FastFloor(double x)
+    {
+        var xi = (int)x;
+        return x < xi ? xi - 1 : xi;
+    }
+
+    public FastSimplexNoise() : this(DateTime.Now.Ticks) { }
+
+    public FastSimplexNoise(long seed)
+    {
+        perm = new byte[256];
+        perm2D = new byte[256];
+        perm3D = new byte[256];
+        perm4D = new byte[256];
+        var source = new byte[256];
+        for (int i = 0; i < 256; i++)
+        {
+            source[i] = (byte)i;
+        }
+        seed = seed * SEEDVAL_1 + SEEDVAL_2;
+        seed = seed * SEEDVAL_1 + SEEDVAL_2;
+        seed = seed * SEEDVAL_1 + SEEDVAL_2;
+        for (int i = 255; i >= 0; i--)
+        {
+            seed = seed * SEEDVAL_1 + SEEDVAL_2;
+            int r = (int)((seed + 31) % (i + 1));
+            if (r < 0)
+            {
+                r += (i + 1);
+            }
+            perm[i] = source[r];
+            perm2D[i] = (byte)(perm[i] & 0x0E);
+            perm3D[i] = (byte)((perm[i] % 24) * 3);
+            perm4D[i] = (byte)(perm[i] & 0xFC);
+            source[r] = source[i];
+        }
+    }
+
+    public double Evaluate(double x, double y)
+    {
+        var stretchOffset = (x + y) * STRETCH_2D;
+        var xs = x + stretchOffset;
+        var ys = y + stretchOffset;
+
+        var xsb = FastFloor(xs);
+        var ysb = FastFloor(ys);
+
+        var squishOffset = (xsb + ysb) * SQUISH_2D;
+        var dx0 = x - (xsb + squishOffset);
+        var dy0 = y - (ysb + squishOffset);
+
+        var xins = xs - xsb;
+        var yins = ys - ysb;
+
+        var inSum = xins + yins;
+
+        var hash =
+           (int)(xins - yins + 1) |
+           (int)(inSum) << 1 |
+           (int)(inSum + yins) << 2 |
+           (int)(inSum + xins) << 4;
+
+        var c = lookup2D[hash];
+
+        var value = 0.0;
+        while (c != null)
+        {
+            var dx = dx0 + c.dx;
+            var dy = dy0 + c.dy;
+            var attn = 2 - dx * dx - dy * dy;
+            if (attn > 0)
+            {
+                var px = xsb + c.xsb;
+                var py = ysb + c.ysb;
+
+                var i = perm2D[(perm[px & 0xFF] + py) & 0xFF];
+                var valuePart = gradients2D[i] * dx + gradients2D[i + 1] * dy;
+
+                attn *= attn;
+                value += attn * attn * valuePart;
+            }
+            c = c.Next;
+        }
+        return value * NORM_2D;
+    }
+
+    public double Evaluate(double x, double y, double z)
+    {
+        var stretchOffset = (x + y + z) * STRETCH_3D;
+        var xs = x + stretchOffset;
+        var ys = y + stretchOffset;
+        var zs = z + stretchOffset;
+
+        var xsb = FastFloor(xs);
+        var ysb = FastFloor(ys);
+        var zsb = FastFloor(zs);
+
+        var squishOffset = (xsb + ysb + zsb) * SQUISH_3D;
+        var dx0 = x - (xsb + squishOffset);
+        var dy0 = y - (ysb + squishOffset);
+        var dz0 = z - (zsb + squishOffset);
+
+        var xins = xs - xsb;
+        var yins = ys - ysb;
+        var zins = zs - zsb;
+
+        var inSum = xins + yins + zins;
+
+        var hash =
+           (int)(yins - zins + 1) |
+           (int)(xins - yins + 1) << 1 |
+           (int)(xins - zins + 1) << 2 |
+           (int)inSum << 3 |
+           (int)(inSum + zins) << 5 |
+           (int)(inSum + yins) << 7 |
+           (int)(inSum + xins) << 9;
+
+        var c = lookup3D[hash];
+
+        var value = 0.0;
+        while (c != null)
+        {
+            var dx = dx0 + c.dx;
+            var dy = dy0 + c.dy;
+            var dz = dz0 + c.dz;
+            var attn = 2 - dx * dx - dy * dy - dz * dz;
+            if (attn > 0)
+            {
+                var px = xsb + c.xsb;
+                var py = ysb + c.ysb;
+                var pz = zsb + c.zsb;
+
+                var i = perm3D[(perm[(perm[px & 0xFF] + py) & 0xFF] + pz) & 0xFF];
+                var valuePart = gradients3D[i] * dx + gradients3D[i + 1] * dy + gradients3D[i + 2] * dz;
+
+                attn *= attn;
+                value += attn * attn * valuePart;
+            }
+
+            c = c.Next;
+        }
+        return value * NORM_3D;
+    }
+
+    public double Evaluate(double x, double y, double z, double w)
+    {
+        var stretchOffset = (x + y + z + w) * STRETCH_4D;
+        var xs = x + stretchOffset;
+        var ys = y + stretchOffset;
+        var zs = z + stretchOffset;
+        var ws = w + stretchOffset;
+
+        var xsb = FastFloor(xs);
+        var ysb = FastFloor(ys);
+        var zsb = FastFloor(zs);
+        var wsb = FastFloor(ws);
+
+        var squishOffset = (xsb + ysb + zsb + wsb) * SQUISH_4D;
+        var dx0 = x - (xsb + squishOffset);
+        var dy0 = y - (ysb + squishOffset);
+        var dz0 = z - (zsb + squishOffset);
+        var dw0 = w - (wsb + squishOffset);
+
+        var xins = xs - xsb;
+        var yins = ys - ysb;
+        var zins = zs - zsb;
+        var wins = ws - wsb;
+
+        var inSum = xins + yins + zins + wins;
+
+        var hash =
+            (int)(zins - wins + 1) |
+            (int)(yins - zins + 1) << 1 |
+            (int)(yins - wins + 1) << 2 |
+            (int)(xins - yins + 1) << 3 |
+            (int)(xins - zins + 1) << 4 |
+            (int)(xins - wins + 1) << 5 |
+            (int)inSum << 6 |
+            (int)(inSum + wins) << 8 |
+            (int)(inSum + zins) << 11 |
+            (int)(inSum + yins) << 14 |
+            (int)(inSum + xins) << 17;
+
+        var c = lookup4D[hash];
+
+        var value = 0.0;
+        while (c != null)
+        {
+            var dx = dx0 + c.dx;
+            var dy = dy0 + c.dy;
+            var dz = dz0 + c.dz;
+            var dw = dw0 + c.dw;
+            var attn = 2 - dx * dx - dy * dy - dz * dz - dw * dw;
+            if (attn > 0)
+            {
+                var px = xsb + c.xsb;
+                var py = ysb + c.ysb;
+                var pz = zsb + c.zsb;
+                var pw = wsb + c.wsb;
+
+                var i = perm4D[(perm[(perm[(perm[px & 0xFF] + py) & 0xFF] + pz) & 0xFF] + pw) & 0xFF];
+                var valuePart = gradients4D[i] * dx + gradients4D[i + 1] * dy + gradients4D[i + 2] * dz + gradients4D[i + 3] * dw;
+
+                attn *= attn;
+                value += attn * attn * valuePart;
+            }
+
+            c = c.Next;
+        }
+        return value * NORM_4D;
+    }
+
+    private class Contribution2
+    {
+        public double dx, dy;
+        public int xsb, ysb;
+        public Contribution2 Next;
+
+        public Contribution2(double multiplier, int xsb, int ysb)
+        {
+            dx = -xsb - multiplier * SQUISH_2D;
+            dy = -ysb - multiplier * SQUISH_2D;
+            this.xsb = xsb;
+            this.ysb = ysb;
+        }
+    }
+
+    private class Contribution3
+    {
+        public double dx, dy, dz;
+        public int xsb, ysb, zsb;
+        public Contribution3 Next;
+
+        public Contribution3(double multiplier, int xsb, int ysb, int zsb)
+        {
+            dx = -xsb - multiplier * SQUISH_3D;
+            dy = -ysb - multiplier * SQUISH_3D;
+            dz = -zsb - multiplier * SQUISH_3D;
+            this.xsb = xsb;
+            this.ysb = ysb;
+            this.zsb = zsb;
+        }
+    }
+
+    private class Contribution4
+    {
+        public double dx, dy, dz, dw;
+        public int xsb, ysb, zsb, wsb;
+        public Contribution4 Next;
+
+        public Contribution4(double multiplier, int xsb, int ysb, int zsb, int wsb)
+        {
+            dx = -xsb - multiplier * SQUISH_4D;
+            dy = -ysb - multiplier * SQUISH_4D;
+            dz = -zsb - multiplier * SQUISH_4D;
+            dw = -wsb - multiplier * SQUISH_4D;
+            this.xsb = xsb;
+            this.ysb = ysb;
+            this.zsb = zsb;
+            this.wsb = wsb;
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/FastSimplexNoise.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/FastSimplexNoise.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 29963f22c48b33848b3d6504d2751f16
+timeCreated: 1509379168
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: 20978cf8cb27a50459a532d464f4fece
+guid: 24388315c45b80a438e6212efaf02be3
 folderAsset: yes
-timeCreated: 1509728667
+timeCreated: 1509729123
 licenseType: Free
 DefaultImporter:
   externalObjects: {}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Bezier.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Bezier.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class Bezier : LineBase
+    {
+        [Serializable]
+        private struct PointSet
+        {
+            public PointSet(float spread) {
+                Point1 = Vector3.right * spread * 0.5f;
+                Point2 = Vector3.right * spread * 0.25f;
+                Point3 = Vector3.left * spread * 0.25f;
+                Point4 = Vector3.left * spread * 0.5f;
+            }
+
+            public Vector3 Point1;
+            public Vector3 Point2;
+            public Vector3 Point3;
+            public Vector3 Point4;
+        }
+
+        [Header("Bezier Settings")]
+        [SerializeField]
+        private PointSet points = new PointSet(0.5f);
+
+        public override int NumPoints {
+            get {
+                return 4;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(int pointIndex) {
+            switch (pointIndex) {
+                case 0:
+                    return points.Point1;
+
+                case 1:
+                    return points.Point2;
+
+                case 2:
+                    return points.Point3;
+
+                case 3:
+                    return points.Point4;
+
+                default:
+                    return Vector3.zero;
+            }
+        }
+
+        protected override void SetPointInternal(int pointIndex, Vector3 point) {
+            switch (pointIndex) {
+                case 0:
+                    points.Point1 = point;
+                    break;
+
+                case 1:
+                    points.Point2 = point;
+                    break;
+
+                case 2:
+                    points.Point3 = point;
+                    break;
+
+                case 3:
+                    points.Point4 = point;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(float normalizedDistance) {
+            return LineUtils.InterpolateBezeirPoints(points.Point1, points.Point2, points.Point3, points.Point4, normalizedDistance);
+        }
+
+        protected override float GetUnclampedWorldLengthInternal() {
+            // Crude approximation
+            // TODO optimize
+            float distance = 0f;
+            Vector3 last = GetUnclampedPoint(0f);
+            for (int i = 1; i < 10; i++) {
+                Vector3 current = GetUnclampedPoint((float)i / 10);
+                distance += Vector3.Distance(last, current);
+            }
+            return distance;
+        }
+
+        protected override Vector3 GetUpVectorInternal(float normalizedLength) {
+            // Bezeir up vectors just use transform up
+            return transform.up;
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(Bezier))]
+        public class CustomEditor : LineBaseEditor
+        {
+            protected override void DrawCustomSceneGUI() {
+                base.DrawCustomSceneGUI();
+
+                Bezier line = (Bezier)target;
+
+                line.SetPoint(0, SphereMoveHandle(line.GetPoint(0)));
+                line.SetPoint(1, SquareMoveHandle(line.GetPoint(1)));
+                line.SetPoint(2, SquareMoveHandle(line.GetPoint(2)));
+                line.SetPoint(3, SphereMoveHandle(line.GetPoint(3)));
+
+                UnityEditor.Handles.color = handleColorTangent;
+                UnityEditor.Handles.DrawLine(line.GetPoint(0), line.GetPoint(1));
+                UnityEditor.Handles.DrawLine(line.GetPoint(2), line.GetPoint(3));
+            }
+        }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Bezier.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Bezier.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 692d8c30071cdf64a8e7bacd05759787
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Ellipse.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Ellipse.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class Ellipse : LineBase
+    {
+        const int MaxPoints = 2048;
+
+        [Header ("Ellipse Settings")]
+        public int Resolution = 36;
+        public Vector2 Radius = new Vector2(1f, 1f);
+
+        public override int NumPoints
+        {
+            get
+            {
+                Resolution = Mathf.Clamp(Resolution, 0, MaxPoints);
+                return Resolution;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(float normalizedDistance)
+        {
+            return LineUtils.GetEllipsePoint(Radius.x, Radius.y, normalizedDistance * 2f * Mathf.PI);
+        }
+
+        protected override Vector3 GetPointInternal(int pointIndex)
+        {
+            float angle = ((float)pointIndex / Resolution) * 2f * Mathf.PI;
+            return LineUtils.GetEllipsePoint(Radius.x, Radius.y, angle);
+        }
+
+        protected override void SetPointInternal(int pointIndex, Vector3 point)
+        {
+            // Does nothing for an ellipse
+            return;
+        }
+
+        protected override float GetUnclampedWorldLengthInternal()
+        {
+            // Crude approximation
+            // TODO optimize
+            float distance = 0f;
+            Vector3 last = GetUnclampedPoint(0f);
+            for (int i = 1; i < 10; i++)
+            {
+                Vector3 current = GetUnclampedPoint((float)i / 10);
+                distance += Vector3.Distance(last, current);
+            }
+            return distance;
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(Ellipse))]
+        public class CustomEditor : LineBaseEditor { }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Ellipse.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Ellipse.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: de408bb391ea251449125ebbb50d896c
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Line.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Line.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class Line : LineBase
+    {
+        [Header("Line Settings")]
+        public Vector3 Start = Vector3.zero;
+        public Vector3 End = Vector3.one;
+
+        public override int NumPoints
+        {
+            get
+            {
+                return 2;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(int pointIndex)
+        {
+            switch (pointIndex)
+            {
+                case 0:
+                default:
+                    return Start;
+
+                case 1:
+                    return End;
+            }
+        }
+
+        protected override void SetPointInternal(int pointIndex, Vector3 point)
+        {
+            switch (pointIndex)
+            {
+                case 0:
+                default:
+                    Start = point;
+                    break;
+
+                case 1:
+                    End = point;
+                    break;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(float normalizedDistance)
+        {
+            return Vector3.Lerp(Start, End, normalizedDistance);
+        }
+
+        protected override float GetUnclampedWorldLengthInternal()
+        {
+            return Vector3.Distance(Start, End);
+        }
+
+        protected override Vector3 GetUpVectorInternal(float normalizedLength)
+        {
+            return transform.up;
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(Line))]
+        public class CustomEditor : LineBaseEditor {
+            protected override void DrawCustomSceneGUI()
+            {
+                base.DrawCustomSceneGUI();
+
+                LineBase line = (LineBase)target;
+                line.FirstPoint = SquareMoveHandle(line.FirstPoint);
+                line.LastPoint = SquareMoveHandle(line.LastPoint);
+            }
+        }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Line.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Line.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: bec4b46028f8fb94c9b03b88fca37bd6
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineBase.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineBase.cs
@@ -1,0 +1,429 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public abstract class LineBase : MonoBehaviour
+    {
+        protected const float MinRotationMagnitude = 0.0001f;
+
+        #region fields & properties
+
+        public float UnclampedWorldLength
+        {
+            get
+            {
+                return GetUnclampedWorldLengthInternal();
+            }
+        }
+
+        [Header("Basic Settings")]
+        [Tooltip("Clamps the line's normalized start point. This setting will affect line renderers.")]
+        [Range(0f, 1f)]
+        public float LineStartClamp = 0f;
+        [Range(0f, 1f)]
+        [Tooltip("Clamps the line's normalized end point. This setting will affect line renderers.")]
+        public float LineEndClamp = 1f;
+        
+        public virtual bool Loops
+        {
+            get
+            {
+                return loops;
+            }
+        }
+
+        [Header("Rotation")]
+        [Tooltip("The rotation mode used in the GetRotation function. You can visualize rotations by checking Draw Rotations under Editor Settings.")]
+        public RotationTypeEnum RotationType = RotationTypeEnum.Velocity;
+
+        [Tooltip("Reverses up vector when determining rotation along line")]
+        public bool FlipUpVector = false;
+
+        [Tooltip("Local space offset to transform position. Used to determine rotation along line in RelativeToOrigin rotation mode")]
+        public Vector3 OriginOffset = Vector3.zero;
+
+        [Tooltip("The weight of manual up vectors in Velocity rotation mode")]
+        [Range(0f,1f)]
+        public float ManualUpVectorBlend = 0f;
+         
+        [Tooltip("These vectors are used with ManualUpVectorBlend to determine rotation along the line in Velocity rotation mode. Vectors are distributed along the normalized length of the line.")]
+        public Vector3[] ManualUpVectors = new Vector3[] { Vector3.up, Vector3.up, Vector3.up };
+
+        [Tooltip("Used in Velocity rotation mode. Smaller values are more accurate but more expensive")]
+        [Range(0.0001f, 0.1f)]
+        public float VelocitySearchRange = 0.02f;
+        [Range(0f, 1f)]
+        public float VelocityBlend = 0.5f;
+
+        [Header ("Distortion")]
+        [Tooltip("NormalizedLength mode uses the DistortionStrength curve for distortion strength, Uniform uses UniformDistortionStrength along entire line")]
+        public DistortionTypeEnum DistortionType = DistortionTypeEnum.NormalizedLength;
+        public AnimationCurve DistortionStrength = AnimationCurve.Linear(0f, 1f, 1f, 1f);
+        [Range(0f, 1f)]
+        public float UniformDistortionStrength = 1f;
+
+        [SerializeField]
+        [Tooltip("A list of distorters that apply to this line")]
+        protected List<Distorter> distorters = new List<Distorter>();
+
+        [Tooltip("Controls whether this line loops (Note: some classes override this setting)")]
+        [SerializeField]
+        protected bool loops = false;
+
+        #endregion
+
+        #region abstract
+
+        public abstract int NumPoints { get; }
+
+        protected abstract void SetPointInternal(int pointIndex, Vector3 point);
+
+        /// <summary>
+        /// Get a point based on normalized distance along line
+        /// Normalized distance will be pre-clamped
+        /// </summary>
+        /// <param name="normalizedLength"></param>
+        /// <returns></returns>
+        protected abstract Vector3 GetPointInternal(float normalizedLength);
+
+        /// <summary>
+        /// Get a point based on point index
+        /// Point index will be pre-clamped
+        /// </summary>
+        /// <param name="pointIndex"></param>
+        /// <returns></returns>
+        protected abstract Vector3 GetPointInternal(int pointIndex);
+
+        /// <summary>
+        /// Gets the up vector at a normalized length along line (used for rotation)
+        /// </summary>
+        /// <param name="normalizedLength"></param>
+        /// <returns></returns>
+        protected virtual Vector3 GetUpVectorInternal(float normalizedLength)
+        {
+            return transform.forward;
+        }
+
+        /// <summary>
+        /// Get the UNCLAMPED world length of the line
+        /// </summary>
+        /// <returns></returns>
+        protected abstract float GetUnclampedWorldLengthInternal();
+
+        #endregion
+
+        #region public
+
+        // Convenience
+        public Vector3 FirstPoint
+        {
+            get
+            {
+                return GetPoint(0);
+            }
+            set
+            {
+                SetPoint(0, value);
+            }
+        }
+
+        public Vector3 LastPoint
+        {
+            get
+            {
+                return GetPoint(NumPoints - 1);
+            }
+            set
+            {
+                SetPoint(NumPoints - 1, value);
+            }
+        }
+
+        public void AddDistorter(Distorter newDistorter)
+        {
+            if (!distorters.Contains(newDistorter))
+            {
+                distorters.Add(newDistorter);
+            }
+        }
+
+        /// <summary>
+        /// Places all points between the first and last point in a straight line
+        /// </summary>
+        public virtual void MakeStraightLine()
+        {
+            if (NumPoints > 2)
+            {
+                Vector3 startPosition = GetPoint(0);
+                Vector3 endPosition = GetPoint(NumPoints - 1);
+                for (int i = 1; i < NumPoints - 2; i++)
+                {
+                    SetPoint(i, Vector3.Lerp(startPosition, endPosition, (1f / NumPoints * 1)));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a normalized length corresponding to a world length
+        /// Useful for determining LineStartClamp / LineEndClamp values
+        /// </summary>
+        /// <param name="worldLength"></param>
+        /// <param name="searchResolution"></param>
+        /// <returns></returns>
+        public float GetNormalizedLengthFromWorldLength (float worldLength, int searchResolution = 10)
+        {
+            Vector3 lastPoint = GetUnclampedPoint(0f);
+            Vector3 currentPoint = Vector3.zero;
+            float normalizedLength = 0f;
+            float distanceSoFar = 0f;
+
+            for (int i = 1; i < searchResolution; i++)
+            {
+                // Get the normalized length of this position along the line
+                normalizedLength = (1f / searchResolution) * i;
+                currentPoint = GetUnclampedPoint(normalizedLength);
+                distanceSoFar += Vector3.Distance(lastPoint, currentPoint);
+                lastPoint = currentPoint;
+
+                if (distanceSoFar >= worldLength)
+                {
+                    // We've reached the world length
+                    break;
+                };
+            }
+
+            return Mathf.Clamp01 (normalizedLength);
+        }
+
+        /// <summary>
+        /// Gets the velocity along the line
+        /// </summary>
+        /// <param name="normalizedLength"></param>
+        /// <returns></returns>
+        public Vector3 GetVelocity(float normalizedLength)
+        {
+            Vector3 velocity = Vector3.zero;
+            if (normalizedLength < VelocitySearchRange)
+            {
+                Vector3 currentPos = GetPoint(normalizedLength);
+                Vector3 nextPos = GetPoint(normalizedLength + VelocitySearchRange);
+                velocity = (nextPos - currentPos).normalized;
+            }
+            else
+            {
+                Vector3 currentPos = GetPoint(normalizedLength);
+                Vector3 prevPos = GetPoint(normalizedLength - VelocitySearchRange);
+                velocity = (currentPos - prevPos).normalized;
+            }
+            return velocity;
+        }
+
+        /// <summary>
+        /// Gets the rotation of a point along the line at the specified length
+        /// </summary>
+        /// <param name="normalizedLength"></param>
+        /// <param name="rotationType"></param>
+        /// <returns></returns>
+        public Quaternion GetRotation(float normalizedLength, RotationTypeEnum rotationType = RotationTypeEnum.None)
+        {
+            rotationType = (rotationType != RotationTypeEnum.None) ? rotationType : RotationType;
+            Vector3 rotationVector = Vector3.zero;
+
+            switch (rotationType)
+            {
+                case RotationTypeEnum.None:
+                default:
+                    break;
+
+                case RotationTypeEnum.Velocity:
+                    rotationVector = GetVelocity(normalizedLength);
+                    break;
+
+                case RotationTypeEnum.RelativeToOrigin:
+                    Vector3 point = GetPoint(normalizedLength);
+                    Vector3 origin = transform.TransformPoint(OriginOffset);
+                    rotationVector = (point - origin).normalized;
+                    break;
+            }
+
+            if (rotationVector.magnitude < MinRotationMagnitude)
+            {
+                return transform.rotation;
+            }
+
+            Vector3 upVector = GetUpVectorInternal(normalizedLength);
+
+            if (ManualUpVectorBlend > 0f)
+            {
+                Vector3 manualUpVector = LineUtils.GetVectorCollectionBlend(ManualUpVectors, normalizedLength, Loops);
+                upVector = Vector3.Lerp(upVector, manualUpVector, manualUpVector.magnitude);
+            }
+
+            if (FlipUpVector)
+            {
+                upVector = -upVector;
+            }
+
+            return Quaternion.LookRotation(rotationVector, upVector);
+        }
+
+        /// <summary>
+        /// Gets the rotation of a point along the line at the specified index
+        /// </summary>
+        /// <param name="pointIndex"></param>
+        /// <param name="rotationType"></param>
+        /// <returns></returns>
+        public Quaternion GetRotation (int pointIndex, RotationTypeEnum rotationType = RotationTypeEnum.None)
+        {
+            return GetRotation((float)pointIndex / NumPoints, (rotationType != RotationTypeEnum.None) ? rotationType : RotationType);
+        }
+
+        /// <summary>
+        /// Gets a point along the line at the specified length
+        /// </summary>
+        /// <param name="normalizedLength"></param>
+        /// <returns></returns>
+        public Vector3 GetPoint(float normalizedLength)
+        {
+            normalizedLength = ClampedLength(normalizedLength);
+            return DistortPoint (transform.TransformPoint(GetPointInternal(normalizedLength)), normalizedLength);
+        }
+
+        /// <summary>
+        /// Gets a point along the line at the specified length without using LineStartClamp or LineEndClamp
+        /// </summary>
+        /// <param name="normalizedLength"></param>
+        /// <returns></returns>
+        public Vector3 GetUnclampedPoint(float normalizedLength)
+        {
+            normalizedLength = Mathf.Clamp01(normalizedLength);
+            return DistortPoint(transform.TransformPoint(GetPointInternal(normalizedLength)), normalizedLength);
+        }
+
+        /// <summary>
+        /// Gets a point along the line at the specified index
+        /// </summary>
+        /// <param name="pointIndex"></param>
+        /// <returns></returns>
+        public Vector3 GetPoint (int pointIndex)
+        {
+            if (pointIndex < 0 || pointIndex >= NumPoints)
+            {
+                throw new System.IndexOutOfRangeException();
+            }
+
+            return transform.TransformPoint(GetPointInternal(pointIndex));
+        }
+
+        /// <summary>
+        /// Sets a point in the line
+        /// This function is not guaranteed to have an effect
+        /// </summary>
+        /// <param name="pointIndex"></param>
+        /// <param name="point"></param>
+        public void SetPoint (int pointIndex, Vector3 point)
+        {
+            if (pointIndex < 0 || pointIndex >= NumPoints)
+            {
+                throw new System.IndexOutOfRangeException();
+            }
+
+            SetPointInternal(pointIndex, transform.InverseTransformPoint(point));
+        }
+
+        public virtual void AppendPoint(Vector3 point)
+        {
+            // Does nothing by default
+        }
+
+        #endregion
+
+        #region private & protected
+
+        protected virtual void OnEnable()
+        {
+            // Sort our distorters
+            distorters.Sort();
+        }
+
+        private Vector3 DistortPoint (Vector3 point, float normalizedLength)
+        {
+            float strength = UniformDistortionStrength;
+            switch (DistortionType)
+            {
+                case DistortionTypeEnum.Uniform:
+                default:
+                    break;
+
+                case DistortionTypeEnum.NormalizedLength:
+                    strength = DistortionStrength.Evaluate(normalizedLength);
+                    break;
+            }
+
+            for (int i = 0; i < distorters.Count; i++)
+            {
+                // Components may be added or removed
+                if (distorters[i] != null)
+                {
+                    point = distorters[i].DistortPoint(point, strength);
+                }
+            }
+            return point;
+        }
+
+        private float ClampedLength(float normalizedLength)
+        {
+            return Mathf.Lerp(Mathf.Max (LineStartClamp, 0.0001f), Mathf.Min (LineEndClamp, 0.9999f), Mathf.Clamp01(normalizedLength));
+        }
+
+        #endregion
+
+#if UNITY_EDITOR
+        protected virtual void OnDrawGizmos()
+        {
+            // Show gizmos if this object is not selected
+            // (SceneGUI will display it otherwise)
+
+            if (Application.isPlaying)
+            {
+                return;
+            }
+
+            if (UnityEditor.Selection.activeGameObject == this.gameObject)
+            {
+                return;
+            }
+
+            // Only draw a gizmo if we don't have a line renderer
+            LineRendererBase lineRenderer = gameObject.GetComponent<LineRendererBase>();
+            if (lineRenderer != null)
+            {
+                return;
+            }
+
+            Vector3 firstPos = GetPoint(0f);
+            Vector3 lastPos = firstPos;
+            Gizmos.color = Color.Lerp (LineBaseEditor.DefaultDisplayLineColor, Color.clear, 0.25f);
+            int numSteps = 16;
+
+            for (int i = 1; i < numSteps; i++)
+            {
+                float normalizedLength = (1f / (numSteps - 1)) * i;
+                Vector3 currentPos = GetPoint(normalizedLength);
+                Gizmos.DrawLine(lastPos, currentPos);
+                lastPos = currentPos;
+            }
+
+            if (Loops)
+            {
+                Gizmos.DrawLine(lastPos, firstPos);
+            }
+        }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineBase.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineBase.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 619114ad7f133054a8e4ad895199e72f
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineBaseEditor.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineBaseEditor.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using UnityEngine;
+using Holotoolkit.Unity.UX;
+#if UNITY_EDITOR
+using UnityEditor;
+
+/// <summary>
+/// Base class for line editors (splines, bezeirs, parabolas, etc)
+/// </summary>
+public class LineBaseEditor : MRTKEditor
+{
+    // Const editor properties
+    public static readonly Color DefaultDisplayLineColor = Color.white;
+    protected static readonly Color lineVelocityColor = new Color(0.9f, 1f, 0f, 0.8f);
+    protected const int linePreviewResolutionUnselected = 16;
+
+    // Static editor properties
+    protected static int linePreviewResolutionSelected = 16;
+    protected static bool drawLinePoints = false;
+    protected static bool drawDottedLine = true;
+    protected static bool drawLineRotations = false;
+    protected static bool drawLineManualUpVectors = false;
+    protected static float lineRotationLength = 0.5f;
+    protected static float lineManualUpVectorLength = 10f;
+
+    protected virtual StepModeEnum EditorStepMode { get { return StepModeEnum.Interpolated; } }
+
+    protected override void DrawCustomSceneGUI()
+    {
+        LineBase line = (LineBase)target;
+        bool selected = Selection.activeGameObject == line.gameObject;
+
+        int previewResolution = Mathf.Min(linePreviewResolutionSelected, linePreviewResolutionUnselected);
+        if (selected)
+        {
+            previewResolution = linePreviewResolutionSelected;
+        }
+
+        // Draw dotted lines regardless of selection
+        if (drawDottedLine)
+        {
+            DrawDottedLine(line, linePreviewResolutionSelected);
+        }
+
+        // Draw rotations only on selected object
+        if (drawLineRotations && selected)
+        {
+            DrawLineRotations(line, linePreviewResolutionSelected);
+        }
+
+        // Draw up vectors only on selected object
+        if (drawLineManualUpVectors && selected)
+        {
+            DrawManualUpVectorHandles(line);
+        }
+
+        if (drawLinePoints)
+        {
+            DrawLinePoints(line);
+        }
+
+        // Since lines are constantly updating themselves
+        // just repaint all by default
+    }
+
+    protected override void DrawCustomFooter()
+    {
+        LineBase line = (LineBase)target;
+
+        if (DrawSectionStart(line.name + " Editor", "Editor Settings"))
+        {
+            linePreviewResolutionSelected = EditorGUILayout.IntSlider("Preview resolution", linePreviewResolutionSelected, 3, 100);
+
+            drawDottedLine = EditorGUILayout.Toggle("Draw Dotted Line", drawDottedLine);
+            drawLinePoints = EditorGUILayout.Toggle("Draw Line Points", drawLinePoints);
+            drawLineRotations = EditorGUILayout.Toggle("Draw Line Rotations", drawLineRotations);
+            drawLineManualUpVectors = EditorGUILayout.Toggle("Draw Manual Up Vectors", drawLineManualUpVectors);
+
+            if (drawLineRotations)
+            {
+                lineRotationLength = EditorGUILayout.Slider("Rotation Arrow Length", lineRotationLength, 0.01f, 5f);
+            }
+
+            if (drawLineManualUpVectors)
+            {
+                lineManualUpVectorLength = EditorGUILayout.Slider("Manual Up Vector Length", lineManualUpVectorLength, 1f, 10f);
+                if (GUILayout.Button("Normalize Up Vectors"))
+                {
+                    for (int i = 0; i < line.ManualUpVectors.Length; i++)
+                    {
+                        Vector3 upVector = line.ManualUpVectors[i];
+                        if (upVector == Vector3.zero)
+                        {
+                            upVector = Vector3.up;
+                        }
+
+                        line.ManualUpVectors[i] = upVector.normalized;
+                    }
+                }
+            }
+        }
+        DrawSectionEnd();
+
+        SceneView.RepaintAll();
+    }
+
+    protected void DrawDottedLine(LineBase line, int numSteps)
+    {
+        Vector3 firstPos = Vector3.zero;
+        Vector3 lastPos = Vector3.zero;
+
+        switch (EditorStepMode)
+        {
+            case StepModeEnum.FromSource:
+                firstPos = line.GetPoint(0);
+                lastPos = firstPos;
+
+                for (int i = 1; i < line.NumPoints; i++)
+                {
+                    Vector3 currentPos = line.GetPoint(i);
+                    Handles.DrawDottedLine(lastPos, currentPos, MRTKEditor.DottedLineScreenSpace);
+                    lastPos = currentPos;
+                }
+
+                if (line.Loops)
+                {
+                    Handles.DrawDottedLine(lastPos, firstPos, MRTKEditor.DottedLineScreenSpace);
+                }
+                break;
+
+            case StepModeEnum.Interpolated:
+            default:
+                firstPos = line.GetPoint(0f);
+                lastPos = firstPos;
+                Handles.color = DefaultDisplayLineColor;
+
+                for (int i = 1; i < numSteps; i++)
+                {
+                    float normalizedLength = (1f / (numSteps - 1)) * i;
+                    Vector3 currentPos = line.GetPoint(normalizedLength);
+                    Handles.DrawDottedLine(lastPos, currentPos, MRTKEditor.DottedLineScreenSpace);
+                    lastPos = currentPos;
+                }
+
+                if (line.Loops)
+                {
+                    Handles.DrawDottedLine(lastPos, firstPos, MRTKEditor.DottedLineScreenSpace);
+                }
+                break;
+        }
+    }
+
+    protected void DrawLinePoints(LineBase line)
+    {
+        Handles.color = DefaultDisplayLineColor;
+        float dotSize = HandleUtility.GetHandleSize(line.transform.position) * 0.025f;
+        for (int i = 0; i < line.NumPoints; i++)
+        {
+            Handles.DotHandleCap(0, line.GetPoint(i), Quaternion.identity, dotSize, EventType.Repaint);
+        }
+    }
+
+    protected void DrawLineRotations(LineBase line, int numSteps)
+    {
+        Handles.color = lineVelocityColor;
+        float arrowSize = HandleUtility.GetHandleSize(line.transform.position) * lineRotationLength;
+
+        for (int i = 1; i < numSteps; i++)
+        {
+            float normalizedLength = (1f / (numSteps - 1)) * i;
+            Vector3 currentPos = line.GetPoint(normalizedLength);
+            Quaternion rotation = line.GetRotation(normalizedLength);
+
+            Handles.color = Color.Lerp(lineVelocityColor, Handles.zAxisColor, 0.75f);
+            Handles.ArrowHandleCap(0, currentPos, Quaternion.LookRotation(rotation * Vector3.forward), arrowSize, EventType.Repaint);
+            Handles.color = Color.Lerp(lineVelocityColor, Handles.xAxisColor, 0.75f);
+            Handles.ArrowHandleCap(0, currentPos, Quaternion.LookRotation(rotation * Vector3.right), arrowSize, EventType.Repaint);
+            Handles.color = Color.Lerp(lineVelocityColor, Handles.yAxisColor, 0.75f);
+            Handles.ArrowHandleCap(0, currentPos, Quaternion.LookRotation(rotation * Vector3.up), arrowSize, EventType.Repaint);
+        }
+    }
+
+    protected void DrawManualUpVectorHandles(LineBase line)
+    {
+        if (line.ManualUpVectors == null || line.ManualUpVectors.Length < 2)
+            line.ManualUpVectors = new Vector3[2];
+
+        for (int i = 0; i < line.ManualUpVectors.Length; i++)
+        {
+            float normalizedLength = (1f / (line.ManualUpVectors.Length - 1)) * i;
+            Vector3 currentPoint = line.GetPoint(normalizedLength);
+            Vector3 currentUpVector = line.ManualUpVectors[i];
+            line.ManualUpVectors[i] = VectorHandle(currentPoint, currentUpVector, false, lineManualUpVectorLength);
+        }
+    }
+}
+#endif

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineBaseEditor.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineBaseEditor.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 203a00afd45e5df44a6dd39d8e794439
+timeCreated: 1507575845
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineMeshes.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineMeshes.cs
@@ -1,0 +1,154 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+using HoloToolkit.Unity;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Holotoolkit.Unity.UX
+{
+    [UseWith(typeof(LineBase))]
+    public class LineMeshes : LineRendererBase
+    {
+        readonly string InvisibleShaderName = "MixedRealityToolkit/InvisibleShader";
+
+        [Header("Instanced Mesh Settings")]
+        public Mesh LineMesh;
+
+        public Material LineMaterial;
+
+        [MaterialProperty(MaterialPropertyAttribute.PropertyTypeEnum.Color, "LineMaterial")]
+        public string ColorProp = "_Color";
+
+        // Command buffer properties
+        private MaterialPropertyBlock linePropertyBlock;
+        private int colorID;
+        private Matrix4x4[] meshTransforms;
+        private Vector4[] colorValues;
+        private bool executeCommandBuffer = false;
+        private Dictionary<Camera, CommandBuffer> cameras = new Dictionary<Camera, CommandBuffer>();
+        // OnWillRenderObject helpers
+        private MeshRenderer onWillRenderHelper;
+        private Mesh onWillRenderMesh;
+        private Material onWillRenderMat;
+        private Vector3[] meshVertices = new Vector3[3];
+
+        protected void OnEnable()
+        {
+            if (LineMaterial == null)
+            {
+                Debug.LogError("Line material cannot be null.");
+                enabled = false;
+                return;
+            }
+
+            if (linePropertyBlock == null)
+            {
+                LineMaterial.enableInstancing = true;
+                linePropertyBlock = new MaterialPropertyBlock();
+                colorID = Shader.PropertyToID(ColorProp);
+            }
+
+            if (onWillRenderHelper == null)
+            {   // OnWillRenderObject won't be called unless there's a renderer attached
+                // and if the renderer's bounds are visbile.
+                // So we create a simple 1-triangle mesh to ensure it's always called.
+                // Hackey, but it works.
+                onWillRenderHelper = gameObject.AddComponent<MeshRenderer>();
+                onWillRenderHelper.receiveShadows = false;
+                onWillRenderHelper.shadowCastingMode = ShadowCastingMode.Off;
+                onWillRenderHelper.lightProbeUsage = LightProbeUsage.Off;
+                onWillRenderHelper.motionVectorGenerationMode = MotionVectorGenerationMode.ForceNoMotion;
+
+                onWillRenderMesh = new Mesh();
+                onWillRenderMesh.vertices = meshVertices;
+                onWillRenderMesh.triangles = new int[] { 0, 1, 2 };
+
+                MeshFilter helperMeshFilter = gameObject.AddComponent<MeshFilter>();
+                helperMeshFilter.sharedMesh = onWillRenderMesh;
+
+                // Create an 'invisible' material so the mesh doesn't show up pink
+                onWillRenderMat = new Material(Shader.Find(InvisibleShaderName));
+                onWillRenderHelper.sharedMaterial = onWillRenderMat;
+            }
+        }
+
+        private void Update()
+        {
+            executeCommandBuffer = false;
+
+            if (Source.enabled)
+            {
+                if (meshTransforms == null || meshTransforms.Length != NumLineSteps)
+                {
+                    meshTransforms = new Matrix4x4[NumLineSteps];
+                }
+
+                if (colorValues == null || colorValues.Length != NumLineSteps)
+                {
+                    colorValues = new Vector4[NumLineSteps];
+                    linePropertyBlock.Clear();
+                }
+
+                for (int i = 0; i < NumLineSteps; i++)
+                {
+                    float normalizedDistance = (1f / (NumLineSteps - 1)) * i;
+                    colorValues[i] = GetColor(normalizedDistance);
+                    meshTransforms[i] = Matrix4x4.TRS(Source.GetPoint(normalizedDistance), Source.GetRotation(normalizedDistance), Vector3.one * GetWidth(normalizedDistance));
+                }
+
+                linePropertyBlock.SetVectorArray(colorID, colorValues);
+
+                executeCommandBuffer = true;
+            }
+        }
+
+        private void OnDisable()
+        {
+            foreach (KeyValuePair<Camera, CommandBuffer> cam in cameras)
+            {
+                if (cam.Key != null)
+                {
+                    cam.Key.RemoveCommandBuffer(CameraEvent.AfterForwardOpaque, cam.Value);
+                }
+            }
+            cameras.Clear();
+        }
+
+        private void OnWillRenderObject()
+        {
+            Camera cam = Camera.current;
+            CommandBuffer buffer = null;
+            if (!cameras.TryGetValue(cam, out buffer))
+            {
+                buffer = new CommandBuffer();
+                buffer.name = "Line Mesh Renderer " + cam.name;
+                cam.AddCommandBuffer(CameraEvent.AfterForwardOpaque, buffer);
+                cameras.Add(cam, buffer);
+            }
+
+            buffer.Clear();
+            if (executeCommandBuffer)
+            {
+                buffer.DrawMeshInstanced(LineMesh, 0, LineMaterial, 0, meshTransforms, meshTransforms.Length, linePropertyBlock);
+            }
+        }
+
+        private void LateUpdate()
+        {
+            // Update our helper mesh so OnWillRenderObject will be called
+            meshVertices[0] = transform.InverseTransformPoint(Source.GetPoint(0.0f));// - transform.position;
+            meshVertices[1] = transform.InverseTransformPoint(Source.GetPoint(0.5f));// - transform.position;
+            meshVertices[2] = transform.InverseTransformPoint(Source.GetPoint(1.0f));// - transform.position;
+            onWillRenderMesh.vertices = meshVertices;
+            onWillRenderMesh.RecalculateBounds();
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(LineMeshes))]
+        public class CustomEditor : MRTKEditor { }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineMeshes.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineMeshes.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 6a32e3ee1459c3d46b0d52d9185d20f8
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectCollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectCollection.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class LineObjectCollection : MonoBehaviour
+    {
+        public List<Transform> Objects = new List<Transform>();
+
+        [Range(-2f, 2f)]
+        public float DistributionOffset = 0f;
+        [Range(0f, 2f)]
+        public float LengthOffset = 0f;
+        [Range(0f, 2f)]
+        public float ScaleOffset = 0f;
+        [Range(0.001f, 2f)]
+        public float ScaleMultiplier = 1f;
+        [Range(0.001f, 2f)]
+        public float PositionMultiplier = 1f;
+
+        public float DistributionOffsetPerObject
+        {
+            get
+            {
+                return 1f / Objects.Count;
+            }
+        }
+
+        public AnimationCurve ObjectScale = AnimationCurve.Linear(0f, 1f, 1f, 1f);
+
+        public AnimationCurve ObjectPosition = AnimationCurve.Linear(0f, 0f, 1f, 0f);
+
+        public bool FlipRotation = false;
+
+        public Vector3 RotationOffset = Vector3.zero;
+
+        public Vector3 PositionOffset = Vector3.zero;
+
+        public RotationTypeEnum RotationTypeOverride = RotationTypeEnum.None;
+
+        public PointDistributionTypeEnum DistributionType = PointDistributionTypeEnum.None;
+
+        [Header("Object Placement")]
+        public StepModeEnum StepMode = StepModeEnum.Interpolated;
+
+        [SerializeField]
+        private LineBase source;
+
+        [SerializeField]
+        private Transform transformHelper;
+
+        public virtual LineBase Source
+        {
+            get
+            {
+                if (source == null)
+                {
+                    source = GetComponent<LineBase>();
+                }
+                return source;
+            }
+            set
+            {
+                source = value;
+                if (source == null)
+                {
+                    enabled = false;
+                }
+            }
+        }
+
+        // Convenience functions
+        public float GetOffsetFromObjectIndex(int index, bool wrap = true)
+        {
+            if (Objects.Count == 0)
+            {
+                return 0;
+            }
+
+            if (wrap)
+            {
+                index = WrapIndex(index, Objects.Count);
+            }
+            else
+            {
+                index = Mathf.Clamp(index, 0, Objects.Count - 1);
+            }
+
+            return (1f / Objects.Count * (index + 1));
+        }
+
+        public int GetNextObjectIndex(int index, bool wrap = true)
+        {
+            if (Objects.Count == 0)
+            {
+                return 0;
+            }
+
+            index++;
+
+            if (wrap)
+            {
+                return WrapIndex(index, Objects.Count);
+            }
+            else
+            {
+                return Mathf.Clamp(index, 0, Objects.Count - 1);
+            }
+        }
+
+        public int GetPrevObjectIndex(int index, bool wrap = true)
+        {
+            if (Objects.Count == 0)
+            {
+                return 0;
+            }
+
+            index--;
+
+            if (wrap)
+            {
+                return WrapIndex(index, Objects.Count);
+            }
+            else
+            {
+                return Mathf.Clamp(index, 0, Objects.Count - 1);
+            }
+        }
+
+        public void Update()
+        {
+            UpdateCollection();
+        }
+
+        public void UpdateCollection()
+        {
+            if (Source == null)
+            {
+                return;
+            }
+
+            if (transformHelper == null)
+            {
+                transformHelper = transform.Find("TransformHelper");
+                if (transformHelper == null)
+                {
+                    transformHelper = new GameObject("TransformHelper").transform;
+                    transformHelper.parent = transform;
+                }
+            }
+
+            switch (StepMode)
+            {
+                case StepModeEnum.FromSource:
+                    break;
+
+                case StepModeEnum.Interpolated:
+                    for (int i = 0; i < Objects.Count; i++)
+                    {
+                        if (Objects[i] == null)
+                        {
+                            continue;
+                        }
+
+                        float normalizedDistance = Mathf.Repeat(((float)i / Objects.Count) + DistributionOffset, 1f);
+                        Objects[i].position = Source.GetPoint(normalizedDistance);
+                        Objects[i].rotation = Source.GetRotation(normalizedDistance, RotationTypeOverride);
+
+                        transformHelper.localScale = Vector3.one;
+                        transformHelper.position = Objects[i].position;
+                        transformHelper.localRotation = Quaternion.identity;
+                        Transform tempParent = Objects[i].parent;
+                        Objects[i].parent = transformHelper;
+                        transformHelper.localEulerAngles = RotationOffset;
+                        Objects[i].parent = tempParent;
+                        Objects[i].transform.localScale = Vector3.one * ObjectScale.Evaluate(Mathf.Repeat(ScaleOffset + normalizedDistance, 1f)) * ScaleMultiplier;
+                    }
+                    break;
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (Application.isPlaying)
+            {
+                return;
+            }
+
+            UpdateCollection();
+        }
+#endif
+
+        private static int WrapIndex(int index, int numObjects)
+        {
+            return ((index % numObjects) + numObjects) % numObjects;
+        }
+    }
+
+#if UNITY_EDITOR
+    [UnityEditor.CustomEditor(typeof(LineObjectCollection))]
+    public class LineObjectCollectionEditor : UnityEditor.Editor
+    {
+        public void OnSceneGUI()
+        {
+            LineObjectCollection loc = (LineObjectCollection)target;
+
+            for (int i = 0; i < loc.Objects.Count; i++)
+            {
+                if (loc.Objects[i] != null)
+                {
+                    UnityEditor.Handles.Label(loc.Objects[i].position, "Index: " + i.ToString("000") + "\nOffset: " + loc.GetOffsetFromObjectIndex(i).ToString("00.00"));
+                }
+            }
+        }
+    }
+#endif
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectCollection.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectCollection.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c509818734592e547a463a2deca85e7d
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectFollower.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectFollower.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    [ExecuteInEditMode]
+    public class LineObjectFollower : MonoBehaviour
+    {
+        public Transform Object;
+
+        [Header("Follow Settings")]
+        [Range(0f, 1f)]
+        public float NormalizedDistance = 0f;
+
+        [SerializeField]
+        private LineBase source;
+
+        private void Update()
+        {
+            Vector3 linePoint = source.GetPoint(NormalizedDistance);
+            Object.position = linePoint;
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectFollower.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectFollower.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 927f2b01b90f51e41a4cd257717d40a8
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectSwarm.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectSwarm.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    [ExecuteInEditMode]
+    public class LineObjectSwarm : MonoBehaviour
+    {
+        const int RandomValueResolution = 1024;
+
+        public List<Transform> Objects = new List<Transform>();
+
+        [Range(0, 100)]
+        public int Seed = 0;
+
+        [SerializeField]
+        private LineBase source;
+
+        [Header("Noise Settings")]
+        public float ScaleMultiplier = 10f;
+        public float SpeedMultiplier = 1f;
+        public float StrengthMultiplier = 0.5f;
+        public Vector3 AxisStrength = Vector3.one;
+        public Vector3 AxisSpeed = Vector3.one;
+        public Vector3 AxisOffset = Vector3.zero;
+
+        private Vector3[] prevPoints;
+        private System.Random randomPosition;
+        private System.Random randomRotation;
+        private FastSimplexNoise noise = new FastSimplexNoise();
+
+        [Header("Swarm Settings")]
+        [Range(0f, 1f)]
+        public float NormalizedDistance = 0f;
+
+        public Vector3 SwarmScale = Vector3.one;
+
+        public AnimationCurve ObjectScale = AnimationCurve.Linear(0f, 1f, 1f, 1f);
+
+        public AnimationCurve ObjectOffset = AnimationCurve.Linear(0f, 0f, 1f, 0f);
+
+        public RotationTypeEnum RotationTypeOverride = RotationTypeEnum.None;
+
+        public bool SwarmVelocities = true;
+
+        public float VelocityBlend = 0.5f;
+
+        public Vector3 RotationOffset = Vector3.zero;
+
+        public Vector3 AxisScale = Vector3.one;
+
+        public virtual LineBase Source
+        {
+            get
+            {
+                if (source == null)
+                {
+                    source = GetComponent<LineBase>();
+                }
+                return source;
+            }
+            set
+            {
+                source = value;
+                if (source == null)
+                {
+                    enabled = false;
+                }
+            }
+        }
+
+        public Vector3 GetRandomPoint()
+        {
+            Vector3 randomPoint = Vector3.one;
+            randomPoint.x = (float)randomPosition.Next(-RandomValueResolution, RandomValueResolution) / (RandomValueResolution * 2);
+            randomPoint.y = (float)randomPosition.Next(-RandomValueResolution, RandomValueResolution) / (RandomValueResolution * 2);
+            randomPoint.z = (float)randomPosition.Next(-RandomValueResolution, RandomValueResolution) / (RandomValueResolution * 2);
+
+            return Vector3.Scale(randomPoint, SwarmScale);
+        }
+
+        public void Update()
+        {
+            UpdateCollection();
+
+#if UNITY_EDITOR
+            UnityEditor.EditorUtility.SetDirty(gameObject);
+#endif
+        }
+
+        public void UpdateCollection()
+        {
+            if (Source == null)
+            {
+                return;
+            }
+
+            if (prevPoints == null || prevPoints.Length != Objects.Count)
+            {
+                prevPoints = new Vector3[Objects.Count];
+            }
+
+            randomPosition = new System.Random(Seed);
+            Vector3 linePoint = source.GetPoint(NormalizedDistance);
+            Quaternion lineRotation = source.GetRotation(NormalizedDistance, RotationTypeOverride);
+
+            for (int i = 0; i < Objects.Count; i++)
+            {
+                if (Objects[i] == null)
+                {
+                    continue;
+                }
+
+                Vector3 point = source.transform.TransformVector(GetRandomPoint());
+                point.x = (float)(point.x + (noise.Evaluate((point.x + AxisOffset.x) * ScaleMultiplier, Time.unscaledTime * AxisSpeed.x * SpeedMultiplier)) * AxisStrength.x * StrengthMultiplier);
+                point.y = (float)(point.y + (noise.Evaluate((point.y + AxisOffset.y) * ScaleMultiplier, Time.unscaledTime * AxisSpeed.y * SpeedMultiplier)) * AxisStrength.y * StrengthMultiplier);
+                point.z = (float)(point.z + (noise.Evaluate((point.z + AxisOffset.z) * ScaleMultiplier, Time.unscaledTime * AxisSpeed.z * SpeedMultiplier)) * AxisStrength.z * StrengthMultiplier);
+
+                Objects[i].position = point + linePoint;
+                if (SwarmVelocities)
+                {
+                    Vector3 velocity = prevPoints[i] - point;
+                    Objects[i].rotation = Quaternion.Lerp(lineRotation, Quaternion.LookRotation(velocity, Vector3.up), VelocityBlend);
+                }
+                else
+                {
+                    Objects[i].rotation = lineRotation;
+                }
+                Objects[i].Rotate(RotationOffset);
+
+                prevPoints[i] = point;
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectSwarm.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectSwarm.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 8bfb73db466be1440a3084f10aedffa6
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineParticles.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineParticles.cs
@@ -1,0 +1,134 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+using HoloToolkit.Unity;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    [UseWith(typeof(LineBase))]
+    public class LineParticles : LineRendererBase
+    {
+        const int GlobalMaxParticles = 2048;
+        const float GlobalParticleStartLifetime = 0.5f;
+
+        [Header("Particle Settings")]
+        public Material LineMaterial;
+        [Range(128, GlobalMaxParticles)]
+        public int MaxParticles = GlobalMaxParticles;
+        [Range(0.001f, 5f)]
+        public float ParticleStartLifetime = GlobalParticleStartLifetime;
+
+        [Header("Noise settings")]
+        public bool ParticleNoiseOnDisabled = true;
+        public Vector3 NoiseStrength = Vector3.one;
+        public float NoiseFrequency = 1.2f;
+        [Range(1, 10)]
+        public int NoiseOcatives = 3;
+        [Range(-10f, 10f)]
+        public float NoiseSpeed = 1f;
+        [Range(0.01f, 0.5f)]
+        public float LifetimeAfterDisabled = 0.25f;
+        public Gradient DecayGradient;
+
+        [SerializeField]
+        private ParticleSystem particles;
+        private ParticleSystem.Particle[] mainParticleArray = new ParticleSystem.Particle[GlobalMaxParticles];
+        private ParticleSystemRenderer mainParticleRenderer;
+        private ParticleSystem.NoiseModule mainNoise;
+        private float decayStartTime = 0f;
+
+        protected void OnEnable()
+        {
+            particles = gameObject.EnsureComponent<ParticleSystem>();
+
+            mainNoise = particles.noise;
+
+            ParticleSystem.EmissionModule emission = particles.emission;
+            emission.rateOverTime = new ParticleSystem.MinMaxCurve(0);
+            emission.rateOverDistance = new ParticleSystem.MinMaxCurve(0);
+            emission.enabled = true;
+
+            ParticleSystem.MainModule main = particles.main;
+            main.loop = false;
+            main.playOnAwake = false;
+            main.maxParticles = Mathf.Min(MaxParticles, GlobalMaxParticles);
+            main.simulationSpace = ParticleSystemSimulationSpace.World;
+
+            ParticleSystem.ShapeModule shape = particles.shape;
+            shape.enabled = false;
+
+            mainParticleRenderer = particles.GetComponent<ParticleSystemRenderer>();
+            mainParticleRenderer.sharedMaterial = LineMaterial;
+
+            // Initialize our particles
+            for (int i = 0; i < mainParticleArray.Length; i++)
+            {
+                ParticleSystem.Particle particle = mainParticleArray[i];
+                particle.startColor = Color.white;
+                particle.startSize = 1f;
+                particle.startLifetime = float.MaxValue;
+                particle.remainingLifetime = float.MaxValue;
+                particle.velocity = Vector3.zero;
+                particle.angularVelocity = 0;
+                mainParticleArray[i] = particle;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (mainParticleRenderer != null)
+            {
+                mainParticleRenderer.enabled = false;
+            }
+        }
+
+        private void Update()
+        {
+            if (!Source.enabled)
+            {
+                mainNoise.enabled = ParticleNoiseOnDisabled;
+                mainNoise.strengthX = NoiseStrength.x;
+                mainNoise.strengthY = NoiseStrength.y;
+                mainNoise.strengthZ = NoiseStrength.z;
+                mainNoise.octaveCount = NoiseOcatives;
+                mainNoise.scrollSpeed = NoiseSpeed;
+                mainNoise.frequency = NoiseFrequency;
+
+                if (decayStartTime < 0)
+                {
+                    decayStartTime = Time.unscaledTime;
+                }
+            }
+            else
+            {
+                mainNoise.enabled = false;
+                decayStartTime = -1;
+            }
+
+            if (Source.enabled)
+            {
+                for (int i = 0; i < NumLineSteps; i++)
+                {
+                    float normalizedDistance = (1f / (NumLineSteps - 1)) * i;
+                    ParticleSystem.Particle particle = mainParticleArray[i];
+                    particle.position = Source.GetPoint(normalizedDistance);
+                    particle.startColor = GetColor(normalizedDistance);
+                    particle.startSize = GetWidth(normalizedDistance);
+                    mainParticleArray[i] = particle;
+                }
+            }
+            else
+            {
+                int numDecayingParticles = particles.GetParticles(mainParticleArray);
+                for (int i = 0; i < numDecayingParticles; i++)
+                {
+                    float normalizedDistance = (1f / (NumLineSteps - 1)) * i;
+                    mainParticleArray[i].startColor = DecayGradient.Evaluate((Time.unscaledTime - decayStartTime) / LifetimeAfterDisabled) * GetColor(normalizedDistance);
+                }
+            }
+            particles.SetParticles(mainParticleArray, NumLineSteps);
+        }
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineParticles.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineParticles.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c56be4f6a3f38c04880a003c6f0a56da
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineRendererBase.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineRendererBase.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public abstract class LineRendererBase : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("The source Line this component will render")]
+        protected LineBase source;
+
+        [Header("Visual Settings")]
+        [Tooltip("Color gradient applied to line's normalized length")]
+        public Gradient LineColor;
+
+        public AnimationCurve LineWidth = AnimationCurve.Linear(0f, 0.05f, 1f, 0.05f);
+        [Range(0f, 10f)]
+        public float WidthMultiplier = 0.25f;
+
+        [Header("Offsets")]
+        [Range(0f, 10f)]
+        [Tooltip("Normalized offset for color gradient")]
+        public float ColorOffset = 0f;
+        [Range(0f, 10f)]
+        [Tooltip("Normalized offset for width curve")]
+        public float WidthOffset = 0f;
+        [Range(0f, 10f)]
+        [Tooltip("Normalized offset for rotation offset")]
+        public float RotationOffset = 0f;
+
+        [Header("Point Placement")]
+        [Tooltip("Method for gathering points along line. Interpolated uses normalized length. FromSource uses line's base points. (FromSource may not look right for all Line types.)")]
+        public StepModeEnum StepMode = StepModeEnum.Interpolated;
+        [Range(0, 2048)]
+        [Tooltip("Number of steps to interpolate along line in Interpolated step mode")]
+        [ShowIfEnumValue("StepMode", StepModeEnum.Interpolated)]
+        public int NumLineSteps = 10;
+
+        [FeatureInProgress]
+        public InterpolationModeEnum InterpolationMode = InterpolationModeEnum.FromLength;
+        [FeatureInProgress]
+        [Range(0.001f, 1f)]
+        public float StepLength = 0.05f;
+        [FeatureInProgress]
+        [Range(1, 2048)]
+        public int MaxLineSteps = 2048;
+        [FeatureInProgress]
+        public AnimationCurve StepLengthCurve = AnimationCurve.Linear(0f, 1f, 1f, 0.5f);
+
+        public virtual LineBase Source
+        {
+            get
+            {
+                if (source == null)
+                {
+                    source = GetComponent<LineBase>();
+                }
+                return source;
+            }
+            set
+            {
+                source = value;
+                if (source == null)
+                {
+                    enabled = false;
+                }
+            }
+        }
+
+        protected virtual Color GetColor(float normalizedLength)
+        {
+            if (LineColor == null)
+            {
+                LineColor = new Gradient();
+            }
+
+            return LineColor.Evaluate(Mathf.Repeat(normalizedLength + ColorOffset, 1f));
+        }
+
+        protected virtual float GetWidth(float normalizedLength)
+        {
+            if (LineWidth == null)
+            {
+                LineWidth = AnimationCurve.Linear(0f, 1f, 1f, 1f);
+            }
+
+            return LineWidth.Evaluate(Mathf.Repeat(normalizedLength + WidthOffset, 1f)) * WidthMultiplier;
+        }
+
+        private float[] normalizedLengths;
+
+#if UNITY_EDITOR
+        protected virtual void OnDrawGizmos()
+        {
+            if (Application.isPlaying)
+                return;
+
+            if (source == null)
+                source = gameObject.GetComponent<LineBase>();
+            if (source == null || !source.enabled)
+                return;
+
+            GizmosDrawLineRenderer(source, this);
+        }
+
+        public static void GizmosDrawLineRenderer(LineBase source, LineRendererBase renderer)
+        {
+            switch (renderer.StepMode)
+            {
+                case StepModeEnum.FromSource:
+                    GizmosDrawLineFromSource(source, renderer);
+                    break;
+
+                case StepModeEnum.Interpolated:
+                    GizmosDrawLineInterpolated(source, renderer);
+                    break;
+            }
+        }
+
+        public static void GizmosDrawLineFromSource(LineBase source, LineRendererBase renderer)
+        {
+            Vector3 firstPos = source.GetPoint(0);
+            Vector3 lastPos = firstPos;
+            Color gColor = renderer.GetColor(0);
+
+            gColor.a = 0.5f;
+            Gizmos.color = gColor;
+            Gizmos.DrawSphere(firstPos, renderer.GetWidth(0) / 2);
+            for (int i = 1; i < source.NumPoints; i++)
+            {
+                float normalizedLength = (1f / (source.NumPoints)) * i;
+                Vector3 currentPos = source.GetPoint(i);
+                gColor = renderer.GetColor(normalizedLength);
+                gColor.a = gColor.a * 0.5f;
+                Gizmos.color = gColor;
+                Gizmos.DrawLine(lastPos, currentPos);
+                Gizmos.DrawSphere(currentPos, renderer.GetWidth(normalizedLength) / 2);
+                lastPos = currentPos;
+            }
+
+            if (source.Loops)
+            {
+                Gizmos.DrawLine(lastPos, firstPos);
+            }
+        }
+
+        public static void GizmosDrawLineInterpolated(LineBase source, LineRendererBase renderer)
+        {
+            Vector3 firstPos = source.GetPoint(0f);
+            Vector3 lastPos = firstPos;
+            Color gColor = renderer.GetColor(0);
+
+            gColor.a = 0.5f;
+            Gizmos.color = gColor;
+            Gizmos.DrawSphere(firstPos, renderer.GetWidth(0) / 2);
+            for (int i = 1; i <= renderer.NumLineSteps; i++)
+            {
+                float normalizedLength = (1f / (renderer.NumLineSteps)) * i;
+                Vector3 currentPos = source.GetPoint(normalizedLength);
+                gColor = renderer.GetColor(normalizedLength);
+                gColor.a = gColor.a * 0.5f;
+                Gizmos.color = gColor;
+                Gizmos.DrawLine(lastPos, currentPos);
+                Gizmos.DrawSphere(currentPos, renderer.GetWidth(normalizedLength) / 2);
+                lastPos = currentPos;
+            }
+
+            if (source.Loops)
+            {
+                Gizmos.DrawLine(lastPos, firstPos);
+            }
+        }
+#endif
+
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineRendererBase.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineRendererBase.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 42a9f853dc01d4c4ba18323c1301f233
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineStripMesh.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineStripMesh.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    [UseWith(typeof(LineBase))]
+    public class LineStripMesh : LineRendererBase
+    {
+        [Header("Strip Mesh Settings")]
+        public Material LineMaterial;
+
+        public Vector3 Forward;
+
+        [SerializeField]
+        private float uvOffset = 0f;
+
+        private Mesh stripMesh;
+        private MeshRenderer stripMeshRenderer;
+        private Material lineMatInstance;
+        private List<Vector3> positions = new List<Vector3>();
+        private List<Vector3> forwards = new List<Vector3>();
+        private List<Color> colors = new List<Color>();
+        private List<float> widths = new List<float>();
+
+        private GameObject meshRendererGameObject;
+
+        protected void OnEnable()
+        {
+            if (LineMaterial == null)
+            {
+                Debug.LogError("Line material cannot be null.");
+                enabled = false;
+                return;
+            }
+
+            lineMatInstance = new Material(LineMaterial);
+
+            // Create a mesh
+            if (stripMesh == null)
+            {
+                stripMesh = new Mesh();
+            }
+
+            if (stripMeshRenderer == null)
+            {
+                meshRendererGameObject = new GameObject("Strip Mesh Renderer");
+                stripMeshRenderer = meshRendererGameObject.AddComponent<MeshRenderer>();
+            }
+
+            stripMeshRenderer.sharedMaterial = lineMatInstance;
+            stripMeshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            stripMeshRenderer.receiveShadows = false;
+            stripMeshRenderer.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+
+            MeshFilter stripMeshFilter = stripMeshRenderer.EnsureComponent<MeshFilter>();
+            stripMeshFilter.sharedMesh = stripMesh;
+        }
+
+        private void OnDisable()
+        {
+            if (lineMatInstance != null)
+            {
+                GameObject.Destroy(lineMatInstance);
+            }
+
+            if (meshRendererGameObject != null)
+            {
+                GameObject.Destroy(meshRendererGameObject);
+                stripMeshRenderer = null;
+            }
+        }
+
+        public void Update()
+        {
+            if (!Source.enabled)
+            {
+                stripMeshRenderer.enabled = false;
+                return;
+            }
+
+            stripMeshRenderer.enabled = true;
+            positions.Clear();
+            forwards.Clear();
+            colors.Clear();
+            widths.Clear();
+
+            for (int i = 0; i <= NumLineSteps; i++)
+            {
+                float normalizedDistance = (1f / (NumLineSteps - 1)) * i;
+                positions.Add(Source.GetPoint(normalizedDistance));
+                colors.Add(GetColor(normalizedDistance));
+                widths.Add(GetWidth(normalizedDistance));
+                forwards.Add(Source.GetRotation(normalizedDistance) * Vector3.down);
+            }
+
+            GenerateStripMesh(positions, colors, widths, uvOffset, forwards, stripMesh);
+        }
+
+        public static void GenerateStripMesh(List<Vector3> positionList, List<Color> colorList, List<float> thicknessList, float uvOffsetLocal, List<Vector3> forwardList, Mesh mesh)
+        {
+            int vertexCount = positionList.Count * 2;
+            int colorCount = colorList.Count * 2;
+            int uvCount = positionList.Count * 2;
+
+            if (stripMeshVertices == null || stripMeshVertices.Length != vertexCount)
+            {
+                stripMeshVertices = new Vector3[vertexCount];
+            }
+            if (stripMeshColors == null || stripMeshColors.Length != colorCount)
+            {
+                stripMeshColors = new Color[colorCount];
+            }
+            if (stripMeshUvs == null || stripMeshUvs.Length != uvCount)
+            {
+                stripMeshUvs = new Vector2[uvCount];
+            }
+
+            for (int x = 0; x < positionList.Count; x++)
+            {
+                Vector3 forward = forwardList[x / 2];
+                Vector3 right = Vector3.Cross(forward, Vector3.up).normalized;
+                float thickness = thicknessList[x / 2] / 2;
+                stripMeshVertices[2 * x] = positionList[x] - right * thickness;
+                stripMeshVertices[2 * x + 1] = positionList[x] + right * thickness;
+                stripMeshColors[2 * x] = colorList[x];
+                stripMeshColors[2 * x + 1] = colorList[x];
+
+                float uv = uvOffsetLocal;
+                if (x == positionList.Count - 1 && x > 1)
+                {
+                    float dist_last = (positionList[x - 2] - positionList[x - 1]).magnitude;
+                    float dist_cur = (positionList[x] - positionList[x - 1]).magnitude;
+                    uv += 1 - dist_cur / dist_last;
+                }
+
+                stripMeshUvs[2 * x] = new Vector2(0, x - uv);
+                stripMeshUvs[2 * x + 1] = new Vector2(1, x - uv);
+            }
+
+            int numTriangles = ((positionList.Count * 2 - 2) * 3);
+            if (stripMeshTriangles == null || stripMeshTriangles.Length != numTriangles)
+            {
+                stripMeshTriangles = new int[numTriangles];
+            }
+            int j = 0;
+            for (int i = 0; i < positionList.Count * 2 - 3; i += 2, j++)
+            {
+                stripMeshTriangles[i * 3] = j * 2;
+                stripMeshTriangles[i * 3 + 1] = j * 2 + 1;
+                stripMeshTriangles[i * 3 + 2] = j * 2 + 2;
+
+                stripMeshTriangles[i * 3 + 3] = j * 2 + 1;
+                stripMeshTriangles[i * 3 + 4] = j * 2 + 3;
+                stripMeshTriangles[i * 3 + 5] = j * 2 + 2;
+            }
+
+            mesh.Clear();
+            mesh.vertices = stripMeshVertices;
+            mesh.uv = stripMeshUvs;
+            mesh.triangles = stripMeshTriangles;
+            mesh.colors = stripMeshColors;
+            mesh.RecalculateBounds();
+            mesh.RecalculateNormals();
+        }
+
+        private static Vector3[] stripMeshVertices = null;
+        private static Color[] stripMeshColors = null;
+        private static Vector2[] stripMeshUvs = null;
+        private static int[] stripMeshTriangles = null;
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(LineStripMesh))]
+        public class CustomEditor : MRTKEditor { }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineStripMesh.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineStripMesh.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f751061e95bd99d4eb0a74afe2692c60
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineUnity.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineUnity.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using System.Collections;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    [UseWith(typeof(LineBase))]
+    public class LineUnity : LineRendererBase
+    {
+        const string DefaultLineShader = "Particles/Alpha Blended";
+        const string DefaultLineShaderColor = "_TintColor";
+
+        [Header("LineUnity Settings")]
+        [Tooltip("The material to use for the Unity LineRenderer (will be auto-generated if null)")]
+        public Material LineMaterial;
+
+        public bool RoundedEdges = true;
+        public bool RoundedCaps = true;
+
+        [SerializeField]
+        private UnityEngine.LineRenderer lineRenderer;
+
+        private Vector3[] positions;
+
+        protected void OnEnable()
+        {
+            // If we haven't specified a line renderer
+            if (lineRenderer == null)
+            {
+                // Get or create one that's attached to this gameObject
+                lineRenderer = gameObject.EnsureComponent<UnityEngine.LineRenderer>();
+            }
+
+            if (LineMaterial == null)
+            {
+                LineMaterial = new Material(Shader.Find(DefaultLineShader));
+                LineMaterial.SetColor(DefaultLineShaderColor, Color.white);
+            }
+
+            StartCoroutine(UpdateLineUnity());
+        }
+
+        private IEnumerator UpdateLineUnity()
+        {
+            while (isActiveAndEnabled)
+            {
+                if (!source.enabled)
+                {
+                    lineRenderer.enabled = false;
+                }
+                else
+                {
+                    lineRenderer.enabled = true;
+
+                    switch (StepMode)
+                    {
+                        case StepModeEnum.FromSource:
+                            lineRenderer.positionCount = source.NumPoints;
+                            if (positions == null || positions.Length != source.NumPoints)
+                            {
+                                positions = new Vector3[source.NumPoints];
+                            }
+                            for (int i = 0; i < positions.Length; i++)
+                            {
+                                positions[i] = source.GetPoint(i);
+                            }
+                            break;
+
+                        case StepModeEnum.Interpolated:
+                            lineRenderer.positionCount = NumLineSteps;
+                            if (positions == null || positions.Length != NumLineSteps)
+                            {
+                                positions = new Vector3[NumLineSteps];
+                            }
+                            for (int i = 0; i < positions.Length; i++)
+                            {
+                                float normalizedDistance = (1f / (NumLineSteps - 1)) * i;
+                                positions[i] = source.GetPoint(normalizedDistance);
+                            }
+                            break;
+                    }
+
+                    // Set line renderer properties
+                    lineRenderer.loop = source.Loops;
+                    lineRenderer.numCapVertices = RoundedCaps ? 8 : 0;
+                    lineRenderer.numCornerVertices = RoundedEdges ? 8 : 0;
+                    lineRenderer.useWorldSpace = true;
+                    lineRenderer.startWidth = 1;
+                    lineRenderer.endWidth = 1;
+                    lineRenderer.startColor = Color.white;
+                    lineRenderer.endColor = Color.white;
+                    lineRenderer.sharedMaterial = LineMaterial;
+                    lineRenderer.widthCurve = LineWidth;
+                    lineRenderer.widthMultiplier = WidthMultiplier;
+                    lineRenderer.colorGradient = LineColor;
+                    lineRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                    lineRenderer.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+                    // Set positions
+                    lineRenderer.positionCount = positions.Length;
+                    lineRenderer.SetPositions(positions);
+                }
+                yield return null;
+            }
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(LineUnity))]
+        public class CustomEditor : MRTKEditor { }
+#endif
+
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineUnity.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineUnity.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f9a4d6e2d0d55194788e9a2df9c0261f
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineUtility.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineUtility.cs
@@ -1,0 +1,252 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public enum InterpolationEnum
+    {
+        Bezeir,
+        CatmullRom,
+        Hermite,
+    }
+
+    /// <summary>
+    /// Default options for getting a rotation along a line
+    /// </summary>
+    public enum RotationTypeEnum
+    {
+        None,                           // Don't rotate
+        Velocity,                       // Use velocity
+        RelativeToOrigin,               // Rotate relative to direction from origin point
+    }
+
+    /// <summary>
+    /// Default options for getting an interpolated point along a line
+    /// </summary>
+    public enum PointDistributionTypeEnum
+    {
+        None,                       // Don't adjust placement
+        Auto,                       // Adjust placement automatically (default)
+        DistanceSingleValue,        // Place based on distance
+        DistanceCurveValue,         // Place based on curve
+    }
+
+    /// <summary>
+    /// Default options for how to generate points in a line renderer
+    /// </summary>
+    public enum StepModeEnum
+    {
+        Interpolated,   // Draw points based on NumLineSteps
+        FromSource,     // Draw only the points available in the source - use this for hard edges
+    }
+
+    /// <summary>
+    /// Default options for how to distribute interpolated points in a line renderer
+    /// </summary>
+    public enum InterpolationModeEnum
+    {
+        FromNumSteps,   // Specify the number of interpolation steps manually
+        FromLength,     // Create steps based on total length of line + manually specified length
+        FromCurve       // Create steps based on total length of line + animation curve
+    }
+
+    public enum DistortionTypeEnum
+    {
+        NormalizedLength,   // Use the normalized length of the line plus its distortion strength curve to determine distortion strength
+        Uniform,            // Use a single value to determine distortion strength
+    }
+
+    public static class LineUtils
+    {
+        #region offset and rotation functions
+
+        public static readonly Vector3 DefaultUpVector = Vector3.up;
+
+        /// <summary>
+        /// Returns normalized length for OffsetModeEnum.Manual
+        /// </summary>
+        /// <param name="step"></param>
+        /// <param name="offsetValue"></param>
+        /// <param name="repeat"></param>
+        /// <returns></returns>
+        public static float GetDistanceSingleValue(int step, float offsetValue, bool repeat)
+        {
+            float value = step * offsetValue;
+            return repeat ? Mathf.Repeat(value, 1f) : Mathf.Clamp01(value);
+        }
+
+        /// <summary>
+        /// Returns normalized length for OffsetModeEnum.CurveNormalized
+        /// </summary>
+        /// <param name="step"></param>
+        /// <param name="numSteps"></param>
+        /// <param name="offsetCurve"></param>
+        /// <param name="repeat"></param>
+        /// <returns></returns>
+        public static float GetDistanceCurveValue(int step, int numSteps, AnimationCurve offsetCurve, bool repeat)
+        {
+            float value = offsetCurve.Evaluate((float)step / numSteps);
+            return repeat ? Mathf.Repeat(value, 1f) : Mathf.Clamp01(value);
+        }
+
+        /// <summary>
+        /// Returns a blended value from a collection of vectors
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="normalizedLength"></param>
+        /// <returns></returns>
+        public static Vector3 GetVectorCollectionBlend(Vector3[] vectorCollection, float normalizedLength, bool repeat)
+        {
+            if (vectorCollection.Length == 0)
+            {
+                return Vector3.zero;
+            }
+            else if (vectorCollection.Length == 1)
+            {
+                return vectorCollection[0];
+            }
+
+            float arrayValueLength = 1f / vectorCollection.Length;
+            int indexA = Mathf.FloorToInt(normalizedLength * vectorCollection.Length);
+            if (indexA >= vectorCollection.Length)
+            {
+                indexA = repeat ? 0 : vectorCollection.Length - 1;
+            }
+
+            int indexB = indexA + 1;
+            if (indexB >= vectorCollection.Length)
+            {
+                indexB = repeat ? 0 : vectorCollection.Length - 1;
+            }
+
+            float blendAmount = (normalizedLength - (arrayValueLength * indexA)) / arrayValueLength;
+            Vector3 blendedVector = Vector3.Lerp(vectorCollection[indexA], vectorCollection[indexB], blendAmount);
+            return blendedVector;
+        }
+
+        public static float ClosestTo(this IEnumerable<float> collection, float target)
+        {
+            // NB Method will return float.MaxValue for a sequence containing no elements.
+            // Apply any defensive coding here as necessary. 
+            var closest = float.MaxValue;
+            var minDifference = float.MaxValue;
+            foreach (var element in collection)
+            {
+                var difference = Mathf.Abs(element - target);
+                if (minDifference > difference)
+                {
+                    minDifference = difference;
+                    closest = element;
+                }
+            }
+
+            return closest;
+        }
+
+        #endregion
+
+        #region line drawing functions
+
+        public static Vector3 GetPointAlongParabola(Vector3 start, Vector3 end, Vector3 up, float height, float normalizedLength)
+        {
+            float parabolaTime = normalizedLength * 2 - 1;
+            Vector3 direction = end - start;
+            Vector3 pos = start + normalizedLength * direction;
+            pos += ((-parabolaTime * parabolaTime + 1) * height) * up.normalized;
+            return pos;
+        }
+
+        public static Vector3 GetPointAlongSpline(SplinePoint[] points, float normalizedLength, InterpolationEnum interpolation = InterpolationEnum.Bezeir)
+        {
+            int pointIndex = (Mathf.RoundToInt(normalizedLength * points.Length));
+            float subnormalizedLength = normalizedLength - ((float)pointIndex / points.Length);
+
+            if (pointIndex + 3 >= points.Length)
+            {
+                return points[points.Length - 1].Point;
+            }
+            if (pointIndex < 0)
+            {
+                return points[0].Point;
+            }
+
+            Vector3 point1 = points[pointIndex].Point;
+            Vector3 point2 = points[pointIndex + 1].Point;
+            Vector3 point3 = points[pointIndex + 2].Point;
+            Vector3 point4 = points[pointIndex + 3].Point;
+
+            switch (interpolation)
+            {
+                case InterpolationEnum.Bezeir:
+                default:
+                    return InterpolateBezeirPoints(point1, point2, point3, point4, subnormalizedLength);
+
+                case InterpolationEnum.CatmullRom:
+                    return InterpolateCatmullRomPoints(point1, point2, point3, point4, subnormalizedLength);
+            }
+        }
+
+        public static Vector3 InterpolateVectorArray(Vector3[] points, float normalizedLength)
+        {
+            float arrayValueLength = 1f / points.Length;
+            int indexA = Mathf.FloorToInt(normalizedLength * points.Length);
+            if (indexA >= points.Length)
+            {
+                indexA = 0;
+            }
+
+            int indexB = indexA + 1;
+            if (indexB >= points.Length)
+            {
+                indexB = 0;
+            }
+
+            float blendAmount = (normalizedLength - (arrayValueLength * indexA)) / arrayValueLength;
+
+            return Vector3.Lerp(points[indexA], points[indexB], blendAmount);
+        }
+
+        public static Vector3 InterpolateCatmullRomPoints(Vector3 point1, Vector3 point2, Vector3 point3, Vector3 point4, float normalizedLength)
+        {
+            Vector3 p1 = 2f * point2;
+            Vector3 p2 = point3 - point1;
+            Vector3 p3 = 2f * point1 - 5f * point2 + 4f * point3 - point4;
+            Vector3 p4 = -point1 + 3f * point2 - 3f * point3 + point4;
+
+            Vector3 point = 0.5f * (p1 + (p2 * normalizedLength) + (p3 * normalizedLength * normalizedLength) + (p4 * normalizedLength * normalizedLength * normalizedLength));
+
+            return point;
+        }
+
+        public static Vector3 InterpolateBezeirPoints(Vector3 point1, Vector3 point2, Vector3 point3, Vector3 point4, float normalizedLength)
+        {
+            float invertedDistance = 1f - normalizedLength;
+            return
+                invertedDistance * invertedDistance * invertedDistance * point1 +
+                3f * invertedDistance * invertedDistance * normalizedLength * point2 +
+                3f * invertedDistance * normalizedLength * normalizedLength * point3 +
+                normalizedLength * normalizedLength * normalizedLength * point4;
+        }
+
+        public static Vector3 InterpolateHermitePoints(Vector3 point1, Vector3 point2, Vector3 point3, Vector3 point4, float normalizedLength)
+        {
+            float invertedDistance = 1f - normalizedLength;
+            return
+                invertedDistance * invertedDistance * invertedDistance * point1 +
+                3f * invertedDistance * invertedDistance * normalizedLength * point2 +
+                3f * invertedDistance * normalizedLength * normalizedLength * point3 +
+                normalizedLength * normalizedLength * normalizedLength * point4;
+        }
+
+        public static Vector3 GetEllipsePoint(float radiusX, float radiusY, float angle)
+        {
+            return new Vector3(radiusX * Mathf.Cos(angle), radiusY * Mathf.Sin(angle), 0.0f);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineUtility.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineUtility.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 6688ae29fe3d5a248a44ead4f7d4dbd3
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Parabola.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Parabola.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class Parabola : LineBase
+    {
+        [Header("Parabola Settings")]
+        public Vector3 Start = Vector3.zero;
+        public Vector3 End = Vector3.forward;
+        public Vector3 UpDirection = Vector3.up;
+        [Range(0.01f, 10f)]
+        public float Height = 1f;
+
+        public override int NumPoints
+        {
+            get
+            {
+                return 2;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(int pointIndex)
+        {
+            switch (pointIndex)
+            {
+                case 0:
+                    return Start;
+
+                case 1:
+                    return End;
+
+                default:
+                    return Vector3.zero;
+            }
+        }
+
+        protected override void SetPointInternal(int pointIndex, Vector3 point)
+        {
+            switch (pointIndex)
+            {
+                case 0:
+                    Start = point;
+                    break;
+
+                case 1:
+                    End = point;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(float normalizedDistance)
+        {
+            return LineUtils.GetPointAlongParabola(Start, End, UpDirection, Height, normalizedDistance);
+        }
+
+        protected override float GetUnclampedWorldLengthInternal()
+        {
+            // Crude approximation
+            // TODO optimize
+            float distance = 0f;
+            Vector3 last = GetUnclampedPoint(0f);
+            for (int i = 1; i < 10; i++)
+            {
+                Vector3 current = GetUnclampedPoint((float)i / 10);
+                distance += Vector3.Distance(last, current);
+            }
+            return distance;
+        }
+
+        protected override Vector3 GetUpVectorInternal(float normalizedLength)
+        {
+            return transform.up;
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(Parabola))]
+        public class CustomEditor : LineBaseEditor
+        {
+            protected override void DrawCustomSceneGUI()
+            {
+                base.DrawCustomSceneGUI();
+
+                Parabola line = (Parabola)target;
+
+                line.FirstPoint = SquareMoveHandle(line.FirstPoint);
+                line.LastPoint = SquareMoveHandle(line.LastPoint);
+                // Draw a handle for the parabola height
+                line.Height = AxisMoveHandle(line.FirstPoint, line.transform.up, line.Height);
+            }
+        }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Parabola.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Parabola.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 080153f9f59bd554bad10c8b12d0441b
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Rectangle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Rectangle.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class Rectangle : LineBase
+    {
+        public override int NumPoints
+        {
+            get
+            {
+                return 8;
+            }
+        }
+
+        public override bool Loops
+        {
+            get
+            {
+                // Force to loop
+                loops = true;
+                return loops;
+            }
+        }
+
+        [Header("Rectangle Settings")]
+        [SerializeField]
+        private Vector3[] points;
+
+        [EditableProp]
+        public float XSize
+        {
+            get { return xSize; }
+            set
+            {
+                if (xSize != value)
+                {
+                    xSize = value;
+                    BuildPoints();
+                }
+            }
+        }
+        [EditableProp]
+        public float YSize
+        {
+            get { return ySize; }
+            set
+            {
+                if (ySize != value)
+                {
+                    ySize = value;
+                    BuildPoints();
+                }
+            }
+        }
+        [EditableProp]
+        public float ZOffset
+        {
+            get
+            {
+                return zOffset;
+            }
+            set
+            {
+                if (zOffset != value)
+                {
+                    zOffset = value;
+                    BuildPoints();
+                }
+            }
+        }
+
+        [SerializeField]
+        [HideInMRTKInspector]
+        private float xSize = 1f;
+        [SerializeField]
+        [HideInMRTKInspector]
+        private float ySize = 1f;
+        [SerializeField]
+        [HideInMRTKInspector]
+        private float zOffset = 0f;
+
+        /// <summary>
+        /// When we get interpolated points we subdivide the square so our sampling has more to work with
+        /// </summary>
+        /// <param name="normalizedDistance"></param>
+        /// <returns></returns>
+        protected override Vector3 GetPointInternal(float normalizedDistance)
+        {
+            if (points == null || points.Length != 8)
+            {
+                points = new Vector3[8];
+            }
+
+            BuildPoints();
+
+            return LineUtils.InterpolateVectorArray(points, normalizedDistance);
+        }
+
+        protected override void SetPointInternal(int pointIndex, Vector3 point)
+        {
+            if (points == null || points.Length != 8)
+            {
+                points = new Vector3[8];
+            }
+
+            if (pointIndex <= 7 && pointIndex >= 0)
+            {
+                points[pointIndex] = point;
+            }
+        }
+
+        protected override Vector3 GetPointInternal(int pointIndex)
+        {
+            if (points == null || points.Length != 8)
+            {
+                points = new Vector3[8];
+            }
+
+            if (pointIndex <= 7 && pointIndex >= 0)
+            {
+                return points[pointIndex];
+            }
+
+            return Vector3.zero;
+        }
+
+        protected override float GetUnclampedWorldLengthInternal()
+        {
+            BuildPoints();
+
+            Vector3 last = points[0];
+            float distance = 0f;
+            for (int i = 1; i < points.Length; i++)
+            {
+                distance += Vector3.Distance(last, points[i]);
+                last = points[i];
+            }
+            return distance;
+        }
+
+        protected override Vector3 GetUpVectorInternal(float normalizedLength)
+        {
+            // Rectangle 'up' vector always points out from center
+            return (GetPoint(normalizedLength) - transform.position).normalized;
+        }
+
+        private void BuildPoints()
+        {
+            Vector3 offset = Vector3.forward * ZOffset;
+            Vector3 top = (Vector3.up * YSize * 0.5f);
+            Vector3 bot = (Vector3.down * YSize * 0.5f);
+            Vector3 left = (Vector3.left * XSize * 0.5f);
+            Vector3 right = (Vector3.right * XSize * 0.5f);
+
+            SetPointInternal(0, top + left + offset);
+            SetPointInternal(1, top + offset);
+            SetPointInternal(2, top + right + offset);
+            SetPointInternal(3, right + offset);
+            SetPointInternal(4, bot + right + offset);
+            SetPointInternal(5, bot + offset);
+            SetPointInternal(6, bot + left + offset);
+            SetPointInternal(7, left + offset);
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(Rectangle))]
+        public class CustomEditor : LineBaseEditor
+        {
+            // Use FromSource step mode for rectangles since interpolated looks weird
+            protected override StepModeEnum EditorStepMode { get { return StepModeEnum.FromSource; } }
+        }
+
+        protected override void OnDrawGizmos()
+        {
+            // Show gizmos if this object is not selected
+            // (SceneGUI will display it otherwise)
+
+            if (Application.isPlaying)
+            {
+                return;
+            }
+
+            if (UnityEditor.Selection.activeGameObject == this.gameObject)
+            {
+                return;
+            }
+
+            // Only draw a gizmo if we don't have a line renderer
+            LineRendererBase lr = gameObject.GetComponent<LineRendererBase>();
+            if (lr != null)
+            {
+                return;
+            }
+
+            Vector3 firstPos = GetPoint(0);
+            Vector3 lastPos = firstPos;
+            Gizmos.color = Color.Lerp(LineBaseEditor.DefaultDisplayLineColor, Color.clear, 0.25f);
+
+            for (int i = 1; i < NumPoints; i++)
+            {
+                Vector3 currentPos = GetPoint(i);
+                Gizmos.DrawLine(lastPos, currentPos);
+                lastPos = currentPos;
+            }
+
+            Gizmos.DrawLine(lastPos, firstPos);
+        }
+#endif
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Rectangle.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Rectangle.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 3b92ef91b40f8354ca95d136161548ec
+timeCreated: 1509374944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Spline.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Spline.cs
@@ -1,0 +1,477 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    public class Spline : LineBase
+    {
+        [Header("Spline Settings")]
+        [SerializeField]
+        private SplinePoint[] points = new SplinePoint[4];
+
+        [SerializeField]
+        private bool alignControlPoints = true;
+
+        public bool AlignControlPoints
+        {
+            get { return alignControlPoints; }
+            set
+            {
+                if (alignControlPoints != value)
+                {
+                    alignControlPoints = value;
+                    ForceUpdateAlignment();
+                }
+            }
+        }
+
+        public override int NumPoints
+        {
+            get
+            {
+                return points.Length;
+            }
+        }
+
+        public void ForceUpdateAlignment()
+        {
+            if (AlignControlPoints)
+            {
+                for (int i = 0; i < NumPoints; i++)
+                {
+                    ForceUpdateAlignment(i);
+                }
+            }
+        }
+
+        private void ForceUpdateAlignment(int pointIndex)
+        {
+            if (AlignControlPoints)
+            {
+                int prevControlPoint = 0;
+                int changedControlPoint = 0;
+                int midPointIndex = ((pointIndex + 1) / 3) * 3;
+
+                if (pointIndex <= midPointIndex)
+                {
+                    prevControlPoint = midPointIndex - 1;
+                    changedControlPoint = midPointIndex + 1;
+                }
+                else
+                {
+                    prevControlPoint = midPointIndex + 1;
+                    changedControlPoint = midPointIndex - 1;
+                }
+
+                if (loops)
+                {
+                    if (changedControlPoint < 0)
+                    {
+                        changedControlPoint = (NumPoints - 1) + changedControlPoint;
+                    }
+                    else if (changedControlPoint >= NumPoints)
+                    {
+                        changedControlPoint = changedControlPoint % (NumPoints - 1);
+                    }
+
+                    if (prevControlPoint < 0)
+                    {
+                        prevControlPoint = (NumPoints - 1) + prevControlPoint;
+                    }
+                    else if (prevControlPoint >= NumPoints)
+                    {
+                        prevControlPoint = prevControlPoint % (NumPoints - 1);
+                    }
+
+                    Vector3 midPoint = points[midPointIndex].Point;
+                    Vector3 tangent = midPoint - points[prevControlPoint].Point;
+                    tangent = tangent.normalized * Vector3.Distance(midPoint, points[changedControlPoint].Point);
+                    points[changedControlPoint].Point = midPoint + tangent;
+
+                }
+                else if (changedControlPoint >= 0 && changedControlPoint < NumPoints && prevControlPoint >= 0 && prevControlPoint < NumPoints)
+                {
+                    Vector3 midPoint = points[midPointIndex].Point;
+                    Vector3 tangent = midPoint - points[prevControlPoint].Point;
+                    tangent = tangent.normalized * Vector3.Distance(midPoint, points[changedControlPoint].Point);
+                    points[changedControlPoint].Point = midPoint + tangent;
+                }
+            }
+        }
+
+        public override void AppendPoint(Vector3 point)
+        {
+            int pointIndex = points.Length;
+            Array.Resize<SplinePoint>(ref points, points.Length + 1);
+            SetPoint(pointIndex, point);
+        }
+
+        protected override Vector3 GetPointInternal(float normalizedDistance)
+        {
+            float totalDistance = normalizedDistance * (NumPoints - 1);
+
+            int point1Index = Mathf.FloorToInt(totalDistance);
+            point1Index -= (point1Index % 3);
+            float subDistance = (totalDistance - point1Index) / 3;
+
+            int point2Index = 0;
+            int point3Index = 0;
+            int point4Index = 0;
+
+            if (!loops)
+            {
+                if (point1Index + 3 >= NumPoints)
+                {
+                    return points[NumPoints - 1].Point;
+                }
+                if (point1Index < 0)
+                {
+                    return points[0].Point;
+                }
+
+                point2Index = point1Index + 1;
+                point3Index = point1Index + 2;
+                point4Index = point1Index + 3;
+
+            }
+            else
+            {
+                point2Index = (point1Index + 1) % (NumPoints - 1);
+                point3Index = (point1Index + 2) % (NumPoints - 1);
+                point4Index = (point1Index + 3) % (NumPoints - 1);
+            }
+
+            Vector3 point1 = points[point1Index].Point;
+            Vector3 point2 = points[point2Index].Point;
+            Vector3 point3 = points[point3Index].Point;
+            Vector3 point4 = points[point4Index].Point;
+
+            return LineUtils.InterpolateBezeirPoints(point1, point2, point3, point4, subDistance);
+        }
+
+        protected override Vector3 GetPointInternal(int pointIndex)
+        {
+            if (pointIndex < 0 || pointIndex >= points.Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            if (loops && pointIndex == NumPoints - 1)
+            {
+                points[pointIndex] = points[0];
+                pointIndex = 0;
+            }
+
+            return points[pointIndex].Point;
+        }
+
+        protected override void SetPointInternal(int pointIndex, Vector3 point)
+        {
+            if (pointIndex < 0 || pointIndex >= points.Length)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            if (loops && pointIndex == NumPoints - 1)
+            {
+                points[pointIndex] = points[0];
+                pointIndex = 0;
+            }
+
+            if (AlignControlPoints)
+            {
+                if (pointIndex % 3 == 0)
+                {
+                    Vector3 delta = point - points[pointIndex].Point;
+                    if (loops)
+                    {
+                        if (pointIndex == 0)
+                        {
+                            points[1].Point += delta;
+                            points[NumPoints - 2].Point += delta;
+                            points[NumPoints - 1].Point = point;
+                        }
+                        else if (pointIndex == NumPoints)
+                        {
+                            points[0].Point = point;
+                            points[1].Point += delta;
+                            points[pointIndex - 1].Point += delta;
+                        }
+                        else
+                        {
+                            points[pointIndex - 1].Point += delta;
+                            points[pointIndex + 1].Point += delta;
+                        }
+                    }
+                    else
+                    {
+                        if (pointIndex > 0)
+                        {
+                            points[pointIndex - 1].Point += delta;
+                        }
+                        if (pointIndex + 1 < points.Length)
+                        {
+                            points[pointIndex + 1].Point += delta;
+                        }
+                    }
+                }
+            }
+
+            points[pointIndex].Point = point;
+
+            ForceUpdateAlignment(pointIndex);
+        }
+
+        protected override Vector3 GetUpVectorInternal(float normalizedLength)
+        {
+
+            float arrayValueLength = 1f / points.Length;
+            int indexA = Mathf.FloorToInt(normalizedLength * points.Length);
+            if (indexA >= points.Length)
+            {
+                indexA = 0;
+            }
+
+            int indexB = indexA + 1;
+            if (indexB >= points.Length)
+            {
+                indexB = 0;
+            }
+
+            float blendAmount = (normalizedLength - (arrayValueLength * indexA)) / arrayValueLength;
+            Quaternion rotation = Quaternion.Lerp(points[indexA].Rotation, points[indexB].Rotation, blendAmount);
+            return rotation * transform.up;
+        }
+
+        protected override float GetUnclampedWorldLengthInternal()
+        {
+            // Crude approximation
+            // TODO optimize
+            float distance = 0f;
+            Vector3 last = GetPoint(0f);
+            for (int i = 1; i < 10; i++)
+            {
+                Vector3 current = GetPoint((float)i / 10);
+                distance += Vector3.Distance(last, current);
+            }
+            return distance;
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(Spline))]
+        public class CustomEditor : LineBaseEditor
+        {
+            private static bool editPositions = true;
+            private static bool editRotations = false;
+            private static List<SplinePoint> pointsList = new List<SplinePoint>();
+            private static HashSet<int> overlappingPointIndexes = new HashSet<int>();
+
+            private const float overlappingPointThreshold = 0.015f;
+
+            // Convenience buttons for adding / removing points
+            protected override void DrawCustomFooter()
+            {
+                base.DrawCustomFooter();
+
+                Spline line = (Spline)target;
+
+                HashSet<int> overlappingPointIndexes = new HashSet<int>();
+
+                if (DrawSectionStart(line.name + " Points", "Point Editing"))
+                {
+                    if (GUILayout.Button(" + Add Points to Start"))
+                    {
+                        pointsList.Clear();
+                        SplinePoint[] newPoints = new SplinePoint[3];
+                        Vector3 direction = line.GetVelocity(0.01f);
+                        float distance = Mathf.Max(line.UnclampedWorldLength * 0.05f, overlappingPointThreshold * 5);
+                        newPoints[2].Point = line.FirstPoint - (direction * distance);
+                        newPoints[1].Point = newPoints[2].Point - (direction * distance);
+                        newPoints[0].Point = newPoints[1].Point - (direction * distance);
+                        pointsList.AddRange(newPoints);
+                        pointsList.AddRange(line.points);
+                        line.points = pointsList.ToArray();
+                    }
+                    if (line.NumPoints > 4)
+                    {
+                        if (GUILayout.Button(" - Remove Points From Start"))
+                        {
+                            // Using lists for maximum clarity
+                            pointsList.Clear();
+                            pointsList.AddRange(line.points);
+                            pointsList.RemoveAt(0);
+                            pointsList.RemoveAt(0);
+                            pointsList.RemoveAt(0);
+                            line.points = pointsList.ToArray();
+                        }
+                    }
+
+                    // Points list
+                    UnityEditor.EditorGUILayout.BeginVertical(UnityEditor.EditorStyles.helpBox);
+                    bool wideModeSetting = UnityEditor.EditorGUIUtility.wideMode;
+                    UnityEditor.EditorGUIUtility.wideMode = false;
+                    UnityEditor.EditorGUILayout.BeginHorizontal();
+
+                    // Positions
+                    UnityEditor.EditorGUILayout.BeginVertical();
+                    GUI.color = (editPositions ? defaultColor : disabledColor);
+                    editPositions = UnityEditor.EditorGUILayout.Toggle("Edit Positions", editPositions);
+                    for (int i = 0; i < line.points.Length; i++)
+                    {
+                        GUI.color = (i % 3 == 0) ? handleColorCircle : handleColorSquare;
+                        if (editPositions)
+                        {
+                            GUI.color = Color.Lerp(GUI.color, defaultColor, 0.75f);
+                            // highlight points that are overlapping
+                            for (int j = 0; j < line.points.Length; j++)
+                            {
+                                if (j == i)
+                                {
+                                    continue;
+                                }
+
+                                if (Vector3.Distance(line.points[j].Point, line.points[i].Point) < overlappingPointThreshold)
+                                {
+                                    overlappingPointIndexes.Add(i);
+                                    overlappingPointIndexes.Add(j);
+                                    GUI.color = errorColor;
+                                    break;
+                                }
+                            }
+                            line.points[i].Point = UnityEditor.EditorGUILayout.Vector3Field(string.Empty, line.points[i].Point);
+                        }
+                        else
+                        {
+                            GUI.color = Color.Lerp(GUI.color, disabledColor, 0.75f);
+                            UnityEditor.EditorGUILayout.Vector3Field(string.Empty, line.points[i].Point);
+                        }
+                    }
+                    UnityEditor.EditorGUILayout.EndVertical();
+
+                    // Rotations
+                    GUI.color = defaultColor;
+                    UnityEditor.EditorGUILayout.BeginVertical();
+                    editRotations = UnityEditor.EditorGUILayout.Toggle("Edit Rotations", editRotations);
+                    GUI.color = (editRotations ? defaultColor : disabledColor);
+                    for (int i = 0; i < line.points.Length; i++)
+                    {
+                        GUI.color = (i % 3 == 0) ? handleColorCircle : handleColorSquare;
+                        if (editRotations)
+                        {
+                            GUI.color = Color.Lerp(GUI.color, defaultColor, 0.75f);
+                            line.points[i].Rotation = Quaternion.Euler(UnityEditor.EditorGUILayout.Vector3Field(string.Empty, line.points[i].Rotation.eulerAngles));
+                        }
+                        else
+                        {
+                            GUI.color = Color.Lerp(GUI.color, disabledColor, 0.75f);
+                            UnityEditor.EditorGUILayout.Vector3Field(string.Empty, line.points[i].Rotation.eulerAngles);
+                        }
+                    }
+                    UnityEditor.EditorGUILayout.EndVertical();
+
+                    UnityEditor.EditorGUILayout.EndHorizontal();
+                    UnityEditor.EditorGUIUtility.wideMode = wideModeSetting;
+
+                    GUI.color = defaultColor;
+                    // If we found overlapping points, provide an option to auto-separate them
+                    if (overlappingPointIndexes.Count > 0)
+                    {
+                        GUI.color = errorColor;
+                        if (GUILayout.Button("Fix overlappoing points"))
+                        {
+                            // Move them slightly out of the way
+                            foreach (int overlappoingPointIndex in overlappingPointIndexes)
+                            {
+                                line.points[overlappoingPointIndex].Point += (UnityEngine.Random.onUnitSphere * overlappingPointThreshold * 2);
+                            }
+                        }
+                    }
+
+                    UnityEditor.EditorGUILayout.EndVertical();
+
+                    GUI.color = defaultColor;
+                    if (GUILayout.Button(" + Add Points To End"))
+                    {
+                        // Using lists for maximum clarity
+                        pointsList.Clear();
+                        SplinePoint[] newPoints = new SplinePoint[3];
+                        Vector3 direction = line.GetVelocity(0.99f);
+                        float distance = Mathf.Max(line.UnclampedWorldLength * 0.05f, overlappingPointThreshold * 5);
+                        newPoints[0].Point = line.LastPoint + (direction * distance);
+                        newPoints[1].Point = newPoints[0].Point + (direction * distance);
+                        newPoints[2].Point = newPoints[1].Point + (direction * distance);
+                        pointsList.AddRange(line.points);
+                        pointsList.AddRange(newPoints);
+                        line.points = pointsList.ToArray();
+                    }
+                    if (line.NumPoints > 4)
+                    {
+                        if (GUILayout.Button(" - Remove Points From End"))
+                        {
+                            // Using lists for maximum clarity
+                            pointsList.Clear();
+                            pointsList.AddRange(line.points);
+                            pointsList.RemoveAt(pointsList.Count - 1);
+                            pointsList.RemoveAt(pointsList.Count - 1);
+                            pointsList.RemoveAt(pointsList.Count - 1);
+                            line.points = pointsList.ToArray();
+                        }
+                    }
+                }
+                DrawSectionEnd();
+            }
+
+            protected override void DrawCustomSceneGUI()
+            {
+                Spline line = (Spline)target;
+
+                base.DrawCustomSceneGUI();
+
+                for (int i = 0; i < line.NumPoints; i++)
+                {
+                    if (editPositions)
+                    {
+                        if (i % 3 == 0)
+                        {
+                            if (i == 0)
+                            {
+                                line.SetPoint(i, SphereMoveHandle(line.GetPoint(i)));
+                                UnityEditor.Handles.color = handleColorTangent;
+                                UnityEditor.Handles.DrawLine(line.GetPoint(i), line.GetPoint(i + 1));
+                            }
+                            else if (i == line.NumPoints - 1)
+                            {
+                                line.SetPoint(i, SphereMoveHandle(line.GetPoint(i)));
+                                UnityEditor.Handles.color = handleColorTangent;
+                                UnityEditor.Handles.DrawLine(line.GetPoint(i), line.GetPoint(i - 1));
+                            }
+                            else
+                            {
+                                line.SetPoint(i, CircleMoveHandle(line.GetPoint(i)));
+                                UnityEditor.Handles.color = handleColorTangent;
+                                UnityEditor.Handles.DrawLine(line.GetPoint(i), line.GetPoint(i + 1));
+                                UnityEditor.Handles.DrawLine(line.GetPoint(i), line.GetPoint(i - 1));
+                            }
+
+                        }
+                        else
+                        {
+                            line.SetPoint(i, SquareMoveHandle(line.GetPoint(i)));
+                        }
+                    }
+
+                    if (editRotations)
+                    {
+                        line.points[i].Rotation = RotationHandle(line.GetPoint(i), line.points[i].Rotation);
+                    }
+                }
+            }
+        }
+#endif
+
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Spline.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Spline.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: b26c15dcaf594844ca59863543510699
+timeCreated: 1509374945
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/SplinePoint.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/SplinePoint.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace Holotoolkit.Unity.UX
+{
+    [Serializable]
+    public struct SplinePoint
+    {
+        public Vector3 Point;
+        public Quaternion Rotation;
+    }
+}

--- a/Assets/HoloToolkit/UX/Scripts/Lines/SplinePoint.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/SplinePoint.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: aae7abc76f2a39b4f82ae17d782c545c
+timeCreated: 1510082250
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Shaders/InvisibleShader.shader
+++ b/Assets/HoloToolkit/UX/Shaders/InvisibleShader.shader
@@ -1,0 +1,45 @@
+﻿Shader "MixedRealityToolkit/InvisibleShader" {
+
+	Subshader
+	{
+		Pass
+		{
+			GLSLPROGRAM
+			#ifdef VERTEX
+			void main() {}
+			#endif
+
+			#ifdef FRAGMENT
+			void main() {}
+			#endif
+			ENDGLSL
+		}
+	}
+
+	Subshader
+	{
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			struct v2f 
+			{
+				fixed4 position : SV_POSITION;
+			};
+
+			v2f vert() 
+			{
+				v2f o;
+				o.position = fixed4(0,0,0,0);
+				return o;
+			}
+
+			fixed4 frag() : COLOR
+			{
+				return fixed4(0,0,0,0);
+			}
+		ENDCG
+		}
+	}
+}

--- a/Assets/HoloToolkit/UX/Shaders/InvisibleShader.shader.meta
+++ b/Assets/HoloToolkit/UX/Shaders/InvisibleShader.shader.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 20978cf8cb27a50459a532d464f4fece
-folderAsset: yes
-timeCreated: 1509728667
+guid: af76b17beddb21a4ead352f9d96577f6
+timeCreated: 1510009044
 licenseType: Free
-DefaultImporter:
+ShaderImporter:
   externalObjects: {}
+  defaultTextures: []
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Textures/KeyboardAtlas.spriteatlas
+++ b/Assets/HoloToolkit/UX/Textures/KeyboardAtlas.spriteatlas
@@ -8,33 +8,34 @@ SpriteAtlas:
   m_Name: KeyboardAtlas
   m_EditorData:
     textureSettings:
+      serializedVersion: 2
       anisoLevel: 1
       compressionQuality: 50
       maxTextureSize: 2048
       textureCompression: 0
-      colorSpace: 1
       filterMode: 1
       generateMipMaps: 0
       readable: 0
       crunchedCompression: 0
+      sRGB: 0
     platformSettings: []
     packingParameters:
-      paddingPower: 2
+      serializedVersion: 2
+      padding: 4
       blockOffset: 1
       allowAlphaSplitting: 0
       enableRotation: 0
       enableTightPacking: 0
     packedHash:
       serializedVersion: 2
-      Hash: 7a51a503fafedb02020be41129e8d68c
+      Hash: 59447b9d27cd467b975647bc4533e86e
     variantMultiplier: 1
     bindAsDefault: 1
     finalFormat: 4
-    hashString: 7a51a503fafedb02020be41129e8d68c
-    totalSpriteSurfaceArea: 2553777
+    hashString: 59447b9d27cd467b975647bc4533e86e
+    totalSpriteSurfaceArea: 2359296
     packables:
     - {fileID: 102900000, guid: ebf9a4ed0c92cc24483bdd4cca5078c2, type: 3}
-    - {fileID: 102900000, guid: bf36f765bd852074bab3404177d5ed3e, type: 3}
     packedSpriteRenderDataKeys:
     - 1dde69ccd9583fa4f8dfab2b590119ee: 21300000
     - 161fc5872226601449a8143014ece469: 21300000
@@ -45,7 +46,6 @@ SpriteAtlas:
     - 7029cbbbce5f0ac4dbc4e93267bfddf4: 21300000
     - b575d7b7d87461b4ea9965b50e367249: 21300000
     - f6f44dc3b387f9d48bcaaee0038969c4: 21300000
-    - 2775a1cee10328748889e019ab01d248: 21300000
   m_MasterAtlas: {fileID: 0}
   m_PackedSprites:
   - {fileID: 21300000, guid: 1dde69ccd9583fa4f8dfab2b590119ee, type: 3}
@@ -57,7 +57,6 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 7029cbbbce5f0ac4dbc4e93267bfddf4, type: 3}
   - {fileID: 21300000, guid: b575d7b7d87461b4ea9965b50e367249, type: 3}
   - {fileID: 21300000, guid: f6f44dc3b387f9d48bcaaee0038969c4, type: 3}
-  - {fileID: 21300000, guid: 2775a1cee10328748889e019ab01d248, type: 3}
   m_PackedSpriteNamesToIndex:
   - KeyboardKeyGlyphs_Shift_Symbols
   - KeyboardKeyGlyphs_Down
@@ -68,6 +67,5 @@ SpriteAtlas:
   - KeyboardKeyGlyphs_Close
   - KeyboardKeyGlyphs_Dictation
   - KeyboardKeyGlyphs_UnShift_Symbols
-  - ButtonBounds
   m_Tag: KeyboardAtlas
   m_IsVariant: 0

--- a/Assets/HoloToolkit/Utilities/Scripts/Attributes/EditablePropAttribute.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Attributes/EditablePropAttribute.cs
@@ -13,7 +13,6 @@ namespace HoloToolkit.Unity
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class EditablePropAttribute : DrawOverrideAttribute
     {
-
         public string CustomLabel { get; private set; }
 
         public EditablePropAttribute(string customLabel = null)
@@ -34,8 +33,20 @@ namespace HoloToolkit.Unity
             {
                 case "Boolean":
                     bool boolValue = (bool)prop.GetValue(target, null);
-                    boolValue = EditorGUILayout.Toggle(SplitCamelCase(prop.Name), boolValue);
+                    boolValue = EditorGUILayout.Toggle(!string.IsNullOrEmpty (CustomLabel) ? CustomLabel : SplitCamelCase(prop.Name), boolValue);
                     prop.SetValue(target, boolValue, null);
+                    break;
+
+                case "Int32":
+                    int intValue = (int)prop.GetValue(target, null);
+                    intValue = EditorGUILayout.IntField(!string.IsNullOrEmpty(CustomLabel) ? CustomLabel : SplitCamelCase(prop.Name), intValue);
+                    prop.SetValue(target, intValue, null);
+                    break;
+
+                case "Single":
+                    float singleValue = (float)prop.GetValue(target, null);
+                    singleValue = EditorGUILayout.FloatField(!string.IsNullOrEmpty(CustomLabel) ? CustomLabel : SplitCamelCase(prop.Name), singleValue);
+                    prop.SetValue(target, singleValue, null);
                     break;
 
                 default:

--- a/Assets/HoloToolkit/Utilities/Scripts/Attributes/FeatureInProgressAttribute.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Attributes/FeatureInProgressAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace HoloToolkit.Unity
+{
+    // Marks a field as 'not implemented' in editor without hiding it
+    // Used for features that are in-progress but not fully completed
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class FeatureInProgressAttribute : Attribute
+    {
+        public  FeatureInProgressAttribute() { }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Attributes/FeatureInProgressAttribute.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Attributes/FeatureInProgressAttribute.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 175b279275802934aaf9e83ff268af3c
+timeCreated: 1510006253
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/CanvasEditorExtension.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/CanvasEditorExtension.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity.InputModule;
+using UnityEditor;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    /// <summary>
+    /// Helper class to assign the UIRaycastCamera when creating a new canvas object and assigning the world space render mode.
+    /// </summary>
+    [CustomEditor(typeof(Canvas))]
+    public class CanvasEditorExtension : Editor
+    {
+        private const string DialogText = "Hi there, we noticed that you've changed this canvas to use WorldSpace.\n\n" +
+                                          "In order for the InputManager to work properly with uGUI raycasting we'd like to update this canvas' " +
+                                          "WorldCamera to use the FocusManager's UIRaycastCamera.\n";
+
+        private Canvas canvas;
+        private bool userPermission;
+
+        private void OnEnable()
+        {
+            canvas = (Canvas)target;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUI.BeginChangeCheck();
+            base.OnInspectorGUI();
+
+            // We will only ask if we have a focus manager in our scene.
+            if (EditorGUI.EndChangeCheck() && FocusManager.Instance)
+            {
+                FocusManager.AssertIsInitialized();
+
+                if (canvas.isRootCanvas && canvas.renderMode == RenderMode.WorldSpace && canvas.worldCamera != FocusManager.Instance.UIRaycastCamera)
+                {
+                    userPermission = EditorUtility.DisplayDialog("Attention!", DialogText, "OK", "Cancel");
+
+                    if (userPermission)
+                    {
+                        canvas.worldCamera = FocusManager.Instance.UIRaycastCamera;
+                    }
+                }
+
+                if (canvas.renderMode != RenderMode.WorldSpace || !userPermission)
+                {
+                    // Sets it back to MainCamera default
+                    canvas.worldCamera = null;
+                }
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/CanvasEditorExtension.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/CanvasEditorExtension.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 899fbd77feae10c4a9c3f6010be1b5ef
+timeCreated: 1510082987
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/CustomHeaderDrawer.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/CustomHeaderDrawer.cs
@@ -15,18 +15,28 @@ namespace HoloToolkit.Unity
     {
         public override float GetHeight()
         {
-            return MRTKEditor.ShowCustomEditors ? 0f : 24f;
+            return (MRTKEditor.ShowCustomEditors && MRTKEditor.CustomEditorActive) ? 0f : 24f;
         }
 
         public override void OnGUI(Rect position)
         {
+            if (headerStyle == null)
+            {
+                headerStyle = new GUIStyle(EditorStyles.boldLabel);
+                headerStyle.alignment = TextAnchor.LowerLeft;
+            }
+
             // If we're using MRDL custom editors, don't show the header
-            if (MRTKEditor.ShowCustomEditors)
+            if (MRTKEditor.ShowCustomEditors && MRTKEditor.CustomEditorActive)
+            {
                 return;
+            }
 
             // Otherwise draw it normally
-            GUI.Label(position, (base.attribute as HeaderAttribute).header, EditorStyles.boldLabel);
+            GUI.Label(position, (base.attribute as HeaderAttribute).header, headerStyle);
         }
+
+        private static GUIStyle headerStyle = null;
     }
 #endif
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SceneSettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SceneSettingsWindow.cs
@@ -95,6 +95,7 @@ namespace HoloToolkit.Unity
                 }
 
                 PrefabUtility.InstantiatePrefab(AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(InputSystemPrefabGUID)));
+                FocusManager.Instance.UpdateCanvasEventSystems();
             }
 
             if (Values[SceneSetting.AddDefaultCursor])

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/CameraExtensions.cs
@@ -13,8 +13,7 @@ namespace HoloToolkit.Unity
         /// <returns></returns>
         public static float GetHorizontalFieldOfViewRadians(this Camera camera)
         {
-            float horizontalFovRadians = 2f * Mathf.Atan(Mathf.Tan(camera.fieldOfView * Mathf.Deg2Rad * 0.5f) * camera.aspect);
-            return horizontalFovRadians;
+            return 2f * Mathf.Atan(Mathf.Tan(camera.fieldOfView * Mathf.Deg2Rad * 0.5f) * camera.aspect);
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/EventSystemExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/EventSystemExtensions.cs
@@ -14,7 +14,7 @@ namespace HoloToolkit.Unity
         private static readonly RaycastResultComparer RaycastResultComparer = new RaycastResultComparer();
 
         /// <summary>
-        /// Executes a raycast all and returns the closest element. Fixes the current issue with Unitys raycast sorting which does not 
+        /// Executes a raycast all and returns the closest element. Fixes the current issue with Unity's raycast sorting which does not 
         /// consider separate canvases.
         /// </summary>
         /// <returns>RaycastResult if hit, or an empty RaycastResult if nothing was hit</returns>

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/Extensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/Extensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace HoloToolkit.Unity
 {
@@ -167,6 +168,18 @@ namespace HoloToolkit.Unity
         public static bool Approximately(this double number, double other, double tolerance)
         {
             return (Math.Abs(number - other) <= tolerance);
+        }
+
+        #endregion
+
+        #region UnityEngine.Object
+
+        public static void DontDestroyOnLoad(this Object target)
+        {
+#if UNITY_EDITOR // Skip Don't Destroy On Load when editor isn't playing so test runner passes.
+            if (UnityEditor.EditorApplication.isPlaying)
+#endif
+                Object.DontDestroyOnLoad(target);
         }
 
         #endregion

--- a/Assets/HoloToolkit/Utilities/Scripts/Inspectors/MRTKEditor.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Inspectors/MRTKEditor.cs
@@ -28,7 +28,8 @@ namespace HoloToolkit.Unity
     {
         #region static vars
         // Toggles custom editors on / off
-        public static bool ShowCustomEditors = true;
+        public static bool ShowCustomEditors { get; private set; }
+        public static bool CustomEditorActive { get; private set; }
         public static GameObject lastTarget;
 
         // Styles
@@ -74,21 +75,32 @@ namespace HoloToolkit.Unity
 
         public override void OnInspectorGUI()
         {
-            CreateStyles();
-            DrawInspectorHeader();
-            Undo.RecordObject(target, target.name);
+            // Set this to true so 
+            CustomEditorActive = true;
 
-            if (ShowCustomEditors)
+            try
             {
-                DrawCustomEditor();
-                DrawCustomFooter();
-            }
-            else
+                CreateStyles();
+                DrawInspectorHeader();
+                Undo.RecordObject(target, target.name);
+
+                if (ShowCustomEditors)
+                {
+                    DrawCustomEditor();
+                    DrawCustomFooter();
+                }
+                else
+                {
+                    base.DrawDefaultInspector();
+                }
+
+                SaveChanges();
+            } catch (Exception e)
             {
-                base.DrawDefaultInspector();
+                DrawError(e.ToString());
             }
 
-            SaveChanges();
+            CustomEditorActive = false;
         }
 
         public void OnSceneGUI()

--- a/Assets/HoloToolkit/Utilities/Scripts/Singleton.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Singleton.cs
@@ -8,7 +8,7 @@ namespace HoloToolkit.Unity
     /// <summary>
     /// Singleton behaviour class, used for components that should only have one instance.
     /// <remarks>Singleton classes live on through scene transitions and will mark their 
-    /// parent root GameObject with <see cref="GameObject.DontDestroyOnLoad"/></remarks>
+    /// parent root GameObject with <see cref="Object.DontDestroyOnLoad"/></remarks>
     /// </summary>
     /// <typeparam name="T">The Singleton Type</typeparam>
     public class Singleton<T> : MonoBehaviour where T : Singleton<T>
@@ -33,7 +33,7 @@ namespace HoloToolkit.Unity
                     if (objects.Length == 1)
                     {
                         instance = objects[0];
-                        DontDestroyOnLoad(instance.gameObject.GetParentRoot());
+                        instance.gameObject.GetParentRoot().DontDestroyOnLoad();
                     }
                     else if (objects.Length > 1)
                     {
@@ -87,7 +87,7 @@ namespace HoloToolkit.Unity
             {
                 instance = (T)this;
                 searchForInstance = false;
-                DontDestroyOnLoad(gameObject.GetParentRoot());
+                gameObject.GetParentRoot().DontDestroyOnLoad();
             }
         }
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -28,14 +28,16 @@ You can install more components and UWP SDK's as you wish.
 
 Make sure you are running the appropriate version of Unity 3D on your machine. You should [download and install the latest version](https://unity3d.com/get-unity/download/archive) this project says it supports on the [main readme page](/README.md).
 
-> The Mixed Reality Toolkit now supports the following Unity 3D versions:
-
 [unity-release]:                  https://unity3d.com/unity/whats-new/unity-2017.1.2
-[unity-version-badge]:            https://img.shields.io/badge/latest%20HoloLens%20release-2017.1.2-blue.svg
-> [![Github Release][unity-version-badge]][unity-release] 
+[unity-version-badge]:            https://img.shields.io/badge/Latest%20Release%20For%20HoloLens-2017.1.2-blue.svg
 
-[unity-beta-release]:                  http://beta.unity3d.com/download/00283454d7e3/download.html
-[unity-beta-version-badge]:            https://img.shields.io/badge/latest%20Mixed%20Reality%20beta-2017.2.0f3%20MRTP3-green.svg
+[unity-beta-release]:             http://beta.unity3d.com/download/b1565bfe4a0c/download.html
+[unity-beta-version-badge]:       https://img.shields.io/badge/Latest%20Mixed%20Reality%20Technical%20Preview-2017.2.0p1%20MRTP4-green.svg
+
+> The Mixed Reality Toolkit now supports the following Unity 3D versions:
+>
+> [![Github Release][unity-version-badge]][unity-release] 
+>
 > [![Github Release][unity-beta-version-badge]][unity-beta-release] 
 
 _Note: Be sure to include the Windows Store .NET scripting backend components._
@@ -45,13 +47,11 @@ _Note: Be sure to include the Windows Store .NET scripting backend components._
 # 2. Download the MixedRealityToolkit-Unity asset packages
 You can download the latest unity package from [Releases](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases) folder.
 
-[github-rel]:                  https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/latest
-[github-rel-badge]:            https://img.shields.io/badge/latest%20HoloLens%20release-2017.1.2-blue.svg
-[![Github Release][github-rel-badge]][github-rel]
+_Note: The latest release should work for both HoloLens and Windows Mixed Reality development._
 
-[mrtk-prerelease]:             https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v1.Dev.2017.2.1
-[unity-mrtp-badge]:            https://img.shields.io/badge/latest%20Immersive%20release-2017.2.0f3%20MRTP-green.svg
-[![Github Release][unity-mrtp-badge]][mrtk-prerelease] 
+[unity-release1]:                 https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/latest
+[mrtk-version-badge]:            https://img.shields.io/github/tag/microsoft/MixedRealityToolkit-unity.svg?style=flat-square&label=Latest%20Master%20Branch%20Release&colorB=007ec6
+[![Github Release][mrtk-version-badge]][unity-release1]
 
 ### Using the source code
 Optionally, If you'd like to build the Mixed Reality Toolkit from the source, you'll need to clone the GitHub repository from:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -194,10 +194,15 @@ PlayerSettings:
   iPadLandscapeSplashScreen: {fileID: 0}
   iPadHighResLandscapeSplashScreen: {fileID: 0}
   appleTVSplashScreen: {fileID: 0}
+  appleTVSplashScreen2x: {fileID: 0}
   tvOSSmallIconLayers: []
+  tvOSSmallIconLayers2x: []
   tvOSLargeIconLayers: []
+  tvOSLargeIconLayers2x: []
   tvOSTopShelfImageLayers: []
+  tvOSTopShelfImageLayers2x: []
   tvOSTopShelfImageWideLayers: []
+  tvOSTopShelfImageWideLayers2x: []
   iOSLaunchScreenType: 0
   iOSLaunchScreenPortrait: {fileID: 0}
   iOSLaunchScreenLandscape: {fileID: 0}
@@ -260,7 +265,7 @@ PlayerSettings:
   - m_BuildTarget: Metro
     m_Enabled: 1
     m_Devices:
-    - HoloLens
+    - WindowsMR
   - m_BuildTarget: N3DS
     m_Enabled: 0
     m_Devices: []
@@ -361,6 +366,9 @@ PlayerSettings:
   switchTitleNames_9: 
   switchTitleNames_10: 
   switchTitleNames_11: 
+  switchTitleNames_12: 
+  switchTitleNames_13: 
+  switchTitleNames_14: 
   switchPublisherNames_0: 
   switchPublisherNames_1: 
   switchPublisherNames_2: 
@@ -373,6 +381,9 @@ PlayerSettings:
   switchPublisherNames_9: 
   switchPublisherNames_10: 
   switchPublisherNames_11: 
+  switchPublisherNames_12: 
+  switchPublisherNames_13: 
+  switchPublisherNames_14: 
   switchIcons_0: {fileID: 0}
   switchIcons_1: {fileID: 0}
   switchIcons_2: {fileID: 0}
@@ -385,6 +396,9 @@ PlayerSettings:
   switchIcons_9: {fileID: 0}
   switchIcons_10: {fileID: 0}
   switchIcons_11: {fileID: 0}
+  switchIcons_12: {fileID: 0}
+  switchIcons_13: {fileID: 0}
+  switchIcons_14: {fileID: 0}
   switchSmallIcons_0: {fileID: 0}
   switchSmallIcons_1: {fileID: 0}
   switchSmallIcons_2: {fileID: 0}
@@ -397,6 +411,9 @@ PlayerSettings:
   switchSmallIcons_9: {fileID: 0}
   switchSmallIcons_10: {fileID: 0}
   switchSmallIcons_11: {fileID: 0}
+  switchSmallIcons_12: {fileID: 0}
+  switchSmallIcons_13: {fileID: 0}
+  switchSmallIcons_14: {fileID: 0}
   switchManualHTML: 
   switchAccessibleURLs: 
   switchLegalInformation: 
@@ -438,6 +455,8 @@ PlayerSettings:
   switchLocalCommunicationIds_7: 
   switchParentalControl: 0
   switchAllowsScreenshot: 1
+  switchAllowsVideoCapturing: 1
+  switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchSupportedNpadStyles: 3
   switchSocketConfigEnabled: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.2.0f3-MRTP3
+m_EditorVersion: 2017.2.0p1-MRTP4

--- a/README.md
+++ b/README.md
@@ -11,30 +11,27 @@ MixedRealityToolkit-Unity uses code from the base [MixedRealityToolkit](https://
 [![Mixed Reality Toolkit GitHub Repo](External/ReadMeImages/MixedRealityStack-MRTK.png)](https://github.com/Microsoft/MixedRealityToolkit)
 [![Read the Mixed Reality Developer Guides](External/ReadMeImages/MixedRealityStack-UWP.png)](https://developer.microsoft.com/en-us/windows/mixed-reality)
 
-> Learn more about [Windows Mixed Reality](https://www.microsoft.com/en-gb/windows/windows-mixed-reality) here
+> Learn more about [Windows Mixed Reality](https://www.microsoft.com/en-gb/windows/windows-mixed-reality) here.
 
-[github-rel]:                  https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v1.Dev.2017.2.1
-[github-rel-badge]:            https://img.shields.io/badge/WMR%20MRTK%20Release-%20v1.Dev.2017.2.1-green.svg
-[![Github Release][github-rel-badge]][github-rel]
+_Note: The latest release should work for both HoloLens and Windows Mixed Reality development._
 
-[unity-download]:                 http://beta.unity3d.com/download/00283454d7e3/download.html
-[unity-version-badge]:            https://img.shields.io/badge/Unity%20Editor%20WMR%20Version-2017.2.0f3%20MRTP3-green.svg
+[github-rel]:                    https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/latest
+[mrtk-version-badge]:            https://img.shields.io/github/tag/microsoft/MixedRealityToolkit-unity.svg?label=Latest%20Master%20Branch%20Release&colorB=9acd32
+[![Github Release][mrtk-version-badge]][github-rel]
+
+[unity-download]:                 http://beta.unity3d.com/download/b1565bfe4a0c/download.html
+[unity-version-badge]:            https://img.shields.io/badge/Current%20Unity%20Editor%20Version-2017.2.0p1%20MRTP4-green.svg
 [![Github Release][unity-version-badge]][unity-download]
 
-[githubhl-rel]:                  https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/latest
-[mrtk-version-badge]:            https://img.shields.io/github/tag/microsoft/MixedRealityToolkit-unity.svg?style=flat-square&label=Latest%20Master%20Branch%20Release&colorB=007ec6
-
 [unity-release]:                 https://unity3d.com/unity/whats-new/unity-2017.1.2
-[githubhl-rel-badge]:            https://img.shields.io/badge/Unity%20Editor%20HoloLens%20Version-2017.1.2f1-blue.svg
+[hololens-rel-badge]:            https://img.shields.io/badge/Unity%20Editor%20HoloLens%20Version-2017.1.2f1-blue.svg
 
 Check out the updates from the [Fall Creators update](/FallCreatorsUpdate.md) for Windows Mixed Reality
 
 > ## HoloLens Developers
 > Currently we are waiting on a fix for HoloLens development from Unity, for now you should use the 2017.1.2 version of Unity and the "Release" version of the MRTK Asset:
 >
-> [![Github Release][mrtk-version-badge]][githubhl-rel]
->
-> [![Github Release][githubhl-rel-badge]][unity-release]
+> [![Github Release][hololens-rel-badge]][unity-release]
 >
 > ### For existing HoloLens developers, also check out the [Breaking Changes](/BreakingChanges.md) information from the previous release.
 


### PR DESCRIPTION
This is a first pass at adding multi-step pointer support to the FocusManager.

The main change is in IPointingSource, where we go from this:
```
public interface IPointingSource
{
    ...
    Ray Ray { get; }
    ...
}
````

To this:

```
public interface IPointingSource
{
    ...
    RayStep[] Rays { get; }
    ...
}
````
Where RayStep is a struct with an origin and terminus.

This enables IPointingSources with curving trajectories, similar to what we see in WMR (parabolic navigation pointers, bendy transform pointers, etc).

![multi-step pointers](https://user-images.githubusercontent.com/9789716/32563240-94c134f8-c465-11e7-8aca-19b5b28cfee4.PNG)

Because this is a breaking change I'm creating a separate pull request to discuss it. So far I can't see a way to do this without breaking previous IPointingSource implementations, but it would be nice if I'm wrong. Would appreciate thoughts / input / suggestions.

 -L