### PR TITLE
Fixed FinishStopRecording() error on non-Windows platform

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/InputSources/DictationInputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/DictationInputManager.cs
@@ -207,6 +207,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private IEnumerator FinishStopRecording()
         {
+#if UNITY_WSA || UNITY_STANDALONE_WIN
             while (dictationRecognizer.Status == SpeechSystemStatus.Running)
             {
                 yield return null;
@@ -214,6 +215,9 @@ namespace HoloToolkit.Unity.InputModule
 
             PhraseRecognitionSystem.Restart();
             isTransitioning = false;
+#else
+            return null;
+#endif
         }
 
         #region Dictation Recognizer Callbacks


### PR DESCRIPTION
Overview
---
FinishStopRecording() uses variables that are only declared in Unity Windows platforms without checking if it's in a Unity Windows platform itself. This fix simply adds this check, so that Unity will not throw errors on non-Windows computers for variables not existing in the scope.

Changes
---
- Adds checks for Unity Windows platform in FinishStopRecording() and simply returns null if not in a Unity Windows Platform.
