### PR TITLE
Fix typo "API's" -> APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _Note: The latest release should work for both HoloLens and Windows Mixed Realit
 Looking to upgrade your projects to Windows Mixed Reality? [Follow the Upgrade Guide](/UpgradeGuide.md).
 
 # Feature areas
-The Mixed Reality Toolkit for Unity includes many API's to accelerate the development of Mixed Reality projects for both HoloLens and the newer Immersive Headsets (IHMD)
+The Mixed Reality Toolkit for Unity includes many APIs to accelerate the development of Mixed Reality projects for both HoloLens and the newer Immersive Headsets (IHMD)
 
 | [![Input](External/ReadMeImages/MRTK170802_Short_03.png)](Assets/HoloToolkit/Input/README.md)  [Input](Assets/HoloToolkit/Input/README.md)                                               | [![Sharing](External/ReadMeImages/MRTK170802_Short_04.png)](Assets/HoloToolkit/Sharing/README.md) [Sharing](Assets/HoloToolkit/Sharing/README.md)   | [![Spatial Mapping](External/ReadMeImages/MRTK170802_Short_05.png)](Assets/HoloToolkit/SpatialMapping/README.md) [Spatial Mapping](Assets/HoloToolkit/SpatialMapping/README.md)| 
 | :--- | :--- | :--- |


### PR DESCRIPTION
The plural of API is APIs, not API's. Reference: https://english.stackexchange.com/questions/323688/what-is-the-plural-of-api

Overview
---


Changes
---
- Fixes: # .
