### PR TITLE
Added check for valid uiRaycastResults and fixed pointer registration

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -779,9 +779,9 @@ namespace HoloToolkit.Unity.InputModule
 
         private PointerData GetPointer(IPointingSource pointingSource)
         {
+            Debug.Assert(pointers.Count > 0, "No Pointers registered!");
             int? iPointer = TryGetPointerIndex(pointingSource);
-            Debug.Assert(iPointer != null);
-            return pointers[iPointer.Value];
+            return iPointer != null ? pointers[iPointer.Value] : pointers[0];
         }
 
         private int? TryGetPointerIndex(IPointingSource pointingSource)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -75,18 +75,6 @@ namespace HoloToolkit.Unity.InputModule
             UpdateFocusedObjects();
         }
 
-        /// <summary>
-        /// It's assumed that if you're using the MRTK's input system you'll
-        /// need to update your canvases to use the proper raycast camera for input.
-        /// </summary>
-        private void OnValidate()
-        {
-            if (UIRaycastCamera != null)
-            {
-                UpdateCanvasEventSystems();
-            }
-        }
-
         #endregion
 
         #region Settings

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -613,7 +613,7 @@ namespace HoloToolkit.Unity.InputModule
             }
 
             // Check if we need to overwrite the physics raycast info
-            if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.module.eventCamera == UIRaycastCamera)
+            if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.isValid && uiRaycastResult.module.eventCamera == UIRaycastCamera)
             {
                 newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
                 newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -530,6 +530,9 @@ namespace HoloToolkit.Unity.InputModule
             bool isHit = false;
             int rayStepIndex = 0;
 
+            Debug.Assert(pointer.PointingSource.Rays != null, "No valid rays for " + pointer.GetType());
+            Debug.Assert(pointer.PointingSource.Rays.Length > 0, "No valid rays for " + pointer.GetType());
+
             // Check raycast for each step in the pointing source
             for (int i = 0; i < pointer.PointingSource.Rays.Length; i++)
             {
@@ -588,6 +591,9 @@ namespace HoloToolkit.Unity.InputModule
             bool overridePhysicsRaycast = false;
             RayStep rayStep = default(RayStep);
             int rayStepIndex = 0;
+
+            Debug.Assert(pointer.PointingSource.Rays != null, "No valid rays for " + pointer.GetType());
+            Debug.Assert(pointer.PointingSource.Rays.Length > 0, "No valid rays for " + pointer.GetType());
 
             // Cast rays for every step until we score a hit
             for (int i = 0; i < pointer.PointingSource.Rays.Length; i++)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -292,9 +292,11 @@ namespace HoloToolkit.Unity.InputModule
 
             int pointerIndex;
             TryGetPointerIndex(pointingSource, out pointerIndex);
+            Debug.Assert(pointerIndex > 0, "Invalid pointer index!");
 
             PointerData pointer;
-            GetPointer(pointingSource, out pointer);
+            GetPointerData(pointingSource, out pointer);
+            Debug.Assert(pointer != null, "Attempting to unregister a pointer that was never registered!");
 
             // Should we be protecting against unregistering the GazeManager?
 
@@ -378,7 +380,7 @@ namespace HoloToolkit.Unity.InputModule
             PointerData pointerData;
             FocusDetails details = default(FocusDetails);
 
-            if (GetPointer(pointingSource, out pointerData))
+            if (GetPointerData(pointingSource, out pointerData))
             {
                 details = pointerData.End;
             }
@@ -391,7 +393,7 @@ namespace HoloToolkit.Unity.InputModule
             PointerData pointerData;
             GameObject focusedObject = null;
 
-            if (GetPointer(pointingSource, out pointerData))
+            if (GetPointerData(pointingSource, out pointerData))
             {
                 focusedObject = pointerData.End.Object;
             }
@@ -438,18 +440,12 @@ namespace HoloToolkit.Unity.InputModule
         public PointerInputEventData GetSpecificPointerEventData(IPointingSource pointer)
         {
             PointerData pointerEventData;
-            return GetPointer(pointer, out pointerEventData) ? pointerEventData.UnityUIPointerData : null;
+            return GetPointerData(pointer, out pointerEventData) ? pointerEventData.UnityUIPointerData : null;
         }
 
         public float GetPointingExtent(IPointingSource pointingSource)
         {
-            PointerData pointerData;
-            return GetPointer(pointingSource, out pointerData) ? GetPointingExtent(pointerData) : pointingExtent;
-        }
-
-        private float GetPointingExtent(PointerData pointer)
-        {
-            return pointer.PointingSource.ExtentOverride ?? pointingExtent;
+            return pointingSource.ExtentOverride ?? pointingExtent;
         }
 
         #endregion
@@ -543,10 +539,10 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         private void RaycastPhysics(PointerData pointer, LayerMask[] prioritizedLayerMasks)
         {
-            RaycastHit physicsHit = default(RaycastHit);
-            RayStep rayStep = default(RayStep);
             bool isHit = false;
             int rayStepIndex = 0;
+            RayStep rayStep = default(RayStep);
+            RaycastHit physicsHit = default(RaycastHit);
 
             Debug.Assert(pointer.PointingSource.Rays != null, "No valid rays for " + pointer.GetType());
             Debug.Assert(pointer.PointingSource.Rays.Length > 0, "No valid rays for " + pointer.GetType());
@@ -571,7 +567,7 @@ namespace HoloToolkit.Unity.InputModule
             }
             else
             {
-                pointer.UpdateHit(GetPointingExtent(pointer));
+                pointer.UpdateHit(GetPointingExtent(pointer.PointingSource));
             }
         }
 
@@ -795,7 +791,7 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
-        private bool GetPointer(IPointingSource pointingSource, out PointerData pointerData)
+        private bool GetPointerData(IPointingSource pointingSource, out PointerData pointerData)
         {
             int pointerIndex;
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -51,7 +51,6 @@ namespace HoloToolkit.Unity.InputModule
         [Obsolete("Will be removed in a later version. Use OnPreRaycast / OnPostRaycast instead.")]
         public void UpdatePointer()
         {
-
         }
 
         public virtual void OnPreRaycast()
@@ -62,9 +61,9 @@ namespace HoloToolkit.Unity.InputModule
             }
             else
             {
-                Debug.Assert(InputSource.SupportsInputInfo(InputSourceId, SupportedInputInfo.Pointing));
+                Debug.Assert(InputSource.SupportsInputInfo(InputSourceId, SupportedInputInfo.Pointing), string.Format("{0} with id {1} does not support pointing!", InputSource, InputSourceId));
 
-                Ray pointingRay = default(Ray);
+                Ray pointingRay;
                 if (InputSource.TryGetPointingRay(InputSourceId, out pointingRay))
                 {
                     rays[0].CopyRay(pointingRay, FocusManager.Instance.GetPointingExtent(this));

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -85,12 +85,9 @@ namespace HoloToolkit.Unity.InputModule
                 FocusManager.Instance.UnregisterPointer(pointingSource);
             }
 
-            if (IsInputSourcePointerActive)
+            if (IsInputSourcePointerActive && inputSourcePointer.InputIsFromSource(eventData))
             {
-                if (inputSourcePointer.InputIsFromSource(eventData))
-                {
-                    ConnectBestAvailablePointer();
-                }
+                ConnectBestAvailablePointer();
             }
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -45,14 +45,12 @@ namespace HoloToolkit.Unity.InputModule
             started = true;
 
             InputManager.AssertIsInitialized();
-            GazeManager.AssertIsInitialized();
             FocusManager.AssertIsInitialized();
+            GazeManager.AssertIsInitialized();
 
             AddInputManagerListenerIfNeeded();
             FindCursorIfNeeded();
             ConnectBestAvailablePointer();
-
-            Debug.Assert(currentPointer != null, this);
         }
 
         private void OnEnable()
@@ -79,12 +77,6 @@ namespace HoloToolkit.Unity.InputModule
 
         void ISourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
-            IPointingSource pointingSource;
-            if (FocusManager.Instance.TryGetPointingSource(eventData, out pointingSource))
-            {
-                FocusManager.Instance.UnregisterPointer(pointingSource);
-            }
-
             if (IsInputSourcePointerActive && inputSourcePointer.InputIsFromSource(eventData))
             {
                 ConnectBestAvailablePointer();
@@ -162,6 +154,11 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (currentPointer != newPointer)
             {
+                if (currentPointer != null)
+                {
+                    FocusManager.Instance.UnregisterPointer(currentPointer);
+                }
+
                 currentPointer = newPointer;
 
                 if (newPointer != null)
@@ -174,6 +171,8 @@ namespace HoloToolkit.Unity.InputModule
                     Cursor.Pointer = newPointer;
                 }
             }
+
+            Debug.Assert(currentPointer != null, "No Pointer Set!");
         }
 
         private void ConnectBestAvailablePointer()
@@ -229,7 +228,6 @@ namespace HoloToolkit.Unity.InputModule
                     // TODO: robertes: see if we can treat voice separately from the other simple committers,
                     //       so voice doesn't steal from a pointing controller. I think input Kind would need
                     //       to come through with the event data.
-
                     SetPointer(GazeManager.Instance);
                     pointerWasChanged = true;
                 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -79,9 +79,19 @@ namespace HoloToolkit.Unity.InputModule
 
         void ISourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
-            if (IsInputSourcePointerActive && inputSourcePointer.InputIsFromSource(eventData))
+            IPointingSource pointingSource;
+            if (FocusManager.Instance.TryGetPointingSource(eventData, out pointingSource))
             {
-                ConnectBestAvailablePointer();
+                FocusManager.Instance.UnregisterPointer(pointingSource);
+            }
+
+            if (IsInputSourcePointerActive)
+            {
+                if (inputSourcePointer.InputIsFromSource(eventData))
+                {
+
+                    ConnectBestAvailablePointer();
+                }
             }
         }
 
@@ -156,11 +166,6 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (currentPointer != newPointer)
             {
-                if (currentPointer != null)
-                {
-                    FocusManager.Instance.UnregisterPointer(currentPointer);
-                }
-
                 currentPointer = newPointer;
 
                 if (newPointer != null)

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -89,7 +89,6 @@ namespace HoloToolkit.Unity.InputModule
             {
                 if (inputSourcePointer.InputIsFromSource(eventData))
                 {
-
                     ConnectBestAvailablePointer();
                 }
             }

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -113,14 +113,14 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("True to draw a debug view of the ray.")]
         public bool DebugDrawRay;
         public PointerResult Result { get; set; }
-        
+
         [Obsolete("Will be removed in a later version. Use Rays instead.")]
         public Ray Ray { get { return Rays[0]; } }
-        
+
         public RayStep[] Rays { get { return rays; } }
 
         private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.zero) };
- 
+
         public float? ExtentOverride
         {
             get { return MaxGazeCollisionDistance; }
@@ -203,7 +203,7 @@ namespace HoloToolkit.Unity.InputModule
                     newGazeNormal = Stabilizer.StableRay.direction;
                 }
 
-                Rays[0].UpdateRayStep(newGazeOrigin, newGazeOrigin + (newGazeNormal * FocusManager.Instance.GetPointingExtent (this)));
+                Rays[0].UpdateRayStep(newGazeOrigin, newGazeOrigin + (newGazeNormal * FocusManager.Instance.GetPointingExtent(this)));
             }
 
             UpdateHitPosition();
@@ -212,7 +212,6 @@ namespace HoloToolkit.Unity.InputModule
         [Obsolete("Will be removed in a later version. Use OnPreRaycast / OnPostRaycast instead.")]
         public void UpdatePointer()
         {
-
         }
 
         public virtual void OnPreRaycast()

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -133,10 +133,7 @@ namespace HoloToolkit.Unity.InputModule
 
         public bool InteractionEnabled
         {
-            get
-            {
-                return true;
-            }
+            get { return true; }
         }
 
         private float lastHitDistance = 2.0f;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/CustomInputSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/CustomInputSelector.cs
@@ -54,9 +54,9 @@ namespace HoloToolkit.Unity.InputModule
             bool spawnControllers = false;
 
 #if UNITY_2017_2_OR_NEWER
-            spawnControllers = (!XRDevice.isPresent && XRSettings.enabled || Application.isEditor) && simulateHandsInEditor;
+            spawnControllers = !XRDevice.isPresent && XRSettings.enabled && simulateHandsInEditor;
 #else
-            spawnControllers = !VRDevice.isPresent;
+            spawnControllers = simulateHandsInEditor;
 #endif
             if (spawnControllers)
             {


### PR DESCRIPTION
Changes
---
- Fixes: #1346
- Fixes: #1344 Fixed Pointer registration.  We still register pointers on the fly but now we only unregister them when we get a source lost event raised by the `InputManager`.
- Removed `OnValidate` checking the `UIRaycastCamera` so there's not a warning every time we recompile. (For some reason during deserailization when the script is loading, the `uiRaycastCamera` is null, even though the serialized value is valid.)
- Fixes: #1356 
- FIxes: #1363