### PR TITLE
Fix to allow in-Editor hands to properly support and report a 'grip' position

### DIFF
--- a/Assets/HoloToolkit/Input/Prefabs/LeftHandInputControl.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/LeftHandInputControl.prefab
@@ -201,6 +201,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -216,6 +217,7 @@ MeshRenderer:
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -326,6 +328,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SupportsPosition: 1
   SupportsRotation: 0
+  SupportsGripPosition: 1
+  SupportsGripRotation: 0
   SupportsRay: 0
   SupportsMenuButton: 0
   SupportsGrasp: 0
@@ -333,6 +337,8 @@ MonoBehaviour:
   SourceKind: 1
   ControllerPosition: {x: 0, y: 0, z: 0}
   ControllerRotation: {x: 0, y: 0, z: 0, w: 0}
+  ControllerGripPosition: {x: 0, y: 0, z: 0}
+  ControllerGripRotation: {x: 0, y: 0, z: 0, w: 0}
   currentButtonStates:
     IsSelectButtonDown: 0
     SelectButtonStateChanged: 0
@@ -344,6 +350,7 @@ MonoBehaviour:
     ManipulationInProgress: 0
     HoldInProgress: 0
     CumulativeDelta: {x: 0, y: 0, z: 0}
+    CumulativeGripDelta: {x: 0, y: 0, z: 0}
   manipulationStartMovementThreshold: 0.03
 --- !u!114 &114832010102587794
 MonoBehaviour:

--- a/Assets/HoloToolkit/Input/Prefabs/RightHandInputControl.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/RightHandInputControl.prefab
@@ -201,6 +201,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -216,6 +217,7 @@ MeshRenderer:
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -318,6 +320,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SupportsPosition: 1
   SupportsRotation: 0
+  SupportsGripPosition: 1
+  SupportsGripRotation: 0
   SupportsRay: 0
   SupportsMenuButton: 0
   SupportsGrasp: 0
@@ -325,6 +329,8 @@ MonoBehaviour:
   SourceKind: 1
   ControllerPosition: {x: 0, y: 0, z: 0}
   ControllerRotation: {x: 0, y: 0, z: 0, w: 0}
+  ControllerGripPosition: {x: 0, y: 0, z: 0}
+  ControllerGripRotation: {x: 0, y: 0, z: 0, w: 0}
   currentButtonStates:
     IsSelectButtonDown: 0
     SelectButtonStateChanged: 0
@@ -336,6 +342,7 @@ MonoBehaviour:
     ManipulationInProgress: 0
     HoldInProgress: 0
     CumulativeDelta: {x: 0, y: 0, z: 0}
+    CumulativeGripDelta: {x: 0, y: 0, z: 0}
   manipulationStartMovementThreshold: 0.03
 --- !u!114 &114983783085117614
 MonoBehaviour:

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/CustomInputControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/CustomInputControl.cs
@@ -78,6 +78,10 @@ namespace HoloToolkit.Unity.InputModule
             InitialPosition = localPosition;
             ControllerSourceState.SourcePose.Position = localPosition;
             ControllerSourceState.SourcePose.Rotation = ControllerVisualizer.transform.rotation;
+            // we reuse localPosition here as we have no real way to source a grip position
+            // in the Editor, other than an arbitrary offset
+            ControllerSourceState.SourcePose.GripPosition = localPosition;
+            ControllerSourceState.SourcePose.GripRotation = ControllerVisualizer.transform.rotation;
 
             visualRenderer = ControllerVisualizer.GetComponent<Renderer>();
             visualPropertyBlock = new MaterialPropertyBlock();
@@ -170,6 +174,7 @@ namespace HoloToolkit.Unity.InputModule
 
             localPosition += translate;
             ControllerSourceState.SourcePose.Position = CameraCache.Main.transform.position + CameraCache.Main.transform.TransformVector(localPosition);
+            ControllerSourceState.SourcePose.GripPosition = CameraCache.Main.transform.position + CameraCache.Main.transform.TransformVector(localPosition);
 
             ControllerVisualizer.transform.position = ControllerSourceState.SourcePose.Position;
             ControllerVisualizer.transform.forward = CameraCache.Main.transform.forward;


### PR DESCRIPTION
Overview
---
Fixes an issue introduced #1870 (& #2050 ) whereby the in-Editor hands no longer report their position, if data is requested through `TryGetGripPosition`

Changes
---
- Fixes: #2131  .
