### PR TITLE
Changed the namespaces to HoloToolkit.Unity.UX

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Distorters/Distorter.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/Distorter.cs
@@ -5,7 +5,7 @@
 using System;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public abstract class Distorter : MonoBehaviour, IComparable<Distorter>
     {

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterBulge.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterBulge.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class DistorterBulge : Distorter
     {

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterGravity.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterGravity.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class DistorterGravity : Distorter
     {

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSimplex.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSimplex.cs
@@ -4,7 +4,7 @@
 //
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class DistorterSimplex : Distorter
     {

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSphere.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterSphere.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class DistorterSphere : Distorter
     {

--- a/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterWiggly.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Distorters/DistorterWiggly.cs
@@ -4,7 +4,7 @@
 //
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class DistorterWiggly : Distorter
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Bezier.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Bezier.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class Bezier : LineBase
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Ellipse.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Ellipse.cs
@@ -3,7 +3,7 @@
 
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class Ellipse : LineBase
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Line.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Line.cs
@@ -4,7 +4,7 @@
 using HoloToolkit.Unity;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class Line : LineBase
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineBase.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineBase.cs
@@ -5,7 +5,7 @@ using HoloToolkit.Unity;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public abstract class LineBase : MonoBehaviour
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineBaseEditor.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineBaseEditor.cs
@@ -3,7 +3,7 @@
 
 using HoloToolkit.Unity;
 using UnityEngine;
-using Holotoolkit.Unity.UX;
+using HoloToolkit.Unity.UX;
 #if UNITY_EDITOR
 using UnityEditor;
 

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineMeshes.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineMeshes.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [UseWith(typeof(LineBase))]
     public class LineMeshes : LineRendererBase

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectCollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectCollection.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class LineObjectCollection : MonoBehaviour
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectFollower.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectFollower.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [ExecuteInEditMode]
     public class LineObjectFollower : MonoBehaviour

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectSwarm.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineObjectSwarm.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [ExecuteInEditMode]
     public class LineObjectSwarm : MonoBehaviour

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineParticles.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineParticles.cs
@@ -5,7 +5,7 @@
 using HoloToolkit.Unity;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [UseWith(typeof(LineBase))]
     public class LineParticles : LineRendererBase

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineRendererBase.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineRendererBase.cs
@@ -4,7 +4,7 @@
 using HoloToolkit.Unity;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public abstract class LineRendererBase : MonoBehaviour
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineStripMesh.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineStripMesh.cs
@@ -5,7 +5,7 @@ using HoloToolkit.Unity;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [UseWith(typeof(LineBase))]
     public class LineStripMesh : LineRendererBase

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineUnity.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineUnity.cs
@@ -5,7 +5,7 @@ using HoloToolkit.Unity;
 using System.Collections;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [UseWith(typeof(LineBase))]
     public class LineUnity : LineRendererBase

--- a/Assets/HoloToolkit/UX/Scripts/Lines/LineUtility.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/LineUtility.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public enum InterpolationEnum
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Parabola.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Parabola.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class Parabola : LineBase
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Rectangle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Rectangle.cs
@@ -4,7 +4,7 @@
 using HoloToolkit.Unity;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class Rectangle : LineBase
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/Spline.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/Spline.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     public class Spline : LineBase
     {

--- a/Assets/HoloToolkit/UX/Scripts/Lines/SplinePoint.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Lines/SplinePoint.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace Holotoolkit.Unity.UX
+namespace HoloToolkit.Unity.UX
 {
     [Serializable]
     public struct SplinePoint


### PR DESCRIPTION
Overview
---
Changed namespaces to `HoloToolkit.Unity.UX`. These changes could be breaking, if someone uses the scripts. All tests ran through, although I could only test them with Unity 2017.1.2f1.

Please run the tests in 2017.2.

I noticed there are a lot of unused dependencies in these scripts, but I didn't remove them to keep the PR clean. Maybe you should refactor that at some point in time. 

Changes
---
- Fixes: #1366 
