### PR TITLE
Keyboard Fix for Missing Keys Bug

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/UICollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/UICollection.cs
@@ -65,6 +65,8 @@ namespace HoloToolkit.UI.Keyboard
             // Verify this is attached to a GameObject with a rect transform
             rectTransform = GetComponent<RectTransform>();
 
+            if (!Application.isEditor) { return; }
+
             // Collect children items already added (likely added in the Editor)
             CollectItems();
             UpdateLayout();
@@ -121,8 +123,7 @@ namespace HoloToolkit.UI.Keyboard
         }
 
         private void CollectItems()
-        {
-            if (!Application.isEditor) { return; }
+        { 
             Items.Clear();
 
             foreach (Transform childTransform in transform)
@@ -137,7 +138,6 @@ namespace HoloToolkit.UI.Keyboard
 
         protected virtual void UpdateLayout()
         {
-            if (!Application.isEditor) { return; }
             Rect rect = rectTransform.rect;
 
             Vector2 updatedSize = Vector2.zero;

--- a/Assets/HoloToolkit/UX/Scripts/UICollection.cs
+++ b/Assets/HoloToolkit/UX/Scripts/UICollection.cs
@@ -122,6 +122,7 @@ namespace HoloToolkit.UI.Keyboard
 
         private void CollectItems()
         {
+            if (!Application.isEditor) { return; }
             Items.Clear();
 
             foreach (Transform childTransform in transform)
@@ -136,6 +137,7 @@ namespace HoloToolkit.UI.Keyboard
 
         protected virtual void UpdateLayout()
         {
+            if (!Application.isEditor) { return; }
             Rect rect = rectTransform.rect;
 
             Vector2 updatedSize = Vector2.zero;


### PR DESCRIPTION

Overview

There was a bug with the keyboard (#1744) which causes the first button in each row to not appear or at least be positioned correctly.

Please note, the bug fixed by this Pull Request was deemed to be a Unity bug that has now been reported as fixed so perhaps this pull request can be ignored.

However, I am still leaving this code in my local respository for the slight performance improvement since the layouts never need to be updated at runtime.   Each keyboard layout is saved as a child gameObject so if you switch between layouts this code never needs to be called.  The only reason I can think of is if you try to customize the keyboard at runtime, but in that case you should just call update layout manually.  

Perhaps I am missing something? @keveleigh
 

Changes
Each of the layouts now only updates in the Editor.
 

- Fixes: # 
#1744 


