### PR TITLE
Remove InteractionMaping Get|SetValue<T> and update relevant tests

### DIFF
--- a/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
@@ -73,107 +73,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test03_TestObjectGenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = (object)1f;
-        //    var testValue2 = (object)false;
-
-        //    var initialValue = inputDef.GetValue<object>();
-
-        //    Assert.IsNull(initialValue);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<object>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<object>();
-
-        //    Assert.IsNotNull(setValue1);
-        //    Assert.AreEqual(setValue1, testValue1);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<object>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<object>();
-
-        //    Assert.IsNotNull(setValue2);
-        //    Assert.AreEqual(setValue2, testValue2);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test04_TestObjectGenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = (object)1f;
-
-        //    var initialValue = inputDef.GetValue<object>();
-
-        //    Assert.IsNull(initialValue);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<object>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<object>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        //[Test]
-        //public void Test05_TestObjectDirectVsGenericSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = (object)1f;
-        //    var testValue2 = (object)false;
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<object>(testValue);
-        //        inputDef.GetValue<object>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetRaw();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Object Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
-
         #endregion objects
 
         #region bools
 
         [Test]
-        public void Test06_TestBoolChanged()
+        public void Test03_TestBoolChanged()
         {
             var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
             var testValue1 = true;
@@ -206,7 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [Test]
-        public void Test07_TestBoolNoChange()
+        public void Test04_TestBoolNoChange()
         {
             var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = true;
@@ -228,108 +133,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test08_TestBoolGenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = true;
-        //    var testValue2 = false;
-
-        //    var initialValue = inputDef.GetValue<bool>();
-
-        //    Assert.IsFalse(initialValue);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<bool>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<bool>();
-
-        //    Assert.IsTrue(setValue1);
-        //    Assert.True(setValue1 == testValue1);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<bool>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<bool>();
-
-        //    Assert.IsFalse(setValue2);
-        //    Assert.True(setValue2 == testValue2);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test09_TestBoolGenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = true;
-
-        //    var initialValue = inputDef.GetValue<bool>();
-
-        //    Assert.IsFalse(initialValue);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<bool>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<bool>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test10_TestBoolDirectVsGenericSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = true;
-        //    var testValue2 = false;
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<bool>(testValue);
-        //        inputDef.GetValue<bool>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetBool();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Bool Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
-
         #endregion bools
 
         #region float
 
         [Test]
-        public void Test11_TestFloatChanged()
+        public void Test05_TestFloatChanged()
         {
             var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
             var testValue1 = 1f;
@@ -360,7 +169,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [Test]
-        public void Test12_TestFloatNoChange()
+        public void Test06_TestFloatNoChange()
         {
             var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = 1f;
@@ -382,106 +191,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test13_TestFloatGenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = 1f;
-        //    var testValue2 = 9001f;
-
-        //    var initialValue = inputDef.GetValue<float>();
-
-        //    Assert.AreEqual(initialValue, 0d, double.Epsilon);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<float>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<float>();
-
-        //    Assert.AreEqual(setValue1, testValue1, double.Epsilon);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<float>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<float>();
-
-        //    Assert.AreEqual(setValue2, testValue2, double.Epsilon);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test14_TestFloatGenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = 1f;
-
-        //    var initialValue = inputDef.GetValue<float>();
-
-        //    Assert.AreEqual(initialValue, 0d, double.Epsilon);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<float>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<float>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test15_TestFloatDirectVsGenericSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = 1f;
-        //    var testValue2 = 9001f;
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<float>(testValue);
-        //        inputDef.GetValue<float>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetFloat();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Float Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
-
         #endregion float
 
         #region Vector2
 
         [Test]
-        public void Test16_TestVector2Changed()
+        public void Test07_TestVector2Changed()
         {
             var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
             var testValue1 = Vector2.one;
@@ -512,7 +227,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [Test]
-        public void Test17_TestVector2NoChange()
+        public void Test08_TestVector2NoChange()
         {
             var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Vector2.one;
@@ -534,106 +249,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test18_TestVector2GenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = Vector2.one;
-        //    var testValue2 = Vector2.zero;
-
-        //    var initialValue = inputDef.GetValue<Vector2>();
-
-        //    Assert.True(initialValue == Vector2.zero);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector2>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<Vector2>();
-
-        //    Assert.True(setValue1 == testValue1);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector2>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<Vector2>();
-
-        //    Assert.True(setValue2 == testValue2);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test19_TestVector2GenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = Vector2.one;
-
-        //    var initialValue = inputDef.GetValue<Vector2>();
-
-        //    Assert.True(initialValue == Vector2.zero);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector2>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector2>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test20_TestVector2DirectVsGenericSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = Vector2.one;
-        //    var testValue2 = Vector2.zero;
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<Vector2>(testValue);
-        //        inputDef.GetValue<Vector2>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetVector2();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Vector2 Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
-
         #endregion Vector2
 
         #region Vector3
 
         [Test]
-        public void Test21_TestVector3Changed()
+        public void Test09_TestVector3Changed()
         {
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
             var testValue1 = Vector3.one;
@@ -664,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [Test]
-        public void Test22_TestVector3NoChange()
+        public void Test10_TestVector3NoChange()
         {
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Vector3.one;
@@ -686,106 +307,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test23_TestVector3GenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = Vector3.one;
-        //    var testValue2 = Vector3.zero;
-
-        //    var initialValue = inputDef.GetValue<Vector3>();
-
-        //    Assert.True(initialValue == Vector3.zero);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector3>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<Vector3>();
-
-        //    Assert.True(setValue1 == testValue1);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector3>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<Vector3>();
-
-        //    Assert.True(setValue2 == testValue2);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test24_TestVector3GenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = Vector3.one;
-
-        //    var initialValue = inputDef.GetValue<Vector3>();
-
-        //    Assert.True(initialValue == Vector3.zero);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector3>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Vector3>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test25_TestVector3DirectVsGenericSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = Vector3.one;
-        //    var testValue2 = Vector3.zero;
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<Vector3>(testValue);
-        //        inputDef.GetValue<Vector3>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetPosition();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Vector3 Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
-
         #endregion Vector3
 
         #region Quaternion
 
         [Test]
-        public void Test26_TestQuaternionChanged()
+        public void Test11_TestQuaternionChanged()
         {
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
             var testValue1 = Quaternion.Euler(45f, 45f, 45f);
@@ -816,7 +343,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [Test]
-        public void Test27_TestQuaternionNoChange()
+        public void Test12_TestQuaternionNoChange()
         {
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Quaternion.Euler(45f, 45f, 45f);
@@ -838,106 +365,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test28_TestQuaternionGenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = Quaternion.Euler(45f, 45f, 45f);
-        //    var testValue2 = Quaternion.identity;
-
-        //    var initialValue = inputDef.GetValue<Quaternion>();
-
-        //    Assert.True(initialValue == Quaternion.identity);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Quaternion>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<Quaternion>();
-
-        //    Assert.True(setValue1 == testValue1);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Quaternion>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<Quaternion>();
-
-        //    Assert.True(setValue2 == testValue2);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test29_TestQuaternionGenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = Quaternion.Euler(45f, 45f, 45f);
-
-        //    var initialValue = inputDef.GetValue<Quaternion>();
-
-        //    Assert.True(initialValue == Quaternion.identity);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Quaternion>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Quaternion>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test30_TestQuaternionDirectVsGenericSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = Quaternion.Euler(45f, 45f, 45f);
-        //    var testValue2 = Quaternion.identity;
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<Quaternion>(testValue);
-        //        inputDef.GetValue<Quaternion>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetRotation();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Quaternion Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
-
-        #endregion Quaternion
-
-        #region Tuples
-
         [Test]
-        public void Test31_TestTupleChanged()
+        public void Test13_TestTupleChanged()
         {
             var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
             var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
@@ -974,7 +403,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [Test]
-        public void Test32_TestTupleNoChange()
+        public void Test14_TestTupleNoChange()
         {
             var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
@@ -995,106 +424,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Make sure if we set the same value it's false
             Assert.IsFalse(inputDef.Changed);
         }
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test33_TestTupleGenericChanged()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
-        //    var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
-
-        //    var initialValue = inputDef.GetTransform();
-
-        //    Assert.IsNull(initialValue);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue1);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue1 = inputDef.GetValue<Tuple<Vector3, Quaternion>>();
-
-        //    Assert.AreEqual(setValue1, testValue1);
-        //    Assert.AreEqual(setValue1.Item1, testValue1.Item1);
-        //    Assert.AreEqual(setValue1.Item2, testValue1.Item2);
-        //    Assert.AreEqual(setValue1.Item2, testValue1.Item2);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue2);
-
-        //    Assert.IsTrue(inputDef.Changed);
-
-        //    var setValue2 = inputDef.GetValue<Tuple<Vector3, Quaternion>>();
-
-        //    Assert.AreEqual(setValue2, testValue2);
-        //    Assert.AreEqual(setValue2.Item1, testValue2.Item1);
-        //    Assert.AreEqual(setValue2.Item2, testValue2.Item2);
-        //    Assert.AreEqual(setValue2.Item2, testValue2.Item2);
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test34_TestTupleGenericNoChange()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
-
-        //    var initialValue = inputDef.GetTransform();
-
-        //    Assert.IsNull(initialValue);
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
-
-        //    Assert.IsTrue(inputDef.Changed);
-        //    // Make sure the second time we query it's false
-        //    Assert.IsFalse(inputDef.Changed);
-
-        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
-
-        //    Assert.IsFalse(inputDef.Changed);
-        //    // Make sure if we set the same value it's false
-        //    Assert.IsFalse(inputDef.Changed);
-        //}
-
-        // todo: remove Generic Get|Set tests
-        //[Test]
-        //public void Test35_TestTupleSpeed()
-        //{
-        //    var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
-        //    var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
-        //    var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
-
-        //    var stopwatch = new Stopwatch();
-        //    stopwatch.Start();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
-        //        inputDef.GetValue<Tuple<Vector3, Quaternion>>();
-        //    }
-
-        //    var genericTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Restart();
-
-        //    for (int i = 0; i < SpeedTestIterations; i++)
-        //    {
-        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
-        //        inputDef.SetValue(testValue);
-        //        inputDef.GetTransform();
-        //    }
-
-        //    var directTime = stopwatch.ElapsedMilliseconds;
-
-        //    stopwatch.Stop();
-
-        //    UnityEngine.Debug.Log($"Tuple Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-        //    Assert.Greater(genericTime, directTime);
-        //}
 
         #endregion Tuples
     }

--- a/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = Vector3.one;
             var testValue2 = Vector3.zero;
 
-            var initialValue = inputDef.GetPositionValue();
+            var initialValue = inputDef.GetPosition();
 
             Assert.True(initialValue == Vector3.zero);
             Assert.IsFalse(inputDef.Changed);
@@ -269,7 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetPositionValue();
+            var setValue1 = inputDef.GetPosition();
 
             Assert.True(setValue1 == testValue1);
             Assert.IsFalse(inputDef.Changed);
@@ -278,7 +278,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetPositionValue();
+            var setValue2 = inputDef.GetPosition();
 
             Assert.True(setValue2 == testValue2);
             Assert.IsFalse(inputDef.Changed);
@@ -290,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Vector3.one;
 
-            var initialValue = inputDef.GetPositionValue();
+            var initialValue = inputDef.GetPosition();
 
             Assert.True(initialValue == Vector3.zero);
             Assert.IsFalse(inputDef.Changed);
@@ -318,7 +318,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = Quaternion.Euler(45f, 45f, 45f);
             var testValue2 = Quaternion.identity;
 
-            var initialValue = inputDef.GetRotationValue();
+            var initialValue = inputDef.GetRotation();
 
             Assert.True(initialValue == Quaternion.identity);
             Assert.IsFalse(inputDef.Changed);
@@ -327,7 +327,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetRotationValue();
+            var setValue1 = inputDef.GetRotation();
 
             Assert.True(setValue1 == testValue1);
             Assert.IsFalse(inputDef.Changed);
@@ -336,7 +336,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetRotationValue();
+            var setValue2 = inputDef.GetRotation();
 
             Assert.True(setValue2 == testValue2);
             Assert.IsFalse(inputDef.Changed);
@@ -348,7 +348,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Quaternion.Euler(45f, 45f, 45f);
 
-            var initialValue = inputDef.GetRotationValue();
+            var initialValue = inputDef.GetRotation();
 
             Assert.True(initialValue == Quaternion.identity);
             Assert.IsFalse(inputDef.Changed);
@@ -365,6 +365,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
+        #endregion Quaternion
+
+        #region Tuples
+
         [Test]
         public void Test13_TestTupleChanged()
         {
@@ -372,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
             var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
 
-            var initialValue = inputDef.GetTransformValue();
+            var initialValue = inputDef.GetTransform();
 
             Assert.IsNull(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -381,7 +385,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetTransformValue();
+            var setValue1 = inputDef.GetTransform();
 
             Assert.AreEqual(setValue1, testValue1);
             Assert.AreEqual(setValue1.Item1, testValue1.Item1);
@@ -393,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetTransformValue();
+            var setValue2 = inputDef.GetTransform();
 
             Assert.AreEqual(setValue2, testValue2);
             Assert.AreEqual(setValue2.Item1, testValue2.Item1);
@@ -408,7 +412,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
 
-            var initialValue = inputDef.GetTransformValue();
+            var initialValue = inputDef.GetTransform();
 
             Assert.IsNull(initialValue);
             Assert.IsFalse(inputDef.Changed);

--- a/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = (object)1f;
             var testValue2 = (object)false;
 
-            var initialValue = inputDef.GetRaw();
+            var initialValue = inputDef.GetRawValue();
 
             Assert.IsNull(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetRaw();
+            var setValue1 = inputDef.GetRawValue();
 
             Assert.IsNotNull(setValue1);
             Assert.AreEqual(setValue1, testValue1);
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetRaw();
+            var setValue2 = inputDef.GetRawValue();
 
             Assert.IsNotNull(setValue2);
             Assert.AreEqual(setValue2, testValue2);
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = new object();
 
-            var initialValue = inputDef.GetRaw();
+            var initialValue = inputDef.GetRawValue();
 
             Assert.IsNull(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -73,98 +73,100 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test03_TestObjectGenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = (object)1f;
-            var testValue2 = (object)false;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test03_TestObjectGenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = (object)1f;
+        //    var testValue2 = (object)false;
 
-            var initialValue = inputDef.GetValue<object>();
+        //    var initialValue = inputDef.GetValue<object>();
 
-            Assert.IsNull(initialValue);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsNull(initialValue);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<object>(testValue1);
+        //    inputDef.SetValue<object>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<object>();
+        //    var setValue1 = inputDef.GetValue<object>();
 
-            Assert.IsNotNull(setValue1);
-            Assert.AreEqual(setValue1, testValue1);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsNotNull(setValue1);
+        //    Assert.AreEqual(setValue1, testValue1);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<object>(testValue2);
+        //    inputDef.SetValue<object>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<object>();
+        //    var setValue2 = inputDef.GetValue<object>();
 
-            Assert.IsNotNull(setValue2);
-            Assert.AreEqual(setValue2, testValue2);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsNotNull(setValue2);
+        //    Assert.AreEqual(setValue2, testValue2);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test04_TestObjectGenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = (object)1f;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test04_TestObjectGenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = (object)1f;
 
-            var initialValue = inputDef.GetValue<object>();
+        //    var initialValue = inputDef.GetValue<object>();
 
-            Assert.IsNull(initialValue);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsNull(initialValue);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<object>(testValue);
+        //    inputDef.SetValue<object>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<object>(testValue);
+        //    inputDef.SetValue<object>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test05_TestObjectDirectVsGenericSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = (object)1f;
-            var testValue2 = (object)false;
+        //[Test]
+        //public void Test05_TestObjectDirectVsGenericSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = (object)1f;
+        //    var testValue2 = (object)false;
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<object>(testValue);
-                inputDef.GetValue<object>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<object>(testValue);
+        //        inputDef.GetValue<object>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetRaw();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetRaw();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Object Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Object Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion objects
 
@@ -177,7 +179,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = true;
             var testValue2 = false;
 
-            var initialValue = inputDef.GetBool();
+            var initialValue = inputDef.GetBooleanValue();
 
             Assert.IsFalse(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -186,7 +188,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetBool();
+            var setValue1 = inputDef.GetBooleanValue();
 
             Assert.IsTrue(setValue1);
             Assert.True(setValue1 == testValue1);
@@ -196,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetBool();
+            var setValue2 = inputDef.GetBooleanValue();
 
             Assert.IsFalse(setValue2);
             Assert.True(setValue2 == testValue2);
@@ -209,7 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = true;
 
-            var initialValue = inputDef.GetBool();
+            var initialValue = inputDef.GetBooleanValue();
 
             Assert.IsFalse(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -226,98 +228,101 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test08_TestBoolGenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = true;
-            var testValue2 = false;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test08_TestBoolGenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = true;
+        //    var testValue2 = false;
 
-            var initialValue = inputDef.GetValue<bool>();
+        //    var initialValue = inputDef.GetValue<bool>();
 
-            Assert.IsFalse(initialValue);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsFalse(initialValue);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<bool>(testValue1);
+        //    inputDef.SetValue<bool>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<bool>();
+        //    var setValue1 = inputDef.GetValue<bool>();
 
-            Assert.IsTrue(setValue1);
-            Assert.True(setValue1 == testValue1);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(setValue1);
+        //    Assert.True(setValue1 == testValue1);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<bool>(testValue2);
+        //    inputDef.SetValue<bool>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<bool>();
+        //    var setValue2 = inputDef.GetValue<bool>();
 
-            Assert.IsFalse(setValue2);
-            Assert.True(setValue2 == testValue2);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(setValue2);
+        //    Assert.True(setValue2 == testValue2);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test09_TestBoolGenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = true;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test09_TestBoolGenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = true;
 
-            var initialValue = inputDef.GetValue<bool>();
+        //    var initialValue = inputDef.GetValue<bool>();
 
-            Assert.IsFalse(initialValue);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsFalse(initialValue);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<bool>(testValue);
+        //    inputDef.SetValue<bool>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<bool>(testValue);
+        //    inputDef.SetValue<bool>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test10_TestBoolDirectVsGenericSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = true;
-            var testValue2 = false;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test10_TestBoolDirectVsGenericSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = true;
+        //    var testValue2 = false;
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<bool>(testValue);
-                inputDef.GetValue<bool>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<bool>(testValue);
+        //        inputDef.GetValue<bool>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetBool();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetBool();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Bool Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Bool Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion bools
 
@@ -330,7 +335,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = 1f;
             var testValue2 = 9001f;
 
-            var initialValue = inputDef.GetFloat();
+            var initialValue = inputDef.GetFloatValue();
 
             Assert.AreEqual(initialValue, 0d, double.Epsilon);
             Assert.IsFalse(inputDef.Changed);
@@ -339,7 +344,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetFloat();
+            var setValue1 = inputDef.GetFloatValue();
 
             Assert.AreEqual(setValue1, testValue1, double.Epsilon);
             Assert.IsFalse(inputDef.Changed);
@@ -348,7 +353,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetFloat();
+            var setValue2 = inputDef.GetFloatValue();
 
             Assert.AreEqual(setValue2, testValue2, double.Epsilon);
             Assert.IsFalse(inputDef.Changed);
@@ -360,7 +365,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = 1f;
 
-            var initialValue = inputDef.GetFloat();
+            var initialValue = inputDef.GetFloatValue();
 
             Assert.AreEqual(initialValue, 0d, double.Epsilon);
             Assert.IsFalse(inputDef.Changed);
@@ -377,96 +382,99 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test13_TestFloatGenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = 1f;
-            var testValue2 = 9001f;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test13_TestFloatGenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = 1f;
+        //    var testValue2 = 9001f;
 
-            var initialValue = inputDef.GetValue<float>();
+        //    var initialValue = inputDef.GetValue<float>();
 
-            Assert.AreEqual(initialValue, 0d, double.Epsilon);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.AreEqual(initialValue, 0d, double.Epsilon);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<float>(testValue1);
+        //    inputDef.SetValue<float>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<float>();
+        //    var setValue1 = inputDef.GetValue<float>();
 
-            Assert.AreEqual(setValue1, testValue1, double.Epsilon);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.AreEqual(setValue1, testValue1, double.Epsilon);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<float>(testValue2);
+        //    inputDef.SetValue<float>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<float>();
+        //    var setValue2 = inputDef.GetValue<float>();
 
-            Assert.AreEqual(setValue2, testValue2, double.Epsilon);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.AreEqual(setValue2, testValue2, double.Epsilon);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test14_TestFloatGenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = 1f;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test14_TestFloatGenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = 1f;
 
-            var initialValue = inputDef.GetValue<float>();
+        //    var initialValue = inputDef.GetValue<float>();
 
-            Assert.AreEqual(initialValue, 0d, double.Epsilon);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.AreEqual(initialValue, 0d, double.Epsilon);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<float>(testValue);
+        //    inputDef.SetValue<float>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<float>(testValue);
+        //    inputDef.SetValue<float>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test15_TestFloatDirectVsGenericSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = 1f;
-            var testValue2 = 9001f;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test15_TestFloatDirectVsGenericSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = 1f;
+        //    var testValue2 = 9001f;
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<float>(testValue);
-                inputDef.GetValue<float>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<float>(testValue);
+        //        inputDef.GetValue<float>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetFloat();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetFloat();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Float Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Float Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion float
 
@@ -479,7 +487,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = Vector2.one;
             var testValue2 = Vector2.zero;
 
-            var initialValue = inputDef.GetVector2();
+            var initialValue = inputDef.GetVector2Value();
 
             Assert.True(initialValue == Vector2.zero);
             Assert.IsFalse(inputDef.Changed);
@@ -488,7 +496,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetVector2();
+            var setValue1 = inputDef.GetVector2Value();
 
             Assert.True(setValue1 == testValue1);
             Assert.IsFalse(inputDef.Changed);
@@ -497,7 +505,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetVector2();
+            var setValue2 = inputDef.GetVector2Value();
 
             Assert.True(setValue2 == testValue2);
             Assert.IsFalse(inputDef.Changed);
@@ -509,7 +517,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Vector2.one;
 
-            var initialValue = inputDef.GetVector2();
+            var initialValue = inputDef.GetVector2Value();
 
             Assert.True(initialValue == Vector2.zero);
             Assert.IsFalse(inputDef.Changed);
@@ -526,96 +534,99 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test18_TestVector2GenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = Vector2.one;
-            var testValue2 = Vector2.zero;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test18_TestVector2GenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = Vector2.one;
+        //    var testValue2 = Vector2.zero;
 
-            var initialValue = inputDef.GetValue<Vector2>();
+        //    var initialValue = inputDef.GetValue<Vector2>();
 
-            Assert.True(initialValue == Vector2.zero);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(initialValue == Vector2.zero);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector2>(testValue1);
+        //    inputDef.SetValue<Vector2>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<Vector2>();
+        //    var setValue1 = inputDef.GetValue<Vector2>();
 
-            Assert.True(setValue1 == testValue1);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(setValue1 == testValue1);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector2>(testValue2);
+        //    inputDef.SetValue<Vector2>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<Vector2>();
+        //    var setValue2 = inputDef.GetValue<Vector2>();
 
-            Assert.True(setValue2 == testValue2);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.True(setValue2 == testValue2);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test19_TestVector2GenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = Vector2.one;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test19_TestVector2GenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = Vector2.one;
 
-            var initialValue = inputDef.GetValue<Vector2>();
+        //    var initialValue = inputDef.GetValue<Vector2>();
 
-            Assert.True(initialValue == Vector2.zero);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(initialValue == Vector2.zero);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector2>(testValue);
+        //    inputDef.SetValue<Vector2>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector2>(testValue);
+        //    inputDef.SetValue<Vector2>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test20_TestVector2DirectVsGenericSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = Vector2.one;
-            var testValue2 = Vector2.zero;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test20_TestVector2DirectVsGenericSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = Vector2.one;
+        //    var testValue2 = Vector2.zero;
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<Vector2>(testValue);
-                inputDef.GetValue<Vector2>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<Vector2>(testValue);
+        //        inputDef.GetValue<Vector2>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetVector2();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetVector2();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Vector2 Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Vector2 Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion Vector2
 
@@ -628,7 +639,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = Vector3.one;
             var testValue2 = Vector3.zero;
 
-            var initialValue = inputDef.GetPosition();
+            var initialValue = inputDef.GetPositionValue();
 
             Assert.True(initialValue == Vector3.zero);
             Assert.IsFalse(inputDef.Changed);
@@ -637,7 +648,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetPosition();
+            var setValue1 = inputDef.GetPositionValue();
 
             Assert.True(setValue1 == testValue1);
             Assert.IsFalse(inputDef.Changed);
@@ -646,7 +657,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetPosition();
+            var setValue2 = inputDef.GetPositionValue();
 
             Assert.True(setValue2 == testValue2);
             Assert.IsFalse(inputDef.Changed);
@@ -658,7 +669,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Vector3.one;
 
-            var initialValue = inputDef.GetPosition();
+            var initialValue = inputDef.GetPositionValue();
 
             Assert.True(initialValue == Vector3.zero);
             Assert.IsFalse(inputDef.Changed);
@@ -675,96 +686,99 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test23_TestVector3GenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = Vector3.one;
-            var testValue2 = Vector3.zero;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test23_TestVector3GenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = Vector3.one;
+        //    var testValue2 = Vector3.zero;
 
-            var initialValue = inputDef.GetValue<Vector3>();
+        //    var initialValue = inputDef.GetValue<Vector3>();
 
-            Assert.True(initialValue == Vector3.zero);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(initialValue == Vector3.zero);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector3>(testValue1);
+        //    inputDef.SetValue<Vector3>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<Vector3>();
+        //    var setValue1 = inputDef.GetValue<Vector3>();
 
-            Assert.True(setValue1 == testValue1);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(setValue1 == testValue1);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector3>(testValue2);
+        //    inputDef.SetValue<Vector3>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<Vector3>();
+        //    var setValue2 = inputDef.GetValue<Vector3>();
 
-            Assert.True(setValue2 == testValue2);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.True(setValue2 == testValue2);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test24_TestVector3GenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = Vector3.one;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test24_TestVector3GenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = Vector3.one;
 
-            var initialValue = inputDef.GetValue<Vector3>();
+        //    var initialValue = inputDef.GetValue<Vector3>();
 
-            Assert.True(initialValue == Vector3.zero);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(initialValue == Vector3.zero);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector3>(testValue);
+        //    inputDef.SetValue<Vector3>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Vector3>(testValue);
+        //    inputDef.SetValue<Vector3>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test25_TestVector3DirectVsGenericSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = Vector3.one;
-            var testValue2 = Vector3.zero;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test25_TestVector3DirectVsGenericSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = Vector3.one;
+        //    var testValue2 = Vector3.zero;
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<Vector3>(testValue);
-                inputDef.GetValue<Vector3>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<Vector3>(testValue);
+        //        inputDef.GetValue<Vector3>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetPosition();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetPosition();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Vector3 Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Vector3 Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion Vector3
 
@@ -777,7 +791,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = Quaternion.Euler(45f, 45f, 45f);
             var testValue2 = Quaternion.identity;
 
-            var initialValue = inputDef.GetRotation();
+            var initialValue = inputDef.GetRotationValue();
 
             Assert.True(initialValue == Quaternion.identity);
             Assert.IsFalse(inputDef.Changed);
@@ -786,7 +800,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetRotation();
+            var setValue1 = inputDef.GetRotationValue();
 
             Assert.True(setValue1 == testValue1);
             Assert.IsFalse(inputDef.Changed);
@@ -795,7 +809,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetRotation();
+            var setValue2 = inputDef.GetRotationValue();
 
             Assert.True(setValue2 == testValue2);
             Assert.IsFalse(inputDef.Changed);
@@ -807,7 +821,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = Quaternion.Euler(45f, 45f, 45f);
 
-            var initialValue = inputDef.GetRotation();
+            var initialValue = inputDef.GetRotationValue();
 
             Assert.True(initialValue == Quaternion.identity);
             Assert.IsFalse(inputDef.Changed);
@@ -824,96 +838,99 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test28_TestQuaternionGenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = Quaternion.Euler(45f, 45f, 45f);
-            var testValue2 = Quaternion.identity;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test28_TestQuaternionGenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = Quaternion.Euler(45f, 45f, 45f);
+        //    var testValue2 = Quaternion.identity;
 
-            var initialValue = inputDef.GetValue<Quaternion>();
+        //    var initialValue = inputDef.GetValue<Quaternion>();
 
-            Assert.True(initialValue == Quaternion.identity);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(initialValue == Quaternion.identity);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Quaternion>(testValue1);
+        //    inputDef.SetValue<Quaternion>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<Quaternion>();
+        //    var setValue1 = inputDef.GetValue<Quaternion>();
 
-            Assert.True(setValue1 == testValue1);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(setValue1 == testValue1);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Quaternion>(testValue2);
+        //    inputDef.SetValue<Quaternion>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<Quaternion>();
+        //    var setValue2 = inputDef.GetValue<Quaternion>();
 
-            Assert.True(setValue2 == testValue2);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.True(setValue2 == testValue2);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test29_TestQuaternionGenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = Quaternion.Euler(45f, 45f, 45f);
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test29_TestQuaternionGenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = Quaternion.Euler(45f, 45f, 45f);
 
-            var initialValue = inputDef.GetValue<Quaternion>();
+        //    var initialValue = inputDef.GetValue<Quaternion>();
 
-            Assert.True(initialValue == Quaternion.identity);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.True(initialValue == Quaternion.identity);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Quaternion>(testValue);
+        //    inputDef.SetValue<Quaternion>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Quaternion>(testValue);
+        //    inputDef.SetValue<Quaternion>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test30_TestQuaternionDirectVsGenericSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = Quaternion.Euler(45f, 45f, 45f);
-            var testValue2 = Quaternion.identity;
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test30_TestQuaternionDirectVsGenericSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = Quaternion.Euler(45f, 45f, 45f);
+        //    var testValue2 = Quaternion.identity;
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<Quaternion>(testValue);
-                inputDef.GetValue<Quaternion>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<Quaternion>(testValue);
+        //        inputDef.GetValue<Quaternion>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetRotation();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetRotation();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Quaternion Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Quaternion Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion Quaternion
 
@@ -926,7 +943,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
             var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
 
-            var initialValue = inputDef.GetTransform();
+            var initialValue = inputDef.GetTransformValue();
 
             Assert.IsNull(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -935,7 +952,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetTransform();
+            var setValue1 = inputDef.GetTransformValue();
 
             Assert.AreEqual(setValue1, testValue1);
             Assert.AreEqual(setValue1.Item1, testValue1.Item1);
@@ -947,7 +964,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetTransform();
+            var setValue2 = inputDef.GetTransformValue();
 
             Assert.AreEqual(setValue2, testValue2);
             Assert.AreEqual(setValue2.Item1, testValue2.Item1);
@@ -962,7 +979,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
             var testValue = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
 
-            var initialValue = inputDef.GetTransform();
+            var initialValue = inputDef.GetTransformValue();
 
             Assert.IsNull(initialValue);
             Assert.IsFalse(inputDef.Changed);
@@ -979,102 +996,105 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(inputDef.Changed);
         }
 
-        [Test]
-        public void Test33_TestTupleGenericChanged()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
-            var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test33_TestTupleGenericChanged()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
+        //    var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
 
-            var initialValue = inputDef.GetTransform();
+        //    var initialValue = inputDef.GetTransform();
 
-            Assert.IsNull(initialValue);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsNull(initialValue);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue1);
+        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue1);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue1 = inputDef.GetValue<Tuple<Vector3, Quaternion>>();
+        //    var setValue1 = inputDef.GetValue<Tuple<Vector3, Quaternion>>();
 
-            Assert.AreEqual(setValue1, testValue1);
-            Assert.AreEqual(setValue1.Item1, testValue1.Item1);
-            Assert.AreEqual(setValue1.Item2, testValue1.Item2);
-            Assert.AreEqual(setValue1.Item2, testValue1.Item2);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.AreEqual(setValue1, testValue1);
+        //    Assert.AreEqual(setValue1.Item1, testValue1.Item1);
+        //    Assert.AreEqual(setValue1.Item2, testValue1.Item2);
+        //    Assert.AreEqual(setValue1.Item2, testValue1.Item2);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue2);
+        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue2);
 
-            Assert.IsTrue(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
 
-            var setValue2 = inputDef.GetValue<Tuple<Vector3, Quaternion>>();
+        //    var setValue2 = inputDef.GetValue<Tuple<Vector3, Quaternion>>();
 
-            Assert.AreEqual(setValue2, testValue2);
-            Assert.AreEqual(setValue2.Item1, testValue2.Item1);
-            Assert.AreEqual(setValue2.Item2, testValue2.Item2);
-            Assert.AreEqual(setValue2.Item2, testValue2.Item2);
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.AreEqual(setValue2, testValue2);
+        //    Assert.AreEqual(setValue2.Item1, testValue2.Item1);
+        //    Assert.AreEqual(setValue2.Item2, testValue2.Item2);
+        //    Assert.AreEqual(setValue2.Item2, testValue2.Item2);
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test34_TestTupleGenericNoChange()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test34_TestTupleGenericNoChange()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
 
-            var initialValue = inputDef.GetTransform();
+        //    var initialValue = inputDef.GetTransform();
 
-            Assert.IsNull(initialValue);
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsNull(initialValue);
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
+        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
 
-            Assert.IsTrue(inputDef.Changed);
-            // Make sure the second time we query it's false
-            Assert.IsFalse(inputDef.Changed);
+        //    Assert.IsTrue(inputDef.Changed);
+        //    // Make sure the second time we query it's false
+        //    Assert.IsFalse(inputDef.Changed);
 
-            inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
+        //    inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
 
-            Assert.IsFalse(inputDef.Changed);
-            // Make sure if we set the same value it's false
-            Assert.IsFalse(inputDef.Changed);
-        }
+        //    Assert.IsFalse(inputDef.Changed);
+        //    // Make sure if we set the same value it's false
+        //    Assert.IsFalse(inputDef.Changed);
+        //}
 
-        [Test]
-        public void Test35_TestTupleSpeed()
-        {
-            var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
-            var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
-            var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
+        // todo: remove Generic Get|Set tests
+        //[Test]
+        //public void Test35_TestTupleSpeed()
+        //{
+        //    var inputDef = new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None"));
+        //    var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
+        //    var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
 
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        //    var stopwatch = new Stopwatch();
+        //    stopwatch.Start();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
-                inputDef.GetValue<Tuple<Vector3, Quaternion>>();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue<Tuple<Vector3, Quaternion>>(testValue);
+        //        inputDef.GetValue<Tuple<Vector3, Quaternion>>();
+        //    }
 
-            var genericTime = stopwatch.ElapsedMilliseconds;
+        //    var genericTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Restart();
+        //    stopwatch.Restart();
 
-            for (int i = 0; i < SpeedTestIterations; i++)
-            {
-                var testValue = i % 2 == 0 ? testValue1 : testValue2;
-                inputDef.SetValue(testValue);
-                inputDef.GetTransform();
-            }
+        //    for (int i = 0; i < SpeedTestIterations; i++)
+        //    {
+        //        var testValue = i % 2 == 0 ? testValue1 : testValue2;
+        //        inputDef.SetValue(testValue);
+        //        inputDef.GetTransform();
+        //    }
 
-            var directTime = stopwatch.ElapsedMilliseconds;
+        //    var directTime = stopwatch.ElapsedMilliseconds;
 
-            stopwatch.Stop();
+        //    stopwatch.Stop();
 
-            UnityEngine.Debug.Log($"Tuple Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
-            Assert.Greater(genericTime, directTime);
-        }
+        //    UnityEngine.Debug.Log($"Tuple Speed Test Results | Generic Time: {genericTime} | Direct Time: {directTime}");
+        //    Assert.Greater(genericTime, directTime);
+        //}
 
         #endregion Tuples
     }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/InteractionMapping.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/InteractionMapping.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Internal.Utilities;
 using System;
 using UnityEngine;
 
@@ -108,61 +109,37 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
 
         #region Get Operators
 
-        public T GetValue<T>()
-        {
-            switch (AxisType)
-            {
-                case AxisType.None:
-                case AxisType.Raw:
-                    return (T)Convert.ChangeType(rawData, typeof(T));
-                case AxisType.Digital:
-                    return (T)Convert.ChangeType(boolData, typeof(T));
-                case AxisType.SingleAxis:
-                    return (T)Convert.ChangeType(floatData, typeof(T));
-                case AxisType.DualAxis:
-                    return (T)Convert.ChangeType(vector2Data, typeof(T));
-                case AxisType.ThreeDoFPosition:
-                    return (T)Convert.ChangeType(positionData, typeof(T));
-                case AxisType.ThreeDoFRotation:
-                    return (T)Convert.ChangeType(rotationData, typeof(T));
-                case AxisType.SixDoF:
-                    return (T)Convert.ChangeType(transformData, typeof(T));
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        public object GetRaw()
+        public object GetRawValue()
         {
             return rawData;
         }
 
-        public bool GetBool()
+        public bool GetBooleanValue()
         {
             return boolData;
         }
 
-        public float GetFloat()
+        public float GetFloatValue()
         {
             return floatData;
         }
 
-        public Vector2 GetVector2()
+        public Vector2 GetVector2Value()
         {
             return vector2Data;
         }
 
-        public Vector3 GetPosition()
+        public Vector3 GetPositionValue()
         {
             return positionData;
         }
 
-        public Quaternion GetRotation()
+        public Quaternion GetRotationValue()
         {
             return rotationData;
         }
 
-        public Tuple<Vector3, Quaternion> GetTransform()
+        public Tuple<Vector3, Quaternion> GetTransformValue()
         {
             return transformData;
         }
@@ -171,140 +148,97 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
 
         #region Set Operators
 
-        public void SetValue<T>(T newValue)
-        {
-            switch (AxisType)
-            {
-                case AxisType.None:
-                case AxisType.Raw:
-                    SetValue((object)newValue);
-                    break;
-                case AxisType.Digital:
-                    SetValue((bool)Convert.ChangeType(newValue, typeof(bool)));
-                    break;
-                case AxisType.SingleAxis:
-                    SetValue((float)Convert.ChangeType(newValue, typeof(float)));
-                    break;
-                case AxisType.DualAxis:
-                    SetValue((Vector2)Convert.ChangeType(newValue, typeof(Vector2)));
-                    break;
-                case AxisType.ThreeDoFPosition:
-                    SetValue((Vector3)Convert.ChangeType(newValue, typeof(Vector3)));
-                    break;
-                case AxisType.ThreeDoFRotation:
-                    SetValue((Quaternion)Convert.ChangeType(newValue, typeof(Quaternion)));
-                    break;
-                case AxisType.SixDoF:
-                    SetValue((Tuple<Vector3, Quaternion>)Convert.ChangeType(newValue, typeof(Tuple<Vector3, Quaternion>)));
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
         public void SetValue(object newValue)
         {
-            if (AxisType == AxisType.Raw)
+            if (AxisType != AxisType.Raw)
             {
-                Changed = rawData != newValue;
-                rawData = newValue;
+                Debug.LogError("SetValue(object) is only valid for AxisType.Raw InteractionMappings");
             }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+
+            Changed = rawData != newValue;
+            rawData = newValue;
         }
 
         public void SetValue(bool newValue)
         {
-            if (AxisType == AxisType.Digital)
+            if (AxisType != AxisType.Digital)
             {
-                Changed = boolData != newValue;
-                boolData = newValue;
+                Debug.LogError("SetValue(bool) is only valid for AxisType.Digital InteractionMappings");
             }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+
+            Changed = boolData != newValue;
+            boolData = newValue;
         }
 
         public void SetValue(float newValue)
         {
-            if (AxisType == AxisType.SingleAxis)
+            if (AxisType != AxisType.SingleAxis)
             {
-                Changed = !floatData.Equals(newValue);
-                floatData = newValue;
+                Debug.LogError("SetValue(float) is only valid for AxisType.SingleAxis InteractionMappings");
             }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+
+            Changed = !floatData.Equals(newValue);
+            floatData = newValue;
         }
 
         public void SetValue(Vector2 newValue)
         {
-            if (AxisType == AxisType.DualAxis)
+            if (AxisType != AxisType.DualAxis)
             {
-                Changed = vector2Data != newValue;
-                vector2Data = newValue;
+                Debug.LogError("SetValue(Vector2) is only valid for AxisType.DualAxis InteractionMappings");
             }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+
+            Changed = vector2Data != newValue;
+            vector2Data = newValue;
         }
 
         public void SetValue(Vector3 newValue)
         {
-            if (AxisType == AxisType.ThreeDoFPosition)
+            if (AxisType != AxisType.ThreeDoFPosition)
             {
-                Changed = positionData != newValue;
-                positionData = newValue;
+                {
+                    Debug.LogError("SetValue(Vector3) is only valid for AxisType.ThreeDoFPosition InteractionMappings");
+                }
             }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+
+            Changed = positionData != newValue;
+            positionData = newValue;
         }
 
         public void SetValue(Quaternion newValue)
         {
-            if (AxisType == AxisType.ThreeDoFRotation)
+            if (AxisType != AxisType.ThreeDoFRotation)
             {
-                Changed = rotationData != newValue;
-                rotationData = newValue;
+                Debug.LogError("SetValue(Quaternion) is only valid for AxisType.ThreeDoFRotation InteractionMappings");
             }
-            else
-            {
-                throw new InvalidOperationException();
-            }
+
+            Changed = rotationData != newValue;
+            rotationData = newValue;
         }
 
         public void SetValue(Tuple<Vector3, Quaternion> newValue)
         {
-            if (AxisType == AxisType.SixDoF)
+            if (AxisType != AxisType.SixDoF)
             {
-                Changed = transformData == null && newValue != null ||
-                          transformData != null && newValue == null ||
-                          transformData != null && newValue != null &&
-                          (transformData.Item1 != newValue.Item1 || transformData.Item2 != newValue.Item2);
+                Debug.LogError("SetValue(Tuple<Vector3, Quaternion>) is only valid for AxisType.SixDoF InteractionMappings");
+            }
 
-                transformData = newValue;
+            Changed = transformData == null && newValue != null ||
+                        transformData != null && newValue == null ||
+                        transformData != null && newValue != null &&
+                        (transformData.Item1 != newValue.Item1 || transformData.Item2 != newValue.Item2);
 
-                if (transformData != null)
-                {
-                    positionData = transformData.Item1;
-                    rotationData = transformData.Item2;
-                }
-                else
-                {
-                    positionData = Vector3.zero;
-                    rotationData = Quaternion.identity;
-                }
+            transformData = newValue;
+
+            if (transformData != null)
+            {
+                positionData = transformData.Item1;
+                rotationData = transformData.Item2;
             }
             else
             {
-                throw new InvalidOperationException();
+                positionData = Vector3.zero;
+                rotationData = Quaternion.identity;
             }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/InteractionMapping.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/InteractionMapping.cs
@@ -129,17 +129,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
             return vector2Data;
         }
 
-        public Vector3 GetPositionValue()
+        public Vector3 GetPosition()
         {
             return positionData;
         }
 
-        public Quaternion GetRotationValue()
+        public Quaternion GetRotation()
         {
             return rotationData;
         }
 
-        public Tuple<Vector3, Quaternion> GetTransformValue()
+        public Tuple<Vector3, Quaternion> GetTransform()
         {
             return transformData;
         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -220,12 +220,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialGrip) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.TouchpadTouch) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -220,17 +220,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialGrip) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.TouchpadTouch) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
                 {
-                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetValue<bool>())
+                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
                         inputSystem?.RaiseOnInputDown(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.TouchpadTouch].InputAction);
                     }
@@ -242,17 +242,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.Touchpad) && controller.Interactions[DeviceInputType.Touchpad].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.ThumbStick) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.Trigger) && controller.Interactions[DeviceInputType.Trigger].Changed)
                 {
-                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetValue<float>());
+                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
@@ -170,12 +170,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
@@ -170,17 +170,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
                 {
-                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetValue<bool>())
+                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
                         inputSystem?.RaiseOnInputDown(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.TouchpadTouch].InputAction);
                     }
@@ -192,17 +192,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
                 {
-                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetValue<float>());
+                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
@@ -170,12 +170,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
@@ -170,17 +170,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
                 {
-                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetValue<bool>())
+                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
                         inputSystem?.RaiseOnInputDown(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.TouchpadTouch].InputAction);
                     }
@@ -192,17 +192,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
                 {
-                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetValue<float>());
+                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
@@ -170,12 +170,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
@@ -170,17 +170,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
                 {
-                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetValue<bool>())
+                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
                         inputSystem?.RaiseOnInputDown(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.TouchpadTouch].InputAction);
                     }
@@ -192,17 +192,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
                 {
-                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetValue<float>());
+                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
@@ -173,17 +173,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetValue<Tuple<Vector3, Quaternion>>());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
                 {
-                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetValue<bool>())
+                    if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
                         inputSystem?.RaiseOnInputDown(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.TouchpadTouch].InputAction);
                     }
@@ -195,17 +195,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
                 {
-                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetValue<Vector2>());
+                    inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
                 {
-                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetValue<float>());
+                    inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
@@ -173,12 +173,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
             {
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
                 {
-                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransformValue());
+                    inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
                 if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)

--- a/Assets/MixedRealityToolkit/_Core/Extensions/CollectionsExtensions.cs
+++ b/Assets/MixedRealityToolkit/_Core/Extensions/CollectionsExtensions.cs
@@ -130,11 +130,13 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Extensions
         /// Overload extension to enable saving of an InteractionDefinition inside a Dictionary collection
         /// *Note can only use generics (in both here and InteractionDefinition)
         /// </summary>
-        /// <typeparam name="T">Type of input being saves</typeparam>
+        /// <typeparam name="T">Type of input being saved</typeparam>
         /// <param name="input">The InteractionDefinition dictionary reference (generics, performed on a Dictionary)</param>
         /// <param name="key">The specific DeviceInputType value to update</param>
         /// <param name="value">The data value to be updated</param>
-        public static void SetDictionaryValue<T>(this Dictionary<Definitions.Devices.DeviceInputType, Definitions.Devices.InteractionMapping> input, Definitions.Devices.DeviceInputType key, T value)
+        public static void SetDictionaryValue<T>(
+            this Dictionary<Definitions.Devices.DeviceInputType, Definitions.Devices.InteractionMapping> input, 
+            Definitions.Devices.DeviceInputType key, T value)
         {
             var entry = input[key];
             entry.SetValue(value);


### PR DESCRIPTION
Overview
---
The generic Get|SetValue methods , as asserted in the test cases, were slower (and produced garbage) than their specific counterparts.

Changes
---
This change:
* removes the generic GetValue<T> and SetValue<T> methods
* renames the Get<type> methods (ex: GetRaw -> GetRawValue)
* updates calling code
* removes test cases that utilized the generic methods
* renumbered the test cases to eliminate the gaps that were introduced
