### PR TITLE
[May18] Fixes SolverBodyLock potential null ref

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs
@@ -1,16 +1,13 @@
-//
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
+
 using UnityEngine;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace HoloToolkit.Unity
 {
     /// <summary>
     /// SolverBodyLock provides a solver that follows the TrackedObject/TargetTransform. Adjusting "LerpTime"
-    /// properties changes how quickly the object moves to the TracketObject/TargetTransform's position.
+    /// properties changes how quickly the object moves to the TrackedObject/TargetTransform's position.
     /// </summary>
     public class SolverBodyLock : Solver
     {
@@ -28,7 +25,6 @@ namespace HoloToolkit.Unity
         }
         #endregion
 
-
         #region public members
         [Tooltip("The desired orientation of this object. Default sets the object to face the TrackedObject/TargetTransform. CameraFacing sets the object to always face the user.")]
         public OrientationReference Orientation = OrientationReference.Default;
@@ -36,14 +32,13 @@ namespace HoloToolkit.Unity
         public Vector3 offset;
         [Tooltip("RotationTether snaps the object to be in front of TrackedObject regardless of the object's local rotation.")]
         public bool RotationTether = false;
-        [Tooltip("TetherAngleSteps is the divison of steps this object can tether to. Higher the number, the more snapple steps.")]
+        [Tooltip("TetherAngleSteps is the division of steps this object can tether to. Higher the number, the more snapple steps.")]
         [Range(4, 12)]
         public int TetherAngleSteps = 6;
         #endregion
 
         public override void SolverUpdate()
         {
-            Vector3 desiredPos = base.solverHandler.TransformTarget != null ? base.solverHandler.TransformTarget.position + offset : Vector3.zero;
             Quaternion desiredRot = Quaternion.identity;
 
             if (RotationTether)
@@ -62,10 +57,10 @@ namespace HoloToolkit.Unity
                 desiredRot = Quaternion.Euler(0f, tetherYRotation, 0f);
             }
 
-            desiredPos = solverHandler.TransformTarget.position + (desiredRot * offset);
+            Vector3 desiredPos = solverHandler.TransformTarget != null ? solverHandler.TransformTarget.position + (desiredRot * offset) : Vector3.zero;
 
-            this.GoalPosition = desiredPos;
-            this.GoalRotation = desiredRot;
+            GoalPosition = desiredPos;
+            GoalRotation = desiredRot;
 
             UpdateWorkingPosToGoal();
             UpdateWorkingRotToGoal();


### PR DESCRIPTION
Overview
---
If the tracked object isn't present, [line 65](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/master/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs#L65) null refs when trying to access transformTarget.

![image](https://user-images.githubusercontent.com/3580640/39894547-12a60fac-545c-11e8-94bf-acef382e4fdd.png)

Dev branch PR is #2079

Changes
---
- Fixes: #2073
