### PR TITLE
handle case of no MotionControllerVisualizer singleton

### DIFF
--- a/Assets/HoloToolkit/Common/Scripts/Singleton.cs
+++ b/Assets/HoloToolkit/Common/Scripts/Singleton.cs
@@ -63,11 +63,21 @@ namespace HoloToolkit.Unity
         }
 
         /// <summary>
-        /// Base Awake method that sets the Singleton's unique instance.
-        /// Called by Unity when initializing a MonoBehaviour.
-        /// Scripts that extend Singleton should be sure to call base.Awake() to ensure the
-        /// static Instance reference is properly created.
+        /// Awake and OnEnable safe way to check if a Singleton is initialized.
         /// </summary>
+        /// <returns>The value of the Singleton's IsInitialized property</returns>
+        public static bool ConfirmInitialized()
+        {
+            T access = Instance;
+            return IsInitialized;
+        }
+        
+        /// <summary>
+                /// Base Awake method that sets the Singleton's unique instance.
+                /// Called by Unity when initializing a MonoBehaviour.
+                /// Scripts that extend Singleton should be sure to call base.Awake() to ensure the
+                /// static Instance reference is properly created.
+                /// </summary>
         protected virtual void Awake()
         {
             if (IsInitialized && instance != this)

--- a/Assets/HoloToolkit/Common/Scripts/Singleton.cs
+++ b/Assets/HoloToolkit/Common/Scripts/Singleton.cs
@@ -73,11 +73,11 @@ namespace HoloToolkit.Unity
         }
         
         /// <summary>
-                /// Base Awake method that sets the Singleton's unique instance.
-                /// Called by Unity when initializing a MonoBehaviour.
-                /// Scripts that extend Singleton should be sure to call base.Awake() to ensure the
-                /// static Instance reference is properly created.
-                /// </summary>
+        /// Base Awake method that sets the Singleton's unique instance.
+        /// Called by Unity when initializing a MonoBehaviour.
+        /// Scripts that extend Singleton should be sure to call base.Awake() to ensure the
+        /// static Instance reference is properly created.
+        /// </summary>
         protected virtual void Awake()
         {
             if (IsInitialized && instance != this)

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -42,6 +42,12 @@ namespace HoloToolkit.Unity.InputModule
         protected virtual void OnEnable()
         {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
+            if (!MotionControllerVisualizer.ConfirmInitialized())
+            {
+                // The motion controller visualizer singleton is likely not present in the scene.
+                return;
+            }
+
             // Look if the controller has loaded.
             if (MotionControllerVisualizer.Instance.TryGetControllerModel(handedness, out ControllerInfo))
             {

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -44,7 +44,7 @@ namespace HoloToolkit.Unity.InputModule
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             if (!MotionControllerVisualizer.ConfirmInitialized())
             {
-                // The motion controller visualizer singleton is likely not present in the scene.
+                // The motion controller visualizer singleton could not be found.
                 return;
             }
 


### PR DESCRIPTION
Overview
---
Eliminates NullReferenceException when using the Solver System if the MotionControllers prefab is not in the scene (typically attached to the camera)


Changes
---
- Adds ConfirmInitialized() to Singleton<T> (back-port from Dev_Working_Branch)
- Checks that the MotionControllerVisualizer has been initialized in ControllerFinder.OnEnable()

- Fixes: #2053.