### PR TITLE
[Dev] Revert misattributed license headers

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/Sharing/Scripts/UserNotifications.cs
+++ b/Assets/MixedRealityToolkit-Examples/Sharing/Scripts/UserNotifications.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using MixedRealityToolkit.Sharing;
+﻿using MixedRealityToolkit.Sharing;
 using System;
 using UnityEngine;
 

--- a/Assets/MixedRealityToolkit-Examples/Sharing/Scripts/UserNotifications.cs
+++ b/Assets/MixedRealityToolkit-Examples/Sharing/Scripts/UserNotifications.cs
@@ -1,4 +1,6 @@
-﻿using MixedRealityToolkit.Sharing;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MixedRealityToolkit.Sharing;
 using System;
 using UnityEngine;
 

--- a/Assets/MixedRealityToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
+++ b/Assets/MixedRealityToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
@@ -1,4 +1,6 @@
-﻿using MixedRealityToolkit.Examples.UX.Controls;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MixedRealityToolkit.Examples.UX.Controls;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/MixedRealityToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
+++ b/Assets/MixedRealityToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using MixedRealityToolkit.Examples.UX.Controls;
+﻿using MixedRealityToolkit.Examples.UX.Controls;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/MixedRealityToolkit-Examples/UX/Scripts/InteractiveGroup.cs
+++ b/Assets/MixedRealityToolkit-Examples/UX/Scripts/InteractiveGroup.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace MixedRealityToolkit.Examples.UX

--- a/Assets/MixedRealityToolkit-Examples/UX/Scripts/InteractiveGroup.cs
+++ b/Assets/MixedRealityToolkit-Examples/UX/Scripts/InteractiveGroup.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace MixedRealityToolkit.Examples.UX

--- a/Assets/MixedRealityToolkit-UnitTests/Editor/Utilities/Extensions/EnumerableExtensionsTests.cs
+++ b/Assets/MixedRealityToolkit-UnitTests/Editor/Utilities/Extensions/EnumerableExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MixedRealityToolkit.Common.Extensions;
 using NUnit.Framework;

--- a/Assets/MixedRealityToolkit-UnitTests/Editor/Utilities/WorldAnchorManagerTests.cs
+++ b/Assets/MixedRealityToolkit-UnitTests/Editor/Utilities/WorldAnchorManagerTests.cs
@@ -1,5 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MixedRealityToolkit.Common;
 using NUnit.Framework;

--- a/Assets/MixedRealityToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Rafael Rivera.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MixedRealityToolkit.Build.DataStructures;

--- a/Assets/MixedRealityToolkit/BuildAndDeploy/Editor/XdeGuestLocator.cs
+++ b/Assets/MixedRealityToolkit/BuildAndDeploy/Editor/XdeGuestLocator.cs
@@ -1,4 +1,5 @@
-﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Rafael Rivera.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;

--- a/Assets/MixedRealityToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
+++ b/Assets/MixedRealityToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 
 namespace MixedRealityToolkit.Common.Extensions

--- a/Assets/MixedRealityToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
+++ b/Assets/MixedRealityToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace MixedRealityToolkit.Common.Extensions

--- a/Assets/MixedRealityToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 Shader "Spatial Mapping/Spatial Mapping Tap"
 {
 	Properties

--- a/Assets/MixedRealityToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
@@ -1,3 +1,5 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 Shader "Spatial Mapping/Spatial Mapping Tap"
 {
 	Properties


### PR DESCRIPTION
Overview
---
Reverts misattributed license headers. Also, removes some copyright headers that were added incorrectly.

Changes
---
- Fixes: #1931 in dev.