### PR TITLE
Resolve future issues... now

### DIFF
--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildSLNUtilities.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildSLNUtilities.cs
@@ -144,7 +144,7 @@ namespace HoloToolkit.Unity
                     buildInfo.Scenes.ToArray(),
                     buildInfo.OutputDirectory,
                     buildInfo.BuildTarget,
-                    buildInfo.BuildOptions);
+                    buildInfo.BuildOptions).ToString();
 
                 if (buildError.StartsWith("Error"))
                 {

--- a/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
@@ -291,7 +291,7 @@ namespace HoloToolkit.Unity
                             {
                                 Light clonedLight = Instantiate(DebugPointLight, closestHit.point, Quaternion.identity) as Light;
                                 clonedLight.color = Color.red;
-                                DestroyObject(clonedLight, 1.0f);
+                                Destroy(clonedLight, 1.0f);
                             }
 #if UNITY_EDITOR
                             DebugDrawLine(DebugDrawLines, cameraPosition, targetCoord, Color.red);


### PR DESCRIPTION
Resolved two issues that will become a problem in 2018, as they are fixable now it seems sensible to resolve them.

Overview
---
2018 highlighted some obsolete code / functions that were now removed.  The new versions of these functions exist now, so we should fix them ahead of them being a problem

Changes
---
- BuildsNSLTools updated to force conversion of it's build output to a string (as Unity will change it from a string to a Type)
 - Changed the Destroy method used in Tagalong script (as destroyobject is scheduled for removal)

Remaining Issues
---
 - EnumMaskField is being replaced with EnumFlagsField (but not in 2.17.2 build so cannot be fixed now)
 - WSA Images are getting tidied up (removing old types and Phone), we should probably remove these now, but need to validate the effect on current WSA builds
