### PR TITLE
Trim end of keywords

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/SpeechInputHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/SpeechInputHandler.cs
@@ -62,7 +62,7 @@ namespace HoloToolkit.Unity.InputModule
             for (int index = 0; index < keywordCount; index++)
             {
                 KeywordAndResponse keywordAndResponse = Keywords[index];
-                string keyword = keywordAndResponse.Keyword.ToLower();
+                string keyword = keywordAndResponse.Keyword.ToLower().TrimEnd();
 
                 if (responses.ContainsKey(keyword))
                 {


### PR DESCRIPTION

Fix so recognized text "example_keyword" and keyword added with SpeechInputSource "example_keyword " (notice the extra space) are treated equally
Appending an extra space when adding keywords is an easy to make mistake and also easy to miss while debugging, causes events not being raised even though keyword is correctly recognized 