### PR TITLE
[Patch4] Revert misattributed license headers

### DIFF
--- a/Assets/HoloToolkit-Examples/Sharing/SharingService/Scripts/UserNotifications.cs
+++ b/Assets/HoloToolkit-Examples/Sharing/SharingService/Scripts/UserNotifications.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace HoloToolkit.Sharing.Tests

--- a/Assets/HoloToolkit-Examples/Sharing/SharingService/Scripts/UserNotifications.cs
+++ b/Assets/HoloToolkit-Examples/Sharing/SharingService/Scripts/UserNotifications.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using UnityEngine;
 
 namespace HoloToolkit.Sharing.Tests

--- a/Assets/HoloToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/HoloToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/ExampleData/NoteDataProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/HoloToolkit-Examples/UX/Scripts/InteractiveGroup.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/InteractiveGroup.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Assets/HoloToolkit-Examples/UX/Scripts/InteractiveGroup.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/InteractiveGroup.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Rafael Rivera.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;

--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/XdeGuestLocator.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/XdeGuestLocator.cs
@@ -1,4 +1,5 @@
-﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Rafael Rivera.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;

--- a/Assets/HoloToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
+++ b/Assets/HoloToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace HoloToolkit.Unity

--- a/Assets/HoloToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
+++ b/Assets/HoloToolkit/Common/Scripts/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 
 namespace HoloToolkit.Unity

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
 Shader "Spatial Mapping/Spatial Mapping Tap"
 {
 	Properties

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
@@ -1,3 +1,5 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 Shader "Spatial Mapping/Spatial Mapping Tap"
 {
 	Properties


### PR DESCRIPTION
Overview
---
Reverts misattributed license headers. Also, removes some copyright headers that were added incorrectly.

Changes
---
- Fixes: #1931 for the next patch release.
