### PR TITLE
Re-enable Sharing with UNET

### DIFF
--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Materials/ButtonBackground.mat
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Materials/ButtonBackground.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: ButtonBackground
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: ETC1_EXTERNAL_ALPHA _BORDER_LIGHT_USES_HOVER_COLOR _DIRECTIONAL_LIGHT
-    _DISABLE_ALBEDO_MAP _HOVER_LIGHT _USECOLOR_ON
+    _HOVER_LIGHT _RIM_LIGHT _USECOLOR_ON
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -109,7 +109,7 @@ Material:
     - _Refraction: 0
     - _RefractiveIndex: 0
     - _RenderQueueOverride: -1
-    - _RimLight: 0
+    - _RimLight: 1
     - _RimPower: 0.25
     - _RoundCornerMargin: 0
     - _RoundCornerRadius: 0.25
@@ -128,7 +128,7 @@ Material:
     m_Colors:
     - _ClipPlane: {r: 0, g: 1, b: 0, a: 0}
     - _ClippingPlaneBorderColor: {r: 1, g: 0.2, b: 0, a: 1}
-    - _Color: {r: 0.49264705, g: 0.20647706, b: 0.23608075, a: 0.753}
+    - _Color: {r: 0.37254903, g: 0.34901962, b: 0.30588236, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
     - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
@@ -137,4 +137,4 @@ Material:
     - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
-    - _RimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _RimColor: {r: 0.007843138, g: 0.007843138, b: 0.007843138, a: 1}

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Prefabs/UIContainer.prefab
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Prefabs/UIContainer.prefab
@@ -1334,8 +1334,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac8d5b128a1d8204fb76c86f47b75912, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PivotAxis: 1
-  TargetTransform: {fileID: 0}
+  pivotAxis: 1
+  targetTransform: {fileID: 0}
 --- !u!114 &114785130695734096
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scenes/SharingWithUnetExample.unity
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scenes/SharingWithUnetExample.unity
@@ -88,6 +88,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 112000001, guid: f7b6b724857b3584584b684aabfb6ff6,
     type: 2}
   m_UseShadowmask: 1
@@ -318,7 +319,6 @@ GameObject:
   m_Component:
   - component: {fileID: 942915100}
   - component: {fileID: 942915101}
-  - component: {fileID: 942915102}
   m_Layer: 0
   m_Name: HologramCollection
   m_TagString: Untagged
@@ -350,17 +350,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 867e702e44bcf964291e6bea2e85b116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &942915102
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 942915099}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 906323c940a3fad4f8f7e9e4fcd747f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &987084763
@@ -852,6 +841,12 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b2db04283121ca74495c2ee000fb4243, type: 2}
   m_IsPrefabParent: 0
+--- !u!114 &1749093971 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114000013851064060, guid: b2db04283121ca74495c2ee000fb4243,
+    type: 2}
+  m_PrefabInternal: {fileID: 1749093970}
+  m_Script: {fileID: 11500000, guid: afa1ae235bc6cfa43addd1435e2fd822, type: 3}
 --- !u!1 &1898807460
 GameObject:
   m_ObjectHideFlags: 0
@@ -1026,6 +1021,11 @@ Prefab:
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114742747811649402, guid: 3eddd1c29199313478dd3f912bfab2ab,
+        type: 2}
+      propertyPath: Cursor
+      value: 
+      objectReference: {fileID: 1749093971}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/GenericNetworkTransmitter.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/GenericNetworkTransmitter.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
 using Windows.Networking.Sockets;
 using Windows.Storage.Streams;
 using Windows.Networking;
@@ -29,6 +29,10 @@ namespace HoloToolkit.Unity.SharingWithUNET
         /// <param name="data">The data that arrived.</param>
         public delegate void OnDataReady(byte[] data);
 
+#if UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
+        public event OnDataReady DataReadyEvent;
+#endif
+
         /// <summary>
         /// The server to connect to when data is needed.
         /// </summary>
@@ -44,7 +48,7 @@ namespace HoloToolkit.Unity.SharingWithUNET
         /// </summary>
         private byte[] mostRecentDataBuffer;
 
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
         /// <summary>
         /// Tracks the network connection to the remote machine we are sending meshes to.
         /// </summary>
@@ -59,8 +63,6 @@ namespace HoloToolkit.Unity.SharingWithUNET
         /// If we cannot connect to the server, this is how long we will wait before retrying.
         /// </summary>
         private float timeToDeferFailedConnections = 10.0f;
-
-        public event OnDataReady DataReadyEvent;
 #endif
 
         /// <summary>
@@ -104,7 +106,7 @@ namespace HoloToolkit.Unity.SharingWithUNET
         }
 
         // A lot of the work done in this class can only be done in UWP. The editor is not a UWP app.
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
         private void RequestDataRetry()
         {
             if (!RequestAndGetData())
@@ -119,7 +121,7 @@ namespace HoloToolkit.Unity.SharingWithUNET
         /// </summary>
         public void ConfigureAsServer()
         {
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
             Task t = new Task(() =>
             {
                 networkListener = new StreamSocketListener();
@@ -140,7 +142,7 @@ namespace HoloToolkit.Unity.SharingWithUNET
         /// </summary>
         private bool ConnectListener()
         {
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
             if (waitingForConnection)
             {
                 Debug.Log("Not a good time to connect listener");
@@ -162,7 +164,7 @@ namespace HoloToolkit.Unity.SharingWithUNET
 #endif
         }
 
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
         /// <summary>
         /// When a connection is made to us, this call back gets called and
         /// we send our data.

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/UNetAnchorManager.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/UNetAnchorManager.cs
@@ -187,7 +187,7 @@ namespace HoloToolkit.Unity.SharingWithUNET
                 return;
             }
 
-#if UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
 #if UNITY_2017_2_OR_NEWER
             if (HolographicSettings.IsDisplayOpaque)
 #else

--- a/Assets/HoloToolkit/Utilities/Scripts/ApplicationViewManager.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ApplicationViewManager.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections;
 using UnityEngine;
 
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
@@ -27,7 +27,7 @@ namespace HoloToolkit.Unity
     {
         private void Start()
         {
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
             UnityEngine.WSA.Application.InvokeOnUIThread(
                 () =>
                 {
@@ -36,7 +36,7 @@ namespace HoloToolkit.Unity
 #endif
         }
 
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
         static int Full3DViewId { get; set; }
         static System.Collections.Concurrent.ConcurrentDictionary<int, Action<object>> CallbackDictionary
             = new System.Collections.Concurrent.ConcurrentDictionary<int, Action<object>>();
@@ -46,7 +46,7 @@ namespace HoloToolkit.Unity
         /// Call this method with Application View Dispatcher， or in Application View Thread, will return to Full3D View and close Application View
         /// </summary>
         /// <param name="returnValue">The return value of the XAML View Execution</param>
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
         public static async void CallbackReturnValue(object returnValue)
         {
             var viewId = ApplicationView.GetForCurrentView().Id;
@@ -80,7 +80,7 @@ namespace HoloToolkit.Unity
         public IEnumerator OnLaunchXamlView<TReturnValue>(string xamlPageName, Action<TReturnValue> callback, object pageNavigateParameter = null)
         {
             bool isCompleted = false;
-#if !UNITY_EDITOR && UNITY_WSA && (!ENABLE_IL2CPP && NET_STANDARD_2_0)
+#if !UNITY_EDITOR && UNITY_WSA && !(ENABLE_IL2CPP && NET_STANDARD_2_0)
             object returnValue = null;
             CoreApplicationView newView = CoreApplication.CreateNewView();
             int newViewId = 0;


### PR DESCRIPTION
Overview
---
Updates some `#if`s from #2127 to run on all build configurations except the intended IL2CPP && .NET Standard 2.0. This was blocking Sharing with UNET from working.

This also contains some minor changes to the scene to bring it up-to-date with the latest components.

Changes
---
- Fixes #2276, fixes #2303
