### PR TITLE
Add demo controls to GrabMechanics readme

### DIFF
--- a/Assets/HoloToolkit-Examples/MotionControllers-GrabMechanics/README.md
+++ b/Assets/HoloToolkit-Examples/MotionControllers-GrabMechanics/README.md
@@ -4,6 +4,9 @@ Useful scripts and examples for implementing various types of grab interaction w
 
 ![](/External/ReadMeImages/MRTK_MotionController_GrabMechanics.jpg)
 
+# Demo Controls
+Use the motion controller joysticks for teleportation-based movement. This demo does not implement gaze or pointer based object grabbing. To activate grab mechanics, overlap your mixed reality controllers with a block. This should cause the block to change color. Press the grab button (middle finger) to interact with the block. 
+
 # Basic Architecture
  
 The Grab family consists of these categories of scripts: 


### PR DESCRIPTION
Overview
---
Hey guys, quick PR here to add control docs to the GrabMechanics readme.

Based on previous experience in WMR, and even another demo in this project, I had expected to use the motion control pointer to interact with the blocks. I searched the forum and saw some similar looking problems. I read this readme, but it didn't clarify anything for me, so I came to the conclusion that there must be a bug.

I was about to file an issue, but checked on closed issues and saw someone else had opened #1261 with the same problem, and that it was user error! The demo turned out really cool, and I'm really excited to start playing around with the scripts. I'm also hoping this update to the README will help the next guy along, as I don't think that closed issues are sufficiently discoverable. 

Changes
---
- Fixes: #1261.
