### PR TITLE
[2017.2.1.4] Fix building on Unity 5.6 and 2017.1

### DIFF
--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployPortal.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployPortal.cs
@@ -71,7 +71,9 @@ namespace HoloToolkit.Unity
                 using (var webRequest = UnityWebRequest.Get(query))
                 {
                     webRequest.SetRequestHeader("Authorization", auth);
+#if UNITY_2017_1_OR_NEWER
                     webRequest.timeout = (int)TimeOut;
+#endif
 
 #if UNITY_2017_2_OR_NEWER
                     webRequest.SendWebRequest();
@@ -149,7 +151,9 @@ namespace HoloToolkit.Unity
                 using (var webRequest = UnityWebRequest.Post(query, postData))
                 {
                     webRequest.SetRequestHeader("Authorization", auth);
+#if UNITY_2017_1_OR_NEWER
                     webRequest.timeout = (int)TimeOut;
+#endif
 
                     // HACK: Workaround for extra quotes around boundary.
                     string contentType = webRequest.GetRequestHeader("Content-Type");
@@ -236,7 +240,9 @@ namespace HoloToolkit.Unity
                 using (var webRequest = UnityWebRequest.Delete(query))
                 {
                     webRequest.SetRequestHeader("Authorization", auth);
+#if UNITY_2017_1_OR_NEWER
                     webRequest.timeout = (int)TimeOut;
+#endif
 
 #if UNITY_2017_2_OR_NEWER
                     webRequest.SendWebRequest();

--- a/Assets/HoloToolkit/Common/Scripts/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/HoloToolkit/Common/Scripts/Extensions/InteractionSourceExtensions.cs
@@ -28,13 +28,14 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class InteractionSourceExtensions
     {
+#if UNITY_2017_2_OR_NEWER
 #if UNITY_EDITOR_WIN && UNITY_WSA
         [DllImport("EditorMotionController")]
         private static extern bool StartHaptics([In] uint controllerId, [In] float intensity, [In] float durationInSeconds);
 
         [DllImport("EditorMotionController")]
         private static extern bool StopHaptics([In] uint controllerId);
-#endif
+#endif // UNITY_EDITOR_WIN && UNITY_WSA
 
         // This value is standardized according to www.usb.org/developers/hidpage/HUTRR63b_-_Haptics_Page_Redline.pdf
         private const ushort ContinuousBuzzWaveform = 0x1004;
@@ -52,7 +53,7 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-#if !UNITY_EDITOR && UNITY_2017_2_OR_NEWER
+#if !UNITY_EDITOR
             UnityEngine.WSA.Application.InvokeOnUIThread(() =>
             {
                 IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView().GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
@@ -80,9 +81,9 @@ namespace HoloToolkit.Unity
                     }
                 }
             }, true);
-#elif UNITY_EDITOR_WIN && UNITY_2017_2_OR_NEWER
+#elif UNITY_EDITOR_WIN
             StartHaptics(interactionSource.id, intensity, durationInSeconds);
-#endif
+#endif // !UNITY_EDITOR
         }
 
         public static void StopHaptics(this InteractionSource interactionSource)
@@ -92,7 +93,7 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-#if !UNITY_EDITOR && UNITY_2017_2_OR_NEWER
+#if !UNITY_EDITOR
             UnityEngine.WSA.Application.InvokeOnUIThread(() =>
             {
                 IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView().GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
@@ -105,12 +106,12 @@ namespace HoloToolkit.Unity
                     }
                 }
             }, true);
-#elif UNITY_EDITOR_WIN && UNITY_2017_2_OR_NEWER
+#elif UNITY_EDITOR_WIN
             StopHaptics(interactionSource.id);
-#endif
+#endif // !UNITY_EDITOR
         }
 
-#if !UNITY_EDITOR && UNITY_2017_2_OR_NEWER
+#if !UNITY_EDITOR
         public static IAsyncOperation<IRandomAccessStreamWithContentType> TryGetRenderableModelAsync(this InteractionSource interactionSource)
         {
             IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
@@ -133,7 +134,8 @@ namespace HoloToolkit.Unity
 
             return returnValue;
         }
-#endif
-#endif
+#endif // !UNITY_EDITOR
+#endif // UNITY_WSA
+#endif // UNITY_2017_2_OR_NEWER
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -347,7 +347,11 @@ namespace HoloToolkit.Unity.InputModule
             TryGetPointingSource(eventData, out pointingSource);
             PointerInputEventData pointerInputEventData = GetSpecificPointerEventData(pointingSource);
 
-            Debug.Assert(pointerInputEventData != null);
+            // GetSpecificPointerEventData can return null. Be sure to handle that case.
+            if (pointerInputEventData == null)
+            {
+                return null;
+            }
             return pointerInputEventData.selectedObject;
         }
 

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
@@ -261,8 +261,6 @@ namespace HoloToolkit.Unity.UX
                 transformToAffect.localRotation = initialRotation;
                 transformToAffect.Rotate(axis, angle * 5.0f);
             }
-#else
-#warning "ApplyRotation(Quaternion currentHandOrientation) is not supported on this version of Unity. Recommend updating to 2017.1 or newer."
 #endif // UNITY_2017_1_OR_NEWER
         }
         private void ApplyRotation(Vector3 currentHandPosition)

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
@@ -224,6 +224,7 @@ namespace HoloToolkit.Unity.UX
         }
         private void ApplyRotation(Quaternion currentHandOrientation)
         {
+#if UNITY_2017_1_OR_NEWER
             Matrix4x4 m = Matrix4x4.Rotate(initialHandOrientation);
             Vector3 initRay = new Vector3(0, 0, 1);
             initRay = m.MultiplyPoint(initRay);
@@ -260,6 +261,9 @@ namespace HoloToolkit.Unity.UX
                 transformToAffect.localRotation = initialRotation;
                 transformToAffect.Rotate(axis, angle * 5.0f);
             }
+#else
+#warning "ApplyRotation(Quaternion currentHandOrientation) is not supported on this version of Unity. Recommend updating to 2017.1 or newer."
+#endif // UNITY_2017_1_OR_NEWER
         }
         private void ApplyRotation(Vector3 currentHandPosition)
         {

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
@@ -489,13 +489,16 @@ namespace HoloToolkit.Unity.UX
                 BoundingBox.GetMeshFilterBoundsPoints(clone, bounds, mask);
                 Vector3 centroid = boxInstance.TargetBoundsCenter;
                 GameObject.Destroy(clone);
+#if UNITY_2017_1_OR_NEWER
                 Matrix4x4 m = Matrix4x4.Rotate(objectToBound.transform.rotation);
                 for (int i = 0; i < bounds.Count; ++i)
                 {
                     bounds[i] = m.MultiplyPoint(bounds[i]);
                     bounds[i] += boxInstance.TargetBoundsCenter;
                 }
-
+#else
+#warning "GetBounds() using rotation is not supported on this version of Unity. Recommend updating to 2017.1 or newer."
+#endif // UNITY_2017_1_OR_NEWER
                 return bounds;
             }
 

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
@@ -496,8 +496,6 @@ namespace HoloToolkit.Unity.UX
                     bounds[i] = m.MultiplyPoint(bounds[i]);
                     bounds[i] += boxInstance.TargetBoundsCenter;
                 }
-#else
-#warning "GetBounds() using rotation is not supported on this version of Unity. Recommend updating to 2017.1 or newer."
 #endif // UNITY_2017_1_OR_NEWER
                 return bounds;
             }

--- a/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/AtlasPrefabReference.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/AtlasPrefabReference.cs
@@ -2,13 +2,17 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using System.Collections.Generic;
 using UnityEngine;
+#if UNITY_2017_1_OR_NEWER
 using UnityEngine.U2D;
+#endif // UNITY_2017_1_OR_NEWER
 
 namespace HoloToolkit.Unity
 {
     public class AtlasPrefabReference : ScriptableObject
     {
+#if UNITY_2017_1_OR_NEWER
         [SerializeField] public List<GameObject> Prefabs;
         [SerializeField] public SpriteAtlas Atlas;
+#endif // UNITY_2017_1_OR_NEWER
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/Editor/AtlasReferenceUpdater.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/Editor/AtlasReferenceUpdater.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     [InitializeOnLoad]
     public class AtlasReferenceUpdater : UnityEditor.AssetModificationProcessor
     {
+#if UNITY_2017_1_OR_NEWER
         private static readonly List<AtlasPrefabReference> References = new List<AtlasPrefabReference>();
 
         static AtlasReferenceUpdater()
@@ -115,5 +116,6 @@ namespace HoloToolkit.Unity
             return prefabs.SelectMany(p => p.GetComponentsInChildren<Image>())
                 .Select(img => img.sprite).Where(img => img != null).Distinct();
         }
+#endif // UNITY_2017_1_OR_NEWER
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/Editor/Extensions/SpriteAtlasExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/Editor/Extensions/SpriteAtlasExtensions.cs
@@ -9,6 +9,8 @@ namespace HoloToolkit.Unity
 {
     public static class SpriteAtlasExtensions
     {
+// SpriteAtlast requires Unity 2017.1 or later
+#if UNITY_2017_1_OR_NEWER
         public const string SpritePackables = "m_EditorData.packables";
 
         public static void SetSprites(this SpriteAtlas spriteAtlas, IList<Sprite> sprites)
@@ -31,5 +33,6 @@ namespace HoloToolkit.Unity
             }
             return false;
         }
+#endif // UNITY_2017_1_OR_NEWER
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/Editor/Extensions/SpriteAtlasExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/AtlasReferenceUpdater/Editor/Extensions/SpriteAtlasExtensions.cs
@@ -9,7 +9,6 @@ namespace HoloToolkit.Unity
 {
     public static class SpriteAtlasExtensions
     {
-// SpriteAtlast requires Unity 2017.1 or later
 #if UNITY_2017_1_OR_NEWER
         public const string SpritePackables = "m_EditorData.packables";
 


### PR DESCRIPTION
There have been a number of instances of APIs used in recent master and Patch4_Dev branch checkins that are not supported on Unity 5.6 and 2017.1.  Add #if version checks around them, and where appropriate use a preprocessor warning directive to alert users to the functionality limitations.

- Fixes: #1958 
- Fixes: #1960 
- Fixes: #1962
- Fixes: #1964