### PR TITLE
Fixed int bug in column calculation of ObjectCollection

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Collections/ObjectCollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Collections/ObjectCollection.cs
@@ -176,7 +176,7 @@ namespace HoloToolkit.Unity.Collections
                     break;
             }
 
-            _columns = Mathf.CeilToInt(NodeList.Count / Rows);
+            _columns = Mathf.CeilToInt((float)NodeList.Count / Rows);
             _width = _columns * CellWidth;
             _height = Rows * CellHeight;
             _halfCell = new Vector2(CellWidth / 2f, CellHeight / 2f);


### PR DESCRIPTION
Column calculation was buggy because of some `int` math.  
As an Example, when calculating columns with a `NodeList.Count` of `4` and `Rows` of `5` (both are `int` values) the result is 0. That resulted in all CollectionNodes being positioned in one place.