### PR TITLE
Added tests for InteractionMappings dictionary

### DIFF
--- a/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit-Tests/InteractionDefinitionTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Internal.Extensions;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
@@ -430,5 +431,243 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         #endregion Tuples
+
+        #region Interaction Dictionary Tests
+
+        [Test]
+        public void Test15_InteractionDictionaryObject()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.Raw, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = (object)1f;
+            var testValue2 = (object)false;
+
+            var initialValue = Interactions[DeviceInputType.None].GetRawValue();
+
+            Assert.IsNull(initialValue);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetRawValue();
+
+            Assert.IsNotNull(setValue1);
+            Assert.AreEqual(setValue1, testValue1);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetRawValue();
+
+            Assert.IsNotNull(setValue2);
+            Assert.AreEqual(setValue2, testValue2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        [Test]
+        public void Test16_InteractionDictionaryBool()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.Digital, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = true;
+            var testValue2 = false;
+
+            var initialValue = Interactions[DeviceInputType.None].GetBooleanValue();
+
+            Assert.IsFalse(initialValue);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetBooleanValue();
+
+            Assert.IsTrue(setValue1);
+            Assert.AreEqual(setValue1, testValue1);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetBooleanValue();
+
+            Assert.IsFalse(setValue2);
+            Assert.AreEqual(setValue2, testValue2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        [Test]
+        public void Test17_InteractionDictionaryFloat()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.SingleAxis, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = 1f;
+            var testValue2 = 9001f;
+
+            var initialValue = Interactions[DeviceInputType.None].GetFloatValue();
+
+            Assert.AreEqual(initialValue, 0d, double.Epsilon);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetFloatValue();
+
+            Assert.AreEqual(setValue1, testValue1, double.Epsilon);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetFloatValue();
+
+            Assert.AreEqual(setValue2, testValue2, double.Epsilon);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        [Test]
+        public void Test18_InteractionDictionaryVector2()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.DualAxis, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = Vector2.one;
+            var testValue2 = Vector2.zero;
+
+            var initialValue = Interactions[DeviceInputType.None].GetVector2Value();
+
+            Assert.True(initialValue == Vector2.zero);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetVector2Value();
+
+            Assert.True(setValue1 == testValue1);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetVector2Value();
+
+            Assert.True(setValue2 == testValue2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        [Test]
+        public void Test19_InteractionDictionaryVector3()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.ThreeDoFPosition, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = Vector3.one;
+            var testValue2 = Vector3.zero;
+
+            var initialValue = Interactions[DeviceInputType.None].GetPosition();
+
+            Assert.True(initialValue == Vector3.zero);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetPosition();
+
+            Assert.True(setValue1 == testValue1);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetPosition();
+
+            Assert.True(setValue2 == testValue2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        [Test]
+        public void Test20_InteractionDictionaryQuaternion()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.ThreeDoFRotation, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = Quaternion.Euler(45f, 45f, 45f);
+            var testValue2 = Quaternion.identity;
+
+            var initialValue = Interactions[DeviceInputType.None].GetRotation();
+
+            Assert.True(initialValue == Quaternion.identity);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetRotation();
+
+            Assert.True(setValue1 == testValue1);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetRotation();
+
+            Assert.True(setValue2 == testValue2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        [Test]
+        public void Test21_InteractionDictionaryTuples()
+        {
+            var Interactions = new System.Collections.Generic.Dictionary<DeviceInputType, InteractionMapping>();
+            Interactions.Add(DeviceInputType.None, new InteractionMapping(1, AxisType.SixDoF, DeviceInputType.None, new InputAction(1, "None")));
+            var testValue1 = new Tuple<Vector3, Quaternion>(Vector3.zero, Quaternion.identity);
+            var testValue2 = new Tuple<Vector3, Quaternion>(Vector3.one, new Quaternion(45f, 45f, 45f, 45f));
+
+            var initialValue = Interactions[DeviceInputType.None].GetTransform();
+
+            Assert.IsNull(initialValue);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue1);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue1 = Interactions[DeviceInputType.None].GetTransform();
+
+            Assert.AreEqual(setValue1, testValue1);
+            Assert.AreEqual(setValue1.Item1, testValue1.Item1);
+            Assert.AreEqual(setValue1.Item2, testValue1.Item2);
+            Assert.AreEqual(setValue1.Item2, testValue1.Item2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            Interactions.SetDictionaryValue(DeviceInputType.None, testValue2);
+
+            Assert.IsTrue(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+
+            var setValue2 = Interactions[DeviceInputType.None].GetTransform();
+
+            Assert.AreEqual(setValue2, testValue2);
+            Assert.AreEqual(setValue2.Item1, testValue2.Item1);
+            Assert.AreEqual(setValue2.Item2, testValue2.Item2);
+            Assert.AreEqual(setValue2.Item2, testValue2.Item2);
+            Assert.IsFalse(Interactions.GetDictionaryValueChanged(DeviceInputType.None));
+        }
+
+        #endregion Interaction Dictionary
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -218,17 +218,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
 
             if (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem)
             {
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialPointer))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialGrip) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialGrip) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialGrip))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.TouchpadTouch) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.TouchpadTouch) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
                 {
                     if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
@@ -240,17 +240,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
                     }
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.Touchpad) && controller.Interactions[DeviceInputType.Touchpad].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.Touchpad) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Touchpad))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.ThumbStick) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.ThumbStick) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.ThumbStick))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.Trigger) && controller.Interactions[DeviceInputType.Trigger].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.Trigger) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Trigger))
                 {
                     inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
@@ -168,17 +168,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 
             if (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem)
             {
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialPointer))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialGrip))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
                 {
                     if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
@@ -190,17 +190,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
                     }
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Touchpad))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.ThumbStick))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Trigger))
                 {
                     inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
@@ -168,17 +168,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
 
             if (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem)
             {
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialPointer))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialGrip))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
                 {
                     if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
@@ -190,17 +190,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
                     }
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Touchpad))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.ThumbStick))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Trigger))
                 {
                     inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
@@ -168,17 +168,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
 
             if (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem)
             {
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialPointer))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialGrip))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
                 {
                     if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
@@ -190,17 +190,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
                     }
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Touchpad))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.ThumbStick))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Trigger))
                 {
                     inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
@@ -181,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions..GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
                 {
                     if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
@@ -171,17 +171,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 
             if (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem)
             {
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialPointer].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialPointer))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialPointer].InputAction, controller.Interactions[DeviceInputType.SpatialPointer].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.SpatialGrip].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.SpatialGrip))
                 {
                     inputSystem?.Raise6DofInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.SpatialGrip].InputAction, controller.Interactions[DeviceInputType.SpatialGrip].GetTransform());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.TouchpadTouch].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions..GetDictionaryValueChanged(DeviceInputType.TouchpadTouch))
                 {
                     if (controller.Interactions[DeviceInputType.TouchpadTouch].GetBooleanValue())
                     {
@@ -193,17 +193,17 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
                     }
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Touchpad].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Touchpad))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Touchpad].InputAction, controller.Interactions[DeviceInputType.Touchpad].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.ThumbStick].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.ThumbStick))
                 {
                     inputSystem?.Raise2DoFInputChanged(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.ThumbStick].InputAction, controller.Interactions[DeviceInputType.ThumbStick].GetVector2Value());
                 }
 
-                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions[DeviceInputType.Trigger].Changed)
+                if (controller.Interactions.ContainsKey(DeviceInputType.SpatialPointer) && controller.Interactions.GetDictionaryValueChanged(DeviceInputType.Trigger))
                 {
                     inputSystem?.RaiseOnInputPressed(controller.InputSource, controller.ControllerHandedness, controller.Interactions[DeviceInputType.Select].InputAction, controller.Interactions[DeviceInputType.Trigger].GetFloatValue());
                 }

--- a/Assets/MixedRealityToolkit/_Core/Extensions/CollectionsExtensions.cs
+++ b/Assets/MixedRealityToolkit/_Core/Extensions/CollectionsExtensions.cs
@@ -142,5 +142,23 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Extensions
             entry.SetValue(value);
             input[key] = entry;
         }
+
+        /// <summary>
+        /// Overload extension to enable saving of an InteractionDefinition inside a Dictionary collection
+        /// *Note can only use generics (in both here and InteractionDefinition)
+        /// </summary>
+        /// <typeparam name="T">Type of input being saved</typeparam>
+        /// <param name="input">The InteractionDefinition dictionary reference (generics, performed on a Dictionary)</param>
+        /// <param name="key">The specific DeviceInputType value to update</param>
+        /// <param name="value">The data value to be updated</param>
+        public static bool GetDictionaryValueChanged(
+            this Dictionary<Definitions.Devices.DeviceInputType, Definitions.Devices.InteractionMapping> input,
+            Definitions.Devices.DeviceInputType key)
+        {
+            var entry = input[key];
+            var changed = entry.Changed;
+            input[key] = entry;
+            return changed;
+        }
     }
 }


### PR DESCRIPTION
Overview
---

Added tests for how the InteractionMappings are used in the device space.  Highlighting the issues now created by removing the generics functions.  These tests all fail with the following error (simply because SETVALUE cannot distinguish a type like Get can)

SetValue(object) is only valid for AxisType.Raw InteractionMappings

Also added another extension for the InteractionMapping Dictionary as I missed that changed was updated between gets.

Known Issues
---

Tests now fail as Dictionary updates ONLY update the raw data type without the generic SET method.

Changes
---
- Added Dictionary Tests for InteractionMappings
- Added new InteractionMapping Dictionary extension to allow changed to be updated for a mapping
- Updated used of "Changed" in the devices to use the new GetChanged extension