### PR TITLE
Make ToggleLogic virtual

### DIFF
--- a/Assets/HoloToolkit-Examples/UX/Scripts/InteractiveToggle.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/InteractiveToggle.cs
@@ -92,7 +92,7 @@ namespace HoloToolkit.Examples.InteractiveElements
             ToggleLogic();
         }
 
-        public void ToggleLogic()
+        public virtual void ToggleLogic()
         {
             if (AllowSelection)
             {


### PR DESCRIPTION
Overview
---
Wanted to make a customized InteractiveToggle script which inherits from InteractiveToggle.cs and needed to change the ToggleLogic() mehtod (use a dynamic Unity bool Event). For this I need ToggleLogic() to be virtual and I think this could help others, as well, because in the current form it is not possible to implement a custom toggle logic.

Changes
---
Made ToggleLogic() virtual in InteractiveToggle
