### PR TITLE
Catch possible uiRaycastResult.module null value

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -629,7 +629,8 @@ namespace HoloToolkit.Unity.InputModule
             }
 
             // Check if we need to overwrite the physics raycast info
-            if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.isValid && uiRaycastResult.module.eventCamera == UIRaycastCamera)
+            if ((pointer.End.Object == null || overridePhysicsRaycast) && uiRaycastResult.isValid && 
+			     uiRaycastResult.module != null && uiRaycastResult.module.eventCamera == UIRaycastCamera)
             {
                 newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
                 newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;


### PR DESCRIPTION
In my app Walk the World I have seen crashes happening on this line, debugging learned that for some reasons sometimes uiRaycastResult.module is indeed null, causing the next clause (uiRaycastResult.module.eventCamera == UIRaycastCamera) to throw a null pointer exception.