### PR TITLE
fix backspace not clearing the last character in the field

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/KeyboardInputField.cs
+++ b/Assets/HoloToolkit/UX/Scripts/KeyboardInputField.cs
@@ -57,10 +57,7 @@ namespace HoloToolkit.UI.Keyboard
         /// <param name="newText"></param>
         private void Keyboard_OnTextUpdated(string newText)
         {
-            if (!string.IsNullOrEmpty(newText))
-            {
-                text = newText;
-            }
+            text = newText;
         }
 
         /// <summary>


### PR DESCRIPTION
Directly set the text value to what is provided in the newText argument of Keyboard_OnTextUpdated.

The previous (broken) implementation failed to set the text value if newText was null or the empty string

- Fixes: #917, #1169, #1927, #1979