### PR TITLE
Wack version fix

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2017.2.1.2
+  bundleVersion: 2017.2.0.0
   preloadedAssets: []
   metroInputSource: 0
   m_HolographicPauseOnTrackingLoss: 0
@@ -619,7 +619,7 @@ PlayerSettings:
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: MixedRealityToolkit-Unity
-  metroPackageVersion: 2017.2.1.2
+  metroPackageVersion: 2017.2.0.0
   metroCertificatePath: Assets/WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: Microsoft


### PR DESCRIPTION
Overview
---
In the current Master build, the Version set in the ProjectSettngs file for new projects breaks WACK, as MS demands the final value on the app version to be 0.


Changes
---
Changes version numbers of 2017.2.1 in the Project Settings asset
to 2017.2.0.0
