### PR TITLE
[Dev] Set KeyboardAtlas as default 

### DIFF
--- a/Assets/MixedRealityToolkit/UX/README_TextPrefab.md.meta
+++ b/Assets/MixedRealityToolkit/UX/README_TextPrefab.md.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 630f0b838bb5d3448bb07453da997f86
+timeCreated: 1526599032
+licenseType: Pro
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/UX/Textures/KeyboardAtlas.spriteatlas
+++ b/Assets/MixedRealityToolkit/UX/Textures/KeyboardAtlas.spriteatlas
@@ -35,7 +35,7 @@ SpriteAtlas:
     - {fileID: 21300000, guid: ec8b4073237c9724ba8422f71fda3694, type: 3}
     - {fileID: 21300000, guid: 11e4524f21fc6434abbbba83d70d0040, type: 3}
     - {fileID: 21300000, guid: 73830216a21a45e499598b2624ef723e, type: 3}
-    bindAsDefault: 0
+    bindAsDefault: 1
   m_MasterAtlas: {fileID: 0}
   m_PackedSprites:
   - {fileID: 21300000, guid: 73830216a21a45e499598b2624ef723e, type: 3}


### PR DESCRIPTION
Overview
---
Without this, symbols dependent on the spriteatlas don't load:
![image](https://user-images.githubusercontent.com/3580640/40208945-5537beb6-59f1-11e8-9249-f64454a9ad7a.png)

After:
![image](https://user-images.githubusercontent.com/3580640/40208970-81c08f12-59f1-11e8-9f38-75940acaa4f3.png)

The atlas was un-defaulted in https://github.com/Microsoft/MixedRealityToolkit-Unity/commit/0033c67f59ca6b5703c892258354c977f2c7ee98.

Pair PR to #2120.

Changes
---
- Related to: #1852

This PR also addresses https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/2029#discussion_r189128675