### PR TITLE
Fixed a bug where solvers would try to attach to the right hand before it was ready

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/Solver.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/Solver.cs
@@ -125,7 +125,7 @@ namespace HoloToolkit.Unity
                     case SolverHandler.TrackedObjectToReferenceEnum.MotionControllerRight:
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
                         solverHandler.Handedness = InteractionSourceHandedness.Right;
-                        while (solverHandler.ElementTransform != null)
+                        while (solverHandler.ElementTransform == null)
                         {
                             yield return null;
                         }


### PR DESCRIPTION
Overview
---
Just switches a != null to a == null so it yields whenever the element transform doesn't exist, rather than yielding when it does.

