### PR TITLE
[may18] remove required component from fpsdisplay.cs (#2006)

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/FpsDisplay.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FpsDisplay.cs
@@ -9,7 +9,6 @@ namespace HoloToolkit.Unity
     /// <summary>
     /// Simple Behaviour which calculates the average frames per second over a number of frames and shows the FPS in a referenced Text control.
     /// </summary>
-    [RequireComponent(typeof(TextMesh))]
     public class FpsDisplay : MonoBehaviour
     {
         /// <summary>


### PR DESCRIPTION
Remove the unneeded RequiredComponent attribute that force adds a TextMesh.

Fixes: #2006
