### PR TITLE
Eliminate API conversion popup when loading in Unity 2017.1

### DIFF
--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployPortal.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployPortal.cs
@@ -96,11 +96,11 @@ namespace HoloToolkit.Unity
                     }
 
                     if (
-#if UNITY_2017_2_OR_NEWER
+#if UNITY_2017_1_OR_NEWER
                         webRequest.isNetworkError || webRequest.isHttpError && 
 #else
                         webRequest.isError &&
-#endif
+#endif // UNITY_2017_1_OR_NEWER
                         webRequest.responseCode != 401)
                     {
                         string response = string.Empty;
@@ -186,11 +186,11 @@ namespace HoloToolkit.Unity
                     EditorUtility.ClearProgressBar();
 
                     if (
-#if UNITY_2017_2_OR_NEWER
-                        webRequest.isNetworkError || webRequest.isHttpError && 
+#if UNITY_2017_1_OR_NEWER
+                        webRequest.isNetworkError || webRequest.isHttpError &&
 #else
                         webRequest.isError &&
-#endif
+#endif // UNITY_2017_1_OR_NEWER
                         webRequest.responseCode != 401)
                     {
                         string response = string.Empty;
@@ -262,11 +262,11 @@ namespace HoloToolkit.Unity
                     EditorUtility.ClearProgressBar();
 
                     if (
-#if UNITY_2017_2_OR_NEWER
-                        webRequest.isNetworkError || webRequest.isHttpError && 
+#if UNITY_2017_1_OR_NEWER
+                        webRequest.isNetworkError || webRequest.isHttpError &&
 #else
                         webRequest.isError &&
-#endif
+#endif // UNITY_2017_1_OR_NEWER
                         webRequest.responseCode != 401)
                     {
                         string response = string.Empty;

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/CustomInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/CustomInputSource.cs
@@ -103,12 +103,20 @@ namespace HoloToolkit.Unity.InputModule
 
             if (SupportsPosition)
             {
+#if UNITY_2017_1_OR_NEWER
+                supportedInputInfo |= SupportedInputInfo.PointerPosition;
+#else
                 supportedInputInfo |= SupportedInputInfo.Position;
+#endif // UNITY_2017_1_OR_NEWER
             }
 
             if (SupportsRotation)
             {
+#if UNITY_2017_1_OR_NEWER
+                supportedInputInfo |= SupportedInputInfo.PointerRotation;
+#else
                 supportedInputInfo |= SupportedInputInfo.Rotation;
+#endif // UNITY_2017_1_OR_NEWER
             }
 
             if (SupportsRay)

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/CustomInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/CustomInputSource.cs
@@ -103,20 +103,12 @@ namespace HoloToolkit.Unity.InputModule
 
             if (SupportsPosition)
             {
-#if UNITY_2017_1_OR_NEWER
                 supportedInputInfo |= SupportedInputInfo.PointerPosition;
-#else
-                supportedInputInfo |= SupportedInputInfo.Position;
-#endif // UNITY_2017_1_OR_NEWER
             }
 
             if (SupportsRotation)
             {
-#if UNITY_2017_1_OR_NEWER
                 supportedInputInfo |= SupportedInputInfo.PointerRotation;
-#else
-                supportedInputInfo |= SupportedInputInfo.Rotation;
-#endif // UNITY_2017_1_OR_NEWER
             }
 
             if (SupportsRay)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -366,19 +366,19 @@ namespace HoloToolkit.Unity.InputModule
                     return;
                 }
             }
-#elif UNITY_2017_1_OR_NEWER
-            if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.PointerPosition))
-            {
-                // The input source must provide positional data for this script to be usable
-                return;
-            }
 #else
-            if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
+            if (!eventData.InputSource.SupportsInputInfo(
+                eventData.SourceId, 
+#if UNITY_2017_1_OR_NEWER
+                SupportedInputInfo.PointerPosition))
+#else
+                SupportedInputInfo.Position))
+#endif // UNITY_2017_1_OR_NEWER
             {
                 // The input source must provide positional data for this script to be usable
                 return;
             }
-#endif
+#endif // UNITY_2017_2_OR_NEWER
 
             eventData.Use(); // Mark the event as used, so it doesn't fall through to other handlers.
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -367,13 +367,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 #else
-            if (!eventData.InputSource.SupportsInputInfo(
-                eventData.SourceId, 
-#if UNITY_2017_1_OR_NEWER
-                SupportedInputInfo.PointerPosition))
-#else
-                SupportedInputInfo.Position))
-#endif // UNITY_2017_1_OR_NEWER
+            if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.PointerPosition))
             {
                 // The input source must provide positional data for this script to be usable
                 return;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/HandDraggable.cs
@@ -366,6 +366,12 @@ namespace HoloToolkit.Unity.InputModule
                     return;
                 }
             }
+#elif UNITY_2017_1_OR_NEWER
+            if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.PointerPosition))
+            {
+                // The input source must provide positional data for this script to be usable
+                return;
+            }
 #else
             if (!eventData.InputSource.SupportsInputInfo(eventData.SourceId, SupportedInputInfo.Position))
             {

--- a/Assets/HoloToolkit/SpectatorView/Scripts/Networking/NewDeviceDiscovery.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/Networking/NewDeviceDiscovery.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using UnityEngine;
 using UnityEngine.Networking;
+
+#if NETFX_CORE
+using System;
+#endif
 
 namespace HoloToolkit.Unity.SpectatorView
 {

--- a/Assets/HoloToolkit/SpectatorView/Scripts/Networking/SpectatorViewNetworkDiscovery.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/Networking/SpectatorViewNetworkDiscovery.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Collections;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
+
+#if NETFX_CORE
+using System;
+#endif
 
 namespace HoloToolkit.Unity.SpectatorView
 {

--- a/Assets/HoloToolkit/SpectatorView/Scripts/Networking/SpectatorViewNetworkManager.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/Networking/SpectatorViewNetworkManager.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Networking;
+
+#if NETFX_CORE
+using System;
+#endif
 
 namespace HoloToolkit.Unity.SpectatorView
 {

--- a/Assets/HoloToolkit/SpectatorView/Scripts/SpatialSync/CameraCaptureHololens.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/SpatialSync/CameraCaptureHololens.cs
@@ -3,10 +3,14 @@
 
 using System.Collections.Generic;
 using UnityEngine;
-using System.Linq;
 
 #if NETFX_CORE
+using System.Linq;
+#if UNITY_2017_2_OR_NEWER
 using UnityEngine.XR.WSA.WebCam;
+#else
+using UnityEngine.VR.WSA.WebCam;
+#endif
 #endif
 
 namespace HoloToolkit.Unity.SpectatorView

--- a/Assets/HoloToolkit/SpectatorView/Scripts/SpatialSync/MarkerDetectionHololens.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/SpatialSync/MarkerDetectionHololens.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.using UnityEngine;
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using UnityEngine;
+
+#if NETFX_CORE
+using System;
+#endif
 
 namespace HoloToolkit.Unity.SpectatorView
 {

--- a/Assets/HoloToolkit/UX/Prefabs/Text.meta
+++ b/Assets/HoloToolkit/UX/Prefabs/Text.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 59c43794cfe522246aaa1d4a04cadf68
+folderAsset: yes
+timeCreated: 1525804722
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add UNITY_2017_1_OR_NEWER blocks (and modify some existing 2017_2 blocks) to eliminate the API conversion popup when loading the MRTK in Unity 2017.1

There isn't an issue for this, it is an extension of #1921.
