### PR TITLE
Fix: gaze cursor appears 0.1m BEFORE a UI element 

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -638,7 +638,7 @@ namespace HoloToolkit.Unity.InputModule
             {
                 newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
                 newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;
-                newUiRaycastPosition.z = uiRaycastResult.distance;
+                newUiRaycastPosition.z = uiRaycastResult.distance + 0.1f;
 
                 Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
 


### PR DESCRIPTION
Issue: gaze cursor appears 0.1m BEFORE a UI element (for instance, the keyboard) in stead of on it

Fix: add 0.1m to z in FocusManager.RaycastUnityUI
