### PR TITLE
TapToPlace: extends the usage of collider to place objects

### DIFF
--- a/Assets/HoloToolkit-Examples/Sharing/SharingService/Scenes/SharingTest.unity
+++ b/Assets/HoloToolkit-Examples/Sharing/SharingService/Scenes/SharingTest.unity
@@ -277,7 +277,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 942915099}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!114 &632692719
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit-Examples/SpatialMapping/Scenes/TapToPlace.unity
+++ b/Assets/HoloToolkit-Examples/SpatialMapping/Scenes/TapToPlace.unity
@@ -182,7 +182,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 0}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!23 &181528116
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -348,7 +348,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 0}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!23 &532765827
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -590,7 +590,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 0}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!23 &1023018528
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -18,6 +18,17 @@ namespace HoloToolkit.Unity.SpatialMapping
     [RequireComponent(typeof(Interpolator))]
     public class TapToPlace : MonoBehaviour, IInputClickHandler
     {
+        /// <summary>
+        /// The collider reference point used to place the object.
+        /// </summary>
+        public enum ReferencePoint
+        {
+            None,
+            Bottom,
+            Center,
+            Top
+        }
+
         [Tooltip("Distance from camera to keep the object while placing it.")]
         public float DefaultGazeDistance = 2.0f;
 
@@ -38,8 +49,8 @@ namespace HoloToolkit.Unity.SpatialMapping
         [Tooltip("Setting this to true will allow this behavior to control the DrawMesh property on the spatial mapping.")]
         public bool AllowMeshVisualizationControl = true;
 
-        [Tooltip("Should the center of the Collider be used instead of the gameObjects world transform.")]
-        public bool UseColliderCenter;
+        [Tooltip("Should the Collider be used to place the object instead of the gameObjects world transform.")]
+        public ReferencePoint UseColliderToPlace = ReferencePoint.None;
 
         private Interpolator interpolator;
 
@@ -74,7 +85,18 @@ namespace HoloToolkit.Unity.SpatialMapping
         private void OnEnable()
         {
             Bounds bounds = transform.GetColliderBounds();
-            PlacementPosOffset = transform.position - bounds.center;
+            Vector3 referencePoint = bounds.center;
+
+            if (UseColliderToPlace == ReferencePoint.Top)
+            {
+                referencePoint.y = bounds.max.y;
+            }
+            else if (UseColliderToPlace == ReferencePoint.Bottom)
+            {
+                referencePoint.y = bounds.min.y;
+            }
+
+            PlacementPosOffset = transform.position - referencePoint;
         }
 
         /// <summary>
@@ -107,7 +129,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
 
-            if (UseColliderCenter)
+            if (UseColliderToPlace != ReferencePoint.None)
             {
                 placementPosition += PlacementPosOffset;
             }


### PR DESCRIPTION
Introduces the ability to use new reference points such as top or bottom
of the collider, helpful for common scenarios where user wants to place
the object on the floor or ceiling.

I used the TapToPlaceScene to test all combinations (None, Center, Bottom, Top) to produce the desired behavior.