### PR TITLE
SimpleSinglePointerSelector: connect pointer upon OnSourceDetected

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -72,7 +72,11 @@ namespace HoloToolkit.Unity.InputModule
 
         void ISourceStateHandler.OnSourceDetected(SourceStateEventData eventData)
         {
-            // Nothing to do on source detected.
+            // If a pointing controller just became available, set it as primary.
+            if (SupportsPointingRay(eventData))
+            {
+                ConnectBestAvailablePointer();
+            }
         }
 
         void ISourceStateHandler.OnSourceLost(SourceStateEventData eventData)


### PR DESCRIPTION
Overview
---
Behaviour of `SimpleSinglePointerSelector` is now to set an activated pointing controller to be primary controller.

Changes
---
- Addresses: #2066  .
