### PR TITLE
add #if around extensions namespace as appropriate, add IsOpaque

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Attributes/ExtendsAttribute.cs
+++ b/Assets/MixedRealityToolkit/_Core/Attributes/ExtendsAttribute.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
+#if WINDOWS_UWP && !ENABLE_IL2CPP
 using Microsoft.MixedReality.Toolkit.Internal.Extensions;
+#endif // WINDOWS_UWP && !ENABLE_IL2CPP
+using System;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Attributes
 {

--- a/Assets/MixedRealityToolkit/_Core/Attributes/ImplementsAttribute.cs
+++ b/Assets/MixedRealityToolkit/_Core/Attributes/ImplementsAttribute.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
+#if WINDOWS_UWP && !ENABLE_IL2CPP
 using Microsoft.MixedReality.Toolkit.Internal.Extensions;
+#endif // WINDOWS_UWP && !ENABLE_IL2CPP
 using System;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Attributes

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/ControllerState.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/ControllerState.cs
@@ -14,6 +14,10 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
         /// </summary>
         None = 0,
         /// <summary>
+        /// Reserved, for systems that provide alternate tracking.
+        /// </summary>
+        Other,
+        /// <summary>
         /// The controller is currently fully tracked and has accurate positioning.
         /// </summary>
         Tracked,
@@ -22,12 +26,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
         /// </summary>
         NotTracked,
         /// <summary>
+        /// The controller is currently only returning position data.
+        /// </summary>
+        PositionOnly,
+        /// <summary>
         /// The controller is currently only returning orientation data.
         /// </summary>
-        OrientationOnly,
-        /// <summary>
-        /// Reserved, for systems that provide alternate tracking.
-        /// </summary>
-        Other
+        OrientationOnly
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/ControllerState.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/ControllerState.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
 {
     /// <summary>
-    /// The Controller State defines whether a controller or headset is currently being tracker or not.
+    /// The Controller State defines how a controller or headset is currently being tracked.
     /// This enables developers to be able to handle non-tracked situations and react accordingly
     /// </summary>
     public enum ControllerState
@@ -18,9 +18,13 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
         /// </summary>
         Tracked,
         /// <summary>
-        /// The controller is currently not visually tracked and has relative positioning.
+        /// The controller is currently not tracked.
         /// </summary>
         NotTracked,
+        /// <summary>
+        /// The controller is currently only returning orientation data.
+        /// </summary>
+        OrientationOnly,
         /// <summary>
         /// Reserved, for systems that provide alternate tracking.
         /// </summary>

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/ControllerState.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/ControllerState.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
         /// </summary>
         Tracked,
         /// <summary>
-        /// The controller is currently not tracked and has relative positioning.
+        /// The controller is currently not visually tracked and has relative positioning.
         /// </summary>
         NotTracked,
         /// <summary>

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/Headset.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/Headset.cs
@@ -35,5 +35,10 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
         /// Outputs the current state of the headset, whether it is tracked or not. As defined by the SDK / Unity.
         /// </summary>
         public ControllerState ControllerState { get; set; }
+
+        /// <summary>
+        /// Indicates whether or not the headset display is opaque. As defined by the SDK / Unity.
+        /// </summary>
+        public bool IsOpaque { get; set; }
     }
 }


### PR DESCRIPTION
Overview
---
Found some references to the Microsoft.MixedReality.Toolkit.Internal.Extensions that should be in closed in #if WINDOWS_UWP && !ENABLE_IL2CPP.

Added IsOpaque to the headset definition to allow differentiation between opaque (vr) and see through (ex: HoloLens).

Also tweaked controller state comments and added OrientationOnly state.