### PR TITLE
MRDL->MRTK: Multi-step pointer sources

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -290,7 +290,8 @@ namespace HoloToolkit.Unity.InputModule
             GameObject newTargetedObject = focusDetails.Object;
 
             // Get the forward vector looking back along the pointing ray.
-            Vector3 lookForward = -Pointer.Ray.direction;
+            RayStep lastStep = Pointer.Rays[Pointer.Rays.Length - 1];
+            Vector3 lookForward = -lastStep.direction;
 
             // Normalize scale on before update
             targetScale = Vector3.one;
@@ -300,7 +301,7 @@ namespace HoloToolkit.Unity.InputModule
             {
                 TargetedObject = null;
                 TargetedCursorModifier = null;
-                targetPosition = Pointer.Ray.origin + Pointer.Ray.direction * DefaultCursorDistance;
+                targetPosition = lastStep.terminus;
                 targetRotation = lookForward.magnitude > 0 ? Quaternion.LookRotation(lookForward, Vector3.up) : transform.rotation;
             }
             else

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/CursorModifier.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/CursorModifier.cs
@@ -78,7 +78,8 @@ namespace HoloToolkit.Unity.InputModule
         {
             Quaternion rotation;
 
-            Vector3 forward = UseGazeBasedNormal ? -cursor.Pointer.Ray.direction : HostTransform.rotation * CursorNormal;
+            RayStep lastStep = cursor.Pointer.Rays[cursor.Pointer.Rays.Length - 1];
+            Vector3 forward = UseGazeBasedNormal ? -lastStep.direction : HostTransform.rotation * CursorNormal;
 
             // Determine the cursor forward
             if (forward.magnitude > 0)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusDetails.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusDetails.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
@@ -9,6 +10,7 @@ namespace HoloToolkit.Unity.InputModule
     /// FocusDetails struct contains information about which game object has the focus currently.
     /// Also contains information about the normal of that point.
     /// </summary>
+    [Serializable]
     public struct FocusDetails
     {
         public Vector3 Point;

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -128,7 +128,7 @@ namespace HoloToolkit.Unity.InputModule
 
         #region Data
 
-        private class PointerData
+        private class PointerData : PointerResult
         {
             public readonly IPointingSource PointingSource;
 
@@ -146,25 +146,24 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-            public Vector3 StartPoint { get; private set; }
-
-            public FocusDetails End { get; private set; }
-
-            public GameObject PreviousEndObject { get; private set; }
-
-            public RaycastHit LastRaycastHit { get; private set; }
-
             public PointerData(IPointingSource pointingSource)
             {
                 PointingSource = pointingSource;
             }
 
+            [Obsolete("Use UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex) or UpdateHit (float extent)")]
             public void UpdateHit(RaycastHit hit)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex)
             {
                 LastRaycastHit = hit;
                 PreviousEndObject = End.Object;
+                RayStepIndex = rayStepIndex;
 
-                StartPoint = PointingSource.Ray.origin;
+                StartPoint = sourceRay.origin;
                 End = new FocusDetails
                 {
                     Point = hit.point,
@@ -173,12 +172,13 @@ namespace HoloToolkit.Unity.InputModule
                 };
             }
 
-            public void UpdateHit(RaycastResult result, RaycastHit hit)
+            public void UpdateHit(RaycastResult result, RaycastHit hit, RayStep sourceRay, int rayStepIndex)
             {
                 // We do not update the PreviousEndObject here because
                 // it's already been updated in the first physics raycast.
-                StartPoint = PointingSource.Ray.origin;
 
+                RayStepIndex = rayStepIndex;
+                StartPoint = sourceRay.origin;
                 End = new FocusDetails
                 {
                     Point = hit.point,
@@ -191,18 +191,26 @@ namespace HoloToolkit.Unity.InputModule
             {
                 PreviousEndObject = End.Object;
 
-                StartPoint = PointingSource.Ray.origin;
+                RayStep firstStep = PointingSource.Rays[0];
+                RayStep finalStep = PointingSource.Rays[PointingSource.Rays.Length - 1];
+                RayStepIndex = 0;
+
+                StartPoint = firstStep.origin;
                 End = new FocusDetails
                 {
-                    Point = (StartPoint + (extent * PointingSource.Ray.direction)),
-                    Normal = (-PointingSource.Ray.direction),
+                    Point = finalStep.terminus,
+                    Normal = (-finalStep.direction),
                     Object = null
                 };
             }
 
-            public void ResetFocusedObjects()
+            public void ResetFocusedObjects(bool clearPreviousObject = true)
             {
-                PreviousEndObject = null;
+                if (clearPreviousObject)
+                {
+                    PreviousEndObject = null;
+                }
+
                 End = new FocusDetails
                 {
                     Point = End.Point,
@@ -489,7 +497,20 @@ namespace HoloToolkit.Unity.InputModule
 
         private void UpdatePointer(PointerData pointer)
         {
-            pointer.PointingSource.UpdatePointer();
+            // Call the pointer's OnPreRaycast function
+            // This will give it a chance to prepare itself for raycasts
+            // eg, by building its Rays array
+            pointer.PointingSource.OnPreRaycast();
+
+            // If pointer interaction isn't enabled, clear its result object and return
+            if (!pointer.PointingSource.InteractionEnabled)
+            {
+                // Don't clear the previous focused object since we still want to trigger FocusExit events
+                pointer.ResetFocusedObjects(false);
+                return;
+            }
+
+            // Otherwise, continue
             var prioritizedLayerMasks = (pointer.PointingSource.PrioritizedLayerMasksOverride ?? pointingRaycastLayerMasks);
 
             // Perform raycast to determine focused object
@@ -501,6 +522,14 @@ namespace HoloToolkit.Unity.InputModule
                 // NOTE: We need to do this AFTER RaycastPhysics so we use the current hit point to perform the correct 2D UI Raycast.
                 RaycastUnityUI(pointer, prioritizedLayerMasks);
             }
+
+            // Set the pointer's result last
+            pointer.PointingSource.Result = pointer;
+
+            // Call the pointer's OnPostRaycast function
+            // This will give it a chance to respond to raycast results
+            // eg by updating its appearance
+            pointer.PointingSource.OnPostRaycast();
         }
 
         /// <summary>
@@ -508,19 +537,49 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         private void RaycastPhysics(PointerData pointer, LayerMask[] prioritizedLayerMasks)
         {
-            bool isHit;
             RaycastHit physicsHit = default(RaycastHit);
-            float extent = GetPointingExtent(pointer);
+            RayStep rayStep = default(RayStep);
+            bool isHit = false;
+            int rayStepIndex = 0;
+
+            // Check raycast for each step in the pointing source
+            for (int i = 0; i < pointer.PointingSource.Rays.Length; i++)
+            {
+                if (RaycastPhysicsStep(pointer.PointingSource.Rays[i], prioritizedLayerMasks, out physicsHit))
+                {
+                    // Set the pointer source's origin ray to this step
+                    isHit = true;
+                    rayStep = pointer.PointingSource.Rays[i];
+                    rayStepIndex = i;
+                    // No need to continue once we've hit something
+                    break;
+                }
+            }
+
+            if (isHit)
+            {
+                pointer.UpdateHit(physicsHit, rayStep, rayStepIndex);
+            }
+            else
+            {
+                pointer.UpdateHit(GetPointingExtent(pointer));
+            }
+        }
+
+        private bool RaycastPhysicsStep(RayStep step, LayerMask[] prioritizedLayerMasks, out RaycastHit physicsHit)
+        {
+            bool isHit = false;
+            physicsHit = default(RaycastHit);
 
             // If there is only one priority, don't prioritize
             if (prioritizedLayerMasks.Length == 1)
             {
-                isHit = Physics.Raycast(pointer.PointingSource.Ray, out physicsHit, extent, prioritizedLayerMasks[0]);
+                isHit = Physics.Raycast(step.origin, step.direction, out physicsHit, step.length, prioritizedLayerMasks[0]);
             }
             else
             {
                 // Raycast across all layers and prioritize
-                RaycastHit? hit = PrioritizeHits(Physics.RaycastAll(pointer.PointingSource.Ray, extent, /*All layers*/ -1), prioritizedLayerMasks);
+                RaycastHit? hit = PrioritizeHits(Physics.RaycastAll(step.origin, step.direction, step.length, Physics.AllLayers), prioritizedLayerMasks);
                 isHit = hit.HasValue;
 
                 if (isHit)
@@ -529,14 +588,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-            if (isHit)
-            {
-                pointer.UpdateHit(physicsHit);
-            }
-            else
-            {
-                pointer.UpdateHit(GetPointingExtent(pointer));
-            }
+            return isHit;
         }
 
         private void RaycastUnityUI(PointerData pointer, LayerMask[] prioritizedLayerMasks)
@@ -544,21 +596,59 @@ namespace HoloToolkit.Unity.InputModule
             Debug.Assert(pointer.End.Point != Vector3.zero, string.Format("No pointer {0} end point found to raycast against!", pointer.PointingSource.GetType()));
             Debug.Assert(UIRaycastCamera != null, "You must assign a UIRaycastCamera on the FocusManager before you can process uGUI raycasting.");
 
+            RaycastResult uiRaycastResult = default(RaycastResult);
+            bool overridePhysicsRaycast = false;
+            RayStep rayStep = default(RayStep);
+            int rayStepIndex = 0;
+
+            // Cast rays for every step until we score a hit
+            for (int i = 0; i < pointer.PointingSource.Rays.Length; i++)
+            {
+                if (RaycastUnityUIStep(pointer, pointer.PointingSource.Rays[i], prioritizedLayerMasks, out overridePhysicsRaycast, out uiRaycastResult))
+                {
+                    rayStepIndex = i;
+                    rayStep = pointer.PointingSource.Rays[i];
+                    break;
+                }
+            }
+
+            // Check if we need to overwrite the physics raycast info
+            if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.module.eventCamera == UIRaycastCamera)
+            {
+                newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
+                newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;
+                newUiRaycastPosition.z = uiRaycastResult.distance;
+
+                Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
+
+                var hitInfo = new RaycastHit
+                {
+                    point = worldPos,
+                    normal = -uiRaycastResult.gameObject.transform.forward
+                };
+
+                pointer.UpdateHit(uiRaycastResult, hitInfo, rayStep, rayStepIndex);
+            }
+        }
+
+        private bool RaycastUnityUIStep(PointerData pointer, RayStep step, LayerMask[] prioritizedLayerMasks, out bool overridePhysicsRaycast, out RaycastResult uiRaycastResult)
+        {
             // Move the uiRaycast camera to the the current pointer's position.
-            UIRaycastCamera.transform.position = pointer.PointingSource.Ray.origin;
-            UIRaycastCamera.transform.forward = pointer.PointingSource.Ray.direction;
+            UIRaycastCamera.transform.position = step.origin;
+            UIRaycastCamera.transform.forward = step.direction;
 
             // We always raycast from the center of the camera.
             pointer.UnityUIPointerData.position = new Vector2(UIRaycastCamera.pixelWidth * 0.5f, UIRaycastCamera.pixelHeight * 0.5f);
 
             // Graphics raycast
-            RaycastResult uiRaycastResult = EventSystem.current.Raycast(pointer.UnityUIPointerData, prioritizedLayerMasks);
+            uiRaycastResult = EventSystem.current.Raycast(pointer.UnityUIPointerData, prioritizedLayerMasks);
             pointer.UnityUIPointerData.pointerCurrentRaycast = uiRaycastResult;
+
+            overridePhysicsRaycast = false;
 
             // If we have a raycast result, check if we need to overwrite the physics raycast info
             if (uiRaycastResult.gameObject != null)
             {
-                bool overridePhysicsRaycast = false;
                 if (pointer.End.Object != null)
                 {
                     // Check layer prioritization
@@ -588,25 +678,11 @@ namespace HoloToolkit.Unity.InputModule
                         }
                     }
                 }
-
-                // Check if we need to overwrite the physics raycast info
-                if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.module.eventCamera == UIRaycastCamera)
-                {
-                    newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
-                    newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;
-                    newUiRaycastPosition.z = uiRaycastResult.distance;
-
-                    Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
-
-                    var hitInfo = new RaycastHit
-                    {
-                        point = worldPos,
-                        normal = -uiRaycastResult.gameObject.transform.forward
-                    };
-
-                    pointer.UpdateHit(uiRaycastResult, hitInfo);
-                }
+                // If we've hit somthing, no need to go further
+                return true;
             }
+            // If we haven't hit something, keep going
+            return false;
         }
 
         private void UpdateFocusedObjects()

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -25,6 +25,9 @@ namespace HoloToolkit.Unity.InputModule
 
         PointerResult Result { get; set; }
 
+        [Obsolete("Will be removed in a later version. Use OnPreRaycast / OnPostRaycast instead.")]
+        void UpdatePointer();
+
         void OnPreRaycast();
 
         void OnPostRaycast();

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -11,13 +12,22 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IPointingSource
     {
-        Ray Ray { get; }
+        bool InteractionEnabled { get; }
 
         float? ExtentOverride { get; }
 
+        [Obsolete("Will be removed in a later version. For equivalent behavior have Rays return a RayStep array with a single element.")]
+        Ray Ray { get; }
+
+        RayStep[] Rays { get; }
+
         LayerMask[] PrioritizedLayerMasksOverride { get; }
 
-        void UpdatePointer();
+        PointerResult Result { get; set; }
+
+        void OnPreRaycast();
+
+        void OnPostRaycast();
 
         bool OwnsInput(BaseEventData eventData);
     }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -24,7 +24,8 @@ namespace HoloToolkit.Unity.InputModule
         [Obsolete("Will be removed in a later version. Use Rays instead.")]
         public Ray Ray { get { return Rays[0]; } }
 
-        public RayStep[] Rays {
+        public RayStep[] Rays
+        {
             get
             {
                 return rays;
@@ -46,8 +47,14 @@ namespace HoloToolkit.Unity.InputModule
         }
 
         private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.forward) };
-        
-        public void OnPreRaycast()
+
+        [Obsolete("Will be removed in a later version. Use OnPreRaycast / OnPostRaycast instead.")]
+        public void UpdatePointer()
+        {
+
+        }
+
+        public virtual void OnPreRaycast()
         {
             if (InputSource == null)
             {
@@ -60,7 +67,7 @@ namespace HoloToolkit.Unity.InputModule
                 Ray pointingRay = default(Ray);
                 if (InputSource.TryGetPointingRay(InputSourceId, out pointingRay))
                 {
-                    rays[0].CopyRay(pointingRay, FocusManager.Instance.GetPointingExtent (this));
+                    rays[0].CopyRay(pointingRay, FocusManager.Instance.GetPointingExtent(this));
                 }
             }
 
@@ -71,7 +78,7 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
-        public void OnPostRaycast()
+        public virtual void OnPostRaycast()
         {
             // Nothing needed
         }
@@ -88,6 +95,6 @@ namespace HoloToolkit.Unity.InputModule
             return (inputData != null)
                 && (inputData.InputSource == InputSource)
                 && (inputData.SourceId == InputSourceId);
-        }    
+        }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -20,39 +21,59 @@ namespace HoloToolkit.Unity.InputModule
 
         public bool OwnAllInput { get; set; }
 
-        public Ray Ray
-        {
+        [Obsolete("Will be removed in a later version. Use Rays instead.")]
+        public Ray Ray { get { return Rays[0]; } }
+
+        public RayStep[] Rays {
             get
             {
-                return (RayStabilizer == null)
-                    ? rawRay
-                    : RayStabilizer.StableRay;
+                return rays;
             }
         }
+
+        public PointerResult Result { get; set; }
 
         public float? ExtentOverride { get; set; }
 
         public LayerMask[] PrioritizedLayerMasksOverride { get; set; }
 
-        private Ray rawRay = default(Ray);
+        public bool InteractionEnabled
+        {
+            get
+            {
+                return true;
+            }
+        }
 
-        public void UpdatePointer()
+        private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.forward) };
+        
+        public void OnPreRaycast()
         {
             if (InputSource == null)
             {
-                rawRay = default(Ray);
+                rays[0] = default(RayStep);
             }
             else
             {
                 Debug.Assert(InputSource.SupportsInputInfo(InputSourceId, SupportedInputInfo.Pointing));
 
-                InputSource.TryGetPointingRay(InputSourceId, out rawRay);
+                Ray pointingRay = default(Ray);
+                if (InputSource.TryGetPointingRay(InputSourceId, out pointingRay))
+                {
+                    rays[0].CopyRay(pointingRay, FocusManager.Instance.GetPointingExtent (this));
+                }
             }
 
             if (RayStabilizer != null)
             {
-                RayStabilizer.UpdateStability(rawRay.origin, rawRay.direction);
+                RayStabilizer.UpdateStability(rays[0].origin, rays[0].direction);
+                rays[0].CopyRay(RayStabilizer.StableRay, FocusManager.Instance.GetPointingExtent(this));
             }
+        }
+
+        public void OnPostRaycast()
+        {
+            // Nothing needed
         }
 
         public bool OwnsInput(BaseEventData eventData)
@@ -67,6 +88,6 @@ namespace HoloToolkit.Unity.InputModule
             return (inputData != null)
                 && (inputData.InputSource == InputSource)
                 && (inputData.SourceId == InputSourceId);
-        }
+        }    
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.InputModule
+{
+    [Serializable]
+    public class PointerResult
+    {
+        public Vector3 StartPoint { get; protected set; }
+
+        public FocusDetails End { get; protected set; }
+
+        public GameObject PreviousEndObject { get; protected set; }
+
+        public RaycastHit LastRaycastHit { get; protected set; }
+
+        /// <summary>
+        /// The index of the step that produced the last raycast hit
+        /// 0 when no raycast hit
+        /// </summary>
+        public int RayStepIndex { get; protected set; }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/PointerResult.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: b87b365aaff84aa4a9f18f6323d917e5
+timeCreated: 1510163952
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    [Serializable]
+    public struct RayStep
+    {
+        public RayStep(Vector3 origin, Vector3 terminus)
+        {
+            this.origin = origin;
+            this.terminus = terminus;
+            length = Vector3.Distance(origin, terminus);
+            direction = (this.terminus - this.origin).normalized;
+        }
+
+        public Vector3 origin { get; private set; }
+        public Vector3 terminus { get; private set; }
+        public Vector3 direction { get; private set; }
+        public float length { get; private set; }
+
+        public Vector3 GetPoint(float distance)
+        {
+            return Vector3.MoveTowards(origin, terminus, distance);
+        }
+
+        public void UpdateRayStep(Vector3 origin, Vector3 terminus)
+        {
+            this.origin = origin;
+            this.terminus = terminus;
+            length = Vector3.Distance(origin, terminus);
+            direction = (this.terminus - this.origin).normalized;
+        }
+
+        public void CopyRay (Ray ray, float rayLength)
+        {
+            length = rayLength;
+            origin = ray.origin;
+            direction = ray.direction;
+            terminus = origin + (direction * length);
+        }
+
+        public static implicit operator Ray(RayStep r)
+        {
+            return new Ray(r.origin, r.direction);
+        }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d4f2bb3817435f84a8471a990b4820c2
+timeCreated: 1509375252
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -209,12 +209,18 @@ namespace HoloToolkit.Unity.InputModule
             UpdateHitPosition();
         }
 
-        public void OnPreRaycast()
+        [Obsolete("Will be removed in a later version. Use OnPreRaycast / OnPostRaycast instead.")]
+        public void UpdatePointer()
+        {
+
+        }
+
+        public virtual void OnPreRaycast()
         {
             UpdateGazeInfo();
         }
 
-        public void OnPostRaycast()
+        public virtual void OnPostRaycast()
         {
             // Nothing needed
         }

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/CustomHeaderDrawer.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/CustomHeaderDrawer.cs
@@ -15,18 +15,28 @@ namespace HoloToolkit.Unity
     {
         public override float GetHeight()
         {
-            return MRTKEditor.ShowCustomEditors ? 0f : 24f;
+            return (MRTKEditor.ShowCustomEditors && MRTKEditor.CustomEditorActive) ? 0f : 24f;
         }
 
         public override void OnGUI(Rect position)
         {
+            if (headerStyle == null)
+            {
+                headerStyle = new GUIStyle(EditorStyles.boldLabel);
+                headerStyle.alignment = TextAnchor.LowerLeft;
+            }
+
             // If we're using MRDL custom editors, don't show the header
-            if (MRTKEditor.ShowCustomEditors)
+            if (MRTKEditor.ShowCustomEditors && MRTKEditor.CustomEditorActive)
+            {
                 return;
+            }
 
             // Otherwise draw it normally
-            GUI.Label(position, (base.attribute as HeaderAttribute).header, EditorStyles.boldLabel);
+            GUI.Label(position, (base.attribute as HeaderAttribute).header, headerStyle);
         }
+
+        private static GUIStyle headerStyle = null;
     }
 #endif
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Inspectors/MRTKEditor.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Inspectors/MRTKEditor.cs
@@ -28,7 +28,8 @@ namespace HoloToolkit.Unity
     {
         #region static vars
         // Toggles custom editors on / off
-        public static bool ShowCustomEditors = true;
+        public static bool ShowCustomEditors { get; private set; }
+        public static bool CustomEditorActive { get; private set; }
         public static GameObject lastTarget;
 
         // Styles
@@ -74,21 +75,32 @@ namespace HoloToolkit.Unity
 
         public override void OnInspectorGUI()
         {
-            CreateStyles();
-            DrawInspectorHeader();
-            Undo.RecordObject(target, target.name);
+            // Set this to true so 
+            CustomEditorActive = true;
 
-            if (ShowCustomEditors)
+            try
             {
-                DrawCustomEditor();
-                DrawCustomFooter();
-            }
-            else
+                CreateStyles();
+                DrawInspectorHeader();
+                Undo.RecordObject(target, target.name);
+
+                if (ShowCustomEditors)
+                {
+                    DrawCustomEditor();
+                    DrawCustomFooter();
+                }
+                else
+                {
+                    base.DrawDefaultInspector();
+                }
+
+                SaveChanges();
+            } catch (Exception e)
             {
-                base.DrawDefaultInspector();
+                DrawError(e.ToString());
             }
 
-            SaveChanges();
+            CustomEditorActive = false;
         }
 
         public void OnSceneGUI()


### PR DESCRIPTION
_(Resubmission of #1318 with clean commit history)_

This is a first pass at adding multi-step pointer support to the FocusManager.

Also Fixes: #1300 with the Header attribute getting overwritten by `MRTKEditor`.

The main change is in IPointingSource, where we go from this:
```
public interface IPointingSource
{
    ...
    Ray Ray { get; }
    ...
}
````

To this:

```
public interface IPointingSource
{
    ...
    RayStep[] Rays { get; }
    ...
}
````
Where RayStep is a struct with an origin and terminus.

This enables IPointingSources with curving trajectories, similar to what we see in WMR (parabolic navigation pointers, bendy transform pointers, etc).

![multi-step pointers](https://user-images.githubusercontent.com/9789716/32563240-94c134f8-c465-11e7-8aca-19b5b28cfee4.PNG)

Because this is a breaking change I'm creating a separate pull request to discuss it. So far I can't see a way to do this without breaking previous IPointingSource implementations, but it would be nice if I'm wrong. Would appreciate thoughts / input / suggestions.

 -L