### PR TITLE
Fix for hidden members in AttachToController

### DIFF
--- a/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
+++ b/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
@@ -88,6 +88,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -123,7 +124,6 @@ GameObject:
   - component: {fileID: 72954881}
   - component: {fileID: 72954880}
   - component: {fileID: 72954879}
-  - component: {fileID: 72954884}
   - component: {fileID: 72954883}
   - component: {fileID: 72954878}
   - component: {fileID: 72954877}
@@ -281,19 +281,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TrackedObjectToReference: 0
-  TransformTarget: {fileID: 0}
---- !u!114 &72954884
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 72954876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abb3fe1ca9da17a4dad15031f86b6f8e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  element: 6
+  handedness: 1
+  trackedObjectToReference: 0
+  transformTarget: {fileID: 0}
 --- !u!1 &120386737
 GameObject:
   m_ObjectHideFlags: 0
@@ -420,7 +411,6 @@ GameObject:
   - component: {fileID: 236969297}
   - component: {fileID: 236969296}
   - component: {fileID: 236969295}
-  - component: {fileID: 236969299}
   - component: {fileID: 236969294}
   - component: {fileID: 236969293}
   m_Layer: 0
@@ -451,7 +441,7 @@ MonoBehaviour:
   GoalScale: {x: 1, y: 1, z: 1}
   Smoothing: 1
   Lifetime: 0
-  Orrientation: 1
+  Orientation: 1
   offset: {x: 0, y: 0.1, z: 0}
   RotationTether: 1
   TetherAngleSteps: 6
@@ -466,8 +456,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TrackedObjectToReference: 1
-  TransformTarget: {fileID: 0}
+  element: 6
+  handedness: 1
+  trackedObjectToReference: 1
+  transformTarget: {fileID: 0}
 --- !u!23 &236969295
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -535,17 +527,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &236969299
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 236969292}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abb3fe1ca9da17a4dad15031f86b6f8e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &342505150
 Prefab:
   m_ObjectHideFlags: 0
@@ -1356,7 +1337,6 @@ GameObject:
   - component: {fileID: 1299772964}
   - component: {fileID: 1299772963}
   - component: {fileID: 1299772962}
-  - component: {fileID: 1299772967}
   - component: {fileID: 1299772961}
   m_Layer: 0
   m_Name: SolverObject_SurfaceMagnetism
@@ -1415,8 +1395,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TrackedObjectToReference: 2
-  TransformTarget: {fileID: 0}
+  element: 6
+  handedness: 1
+  trackedObjectToReference: 2
+  transformTarget: {fileID: 0}
 --- !u!23 &1299772963
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1484,17 +1466,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1299772967
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1299772960}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abb3fe1ca9da17a4dad15031f86b6f8e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1391495929
 GameObject:
   m_ObjectHideFlags: 0
@@ -2128,7 +2099,6 @@ GameObject:
   - component: {fileID: 1878976468}
   - component: {fileID: 1878976467}
   - component: {fileID: 1878976466}
-  - component: {fileID: 1878976470}
   - component: {fileID: 1878976465}
   - component: {fileID: 1878976464}
   - component: {fileID: 1878976471}
@@ -2180,8 +2150,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TrackedObjectToReference: 0
-  TransformTarget: {fileID: 1531362364}
+  element: 6
+  handedness: 1
+  trackedObjectToReference: 0
+  transformTarget: {fileID: 0}
 --- !u!23 &1878976466
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -2249,17 +2221,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1878976470
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1878976463}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abb3fe1ca9da17a4dad15031f86b6f8e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1878976471
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
+++ b/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
@@ -88,6 +88,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -123,7 +124,6 @@ GameObject:
   - component: {fileID: 72954881}
   - component: {fileID: 72954880}
   - component: {fileID: 72954879}
-  - component: {fileID: 72954884}
   - component: {fileID: 72954883}
   - component: {fileID: 72954878}
   - component: {fileID: 72954877}
@@ -281,19 +281,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  element: 6
+  handedness: 1
   TrackedObjectToReference: 0
   TransformTarget: {fileID: 0}
---- !u!114 &72954884
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 72954876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abb3fe1ca9da17a4dad15031f86b6f8e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &120386737
 GameObject:
   m_ObjectHideFlags: 0
@@ -451,7 +442,7 @@ MonoBehaviour:
   GoalScale: {x: 1, y: 1, z: 1}
   Smoothing: 1
   Lifetime: 0
-  Orrientation: 1
+  Orientation: 0
   offset: {x: 0, y: 0.1, z: 0}
   RotationTether: 1
   TetherAngleSteps: 6
@@ -466,6 +457,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  element: 6
+  handedness: 1
   TrackedObjectToReference: 1
   TransformTarget: {fileID: 0}
 --- !u!23 &236969295
@@ -1415,6 +1408,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  element: 6
+  handedness: 1
   TrackedObjectToReference: 2
   TransformTarget: {fileID: 0}
 --- !u!23 &1299772963
@@ -2180,6 +2175,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  element: 6
+  handedness: 1
   TrackedObjectToReference: 0
   TransformTarget: {fileID: 1531362364}
 --- !u!23 &1878976466

--- a/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
+++ b/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
@@ -88,7 +88,6 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -124,6 +123,7 @@ GameObject:
   - component: {fileID: 72954881}
   - component: {fileID: 72954880}
   - component: {fileID: 72954879}
+  - component: {fileID: 72954884}
   - component: {fileID: 72954883}
   - component: {fileID: 72954878}
   - component: {fileID: 72954877}
@@ -281,10 +281,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  element: 6
-  handedness: 1
   TrackedObjectToReference: 0
   TransformTarget: {fileID: 0}
+--- !u!114 &72954884
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72954876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: abb3fe1ca9da17a4dad15031f86b6f8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &120386737
 GameObject:
   m_ObjectHideFlags: 0
@@ -442,7 +451,7 @@ MonoBehaviour:
   GoalScale: {x: 1, y: 1, z: 1}
   Smoothing: 1
   Lifetime: 0
-  Orientation: 0
+  Orrientation: 1
   offset: {x: 0, y: 0.1, z: 0}
   RotationTether: 1
   TetherAngleSteps: 6
@@ -457,8 +466,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  element: 6
-  handedness: 1
   TrackedObjectToReference: 1
   TransformTarget: {fileID: 0}
 --- !u!23 &236969295
@@ -1408,8 +1415,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  element: 6
-  handedness: 1
   TrackedObjectToReference: 2
   TransformTarget: {fileID: 0}
 --- !u!23 &1299772963
@@ -2175,8 +2180,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c87713fbad4edbc46a3cc23770b0b4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  element: 6
-  handedness: 1
   TrackedObjectToReference: 0
   TransformTarget: {fileID: 1531362364}
 --- !u!23 &1878976466

--- a/Assets/HoloToolkit/Input/Scripts/Editor/AttachToControllerEditor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/AttachToControllerEditor.cs
@@ -2,24 +2,23 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using UnityEditor;
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
 {
     [CustomEditor(typeof(AttachToController))]
-    public class AttachToControllerEditor : Editor
+    public class AttachToControllerEditor : ControllerFinderEditor
     {
-        private SerializedProperty handednessProperty;
-        private SerializedProperty elementProperty;
         private SerializedProperty positionOffsetProperty;
         private SerializedProperty rotationOffsetProperty;
         private SerializedProperty scaleOffsetProperty;
         private SerializedProperty setScaleOnAttachProperty;
         private SerializedProperty setChildrenInactiveWhenDetachedProperty;
 
-        private void OnEnable()
+        protected override void OnEnable()
         {
-            handednessProperty = serializedObject.FindProperty("handedness");
-            elementProperty = serializedObject.FindProperty("element");
+            base.OnEnable();
+
             positionOffsetProperty = serializedObject.FindProperty("PositionOffset");
             rotationOffsetProperty = serializedObject.FindProperty("RotationOffset");
             scaleOffsetProperty = serializedObject.FindProperty("ScaleOffset");
@@ -29,15 +28,21 @@ namespace HoloToolkit.Unity.InputModule
 
         public override void OnInspectorGUI()
         {
+            base.OnInspectorGUI();
             serializedObject.Update();
+
             EditorGUILayout.Space();
-            EditorGUILayout.PropertyField(handednessProperty);
-            EditorGUILayout.PropertyField(elementProperty);
+            EditorGUILayout.LabelField("Attachment Options", new GUIStyle("Label") { fontStyle = FontStyle.Bold });
+            EditorGUILayout.Space();
+            EditorGUI.indentLevel++;
+
             EditorGUILayout.PropertyField(positionOffsetProperty);
             EditorGUILayout.PropertyField(rotationOffsetProperty);
             EditorGUILayout.PropertyField(scaleOffsetProperty);
             EditorGUILayout.PropertyField(setScaleOnAttachProperty);
             EditorGUILayout.PropertyField(setChildrenInactiveWhenDetachedProperty);
+
+            EditorGUI.indentLevel--;
             serializedObject.ApplyModifiedProperties();
         }
     }

--- a/Assets/HoloToolkit/Input/Scripts/Editor/AttachToControllerEditor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/AttachToControllerEditor.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using UnityEditor;
+
+namespace HoloToolkit.Unity.InputModule
+{
+    [CustomEditor(typeof(AttachToController))]
+    public class AttachToControllerEditor : Editor
+    {
+        private SerializedProperty handednessProperty;
+        private SerializedProperty elementProperty;
+        private SerializedProperty positionOffsetProperty;
+        private SerializedProperty rotationOffsetProperty;
+        private SerializedProperty scaleOffsetProperty;
+        private SerializedProperty setScaleOnAttachProperty;
+        private SerializedProperty setChildrenInactiveWhenDetachedProperty;
+
+        private void OnEnable()
+        {
+            handednessProperty = serializedObject.FindProperty("handedness");
+            elementProperty = serializedObject.FindProperty("element");
+            positionOffsetProperty = serializedObject.FindProperty("PositionOffset");
+            rotationOffsetProperty = serializedObject.FindProperty("RotationOffset");
+            scaleOffsetProperty = serializedObject.FindProperty("ScaleOffset");
+            setScaleOnAttachProperty = serializedObject.FindProperty("SetScaleOnAttach");
+            setChildrenInactiveWhenDetachedProperty = serializedObject.FindProperty("SetChildrenInactiveWhenDetached");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            EditorGUILayout.Space();
+            EditorGUILayout.PropertyField(handednessProperty);
+            EditorGUILayout.PropertyField(elementProperty);
+            EditorGUILayout.PropertyField(positionOffsetProperty);
+            EditorGUILayout.PropertyField(rotationOffsetProperty);
+            EditorGUILayout.PropertyField(scaleOffsetProperty);
+            EditorGUILayout.PropertyField(setScaleOnAttachProperty);
+            EditorGUILayout.PropertyField(setChildrenInactiveWhenDetachedProperty);
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/Editor/AttachToControllerEditor.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/AttachToControllerEditor.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d26656ef2afdc0d4abf235491bf44d56
+timeCreated: 1516667275
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Editor/ControllerFinderEditor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/ControllerFinderEditor.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using UnityEditor;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.InputModule
+{
+    [CustomEditor(typeof(ControllerFinder))]
+    public abstract class ControllerFinderEditor : Editor
+    {
+        private SerializedProperty handednessProperty;
+        private SerializedProperty elementProperty;
+
+        protected virtual void OnEnable()
+        {
+            handednessProperty = serializedObject.FindProperty("handedness");
+            elementProperty = serializedObject.FindProperty("element");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Controller Options", new GUIStyle("Label") { fontStyle = FontStyle.Bold });
+            EditorGUILayout.Space();
+            EditorGUI.indentLevel++;
+
+            EditorGUILayout.PropertyField(handednessProperty);
+            EditorGUILayout.PropertyField(elementProperty);
+
+            EditorGUI.indentLevel--;
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/Editor/ControllerFinderEditor.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/ControllerFinderEditor.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 9996de847f4442948b3354429d577f60
+timeCreated: 1516737926
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
@@ -16,16 +16,16 @@ namespace HoloToolkit.Unity.InputModule
         public bool SetChildrenInactiveWhenDetached = true;
 
         [SerializeField]
-        protected Vector3 positionOffset = Vector3.zero;
+        protected Vector3 PositionOffset = Vector3.zero;
 
         [SerializeField]
-        protected Vector3 rotationOffset = Vector3.zero;
+        protected Vector3 RotationOffset = Vector3.zero;
 
         [SerializeField]
-        protected Vector3 scale = Vector3.one;
+        protected Vector3 ScaleOffset = Vector3.one;
 
         [SerializeField]
-        protected bool setScaleOnAttach = false;
+        protected bool SetScaleOnAttach = false;
 
         public bool IsAttached { get; private set; }
 
@@ -38,7 +38,7 @@ namespace HoloToolkit.Unity.InputModule
 
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             // Look if the controller has loaded.
-            if (MotionControllerVisualizer.Instance.TryGetControllerModel(handedness, out ControllerInfo))
+            if (MotionControllerVisualizer.Instance.TryGetControllerModel(Handedness, out ControllerInfo))
             {
                 AddControllerTransform(ControllerInfo);
             }
@@ -50,7 +50,7 @@ namespace HoloToolkit.Unity.InputModule
         protected override void AddControllerTransform(MotionControllerInfo newController)
         {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-            if (!IsAttached && newController.Handedness == handedness)
+            if (!IsAttached && newController.Handedness == Handedness)
             {
                 base.AddControllerTransform(newController);
 
@@ -58,12 +58,12 @@ namespace HoloToolkit.Unity.InputModule
 
                 // Parent ourselves under the element and set our offsets
                 transform.parent = ElementTransform;
-                transform.localPosition = positionOffset;
-                transform.localEulerAngles = rotationOffset;
+                transform.localPosition = PositionOffset;
+                transform.localEulerAngles = RotationOffset;
 
-                if (setScaleOnAttach)
+                if (SetScaleOnAttach)
                 {
-                    transform.localScale = scale;
+                    transform.localScale = ScaleOffset;
                 }
 
                 // Announce that we're attached
@@ -77,7 +77,7 @@ namespace HoloToolkit.Unity.InputModule
         protected override void RemoveControllerTransform(MotionControllerInfo oldController)
         {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-            if (IsAttached && oldController.Handedness == handedness)
+            if (IsAttached && oldController.Handedness == Handedness)
             {
                 base.RemoveControllerTransform(oldController);
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
@@ -13,14 +13,6 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class AttachToController : ControllerFinder
     {
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
-        [Header("AttachToController Elements")]
-        [SerializeField]
-        protected new InteractionSourceHandedness handedness = InteractionSourceHandedness.Left;
-#endif
-        [SerializeField]
-        protected new MotionControllerInfo.ControllerElementEnum element = MotionControllerInfo.ControllerElementEnum.PointingPose;
-
         public bool SetChildrenInactiveWhenDetached = true;
 
         [SerializeField]

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
-using UnityEngine.XR.WSA.Input;
-#endif
 
 namespace HoloToolkit.Unity.InputModule
 {

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AttachToController.cs
@@ -38,9 +38,9 @@ namespace HoloToolkit.Unity.InputModule
 
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             // Look if the controller has loaded.
-            if (MotionControllerVisualizer.Instance.TryGetControllerModel(handedness, out controller))
+            if (MotionControllerVisualizer.Instance.TryGetControllerModel(handedness, out ControllerInfo))
             {
-                AddControllerTransform(controller);
+                AddControllerTransform(ControllerInfo);
             }
 #endif 
             MotionControllerVisualizer.Instance.OnControllerModelLoaded += AddControllerTransform;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -21,7 +21,7 @@ namespace HoloToolkit.Unity.InputModule
         public MotionControllerInfo.ControllerElementEnum Element
         {
             get { return element; }
-            protected set { element = value; }
+            set { element = value; }
         }
 
         [SerializeField]

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -25,7 +25,6 @@ namespace HoloToolkit.Unity.InputModule
         }
 
         [SerializeField]
-        [HideInInspector]
         private MotionControllerInfo.ControllerElementEnum element = MotionControllerInfo.ControllerElementEnum.PointingPose;
 
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
@@ -36,7 +35,6 @@ namespace HoloToolkit.Unity.InputModule
         }
 
         [SerializeField]
-        [HideInInspector]
         private InteractionSourceHandedness handedness = InteractionSourceHandedness.Left;
 #endif
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-using System.Collections;
-using System.Collections.Generic;
+
 using UnityEngine;
+
 #if UNITY_WSA
 #if UNITY_2017_2_OR_NEWER
 using UnityEngine.XR.WSA.Input;
@@ -16,33 +16,33 @@ namespace HoloToolkit.Unity.InputModule
     /// <summary>
     /// ControllerFinder is a base class providing simple event handling for getting/releasing MotionController Transforms
     /// </summary>
-    public class ControllerFinder : MonoBehaviour
+    public abstract class ControllerFinder : MonoBehaviour
     {
-        #region public members
         public MotionControllerInfo.ControllerElementEnum Element { get { return element; } }
-        public Transform ElementTransform { get { return elementTransform; } private set { elementTransform = value; } }
-        #endregion
 
-    #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-        public virtual InteractionSourceHandedness Handedness { get { return handedness; } set { handedness = value; } }
-        protected InteractionSourceHandedness handedness = InteractionSourceHandedness.Left;
-    
-    #endif
-
-        #region private members
-        protected MotionControllerInfo controller;
+        [Header("Controller Attachment Options")]
+        [SerializeField]
         protected MotionControllerInfo.ControllerElementEnum element = MotionControllerInfo.ControllerElementEnum.PointingPose;
-        private Transform elementTransform;
-        #endregion
 
+#if UNITY_WSA && UNITY_2017_2_OR_NEWER
+        public InteractionSourceHandedness Handedness { get { return handedness; } set { handedness = value; } }
+
+        [SerializeField]
+        protected InteractionSourceHandedness handedness = InteractionSourceHandedness.Left;
+#endif
+
+        public Transform ElementTransform { get { return elementTransform; } private set { elementTransform = value; } }
+        private Transform elementTransform;
+
+        protected MotionControllerInfo ControllerInfo;
 
         protected virtual void OnEnable()
         {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             // Look if the controller has loaded.
-            if (MotionControllerVisualizer.Instance.TryGetControllerModel(handedness, out controller))
+            if (MotionControllerVisualizer.Instance.TryGetControllerModel(handedness, out ControllerInfo))
             {
-                AddControllerTransform(controller);
+                AddControllerTransform(ControllerInfo);
             }
 #endif
             MotionControllerVisualizer.Instance.OnControllerModelLoaded += AddControllerTransform;
@@ -77,9 +77,9 @@ namespace HoloToolkit.Unity.InputModule
                     Debug.LogError("Unable to find element of type " + element + " under controller " + newController.ControllerParent.name + "; not attaching.");
                     return;
                 }
-                controller = newController;
+                ControllerInfo = newController;
                 // update elementTransform for consumption
-                controller.TryGetElement(element, out elementTransform);
+                ControllerInfo.TryGetElement(element, out elementTransform);
                 ElementTransform = elementTransform;
             }
 #endif
@@ -90,7 +90,7 @@ namespace HoloToolkit.Unity.InputModule
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             if (oldController.Handedness == handedness)
             {
-                controller = null;
+                ControllerInfo = null;
                 ElementTransform = null;
             }
 #endif

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -18,17 +18,26 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public abstract class ControllerFinder : MonoBehaviour
     {
-        public MotionControllerInfo.ControllerElementEnum Element { get { return element; } }
+        public MotionControllerInfo.ControllerElementEnum Element
+        {
+            get { return element; }
+            protected set { element = value; }
+        }
 
-        [Header("Controller Attachment Options")]
         [SerializeField]
-        protected MotionControllerInfo.ControllerElementEnum element = MotionControllerInfo.ControllerElementEnum.PointingPose;
+        [HideInInspector]
+        private MotionControllerInfo.ControllerElementEnum element = MotionControllerInfo.ControllerElementEnum.PointingPose;
 
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-        public InteractionSourceHandedness Handedness { get { return handedness; } set { handedness = value; } }
+        public InteractionSourceHandedness Handedness
+        {
+            get { return handedness; }
+            set { handedness = value; }
+        }
 
         [SerializeField]
-        protected InteractionSourceHandedness handedness = InteractionSourceHandedness.Left;
+        [HideInInspector]
+        private InteractionSourceHandedness handedness = InteractionSourceHandedness.Left;
 #endif
 
         public Transform ElementTransform { get { return elementTransform; } private set { elementTransform = value; } }

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SolverHandlerEditor.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SolverHandlerEditor.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using HoloToolkit.Unity.InputModule;
+using UnityEditor;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.UX
+{
+    [CustomEditor(typeof(SolverHandler))]
+    public class SolverHandlerEditor : ControllerFinderEditor
+    {
+        private SerializedProperty trackedObjectReferenceProperty;
+        private SerializedProperty transformTargetProperty;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            trackedObjectReferenceProperty = serializedObject.FindProperty("trackedObjectToReference");
+            transformTargetProperty = serializedObject.FindProperty("transformTarget");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            EditorGUILayout.Space();
+
+            EditorGUILayout.PropertyField(trackedObjectReferenceProperty);
+            EditorGUILayout.PropertyField(transformTargetProperty);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SolverHandlerEditor.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SolverHandlerEditor.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 1671855e569227546b601c21eb8986a3
+timeCreated: 1516743223
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverHandler.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverHandler.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
-using UnityEngine;
 using HoloToolkit.Unity.InputModule;
+using UnityEngine;
 
 namespace HoloToolkit.Unity
 {
     public class SolverHandler : ControllerFinder
     {
-        #region public enums
         public enum TrackedObjectToReferenceEnum
         {
             /// <summary>
@@ -25,24 +25,40 @@ namespace HoloToolkit.Unity
             /// </summary>
             MotionControllerRight
         }
-        #endregion
 
-        #region public members
-        [Tooltip("Tracked object to calculate position and orrientation from. If you want to manually override and use a scene object, use the TransformTarget field")]
-        public TrackedObjectToReferenceEnum TrackedObjectToReference = TrackedObjectToReferenceEnum.Head;
+        [SerializeField]
+        [Tooltip("Tracked object to calculate position and orientation from. If you want to manually override and use a scene object, use the TransformTarget field")]
+        private TrackedObjectToReferenceEnum trackedObjectToReference = TrackedObjectToReferenceEnum.Head;
 
+        public TrackedObjectToReferenceEnum TrackedObjectToReference
+        {
+            get { return trackedObjectToReference; }
+            set { trackedObjectToReference = value; }
+        }
+
+        [SerializeField]
         [Tooltip("Manual override for TrackedObjectToReference if you want to use a scene object. Leave empty if you want to use Head or Motion controllers")]
-        public Transform TransformTarget;
-        #endregion
+        private Transform transformTarget;
 
-        private List<Solver> m_Solvers = new List<Solver>();
+        public Transform TransformTarget
+        {
+            get { return transformTarget; }
+            set { transformTarget = value; }
+        }
+
         public Vector3 GoalPosition { get; set; }
+
         public Quaternion GoalRotation { get; set; }
+
         public Vector3 GoalScale { get; set; }
+
         public Vector3Smoothed AltScale { get; set; }
+
         public float DeltaTime { get; set; }
 
         private float LastUpdateTime { get; set; }
+
+        private List<Solver> m_Solvers = new List<Solver>();
 
         private void Awake()
         {
@@ -51,11 +67,6 @@ namespace HoloToolkit.Unity
             GoalScale = Vector3.one;
             AltScale = new Vector3Smoothed(Vector3.one, 0.1f);
             DeltaTime = 0.0f;
-        }
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
         }
 
         private void Update()
@@ -77,7 +88,7 @@ namespace HoloToolkit.Unity
             }
         }
 
-        [System.Serializable]
+        [Serializable]
         public struct Vector3Smoothed
         {
             public Vector3 Current { get; set; }
@@ -93,7 +104,7 @@ namespace HoloToolkit.Unity
 
             public void Update(float deltaTime)
             {
-                Current = Vector3.Lerp(Current, Goal, (System.Math.Abs(SmoothTime) < Mathf.Epsilon) ? 1.0f : deltaTime / SmoothTime);
+                Current = Vector3.Lerp(Current, Goal, (Math.Abs(SmoothTime) < Mathf.Epsilon) ? 1.0f : deltaTime / SmoothTime);
             }
 
             public void SetGoal(Vector3 newGoal)
@@ -102,7 +113,7 @@ namespace HoloToolkit.Unity
             }
         }
 
-        [System.Serializable]
+        [Serializable]
         public struct QuaternionSmoothed
         {
             public Quaternion Current { get; set; }
@@ -118,7 +129,7 @@ namespace HoloToolkit.Unity
 
             public void Update(float deltaTime)
             {
-                Current = Quaternion.Slerp(Current, Goal, (System.Math.Abs(SmoothTime) < Mathf.Epsilon) ? 1.0f : deltaTime / SmoothTime);
+                Current = Quaternion.Slerp(Current, Goal, (Math.Abs(SmoothTime) < Mathf.Epsilon) ? 1.0f : deltaTime / SmoothTime);
             }
 
             public void SetGoal(Quaternion newGoal)


### PR DESCRIPTION
Overview
---
Fix for hidden members in AttachToController.  Second attempt.

This time I simply made ControllerFinder Abstract so no one could use it directly on a GameObject.  I couldn't think of any reason to really have it unless you needed to inherit anyway. (Mostly a helper).

Added a industry standard editor for SolverHandler to make sure we don't show the fields we didn't need to change.

Also added editors for the Controller Finder and Attach To Controller classes for aesthetics.

![image](https://user-images.githubusercontent.com/13334553/35299671-d3b035fe-003a-11e8-8e11-e5bd42ed2c84.png)

Changes
---
Fixes #1661
