### PR TITLE
[Cursor] Properly track sources that were detected before registering as a global listener

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -204,6 +204,10 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         protected virtual void RegisterManagers()
         {
+            // This accounts for any input sources that were detected before we register as a global listener below.
+            visibleHandsCount = (uint)InputManager.Instance.DetectedInputSources.Count;
+            IsHandVisible = visibleHandsCount > 0;
+
             // Register the cursor as a global listener, so that it can always get input events it cares about
             InputManager.Instance.AddGlobalListener(gameObject);
 


### PR DESCRIPTION
Overview
---
This bug wouldn't repro in the Editor or when launching from VS. It was only present when the app was built and launched by a user with controllers already connected.

If a controller is already connected, the Cursor would never get a `SourceDetected`, as it didn't register as a global listener on the InputManager until `Start()`, and the `SourceDetected` events had already fired at that point. Now, right before registering as a global listener, the `visibleHandsCount` and `IsHandVisible` values are properly set with any sources we already missed.