### PR TITLE
.NET 4.6 Compatibility

### DIFF
--- a/Assets/HoloToolkit/Common/Scripts/CrossPlatform/Reflection/ReflectionExtensions.cs
+++ b/Assets/HoloToolkit/Common/Scripts/CrossPlatform/Reflection/ReflectionExtensions.cs
@@ -179,11 +179,12 @@ namespace HoloToolkit
 
     public static class ReflectionExtensions
     {
+#if !NET_4_6
         public static Type GetTypeInfo(this Type type)
         {
             return type;
         }
-
+#endif
         public static Type AsType(this Type type)
         {
             return type;


### PR DESCRIPTION
Fixed issue with compiling against .NET 4.6 and the `GetTypeInfo` Reflection Extension

Changes
---
- Fixes: #1730
