### PR TITLE
Changed SpatialUnderstanding DllImports to cdecl.

### DIFF
--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDll.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDll.cs
@@ -362,12 +362,12 @@ namespace HoloToolkit.Unity
             /// before any other DLL function.
             /// </summary>
             /// <returns>Zero if fails, one if success</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int SpatialUnderstanding_Init();
             /// <summary>
             /// Terminate the spatial understanding DLL. 
             /// </summary>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern void SpatialUnderstanding_Term();
 
             /// <summary>
@@ -384,7 +384,7 @@ namespace HoloToolkit.Unity
             /// <param name="camUp_Z">The user's camera/view unit up vector, z value</param>
             /// <param name="searchDst">Suggested search distance for playspace center</param>
             /// <param name="optimalSize">Optimal room size. Used to determined the playspace size</param>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern void GeneratePlayspace_InitScan(
                 [In] float camPos_X, [In] float camPos_Y, [In] float camPos_Z,
                 [In] float camFwd_X, [In] float camFwd_Y, [In] float camFwd_Z,
@@ -407,7 +407,7 @@ namespace HoloToolkit.Unity
             /// <param name="camUp_Z">The user's camera/view unit up vector, z value</param>
             /// <param name="deltaTime">Time since last update</param>
             /// <returns>One if scanning has been finalized, zero if more updates are required.</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int GeneratePlayspace_UpdateScan(
                 [In] int meshCount, [In] IntPtr meshes,
                 [In] float camPos_X, [In] float camPos_Y, [In] float camPos_Z,
@@ -420,7 +420,7 @@ namespace HoloToolkit.Unity
             /// finalized. This should be called once the user is happy with the currently
             /// scanned in playspace.
             /// </summary>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern void GeneratePlayspace_RequestFinish();
 
             /// <summary>
@@ -432,7 +432,7 @@ namespace HoloToolkit.Unity
             /// <param name="vertexCount">Filled in with the number of vertices to be returned in the subsequent extract call</param>
             /// <param name="indexCount">Filled in with the number of indices to be returned in the subsequent extract call</param>
             /// <returns>Zero if fails, one if success</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int GeneratePlayspace_ExtractMesh_Setup(
                 [Out] out int vertexCount,
                 [Out] out int indexCount);
@@ -447,7 +447,7 @@ namespace HoloToolkit.Unity
             /// <param name="bufferIndexCount">Size of indices, in number of elements</param>
             /// <param name="indices">Array to receive the mesh indices</param>
             /// <returns>Zero if fails, one if success</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int GeneratePlayspace_ExtractMesh_Extract(
                 [In] int bufferVertexCount,
                 [In] IntPtr verticesPos,        // (vertexCount) DirectX::XMFLOAT3*
@@ -460,7 +460,7 @@ namespace HoloToolkit.Unity
             /// </summary>
             /// <param name="playspaceStats">playspace stats structure to receive the statistics data</param>
             /// <returns>Zero if fails, one if success</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int QueryPlayspaceStats(
                 [In] IntPtr playspaceStats);    // PlayspaceStats
 
@@ -469,7 +469,7 @@ namespace HoloToolkit.Unity
             /// </summary>
             /// <param name="playspaceAlignment">playspace alignment structure to receive the alignment data</param>
             /// <returns>Zero if fails, one if success</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int QueryPlayspaceAlignment(
                 [In] IntPtr playspaceAlignment); // PlayspaceAlignment
 
@@ -485,7 +485,7 @@ namespace HoloToolkit.Unity
             /// <param name="rayVec_Z">Ray direction vector, z component. Length of ray indicates the length of the ray cast query.</param>
             /// <param name="result">Structure to receive the results of the raycast</param>
             /// <returns>Zero if fails or no intersection, one if an intersection is detected</returns>
-            [DllImport("SpatialUnderstanding")]
+            [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
             public static extern int PlayspaceRaycast(
                 [In] float rayPos_X, [In] float rayPos_Y, [In] float rayPos_Z,
                 [In] float rayVec_X, [In] float rayVec_Y, [In] float rayVec_Z,

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllObjectPlacement.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllObjectPlacement.cs
@@ -446,7 +446,7 @@ namespace HoloToolkit.Unity
         /// scanning phase has finish and the playspace has been finalized.
         /// </summary>
         /// <returns></returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int Solver_Init();
 
         /// <summary>
@@ -470,7 +470,7 @@ namespace HoloToolkit.Unity
         /// <param name="placementConstraints">Array of ObjectPlacementConstraint structures, defining the constraints</param>
         /// <param name="placementResult">Pointer to an ObjectPlacementResult structure to receive the result of the query </param>
         /// <returns>Zero on failure, one on success</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int Solver_PlaceObject(
             [In, MarshalAs(UnmanagedType.LPStr)] string objectName,
             [In] IntPtr placementDefinition,// ObjectPlacementDefinition
@@ -488,7 +488,7 @@ namespace HoloToolkit.Unity
         /// </summary>
         /// <param name="objectName"></param>
         /// <returns></returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int Solver_RemoveObject(
             [In, MarshalAs(UnmanagedType.LPStr)] string objectName);
 
@@ -498,7 +498,7 @@ namespace HoloToolkit.Unity
         /// Objects placed with Solver_PlaceObject persist until removed
         /// and are considered in subsequent queries by some rules and constraints.
         /// </summary>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern void Solver_RemoveAllObjects();
     }
 }

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllShapes.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllShapes.cs
@@ -838,7 +838,7 @@ namespace HoloToolkit.Unity
         /// <param name="shapeData">An array of ShapeResult structures to receive the results of the query</param>
         /// <returns>Number of positions found. This number will never exceed shapeCount (the space provided for the results in shapeData).</returns>
         // Queries (shapes)
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryShape_FindPositionsOnShape(
             [In, MarshalAs(UnmanagedType.LPStr)] string shapeName,          // char*
             [In] float minRadius,
@@ -853,7 +853,7 @@ namespace HoloToolkit.Unity
         /// <param name="shapeCount">Length of the array passed in shapeData, the return value will never exceed this value</param>
         /// <param name="shapeData">An array of ShapeResult structures to receive the results of the query</param>
         /// <returns>Number of shapes found. This number will never exceed shapeCount (the space provided for the results in shapeData).</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryShape_FindShapeHalfDims(
             [In, MarshalAs(UnmanagedType.LPStr)] string shapeName,         // char*
             [In] int shapeCount,                                            // Pass in the space allocated in shapeData
@@ -870,7 +870,7 @@ namespace HoloToolkit.Unity
         /// <param name="shapeConstraints">Length of the shape constraint array passed in the constraints parameter</param>
         /// <param name="constraints">Array of ShapeConstraint structures</param>
         /// <returns></returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int AddShape(
             [In, MarshalAs(UnmanagedType.LPStr)] string shapeName,
             [In] int componentCount,
@@ -882,13 +882,13 @@ namespace HoloToolkit.Unity
         /// Runs the shape analysis. This should be called after scanning has been 
         /// finalized and shapes have been defined with AddShape.
         /// </summary>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern void ActivateShapeAnalysis();
 
         /// <summary>
         /// Removes all shapes defined by AddShape.
         /// </summary>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern void RemoveAllShapes();
     }
 }

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllTopology.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllTopology.cs
@@ -40,7 +40,7 @@ namespace HoloToolkit.Unity
         /// <param name="locationData">Location result array of TopologyResult to be filled with the spaces found by the query</param>
         /// <returns>Number of spaces found by the query. This value is limited by the number of results supplied by the caller (locationCount)</returns>
         // Queries (topology)
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryTopology_FindPositionsOnWalls(
             [In] float minHeightOfWallSpace,
             [In] float minWidthOfWallSpace,
@@ -59,7 +59,7 @@ namespace HoloToolkit.Unity
         /// <param name="locationCount">Number of location results supplied by the user in locationData</param>
         /// <param name="locationData">Location result array of TopologyResult to be filled with the spaces found by the query</param>
         /// <returns>Number of spaces found by the query. This value is limited by the number of results supplied by the caller (locationCount)</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryTopology_FindLargePositionsOnWalls(
             [In] float minHeightOfWallSpace,
             [In] float minWidthOfWallSpace,
@@ -73,7 +73,7 @@ namespace HoloToolkit.Unity
         /// </summary>
         /// <param name="wall">Pointer to a TopologyResult structure, to be filled with the found wall</param>
         /// <returns>Zero if fails, one if success</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryTopology_FindLargestWall(
             [In, Out] IntPtr wall);             // TopologyResult
 
@@ -85,7 +85,7 @@ namespace HoloToolkit.Unity
         /// <param name="locationCount">Number of location results supplied by the user in locationData</param>
         /// <param name="locationData">Location result array of TopologyResult to be filled with the spaces found by the query</param>
         /// <returns>Number of spaces found by the query. This value is limited by the number of results supplied by the caller (locationCount)</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryTopology_FindPositionsOnFloor(
             [In] float minLengthOfFloorSpace,
             [In] float minWidthOfFloorSpace,
@@ -98,7 +98,7 @@ namespace HoloToolkit.Unity
         /// <param name="locationCount">Number of location results supplied by the user in locationData</param>
         /// <param name="locationData">Location result array of TopologyResult to be filled with the spaces found by the query</param>
         /// <returns>Number of spaces found by the query. This value is limited by the number of results supplied by the caller (locationCount)</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryTopology_FindLargestPositionsOnFloor(
             [In] int locationCount,             // Pass in the space allocated in locationData
             [In, Out] IntPtr locationData);     // TopologyResult
@@ -112,7 +112,7 @@ namespace HoloToolkit.Unity
         /// <param name="locationCount">Number of location results supplied by the user in locationData</param>
         /// <param name="locationData">Location result array of TopologyResult to be filled with the spaces found by the query</param>
         /// <returns>Number of spaces found by the query. This value is limited by the number of results supplied by the caller (locationCount)</returns>
-        [DllImport("SpatialUnderstanding")]
+        [DllImport("SpatialUnderstanding", CallingConvention = CallingConvention.Cdecl)]
         public static extern int QueryTopology_FindPositionsSittable(
             [In] float minHeight,
             [In] float maxHeight,


### PR DESCRIPTION
Overview
---
Explicitly added calling convention to SpatialUnderstanding imports to prevent application from crashing when built using IL2CPP.

Changes
---


- Fixes: #1784 .
