### PR TITLE
TapToPlace: extends the usage of collider to place objects

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/Sharing/Scenes/SharingTest.unity
+++ b/Assets/MixedRealityToolkit-Examples/Sharing/Scenes/SharingTest.unity
@@ -277,7 +277,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 942915099}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!114 &632692719
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit-Examples/SpatialMapping/Scenes/TapToPlace.unity
+++ b/Assets/MixedRealityToolkit-Examples/SpatialMapping/Scenes/TapToPlace.unity
@@ -182,7 +182,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 0}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!23 &181528116
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -348,7 +348,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 0}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!23 &532765827
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -590,7 +590,7 @@ MonoBehaviour:
   ParentGameObjectToPlace: {fileID: 0}
   IsBeingPlaced: 0
   AllowMeshVisualizationControl: 1
-  UseColliderCenter: 0
+  UseColliderToPlace: 0
 --- !u!23 &1023018528
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -23,17 +23,6 @@ namespace MixedRealityToolkit.SpatialMapping
     [RequireComponent(typeof(Interpolator))]
     public class TapToPlace : MonoBehaviour, IInputClickHandler
     {
-        /// <summary>
-        /// The collider reference point used to place the object.
-        /// </summary>
-        public enum ColliderPlacement
-        {
-            DontUse,
-            UseBottom,
-            UseCenter,
-            UseTop
-        }
-
         [Tooltip("Distance from camera to keep the object while placing it.")]
         public float DefaultGazeDistance = 2.0f;
 
@@ -55,7 +44,7 @@ namespace MixedRealityToolkit.SpatialMapping
         public bool AllowMeshVisualizationControl = true;
 
         [Tooltip("Should the Collider be used to place the object instead of the gameObjects world transform.")]
-        public ColliderPlacement UseColliderToPlace = ColliderPlacement.DontUse;
+        public TapToPlaceColliderPlacement UseColliderToPlace = TapToPlaceColliderPlacement.DontUse;
 
         private Interpolator interpolator;
 
@@ -92,11 +81,11 @@ namespace MixedRealityToolkit.SpatialMapping
             Bounds bounds = transform.GetColliderBounds();
             Vector3 referencePoint = bounds.center;
 
-            if (UseColliderToPlace == ColliderPlacement.UseTop)
+            if (UseColliderToPlace == TapToPlaceColliderPlacement.UseTop)
             {
                 referencePoint.y = bounds.max.y;
             }
-            else if (UseColliderToPlace == ColliderPlacement.UseBottom)
+            else if (UseColliderToPlace == TapToPlaceColliderPlacement.UseBottom)
             {
                 referencePoint.y = bounds.min.y;
             }
@@ -134,7 +123,7 @@ namespace MixedRealityToolkit.SpatialMapping
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
 
-            if (UseColliderToPlace != ColliderPlacement.DontUse)
+            if (UseColliderToPlace != TapToPlaceColliderPlacement.DontUse)
             {
                 placementPosition += PlacementPosOffset;
             }

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -23,6 +23,17 @@ namespace MixedRealityToolkit.SpatialMapping
     [RequireComponent(typeof(Interpolator))]
     public class TapToPlace : MonoBehaviour, IInputClickHandler
     {
+        /// <summary>
+        /// The collider reference point used to place the object.
+        /// </summary>
+        public enum ColliderPlacement
+        {
+            DontUse,
+            UseBottom,
+            UseCenter,
+            UseTop
+        }
+
         [Tooltip("Distance from camera to keep the object while placing it.")]
         public float DefaultGazeDistance = 2.0f;
 
@@ -43,8 +54,8 @@ namespace MixedRealityToolkit.SpatialMapping
         [Tooltip("Setting this to true will allow this behavior to control the DrawMesh property on the spatial mapping.")]
         public bool AllowMeshVisualizationControl = true;
 
-        [Tooltip("Should the center of the Collider be used instead of the gameObjects world transform.")]
-        public bool UseColliderCenter;
+        [Tooltip("Should the Collider be used to place the object instead of the gameObjects world transform.")]
+        public ColliderPlacement UseColliderToPlace = ColliderPlacement.DontUse;
 
         private Interpolator interpolator;
 
@@ -79,7 +90,18 @@ namespace MixedRealityToolkit.SpatialMapping
         private void OnEnable()
         {
             Bounds bounds = transform.GetColliderBounds();
-            PlacementPosOffset = transform.position - bounds.center;
+            Vector3 referencePoint = bounds.center;
+
+            if (UseColliderToPlace == ColliderPlacement.UseTop)
+            {
+                referencePoint.y = bounds.max.y;
+            }
+            else if (UseColliderToPlace == ColliderPlacement.UseBottom)
+            {
+                referencePoint.y = bounds.min.y;
+            }
+
+            PlacementPosOffset = transform.position - referencePoint;
         }
 
         /// <summary>
@@ -112,7 +134,7 @@ namespace MixedRealityToolkit.SpatialMapping
 
             Vector3 placementPosition = GetPlacementPosition(cameraTransform.position, cameraTransform.forward, DefaultGazeDistance);
 
-            if (UseColliderCenter)
+            if (UseColliderToPlace != ColliderPlacement.DontUse)
             {
                 placementPosition += PlacementPosOffset;
             }

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlaceColliderPlacement.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlaceColliderPlacement.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace MixedRealityToolkit.SpatialMapping
+{
+    /// <summary>
+    /// The collider reference point used to place the object.
+    /// </summary>
+    public enum TapToPlaceColliderPlacement
+    {
+        DontUse,
+        UseBottom,
+        UseCenter,
+        UseTop
+    }
+}

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlaceColliderPlacement.cs.meta
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/TapToPlaceColliderPlacement.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 6eef36ba3e719114babc609528234e01
+timeCreated: 1521692294
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Introduces the ability to use other parts of the collider like top or bottom, useful for common scenarios where user wants to place the object on the floor or ceiling.

Used the TapToPlace scene to test combinations (DontUse, UseCenter, UseBottom and UseTop) to validate the desired behavior.