### PR TITLE
Allow remote mapping to UWP / Immersive Windows MR apps

### DIFF
--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
@@ -4,7 +4,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace HoloToolkit.Unity.SpatialMapping
 {
     public class FileSurfaceObserver : SpatialMappingSource
     {
@@ -55,7 +59,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         private void Update()
         {
             // Keyboard commands for saving and loading a remotely generated mesh file.
-#if UNITY_EDITOR || UNITY_STANDALONE
+#if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA
             // S - saves the active mesh
             if (Input.GetKeyUp(SaveFileKey))
             {
@@ -71,4 +75,21 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
 #endif
         }
     }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(FileSurfaceObserver))]
+    public class FileSurfaceObserverEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            // Quick way for the user to get access to the room file location.
+            if (GUILayout.Button("Open File Location"))
+            {
+                System.Diagnostics.Process.Start(MeshSaver.MeshFolderName);
+            }
+        }
+    }
+#endif
 }

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 using UnityEditor;
 #endif
 
-namespace HoloToolkit.Unity.SpatialMapping
+namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
 {
     public class FileSurfaceObserver : SpatialMappingSource
     {

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
@@ -4,10 +4,6 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
-
 namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
 {
     public class FileSurfaceObserver : SpatialMappingSource
@@ -75,21 +71,4 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
 #endif
         }
     }
-
-#if UNITY_EDITOR
-    [CustomEditor(typeof(FileSurfaceObserver))]
-    public class FileSurfaceObserverEditor : Editor
-    {
-        public override void OnInspectorGUI()
-        {
-            base.OnInspectorGUI();
-
-            // Quick way for the user to get access to the room file location.
-            if (GUILayout.Button("Open File Location"))
-            {
-                System.Diagnostics.Process.Start(MeshSaver.MeshFolderName);
-            }
-        }
-    }
-#endif
 }

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMappingManager.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMappingManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using MixedRealityToolkit.Common;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -9,7 +10,7 @@ using UnityEngine;
 using UnityEngine.Windows.Speech;
 #endif
 
-namespace HoloToolkit.Unity.SpatialMapping
+namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
 {
     [RequireComponent(typeof(RemoteMeshTarget))]
     public partial class RemoteMappingManager : Singleton<RemoteMappingManager>

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMappingManager.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMappingManager.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using MixedRealityToolkit.Common;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -10,7 +9,7 @@ using UnityEngine;
 using UnityEngine.Windows.Speech;
 #endif
 
-namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
+namespace HoloToolkit.Unity.SpatialMapping
 {
     [RequireComponent(typeof(RemoteMeshTarget))]
     public partial class RemoteMappingManager : Singleton<RemoteMappingManager>
@@ -21,7 +20,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         [Tooltip("Keyword for sending meshes from HoloLens to Unity over the network.")]
         public string SendMeshesKeyword = "send meshes";
 
-#if UNITY_EDITOR || UNITY_STANDALONE
+#if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA
         /// <summary>
         /// Receives meshes collected over the network.
         /// </summary>
@@ -54,7 +53,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
             keywordRecognizer.Start();
 #endif
 
-#if UNITY_EDITOR || UNITY_STANDALONE
+#if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA
             remoteMeshTarget = GetComponent<RemoteMeshTarget>();
 
             if (remoteMeshTarget != null && SpatialMappingManager.Instance.Source == null)
@@ -68,7 +67,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         // Called every frame by the Unity engine.
         private void Update()
         {
-#if UNITY_EDITOR || UNITY_STANDALONE
+#if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA
             // Use the 'network' sourced mesh.  
             if (Input.GetKeyUp(RemoteMappingKey))
             {

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
@@ -65,8 +65,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         /// </summary>
         private ConcurrentQueue<byte[]> ReceivedMeshes;
 
-        // Use this for initialization.
-        void Start()
+        private void Start()
         {
             // Initiate the queue for storing the mesh data until the game objects are created
             ReceivedMeshes = new ConcurrentQueue<byte[]>();
@@ -75,8 +74,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
             StartServer();
         }
 
-        // Update is called once per frame.
-        void Update()
+        private void Update()
         {
             if (ReceivedMeshes.TryDequeue(out byte[] result))
             {

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
@@ -4,13 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using UnityEngine;
+
 #if UNITY_EDITOR || UNITY_STANDALONE_WIN
 using System.Net;
 using System.Net.Sockets;
 #endif
-using UnityEngine;
 
-namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
+#if UNITY_WSA && !UNITY_EDITOR
+using System.Collections.Concurrent;
+#endif
+
+namespace HoloToolkit.Unity.SpatialMapping
 {
     /// <summary>
     /// RemoteMeshTarget will listen for meshes being sent from a remote system (HoloLens).
@@ -25,7 +30,158 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         [Tooltip("The connection port on the machine to use.")]
         public int ConnectionPort = 11000;
 
+        /// <summary>
+        /// Reads an int from the next 4 bytes of the supplied stream.
+        /// </summary>
+        /// <param name="stream">The stream to read the bytes from.</param>
+        /// <returns>An integer representing the bytes.</returns>
+        private int ReadInt(Stream stream)
+        {
+            // The bytes arrive in the wrong order, so swap them.
+            byte[] bytes = new byte[4];
+            stream.Read(bytes, 0, 4);
+            byte t = bytes[0];
+            bytes[0] = bytes[3];
+            bytes[3] = t;
+
+            t = bytes[1];
+            bytes[1] = bytes[2];
+            bytes[2] = t;
+
+            // Then bitconverter can read the int32.
+            return BitConverter.ToInt32(bytes, 0);
+        }
+
+// Remote mapping for Immmersive Windows MR and UWP Apps
+#if UNITY_WSA && !UNITY_EDITOR
+
+        /// <summary>
+        /// Listens for network connections over TCP in an UWP app
+        /// </summary> 
+        private Windows.Networking.Sockets.StreamSocketListener streamSocketListener;
+
+        /// <summary>
+        /// Buffers the received meshes to process and display
+        /// </summary>
+        private ConcurrentQueue<byte[]> ReceivedMeshes;
+
+        // Use this for initialization.
+        void Start()
+        {
+            // Initiate the queue for storing the mesh data until the game objects are created
+            ReceivedMeshes = new ConcurrentQueue<byte[]>();
+
+            // Start the server for receiving mesh data
+            StartServer();
+        }
+
+        // Update is called once per frame.
+        void Update()
+        {
+            if (ReceivedMeshes.TryDequeue(out byte[] result))
+            {
+                // Pass the data to the mesh serializer. 
+                List<Mesh> meshes = new List<Mesh>(SimpleMeshSerializer.Deserialize(result));
+
+                if (meshes.Count > 0 && SpatialMappingManager.Instance.Source != this)
+                {
+                    // Use the network-based mapping source to receive meshes in the Unity editor.
+                    SpatialMappingManager.Instance.SetSpatialMappingSource(this);
+                    System.Diagnostics.Debug.WriteLine("Set the network-based mapping source.");
+                }
+
+                // For each mesh, create a GameObject to render it.
+                for (int index = 0; index < meshes.Count; index++)
+                {
+                    int meshID = SurfaceObjects.Count;
+
+                    SurfaceObject surface = CreateSurfaceObject(
+                        mesh: meshes[index],
+                        objectName: "Beamed-" + meshID,
+                        parentObject: transform,
+                        meshID: meshID
+                        );
+
+                    surface.Object.transform.parent = SpatialMappingManager.Instance.transform;
+
+                    AddSurfaceObject(surface);
+                    System.Diagnostics.Debug.WriteLine("Added object " + surface.Object.name);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Used to start the stream socket listener and attach the event handler for incoming connections
+        /// </summary>
+        private async void StartServer()
+        {
+            try
+            {
+                streamSocketListener = new Windows.Networking.Sockets.StreamSocketListener();
+
+                // The ConnectionReceived event is raised when connections are received.
+                streamSocketListener.ConnectionReceived += this.StreamSocketListener_ConnectionReceived;
+
+                // Start listening for incoming TCP connections on the specified port. You can specify any port that's not currently in use.
+                await streamSocketListener.BindServiceNameAsync(ConnectionPort.ToString());
+
+                System.Diagnostics.Debug.WriteLine("Listener started on port " + ConnectionPort);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Couldn't open socket listener.");
+            }
+        }
+
+        /// <summary>
+        /// Used to dispose of the stream socket listener
+        /// </summary>
+        private async void StopServer()
+        {
+            if (streamSocketListener != null)
+            {
+                streamSocketListener.Dispose();
+                System.Diagnostics.Debug.WriteLine("Listener stopped.");
+            }
+        }
+
+        /// <summary>
+        /// Event handler for handling incoming connections and save the mesh data
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        private async void StreamSocketListener_ConnectionReceived(Windows.Networking.Sockets.StreamSocketListener sender, Windows.Networking.Sockets.StreamSocketListenerConnectionReceivedEventArgs args)
+        {
+            using (var stream = args.Socket.InputStream.AsStreamForRead())
+            {
+                // TODO Make sure there is data in the stream.
+
+                // The first 4 bytes will be the size of the data containing the mesh(es).
+                int datasize = ReadInt(stream);
+
+                // Allocate a buffer to hold the data.  
+                byte[] dataBuffer = new byte[datasize];
+
+                // Read the data.
+                // The data can come in chunks. 
+                int readsize = 0;
+
+                while (readsize != datasize)
+                {
+                    readsize += stream.Read(dataBuffer, readsize, datasize - readsize);
+                }
+
+                System.Diagnostics.Debug.WriteLine("Received:" + datasize + "bytes");
+
+                ReceivedMeshes.Enqueue(dataBuffer);
+            }
+        }
+#endif
+
+// Remote mapping inside the Unity Editor
 #if UNITY_EDITOR || UNITY_STANDALONE_WIN
+
         /// <summary>
         /// Listens for network connections over TCP.
         /// </summary> 
@@ -36,10 +192,7 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         /// </summary>
         private TcpClient networkClient;
 
-        /// <summary>
-        /// Tracks if a client is connected.
-        /// </summary>
-        private bool clientConnected;
+        private bool clientConnected = false;
 
         // Use this for initialization.
         private void Start()
@@ -124,28 +277,6 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
         }
 
         /// <summary>
-        /// Reads an int from the next 4 bytes of the supplied stream.
-        /// </summary>
-        /// <param name="stream">The stream to read the bytes from.</param>
-        /// <returns>An integer representing the bytes.</returns>
-        private int ReadInt(Stream stream)
-        {
-            // The bytes arrive in the wrong order, so swap them.
-            byte[] bytes = new byte[4];
-            stream.Read(bytes, 0, 4);
-            byte t = bytes[0];
-            bytes[0] = bytes[3];
-            bytes[3] = t;
-
-            t = bytes[1];
-            bytes[1] = bytes[2];
-            bytes[2] = t;
-
-            // Then bitconverter can read the int32.
-            return BitConverter.ToInt32(bytes, 0);
-        }
-
-        /// <summary>
         /// Called when a client connects.
         /// </summary>
         /// <param name="result">The result of the connection.</param>
@@ -162,5 +293,6 @@ namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
             }
         }
 #endif
+
     }
 }

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
@@ -15,7 +15,7 @@ using System.Net.Sockets;
 using System.Collections.Concurrent;
 #endif
 
-namespace HoloToolkit.Unity.SpatialMapping
+namespace MixedRealityToolkit.SpatialMapping.RemoteMapping
 {
     /// <summary>
     /// RemoteMeshTarget will listen for meshes being sent from a remote system (HoloLens).
@@ -192,6 +192,9 @@ namespace HoloToolkit.Unity.SpatialMapping
         /// </summary>
         private TcpClient networkClient;
 
+        /// <summary>
+        /// Tracks if a client is connected.
+        /// </summary>
         private bool clientConnected = false;
 
         // Use this for initialization.


### PR DESCRIPTION
Extend the RemoteMeshTarget so it can not only be used in the Unity Editor to receive a mesh from a Hololens but also within UWP Immersive Windows Mixed Reality applications. Also allow the saving and loading of a mesh file from an UWP app.
