### PR TITLE
Removing BoundaryManager from HoloLens

### DIFF
--- a/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
@@ -84,7 +84,11 @@ namespace HoloToolkit.Unity.Boundary
             }
             else
             {
-                XRDevice.SetTrackingSpaceType(transparentTrackingSpaceType);
+                // Removed for now, until the HoloLens tracking space type story is more clear.
+                //XRDevice.SetTrackingSpaceType(transparentTrackingSpaceType);
+
+                enabled = false;
+                return;
             }
 
             // Render the floor based on if you are in editor or immersive device.

--- a/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
@@ -87,7 +87,7 @@ namespace HoloToolkit.Unity.Boundary
                 // Removed for now, until the HoloLens tracking space type story is more clear.
                 //XRDevice.SetTrackingSpaceType(transparentTrackingSpaceType);
 
-                enabled = false;
+                Destroy(this);
                 return;
             }
 


### PR DESCRIPTION
Overview
---
If a HoloLens is detected, now the `BoundaryManager` script is disabled.

Changes
---
- Fixes: #1505.
