### PR TITLE
Fix for setting worldCamera to null even when user chose UIRaycastCamera

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/CanvasEditorExtension.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/CanvasEditorExtension.cs
@@ -35,20 +35,24 @@ namespace HoloToolkit.Unity
             {
                 FocusManager.AssertIsInitialized();
 
-                if (canvas.isRootCanvas && canvas.renderMode == RenderMode.WorldSpace && canvas.worldCamera != FocusManager.Instance.UIRaycastCamera)
+                // We only need to ask if the worldCamera is not already the UIRaycastCamera
+                if (canvas.worldCamera != FocusManager.Instance.UIRaycastCamera)
                 {
-                    userPermission = EditorUtility.DisplayDialog("Attention!", DialogText, "OK", "Cancel");
-
-                    if (userPermission)
+                    if (canvas.isRootCanvas && canvas.renderMode == RenderMode.WorldSpace)
                     {
-                        canvas.worldCamera = FocusManager.Instance.UIRaycastCamera;
-                    }
-                }
+                        userPermission = EditorUtility.DisplayDialog("Attention!", DialogText, "OK", "Cancel");
 
-                if (canvas.renderMode != RenderMode.WorldSpace || !userPermission)
-                {
-                    // Sets it back to MainCamera default
-                    canvas.worldCamera = null;
+                        if (userPermission)
+                        {
+                            canvas.worldCamera = FocusManager.Instance.UIRaycastCamera;
+                        }
+                    }
+
+                    if (canvas.renderMode != RenderMode.WorldSpace || !userPermission)
+                    {
+                        // Sets it back to MainCamera default
+                        canvas.worldCamera = null;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix for setting worldCamera of a Canvas to null even when the user chose the UIRaycastCamera. This way way the user could only change the Canvas Camera to UIRaycastCamera when he deliberatly chose a wrong camera, so that the script kicked in and changed it for him.