### PR TITLE
MRDL->MRTK: Pointer focus locking

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -288,10 +288,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             FocusDetails focusDetails = FocusManager.Instance.GetFocusDetails(Pointer);
             GameObject newTargetedObject = focusDetails.Object;
-
-            // Get the forward vector looking back along the pointing ray.
-            RayStep lastStep = Pointer.Rays[Pointer.Rays.Length - 1];
-            Vector3 lookForward = -lastStep.direction;
+            Vector3 lookForward = Vector3.forward;
 
             // Normalize scale on before update
             targetScale = Vector3.one;
@@ -301,7 +298,9 @@ namespace HoloToolkit.Unity.InputModule
             {
                 TargetedObject = null;
                 TargetedCursorModifier = null;
-                targetPosition = lastStep.terminus;
+
+                targetPosition = RayStep.GetPointByDistance(Pointer.Rays, DefaultCursorDistance);
+                lookForward = -RayStep.GetDirectionByDistance(Pointer.Rays, DefaultCursorDistance);
                 targetRotation = lookForward.magnitude > 0 ? Quaternion.LookRotation(lookForward, Vector3.up) : transform.rotation;
             }
             else
@@ -316,6 +315,10 @@ namespace HoloToolkit.Unity.InputModule
                 else
                 {
                     // If no modifier is on the target, just use the hit result to set cursor position
+                    // Get the look forward by using distance between pointer origin and target position
+                    // (This may not be strictly accurate for extremely wobbly pointers, but it should produce usable results)
+                    float distanceToTarget = Vector3.Distance(Pointer.Rays[0].origin, focusDetails.Point);
+                    lookForward = -RayStep.GetDirectionByDistance(Pointer.Rays, distanceToTarget);
                     targetPosition = focusDetails.Point + (lookForward * SurfaceCursorDistance);
                     Vector3 lookRotation = Vector3.Slerp(focusDetails.Normal, lookForward, LookRotationBlend);
                     targetRotation = Quaternion.LookRotation(lookRotation == Vector3.zero ? lookForward : lookRotation, Vector3.up);

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -507,24 +507,32 @@ namespace HoloToolkit.Unity.InputModule
             {
                 // Don't clear the previous focused object since we still want to trigger FocusExit events
                 pointer.ResetFocusedObjects(false);
-                return;
             }
-
-            // Otherwise, continue
-            var prioritizedLayerMasks = (pointer.PointingSource.PrioritizedLayerMasksOverride ?? pointingRaycastLayerMasks);
-
-            // Perform raycast to determine focused object
-            RaycastPhysics(pointer, prioritizedLayerMasks);
-
-            // If we have a unity event system, perform graphics raycasts as well to support Unity UI interactions
-            if (EventSystem.current != null)
+            else
             {
-                // NOTE: We need to do this AFTER RaycastPhysics so we use the current hit point to perform the correct 2D UI Raycast.
-                RaycastUnityUI(pointer, prioritizedLayerMasks);
-            }
+                // If the pointer is locked
+                // Keep the focus objects the same
+                // This will ensure that we execute events on those objects
+                // even if the pointer isn't pointing at them
+                if (!pointer.PointingSource.FocusLocked)
+                {
+                    // Otherwise, continue
+                    var prioritizedLayerMasks = (pointer.PointingSource.PrioritizedLayerMasksOverride ?? pointingRaycastLayerMasks);
 
-            // Set the pointer's result last
-            pointer.PointingSource.Result = pointer;
+                    // Perform raycast to determine focused object
+                    RaycastPhysics(pointer, prioritizedLayerMasks);
+
+                    // If we have a unity event system, perform graphics raycasts as well to support Unity UI interactions
+                    if (EventSystem.current != null)
+                    {
+                        // NOTE: We need to do this AFTER RaycastPhysics so we use the current hit point to perform the correct 2D UI Raycast.
+                        RaycastUnityUI(pointer, prioritizedLayerMasks);
+                    }
+
+                    // Set the pointer's result last
+                    pointer.PointingSource.Result = pointer;
+                }
+            }
 
             // Call the pointer's OnPostRaycast function
             // This will give it a chance to respond to raycast results
@@ -601,6 +609,9 @@ namespace HoloToolkit.Unity.InputModule
             RayStep rayStep = default(RayStep);
             int rayStepIndex = 0;
 
+            Debug.Assert(pointer.PointingSource.Rays != null);
+            Debug.Assert(pointer.PointingSource.Rays.Length > 0);
+
             // Cast rays for every step until we score a hit
             for (int i = 0; i < pointer.PointingSource.Rays.Length; i++)
             {
@@ -613,7 +624,7 @@ namespace HoloToolkit.Unity.InputModule
             }
 
             // Check if we need to overwrite the physics raycast info
-            if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.module.eventCamera == UIRaycastCamera)
+            if ((pointer.End.Object == null || overridePhysicsRaycast) && (uiRaycastResult.module != null && uiRaycastResult.module.eventCamera == UIRaycastCamera))
             {
                 newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
                 newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;

--- a/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/IPointingSource.cs
@@ -33,5 +33,7 @@ namespace HoloToolkit.Unity.InputModule
         void OnPostRaycast();
 
         bool OwnsInput(BaseEventData eventData);
+
+        bool FocusLocked { get; set; }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -46,6 +46,8 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
+        public bool FocusLocked { get; set; }
+
         private RayStep[] rays = new RayStep[1] { new RayStep(Vector3.zero, Vector3.forward) };
 
         [Obsolete("Will be removed in a later version. Use OnPreRaycast / OnPostRaycast instead.")]

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
@@ -44,5 +44,94 @@ namespace HoloToolkit.Unity
         {
             return new Ray(r.origin, r.direction);
         }
+
+        #region static utility functions
+
+        /// <summary>
+        /// Returns a point along an array of RaySteps by distance
+        /// </summary>
+        /// <param name="steps"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        public static Vector3 GetPointByDistance(RayStep[] steps, float distance)
+        {
+            Debug.Assert(steps != null);
+            Debug.Assert(steps.Length > 0);
+
+            Vector3 point = Vector3.zero;
+            float remainingDistance = distance;
+
+            for (int i = 0; i < steps.Length; i++)
+            {
+                if (remainingDistance > steps[i].length)
+                {
+                    remainingDistance -= steps[i].length;
+                }
+                else
+                {
+                    point = Vector3.Lerp(steps[i].origin, steps[i].terminus, remainingDistance / steps[i].length);
+                    remainingDistance = 0;
+                    break;
+                }
+            }
+
+            if (remainingDistance > 0)
+            {
+                // If we reach the end and still have distance left, set the point to the terminus of the last step
+                point = steps[steps.Length - 1].terminus;
+            }
+
+            return point;
+        }
+
+        /// <summary>
+        /// Returns a RayStep along an array of RaySteps by distance
+        /// </summary>
+        /// <param name="steps"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        public static RayStep GetStepByDistance(RayStep[] steps, float distance)
+        {
+            Debug.Assert(steps != null);
+            Debug.Assert(steps.Length > 0);
+
+            RayStep step = new RayStep();
+            float remainingDistance = distance;
+
+            for (int i = 0; i < steps.Length; i++)
+            {
+                if (remainingDistance > steps[i].length)
+                {
+                    remainingDistance -= steps[i].length;
+                }
+                else
+                {
+                    step = steps[i];
+                    remainingDistance = 0;
+                    break;
+                }
+            }
+            
+            if (remainingDistance > 0)
+            {
+                // If we reach the end and still have distance left, return the last step
+                step = steps[steps.Length - 1];
+            }
+
+            return step;
+        }
+
+        /// <summary>
+        /// Returns a direction along an array of RaySteps by distance
+        /// </summary>
+        /// <param name="steps"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        public static Vector3 GetDirectionByDistance(RayStep[] steps, float distance)
+        {
+            return GetStepByDistance(steps, distance).direction;
+        }
+
+        #endregion
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/RayStep.cs
@@ -129,6 +129,9 @@ namespace HoloToolkit.Unity
         /// <returns></returns>
         public static Vector3 GetDirectionByDistance(RayStep[] steps, float distance)
         {
+            Debug.Assert(steps != null);
+            Debug.Assert(steps.Length > 0);
+
             return GetStepByDistance(steps, distance).direction;
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -139,6 +139,8 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
+        public bool FocusLocked { get; set; }
+
         private float lastHitDistance = 2.0f;
 
         protected override void Awake()


### PR DESCRIPTION
This PR adds a FocusLocked field to IPointingSource.

While a pointer's FocusLocked is true, focus enter / exit events are suspended and that pointer will continue to send manipulation to the last focused object.

This is needed for tools like bounding boxes, which require gaze focus for initial selection but not for subsequent manipulation.

PR passes all input tests.