### PR TITLE
Wack version fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ obj/
 
 Assets/ThirdParty/
 Assets/ThirdParty.meta
+
+artifacts/

--- a/Assets/HoloToolkit-Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/HoloToolkit-Examples/MixedReality.Toolkit.Examples.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.MixedReality.Toolkit.Examples</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,MixedReality</owners>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/master/License.txt</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Examples of the Mixed Reality Toolkit</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>Unity MixedReality</tags>
+    <dependencies>
+      <dependency id="Microsoft.MixedReality.Toolkit.Sharing" version="$version$" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Assets/HoloToolkit-Examples/MixedReality.Toolkit.Examples.nuspec.meta
+++ b/Assets/HoloToolkit-Examples/MixedReality.Toolkit.Examples.nuspec.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1cab4222ab4a5744f8b33cf7290d17bf
+timeCreated: 1518654530
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/MixedReality.Toolkit.nuspec
+++ b/Assets/HoloToolkit/MixedReality.Toolkit.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.MixedReality.Toolkit</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,MixedReality</owners>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/master/License.txt</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>The Mixed Reality Toolkit is a collection of scripts and components intended to accelerate development of applications targeting Microsoft HoloLens and Windows Mixed Reality headsets.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>Unity MixedReality</tags>
+  </metadata>
+  <files>
+        <file src="**" target="" exclude="Sharing\**;Sharing.meta" />
+  </files>
+</package>

--- a/Assets/HoloToolkit/MixedReality.Toolkit.nuspec.meta
+++ b/Assets/HoloToolkit/MixedReality.Toolkit.nuspec.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 79458081458c2a648a1db5c1240688b9
+timeCreated: 1518654530
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Sharing/MixedReality.Toolkit.Sharing.nuspec
+++ b/Assets/HoloToolkit/Sharing/MixedReality.Toolkit.Sharing.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.MixedReality.Toolkit.Sharing</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,MixedReality</owners>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/master/License.txt</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>The Mixed Reality Toolkit is a collection of scripts and components intended to accelerate development of applications targeting Microsoft HoloLens and Windows Mixed Reality headsets.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>Unity MixedReality</tags>
+    <dependencies>
+      <dependency id="Microsoft.MixedReality.Toolkit" version="$version$" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Assets/HoloToolkit/Sharing/MixedReality.Toolkit.Sharing.nuspec.meta
+++ b/Assets/HoloToolkit/Sharing/MixedReality.Toolkit.Sharing.nuspec.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e01cf7ff1e7440d4c9e24e25e2f1ad86
+timeCreated: 1518654530
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2017.2.1.2
+  bundleVersion: 2017.2.0.0
   preloadedAssets: []
   metroInputSource: 0
   m_HolographicPauseOnTrackingLoss: 0
@@ -619,7 +619,7 @@ PlayerSettings:
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: MixedRealityToolkit-Unity
-  metroPackageVersion: 2017.2.1.2
+  metroPackageVersion: 2017.2.0.0
   metroCertificatePath: Assets/WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: Microsoft

--- a/README.md
+++ b/README.md
@@ -75,3 +75,35 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 | ![Academy](External/ReadMeImages/icon_academy.png) [Academy](https://developer.microsoft.com/en-us/windows/mixed-reality/academy)| ![Design](External/ReadMeImages/icon_design.png) [Design](https://developer.microsoft.com/en-us/windows/mixed-reality/design)| ![Development](External/ReadMeImages/icon_development.png) [Development](https://developer.microsoft.com/en-us/windows/mixed-reality/development)| ![Community)](External/ReadMeImages/icon_community.png) [Community](https://developer.microsoft.com/en-us/windows/mixed-reality/community)|
 | :--------------------- | :----------------- | :------------------ | :------------------------ |
 | See code examples. Do a coding tutorial. Watch guest lectures.          | Get design guides. Build user interface. Learn interactions and input.     | Get development guides. Learn the technology. Understand the science.       | Join open source projects. Ask questions on forums. Attend events and meetups. |
+
+# Building the Artifacts
+
+## Requirements
+
+### NuGet
+[NuGet](https://www.nuget.org/downloads) is the package manager for .Net and you'll need to have it available in the PATH.
+
+### UnitySetup
+The build process leverages [UnitySetup](https://www.powershellgallery.com/packages/UnitySetup), an OSS PowerShell Module from Microsoft. 
+
+Install from PowerShell:
+
+```powershell
+Install-Module UnitySetup -Scope CurrentUser
+```
+
+### Git
+If you do not specify a version, then [Git](https://git-scm.com/downloads) is used to find relevant tags. In this case it will need to be available in the PATH.
+
+## Run the Build
+Simply execute the build script as such:
+
+```powershell
+.\build.ps1 -Version '1.2.3'
+```
+For help and examples simply use the PowerShell help command:
+```
+help .\build.ps1 -Detailed
+```
+
+> Note: If you don't specify `-Version <version>` the script will try to infer it from tags pointing to the current git commit. An error is produced if you don't have a tag and no version is provided.

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,126 @@
+#Requires -Modules UnitySetup
+
+<#
+.SYNOPSIS
+    Builds the Mixed Reality Toolkit artifacts.
+.DESCRIPTION
+    Builds nuget and unity package artifacts for the Mixed Reality Toolkit.
+.PARAMETER OutputDirectory
+    Where should we place the output? Defaults to ".\artifacts"
+.PARAMETER Version
+    What version of the artifacts should we build? If unspecified, the highest
+    git tag pointing to HEAD is searched. If none is found, an error is reported.
+.PARAMETER UnityVersion
+    What version of Unity should we use? Falls back to -ge, then to -latest.
+.PARAMETER Clean
+    Should we clean OutputDirectory before building?
+.EXAMPLE
+    .\build.ps1 -Version 1.2.3
+.EXAMPLE
+    .\build.ps1 -OutputDirectory .\artifacts -Version 1.2.3 -Clean
+#>
+param(
+    [string]$OutputDirectory = ".\artifacts",
+    [ValidatePattern("^\d+\.\d+\.\d+$")]
+    [string]$Version,
+    [ValidatePattern("^\d+\.\d+\.\d+[fpb]\d+$")]
+    [string]$UnityVersion, 
+    [switch]$Clean,
+    [switch]$Verbose
+)
+
+if ( $Verbose ) { $VerbosePreference = 'Continue' }
+
+# No version is specified, try to pull one from relevant git tags
+if ( -not $Version) {
+    $Version = git tag --points-at HEAD | 
+        Foreach-Object { if ( $_ -match "^(\d+\.\d+\.\d+)$" ) { [version]$matches[1] } } | 
+        Sort-Object -Descending |
+        Select-Object -First 1
+}
+
+if ( -not $Version ) { 
+    throw "Could not find a valid version to build. Specify -Version when building, or tag your git commit."
+}
+
+Write-Verbose "Build version $Version of Mixed Reality Toolkit packages."
+
+if ( $Clean ) {
+    Remove-Item -ErrorAction SilentlyContinue $OutputDirectory -Recurse 
+}
+if (-not (Test-Path $OutputDirectory -PathType Container)) {
+    New-Item $OutputDirectory -ItemType Directory | Out-Null
+}
+
+
+$upi = Get-UnityProjectInstance
+$OutputDirectory = Resolve-Path $OutputDirectory
+$releaseNotes = "Built on Unity $($upi.Version)"
+
+# Kick jobs for bundling up the nuget packages
+$nugetJobs = Get-ChildItem *.nuspec -Recurse | Foreach-Object {
+    Write-Verbose "Starting nuget job for $($_.FullName)"
+    Start-Job { 
+        param($name, $outDir, $props) 
+        nuget pack $name -OutputDirectory $outDir -Properties $props 
+    } -ArgumentList $_.FullName, $OutputDirectory, "version=$Version;releaseNotes=$releaseNotes"
+}
+
+# Structure analagous unity packages for all non-sharing nuget packages
+$unityPackages = Get-ChildItem *.nuspec -Recurse | ForEach-Object {
+    [xml]$xmlDoc = Get-Content $_.FullName
+    [pscustomobject]@{ 
+        "packageName" = $xmlDoc.package.metadata.id
+        "directory"   = (Resolve-Path -Relative $_.DirectoryName).Trim(".\")
+    }
+} | Where-Object {  $_.packageName -notmatch "Sharing" }
+
+
+if ( -not $UnityVersion ) {
+    $usis = Get-UnitySetupInstance
+
+    # Try to find an equal or greater version than our project
+    $usi = $usis | Where-Object { $_.Version -ge $upi.Version } | 
+        Sort-Object -Property 'Version' | 
+        Select-Object -First 1
+
+    # well, just use the latest then.
+    if ( -not $usi ) { $usi = $usis | Select-UnitySetupInstance -Latest }
+    if ( -not $usi ) { throw 'Could not find version of Unity to build with.' }
+
+    # warn if we're not using the exact version
+    if ( $usi.Version.CompareTo( $upi.Version ) -ne 0 ) {
+        Write-Warning "Could not find Unity $($upi.Version), falling back to $($usi.Version)"
+    }
+
+    $UnityVersion = $usi.Version
+}
+
+# Build all the unity packages one at a time
+$unityPackages | Foreach-Object {
+    try {
+        # Output the Unity package associated with this nuspec location
+        $unityPackagePath = "$OutputDirectory\$($_.packageName).$Version.unitypackage"
+        Write-Verbose "Attempting to create unity package $unityPackagePath from $($_.directory)"
+        
+        $sueArgs = @{
+            'PassThru'      = $true
+            'Wait'          = $true
+            'ExportPackage' = "$($_.directory)", "$unityPackagePath"
+            'BatchMode'     = $true
+            'Quit'          = $true
+            'LogFile'       = 'build.log'
+            'Version'       = $UnityVersion
+        }
+
+        $process = Start-UnityEditor @sueArgs
+        if (($process.ExitCode -eq 0) -and (Test-Path $unityPackagePath)) {
+            Write-Verbose "Successfully created $unityPackagePath"
+        }
+        else { Write-Error "Failed to create $unityPackagePath" }
+    }
+    catch { Write-Error $_ }
+}
+
+# Wait for, receive, and remove all the nuget jobs
+$nugetJobs | Receive-Job -Wait -AutoRemoveJob


### PR DESCRIPTION
Overview
---
In the current Master build, the Version set in the ProjectSettngs file for new projects breaks WACK, as MS demands the final value on the app version to be 0.


Changes
---
Changes version numbers of 2017.2.1 in the Project Settings asset
to 2017.2.0.0
