### PR TITLE
App Bar highlighted state bug fix #1877

### DIFF
--- a/Assets/MixedRealityToolkit/UX/Scripts/AppBar/AppBarButton.cs
+++ b/Assets/MixedRealityToolkit/UX/Scripts/AppBar/AppBarButton.cs
@@ -137,6 +137,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             icon.Alpha = 0f;
             text.DisableText = true;
             cButton.enabled = false;
+            cButton.transform.Find("FrontPlate").GetComponent<MeshRenderer>().enabled = false;
             cButton.gameObject.layer = LayerMask.NameToLayer("Ignore Raycast");
         }
 
@@ -148,6 +149,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             icon.Alpha = 1f;
             text.DisableText = false;
             cButton.enabled = true;
+            cButton.transform.Find("FrontPlate").GetComponent<MeshRenderer>().enabled = true;
             cButton.gameObject.layer = LayerMask.NameToLayer("UI");
         }
 

--- a/Assets/MixedRealityToolkit/UX/Scripts/AppBar/AppBarButton.cs
+++ b/Assets/MixedRealityToolkit/UX/Scripts/AppBar/AppBarButton.cs
@@ -19,7 +19,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
         private Vector3 hiddenOffset;
         private Vector3 manipulationOffset;
         private CompoundButton cButton;
-        private MeshRenderer highlightMesh;
+        private Renderer highlightMeshRenderer;
         private CompoundButtonText text;
         private CompoundButtonIcon icon;
         private AppBar parentToolBar;
@@ -40,7 +40,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             text = GetComponent<CompoundButtonText>();
             text.Text = template.Text;
             icon = GetComponent<CompoundButtonIcon>();
-            highlightMesh = cButton.transform.Find("FrontPlate").GetComponent<MeshRenderer>();
+            highlightMeshRenderer = cButton.GetComponent<CompoundButtonMesh>().Renderer;
 
             if (customIconProfile != null)
             {
@@ -140,7 +140,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             icon.Alpha = 0f;
             text.DisableText = true;
             cButton.enabled = false;
-            highlightMesh.enabled = false;
+            highlightMeshRenderer.enabled = false;
             cButton.gameObject.layer = LayerMask.NameToLayer("Ignore Raycast");
         }
 
@@ -152,7 +152,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             icon.Alpha = 1f;
             text.DisableText = false;
             cButton.enabled = true;
-            highlightMesh.enabled = true;
+            highlightMeshRenderer.enabled = true;
             cButton.gameObject.layer = LayerMask.NameToLayer("UI");
         }
 

--- a/Assets/MixedRealityToolkit/UX/Scripts/AppBar/AppBarButton.cs
+++ b/Assets/MixedRealityToolkit/UX/Scripts/AppBar/AppBarButton.cs
@@ -19,6 +19,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
         private Vector3 hiddenOffset;
         private Vector3 manipulationOffset;
         private CompoundButton cButton;
+        private MeshRenderer highlightMesh;
         private CompoundButtonText text;
         private CompoundButtonIcon icon;
         private AppBar parentToolBar;
@@ -39,6 +40,8 @@ namespace MixedRealityToolkit.UX.AppBarControl
             text = GetComponent<CompoundButtonText>();
             text.Text = template.Text;
             icon = GetComponent<CompoundButtonIcon>();
+            highlightMesh = cButton.transform.Find("FrontPlate").GetComponent<MeshRenderer>();
+
             if (customIconProfile != null)
             {
                 icon.Profile = customIconProfile;
@@ -137,7 +140,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             icon.Alpha = 0f;
             text.DisableText = true;
             cButton.enabled = false;
-            cButton.transform.Find("FrontPlate").GetComponent<MeshRenderer>().enabled = false;
+            highlightMesh.enabled = false;
             cButton.gameObject.layer = LayerMask.NameToLayer("Ignore Raycast");
         }
 
@@ -149,7 +152,7 @@ namespace MixedRealityToolkit.UX.AppBarControl
             icon.Alpha = 1f;
             text.DisableText = false;
             cButton.enabled = true;
-            cButton.transform.Find("FrontPlate").GetComponent<MeshRenderer>().enabled = true;
+            highlightMesh.enabled = true;
             cButton.gameObject.layer = LayerMask.NameToLayer("UI");
         }
 


### PR DESCRIPTION
Overview
---
App Bar's Done/Hide menu button stays highlighted once you enter/exit the adjust mode.
In Show() and Hide(), added code for disabling/enabling the render of the highlighting mesh.

Changes
---
- Fixes: #1877 

![2018-03-29 16_37_36-unity 2017 2 1p2 64bit - boundingboxgizmoexample unity - mrtk-original - unive](https://user-images.githubusercontent.com/13754172/38118611-bbcb8768-3370-11e8-8c30-55bae01040f9.png)

![2018-03-29 16_37_53-unity 2017 2 1p2 64bit - boundingboxgizmoexample unity - mrtk-original - unive](https://user-images.githubusercontent.com/13754172/38118610-bbb75220-3370-11e8-8edb-7c9487f2c540.png)
