### PR TITLE
eliminate .net native pinvoke warnings

### DIFF
--- a/Assets/HoloToolkit/SpectatorView/Scripts/SpatialSync/MarkerDetector.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/SpatialSync/MarkerDetector.cs
@@ -13,22 +13,22 @@ namespace HoloToolkit.Unity.SpectatorView
     /// </summary>
     public class MarkerDetector
     {
-        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_Initialize")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_Initialize", ExactSpelling=true)]
         internal static extern void InitalizeMarkerDetector();
 
-        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_Terminate")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_Terminate", ExactSpelling=true)]
         internal static extern void TerminateMarkerDetector();
 
-        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_DetectMarkers")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_DetectMarkers", ExactSpelling=true)]
         internal static extern bool DetectMarkers(int _imageWidth, int _imageHeight, IntPtr _imageDate, float _markerSize);
 
-        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_GetNumMarkersDetected")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_GetNumMarkersDetected", ExactSpelling=true)]
         internal static extern bool GetNumMarkersDetected(out int _numMarkersDetected);
 
-        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_GetDetectedMarkerIds")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_GetDetectedMarkerIds", ExactSpelling=true)]
         internal static extern bool GetDetectedMarkerIds(IntPtr _detectedMarkers);
 
-        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_GetDetectedMarkerPose")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="MarkerDetector_GetDetectedMarkerPose", ExactSpelling=true)]
         internal static extern bool GetDetectedMarkerPose(int _markerId, out float _xPos, out float _yPos, out float _zPos, out float _xRot, out float _yRot, out float _zRot);
 
         /// <summary>

--- a/Assets/HoloToolkit/SpectatorView/Scripts/Utilities/OpenCVUtils.cs
+++ b/Assets/HoloToolkit/SpectatorView/Scripts/Utilities/OpenCVUtils.cs
@@ -14,7 +14,7 @@ namespace HoloToolkit.Unity.SpectatorView
         /// <summary>
         /// Utility function to ensure the OpenCVWrapper has been successfully loaded
         /// </summary>
-        [DllImport("SpectatorViewPlugin", EntryPoint = "CheckLibraryHasLoaded")]
+        [DllImport("SpectatorViewPlugin", EntryPoint="CheckLibraryHasLoaded", ExactSpelling=true)]
         public static extern void CheckOpenCVWrapperHasLoaded();
     }
 }


### PR DESCRIPTION
Overview
---
The SpectatorView feature references, but does not ship a companion dll (it must be built from https://github.com/microsoft/mixedrealitytoolkit and added to the project by the app developer). As a result, the .net native compiler (used for master builds) cannot resolve the pinvokes and reports warnings.

Changes
---
Tell the .net native compiler that it can trust the pinvoke calls by setting ExactSpelling=true in the DllImport attribute.

- Fixes: #2126
