### PR TITLE
Fixed null ref when pointer data does not have a selected object.

### DIFF
--- a/Assets/MixedRealityToolkit/InputModule/Scripts/Focus/FocusManager.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/Focus/FocusManager.cs
@@ -340,21 +340,11 @@ namespace MixedRealityToolkit.InputModule.Focus
 
         public GameObject TryGetFocusedObject(BaseEventData eventData)
         {
-            FocusDetails? details = TryGetFocusDetails(eventData);
-
-            if (details == null)
-            {
-                return null;
-            }
-
             IPointingSource pointingSource;
             TryGetPointingSource(eventData, out pointingSource);
             PointerInputEventData pointerInputEventData = GetSpecificPointerEventData(pointingSource);
-
             Debug.Assert(pointerInputEventData != null);
-            pointerInputEventData.selectedObject = details.Value.Object;
-
-            return details.Value.Object;
+            return pointerInputEventData.selectedObject;
         }
 
         public bool TryGetPointingSource(BaseEventData eventData, out IPointingSource pointingSource)
@@ -437,7 +427,11 @@ namespace MixedRealityToolkit.InputModule.Focus
         public PointerInputEventData GetSpecificPointerEventData(IPointingSource pointer)
         {
             PointerData pointerEventData;
-            return GetPointerData(pointer, out pointerEventData) ? pointerEventData.UnityUIPointerData : null;
+
+            if (!GetPointerData(pointer, out pointerEventData)) { return null; }
+
+            pointerEventData.UnityUIPointerData.selectedObject = GetFocusedObject(pointer);
+            return pointerEventData.UnityUIPointerData;
         }
 
         public float GetPointingExtent(IPointingSource pointingSource)

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputManager.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputManager.cs
@@ -431,13 +431,17 @@ namespace MixedRealityToolkit.InputModule
             IPointingSource pointingSource;
             FocusManager.Instance.TryGetPointingSource(inputEventData, out pointingSource);
             PointerInputEventData pointerInputEventData = FocusManager.Instance.GetSpecificPointerEventData(pointingSource);
-            if (pointerInputEventData != null && inputEventData.selectedObject != null && pressType == InteractionSourcePressInfo.Select)
+            if (pointerInputEventData != null && pressType == InteractionSourcePressInfo.Select)
             {
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
 
-                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
-                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                if (inputEventData.selectedObject != null)
+                {
+                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
+                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                }
+
                 pointerInputEventData.Clear();
             }
         }
@@ -461,7 +465,7 @@ namespace MixedRealityToolkit.InputModule
             IPointingSource pointingSource;
             FocusManager.Instance.TryGetPointingSource(inputEventData, out pointingSource);
             PointerInputEventData pointerInputEventData = FocusManager.Instance.GetSpecificPointerEventData(pointingSource);
-            if (pointerInputEventData != null && inputEventData.selectedObject != null && pressType == InteractionSourcePressInfo.Select)
+            if (pointerInputEventData != null && pressType == InteractionSourcePressInfo.Select)
             {
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
@@ -474,7 +478,10 @@ namespace MixedRealityToolkit.InputModule
                 pointerInputEventData.pressPosition = pointerInputEventData.position;
                 pointerInputEventData.pointerPressRaycast = pointerInputEventData.pointerCurrentRaycast;
 
-                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
+                if (inputEventData.selectedObject != null)
+                {
+                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputManager.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputManager.cs
@@ -431,7 +431,7 @@ namespace MixedRealityToolkit.InputModule
             IPointingSource pointingSource;
             FocusManager.Instance.TryGetPointingSource(inputEventData, out pointingSource);
             PointerInputEventData pointerInputEventData = FocusManager.Instance.GetSpecificPointerEventData(pointingSource);
-            if (pointerInputEventData != null && pressType == InteractionSourcePressInfo.Select)
+            if (pointerInputEventData != null && inputEventData.selectedObject != null && pressType == InteractionSourcePressInfo.Select)
             {
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
@@ -461,7 +461,7 @@ namespace MixedRealityToolkit.InputModule
             IPointingSource pointingSource;
             FocusManager.Instance.TryGetPointingSource(inputEventData, out pointingSource);
             PointerInputEventData pointerInputEventData = FocusManager.Instance.GetSpecificPointerEventData(pointingSource);
-            if (pointerInputEventData != null && pressType == InteractionSourcePressInfo.Select)
+            if (pointerInputEventData != null && inputEventData.selectedObject != null && pressType == InteractionSourcePressInfo.Select)
             {
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;

--- a/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/CustomInputSource.cs
+++ b/Assets/MixedRealityToolkit/InputModule/Scripts/InputSources/CustomInputSource.cs
@@ -102,12 +102,12 @@ namespace MixedRealityToolkit.InputModule.InputSources
 
             if (SupportsPosition)
             {
-                supportedInputInfo |= SupportedInputInfo.Position;
+                supportedInputInfo |= SupportedInputInfo.PointerPosition;
             }
 
             if (SupportsRotation)
             {
-                supportedInputInfo |= SupportedInputInfo.Rotation;
+                supportedInputInfo |= SupportedInputInfo.PointerRotation;
             }
 
             if (SupportsRay)


### PR DESCRIPTION
Overview
---
Updated Focus Manager `TryGetFocusedObject` to make sure we set the pointer data's selected object with the focus details.

Also added a null check in the Input Manager's `RaiseInputUp` and `RaiseInputDown` methods before we execute the pointer handlers for the `UnityEngine.Graphic` objects.

Changes
---
- Fixes: #1872
