### PR TITLE
[May18] Set KeyboardAtlas as default

### DIFF
--- a/Assets/HoloToolkit/UX/Textures/KeyboardAtlas.spriteatlas
+++ b/Assets/HoloToolkit/UX/Textures/KeyboardAtlas.spriteatlas
@@ -35,7 +35,7 @@ SpriteAtlas:
     - {fileID: 21300000, guid: ec8b4073237c9724ba8422f71fda3694, type: 3}
     - {fileID: 21300000, guid: 11e4524f21fc6434abbbba83d70d0040, type: 3}
     - {fileID: 21300000, guid: 73830216a21a45e499598b2624ef723e, type: 3}
-    bindAsDefault: 0
+    bindAsDefault: 1
   m_MasterAtlas: {fileID: 0}
   m_PackedSprites:
   - {fileID: 21300000, guid: 73830216a21a45e499598b2624ef723e, type: 3}


### PR DESCRIPTION
Overview
---
Without this, symbols dependent on the spriteatlas don't load:
![image](https://user-images.githubusercontent.com/3580640/40208945-5537beb6-59f1-11e8-9249-f64454a9ad7a.png)

After:
![image](https://user-images.githubusercontent.com/3580640/40208970-81c08f12-59f1-11e8-9f38-75940acaa4f3.png)

The atlas was un-defaulted in https://github.com/Microsoft/MixedRealityToolkit-Unity/commit/0033c67f59ca6b5703c892258354c977f2c7ee98.

Pair PR to #2121.

Changes
---
- Fixes: #1852
