### PR TITLE
Fixed bug in UserNotifications example that didn't correctly check for local user.

### DIFF
--- a/Assets/HoloToolkit-Examples/Sharing/SharingService/Scripts/UserNotifications.cs
+++ b/Assets/HoloToolkit-Examples/Sharing/SharingService/Scripts/UserNotifications.cs
@@ -35,17 +35,17 @@ namespace HoloToolkit.Sharing.Tests
             usersTracker.UserLeft += NotifyUserLeft;
         }
 
-        private static void NotifyUserJoined(User user)
+        private void NotifyUserJoined(User user)
         {
-            if (user.IsValid() && localUser != user)
+            if (user.IsValid() && localUser.GetID() != user.GetID())
             {
                 Debug.LogFormat("[User Notifications] User {0} has joined the room.", user.GetName());
             }
         }
 
-        private static void NotifyUserLeft(User user)
+        private void NotifyUserLeft(User user)
         {
-            if (user.IsValid() && localUser != user)
+            if (user.IsValid() && localUser.GetID() != user.GetID())
             {
                 Debug.LogFormat("[User Notifications] User {0} has left the room.", user.GetName());
             }


### PR DESCRIPTION

Overview
---
Simple fix to have the code behave as it was intended - only notify when a remote user joined instead of all users (including the local user).

