### PR TITLE
update class visibility and add runtime assert/logging

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityController.cs
@@ -15,7 +15,7 @@ using UnityEngine.XR.WSA.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
 {
-    public struct WindowsMixedRealityController : IMixedRealityController
+    internal struct WindowsMixedRealityController : IMixedRealityController
     {
         #region Private properties
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -15,7 +15,7 @@ using UnityEngine.XR.WSA.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
 {
-    class WindowsMixedRealityDeviceManager : IMixedRealityDevice
+    internal class WindowsMixedRealityDeviceManager : IMixedRealityDevice
     {
         public WindowsMixedRealityDeviceManager(string name, uint priority)
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityGestureController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityGestureController.cs
@@ -13,7 +13,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
 {
     // TODO - Only scaffold at present
-    public struct WindowsMixedRealityGestureController : IMixedRealityController
+    internal struct WindowsMixedRealityGestureController : IMixedRealityController
     {
         #region Private properties
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/GenericOpenVRController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 {
     // TODO
-    public struct GenericOpenVRController : IMixedRealityController
+    internal struct GenericOpenVRController : IMixedRealityController
     {
         public GenericOpenVRController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/HTCViveController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/HTCViveController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 {
     // TODO
-    public struct HTCViveController : IMixedRealityController
+    internal struct HTCViveController : IMixedRealityController
     {
         public HTCViveController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OculusTouchController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OculusTouchController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 {
     // TODO
-    public struct OculusTouchController : IMixedRealityController
+    internal struct OculusTouchController : IMixedRealityController
     {
         public OculusTouchController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
@@ -16,7 +16,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 {
     // TODO - Implement
-    public class OpenVRDevice : IMixedRealityDevice
+    class OpenVRDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDevice.cs
@@ -16,7 +16,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 {
     // TODO - Implement
-    class OpenVRDevice : IMixedRealityDevice
+    internal class OpenVRDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/ValveKnucklesController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/ValveKnucklesController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
 {
     // TODO
-    public struct ValveKnucklesController : IMixedRealityController
+    internal struct ValveKnucklesController : IMixedRealityController
     {
         public ValveKnucklesController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/GenericOpenXRController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/GenericOpenXRController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
 {
     // TODO
-    public struct GenericOpenXRController : IMixedRealityController
+    internal struct GenericOpenXRController : IMixedRealityController
     {
         public GenericOpenXRController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
@@ -16,7 +16,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
 {
     // TODO - Implement
-    public class OpenXRDevice : IMixedRealityDevice
+    class OpenXRDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenXR/OpenXRDevice.cs
@@ -16,7 +16,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenXR
 {
     // TODO - Implement
-    class OpenXRDevice : IMixedRealityDevice
+    internal class OpenXRDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
 {
     // TODO
-    public struct SimulatedController : IMixedRealityController
+    internal struct SimulatedController : IMixedRealityController
     {
         public SimulatedController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
@@ -16,7 +16,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
 {
     // TODO - Implement
-    public class SimulatedDevice : IMixedRealityDevice
+    class SimulatedDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedDevice.cs
@@ -16,7 +16,7 @@ using UnityEngine.XR.WSA.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
 {
     // TODO - Implement
-    class SimulatedDevice : IMixedRealityDevice
+    internal class SimulatedDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedHandController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/Simulator/SimulatedHandController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.Simulator
 {
     // TODO
-    public struct SimulatedHandController : IMixedRealityController
+    internal struct SimulatedHandController : IMixedRealityController
     {
         public SimulatedHandController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/ArcadeStickController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/ArcadeStickController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 {
     // TODO
-    public struct ArcadeStickController : IMixedRealityController
+    internal struct ArcadeStickController : IMixedRealityController
     {
         public ArcadeStickController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/GamepadController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/GamepadController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 {
     // TODO
-    public struct GamepadController : IMixedRealityController
+    internal struct GamepadController : IMixedRealityController
     {
         public GamepadController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/JoystickController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/JoystickController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 {
     // TODO
-    public struct JoystickController : IMixedRealityController
+    internal struct JoystickController : IMixedRealityController
     {
         public JoystickController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/RacingWheelController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/RacingWheelController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 {
     // TODO
-    public struct RacingWheelController : IMixedRealityController
+    internal struct RacingWheelController : IMixedRealityController
     {
         public RacingWheelController(ControllerState controllerState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, Dictionary<DeviceInputType, InteractionMapping> interactions = null) : this()
         {

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
@@ -20,7 +20,7 @@ using Windows.Gaming.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 {
     // TODO - Implement
-    class WindowsGamingDevice : IMixedRealityDevice
+    internal class WindowsGamingDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDevice.cs
@@ -20,7 +20,7 @@ using Windows.Gaming.Input;
 namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsGaming
 {
     // TODO - Implement
-    public class WindowsGamingDevice : IMixedRealityDevice
+    class WindowsGamingDevice : IMixedRealityDevice
     {
         /// <summary>
         /// Dictionary to capture all active controllers detected

--- a/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using UnityEngine;
+using SystemDebug = System.Diagnostics.Debug;
+using UnityApplication = UnityEngine.Application;
+using UnityDebug = UnityEngine.Debug;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
 {
@@ -9,35 +11,54 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
     {
         public static void DebugAssert(bool condition, string message)
         {
-            Debug.Assert(condition, message);
+            if (UnityApplication.isEditor)
+            {
+                UnityDebug.Assert(condition, message);
+            }
+            else
+            {
+                SystemDebug.Assert(condition, message);
+            }
         }
 
         public static void DebugAssert(bool condition)
         {
-            Debug.Assert(condition);
+            DebugAssert(condition, string.Empty);
         }
 
         public static void DebugLogError(string message)
         {
-            if (Application.isEditor)
+            if (UnityApplication.isEditor)
             {
-                Debug.LogError(message);
+                UnityDebug.LogError(message);
+            }
+            else
+            {
+                SystemDebug.WriteLine("Error: {0}", message);
             }
         }
 
         public static void DebugLogWarning(string message)
         {
-            if (Application.isEditor)
+            if (UnityApplication.isEditor)
             {
-                Debug.LogWarning(message);
+                UnityDebug.LogWarning(message);
+            }
+            else
+            {
+                SystemDebug.WriteLine("Warning: {0}", message);
             }
         }
 
         public static void DebugLog(string message)
         {
-            if (Application.isEditor)
+            if (UnityApplication.isEditor)
             {
-                Debug.Log(message);
+                UnityDebug.Log(message);
+            }
+            else
+            {
+                SystemDebug.WriteLine(message);
             }
         }
     }

--- a/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
@@ -7,8 +7,18 @@ using UnityDebug = UnityEngine.Debug;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
 {
+    /// <summary>
+    /// The DebugUtilities class will use the UnityEngine Debug class while in the Editor
+    /// and the Debug class from the .NET Framework when running a compiled version of the
+    /// application.
+    /// </summary>
     public static class DebugUtilities
     {
+        /// <summary>
+        /// Asserts a condition.
+        /// </summary>
+        /// <param name="condition">The condition that is expected to be true.</param>
+        /// <param name="message">The message to display if the condition evaluates to false.</param>
         public static void DebugAssert(bool condition, string message)
         {
             if (UnityApplication.isEditor)
@@ -21,11 +31,19 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
             }
         }
 
+        /// <summary>
+        /// Asserts a condition.
+        /// </summary>
+        /// <param name="condition">The condition that is expected to be true.</param>
         public static void DebugAssert(bool condition)
         {
             DebugAssert(condition, string.Empty);
         }
 
+        /// <summary>
+        /// Logs an error message.
+        /// </summary>
+        /// <param name="condition">The message to log.</param>
         public static void DebugLogError(string message)
         {
             if (UnityApplication.isEditor)
@@ -38,6 +56,10 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
             }
         }
 
+        /// <summary>
+        /// Logs a warning message.
+        /// </summary>
+        /// <param name="condition">The message to log.</param>
         public static void DebugLogWarning(string message)
         {
             if (UnityApplication.isEditor)
@@ -50,6 +72,10 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
             }
         }
 
+        /// <summary>
+        /// Logs a message.
+        /// </summary>
+        /// <param name="condition">The message to log.</param>
         public static void DebugLog(string message)
         {
             if (UnityApplication.isEditor)

--- a/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
@@ -1,17 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using SystemDebug = System.Diagnostics.Debug;
-using UnityApplication = UnityEngine.Application;
-using UnityDebug = UnityEngine.Debug;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
 {
-    /// <summary>
-    /// The DebugUtilities class will use the UnityEngine Debug class while in the Editor
-    /// and the Debug class from the .NET Framework when running a compiled version of the
-    /// application.
-    /// </summary>
     public static class DebugUtilities
     {
         /// <summary>
@@ -21,14 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="message">The message to display if the condition evaluates to false.</param>
         public static void DebugAssert(bool condition, string message)
         {
-            if (UnityApplication.isEditor)
-            {
-                UnityDebug.Assert(condition, message);
-            }
-            else
-            {
-                SystemDebug.Assert(condition, message);
-            }
+            Debug.Assert(condition, message);
         }
 
         /// <summary>
@@ -46,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="condition">The message to log.</param>
         public static void DebugLogError(string message)
         {
-            UnityDebug.LogError(message);
+            Debug.LogError(message);
         }
 
         /// <summary>
@@ -55,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="condition">The message to log.</param>
         public static void DebugLogWarning(string message)
         {
-            UnityDebug.LogWarning(message);
+            Debug.LogWarning(message);
         }
 
         /// <summary>
@@ -64,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="condition">The message to log.</param>
         public static void DebugLog(string message)
         {
-            UnityDebug.Log(message);
+            Debug.Log(message);
         }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/DebugUtilities.cs
@@ -46,14 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="condition">The message to log.</param>
         public static void DebugLogError(string message)
         {
-            if (UnityApplication.isEditor)
-            {
-                UnityDebug.LogError(message);
-            }
-            else
-            {
-                SystemDebug.WriteLine("Error: {0}", message);
-            }
+            UnityDebug.LogError(message);
         }
 
         /// <summary>
@@ -62,14 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="condition">The message to log.</param>
         public static void DebugLogWarning(string message)
         {
-            if (UnityApplication.isEditor)
-            {
-                UnityDebug.LogWarning(message);
-            }
-            else
-            {
-                SystemDebug.WriteLine("Warning: {0}", message);
-            }
+            UnityDebug.LogWarning(message);
         }
 
         /// <summary>
@@ -78,14 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities
         /// <param name="condition">The message to log.</param>
         public static void DebugLog(string message)
         {
-            if (UnityApplication.isEditor)
-            {
-                UnityDebug.Log(message);
-            }
-            else
-            {
-                SystemDebug.WriteLine(message);
-            }
+            UnityDebug.Log(message);
         }
     }
 }


### PR DESCRIPTION
The controller classes (deriving from IMixedRealityController) were marked as public. Since apps should not have access to them and should be getting their data via the interface, therefore I have marked them as internal.

The device classes (deriving from IMixedRealityDevice) had inconsistent visibility. Some were private and others public. Similar to the controllers, there is no need for these classes to be available to applications. Since WindowsMixedRealityDevice had the most restrictive visibility and is what we have successfully used, I have made them all private.

While not strictly related, the intent of adjusting the visibility of classes is to enable use of asserts during development and free the release/master builds from needing to check for situations that should not be possible. Since Unity's Debug.Assert does not provide runtime assertions (when an app has been built in VS and not running in the editor) I added an editor check and switched which assert (and logging method) is called.