### PR TITLE
Hand draggable and clicker fixes

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -222,7 +222,6 @@ namespace HoloToolkit.Unity.InputModule
             {
                 // Nothing to do. Keep the pointer that must have been set programmatically.
             }
-
             else if (LoadPointer != null)
             {
                 Pointer = LoadPointer.GetComponent<IPointingSource>();
@@ -369,7 +368,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="eventData"></param>
         public virtual void OnInputUp(InputEventData eventData)
         {
-            if (Pointer.OwnsInput(eventData))
+            if (Pointer != null && Pointer.OwnsInput(eventData))
             {
                 IsInputSourceDown = false;
             }
@@ -381,7 +380,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="eventData"></param>
         public virtual void OnInputDown(InputEventData eventData)
         {
-            if (Pointer.OwnsInput(eventData))
+            if (Pointer != null && Pointer.OwnsInput(eventData))
             {
                 IsInputSourceDown = true;
             }
@@ -403,7 +402,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="eventData"></param>
         public virtual void OnSourceDetected(SourceStateEventData eventData)
         {
-            if (Pointer.OwnsInput(eventData))
+            if (Pointer != null && Pointer.OwnsInput(eventData))
             {
                 visibleHandsCount++;
                 IsHandVisible = true;
@@ -417,7 +416,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="eventData"></param>
         public virtual void OnSourceLost(SourceStateEventData eventData)
         {
-            if (Pointer.OwnsInput(eventData))
+            if (Pointer != null && Pointer.OwnsInput(eventData))
             {
                 visibleHandsCount--;
                 if (visibleHandsCount == 0)
@@ -441,7 +440,7 @@ namespace HoloToolkit.Unity.InputModule
         }
 
         /// <summary>
-        /// Virtual function for checking state changess.
+        /// Virtual function for checking state changes.
         /// </summary>
         public virtual CursorStateEnum CheckCursorState()
         {

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
@@ -953,64 +953,64 @@ namespace HoloToolkit.Unity.InputModule
 
         // TODO: robertes: Should these also cause source state data to be stored/updated? What about SourceDetected synthesized events?
 
-        protected void GestureRecognizer_Tapped(TappedEventArgs obj)
+        protected void GestureRecognizer_Tapped(TappedEventArgs args)
         {
-            InputManager.Instance.RaiseInputClicked(this, obj.source.id, InteractionSourcePressInfo.Select, obj.tapCount);
+            InputManager.Instance.RaiseInputClicked(this, args.source.id, InteractionSourcePressInfo.Select, args.tapCount);
         }
 
-        protected void GestureRecognizer_HoldStarted(HoldStartedEventArgs obj)
+        protected void GestureRecognizer_HoldStarted(HoldStartedEventArgs args)
         {
-            InputManager.Instance.RaiseHoldStarted(this, obj.source.id);
+            InputManager.Instance.RaiseHoldStarted(this, args.source.id);
         }
 
-        protected void GestureRecognizer_HoldCanceled(HoldCanceledEventArgs obj)
+        protected void GestureRecognizer_HoldCanceled(HoldCanceledEventArgs args)
         {
-            InputManager.Instance.RaiseHoldCanceled(this, obj.source.id);
+            InputManager.Instance.RaiseHoldCanceled(this, args.source.id);
         }
 
-        protected void GestureRecognizer_HoldCompleted(HoldCompletedEventArgs obj)
+        protected void GestureRecognizer_HoldCompleted(HoldCompletedEventArgs args)
         {
-            InputManager.Instance.RaiseHoldCompleted(this, obj.source.id);
+            InputManager.Instance.RaiseHoldCompleted(this, args.source.id);
         }
 
-        protected void GestureRecognizer_ManipulationStarted(ManipulationStartedEventArgs obj)
+        protected void GestureRecognizer_ManipulationStarted(ManipulationStartedEventArgs args)
         {
-            InputManager.Instance.RaiseManipulationStarted(this, obj.source.id);
+            InputManager.Instance.RaiseManipulationStarted(this, args.source.id);
         }
 
-        protected void GestureRecognizer_ManipulationUpdated(ManipulationUpdatedEventArgs obj)
+        protected void GestureRecognizer_ManipulationUpdated(ManipulationUpdatedEventArgs args)
         {
-            InputManager.Instance.RaiseManipulationUpdated(this, obj.source.id, obj.cumulativeDelta);
+            InputManager.Instance.RaiseManipulationUpdated(this, args.source.id, args.cumulativeDelta);
         }
 
-        protected void GestureRecognizer_ManipulationCompleted(ManipulationCompletedEventArgs obj)
+        protected void GestureRecognizer_ManipulationCompleted(ManipulationCompletedEventArgs args)
         {
-            InputManager.Instance.RaiseManipulationCompleted(this, obj.source.id, obj.cumulativeDelta);
+            InputManager.Instance.RaiseManipulationCompleted(this, args.source.id, args.cumulativeDelta);
         }
 
-        protected void GestureRecognizer_ManipulationCanceled(ManipulationCanceledEventArgs obj)
+        protected void GestureRecognizer_ManipulationCanceled(ManipulationCanceledEventArgs args)
         {
-            InputManager.Instance.RaiseManipulationCanceled(this, obj.source.id);
+            InputManager.Instance.RaiseManipulationCanceled(this, args.source.id);
         }
 
-        protected void NavigationGestureRecognizer_NavigationStarted(NavigationStartedEventArgs obj)
+        protected void NavigationGestureRecognizer_NavigationStarted(NavigationStartedEventArgs args)
         {
-            InputManager.Instance.RaiseNavigationStarted(this, obj.source.id);
+            InputManager.Instance.RaiseNavigationStarted(this, args.source.id);
         }
 
-        protected void NavigationGestureRecognizer_NavigationUpdated(NavigationUpdatedEventArgs obj)
+        protected void NavigationGestureRecognizer_NavigationUpdated(NavigationUpdatedEventArgs args)
         {
-            InputManager.Instance.RaiseNavigationUpdated(this, obj.source.id, obj.normalizedOffset);
+            InputManager.Instance.RaiseNavigationUpdated(this, args.source.id, args.normalizedOffset);
         }
 
-        protected void NavigationGestureRecognizer_NavigationCompleted(NavigationCompletedEventArgs obj)
+        protected void NavigationGestureRecognizer_NavigationCompleted(NavigationCompletedEventArgs args)
         {
-            InputManager.Instance.RaiseNavigationCompleted(this, obj.source.id, obj.normalizedOffset);
+            InputManager.Instance.RaiseNavigationCompleted(this, args.source.id, args.normalizedOffset);
         }
 
-        protected void NavigationGestureRecognizer_NavigationCanceled(NavigationCanceledEventArgs obj)
+        protected void NavigationGestureRecognizer_NavigationCanceled(NavigationCanceledEventArgs args)
         {
-            InputManager.Instance.RaiseNavigationCanceled(this, obj.source.id);
+            InputManager.Instance.RaiseNavigationCanceled(this, args.source.id);
         }
 
         #endregion //Raise GestureRecognizer Events

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
@@ -911,7 +911,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             var pressType = (InteractionSourcePressInfo)args.pressType;
             // HACK: If we're not dealing with a spatial controller we may not get Select called properly
-            if (args.state.source.kind != InteractionSourceKind.Controller)
+            if (args.state.source.kind != InteractionSourceKind.Controller || !args.state.source.supportsPointing)
             {
                 pressType = InteractionSourcePressInfo.Select;
             }
@@ -923,7 +923,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             var pressType = (InteractionSourcePressInfo)args.pressType;
             // HACK: If we're not dealing with a spatial controller we may not get Select called properly
-            if (args.state.source.kind != InteractionSourceKind.Controller)
+            if (args.state.source.kind != InteractionSourceKind.Controller || !args.state.source.supportsPointing)
             {
                 pressType = InteractionSourcePressInfo.Select;
             }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
@@ -63,12 +63,10 @@ namespace HoloToolkit.Unity.InputModule
         private void Awake()
         {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-            foreach (var sourceState in InteractionManager.GetCurrentReading())
+            InteractionSourceState[] states = InteractionManager.GetCurrentReading();
+            for (var i = 0; i < states.Length; i++)
             {
-                if (sourceState.source.kind == InteractionSourceKind.Controller)
-                {
-                    StartTrackingController(sourceState.source);
-                }
+                StartTrackingController(states[i].source);
             }
 
             Application.onBeforeRender += Application_onBeforeRender;
@@ -170,7 +168,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private void StartTrackingController(InteractionSource source)
         {
-            if (source.kind == InteractionSourceKind.Controller && !controllerDictionary.ContainsKey(source.id) && !loadingControllers.Contains(source.id))
+            if (source.kind == InteractionSourceKind.Controller && !controllerDictionary.ContainsKey(source.id) && !loadingControllers.Contains(source.id) && source.supportsPointing)
             {
                 StartCoroutine(LoadControllerModel(source));
             }
@@ -199,7 +197,7 @@ namespace HoloToolkit.Unity.InputModule
         private IEnumerator LoadControllerModel(InteractionSource source)
         {
             loadingControllers.Add(source.id);
-            
+
             if (AlwaysUseAlternateLeftModel && source.handedness == InteractionSourceHandedness.Left)
             {
                 if (AlternateLeftController == null)


### PR DESCRIPTION
Overview
---
Updated HandDraggable to support knowing the difference between Hand and Controller input. 
 Because the clicker is considered a controller, but does not raise the `Select` press type, we need to update its press type.  We know it's the clicker because pointer position is not supported.

Also, updated the cursor to support not having a pointer.

Changes
---
- Fixes: #1271
- Fixes: #1203
- Fixes: #741
