### PR TITLE
Fixing building for Standalone

### DIFF
--- a/Assets/HoloToolkit-Preview/SpectatorView/Scripts/Utilities/ARMarkerController.cs
+++ b/Assets/HoloToolkit-Preview/SpectatorView/Scripts/Utilities/ARMarkerController.cs
@@ -87,7 +87,9 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
         /// </summary>
         public void OnCodeFound()
         {
+#if UNITY_IOS
             Handheld.Vibrate();
+#endif
             TurnOffMarker();
         }
 


### PR DESCRIPTION
Overview
---
The UnityEngine.Handheld class doesn't exist when building for Standalone (it probably doesn't exist in some number of other non-handheld platforms as well).

Since SV only supports iOS at the moment, I wrapped the call in `#if UNITY_IOS`.

Changes
---
- Fixes: #2225.
