### PR TITLE
Eliminated unnecessary check that resulted in bad behavior at short distances

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverRadialView.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverRadialView.cs
@@ -179,7 +179,6 @@ namespace HoloToolkit.Unity
             Vector3 elementDelta = elementPoint - refPoint;
             float elementDist = elementDelta.magnitude;
             Vector3 elementDir = elementDist > 0 ? elementDelta / elementDist : Vector3.one;
-            float flip = Vector3.Dot(elementDelta, refDir);
 
             // Generate basis: First get axis perp to refDir pointing toward element
             Vector3 elementDirPerp = (elementDir - refDir);
@@ -198,11 +197,7 @@ namespace HoloToolkit.Unity
             float clampedDistance = IgnoreDistanceClamp ? elementDist : Mathf.Clamp(elementDist, MinDistance, MaxDistance);
 
             // If the angle was clamped, do some special update stuff
-            if (flip < 0)
-            {
-                desiredPos = refPoint + refDir;
-            }
-            else if (angDegree != angDegreeClamped)
+            if (angDegree != angDegreeClamped)
             {
                 float angRad = angDegreeClamped * Mathf.Deg2Rad;
 


### PR DESCRIPTION
Overview
---
Removed the flip check which caused a temporary gimble lock when the solver was used in small numbers < .01.

Works as expected now.


Changes
---
- Fixes: 1
SolverRadialView.cs
