### PR TITLE
Fixing building glTF libraries for other build types

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/GLTF/Plugins/GLTFSerialization/GLTFSerialization.dll.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/GLTF/Plugins/GLTFSerialization/GLTFSerialization.dll.meta
@@ -16,17 +16,19 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Editor: 0
-        Exclude Linux: 0
-        Exclude Linux64: 0
-        Exclude LinuxUniversal: 0
-        Exclude OSXUniversal: 0
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXIntel: 1
+        Exclude OSXIntel64: 1
+        Exclude OSXUniversal: 1
         Exclude Win: 0
         Exclude Win64: 0
         Exclude WindowsStoreApps: 1
   - first:
       Any: 
     second:
-      enabled: 0
+      enabled: 1
       settings: {}
   - first:
       Editor: Editor
@@ -51,26 +53,39 @@ PluginImporter:
   - first:
       Standalone: Linux
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86
+        CPU: None
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86_64
+        CPU: None
   - first:
       Standalone: LinuxUniversal
     second:
-      enabled: 1
-      settings: {}
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXIntel
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXIntel64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: Win
     second:

--- a/Assets/HoloToolkit/Utilities/Scripts/GLTF/Plugins/JsonNet/Newtonsoft.Json.dll.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/GLTF/Plugins/JsonNet/Newtonsoft.Json.dll.meta
@@ -16,17 +16,19 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Editor: 0
-        Exclude Linux: 0
-        Exclude Linux64: 0
-        Exclude LinuxUniversal: 0
-        Exclude OSXUniversal: 0
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXIntel: 1
+        Exclude OSXIntel64: 1
+        Exclude OSXUniversal: 1
         Exclude Win: 0
         Exclude Win64: 0
         Exclude WindowsStoreApps: 1
   - first:
       Any: 
     second:
-      enabled: 0
+      enabled: 1
       settings: {}
   - first:
       Editor: Editor
@@ -51,26 +53,39 @@ PluginImporter:
   - first:
       Standalone: Linux
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86
+        CPU: None
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86_64
+        CPU: None
   - first:
       Standalone: LinuxUniversal
     second:
-      enabled: 1
-      settings: {}
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXIntel
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXIntel64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: Win
     second:

--- a/Assets/HoloToolkit/Utilities/Scripts/GLTF/Shaders/GLTFStandard.shader
+++ b/Assets/HoloToolkit/Utilities/Scripts/GLTF/Shaders/GLTFStandard.shader
@@ -59,9 +59,12 @@ Shader "GLTF/GLTFStandard" {
 
 			#pragma vertex vertBase
 			#pragma fragment fragBase
+
 			#include "GLTFStandardInput.cginc"
+
+#if !SHADER_API_GLES
 			#include "UnityStandardCoreForward.cginc"
-	
+#endif
 			ENDCG
 		}
 		// ------------------------------------------------------------------
@@ -90,9 +93,12 @@ Shader "GLTF/GLTFStandard" {
 
 			#pragma vertex vertAdd
 			#pragma fragment fragAdd
-			#include "GLTFStandardInput.cginc"
-			#include "UnityStandardCoreForward.cginc"
 
+			#include "GLTFStandardInput.cginc"
+
+#if !SHADER_API_GLES
+			#include "UnityStandardCoreForward.cginc"
+#endif
 			ENDCG
 		}
 		// ------------------------------------------------------------------


### PR DESCRIPTION
Overview
---
Issue mentioned at https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/1708#issuecomment-364632400

This updates the glTF DLLs to be included for any build type not explicitly excluded, which allows for arbitrary build types to be selected without getting the "namespace GLTF cannot be found" error.

I only have the Android build type installed to test with, but the shader change fixes building there (no guarantee on it working, just building).