### PR TITLE
[May18] Updating pointing rays to extend out to the pointing extent off holograms

### DIFF
--- a/Assets/HoloToolkit/Input/Prefabs/LinearControllerPointer.prefab
+++ b/Assets/HoloToolkit/Input/Prefabs/LinearControllerPointer.prefab
@@ -62,7 +62,6 @@ MonoBehaviour:
   ScaleOffset: {x: 1, y: 1, z: 1}
   SetScaleOnAttach: 0
   CurrentPointerOrientation: 0
-  extentOverride: 2
   RaycastOrigin: {fileID: 0}
   LineColorSelected:
     serializedVersion: 2

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -25,13 +25,18 @@ namespace HoloToolkit.Unity.InputModule
             get { return pointer; }
             set
             {
+                // This value is used to determine the cursor's default distance.
+                // It is cached here to prevent repeated casting in the update loop.
                 pointerIsInputSourcePointer = value is InputSourcePointer;
                 pointer = value;
             }
         }
-
         private IPointingSource pointer;
 
+        /// <summary>
+        /// Cached value if the pointer is of type InputSourcePointer,
+        /// to prevent repeated casting in the update loop.
+        /// </summary>
         private bool pointerIsInputSourcePointer = false;
 
         /// <summary>
@@ -122,6 +127,10 @@ namespace HoloToolkit.Unity.InputModule
         private Vector3 targetScale;
         private Quaternion targetRotation;
 
+        /// <summary>
+        /// Keeps track of the starting setting for DefaultCursorDistance,
+        /// to revert after a pointer overrides the value.
+        /// </summary>
         private float originalDefaultCursorDistance;
 
         /// <summary>

--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -129,7 +129,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (PointerRay != null)
             {
-                PointerRay.UpdateRenderedLine(rays, Result, selectPressed);
+                PointerRay.UpdateRenderedLine(rays, Result, selectPressed, FocusManager.Instance.GetPointingExtent(this));
             }
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -305,16 +305,19 @@ namespace HoloToolkit.Unity.InputModule
 
             InteractionInputSource interactionInputSource = inputSource as InteractionInputSource;
 
+            // If the InputSource is not an InteractionInputSource, we don't display any ray visualizations.
             if (interactionInputSource == null)
             {
                 return;
             }
 
+            // If no pointing ray prefab has been provided, we return early as there's nothing to display.
             if (linePointerPrefab == null)
             {
                 return;
             }
 
+            // If the pointer line hasn't already been instantiated, create it and store it here.
             if (instantiatedPointerLine == null)
             {
                 instantiatedPointerLine = Instantiate(linePointerPrefab).GetComponent<PointerLine>();
@@ -326,6 +329,7 @@ namespace HoloToolkit.Unity.InputModule
             if (interactionInputSource.TryGetHandedness(sourceId, out handedness))
             {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
+                // This updates the handedness of the pointer line, allowing for re-use if it was already in the scene.
                 instantiatedPointerLine.ChangeHandedness((InteractionSourceHandedness)handedness);
 #endif
             }

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -30,14 +30,14 @@ namespace HoloToolkit.Unity.InputModule
         private bool searchForCursorIfUnset = true;
         public bool SearchForCursorIfUnset { get { return searchForCursorIfUnset; } set { searchForCursorIfUnset = value; } }
 
-        [Tooltip("If true, always select the best pointer available (OS behaviour does not autoselect).")]
+        [Tooltip("If true, always select the best pointer available (OS behavior does not auto-select).")]
         [SerializeField]
         private bool autoselectBestAvailable = false;
         public bool AutoselectBestAvailable { get { return autoselectBestAvailable; } set { autoselectBestAvailable = value; } }
 
         [Tooltip("The line pointer prefab to use, if any.")]
         [SerializeField]
-        private GameObject linePointerPrefab;
+        private GameObject linePointerPrefab = null;
 
         private PointerLine instantiatedPointerLine;
 

--- a/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/SimpleSinglePointerSelector.cs
@@ -39,6 +39,8 @@ namespace HoloToolkit.Unity.InputModule
         [SerializeField]
         private GameObject linePointerPrefab;
 
+        private PointerLine instantiatedPointerLine;
+
         #endregion
 
         #region Data
@@ -301,30 +303,39 @@ namespace HoloToolkit.Unity.InputModule
             inputSourcePointer.ExtentOverride = null;
             inputSourcePointer.PrioritizedLayerMasksOverride = null;
 
-            if (inputSourcePointer.PointerRay != null)
+            InteractionInputSource interactionInputSource = inputSource as InteractionInputSource;
+
+            if (interactionInputSource == null)
             {
-                Destroy(inputSourcePointer.PointerRay.gameObject);
+                return;
             }
 
-            if (inputSource is InteractionInputSource && linePointerPrefab != null)
+            if (linePointerPrefab == null)
             {
-                inputSourcePointer.PointerRay = Instantiate(linePointerPrefab).GetComponent<PointerLine>();
-                inputSourcePointer.PointerRay.ExtentOverride = Cursor.DefaultCursorDistance;
-                Handedness handedness;
-                if (((InteractionInputSource)inputSource).TryGetHandedness(sourceId, out handedness))
-                {
+                return;
+            }
+
+            if (instantiatedPointerLine == null)
+            {
+                instantiatedPointerLine = Instantiate(linePointerPrefab).GetComponent<PointerLine>();
+            }
+
+            inputSourcePointer.PointerRay = instantiatedPointerLine;
+
+            Handedness handedness;
+            if (interactionInputSource.TryGetHandedness(sourceId, out handedness))
+            {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
-                    inputSourcePointer.PointerRay.Handedness = (InteractionSourceHandedness)handedness;
+                instantiatedPointerLine.ChangeHandedness((InteractionSourceHandedness)handedness);
 #endif
-                }
             }
         }
 
         private void DetachInputSourcePointer()
         {
-            if (inputSourcePointer.PointerRay != null)
+            if (instantiatedPointerLine != null)
             {
-                Destroy(inputSourcePointer.PointerRay.gameObject);
+                Destroy(instantiatedPointerLine.gameObject);
             }
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/BaseControllerPointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/BaseControllerPointer.cs
@@ -11,18 +11,8 @@ public abstract class BaseControllerPointer : AttachToController
     protected float CurrentPointerOrientation;
 
     [SerializeField]
-    [Range(0.5f, 50f)]
-    private float extentOverride = 2f;
-
-    [SerializeField]
     [Tooltip("Source transform for raycast origin - leave null to use default transform")]
     protected Transform RaycastOrigin;
-
-    public float? ExtentOverride
-    {
-        get { return extentOverride; }
-        set { extentOverride = value ?? FocusManager.Instance.GlobalPointingExtent; }
-    }
 
     /// <summary>
     /// The Y orientation of the pointer target - used for touchpad rotation and navigation

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -90,6 +90,10 @@ namespace HoloToolkit.Unity.InputModule
 #endif
         }
 
+        /// <summary>
+        /// Allows the object to change which controller it tracks, based on handedness.
+        /// </summary>
+        /// <param name="newHandedness">The new handedness to track. Does nothing if the handedness doesn't change.</param>
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
         public void ChangeHandedness(InteractionSourceHandedness newHandedness)
         {

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -90,6 +90,18 @@ namespace HoloToolkit.Unity.InputModule
 #endif
         }
 
+#if UNITY_WSA && UNITY_2017_2_OR_NEWER
+        public void ChangeHandedness(InteractionSourceHandedness newHandedness)
+        {
+            if (newHandedness != handedness)
+            {
+                RemoveControllerTransform(ControllerInfo);
+                handedness = newHandedness;
+                CheckModelAlreadyLoaded();
+            }
+        }
+#endif
+
         protected virtual void AddControllerTransform(MotionControllerInfo newController)
         {
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/PointerLine.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/PointerLine.cs
@@ -67,7 +67,7 @@ namespace HoloToolkit.Unity.InputModule
             LineBase.enabled = false;
         }
 
-        public void UpdateRenderedLine(RayStep[] lines, PointerResult result, bool selectPressed)
+        public void UpdateRenderedLine(RayStep[] lines, PointerResult result, bool selectPressed, float extent)
         {
             if (LineBase == null) { return; }
 
@@ -85,7 +85,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
                 else
                 {
-                    LineBase.LastPoint = RayStep.GetPointByDistance(lines, ExtentOverride.Value);
+                    LineBase.LastPoint = RayStep.GetPointByDistance(lines, extent);
                 }
 
                 if (selectPressed)


### PR DESCRIPTION
Overview
---
This PR updates the pointing ray visualization to extend out the full length of the pointer's pointing extent (or the FocusManager's default, if no override is specified), instead of the previous cursor default.

This is implemented in a way to preserve the default behavior of the Gaze cursor being placed at 2m, which is closer than the default pointing extent.

Changes
---
- Fixes: #2166.