### PR TITLE
Updated the Mixed Reality manager to now also support runtime Managers.

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/MixedRealityToolkit-Examples.asmdef
+++ b/Assets/MixedRealityToolkit-Examples/MixedRealityToolkit-Examples.asmdef
@@ -1,0 +1,10 @@
+{
+    "name": "MixedRealityToolkit-Examples",
+    "references": [
+        "MixedRealityToolkit"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/Assets/MixedRealityToolkit-Examples/MixedRealityToolkit-Examples.asmdef.meta
+++ b/Assets/MixedRealityToolkit-Examples/MixedRealityToolkit-Examples.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51e639ec44665bc4282e944692d96d7d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-SDK/MixedRealityToolkit-SDK.asmdef
+++ b/Assets/MixedRealityToolkit-SDK/MixedRealityToolkit-SDK.asmdef
@@ -1,0 +1,10 @@
+{
+    "name": "MixedRealityToolkit-SDK",
+    "references": [
+        "MixedRealityToolkit"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/Assets/MixedRealityToolkit-SDK/MixedRealityToolkit-SDK.asmdef.meta
+++ b/Assets/MixedRealityToolkit-SDK/MixedRealityToolkit-SDK.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dabc5b5a89971e34d92f9fa3a4207f09
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-SDK/Profiles/Mixed Reality Configuration Default Profile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/Mixed Reality Configuration Default Profile.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41718b8e5d86c37409b7ce6847fa00a3, type: 3}
+  m_Name: Mixed Reality Configuration Profile
+  m_EditorClassIdentifier: 
+  enableInputSystem: 1
+  enableControllers: 1
+  enableBoundarySystem: 1

--- a/Assets/MixedRealityToolkit-SDK/Profiles/Mixed Reality Configuration Default Profile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/Mixed Reality Configuration Default Profile.asset
@@ -9,8 +9,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 41718b8e5d86c37409b7ce6847fa00a3, type: 3}
-  m_Name: Mixed Reality Configuration Profile
+  m_Name: Mixed Reality Configuration Default Profile
   m_EditorClassIdentifier: 
   enableInputSystem: 1
-  enableControllers: 1
-  enableBoundarySystem: 1
+  enableControllers: 0
+  enableBoundarySystem: 0

--- a/Assets/MixedRealityToolkit-SDK/Profiles/Mixed Reality Configuration Default Profile.asset.meta
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/Mixed Reality Configuration Default Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15a347c14c563b9448e99e5d64a1bd6f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-Tests.meta
+++ b/Assets/MixedRealityToolkit-Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09e3f5409eb06e04a9685f95b59692f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.asmdef
+++ b/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "MixedReality-Tests",
+    "references": [
+        "MixedRealityToolkit"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.asmdef.meta
+++ b/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5558f43bb800fdb409250c0fb7c7fc2e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.cs
+++ b/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.cs
@@ -1,0 +1,403 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Internal.Managers;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class MixedRealityManagerTests
+    {
+        public void CreateMRManager()
+        {
+            // Create The MR Manager
+            GameObject go = GameObject.Find("Mixed Reality Manager");
+            if (!go)
+            {
+                go = new GameObject("Mixed Reality Manager");
+            }
+            go.AddComponent<MixedRealityManager>();
+        }
+
+        [Test]
+        public void Test01_CreateMixedRealityManager()
+        {
+            // Create The MR Manager
+            CreateMRManager();
+            GameObject go = GameObject.Find("Mixed Reality Manager");
+            Assert.AreEqual("Mixed Reality Manager", go.name);
+        }
+
+
+        [Test]
+        public void Test02_TestNoMixedRealityConfigurationFound()
+        {
+            LogAssert.Expect(LogType.Error, "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Manager");
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+        }
+
+        [Test]
+        public void Test03_CreateMixedRealityManager()
+        {
+            //Test the Manager
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+            Assert.IsNotNull(MixedRealityManager.Instance);
+
+            // Create Test Configuration
+            Assert.IsEmpty(MixedRealityManager.Instance.ActiveProfile.ActiveManagers);
+            Assert.IsEmpty(MixedRealityManager.Instance.MixedRealityComponents);
+        }
+
+        [Test]
+        public void Test04_CreateMixedRealityInputManager()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            // Add Input System
+            MixedRealityManager.Instance.AddManager(typeof(Internal.Interfaces.IMixedRealityInputSystem), new InputSystem.MixedRealityInputManager());
+
+            // Tests
+            Assert.IsNotNull(MixedRealityManager.Instance.ActiveProfile);
+            Assert.IsNotEmpty(MixedRealityManager.Instance.ActiveProfile.ActiveManagers);
+            Assert.AreEqual(MixedRealityManager.Instance.ActiveProfile.ActiveManagers.Count, 1);
+            Assert.IsEmpty(MixedRealityManager.Instance.MixedRealityComponents);
+
+        }
+
+        [Test]
+        public void Test05_TestGetMixedRealityInputManager()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            // Add Input System
+            MixedRealityManager.Instance.AddManager(typeof(Internal.Interfaces.IMixedRealityInputSystem), new InputSystem.MixedRealityInputManager());
+
+            // Retrieve Input System
+            var inputSystem = MixedRealityManager.Instance.GetManager<Internal.Interfaces.IMixedRealityInputSystem>();
+
+            // Tests
+            Assert.IsNotNull(inputSystem);
+        }
+
+        [Test]
+        public void Test06_TestMixedRealityInputManagerDoesNotExist()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            //Check for Input System
+            var inputSystemExists = MixedRealityManager.Instance.ManagerExists<Internal.Interfaces.IMixedRealityInputSystem>();
+
+            // Tests
+            Assert.IsFalse(inputSystemExists);
+        }
+
+
+        [Test]
+        public void Test07_TestMixedRealityInputManagerExists()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            // Add Input System
+            MixedRealityManager.Instance.AddManager(typeof(Internal.Interfaces.IMixedRealityInputSystem), new InputSystem.MixedRealityInputManager());
+
+            //Check for Input System
+            var inputSystemExists = MixedRealityManager.Instance.ManagerExists<Internal.Interfaces.IMixedRealityInputSystem>();
+
+            // Tests
+            Assert.IsTrue(inputSystemExists);
+        }
+
+        [Test]
+        public void Test08_CreateMixedRealityComponent()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            var component = new TestComponentManager1();
+
+            //Add test component
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), component);
+
+            // Tests
+            Assert.IsNotNull(MixedRealityManager.Instance.ActiveProfile);
+            Assert.IsEmpty(MixedRealityManager.Instance.ActiveProfile.ActiveManagers);
+            Assert.AreEqual(MixedRealityManager.Instance.MixedRealityComponents.Count, 1);
+        }
+
+        [Test]
+        public void Test09_TestMixedRealityComponentExists()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+            
+            //Add test component
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+            //Retrieve Component1
+            var component1 = MixedRealityManager.Instance.GetManager(typeof(ITestComponentManager1));
+
+            // Tests
+            Assert.IsNotNull(component1);
+        }
+
+        [Test]
+        public void Test10_TestMixedRealityComponents()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            //Add test component
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+            //Retrieve Component1
+            var components = MixedRealityManager.Instance.GetManagers(typeof(ITestComponentManager1));
+
+            int i = 0;
+            foreach (var item in components)
+            {
+                i++;
+            }
+
+            // Tests
+            Assert.AreEqual(i,3);
+        }
+
+        [Test]
+        public void Test11_TestMixedRealityComponent2DoesNotReturn()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            //Add test component
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+            //Validate non-existent component
+            var component2 = (TestComponentManager2)MixedRealityManager.Instance.GetManager(typeof(ITestComponentManager2), "Test2");
+
+            // Tests
+            Assert.IsNull(component2);
+        }
+
+        [Test]
+        public void Test12_TestMixedRealityComponent2DoesNotExist()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            //Add test component 1
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+            //Validate non-existent component
+            var component2 = MixedRealityManager.Instance.ManagerExists<ITestComponentManager2>();
+
+            // Tests
+            Assert.IsFalse(component2);
+        }
+
+        [Test]
+        public void Test13_CreateMixedRealityComponentNameWithInput()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            // Add Input System
+            MixedRealityManager.Instance.AddManager(typeof(Internal.Interfaces.IMixedRealityInputSystem), new InputSystem.MixedRealityInputManager());
+
+            //Add test component 1
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+            //Add test component 2
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager2), new TestComponentManager2() { Name = "Test2-1" });
+
+            // Tests
+            Assert.IsNotNull(MixedRealityManager.Instance.ActiveProfile);
+            Assert.IsNotEmpty(MixedRealityManager.Instance.ActiveProfile.ActiveManagers);
+            Assert.AreEqual(MixedRealityManager.Instance.ActiveProfile.ActiveManagers.Count, 1);
+            Assert.AreEqual(MixedRealityManager.Instance.MixedRealityComponents.Count, 7);
+        }
+
+        [Test]
+        public void Test14_ValidateComponentNameWithInput()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            // Add Input System
+            MixedRealityManager.Instance.AddManager(typeof(Internal.Interfaces.IMixedRealityInputSystem), new InputSystem.MixedRealityInputManager());
+
+            //Add test component 1
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+            //Add test component 2
+            MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager2), new TestComponentManager2() { Name = "Test2-2" });
+
+            //Retrieve Test component 2-2
+            TestComponentManager2 component2_2 = (TestComponentManager2)MixedRealityManager.Instance.GetManager(typeof(ITestComponentManager2),"Test2-2");
+
+            // Component 2-2 Tests
+            Assert.IsNotNull(component2_2.inputSystem);
+            Assert.AreEqual(component2_2.Name, "Test2-2");
+
+            //Retrieve Test component 2-1
+            TestComponentManager2 component2_1 = (TestComponentManager2)MixedRealityManager.Instance.GetManager(typeof(ITestComponentManager2), "Test2-1");
+
+            // Component 2-1 Tests
+            Assert.IsNotNull(component2_1.inputSystem);
+            Assert.AreEqual(component2_1.Name, "Test2-1");
+
+        }
+
+        [Test]
+        public void Test15_GetMixedRealityComponentsCollection()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            //Retrieve Component1
+            var components = MixedRealityManager.Instance.GetManagers(typeof(ITestComponentManager2));
+
+            int i = 0;
+            foreach (var item in components)
+            {
+                i++;
+            }
+
+            // Tests
+            Assert.AreEqual(i, 2);
+        }
+
+        [Test]
+        public void Test16_GetAllMixedRealityComponents()
+        {
+            // Create The MR Manager & Test configuration
+            CreateMixedRealityConfiguration(MixedRealityManager.Instance);
+
+            //Retrieve Component1
+            var allComponents = MixedRealityManager.Instance.MixedRealityComponents;
+
+            int i = 0;
+            foreach (var item in allComponents)
+            {
+                i++;
+            }
+
+            // Tests
+            Assert.AreEqual(i, 9);
+        }
+
+        #region Helper Functions
+
+        private static void CreateMixedRealityConfiguration(MixedRealityManager mixedRealityManager)
+        {
+            var mrConfiguration = ScriptableObject.CreateInstance<Internal.Definitions.MixedRealityConfigurationProfile>();
+            mixedRealityManager.ActiveProfile = mrConfiguration;
+        }
+
+        #endregion
+    }
+
+    #region Test Components
+
+    public interface ITestComponentManager1 : Internal.Interfaces.IMixedRealityManager { }
+
+    public interface ITestComponentManager2 : Internal.Interfaces.IMixedRealityManager { }
+
+
+    internal class TestComponentManager1 : Internal.Definitions.BaseManager, ITestComponentManager1
+    {
+        /// <summary>
+        /// TestComponentManager1 constructor
+        /// </summary>
+        public TestComponentManager1()
+        {
+            // TODO define any constructor requirements
+        }
+
+        /// <summary>
+        /// The initialize function is used to setup the manager once created.
+        /// This method is called once all managers have been registered in the Mixed Reality Manager.
+        /// </summary>
+        public override void Initialize()
+        {
+            // TODO Initialize stuff 
+        }
+
+        /// <summary>
+        /// Optional Update function to perform per-frame updates of the manager
+        /// </summary>
+        public override void Update()
+        {
+            // TODO Update stuff 
+        }
+
+        /// <summary>
+        /// Optional ProfileUpdate function to allow reconfiguration when the active configuration profile of the Mixed Reality Manager is replaced
+        /// </summary>
+        public override void Reset()
+        {
+            // TODO React to profile change
+        }
+
+        /// <summary>
+        /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed
+        /// </summary>
+        public override void Destroy()
+        {
+            // TODO Destroy stuff 
+        }
+    }
+
+    internal class TestComponentManager2 : Internal.Definitions.BaseManager, ITestComponentManager2
+    {
+        public Internal.Interfaces.IMixedRealityInputSystem inputSystem = null;
+
+        /// <summary>
+        /// TestComponentManager2 constructor
+        /// </summary>
+        public TestComponentManager2()
+        {
+            // TODO define any constructor requirements
+        }
+
+        /// <summary>
+        /// The initialize function is used to setup the manager once created.
+        /// This method is called once all managers have been registered in the Mixed Reality Manager.
+        /// </summary>
+        public override void Initialize()
+        {
+            // TODO Initialize stuff 
+            inputSystem = MixedRealityManager.Instance.GetManager<Internal.Interfaces.IMixedRealityInputSystem>();
+        }
+
+        /// <summary>
+        /// Optional Update function to perform per-frame updates of the manager
+        /// </summary>
+        public override void Update()
+        {
+            // TODO Update stuff 
+        }
+
+        /// <summary>
+        /// Optional ProfileUpdate function to allow reconfiguration when the active configuration profile of the Mixed Reality Manager is replaced
+        /// </summary>
+        public override void Reset()
+        {
+            // TODO React to profile change
+        }
+
+        /// <summary>
+        /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed
+        /// </summary>
+        public override void Destroy()
+        {
+            // TODO Destroy stuff 
+        }
+    }
+    #endregion
+}

--- a/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.cs.meta
+++ b/Assets/MixedRealityToolkit-Tests/MixedRealityManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc6f4054a5a7743458a0fcf11a99ec5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Boundary/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit/Boundary/MixedRealityBoundarySystem.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
     public class MixedRealityBoundaryManager : BaseManager, IMixedRealityBoundarySystem
     {
         private IMixedRealityInputSystem inputSystem = null;
-        
+
         /// <summary>
         /// MixedRealityBoundaryManager constructor
         /// </summary>
@@ -32,19 +32,19 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
         }
 
         /// <summary>
-        /// Optional Update function to perform per-frame updates of the manager
-        /// </summary>
-        public override void Update()
-        {
-            // TODO Update stuff 
-        }
-
-        /// <summary>
         /// Optional ProfileUpdate function to allow reconfiguration when the active configuration profile of the Mixed Reality Manager is replaced
         /// </summary>
         public override void Reset()
         {
             // TODO React to profile change
+        }
+
+        /// <summary>
+        /// Optional Update function to perform per-frame updates of the manager
+        /// </summary>
+        public override void Update()
+        {
+            // TODO Update stuff 
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/InputSystem/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/MixedRealityInputManager.cs
@@ -85,15 +85,6 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
             InitializeInternal();
         }
 
-        /// <summary>
-        /// Optional ProfileUpdate function to allow reconfiguration when the active configuration profile of the Mixed Reality Manager is replaced
-        /// </summary>
-        public override void Reset()
-        {
-            base.Reset();
-            InitializeInternal();
-        }
-
         private void InitializeInternal()
         {
             FocusProvider = CameraCache.Main.gameObject.EnsureComponent<FocusProvider>();
@@ -119,6 +110,15 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
             speechEventData = new SpeechEventData(EventSystem.current);
             dictationEventData = new DictationEventData(EventSystem.current);
 #endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+        }
+
+        /// <summary>
+        /// Optional ProfileUpdate function to allow reconfiguration when the active configuration profile of the Mixed Reality Manager is replaced
+        /// </summary>
+        public override void Reset()
+        {
+            base.Reset();
+            InitializeInternal();
         }
 
         public override void Destroy()

--- a/Assets/MixedRealityToolkit/MixedRealityToolkit.asmdef
+++ b/Assets/MixedRealityToolkit/MixedRealityToolkit.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "MixedRealityToolkit"
+}

--- a/Assets/MixedRealityToolkit/MixedRealityToolkit.asmdef.meta
+++ b/Assets/MixedRealityToolkit/MixedRealityToolkit.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5cc3a11739556b142962bcd9071c581f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BaseManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BaseManager.cs
@@ -30,6 +30,11 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         public virtual void Reset() { }
 
         /// <summary>
+        /// Optional Enable function to enable / re-enable the manager.
+        /// </summary>
+        public virtual void Enable() { }
+
+        /// <summary>
         /// Optional Update function to perform per-frame updates of the manager.
         /// </summary>
         public virtual void Update() { }
@@ -38,11 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// Optional Disable function to pause the manager.
         /// </summary>
         public virtual void Disable() { }
-
-        /// <summary>
-        /// Optional Enable function to enable / re-enable the manager.
-        /// </summary>
-        public virtual void Enable() { }
 
         /// <summary>
         /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed.

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BaseManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BaseManager.cs
@@ -9,6 +9,16 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
     public class BaseManager : Interfaces.IMixedRealityManager
     {
         /// <summary>
+        /// Optional Name attribute if multiple managers of the same type are required, enables targeting a manager for action
+        /// </summary>
+        public virtual string Name { get; set; }
+
+        /// <summary>
+        /// Optional Priority to reorder registered managers based on their respective priority, reduces the risk of race conditions by prioritizing the order in which managers are evaluated.
+        /// </summary>
+        public virtual uint Priority { get; set; }
+
+        /// <summary>
         /// The initialize function is used to setup the manager once created.
         /// This method is called once all managers have been registered in the Mixed Reality Manager.
         /// </summary>
@@ -23,6 +33,16 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// Optional Update function to perform per-frame updates of the manager.
         /// </summary>
         public virtual void Update() { }
+
+        /// <summary>
+        /// Optional Disable function to pause the manager.
+        /// </summary>
+        public virtual void Disable() { }
+
+        /// <summary>
+        /// Optional Enable function to enable / re-enable the manager.
+        /// </summary>
+        public virtual void Enable() { }
 
         /// <summary>
         /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed.

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -93,9 +93,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
             // *Note This will only take effect once the Mixed Reality Toolkit has a custom editor for the MixedRealityConfigurationProfile
 
             ActiveManagers.Clear();
-            for (int i = 0; i < initialManagers.Length; i++)
+            if (initialManagers != null && initialManagers.Length > 0)
             {
-                ActiveManagers.Add(initialManagerTypes[i], initialManagers[i]);
+                for (int i = 0; i < initialManagers.Length; i++)
+                {
+                    Managers.MixedRealityManager.Instance.AddManager(initialManagerTypes[i], initialManagers[i]);
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -93,12 +93,9 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
             // *Note This will only take effect once the Mixed Reality Toolkit has a custom editor for the MixedRealityConfigurationProfile
 
             ActiveManagers.Clear();
-            if (initialManagers != null && initialManagers.Length > 0)
+            for (int i = 0; i < initialManagers?.Length; i++)
             {
-                for (int i = 0; i < initialManagers.Length; i++)
-                {
-                    Managers.MixedRealityManager.Instance.AddManager(initialManagerTypes[i], initialManagers[i]);
-                }
+                Managers.MixedRealityManager.Instance.AddManager(initialManagerTypes[i], initialManagers[i]);
             }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealityManager.cs
@@ -9,6 +9,16 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces
     public interface IMixedRealityManager
     {
         /// <summary>
+        /// Optional Priority attribute if multiple managers of the same type are required, enables targeting a manager for action
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Optional Priority to reorder registered managers based on their respective priority, reduces the risk of race conditions by prioritizing the order in which managers are evaluated.
+        /// </summary>
+        uint Priority { get; }
+
+        /// <summary>
         /// The initialize function is used to setup the manager once created.
         /// This method is called once all managers have been registered in the Mixed Reality Manager.
         /// </summary>
@@ -23,6 +33,16 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces
         /// Optional Update function to perform per-frame updates of the manager.
         /// </summary>
         void Update();
+
+        /// <summary>
+        /// Optional Disable function to pause the manager.
+        /// </summary>
+        void Disable();
+
+        /// <summary>
+        /// Optional Enable function to enable / re-enable the manager.
+        /// </summary>
+        void Enable();
 
         /// <summary>
         /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed.

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealityManager.cs
@@ -30,6 +30,11 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces
         void Reset();
 
         /// <summary>
+        /// Optional Enable function to enable / re-enable the manager.
+        /// </summary>
+        void Enable();
+
+        /// <summary>
         /// Optional Update function to perform per-frame updates of the manager.
         /// </summary>
         void Update();
@@ -38,11 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces
         /// Optional Disable function to pause the manager.
         /// </summary>
         void Disable();
-
-        /// <summary>
-        /// Optional Enable function to enable / re-enable the manager.
-        /// </summary>
-        void Enable();
 
         /// <summary>
         /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed.

--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs.meta
@@ -3,7 +3,8 @@ guid: 38fefd0e8bfa04349a0184d73493b89d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - activeProfile: {instanceID: 0}
   executionOrder: 0
   icon: {fileID: 2800000, guid: 8a1b00ef1a7a8b94891466c1f0911027, type: 3}
   userData: 

--- a/External/Documentation/MixedRealityManagerConstruction.md
+++ b/External/Documentation/MixedRealityManagerConstruction.md
@@ -29,18 +29,13 @@ namespace Microsoft.MixedReality.Toolkit.<Feature>
     /// <summary>
     /// An example manager
     /// </summary>
-    public class MyManager : BaseManager
+    public class MyManager : BaseManager, IManagerIdentifierInterface
     {
         /// <summary>
         /// MyManager constructor
         /// </summary>
         public MyManager()
         {
-            //Attach to Manager events
-            MixedRealityManager.Instance.InitializeEvent += InitializeInternal;
-            MixedRealityManager.Instance.UpdateEvent += Update;
-            MixedRealityManager.Instance.DestroyEvent += Destroy;
-
             //Get relevant properties from the active profile of the Manager 
             MyManagerProperty1 = MixedRealityManager.Instance.ActiveProfile.ManagerProperty1;
             MyManagerProperty2 = MixedRealityManager.Instance.ActiveProfile.ManagerProperty2;
@@ -48,42 +43,118 @@ namespace Microsoft.MixedReality.Toolkit.<Feature>
 
         /// <summary>
         /// IMixedRealityManager Initialize function, called once the Mixed Reality Manager has finished registering all managers
-        /// Subscription required to the "InitializeEvent" event of the MixedRealityManager
         /// </summary>
-        void InitializeInternal()
+        void Initialize()
         {
-            //Initialize stuff 
-        }
-
-        /// <summary>
-        /// Optional Update function to perform per-frame updates of the manager
-        /// Subscription required to the "UpdateEvent" event of the MixedRealityManager
-        /// </summary>
-        void Update()
-        {
-            if (Enabled)
-            {
-                //Update stuff 
-
-            }
+            //Initialize stuff
         }
 
         /// <summary>
         /// Optional ProfileUpdate function to allow reconfiguration when the active configuration profile of the Mixed Reality Manager is replaced
-        /// Subscription required to the "ProfileUpdateEvent" event of the MixedRealityManager
         /// </summary>
-        private void ProfileUpdate()
+        private void Reset()
         {
             //React to profile change
         }
 
         /// <summary>
+        /// Optional Update function to perform per-frame updates of the manager
+        /// </summary>
+        void Update()
+        {
+            if (Enabled)
+            {
+                //Update stuff
+
+            }
+        }
+
+        /// <summary>
+        /// Optional Disable function to pause the manager.
+        /// </summary>
+        void Disable()
+        {
+            //Destroy stuff
+        }
+
+        /// <summary>
+        /// Optional Enable function to enable / re-enable the manager.
+        /// </summary>
+        void Enable()
+        {
+            //Destroy stuff
+        }
+
+        /// <summary>
         /// Optional Destroy function to perform cleanup of the manager before the Mixed Reality Manager is destroyed
-        /// Subscription required to the "DestroyEvent" event of the MixedRealityManager
         /// </summary>
         void Destroy()
         {
-            //Destroy stuff 
+            //Destroy stuff
         }
     }
 ```
+
+# MixedReality Runtime Managers (Components)
+The Mixed Reality Manager is also extensible enough that is can support runtime as well as design time managers, the key differences being:
+
+## Mixed Reality Design Time Managers 
+
+* Can only have a single instance (e.g. InputSystem, there can only be one)
+
+Register
+---
+```
+MixedRealityManager.Instance.AddManager(typeof(Internal.Interfaces.IMixedRealityInputSystem), new InputSystem.MixedRealityInputManager());
+```
+
+Retrieve
+---
+```
+var inputSystem = MixedRealityManager.Instance.GetManager<Internal.Interfaces.IMixedRealityInputSystem>();
+```
+
+## Mixed Reality Runtime Managers
+
+* Supports as many instances as you like, stored by interface type
+* Also supports being named, in case you need an individual manager of a type that has a specific name
+
+Register
+---
+```
+//Add test component 1
+MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager1), new TestComponentManager1());
+
+//Add test component 2
+MixedRealityManager.Instance.AddManager(typeof(ITestComponentManager2), new TestComponentManager2() { Name = "Tester2" });
+```
+
+Retrieve
+---
+```
+//Retrieve Component1
+var component1 = MixedRealityManager.Instance.GetManager(typeof(ITestComponentManager1));
+
+//Retrieve component named Tester2
+TestComponentManager2 component2 = (TestComponentManager2)MixedRealityManager.Instance.GetManager(typeof(ITestComponentManager2), "Tester2");
+
+//Get all components of Type 2
+var type2Components = MixedRealityManager.Instance.GetManagers(typeof(ITestComponentManager2));
+```
+
+To keep things simple, the Mixed Reality Manager can already distinguish between each type of Manager and will manage them accordingly, so it is the same code for registering and retrieving managers.
+
+# Manager Interfaces
+
+The Manager container uses a predefined Interface type for storage and retrieval of any Manager, this ensures there are no hard dependencies within the Mixed Reality Toolkit, so that each subsystem can easily be swapped out with another (so long as it confirms to the interface).
+
+Current System interfaces provided by the Mixed Reality Toolkit include:
+
+* IMixedRealityInputSystem
+* IMixedRealityBoundarySystem
+
+When creating your own bespoke versions of these systems, you much ensure they comply with the interfaces provided by the Mixed Reality Toolkit (e.g. if you replace the InputSystem with another of your own design).
+
+Additionally, if you create your own Runtime managers, these must also have their own Interface which derives from *IMixedRealityManager* to ensure it is supported by the Mixed Reality Manager.
+
+> All Managers must also inherit from the **BaseManager** class, to implement the functions required by the Mixed Reality Manager for individual manager operation.  E.G. Initialize, Update, Destroy.


### PR DESCRIPTION
Overview
---
Updated the Mixed Reality manager to now also support runtime Managers.  Main difference is that design time managers are unique (e.g. InputSystemManager) whereas there maybe many runtime managers.
Also added support for the Disable and Enable MonoBehaviour functions.

See "/External/Documentation/MixedRealityManagerConstruction.md" for more details

Also added some simple Unit Tests (WIP) for the MR Manager, to test DI implementation and use.

Changes
---
- Fixes: Resolved some null reference issues when initialising
- Fixes: Singleton pattern updated in manager to be Unit Test Friendly
- Additions: Assembly refs added for Unit Testing only atm.  For further review.

TODO
---
- [ ] Review new Input System components for manager adoption (design and runtime)
- [ ] Evolve (still much to do )
