### PR TITLE
Removing casting and recieving shadows from the FadePlane

### DIFF
--- a/Assets/HoloToolkit/Input/Prefabs/MixedRealityCameraParent.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/MixedRealityCameraParent.prefab
@@ -538,8 +538,8 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1586147040494190}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1


### PR DESCRIPTION
Overview
---
In certain scenarios, the fade plane casts a large shadow, which isn't ideal.

![image](https://user-images.githubusercontent.com/3580640/33464098-784e8cfc-d5f5-11e7-9561-2d251f8d4bb2.png)


Changes
---
- Related to: #1257, Q6.
