### PR TITLE
Validation for Position and Rotation Coords Issue#1290

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
@@ -157,13 +157,13 @@ namespace HoloToolkit.Unity.InputModule
                     }
 
                     Vector3 newPosition;
-                    if (sourceState.sourcePose.TryGetPosition(out newPosition, InteractionSourceNode.Grip))
+                    if (sourceState.sourcePose.TryGetPosition(out newPosition, InteractionSourceNode.Grip) && ValidPosition(newPosition)) // issue #1290
                     {
                         currentController.ControllerParent.transform.localPosition = newPosition;
                     }
 
                     Quaternion newRotation;
-                    if (sourceState.sourcePose.TryGetRotation(out newRotation, InteractionSourceNode.Grip))
+                    if (sourceState.sourcePose.TryGetRotation(out newRotation, InteractionSourceNode.Grip) && ValidRotation(newRotation)) // #issue #1290
                     {
                         currentController.ControllerParent.transform.localRotation = newRotation;
                     }
@@ -171,9 +171,19 @@ namespace HoloToolkit.Unity.InputModule
             }
 #endif
         }
+		#region Validation for Rotation and Position Issue # 1290
+		private bool ValidRotation(Quaternion newRotation)
+		{
+			return !float.IsNaN(newRotation.x) && !float.IsNaN(newRotation.y) && !float.IsNaN(newRotation.z) && !float.IsNaN(newRotation.w);
+		}
 
+		private bool ValidPosition(Vector3 newPosition)
+		{
+			return !float.IsNaN(newPosition.x) && !float.IsNaN(newPosition.y) && !float.IsNaN(newPosition.z);
+		}
+		#endregion
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-        private void InteractionManager_InteractionSourceDetected(InteractionSourceDetectedEventArgs obj)
+		private void InteractionManager_InteractionSourceDetected(InteractionSourceDetectedEventArgs obj)
         {
             StartTrackingController(obj.state.source);
         }
@@ -438,7 +448,7 @@ namespace HoloToolkit.Unity.InputModule
         }
 #endif
 
-        public GameObject SpawnTouchpadVisualizer(Transform parentTransform)
+		public GameObject SpawnTouchpadVisualizer(Transform parentTransform)
         {
             GameObject touchVisualizer;
             if (TouchpadTouchedOverride != null)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
@@ -171,19 +171,19 @@ namespace HoloToolkit.Unity.InputModule
             }
 #endif
         }
-		private bool ValidRotation(Quaternion newRotation)
-		{
-			return !float.IsNaN(newRotation.x) && !float.IsNaN(newRotation.y) && !float.IsNaN(newRotation.z) && !float.IsNaN(newRotation.w) &&
-				!float.IsInfinity(newRotation.x) && !float.IsInfinity(newRotation.y) && !float.IsInfinity(newRotation.z) && !float.IsInfinity(newRotation.w);
-		}
+        private bool ValidRotation(Quaternion newRotation)
+        {
+            return !float.IsNaN(newRotation.x) && !float.IsNaN(newRotation.y) && !float.IsNaN(newRotation.z) && !float.IsNaN(newRotation.w) &&
+                !float.IsInfinity(newRotation.x) && !float.IsInfinity(newRotation.y) && !float.IsInfinity(newRotation.z) && !float.IsInfinity(newRotation.w);
+        }
 
-		private bool ValidPosition(Vector3 newPosition)
-		{
-			return !float.IsNaN(newPosition.x) && !float.IsNaN(newPosition.y) && !float.IsNaN(newPosition.z) &&
-				!float.IsInfinity(newPosition.x) && !float.IsInfinity(newPosition.y) && !float.IsInfinity(newPosition.z);
-		}
+        private bool ValidPosition(Vector3 newPosition)
+        {
+            return !float.IsNaN(newPosition.x) && !float.IsNaN(newPosition.y) && !float.IsNaN(newPosition.z) &&
+                !float.IsInfinity(newPosition.x) && !float.IsInfinity(newPosition.y) && !float.IsInfinity(newPosition.z);
+        }
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-		private void InteractionManager_InteractionSourceDetected(InteractionSourceDetectedEventArgs obj)
+        private void InteractionManager_InteractionSourceDetected(InteractionSourceDetectedEventArgs obj)
         {
             StartTrackingController(obj.state.source);
         }
@@ -448,7 +448,7 @@ namespace HoloToolkit.Unity.InputModule
         }
 #endif
 
-		public GameObject SpawnTouchpadVisualizer(Transform parentTransform)
+        public GameObject SpawnTouchpadVisualizer(Transform parentTransform)
         {
             GameObject touchVisualizer;
             if (TouchpadTouchedOverride != null)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
@@ -174,12 +174,14 @@ namespace HoloToolkit.Unity.InputModule
 		#region Validation for Rotation and Position Issue # 1290
 		private bool ValidRotation(Quaternion newRotation)
 		{
-			return !float.IsNaN(newRotation.x) && !float.IsNaN(newRotation.y) && !float.IsNaN(newRotation.z) && !float.IsNaN(newRotation.w);
+			return !float.IsNaN(newRotation.x) && !float.IsNaN(newRotation.y) && !float.IsNaN(newRotation.z) && !float.IsNaN(newRotation.w) &&
+				!float.IsInfinity(newRotation.x) && !float.IsInfinity(newRotation.y) && !float.IsInfinity(newRotation.z) && !float.IsInfinity(newRotation.w);
 		}
 
 		private bool ValidPosition(Vector3 newPosition)
 		{
-			return !float.IsNaN(newPosition.x) && !float.IsNaN(newPosition.y) && !float.IsNaN(newPosition.z);
+			return !float.IsNaN(newPosition.x) && !float.IsNaN(newPosition.y) && !float.IsNaN(newPosition.z) &&
+				!float.IsInfinity(newPosition.x) && !float.IsInfinity(newPosition.y) && !float.IsInfinity(newPosition.z);
 		}
 		#endregion
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
@@ -157,13 +157,13 @@ namespace HoloToolkit.Unity.InputModule
                     }
 
                     Vector3 newPosition;
-                    if (sourceState.sourcePose.TryGetPosition(out newPosition, InteractionSourceNode.Grip) && ValidPosition(newPosition)) // issue #1290
+                    if (sourceState.sourcePose.TryGetPosition(out newPosition, InteractionSourceNode.Grip) && ValidPosition(newPosition))
                     {
                         currentController.ControllerParent.transform.localPosition = newPosition;
                     }
 
                     Quaternion newRotation;
-                    if (sourceState.sourcePose.TryGetRotation(out newRotation, InteractionSourceNode.Grip) && ValidRotation(newRotation)) // #issue #1290
+                    if (sourceState.sourcePose.TryGetRotation(out newRotation, InteractionSourceNode.Grip) && ValidRotation(newRotation))
                     {
                         currentController.ControllerParent.transform.localRotation = newRotation;
                     }
@@ -171,7 +171,6 @@ namespace HoloToolkit.Unity.InputModule
             }
 #endif
         }
-		#region Validation for Rotation and Position Issue # 1290
 		private bool ValidRotation(Quaternion newRotation)
 		{
 			return !float.IsNaN(newRotation.x) && !float.IsNaN(newRotation.y) && !float.IsNaN(newRotation.z) && !float.IsNaN(newRotation.w) &&
@@ -183,7 +182,6 @@ namespace HoloToolkit.Unity.InputModule
 			return !float.IsNaN(newPosition.x) && !float.IsNaN(newPosition.y) && !float.IsNaN(newPosition.z) &&
 				!float.IsInfinity(newPosition.x) && !float.IsInfinity(newPosition.y) && !float.IsInfinity(newPosition.z);
 		}
-		#endregion
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
 		private void InteractionManager_InteractionSourceDetected(InteractionSourceDetectedEventArgs obj)
         {


### PR DESCRIPTION
Overview
UnityEngine.XR.WSA   InteractionSourceState.sourcePose.TryGetPosition and InteractionSourceState.sourcePose.TryGetRotation can return 'NaN' and or 'Infinity/NegativeInfinty' as a coordinate value. When setting a transform.postion or transform.rotation with non numeric coord values will through an error.


Changes
Added two validation methods to test for 'IsNaN' and 'IsInfinity'. Applied these changes to the condition statement befor setting prosition and rotation of controller model.
- Fixes: #1290.
