### PR TITLE
[Dev] Fixes SolverBodyLock potential null ref

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs
@@ -8,7 +8,7 @@ namespace MixedRealityToolkit.Utilities.Solvers
 {
     /// <summary>
     /// SolverBodyLock provides a solver that follows the TrackedObject/TargetTransform. Adjusting "LerpTime"
-    /// properties changes how quickly the object moves to the TracketObject/TargetTransform's position.
+    /// properties changes how quickly the object moves to the TrackedObject/TargetTransform's position.
     /// </summary>
     public class SolverBodyLock : Solver
     {
@@ -26,7 +26,6 @@ namespace MixedRealityToolkit.Utilities.Solvers
         }
         #endregion
 
-
         #region public members
         [Tooltip("The desired orientation of this object. Default sets the object to face the TrackedObject/TargetTransform. CameraFacing sets the object to always face the user.")]
         public OrientationReference Orientation = OrientationReference.Default;
@@ -34,14 +33,13 @@ namespace MixedRealityToolkit.Utilities.Solvers
         public Vector3 offset;
         [Tooltip("RotationTether snaps the object to be in front of TrackedObject regardless of the object's local rotation.")]
         public bool RotationTether = false;
-        [Tooltip("TetherAngleSteps is the divison of steps this object can tether to. Higher the number, the more snapple steps.")]
+        [Tooltip("TetherAngleSteps is the division of steps this object can tether to. Higher the number, the more snapple steps.")]
         [Range(4, 12)]
         public int TetherAngleSteps = 6;
         #endregion
 
         public override void SolverUpdate()
         {
-            Vector3 desiredPos = base.solverHandler.TransformTarget != null ? base.solverHandler.TransformTarget.position + offset : Vector3.zero;
             Quaternion desiredRot = Quaternion.identity;
 
             if (RotationTether)
@@ -60,10 +58,10 @@ namespace MixedRealityToolkit.Utilities.Solvers
                 desiredRot = Quaternion.Euler(0f, tetherYRotation, 0f);
             }
 
-            desiredPos = solverHandler.TransformTarget.position + (desiredRot * offset);
+            Vector3 desiredPos = solverHandler.TransformTarget != null ? solverHandler.TransformTarget.position + (desiredRot * offset) : Vector3.zero;
 
-            this.GoalPosition = desiredPos;
-            this.GoalRotation = desiredRot;
+            GoalPosition = desiredPos;
+            GoalRotation = desiredRot;
 
             UpdateWorkingPosToGoal();
             UpdateWorkingRotToGoal();


### PR DESCRIPTION
Overview
---
If the tracked object isn't present, [line 65](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/master/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs#L65) null refs when trying to access transformTarget.

![image](https://user-images.githubusercontent.com/3580640/39894547-12a60fac-545c-11e8-94bf-acef382e4fdd.png)

#2078 for the dev branch.

Changes
---
- Fixes: #2073
