### PR TITLE
Added the missing meta file and removing MonoBehaviour from BoundingBoxHelper

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/BoundingBoxHelper.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/BoundingBoxHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,7 +12,7 @@ using UnityEngine;
 /// The dynamic functions can be used to obtain boundingcube info on an object's Update loop. Operations
 /// are minimized in the dynamic use scenario.
 /// </summary>
-public class BoundingBoxHelper : MonoBehaviour
+public class BoundingBoxHelper
 {
     readonly int[] face0 = { 0, 1, 3, 2 };
     readonly int[] face1 = { 1, 5, 7, 3 };

--- a/Assets/HoloToolkit/Utilities/Scripts/BoundingBoxHelper.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/BoundingBoxHelper.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 791849c2205475040acd27e0d0ce981a
+timeCreated: 1527894238
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Overview
---
BoundingBoxHelper is [only used with the `new` keyword](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/june18_dev/Assets/HoloToolkit/UX/Scripts/AppBar/AppBar.cs#L249), which throws a Unity warning when called on MonoBehaviours.

![image](https://user-images.githubusercontent.com/3580640/40868278-31c99b90-65c0-11e8-8272-60972465ccdf.png)

Also, the meta file wasn't included. 
