### PR TITLE
Adding GripPosition and GripRotation to SupportedInputInfo and adding support to WSA input source and related classes

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/SpatialUnderstanding/Scripts/AppState.cs
+++ b/Assets/MixedRealityToolkit-Examples/SpatialUnderstanding/Scripts/AppState.cs
@@ -279,7 +279,7 @@ namespace MixedRealityToolkit.Examples.SpatialUnderstanding
         public void OnSourceDetected(SourceStateEventData eventData)
         {
             // If the source has positional info and there is currently no visible source
-            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.GripPosition))
             {
                 trackedHandsCount++;
             }
@@ -287,7 +287,7 @@ namespace MixedRealityToolkit.Examples.SpatialUnderstanding
 
         public void OnSourceLost(SourceStateEventData eventData)
         {
-            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.GripPosition))
             {
                 trackedHandsCount--;
             }

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/CustomInputSource.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/CustomInputSource.cs
@@ -47,18 +47,28 @@ namespace MixedRealityToolkit.InputModule.InputSources
             public bool ManipulationInProgress;
             public bool HoldInProgress;
             public Vector3 CumulativeDelta;
+            public Vector3 CumulativeGripDelta;
         }
 
+        [Tooltip("This property now represents Pointer position (contrast with Grip position)")]
         public bool SupportsPosition;
+        [Tooltip("This property now represents Pointer rotation (contrast with Grip rotation)")]
         public bool SupportsRotation;
+        public bool SupportsGripPosition;
+        public bool SupportsGripRotation;
         public bool SupportsRay;
         public bool SupportsMenuButton;
         public bool SupportsGrasp;
         public bool RaiseEventsBasedOnVisibility;
         public InteractionSourceInfo SourceKind;
 
+        [Tooltip("This property now represents controller's Pointer position (contrast with controller Grip position)")]
         public Vector3 ControllerPosition;
+        [Tooltip("This property now represents controller's Pointer rotation (contrast with controller Grip rotation)")]
         public Quaternion ControllerRotation;
+
+        public Vector3 ControllerGripPosition;
+        public Quaternion ControllerGripRotation;
 
         public Ray? PointingRay;
 
@@ -103,6 +113,16 @@ namespace MixedRealityToolkit.InputModule.InputSources
             if (SupportsRay)
             {
                 supportedInputInfo |= SupportedInputInfo.Pointing;
+            }
+
+            if (SupportsGripPosition)
+            {
+                supportedInputInfo |= SupportedInputInfo.GripPosition;
+            }
+
+            if (SupportsGripRotation)
+            {
+                supportedInputInfo |= SupportedInputInfo.GripRotation;
             }
 
             if (SupportsMenuButton)
@@ -172,9 +192,9 @@ namespace MixedRealityToolkit.InputModule.InputSources
         {
             Debug.Assert(sourceId == controllerId, "Controller data requested for a mismatched source ID.");
 
-            if (SupportsPosition)
+            if (SupportsGripPosition)
             {
-                position = ControllerPosition;
+                position = ControllerGripPosition;
                 return true;
             }
 
@@ -186,9 +206,9 @@ namespace MixedRealityToolkit.InputModule.InputSources
         {
             Debug.Assert(sourceId == controllerId, "Controller data requested for a mismatched source ID.");
 
-            if (SupportsRotation)
+            if (SupportsGripRotation)
             {
-                rotation = ControllerRotation;
+                rotation = ControllerGripRotation;
                 return true;
             }
 
@@ -378,6 +398,25 @@ namespace MixedRealityToolkit.InputModule.InputSources
             if (SupportsRay)
             {
                 PointingRay = source.SourcePose.PointerRay;
+            }
+
+            if (SupportsGripPosition)
+            {
+                Vector3 controllerGripPosition;
+                if (source.SourcePose.TryGetGripPosition(out controllerGripPosition))
+                {
+                    currentButtonStates.CumulativeGripDelta += controllerGripPosition - ControllerGripPosition;
+                    ControllerGripPosition = controllerGripPosition;
+                }
+            }
+
+            if (SupportsGripRotation)
+            {
+                Quaternion controllerGripRotation;
+                if (source.SourcePose.TryGetGripRotation(out controllerGripRotation))
+                {
+                    ControllerGripRotation = controllerGripRotation;
+                }
             }
 
             if (SupportsMenuButton)

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/InteractionInputSource.cs
@@ -462,8 +462,10 @@ namespace MixedRealityToolkit.InputModule.InputSources
             SourceData sourceData;
             if (sourceIdToData.TryGetValue(sourceId, out sourceData))
             {
-                retVal |= GetSupportFlag(sourceData.PointerPosition, SupportedInputInfo.Position);
-                retVal |= GetSupportFlag(sourceData.PointerRotation, SupportedInputInfo.Rotation);
+                retVal |= GetSupportFlag(sourceData.PointerPosition, SupportedInputInfo.PointerPosition);
+                retVal |= GetSupportFlag(sourceData.PointerRotation, SupportedInputInfo.PointerRotation);
+                retVal |= GetSupportFlag(sourceData.GripPosition, SupportedInputInfo.GripPosition);
+                retVal |= GetSupportFlag(sourceData.GripRotation, SupportedInputInfo.GripRotation);
                 retVal |= GetSupportFlag(sourceData.PointingRay, SupportedInputInfo.Pointing);
                 retVal |= GetSupportFlag(sourceData.Thumbstick, SupportedInputInfo.Thumbstick);
                 retVal |= GetSupportFlag(sourceData.Touchpad, SupportedInputInfo.Touchpad);
@@ -472,7 +474,7 @@ namespace MixedRealityToolkit.InputModule.InputSources
                 retVal |= GetSupportFlag(sourceData.Grasp, SupportedInputInfo.Grasp);
             }
 #endif
-            return retVal;
+			return retVal;
         }
 
         public override bool TryGetSourceKind(uint sourceId, out InteractionSourceInfo sourceKind)

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/SupportedInputInfo.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/SupportedInputInfo.cs
@@ -12,13 +12,23 @@ namespace MixedRealityToolkit.InputModule.InputSources
     public enum SupportedInputInfo
     {
         None = 0,
+        /// <summary>
+        /// Deprecated: use PointerPosition
+        /// </summary>
         Position = (1 << 0),
+        PointerPosition = (1 << 0),
+        /// <summary>
+        /// Deprecated: use PointerRotation
+        /// </summary>
         Rotation = (1 << 1),
+        PointerRotation = (1 << 1),
         Pointing = (1 << 2),
         Thumbstick = (1 << 3),
         Touchpad = (1 << 4),
         Select = (1 << 5),
         Menu = (1 << 6),
         Grasp = (1 << 7),
+        GripPosition = (1 << 8),
+        GripRotation = (1 << 9)
     }
 }

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/SupportedInputInfo.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/SupportedInputInfo.cs
@@ -12,14 +12,10 @@ namespace MixedRealityToolkit.InputModule.InputSources
     public enum SupportedInputInfo
     {
         None = 0,
-        /// <summary>
-        /// Deprecated: use PointerPosition
-        /// </summary>
+        [Obsolete("use PointerPosition")]
         Position = (1 << 0),
         PointerPosition = (1 << 0),
-        /// <summary>
-        /// Deprecated: use PointerRotation
-        /// </summary>
+        [Obsolete("use PointerRotation")]
         Rotation = (1 << 1),
         PointerRotation = (1 << 1),
         Pointing = (1 << 2),

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/TouchscreenInputSource.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/TouchscreenInputSource.cs
@@ -216,7 +216,7 @@ namespace MixedRealityToolkit.InputModule.InputSources
 
         public override SupportedInputInfo GetSupportedInputInfo(uint sourceId)
         {
-            return SupportedInputInfo.Position | SupportedInputInfo.Pointing;
+            return SupportedInputInfo.PointerPosition | SupportedInputInfo.Pointing;
         }
 
         public override bool TryGetThumbstick(uint sourceId, out bool isPressed, out Vector2 position)

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/Utilities/Interactions/DebugInteractionSourcePose.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/Utilities/Interactions/DebugInteractionSourcePose.cs
@@ -19,17 +19,23 @@ namespace MixedRealityToolkit.InputModule.Utilities.Interations
         public bool TryGetFunctionsReturnTrue;
         public bool IsPositionAvailable;
         public bool IsRotationAvailable;
+        public bool IsGripPositionAvailable;
+        public bool IsGripRotationAvailable;
 
         public Vector3 Position;
         public Vector3 Velocity;
         public Quaternion Rotation;
         public Ray? PointerRay;
+        public Vector3 GripPosition;
+        public Quaternion GripRotation;
 
         public DebugInteractionSourcePose()
         {
             TryGetFunctionsReturnTrue = false;
             IsPositionAvailable = false;
             IsRotationAvailable = false;
+            IsGripPositionAvailable = false;
+            IsGripRotationAvailable = false;
             Position = new Vector3(0, 0, 0);
             Velocity = new Vector3(0, 0, 0);
             Rotation = Quaternion.identity;
@@ -38,7 +44,7 @@ namespace MixedRealityToolkit.InputModule.Utilities.Interations
         public bool TryGetPosition(out Vector3 position)
         {
             position = Position;
-            if (!TryGetFunctionsReturnTrue)
+            if (!TryGetFunctionsReturnTrue)     // TODO: bug? does not test IsPositionAvailable (see TryGetRotation)
             {
                 return false;
             }
@@ -69,6 +75,26 @@ namespace MixedRealityToolkit.InputModule.Utilities.Interations
         {
             pointerRay = (Ray)PointerRay;
             if (PointerRay == null)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public bool TryGetGripPosition(out Vector3 position)
+        {
+            position = GripPosition;
+            if (!TryGetFunctionsReturnTrue)     // TODO: should test IsGripPositionAvailable? (see TryGetPosition)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public bool TryGetGripRotation(out Quaternion rotation)
+        {
+            rotation = GripRotation;
+            if (!TryGetFunctionsReturnTrue || !IsGripRotationAvailable)
             {
                 return false;
             }

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -367,9 +367,9 @@ namespace MixedRealityToolkit.InputModule.Utilities.Interations
             eventData.InputSource.TryGetSourceKind(eventData.SourceId, out sourceKind);
             if (sourceKind != InteractionSourceInfo.Hand)
             {
-                if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+                if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.GripPosition))
                 {
-                    // The input source must provide positional data for this script to be usable
+                    // The input source must provide grip positional data for this script to be usable
                     return;
                 }
             }


### PR DESCRIPTION
Overview
---
WSA input sources do not currently report their capabilities correctly in regards to Pointer position/rotation and grip position/rotation. This PR attempts to fix the situation by adding GripPosition/GripRotation input info types, and clearly differentiating between the Pointer and Grip types. InteractionInputSource and a number of related classes are updated to accommodate use of the new types.

Changes
---
* added PointerPosition (Position-equivalent), PointerRotation (Rotation-equivalent), GripPosition and GripRotation  to SupportedInputInfo enumeration
* deprecated existing Position and Rotation enum ids

- Fixes: #1824 .
