### PR TITLE
fix #1887, src lost had a backwards compare

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
@@ -286,7 +286,7 @@ namespace HoloToolkit.Unity.Buttons
                 if (sourceInfo == InteractionSourceInfo.Hand)
                 {
                     _handCount--;
-                    _bHandVisible = _handCount <= 0;
+                    _bHandVisible = _handCount > 0;
                 }
             }
         }


### PR DESCRIPTION
Changed <= to > when comparing _handCount against zero in OnSourceLost. This fixed our inability to return to ObservationTargeted and Observation button states

Changes
---
- Fixes: #1887.
