### PR TITLE
[master] Update ObjectCollection.cs

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Collections/ObjectCollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Collections/ObjectCollection.cs
@@ -123,7 +123,7 @@ namespace HoloToolkit.Unity.Collections
 
             for (int i = 0; i < NodeList.Count; i++)
             {
-                if (NodeList[i].transform == null || (IgnoreInactiveTransforms && !NodeList[i].transform.gameObject.activeSelf))
+                if (NodeList[i].transform == null || (IgnoreInactiveTransforms && !NodeList[i].transform.gameObject.activeSelf) || !NodeList[i].transform.IsChildOf(this.transform))
                 {
                     emptyNodes.Add(NodeList[i]);
                 }


### PR DESCRIPTION
Fixes issue with GameObject staying in NodeList even though it is not a child anymore.

Overview
---
Remove GameObject from NodeList, when it is not a child of this.transform anymore
!NodeList[i].transform.IsChildOf(this.transform))

Changes
---
- Fixes: #1868 
