### PR TITLE
Updating Opaque clipping plane in code to match prefabs

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityCameraManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityCameraManager.cs
@@ -22,7 +22,7 @@ namespace HoloToolkit.Unity.InputModule
     public class MixedRealityCameraManager : Singleton<MixedRealityCameraManager>
     {
         [Tooltip("The near clipping plane distance for an opaque display.")]
-        public float NearClipPlane_OpaqueDisplay = 0.3f;
+        public float NearClipPlane_OpaqueDisplay = 0.1f;
 
         [Tooltip("Values for Camera.clearFlags, determining what to clear when rendering a Camera for an opaque display.")]
         public CameraClearFlags CameraClearFlags_OpaqueDisplay = CameraClearFlags.Skybox;


### PR DESCRIPTION
Overview
---
Updates the code to match the prefabs to prevent confusion.
Previously, the prefabs were updated to use a near clipping plane of 0.1. The code still had 0.3 as its default.

Changes
---
- Fixes: #1337 
