### PR TITLE
[May18] Disable keyboard for the MRTK keyboard's inputfield

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Keyboard.cs
@@ -251,6 +251,8 @@ namespace HoloToolkit.UI.Keyboard
                 }
             }
 
+            InputField.keyboardType = (TouchScreenKeyboardType)(-1);
+
             // Keep keyboard deactivated until needed
             gameObject.SetActive(false);
         }

--- a/Assets/HoloToolkit/UX/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Keyboard.cs
@@ -251,6 +251,8 @@ namespace HoloToolkit.UI.Keyboard
                 }
             }
 
+            // Setting the keyboardType to an undefined TouchScreenKeyboardType,
+            // which prevents the MRTK keyboard from triggering the system keyboard itself.
             InputField.keyboardType = (TouchScreenKeyboardType)(-1);
 
             // Keep keyboard deactivated until needed


### PR DESCRIPTION
Overview
---
This sets the slider input field in the MRTK keyboard to have a keyboardType that isn't defined, which prevents a keyboard from popping up.

This PR does not address the situation where both the MRTK and the system keyboard pop up on other input fields. This only addresses the situation where the MRTK keyboard triggers the system keyboard itself.

Changes
---
- Fixes: #1940
