### PR TITLE
[master] fixes #1831 - replace update with lateupdate in FixedAngularSize

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -12,13 +12,43 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class FixedAngularSize : MonoBehaviour
     {
-        [Tooltip("Off sets the scale ratio so that text does not scale down too much. (Set to zero for linear scaling)")]
-        public float SizeRatio = 0;
+        /// <summary>
+        /// Offsets the scale ratio so that text does not scale down too much. (Set to zero for linear scaling)
+        /// </summary>
+        [Tooltip("Offsets the scale ratio so that text does not scale down too much. (Set to zero for linear scaling)")]
+        [Range(0.0f, 1.0f)]
+        [SerializeField]
+        private float sizeRatio = 0.0f;
+        public float SizeRatio
+        {
+            get { return sizeRatio; }
+            set
+            {
+                // Set the value of sizeRatio, while maintaining the supported range.
+                if (value < 0.0f)
+                {
+                    sizeRatio = 0.0f;
+                }
+                else if (value > 1.0f)
+                {
+                    sizeRatio = 1.0f;
+                }
+                else
+                {
+                    sizeRatio = value;
+                }
+            }
+        }
 
-        // The ratio between the transform's local scale and its starting
-        // distance from the camera.
-        private float startingDistance;
+        /// <summary>
+        /// The ratio between the transform's local scale and its starting distance from the camera.
+        /// </summary>
         private Vector3 startingScale;
+
+        /// <summary>
+        /// The starting distance from the camera.
+        /// </summary>
+        private float startingDistance;
 
         private void Start()
         {
@@ -61,7 +91,10 @@ namespace HoloToolkit.Unity
             }
         }
 
-        private void Update()
+        /// <summary>
+        /// LateUpdate is used to ensure that the scaling occurs after any other processing (ex: cursor placement).
+        /// </summary>
+        private void LateUpdate()
         {
             float distanceToHologram = Vector3.Distance(CameraCache.Main.transform.position, transform.position);
             // create an offset ratio based on the starting position. This value creates a new angle that pivots


### PR DESCRIPTION
Overview
FixedAngularSize was previously using Update to adjust the element's visible size. This caused a flicker when applied to a cursor and this update came before the update performed by the GazeManager (as reported in #1831).

Changes
---
* Replaced Update with LateUpdate to ensure the scaling occurs after other modifications.
* Encapsulated the SizeRatio field per the pending code style guide and applied a range check in the setter.
* Add a range to SizeRatio (was defined as 0 - 1 in SetSizeRatio())
* Add summary tag comments throughout.

- Fixes: #1831 .
