### PR TITLE
Replace "IsChildOf" test with exact parent test

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Collections/ObjectCollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Collections/ObjectCollection.cs
@@ -123,7 +123,7 @@ namespace HoloToolkit.Unity.Collections
 
             for (int i = 0; i < NodeList.Count; i++)
             {
-                if (NodeList[i].transform == null || (IgnoreInactiveTransforms && !NodeList[i].transform.gameObject.activeSelf) || !NodeList[i].transform.IsChildOf(this.transform))
+                if (NodeList[i].transform == null || (IgnoreInactiveTransforms && !NodeList[i].transform.gameObject.activeSelf) || NodeList[i].transform.parent==null || !(NodeList[i].transform.parent.gameObject==this.gameObject))
                 {
                     emptyNodes.Add(NodeList[i]);
                 }


### PR DESCRIPTION
The previous test using "IsChildOf" did process deep children also, that are not supposed to be considered for layout purposes in this case.
An additional test for "transform.parent == null" is necessary to a) allow transform.parent.gameObject to evaluate and b) to account for nodes that are now in the root of the scene hierarchy.

Overview
---
`!NodeList[i].transform.IsChildOf(this.transform)`
did also consider DeepChildren to be proper children, for layout purposes we only want direct children.

`NodeList[i].transform.parent==null`
checks if a GameObject is in the root of the scene. If so, then it should not participate in the layout of ObjectCollection, also a subsequent test to compare the parent would fail.

`!(NodeList[i].transform.parent.gameObject==this.gameObject)`
is an exact test for the parent relationship not existing anymore.

Changes
---
- Fixes: #1885 related to #1868
