### PR TITLE
Fix crash (null reference exception) when air-tapping objects

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -353,6 +353,10 @@ namespace HoloToolkit.Unity.InputModule
 
         public bool TryGetPointingSource(BaseEventData eventData, out IPointingSource pointingSource)
         {
+            // pre-initialize pointingSource to null, assuming we will return false
+            pointingSource = null;
+            if (eventData == null) { return false; }
+
             for (int i = 0; i < pointers.Count; i++)
             {
                 if (pointers[i].PointingSource.OwnsInput(eventData))
@@ -362,7 +366,6 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-            pointingSource = null;
             return false;
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -343,21 +343,12 @@ namespace HoloToolkit.Unity.InputModule
 
         public GameObject TryGetFocusedObject(BaseEventData eventData)
         {
-            FocusDetails? details = TryGetFocusDetails(eventData);
-
-            if (details == null)
-            {
-                return null;
-            }
-
             IPointingSource pointingSource;
             TryGetPointingSource(eventData, out pointingSource);
             PointerInputEventData pointerInputEventData = GetSpecificPointerEventData(pointingSource);
 
             Debug.Assert(pointerInputEventData != null);
-            pointerInputEventData.selectedObject = details.Value.Object;
-
-            return details.Value.Object;
+            return pointerInputEventData.selectedObject;
         }
 
         public bool TryGetPointingSource(BaseEventData eventData, out IPointingSource pointingSource)
@@ -440,7 +431,11 @@ namespace HoloToolkit.Unity.InputModule
         public PointerInputEventData GetSpecificPointerEventData(IPointingSource pointer)
         {
             PointerData pointerEventData;
-            return GetPointerData(pointer, out pointerEventData) ? pointerEventData.UnityUIPointerData : null;
+
+            if (!GetPointerData(pointer, out pointerEventData)) { return null; }
+
+            pointerEventData.UnityUIPointerData.selectedObject = GetFocusedObject(pointer);
+            return pointerEventData.UnityUIPointerData;
         }
 
         public float GetPointingExtent(IPointingSource pointingSource)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
@@ -435,10 +435,10 @@ namespace HoloToolkit.Unity.InputModule
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
 
-                if (inputEventData.selectedObject != null)
+                if (pointerInputEventData.selectedObject != null)
                 {
-                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
-                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                    ExecuteEvents.ExecuteHierarchy(pointerInputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
+                    ExecuteEvents.ExecuteHierarchy(pointerInputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
                 }
 
                 pointerInputEventData.Clear();
@@ -477,9 +477,9 @@ namespace HoloToolkit.Unity.InputModule
                 pointerInputEventData.pressPosition = pointerInputEventData.position;
                 pointerInputEventData.pointerPressRaycast = pointerInputEventData.pointerCurrentRaycast;
 
-                if (inputEventData.selectedObject != null)
+                if (pointerInputEventData.selectedObject != null)
                 {
-                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
+                    ExecuteEvents.ExecuteHierarchy(pointerInputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
                 }
             }
         }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Managers/InputManager.cs
@@ -435,8 +435,12 @@ namespace HoloToolkit.Unity.InputModule
                 pointerInputEventData.InputSource = source;
                 pointerInputEventData.SourceId = sourceId;
 
-                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
-                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                if (inputEventData.selectedObject != null)
+                {
+                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerUpHandler);
+                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerClickHandler);
+                }
+
                 pointerInputEventData.Clear();
             }
         }
@@ -473,7 +477,10 @@ namespace HoloToolkit.Unity.InputModule
                 pointerInputEventData.pressPosition = pointerInputEventData.position;
                 pointerInputEventData.pointerPressRaycast = pointerInputEventData.pointerCurrentRaycast;
 
-                ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
+                if (inputEventData.selectedObject != null)
+                {
+                    ExecuteEvents.ExecuteHierarchy(inputEventData.selectedObject, pointerInputEventData, ExecuteEvents.pointerDownHandler);
+                }
             }
         }
 


### PR DESCRIPTION
Add protections for null in FocusMananger and InputManager based on dev_working_branch changes from #1896.

This issue was found on 2017.2.1.4 RC and is needed for the release.

Fixes: #1949 .
