### PR TITLE
Turn off the influence of the physics engine while dragging.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -64,6 +64,7 @@ namespace HoloToolkit.Unity.InputModule
         private IInputSource currentInputSource;
         private uint currentInputSourceId;
         private Rigidbody hostRigidbody;
+        private bool hostRigidbodyWasKinematic;
 
         private void Start()
         {
@@ -120,6 +121,7 @@ namespace HoloToolkit.Unity.InputModule
             isDragging = true;
             if (hostRigidbody != null)
             {
+                hostRigidbodyWasKinematic = hostRigidbody.isKinematic;
                 hostRigidbody.isKinematic = true;
             }
 
@@ -299,7 +301,7 @@ namespace HoloToolkit.Unity.InputModule
             currentInputSourceId = 0;
             if (hostRigidbody != null)
             {
-                hostRigidbody.isKinematic = false;
+                hostRigidbody.isKinematic = hostRigidbodyWasKinematic;
             }
             StoppedDragging.RaiseEvent();
         }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -119,7 +119,9 @@ namespace HoloToolkit.Unity.InputModule
 
             isDragging = true;
             if (hostRigidbody != null)
+            {
                 hostRigidbody.isKinematic = true;
+            }
 
             Transform cameraTransform = CameraCache.Main.transform;
 
@@ -296,7 +298,9 @@ namespace HoloToolkit.Unity.InputModule
             currentInputSource = null;
             currentInputSourceId = 0;
             if (hostRigidbody != null)
+            {
                 hostRigidbody.isKinematic = false;
+            }
             StoppedDragging.RaiseEvent();
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -118,6 +118,8 @@ namespace HoloToolkit.Unity.InputModule
             InputManager.Instance.PushModalInputHandler(gameObject);
 
             isDragging = true;
+            if (hostRigidbody != null)
+                hostRigidbody.isKinematic = true;
 
             Transform cameraTransform = CameraCache.Main.transform;
 
@@ -293,6 +295,8 @@ namespace HoloToolkit.Unity.InputModule
             isDragging = false;
             currentInputSource = null;
             currentInputSourceId = 0;
+            if (hostRigidbody != null)
+                hostRigidbody.isKinematic = false;
             StoppedDragging.RaiseEvent();
         }
 


### PR DESCRIPTION
If you attach both RigidBody and HandDraggable to an object, then it will be affected by both gravity and the user's motion controller while dragging. The result is that it flops on the ground like a struggling flounder. This change turns off the influence that the physics engine has over the object while the user is in control of it.