### PR TITLE
'Cherry pick' of work previously committed to Dev_Working with PR #1870:

### DIFF
--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/Scripts/AppState.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/Scripts/AppState.cs
@@ -275,7 +275,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
         public void OnSourceDetected(SourceStateEventData eventData)
         {
             // If the source has positional info and there is currently no visible source
-            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.GripPosition))
             {
                 trackedHandsCount++;
             }
@@ -283,7 +283,7 @@ namespace HoloToolkit.Examples.SpatialUnderstandingFeatureOverview
 
         public void OnSourceLost(SourceStateEventData eventData)
         {
-            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+            if (eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.GripPosition))
             {
                 trackedHandsCount--;
             }

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/CustomInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/CustomInputSource.cs
@@ -46,23 +46,33 @@ namespace HoloToolkit.Unity.InputModule
             public bool ManipulationInProgress;
             public bool HoldInProgress;
             public Vector3 CumulativeDelta;
+            public Vector3 CumulativeGripDelta;
         }
 
+        [Tooltip("This property now represents Pointer position (contrast with Grip position)")]
         public bool SupportsPosition;
+        [Tooltip("This property now represents Pointer rotation (contrast with Grip rotation)")]
         public bool SupportsRotation;
+        public bool SupportsGripPosition;
+        public bool SupportsGripRotation;
         public bool SupportsRay;
         public bool SupportsMenuButton;
         public bool SupportsGrasp;
         public bool RaiseEventsBasedOnVisibility;
         public InteractionSourceInfo SourceKind;
 
+        [Tooltip("This property now represents controller's Pointer position (contrast with controller Grip position)")]
+        public Vector3 ControllerPosition;
+        [Tooltip("This property now represents controller's Pointer rotation (contrast with controller Grip rotation)")]
+        public Quaternion ControllerRotation;
+
         //Navigation Gesture Emulation vars
         Vector3 NavigatorValues = Vector3.zero; //holds the navigation gesture values [-1,1]
         Vector2 railUsedCurrently = Vector2.one;
         bool    isNavigatorUsingRails = false;
 
-        public Vector3 ControllerPosition;
-        public Quaternion ControllerRotation;
+        public Vector3 ControllerGripPosition;
+        public Quaternion ControllerGripRotation;
 
         public Ray? PointingRay;
 
@@ -104,6 +114,16 @@ namespace HoloToolkit.Unity.InputModule
             if (SupportsRay)
             {
                 supportedInputInfo |= SupportedInputInfo.Pointing;
+            }
+
+            if (SupportsGripPosition)
+            {
+                supportedInputInfo |= SupportedInputInfo.GripPosition;
+            }
+
+            if (SupportsGripRotation)
+            {
+                supportedInputInfo |= SupportedInputInfo.GripRotation;
             }
 
             if (SupportsMenuButton)
@@ -173,9 +193,9 @@ namespace HoloToolkit.Unity.InputModule
         {
             Debug.Assert(sourceId == controllerId, "Controller data requested for a mismatched source ID.");
 
-            if (SupportsPosition)
+            if (SupportsGripPosition)
             {
-                position = ControllerPosition;
+                position = ControllerGripPosition;
                 return true;
             }
 
@@ -187,9 +207,9 @@ namespace HoloToolkit.Unity.InputModule
         {
             Debug.Assert(sourceId == controllerId, "Controller data requested for a mismatched source ID.");
 
-            if (SupportsRotation)
+            if (SupportsGripRotation)
             {
-                rotation = ControllerRotation;
+                rotation = ControllerGripRotation;
                 return true;
             }
 
@@ -385,6 +405,25 @@ namespace HoloToolkit.Unity.InputModule
             if (SupportsRay)
             {
                 PointingRay = source.SourcePose.PointerRay;
+            }
+
+            if (SupportsGripPosition)
+            {
+                Vector3 controllerGripPosition;
+                if (source.SourcePose.TryGetGripPosition(out controllerGripPosition))
+                {
+                    currentButtonStates.CumulativeGripDelta += controllerGripPosition - ControllerGripPosition;
+                    ControllerGripPosition = controllerGripPosition;
+                }
+            }
+
+            if (SupportsGripRotation)
+            {
+                Quaternion controllerGripRotation;
+                if (source.SourcePose.TryGetGripRotation(out controllerGripRotation))
+                {
+                    ControllerGripRotation = controllerGripRotation;
+                }
             }
 
             if (SupportsMenuButton)

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
@@ -460,8 +460,10 @@ namespace HoloToolkit.Unity.InputModule
             SourceData sourceData;
             if (sourceIdToData.TryGetValue(sourceId, out sourceData))
             {
-                retVal |= GetSupportFlag(sourceData.PointerPosition, SupportedInputInfo.Position);
-                retVal |= GetSupportFlag(sourceData.PointerRotation, SupportedInputInfo.Rotation);
+                retVal |= GetSupportFlag(sourceData.PointerPosition, SupportedInputInfo.PointerPosition);
+                retVal |= GetSupportFlag(sourceData.PointerRotation, SupportedInputInfo.PointerRotation);
+                retVal |= GetSupportFlag(sourceData.GripPosition, SupportedInputInfo.GripPosition);
+                retVal |= GetSupportFlag(sourceData.GripRotation, SupportedInputInfo.GripRotation);
                 retVal |= GetSupportFlag(sourceData.PointingRay, SupportedInputInfo.Pointing);
                 retVal |= GetSupportFlag(sourceData.Thumbstick, SupportedInputInfo.Thumbstick);
                 retVal |= GetSupportFlag(sourceData.Touchpad, SupportedInputInfo.Touchpad);

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/SupportedInputInfo.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/SupportedInputInfo.cs
@@ -12,13 +12,19 @@ namespace HoloToolkit.Unity.InputModule
     public enum SupportedInputInfo
     {
         None = 0,
+        [Obsolete("use PointerPosition")]
         Position = (1 << 0),
+        PointerPosition = (1 << 0),
+        [Obsolete("use PointerRotation")]
         Rotation = (1 << 1),
+        PointerRotation = (1 << 1),
         Pointing = (1 << 2),
         Thumbstick = (1 << 3),
         Touchpad = (1 << 4),
         Select = (1 << 5),
         Menu = (1 << 6),
         Grasp = (1 << 7),
+        GripPosition = (1 << 8),
+        GripRotation = (1 << 9)
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/TouchscreenInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/TouchscreenInputSource.cs
@@ -215,7 +215,7 @@ namespace HoloToolkit.Unity.InputModule
 
         public override SupportedInputInfo GetSupportedInputInfo(uint sourceId)
         {
-            return SupportedInputInfo.Position | SupportedInputInfo.Pointing;
+            return SupportedInputInfo.PointerPosition | SupportedInputInfo.Pointing;
         }
 
         public override bool TryGetThumbstick(uint sourceId, out bool isPressed, out Vector2 position)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/DebugInteractionSourcePose.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/DebugInteractionSourcePose.cs
@@ -19,17 +19,23 @@ namespace HoloToolkit.Unity.InputModule
         public bool TryGetFunctionsReturnTrue;
         public bool IsPositionAvailable;
         public bool IsRotationAvailable;
+        public bool IsGripPositionAvailable;
+        public bool IsGripRotationAvailable;
 
         public Vector3 Position;
         public Vector3 Velocity;
         public Quaternion Rotation;
         public Ray? PointerRay;
+        public Vector3 GripPosition;
+        public Quaternion GripRotation;
 
         public DebugInteractionSourcePose()
         {
             TryGetFunctionsReturnTrue = false;
             IsPositionAvailable = false;
             IsRotationAvailable = false;
+            IsGripPositionAvailable = false;
+            IsGripRotationAvailable = false;
             Position = new Vector3(0, 0, 0);
             Velocity = new Vector3(0, 0, 0);
             Rotation = Quaternion.identity;
@@ -38,7 +44,7 @@ namespace HoloToolkit.Unity.InputModule
         public bool TryGetPosition(out Vector3 position)
         {
             position = Position;
-            if (!TryGetFunctionsReturnTrue)
+            if (!TryGetFunctionsReturnTrue)     // TODO: bug? does not test IsPositionAvailable (see TryGetRotation)
             {
                 return false;
             }
@@ -69,6 +75,26 @@ namespace HoloToolkit.Unity.InputModule
         {
             pointerRay = (Ray)PointerRay;
             if (PointerRay == null)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public bool TryGetGripPosition(out Vector3 position)
+        {
+            position = GripPosition;
+            if (!TryGetFunctionsReturnTrue)     // TODO: should test IsGripPositionAvailable? (see TryGetPosition)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public bool TryGetGripRotation(out Quaternion rotation)
+        {
+            rotation = GripRotation;
+            if (!TryGetFunctionsReturnTrue || !IsGripRotationAvailable)
             {
                 return false;
             }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -360,9 +360,9 @@ namespace HoloToolkit.Unity.InputModule
             eventData.InputSource.TryGetSourceKind(eventData.SourceId, out sourceKind);
             if (sourceKind != InteractionSourceInfo.Hand)
             {
-                if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+                if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.GripPosition))
                 {
-                    // The input source must provide positional data for this script to be usable
+                    // The input source must provide grip positional data for this script to be usable
                     return;
                 }
             }


### PR DESCRIPTION
Overview
---
Adding GripPosition and GripRotation to SupportedInputInfo and adding support to WSA input source and related classes, originally submitted in Dev_Working_Branch as PR #1870. Now 'cherry picked' and submitted for the May18 release in the original HoloToolkit hierarchy.

Changes
---
* added new input info types to SupportedInputInfo;
PointerPosition and PointerRotation have equivalence to, and deprecate, Position and Rotation;
GripPosition and GripRotation extend the bitfield

* InteractionInputSource now reports support for grip position & rotation; replaced deprecated type id's with replacements

* replacing use of deprecated SupportedInputInfo types in simple use cases

* adding support for GripPosition/Rotation, and updating uses of now-deprecated Position/Rotation type enums, in CustomInputSource and DebugInteractionSourcePose

* replaced "summary"-tag comments with [Obsolete] attributes to denote changes to enum ids

