### PR TITLE
Write documentation guidelines document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,8 @@ If you have any questions, please reach out on the [HoloLens forums](https://for
 
 1. [Make a proposal](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues) (either new, or for one of the elements in our backlog)
 2. Implement the proposal and its tests.
-3. Rebase commits to tell a compelling story.
-4. Start a pull request & address comments.
-5. Merge.
+3. Start a pull request & address comments.
+4. Merge.
 
 # Proposal
 
@@ -33,23 +32,6 @@ Note:  If you wish to work on something that already exists on our backlog, you 
 8. Ensure the code is [WACK compliant](https://developer.microsoft.com/en-us/windows/develop/app-certification-kit). To do this, generate a Visual Studio solution, right click on project; Store -> Create App Packages. Follow the prompts and run WACK tests. Make sure they all succeed.
 9. Ensure you update the [README](README.md) with additional documentation as needed.
 10. Also update the [MixedRealityToolkit-Unity wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki) if you think it will be useful for other developers.
-
-# Rebase commits
-
-The commits in your pull request should tell a story about how the code got from point A to point B. 
-Good stories are edited, so you'll want to rebase your commits so that they tell a good story.
-
-Each commit should build and pass all of the tests. 
-If you want to add new tests for functionality that's not yet written, ensure the tests are added disabled.
-
-Don't forget to run git diff --check to catch those annoying whitespace changes.
- 
-Please follow the established [Git convention for commit messages](https://www.git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines). 
-The first line is a summary in the imperative, about 50 characters or less, and should not end with a period. 
-An optional, longer description must be preceded by an empty line and should be wrapped at around 72 characters. 
-This helps with various outputs from Git or other tools.
-
-You can update message of local commits you haven't pushed yet using git commit --amend or git rebase --interactivewith reword command.
 
 # Pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,11 @@ Note:  If you wish to work on something that already exists on our backlog, you 
 3. Instructions for getting the project building and running the tests are in the [README](README.md). 
 4. Make small and frequent commits that include tests which could be a unity scene showing usage of your feature.
 5. Make sure that all the tests continue to pass.
-6. Ensure the code is [WACK compliant](https://developer.microsoft.com/en-us/windows/develop/app-certification-kit). To do this, generate a Visual Studio solution, right click on project; Store -> Create App Packages. Follow the prompts and run WACK tests. Make sure they all succeed.
-7. Ensure you update the [README](README.md) with additional documentation as needed.
-8. Also update the [MixedRealityToolkit-Unity wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki) if you think it will be useful for other developers.
+6. Follow the [Coding Guidelines](/CodingGuidelines.md).
+7. Ensure the code and feature(s) are documented as describred in the [Documentation Guidelines](/DocumentationGuidelines.md).
+8. Ensure the code is [WACK compliant](https://developer.microsoft.com/en-us/windows/develop/app-certification-kit). To do this, generate a Visual Studio solution, right click on project; Store -> Create App Packages. Follow the prompts and run WACK tests. Make sure they all succeed.
+9. Ensure you update the [README](README.md) with additional documentation as needed.
+10. Also update the [MixedRealityToolkit-Unity wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki) if you think it will be useful for other developers.
 
 # Rebase commits
 

--- a/DocumentationGuide.md
+++ b/DocumentationGuide.md
@@ -4,19 +4,22 @@
 
 This document outlines the documentation guidelines and standards for the Mixed Reality Toolkit (MRTK). Herein you will find the standards for the following formsfs of the MRTK documentation:
 
-- API / Source
-- Conceptual / How-To
-- Design
-- Performance Notes
-- Breaking Changes
+- [Source](#source-documentation)
+- [Conceptual](#conceptual-documentation)
+- [Design](#design-documentation)
+- [Performance Notes](#performance-notes)
+- [Breaking Changes](#breaking-changes)
 
 ---
 
-## API / Source Documentation
+## Source Documentation
 API documentation will be generated automatically from the MRTK source files. To facilitate this, source files are required to contain the following: 
 
-- Class, Struct, Enum Summary Blocks
-- Property, Method, Event (PME) Summary Blocks
+- [Class, Struct, Enum Summary Blocks](#class-struct-enum-summary-blocks)
+- [Property, Method, Event Summary Blocks](#property-method-event-summary-blocks)
+- [Feature Introduction Version and Dependencies](#feature-introductuin-version-and-dependencies)
+- [Serialized Fields](#serialized-fields)
+- [Enumeration Values](#enumeration-values)
 
 In addition to the above, the code should be well commented to allow for maintenance, bug fixes and ease of customization. 
 
@@ -40,7 +43,7 @@ If there are any class level dependencies, they should be documented in a remark
 
 Pull Requests submitted without summaries for classes, strutures or enums will not be approved.
 
-### Property, Method, Event (PME) Summary Blocks
+### Property, Method, Event Summary Blocks
 As with classes, structures and enums, PMEs (and fields) are to be documented with summary blocks, regardless of code visibility (public, private, protected and internal). The documentation generation tool is responsible for filtering out and publishing only the public and protected features.
 
 NOTE: A summary block is **not** required for Unity methods (ex: Awake, Start, Update).
@@ -58,8 +61,10 @@ As part of a PME summary block, the meaning and purpose of parameters and return
 
 ```
 
-#### Feature Introduction Version and Dependencies
-As part of the PME summary documentation, information regarding the MRTK version in which the feature was introduced and any dependencies should be documented in a remarks block.
+[Go Up](#source-documentation)
+
+### Feature Introduction Version and Dependencies
+As part of the API summary documentation, information regarding the MRTK version in which the feature was introduced and any dependencies should be documented in a remarks block.
 
 Dependencies should include extension and/or platform dependencies.
 
@@ -71,7 +76,9 @@ Dependencies should include extension and/or platform dependencies.
     /// </remarks>
 ```
 
-#### Serialized Fields Visible in the Unity Inspector
+[Go Up](#source-documentation)
+
+### Serialized Fields
 It is a good practice to use Unity's Tooltip attribute to provide runtime documentation for a script's fields in the Inspector.
 
 So that configuration options are included in the API documentation, scripts are required to include *at least* the tooltip contents in a summary block.
@@ -83,8 +90,24 @@ So that configuration options are included in the API documentation, scripts are
         [Tooltip("The quality level of the simulated audio source.")]
 ```
 
-#### Enumeration Values
+[Go Up](#source-documentation)
+
+### Enumeration Values
 When defining and enumeration, code must also document the meaning of the enum values using a summary block. Remarks blocks can optionally be used to provide additional details to enhance understanding.
+
+```
+        /// <summary>
+        /// Full range of human hearing.
+        /// </summary>
+        /// <remarks>
+        /// The frequency range used is a bit wider than that of human
+        /// hearing. It closely resembles the range used for audio CDs.
+        /// </remarks>
+```
+
+[Go Up](#source-documentation)
+
+[Go to Top](#documentation-guidelines)
 
 ---
 
@@ -98,6 +121,8 @@ When a feature is added (or the usage is changed), overview documentation must b
 
 As part of this documentation, how-to sections, including illustrations, should be provided to assist customers new to a featur or concept in getting started.
 
+[Go to Top](#documentation-guidelines)
+
 ---
 
 ## Design Documentation
@@ -109,7 +134,24 @@ Some examples where design documentation can be helpful:
 - Spatial Mapping visualizations
 - Sound effect files
 
-This type of documentation is **strongly** recommended, and may be requested as part of a Pull Request review. 
+This type of documentation is **strongly** recommended, and **may** be requested as part of a Pull Request review. 
+
+[Go to Top](#documentation-guidelines)
+
+---
+
+## Performance Notes
+
+Some important features come at a performance cost. Often this code will very depending how they are configured.
+
+For example:
+```
+When using the Spatial Mapping component, the performance impact will increase with the level of detail requested. It is recommended to use the least detail possible for your experience.
+```
+
+Performance notes are recommended for CPU and/or GPU heavy components and **may** be requested as part of a Pull Request review. Any applicable performance notes are to be included in API **and** overiew documentation. 
+
+[Go to Top](#documentation-guidelines)
 
 ---
 
@@ -120,12 +162,12 @@ Breaking changes documentation is to consist of a top level [file](/BreakingChan
 The feature area BreakingChanges.md files are to contain the list of all known breaking changes for a given release **as well as** the history of breaking changes from past releases.
 
 For example:
-fs```
+```
 Spatial Sound Breaking Changes
 
 2018.07.2
 * Spatialization of the imaginary effect is now required.
-* Management of randomized AudioClip files requires an entopy value in the manager node.
+* Management of randomized AudioClip files requires an entropy value in the manager node.
 
 2018.07.1
 No known breaking changes
@@ -136,5 +178,6 @@ No known breaking changes
 
 The information contained within the feature level BreakingChanges.md files will be aggregated to the release notes for each new MRTK release.
 
-Breaking changes **must** be documented as part of a Pull Request.
+Any breaking changes that are part of a change **must** be documented as part of a Pull Request.
 
+[Go to Top](#documentation-guidelines)

--- a/DocumentationGuide.md
+++ b/DocumentationGuide.md
@@ -44,7 +44,7 @@ If there are any class level dependencies, they should be documented in a remark
 Pull Requests submitted without summaries for classes, strutures or enums will not be approved.
 
 ### Property, Method, Event Summary Blocks
-As with classes, structures and enums, PMEs (and fields) are to be documented with summary blocks, regardless of code visibility (public, private, protected and internal). The documentation generation tool is responsible for filtering out and publishing only the public and protected features.
+Properties, methods and events (PMEs) as well as fields are to be documented with summary blocks, regardless of code visibility (public, private, protected and internal). The documentation generation tool is responsible for filtering out and publishing only the public and protected features.
 
 NOTE: A summary block is **not** required for Unity methods (ex: Awake, Start, Update).
 

--- a/DocumentationGuide.md
+++ b/DocumentationGuide.md
@@ -29,7 +29,7 @@ If a class, struct or enum is being added to the MRTK, it's purpose must be desc
 ```
     /// <summary>
     /// AudioOccluder implements IAudioInfluencer to provide an occlusion effect.
-    /// </summary><< >>
+    /// </summary>
 ```
 
 If there are any class level dependencies, they should be documented in a remarks block, immediately below the summary.
@@ -57,7 +57,7 @@ As part of a PME summary block, the meaning and purpose of parameters and return
         /// Sets the cached native cutoff frequency of the attached low pass filter.
         /// </summary>
         /// <param name="frequency">The new low pass filter cutoff frequency.</param>
-        /// <returns>The new cutoff frequency value.</remarks>
+        /// <returns>The new cutoff frequency value.</returns>
 
 ```
 
@@ -70,9 +70,10 @@ Dependencies should include extension and/or platform dependencies.
 
 ```
     /// <remarks>
-    /// Introduced in MRTK version: 2018.06.0 
-    /// Requires installation of: ImaginarySDK v2.1
+    /// Introduced in MRTK version: 2018.06.0
+    /// Minimum Unity version: 2018.0.0f1
     /// Minimum Operating System: Windows 10.0.11111.0
+    /// Requires installation of: ImaginarySDK v2.1
     /// </remarks>
 ```
 

--- a/DocumentationGuide.md
+++ b/DocumentationGuide.md
@@ -1,0 +1,140 @@
+<img src="External/ReadMeImages/MRTK_Logo_Rev.png">
+
+# Documentation Guidelines
+
+This document outlines the documentation guidelines and standards for the Mixed Reality Toolkit (MRTK). Herein you will find the standards for the following formsfs of the MRTK documentation:
+
+- API / Source
+- Conceptual / How-To
+- Design
+- Performance Notes
+- Breaking Changes
+
+---
+
+## API / Source Documentation
+API documentation will be generated automatically from the MRTK source files. To facilitate this, source files are required to contain the following: 
+
+- Class, Struct, Enum Summary Blocks
+- Property, Method, Event (PME) Summary Blocks
+
+In addition to the above, the code should be well commented to allow for maintenance, bug fixes and ease of customization. 
+
+### Class, Struct, Enum Summary Blocks
+If a class, struct or enum is being added to the MRTK, it's purpose must be described. This is to take the form of a summary block above the class.
+
+```
+    /// <summary>
+    /// AudioOccluder implements IAudioInfluencer to provide an occlusion effect.
+    /// </summary><< >>
+```
+
+If there are any class level dependencies, they should be documented in a remarks block, immediately below the summary.
+
+```
+    /// <remarks>
+    /// Ensure that all sound emitting objects have an attached AudioInfluencerController. 
+    /// Failing to do so will result in the desired effect not being applied to the sound.
+    /// </remarks>
+```
+
+Pull Requests submitted without summaries for classes, strutures or enums will not be approved.
+
+### Property, Method, Event (PME) Summary Blocks
+As with classes, structures and enums, PMEs (and fields) are to be documented with summary blocks, regardless of code visibility (public, private, protected and internal). The documentation generation tool is responsible for filtering out and publishing only the public and protected features.
+
+NOTE: A summary block is **not** required for Unity methods (ex: Awake, Start, Update).
+
+PME documentation is **required** for a Pull Request to be approved.
+
+As part of a PME summary block, the meaning and purpose of parameters and returned data is required.
+
+```
+        /// <summary>
+        /// Sets the cached native cutoff frequency of the attached low pass filter.
+        /// </summary>
+        /// <param name="frequency">The new low pass filter cutoff frequency.</param>
+        /// <returns>The new cutoff frequency value.</remarks>
+
+```
+
+#### Feature Introduction Version and Dependencies
+As part of the PME summary documentation, information regarding the MRTK version in which the feature was introduced and any dependencies should be documented in a remarks block.
+
+Dependencies should include extension and/or platform dependencies.
+
+```
+    /// <remarks>
+    /// Introduced in MRTK version: 2018.06.0 
+    /// Requires installation of: ImaginarySDK v2.1
+    /// Minimum Operating System: Windows 10.0.11111.0
+    /// </remarks>
+```
+
+#### Serialized Fields Visible in the Unity Inspector
+It is a good practice to use Unity's Tooltip attribute to provide runtime documentation for a script's fields in the Inspector.
+
+So that configuration options are included in the API documentation, scripts are required to include *at least* the tooltip contents in a summary block.
+
+```
+        /// <summary>
+        /// The quality level of the simulated audio source (ex: AM radio).
+        /// </summary>
+        [Tooltip("The quality level of the simulated audio source.")]
+```
+
+#### Enumeration Values
+When defining and enumeration, code must also document the meaning of the enum values using a summary block. Remarks blocks can optionally be used to provide additional details to enhance understanding.
+
+---
+
+## Conceptual Documentation
+
+Many users of the Mixed Reality Toolkit may not need to use the API documentation. These users will take advantage of our pre-made, reusable prefabs and scripts to create their experiences.
+
+Each feature area will contain one or more markdown (.md) files that describe at a fairly high level, what is provided. Depending on the size and/or complexity of a given feature area, there may be a need for additional files, up to one per feature provided.
+
+When a feature is added (or the usage is changed), overview documentation must be provided.
+
+As part of this documentation, how-to sections, including illustrations, should be provided to assist customers new to a featur or concept in getting started.
+
+---
+
+## Design Documentation
+
+Mixed Reality provides an opportunity to create entirely new worlds. Part of this is likely to involve the creation of custom assets for use with the MRTK. To make this as friction free as possible for customers, components should provide design documentation describing any formatting or other requirements for art assets.
+
+Some examples where design documentation can be helpful:
+- Cursor models
+- Spatial Mapping visualizations
+- Sound effect files
+
+This type of documentation is **strongly** recommended, and may be requested as part of a Pull Request review. 
+
+---
+
+## Breaking Changes
+
+Breaking changes documentation is to consist of a top level [file](/BreakingChanges.md) which links to each feature area's individual BreakingChanges.md.
+
+The feature area BreakingChanges.md files are to contain the list of all known breaking changes for a given release **as well as** the history of breaking changes from past releases.
+
+For example:
+fs```
+Spatial Sound Breaking Changes
+
+2018.07.2
+* Spatialization of the imaginary effect is now required.
+* Management of randomized AudioClip files requires an entopy value in the manager node.
+
+2018.07.1
+No known breaking changes
+
+2018.07.0
+...
+```
+
+The information contained within the feature level BreakingChanges.md files will be aggregated to the release notes for each new MRTK release.
+
+Breaking changes **must** be documented as part of a Pull Request.
+


### PR DESCRIPTION
Write documentation guidelines file based on the v.Next Documentation proposal (#1814). Add steps (and links to the Coding/Documentation guidelines) in the Implementation section of CONTRIBUTING,md to improve process clarity and visibility.

- Fixes: #1893.
