### PR TITLE
TapToPlace needs to let event system know when a click is handled

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TapToPlace.cs
@@ -134,6 +134,7 @@ namespace HoloToolkit.Unity.InputModule
             // On each tap gesture, toggle whether the user is in placing mode.
             IsBeingPlaced = !IsBeingPlaced;
             HandlePlacement();
+            eventData.Use();
         }
 
         private void HandlePlacement()


### PR DESCRIPTION
Fixes #1328. If TapToPlace does not call eventData.Use() then fallback handlers will respond to the tap/click event. This can lead to undersirable behavior while placing an object.