### PR TITLE
Fix build for non windows platforms

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Buttons/CompoundButtonSpeech.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/CompoundButtonSpeech.cs
@@ -3,9 +3,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
 using UnityEngine;
-#if UNITY_WSA || UNITY_STANDALONE_WIN
-using UnityEngine.Windows.Speech;
-#endif
 using HoloToolkit.Unity.InputModule;
 using HoloToolkit.Unity;
 
@@ -37,14 +34,6 @@ namespace HoloToolkit.Unity.Buttons
         /// </summary>
         [HideInMRTKInspector]
         public string Keyword = string.Empty;
-
-#if UNITY_WSA || UNITY_STANDALONE_WIN
-        /// <summary>
-        /// The confidence level to use for this speech command
-        /// </summary>
-        [HideInMRTKInspector]
-        public ConfidenceLevel ConfidenceLevel = ConfidenceLevel.Medium;
-#endif
 
         /// <summary>
         /// Variable to keep track of previous button text in case the button text changes after registration.

--- a/Assets/HoloToolkit/UX/Scripts/Buttons/CompoundButtonSpeech.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/CompoundButtonSpeech.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
 using UnityEngine;
+#if UNITY_WSA || UNITY_STANDALONE_WIN
 using UnityEngine.Windows.Speech;
+#endif
 using HoloToolkit.Unity.InputModule;
 using HoloToolkit.Unity;
 
@@ -36,11 +38,13 @@ namespace HoloToolkit.Unity.Buttons
         [HideInMRTKInspector]
         public string Keyword = string.Empty;
 
+#if UNITY_WSA || UNITY_STANDALONE_WIN
         /// <summary>
         /// The confidence level to use for this speech command
         /// </summary>
         [HideInMRTKInspector]
         public ConfidenceLevel ConfidenceLevel = ConfidenceLevel.Medium;
+#endif
 
         /// <summary>
         /// Variable to keep track of previous button text in case the button text changes after registration.


### PR DESCRIPTION
Overview
---

Using UnityEngine.Windows.Speech namespace prevents build for other platforms than UWP (e.g. iOS).
Platform dependent compilation is used in other places in code, e.g. HoloToolkit.UI.Keyboard.Keyboard

But it is missed in HoloToolkit.Unity.Buttons.CompoundButtonSpeech that prevents build for ios.

