### PR TITLE
MixedRealityTeleport option to stay in same horizontal plane, fixed Editor

### DIFF
--- a/Assets/HoloToolkit-Examples/Input/Scenes/InteractiveMeshCursor.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/InteractiveMeshCursor.unity
@@ -88,6 +88,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 0
 --- !u!196 &4
@@ -362,6 +363,94 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 906323c940a3fad4f8f7e9e4fcd747f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  containerObject: {fileID: 0}
+  alignmentType: 0
+  stationarySpaceTypePosition: {x: 0, y: 0, z: 0}
+  roomScaleSpaceTypePosition: {x: 0, y: 0, z: 0}
+--- !u!1 &1166889112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1166889117}
+  - component: {fileID: 1166889116}
+  - component: {fileID: 1166889115}
+  - component: {fileID: 1166889114}
+  m_Layer: 0
+  m_Name: CubeToStandOn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1166889114
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166889112}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &1166889115
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166889112}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1166889116
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166889112}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1166889117
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166889112}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.25, z: 3}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1347081833
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit/Input/Scripts/Editor/MixedRealityTeleportEditor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/MixedRealityTeleportEditor.cs
@@ -12,8 +12,27 @@ namespace HoloToolkit.Unity.InputModule
         private readonly GUIContent verticalRotationLabel = new GUIContent("Vertical Rotation", "Used to check the Horizontal Rotation and the intent of the user to rotate in that direction");
 
         private static MixedRealityTeleport mixedRealityTeleport;
+
         private static SerializedProperty teleportMakerPrefab;
         private static SerializedProperty useCustomMappingProperty;
+
+        private static SerializedProperty stayOnTheFloorProperty;
+        private static SerializedProperty enableTeleportProperty;
+        private static SerializedProperty enableStrafeProperty;
+        private static SerializedProperty strafeAmountProperty;
+        private static SerializedProperty enableRotationProperty;
+        private static SerializedProperty rotationSizeProperty;
+
+        private static SerializedProperty leftThumbstickXProperty;
+        private static SerializedProperty leftThumbstickYProperty;
+        private static SerializedProperty rightThumbstickXProperty;
+        private static SerializedProperty rightThumbstickYProperty;
+
+        private static SerializedProperty horizontalStrafeProperty;
+        private static SerializedProperty forwardMovementProperty;
+        private static SerializedProperty horizontalRotationProperty;
+        private static SerializedProperty verticalRotationProperty;
+
         private static bool useCustomMapping;
         private static bool mappingOverride;
 
@@ -21,9 +40,28 @@ namespace HoloToolkit.Unity.InputModule
         {
             mixedRealityTeleport = (MixedRealityTeleport)target;
 
-
             teleportMakerPrefab = serializedObject.FindProperty("teleportMarker");
             useCustomMappingProperty = serializedObject.FindProperty("useCustomMapping");
+
+            enableTeleportProperty = serializedObject.FindProperty("EnableTeleport");
+            enableStrafeProperty = serializedObject.FindProperty("EnableStrafe");
+            strafeAmountProperty = serializedObject.FindProperty("StrafeAmount");
+            enableRotationProperty = serializedObject.FindProperty("EnableRotation");
+            rotationSizeProperty = serializedObject.FindProperty("RotationSize");
+
+            stayOnTheFloorProperty = serializedObject.FindProperty("StayOnTheFloor");
+
+            leftThumbstickXProperty = serializedObject.FindProperty("LeftThumbstickX");
+            leftThumbstickYProperty = serializedObject.FindProperty("LeftThumbstickY");
+            rightThumbstickXProperty = serializedObject.FindProperty("RightThumbstickX");
+            rightThumbstickYProperty = serializedObject.FindProperty("RightThumbstickY");
+
+            horizontalStrafeProperty = serializedObject.FindProperty("HorizontalStrafe");
+            forwardMovementProperty = serializedObject.FindProperty("ForwardMovement");
+            horizontalRotationProperty = serializedObject.FindProperty("HorizontalRotation");
+            verticalRotationProperty = serializedObject.FindProperty("VerticalRotation");
+
+
         }
 
         public override void OnInspectorGUI()
@@ -34,15 +72,17 @@ namespace HoloToolkit.Unity.InputModule
 
             EditorGUILayout.LabelField("Teleport Options", new GUIStyle("Label") { fontStyle = FontStyle.Bold });
 
-            mixedRealityTeleport.EnableTeleport = EditorGUILayout.Toggle("Enable Teleport", mixedRealityTeleport.EnableTeleport);
+            EditorGUILayout.PropertyField(enableTeleportProperty, new GUIContent("Enable Teleport"));
+            EditorGUILayout.PropertyField(enableStrafeProperty, new GUIContent("Enable Strafe"));
+            EditorGUILayout.PropertyField(strafeAmountProperty, new GUIContent("Strafe Amount"));
 
-            mixedRealityTeleport.EnableStrafe = EditorGUILayout.Toggle("Enable Strafe", mixedRealityTeleport.EnableStrafe);
-            mixedRealityTeleport.StrafeAmount = EditorGUILayout.FloatField("Strafe Amount", mixedRealityTeleport.StrafeAmount);
+            EditorGUILayout.PropertyField(enableRotationProperty, new GUIContent("Enable Rotation"));
+            EditorGUILayout.PropertyField(rotationSizeProperty, new GUIContent("Rotation Amount"));
 
-            mixedRealityTeleport.EnableRotation = EditorGUILayout.Toggle("Enable Rotation", mixedRealityTeleport.EnableRotation);
-            mixedRealityTeleport.RotationSize = EditorGUILayout.FloatField("Rotation Amount", mixedRealityTeleport.RotationSize);
+            EditorGUILayout.PropertyField(stayOnTheFloorProperty, new GUIContent("Stay on the floor"));
 
             EditorGUILayout.PropertyField(teleportMakerPrefab);
+
 
             EditorGUILayout.LabelField("Teleport Controller Mappings", new GUIStyle("Label") { fontStyle = FontStyle.Bold });
 
@@ -69,17 +109,17 @@ namespace HoloToolkit.Unity.InputModule
 
             if (useCustomMapping)
             {
-                mixedRealityTeleport.LeftThumbstickX = EditorGUILayout.TextField("Horizontal Strafe", mixedRealityTeleport.LeftThumbstickX);
-                mixedRealityTeleport.LeftThumbstickY = EditorGUILayout.TextField("Forward Movement", mixedRealityTeleport.LeftThumbstickY);
-                mixedRealityTeleport.RightThumbstickX = EditorGUILayout.TextField("Horizontal Rotation", mixedRealityTeleport.RightThumbstickX);
-                mixedRealityTeleport.RightThumbstickY = EditorGUILayout.TextField(verticalRotationLabel, mixedRealityTeleport.RightThumbstickY);
+                EditorGUILayout.PropertyField(leftThumbstickXProperty, new GUIContent("Horizontal Strafe"));
+                EditorGUILayout.PropertyField(leftThumbstickYProperty, new GUIContent("Forward Movement"));
+                EditorGUILayout.PropertyField(rightThumbstickXProperty, new GUIContent("Horizontal Rotation"));
+                EditorGUILayout.PropertyField(rightThumbstickYProperty, new GUIContent(verticalRotationLabel));
             }
             else
             {
-                mixedRealityTeleport.HorizontalStrafe = (XboxControllerMappingTypes)EditorGUILayout.EnumPopup("Horizontal Strafe", mixedRealityTeleport.HorizontalStrafe);
-                mixedRealityTeleport.ForwardMovement = (XboxControllerMappingTypes)EditorGUILayout.EnumPopup("Forward Movement", mixedRealityTeleport.ForwardMovement);
-                mixedRealityTeleport.HorizontalRotation = (XboxControllerMappingTypes)EditorGUILayout.EnumPopup("Horizontal Rotation", mixedRealityTeleport.HorizontalRotation);
-                mixedRealityTeleport.VerticalRotation = (XboxControllerMappingTypes)EditorGUILayout.EnumPopup(verticalRotationLabel, mixedRealityTeleport.VerticalRotation);
+                EditorGUILayout.PropertyField(horizontalStrafeProperty, new GUIContent("Horizontal Strafe"));
+                EditorGUILayout.PropertyField(forwardMovementProperty, new GUIContent("Forward Movement"));
+                EditorGUILayout.PropertyField(horizontalRotationProperty, new GUIContent("Horizontal Rotation"));
+                EditorGUILayout.PropertyField(verticalRotationProperty, new GUIContent("Verizontal Rotation"));
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityTeleport.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityTeleport.cs
@@ -54,6 +54,9 @@ namespace HoloToolkit.Unity.InputModule
         public bool EnableRotation = true;
         public bool EnableStrafe = true;
 
+        [Tooltip("Makes sure you don't get put 'on top' of holograms, just on the floor")]
+        public bool StayOnTheFloor = false;
+
         public float RotationSize = 45.0f;
         public float StrafeAmount = 0.5f;
 
@@ -287,11 +290,18 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="worldPosition"></param>
         public void SetWorldPosition(Vector3 worldPosition)
         {
+            var orginaly = transform.position.y;
+
             // There are two things moving the camera: the camera parent (that this script is attached to)
             // and the user's head (which the MR device is attached to. :)). When setting the world position,
             // we need to set it relative to the user's head in the scene so they are looking/standing where 
             // we expect.
-            transform.position = worldPosition - (CameraCache.Main.transform.position - transform.position);
+            var newPosition = worldPosition - (CameraCache.Main.transform.position - transform.position);
+            if (StayOnTheFloor)
+            {
+                newPosition.y = orginaly;
+            }
+            transform.position = newPosition;
         }
 
         private void EnableMarker()

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityTeleport.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/MixedRealityTeleport.cs
@@ -290,7 +290,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="worldPosition"></param>
         public void SetWorldPosition(Vector3 worldPosition)
         {
-            var orginaly = transform.position.y;
+            var originalY = transform.position.y;
 
             // There are two things moving the camera: the camera parent (that this script is attached to)
             // and the user's head (which the MR device is attached to. :)). When setting the world position,
@@ -299,7 +299,7 @@ namespace HoloToolkit.Unity.InputModule
             var newPosition = worldPosition - (CameraCache.Main.transform.position - transform.position);
             if (StayOnTheFloor)
             {
-                newPosition.y = orginaly;
+                newPosition.y = originalY;
             }
             transform.position = newPosition;
         }


### PR DESCRIPTION
- Added an option "Stay on the floor" to actually stay in the same horizontal plane, regardless whether or not the user puts the teleport marker on something higher. 
- Added a cube to step on to the InteractiveMeshCursor to be able to test the above
- Fixed MixedRealityTeleportEditor because it did never serialize only three of the twelve properties it edits.