### PR TITLE
Adding two-axis pivots, fixing free, and adding other missing axes to Billboard

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scripts/Billboard.cs
@@ -8,10 +8,17 @@ namespace MixedRealityToolkit.Utilities
 {
     public enum PivotAxis
     {
-        // Rotate about all axes.
-        Free,
+        // Most common options, preserving current functionality with the same enum order.
+        XY,
+        Y,
         // Rotate about an individual axis.
-        Y
+        X,
+        Z,
+        // Rotate about a pair of axes.
+        XZ,
+        YZ,
+        // Rotate about all axes.
+        Free
     }
 
     /// <summary>
@@ -23,7 +30,7 @@ namespace MixedRealityToolkit.Utilities
         /// The axis about which the object will rotate.
         /// </summary>
         [Tooltip("Specifies the axis about which the object will rotate.")]
-        public PivotAxis PivotAxis = PivotAxis.Free;
+        public PivotAxis PivotAxis = PivotAxis.XY;
 
         [Tooltip("Specifies the target we will orient to. If no Target is specified the main camera will be used.")]
         public Transform TargetTransform;
@@ -50,11 +57,35 @@ namespace MixedRealityToolkit.Utilities
 
             // Get a Vector that points from the target to the main camera.
             Vector3 directionToTarget = TargetTransform.position - transform.position;
+            Vector3 targetUpVector = CameraCache.Main.transform.up;
 
             // Adjust for the pivot axis.
             switch (PivotAxis)
             {
+                case PivotAxis.X:
+                    directionToTarget.x = 0.0f;
+                    targetUpVector = Vector3.up;
+                    break;
+
                 case PivotAxis.Y:
+                    directionToTarget.y = 0.0f;
+                    targetUpVector = Vector3.up;
+                    break;
+
+                case PivotAxis.Z:
+                    directionToTarget.x = 0.0f;
+                    directionToTarget.y = 0.0f;
+                    break;
+
+                case PivotAxis.XY:
+                    targetUpVector = Vector3.up;
+                    break;
+
+                case PivotAxis.XZ:
+                    directionToTarget.x = 0.0f;
+                    break;
+
+                case PivotAxis.YZ:
                     directionToTarget.y = 0.0f;
                     break;
 
@@ -71,7 +102,7 @@ namespace MixedRealityToolkit.Utilities
             }
 
             // Calculate and apply the rotation required to reorient the object
-            transform.rotation = Quaternion.LookRotation(-directionToTarget);
+            transform.rotation = Quaternion.LookRotation(-directionToTarget, targetUpVector);
         }
     }
 }


### PR DESCRIPTION
Overview
---
Added support for all combinations of axes. I rearranged the enum to preserve existing behavior (the previous Free was actually only the X and Y axes).

Changes
---
- Fixes #1672, fixes #383, fixes #208.
