### PR TITLE
[may18] Update SetManipulationMode to public in TwoHandManipulatable

### DIFF
--- a/Assets/HoloToolkit-Examples/Input/Scenes/TwoHandManipulationTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/TwoHandManipulationTest.unity
@@ -712,12 +712,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6eb034688bcf84b4bb52b3a3310868c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HostTransform: {fileID: 0}
+  hostTransform: {fileID: 0}
   boundingBoxPrefab: {fileID: 114030465538688920, guid: 865a8ded6c47efd4285f04f3aebe99e9,
     type: 2}
-  ManipulationMode: 1
-  ConstraintOnRotation: 3
-  OneHandMovement: 1
+  manipulationMode: 4
+  constraintOnRotation: 3
+  oneHandMovement: 1
 --- !u!65 &687798438
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1425,12 +1425,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6eb034688bcf84b4bb52b3a3310868c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HostTransform: {fileID: 0}
+  hostTransform: {fileID: 0}
   boundingBoxPrefab: {fileID: 114030465538688920, guid: 865a8ded6c47efd4285f04f3aebe99e9,
     type: 2}
-  ManipulationMode: 1
-  ConstraintOnRotation: 2
-  OneHandMovement: 1
+  manipulationMode: 4
+  constraintOnRotation: 2
+  oneHandMovement: 1
 --- !u!65 &1141423121
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1652,12 +1652,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6eb034688bcf84b4bb52b3a3310868c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HostTransform: {fileID: 0}
+  hostTransform: {fileID: 0}
   boundingBoxPrefab: {fileID: 114030465538688920, guid: 865a8ded6c47efd4285f04f3aebe99e9,
     type: 2}
-  ManipulationMode: 2
-  ConstraintOnRotation: 0
-  OneHandMovement: 1
+  manipulationMode: 3
+  constraintOnRotation: 0
+  oneHandMovement: 1
 --- !u!65 &1337778049
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -2448,12 +2448,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6eb034688bcf84b4bb52b3a3310868c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HostTransform: {fileID: 0}
+  hostTransform: {fileID: 0}
   boundingBoxPrefab: {fileID: 114030465538688920, guid: 865a8ded6c47efd4285f04f3aebe99e9,
     type: 2}
-  ManipulationMode: 4
-  ConstraintOnRotation: 0
-  OneHandMovement: 1
+  manipulationMode: 7
+  constraintOnRotation: 0
+  oneHandMovement: 1
 --- !u!1 &1838090887
 GameObject:
   m_ObjectHideFlags: 0
@@ -2551,12 +2551,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6eb034688bcf84b4bb52b3a3310868c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HostTransform: {fileID: 0}
+  hostTransform: {fileID: 0}
   boundingBoxPrefab: {fileID: 114030465538688920, guid: 865a8ded6c47efd4285f04f3aebe99e9,
     type: 2}
-  ManipulationMode: 0
-  ConstraintOnRotation: 0
-  OneHandMovement: 1
+  manipulationMode: 2
+  constraintOnRotation: 0
+  oneHandMovement: 1
 --- !u!65 &1886941386
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/ManipulationMode.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/ManipulationMode.cs
@@ -8,12 +8,15 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
     /// Sorting type for collections
     /// </summary>
     [Flags]
-    public enum TwoHandManipulatableMode
+    public enum ManipulationMode
     {
-        Scale = (1 << 0),
-        Rotate = (1 << 1),
-        MoveScale = (1 << 2),
-        RotateScale = (1 << 3),
-        MoveRotateScale = (1 << 4),
+        None = 0,
+        Move = 1 << 0,
+        Scale = 1 << 1,
+        Rotate = 1 << 2,
+        MoveAndScale = Move | Scale,
+        MoveAndRotate = Move | Rotate,
+        RotateAndScale = Rotate | Scale,
+        MoveScaleAndRotate = Move | Scale | Rotate,
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/ManipulationMode.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/ManipulationMode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 8bc58ef7ce3e73242b5b7000c7dff94b
+timeCreated: 1525128518
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
@@ -47,6 +47,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
 
         [SerializeField]
         [Tooltip("What manipulation will two hands perform?")]
+        [EnumFlags]
         private TwoHandManipulatableMode ManipulationMode = TwoHandManipulatableMode.Scale;
 
         [SerializeField]

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
@@ -30,18 +30,6 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
         private BoundingBox boundingBoxPrefab = null;
 
         /// <summary>
-        /// enum describing range of affine xforms that are allowed.
-        /// </summary>
-        private enum TwoHandedManipulation
-        {
-            Scale,
-            Rotate,
-            MoveScale,
-            RotateScale,
-            MoveRotateScale
-        };
-
-        /// <summary>
         /// Reference to the Prefab from which clone is instantiated.
         /// </summary>
         public BoundingBox BoundingBoxPrefab
@@ -59,7 +47,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
 
         [SerializeField]
         [Tooltip("What manipulation will two hands perform?")]
-        private TwoHandedManipulation ManipulationMode = TwoHandedManipulation.Scale;
+        private TwoHandManipulatableMode ManipulationMode = TwoHandManipulatableMode.Scale;
 
         [SerializeField]
         [Tooltip("Constrain rotation along an axis")]
@@ -132,7 +120,7 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
         /// <summary>
         /// SetManipulationMode
         /// </summary>
-        private void SetManipulationMode(TwoHandedManipulation mode)
+        public void SetManipulationMode(TwoHandManipulatableMode mode)
         {
             ManipulationMode = mode;
         }
@@ -255,19 +243,19 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
                     {
                         switch (ManipulationMode)
                         {
-                            case TwoHandedManipulation.Scale:
+                            case TwoHandManipulatableMode.Scale:
                                 newState = State.Scaling;
                                 break;
-                            case TwoHandedManipulation.Rotate:
+                            case TwoHandManipulatableMode.Rotate:
                                 newState = State.Rotating;
                                 break;
-                            case TwoHandedManipulation.MoveScale:
+                            case TwoHandManipulatableMode.MoveScale:
                                 newState = State.MovingScaling;
                                 break;
-                            case TwoHandedManipulation.RotateScale:
+                            case TwoHandManipulatableMode.RotateScale:
                                 newState = State.RotatingScaling;
                                 break;
-                            case TwoHandedManipulation.MoveRotateScale:
+                            case TwoHandManipulatableMode.MoveRotateScale:
                                 newState = State.MovingRotatingScaling;
                                 break;
                             default:

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatableMode.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatableMode.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+using System;
 
 namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
 {
     /// <summary>
     /// Sorting type for collections
     /// </summary>
+    [Flags]
     public enum TwoHandManipulatableMode
     {
-        Scale,
-        Rotate,
-        MoveScale,
-        RotateScale,
-        MoveRotateScale
+        Scale = (1 << 0),
+        Rotate = (1 << 1),
+        MoveScale = (1 << 2),
+        RotateScale = (1 << 3),
+        MoveRotateScale = (1 << 4),
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatableMode.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatableMode.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
+{
+    /// <summary>
+    /// Sorting type for collections
+    /// </summary>
+    public enum TwoHandManipulatableMode
+    {
+        Scale,
+        Rotate,
+        MoveScale,
+        RotateScale,
+        MoveRotateScale
+    }
+}


### PR DESCRIPTION
Overview
---
Update private SetManipulationMode to public in TwoHandManipulatable.cs. This allows the user change manipulation mode option in real-time. (possibly through menu buttons or voice command) Currently, it is only supported in the editor's inspector panel.
![2018-04-20 14_27_20-unity 2017 2 1p2 64bit - uxdemoscene unity - mrtk-demo - universal windows pla](https://user-images.githubusercontent.com/13754172/39074623-055d4fb4-44a7-11e8-9219-c0a0f1d7687d.png)

Separated enum TwoHandManipulatableMode into a new file.

FYI, supported manipulation mode:
- Scale
- Rotate
- Move, Scale
- Rotate, Scale
- Move, Rotate, Scale

Changes
---
- Fixes: #1994 
