### PR TITLE
[Patch4] Disable two hand manipulation for Unity versions prior to 2017.2

### DIFF
--- a/Assets/HoloToolkit-Examples/UX/Scenes/BoundingBoxGizmoExample.unity
+++ b/Assets/HoloToolkit-Examples/UX/Scenes/BoundingBoxGizmoExample.unity
@@ -543,7 +543,7 @@ Prefab:
         type: 2}
       propertyPath: m_Text
       value: "BoundingBoxRig \n+ TwoHandManipulatable script\n(Move/Rotate/Scale with
-        two hands)"
+        two hands)\nNote: Some behaviors require \nUnity 2017.2 or Newer"
       objectReference: {fileID: 0}
     - target: {fileID: 102000010767390410, guid: bfdc7f60d7205c84f82a4806a5352d60,
         type: 2}
@@ -1759,7 +1759,7 @@ Prefab:
     - target: {fileID: 102000010767390410, guid: bfdc7f60d7205c84f82a4806a5352d60,
         type: 2}
       propertyPath: m_Text
-      value: Flat option
+      value: "Flat option\nNote: Some behaviors require \nUnity 2017.2 or Newer"
       objectReference: {fileID: 0}
     - target: {fileID: 102000010767390410, guid: bfdc7f60d7205c84f82a4806a5352d60,
         type: 2}

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
@@ -353,6 +353,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
 
         private void OnTwoHandManipulationUpdated()
         {
+#if UNITY_2017_2_OR_NEWER
             var targetRotation = HostTransform.rotation;
             var targetPosition = HostTransform.position;
             var targetScale = HostTransform.localScale;
@@ -373,6 +374,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
             HostTransform.position = targetPosition;
             HostTransform.rotation = targetRotation;
             HostTransform.localScale = targetScale;
+#endif // UNITY_2017_2_OR_NEWER
         }
 
         private void OnOneHandMoveUpdated()
@@ -384,6 +386,9 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
 
         private void OnTwoHandManipulationEnded()
         {
+#if UNITY_2017_2_OR_NEWER
+            // This implementation currently does nothing
+#endif // UNITY_2017_2_OR_NEWER
         }
 
         private Vector3 GetHandsCentroid()
@@ -394,6 +399,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
 
         private void OnTwoHandManipulationStarted(State newState)
         {
+#if UNITY_2017_2_OR_NEWER
             if ((newState & State.Rotating) > 0)
             {
                 m_rotateLogic.Setup(m_handsPressedLocationsMap, HostTransform);
@@ -406,6 +412,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
             {
                 m_scaleLogic.Setup(m_handsPressedLocationsMap, HostTransform);
             }
+#endif // UNITY_2017_2_OR_NEWER
         }
 
         private void OnOneHandMoveStarted()


### PR DESCRIPTION
Disables the logic in OnTwoHandManipulationStarted, OnTwoHandManipulationEnded and OnTwoHandManipulationUpdated for Unity 2017.1 and older.

Also adds a message in the test scene noting the above.

Fixes: #1967 .
