### PR TITLE
Fix for dragging of rotation handles of BoundBoxRig

### DIFF
--- a/Assets/MixedRealityToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
+++ b/Assets/MixedRealityToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
@@ -55,6 +55,7 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
         private float maxScale = 10.0f;
         private RotationType rotationCoordinateSystem;
         private HandMotionType handMotionForRotation;
+        private Vector3 lastHandWorldPos = Vector3.zero;
 
         public TransformType AffineType
         {
@@ -160,6 +161,7 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
                 rig = value;
             }
         }
+        public bool RotateAroundPivot { get; set; }
 
         private void Start()
         {
@@ -203,6 +205,8 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
                         ApplyRotation(currentHandPosition);
                     }
                 }
+
+                lastHandWorldPos = currentHandPosition;
             }
         }
 
@@ -283,6 +287,14 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
         }
         private void ApplyRotation(Vector3 currentHandPosition)
         {
+            if (RotateAroundPivot)
+                ApplyRotationPivot(currentHandPosition);
+            else
+                ApplyRotationContinuous(currentHandPosition);
+        }
+
+        private void ApplyRotationContinuous(Vector3 currentHandPosition)
+        {
             Vector3 initialRay = initialHandPosition - transformToAffect.position;
             initialRay.Normalize();
 
@@ -323,6 +335,32 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
                 transformToAffect.Rotate(axis, angle * 2.0f);
             }
         }
+        
+        private void ApplyRotationPivot(Vector3 currentHandPosition)
+        {
+            Vector3 delta = currentHandPosition - lastHandWorldPos;
+
+            if (delta.sqrMagnitude == 0)
+                return;
+
+            delta.Scale(rotationFromPositionScale);
+
+            var pivotToHandleDir = (transform.position - transformToAffect.position).normalized;
+            switch (Axis)
+            {
+                default:
+                case BoundingBoxGizmoHandle.AxisToAffect.X:
+                    transformToAffect.Rotate(Vector3.right, Vector3.Dot(delta, Vector3.Cross(pivotToHandleDir, transformToAffect.right)), Space.Self);
+                    break;
+                case BoundingBoxGizmoHandle.AxisToAffect.Y:
+                    transformToAffect.Rotate(Vector3.up, Vector3.Dot(delta, Vector3.Cross(pivotToHandleDir, transformToAffect.up)), Space.Self);
+                    break;
+                case BoundingBoxGizmoHandle.AxisToAffect.Z:
+                    transformToAffect.Rotate(Vector3.forward, Vector3.Dot(delta, Vector3.Cross(pivotToHandleDir, transformToAffect.forward)), Space.Self);
+                    break;
+            }
+        }
+
         private Vector3 GetBoundedScaleChange(Vector3 scale)
         {
             Vector3 maximumScale = new Vector3(initialScale.x * maxScale, initialScale.y * maxScale, initialScale.z * maxScale);
@@ -360,6 +398,7 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
             inputDownEventData = eventData;
 
             initialHandPosition     = GetHandPosition(eventData.SourceId);
+            lastHandWorldPos        = initialHandPosition;
             initialScale            = transformToAffect.localScale;
             initialPosition         = transformToAffect.position;
             initialOrientation      = transformToAffect.rotation.eulerAngles;

--- a/Assets/MixedRealityToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
+++ b/Assets/MixedRealityToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
@@ -39,6 +39,9 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
         [SerializeField]
         private BoundingBoxGizmoHandle.HandMotionType handMotionToRotate = BoundingBoxGizmoHandle.HandMotionType.handRotatesToRotateObject;
 
+        [SerializeField]
+        private bool rotateAroundPivot = false;
+
         [Header("Preset Components")]
         [SerializeField]
         [Tooltip("To visualize the object bounding box, drop the MixedRealityToolkit/UX/Prefabs/BoundingBoxes/BoundingBoxBasic.prefab here.")]
@@ -298,6 +301,7 @@ namespace MixedRealityToolkit.UX.BoundingBoxes
                     rotateHandles[i].transform.localScale = rotateHandleSize;
                     rotateHandles[i].name = "Middle " + i.ToString();
                     rigRotateGizmoHandles[i] = rotateHandles[i].AddComponent<BoundingBoxGizmoHandle>();
+                    rigRotateGizmoHandles[i].RotateAroundPivot = rotateAroundPivot;
                     rigRotateGizmoHandles[i].Rig = this;
                     rigRotateGizmoHandles[i].HandMotionForRotation = handMotionToRotate;
                     rigRotateGizmoHandles[i].RotationCoordinateSystem = rotationType;


### PR DESCRIPTION
Current method of rotation is not consistent; the object is rotated different directions
depending on orientation of object.

This commit adds an option (rotateAroundPivot) which allows the user to rotate an object in a more natural way.

To avoid breaking existing usage, this new rotation is enabled via a bool in BoundingBoxRig.

Existing behaviour:
![boundingboxgizmoold](https://user-images.githubusercontent.com/4314853/40498945-6573e890-5f78-11e8-9268-0dd08701ffd2.gif)

New behaviour:
![boundingboxgizmonew](https://user-images.githubusercontent.com/4314853/40498949-68375396-5f78-11e8-82d1-36e322d07808.gif)
