### PR TITLE
Properly expose MonoBehaviour methods in Cursor.cs

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -118,6 +118,9 @@ namespace HoloToolkit.Unity.InputModule
         protected ICursorModifier TargetedCursorModifier;
 
         private uint visibleHandsCount = 0;
+
+        [SerializeField]
+        [Tooltip("Set this to specify if the Cursor should start visible or invisible in the scene.")]
         private bool isVisible = true;
 
         /// <summary>
@@ -147,22 +150,21 @@ namespace HoloToolkit.Unity.InputModule
 
         #region MonoBehaviour Functions
 
-        private void Awake()
+        protected virtual void Awake()
         {
             originalDefaultCursorDistance = DefaultCursorDistance;
 
             // Use the setter to update visibility of the cursor at startup based on user preferences
             IsVisible = isVisible;
-            SetVisibility(isVisible);
         }
 
-        private void Start()
+        protected virtual void Start()
         {
             RegisterManagers();
             TryLoadPointerIfNeeded();
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             UpdateCursorState();
             UpdateCursorTransform();
@@ -192,7 +194,7 @@ namespace HoloToolkit.Unity.InputModule
             OnCursorStateChange(CursorStateEnum.Contextual);
         }
 
-        private void OnDestroy()
+        protected virtual void OnDestroy()
         {
             UnregisterManagers();
         }

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/InteractiveMeshCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/InteractiveMeshCursor.cs
@@ -51,8 +51,10 @@ namespace HoloToolkit.Unity.InputModule
 
         private Vector3 mAwakeScale;
 
-        private void Awake()
+        protected override void Awake()
         {
+            base.Awake();
+
             mAwakeScale = transform.localScale;
         }
 


### PR DESCRIPTION
InteractiveMeshCursor was unknowingly hiding Cursor's Awake. This wasn't an issue previously, since the only thing in Awake actually didn't really do anything due to a different bug (also fixed here). 

Update Cursor to make its Awake (and others) overridable.

This commit also exposes `isVisible` in the Editor, as the comment in
Awake() indicates that it should be settable before startup.

Also, removes an extra SetVisibility call that already happens in the
public setter.

Fixes #2294.
