### PR TITLE
Fix for choosing closest grabbable object to grab

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/MotionControllers-GrabMechanics/Scripts/BaseGrabber.cs
+++ b/Assets/MixedRealityToolkit-Examples/MotionControllers-GrabMechanics/Scripts/BaseGrabber.cs
@@ -185,7 +185,7 @@ namespace MixedRealityToolkit.Examples.Grabbables
         {
             contactObjects.Sort(delegate (BaseGrabbable b1, BaseGrabbable b2)
             {
-                return Vector3.Distance(b1.GrabPoint, GrabHandle.position).CompareTo(Vector3.Distance(b1.GrabPoint, GrabHandle.position));
+                return Vector3.Distance(b1.GrabPoint, GrabHandle.position).CompareTo(Vector3.Distance(b2.GrabPoint, GrabHandle.position));
             });
         }
 


### PR DESCRIPTION
Sort method was comparing distance of first object to itself, rather than second object.

Let me know if I need to sign a contribution licence agreement.