### PR TITLE
XboxControllerHandlerBase fixes

### DIFF
--- a/Assets/HoloToolkit-Examples/Input/Scenes/GamepadTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/GamepadTest.unity
@@ -452,6 +452,26 @@ Prefab:
       propertyPath: JoystickSupported
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114812681035175298, guid: d29bc40b7f3df26479d6a0aac211c355,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114812681035175298, guid: d29bc40b7f3df26479d6a0aac211c355,
+        type: 2}
+      propertyPath: EnableTeleport
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114812681035175298, guid: d29bc40b7f3df26479d6a0aac211c355,
+        type: 2}
+      propertyPath: EnableRotation
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114812681035175298, guid: d29bc40b7f3df26479d6a0aac211c355,
+        type: 2}
+      propertyPath: EnableStrafe
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/HoloToolkit-Examples/Input/Scenes/GamepadTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/GamepadTest.unity
@@ -262,7 +262,7 @@ Transform:
   - {fileID: 2095686945}
   - {fileID: 293671890}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &509293012
 MonoBehaviour:
@@ -279,40 +279,6 @@ MonoBehaviour:
   alignmentType: 0
   stationarySpaceTypePosition: {x: 0, y: 0, z: 0}
   roomScaleSpaceTypePosition: {x: 0, y: 0, z: 0}
---- !u!1 &648067039
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 648067040}
-  m_Layer: 0
-  m_Name: Managers
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &648067040
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 648067039}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 844015981}
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &844015981 stripped
-Transform:
-  m_PrefabParentObject: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab,
-    type: 2}
-  m_PrefabInternal: {fileID: 1873443075}
 --- !u!1 &1020433839
 GameObject:
   m_ObjectHideFlags: 0
@@ -376,7 +342,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1001 &1173812366
 Prefab:
@@ -512,7 +478,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4000013535415816, guid: b2db04283121ca74495c2ee000fb4243, type: 2}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 114000013851064060, guid: b2db04283121ca74495c2ee000fb4243,
         type: 2}
@@ -522,12 +488,18 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b2db04283121ca74495c2ee000fb4243, type: 2}
   m_IsPrefabParent: 0
+--- !u!114 &1662233529 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114000013851064060, guid: b2db04283121ca74495c2ee000fb4243,
+    type: 2}
+  m_PrefabInternal: {fileID: 1662233528}
+  m_Script: {fileID: 11500000, guid: afa1ae235bc6cfa43addd1435e2fd822, type: 3}
 --- !u!1001 &1873443075
 Prefab:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 648067040}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
       propertyPath: m_LocalPosition.x
@@ -543,15 +515,15 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
       propertyPath: m_LocalRotation.w
@@ -559,15 +531,14 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4000011656901714, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
       propertyPath: m_RootOrder
-      value: 0
+      value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 114708646396671696, guid: 3eddd1c29199313478dd3f912bfab2ab,
+    - target: {fileID: 114742747811649402, guid: 3eddd1c29199313478dd3f912bfab2ab,
         type: 2}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 114708646396671696, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
+      propertyPath: Cursor
+      value: 
+      objectReference: {fileID: 1662233529}
+    m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
 --- !u!1 &1956520457 stripped
@@ -575,26 +546,6 @@ GameObject:
   m_PrefabParentObject: {fileID: 1000011070707148, guid: 3eddd1c29199313478dd3f912bfab2ab,
     type: 2}
   m_PrefabInternal: {fileID: 1873443075}
---- !u!114 &1956520458
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1956520457}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acb07a2de49ca4d478750eedc4858f17, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  pointingExtent: 10
-  pointingRaycastLayerMasks:
-  - serializedVersion: 2
-    m_Bits: 4294967291
-  registeredPointers: []
-  autoRegisterGazePointerIfNoPointersRegistered: 1
-  debugDrawPointingRays: 0
-  debugDrawPointingRayColors: []
-  uiRaycastCamera: {fileID: 0}
 --- !u!1 &2095686941
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit-Examples/Input/Scripts/XboxControllerHandlerTest.cs
+++ b/Assets/HoloToolkit-Examples/Input/Scripts/XboxControllerHandlerTest.cs
@@ -25,7 +25,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         private Vector3 newPosition;
         private Vector3 newRotation;
 
-        private void Start()
+        protected virtual void Start()
         {
             initialPosition = transform.position;
         }

--- a/Assets/HoloToolkit-Examples/Input/Scripts/XboxControllerHandlerTest.cs
+++ b/Assets/HoloToolkit-Examples/Input/Scripts/XboxControllerHandlerTest.cs
@@ -25,9 +25,8 @@ namespace HoloToolkit.Unity.InputModule.Tests
         private Vector3 newPosition;
         private Vector3 newRotation;
 
-        protected override void Start()
+        private void Start()
         {
-            base.Start();
             initialPosition = transform.position;
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/GamePad/GamePadHandlerBase.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GamePad/GamePadHandlerBase.cs
@@ -12,11 +12,6 @@ namespace HoloToolkit.Unity.InputModule
 
         private void OnEnable()
         {
-            InputManager.Instance.AddGlobalListener(gameObject);
-        }
-
-        protected virtual void Start()
-        {
             if (IsGlobalListener)
             {
                 InputManager.Instance.AddGlobalListener(gameObject);

--- a/Assets/HoloToolkit/Input/Scripts/GamePad/XboxController/XboxControllerHandlerBase.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GamePad/XboxController/XboxControllerHandlerBase.cs
@@ -49,7 +49,7 @@ namespace HoloToolkit.Unity.InputModule
                 GamePadName = eventData.GamePadName;
             }
 
-            if (eventData.XboxA_Down)
+            if (XboxControllerMapping.GetButton_Down(SelectButton, eventData))
             {
                 CurrentGestureState = GestureState.SelectButtonPressed;
 
@@ -58,12 +58,12 @@ namespace HoloToolkit.Unity.InputModule
                 HoldStartedRoutine = StartCoroutine(HandleHoldStarted(eventData));
             }
 
-            if (eventData.XboxA_Pressed)
+            if (XboxControllerMapping.GetButton_Pressed(SelectButton, eventData))
             {
                 HandleNavigation(eventData);
             }
 
-            if (eventData.XboxA_Up)
+            if (XboxControllerMapping.GetButton_Up(SelectButton, eventData))
             {
                 HandleSelectButtonReleased(eventData);
             }

--- a/Assets/HoloToolkit/Input/Scripts/GamePad/XboxController/XboxControllerHandlerBase.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GamePad/XboxController/XboxControllerHandlerBase.cs
@@ -49,7 +49,7 @@ namespace HoloToolkit.Unity.InputModule
                 GamePadName = eventData.GamePadName;
             }
 
-            if (XboxControllerMapping.GetButton_Down(SelectButton, eventData))
+            if (eventData.XboxA_Down)
             {
                 CurrentGestureState = GestureState.SelectButtonPressed;
 
@@ -58,12 +58,12 @@ namespace HoloToolkit.Unity.InputModule
                 HoldStartedRoutine = StartCoroutine(HandleHoldStarted(eventData));
             }
 
-            if (XboxControllerMapping.GetButton_Pressed(SelectButton, eventData))
+            if (eventData.XboxA_Pressed)
             {
                 HandleNavigation(eventData);
             }
 
-            if (XboxControllerMapping.GetButton_Up(SelectButton, eventData))
+            if (eventData.XboxA_Up)
             {
                 HandleSelectButtonReleased(eventData);
             }


### PR DESCRIPTION
Overview
---
Simplified the state machine in `XboxControllerHandlerBase` to reduce confusion and cases where states may conflict with each other.
Also resolved a bug where `GamePadHandlerBase` was registering as a global listener twice, thus receiving all events from the `InputManager` twice.

Changes
---
- Fixes: #1517
