### PR TITLE
Fixed some Profile Serialization Issues and added Quickstart Menu

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -218,7 +218,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         public MixedRealityControllerMapping GetControllerMapping(Type controllerType, Handedness hand)
         {
             var systemType = SystemType.GetReference(controllerType);
-            for (int i = 0; i < ControllersProfile?.MixedRealityControllerMappingProfiles.Length; i++)
+            for (int i = 0; i < ControllersProfile.MixedRealityControllerMappingProfiles.Length; i++)
             {
                 if (ControllersProfile.MixedRealityControllerMappingProfiles[i].Controller == systemType && ControllersProfile.MixedRealityControllerMappingProfiles[i].Handedness == hand)
                 {

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -52,7 +52,11 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool EnableCameraProfile
         {
-            get { return enableCameraProfile; }
+            get
+            {
+                return CameraProfile != null && enableCameraProfile;
+            }
+
             private set { enableCameraProfile = value; }
         }
 
@@ -78,7 +82,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool EnableInputSystem
         {
-            get { return enableInputSystem; }
+            get
+            {
+                return inputSystemType.Type != null &&
+                       inputActionsProfile != null &&
+                       enableInputSystem;
+            }
             private set { enableInputSystem = value; }
         }
 
@@ -118,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool EnableSpeechCommands
         {
-            get { return enableSpeechCommands; }
+            get { return speechCommandsProfile != null && enableSpeechCommands; }
             private set { enableSpeechCommands = value; }
         }
 
@@ -144,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool EnableControllerProfiles
         {
-            get { return enableControllerProfiles; }
+            get { return controllersProfile != null && enableControllerProfiles; }
             private set { enableControllerProfiles = value; }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -218,28 +218,21 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         public MixedRealityControllerMapping GetControllerMapping(Type controllerType, Handedness hand)
         {
             var systemType = SystemType.GetReference(controllerType);
-            for (int i = 0; i < ControllersProfile.MixedRealityControllerMappingProfiles.Length; i++)
+
+            if (ControllersProfile != null)
             {
-                if (ControllersProfile.MixedRealityControllerMappingProfiles[i].Controller == systemType && ControllersProfile.MixedRealityControllerMappingProfiles[i].Handedness == hand)
+                for (int i = 0; i < ControllersProfile.MixedRealityControllerMappingProfiles.Length; i++)
                 {
-                    return ControllersProfile.MixedRealityControllerMappingProfiles[i];
+                    if (ControllersProfile.MixedRealityControllerMappingProfiles[i].Controller == systemType && ControllersProfile.MixedRealityControllerMappingProfiles[i].Handedness == hand)
+                    {
+                        return ControllersProfile.MixedRealityControllerMappingProfiles[i];
+                    }
                 }
             }
+
             return default(MixedRealityControllerMapping);
         }
 
-        // TODO - Which is better?
-        //public MixedRealityControllerMappingProfile GetControllerMapping<T>(Handedness handedness)
-        //{
-        //    for (int i = 0; i < controllerMappingsProfile?.Length; i++)
-        //    {
-        //        if (controllerMappingsProfile[i].ControllerType == SystemType.GetReference(typeof(T)) && controllerMappingsProfile[i].ControllingHand == handedness)
-        //        {
-        //            return controllerMappingsProfile[i];
-        //        }
-        //    }
-        //    return default(MixedRealityControllerMappingProfile);
-        //}
         #endregion Mixed Reality Controller Mapping helpers
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -9,6 +9,7 @@ using Microsoft.MixedReality.Toolkit.Internal.Interfaces;
 using Microsoft.MixedReality.Toolkit.Internal.Interfaces.InputSystem;
 using System;
 using System.Collections.Generic;
+using Microsoft.MixedReality.Toolkit.Internal.Managers;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
@@ -199,13 +200,12 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
-            // From the serialized fields for the MixedRealityConfigurationProfile, populate the Active managers list
-            // *Note This will only take effect once the Mixed Reality Toolkit has a custom editor for the MixedRealityConfigurationProfile
-
-            ActiveManagers.Clear();
-            for (int i = 0; i < initialManagers?.Length; i++)
+            if (ActiveManagers.Count == 0)
             {
-                Managers.MixedRealityManager.Instance.AddManager(initialManagerTypes[i], initialManagers[i]);
+                for (int i = 0; i < initialManagers?.Length; i++)
+                {
+                    MixedRealityManager.Instance.AddManager(initialManagerTypes[i], initialManagers[i]);
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/_Core/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -16,21 +17,26 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Extensions.EditorClassExtensio
         /// Creates, saves, and then opens a new asset for the target <see cref="ScriptableObject"/>.
         /// </summary>
         /// <param name="scriptableObject"><see cref="ScriptableObject"/> you want to create an asset file for.</param>
+        /// <param name="path">Optional path for the new asset.</param>
         /// <param name="fileName">Optional filename for the new asset.</param>
-        public static void CreateAsset(this ScriptableObject scriptableObject, string fileName = null)
+        public static void CreateAsset(this ScriptableObject scriptableObject, string path = null, string fileName = null)
         {
             var name = string.IsNullOrEmpty(fileName) ? $"{scriptableObject.GetType().Name}" : fileName;
-            var path = AssetDatabase.GetAssetPath(Selection.activeObject);
 
-            if (path == string.Empty)
+            if (string.IsNullOrEmpty(path))
             {
-                path = "Assets/Profiles";
+                path = "Assets/MixedRealityToolkit-SDK/Profiles";
             }
-            else if (Path.GetExtension(path) != string.Empty)
+
+            if (Path.GetExtension(path) != string.Empty)
             {
-                var assetPath = AssetDatabase.GetAssetPath(Selection.activeObject);
-                Debug.Assert(assetPath != null);
-                path = path.Replace(Path.GetFileName(assetPath), string.Empty);
+                var subtractedPath = path.Substring(path.LastIndexOf("/", StringComparison.Ordinal));
+                path = path.Replace(subtractedPath, string.Empty);
+            }
+
+            if (!Directory.Exists(Path.GetFullPath(path)))
+            {
+                Directory.CreateDirectory(Path.GetFullPath(path));
             }
 
             string assetPathAndName = AssetDatabase.GenerateUniqueAssetPath($"{path}/{name}.asset");

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityCameraProfileInspector.cs
@@ -20,12 +20,16 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private SerializedProperty transparentBackgroundColor;
         private SerializedProperty holoLensQualityLevel;
 
-        private GUIContent nearClipTitle;
-        private GUIContent clearFlagsTitle;
-        private GUIStyle headerStyle;
+        private GUIContent nearClipTitle = new GUIContent("Near Clip");
+        private GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
 
         private void OnEnable()
         {
+            if (!CheckMixedRealityManager())
+            {
+                return;
+            }
+
             opaqueNearClip = serializedObject.FindProperty("nearClipPlaneOpaqueDisplay");
             opaqueClearFlags = serializedObject.FindProperty("cameraClearFlagsOpaqueDisplay");
             opaqueBackgroundColor = serializedObject.FindProperty("backgroundColorOpaqueDisplay");
@@ -39,14 +43,20 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
         public override void OnInspectorGUI()
         {
-            nearClipTitle = new GUIContent("Near Clip");
-            clearFlagsTitle = new GUIContent("Clear Flags");
-            headerStyle = new GUIStyle("label") { richText = true };
+            RenderMixedRealityToolkitLogo();
+            EditorGUILayout.LabelField("Camera Profile", EditorStyles.boldLabel);
+
+            if (!CheckMixedRealityManager())
+            {
+                return;
+            }
+
+            EditorGUILayout.HelpBox("The Camera Profile helps tweak camera settings no matter what platform you're building for.", MessageType.Info);
 
             serializedObject.Update();
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("<b>Opaque Display Settings:</b>", headerStyle);
+            EditorGUILayout.LabelField("Opaque Display Settings:", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(opaqueNearClip, nearClipTitle);
             EditorGUILayout.PropertyField(opaqueClearFlags, clearFlagsTitle);
 
@@ -58,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
             opaqueQualityLevel.intValue = EditorGUILayout.Popup("Quality Setting", opaqueQualityLevel.intValue, QualitySettings.names);
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("<b>Transparent Display Settings:</b>", headerStyle);
+            EditorGUILayout.LabelField("Transparent Display Settings:", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(transparentNearClip, nearClipTitle);
             EditorGUILayout.PropertyField(transparentClearFlags, clearFlagsTitle);
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityConfigurationProfileInspector.cs
@@ -131,7 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                     var profileTypeName = property.type.Replace("PPtr<$", string.Empty).Replace(">", string.Empty);
                     Debug.Assert(profileTypeName != null, "No Type Found");
                     ScriptableObject profile = CreateInstance(profileTypeName);
-                    profile.CreateAsset();
+                    profile.CreateAsset(AssetDatabase.GetAssetPath(Selection.activeObject));
                     property.objectReferenceValue = profile;
                 }
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityConfigurationProfileInspector.cs
@@ -39,7 +39,10 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                         "There is no active Mixed Reality Manager in your scene. Would you like to create one now?", "Yes",
                         "Later"))
                     {
-                        MixedRealityManager.Instance.ActiveProfile = (MixedRealityConfigurationProfile)target;
+                        var profile = target as MixedRealityConfigurationProfile;
+                        Debug.Assert(profile != null);
+                        profile.ActiveManagers.Clear();
+                        MixedRealityManager.Instance.ActiveProfile = profile;
                     }
                     else
                     {

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityManagerInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityManagerInspector.cs
@@ -71,13 +71,12 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                 }
             }
 
+            serializedObject.ApplyModifiedProperties();
+
             if (changed)
             {
-                serializedObject.ApplyModifiedProperties();
                 MixedRealityManager.Instance.ResetConfiguration((MixedRealityConfigurationProfile)activeProfile.objectReferenceValue);
             }
-
-            serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityManagerInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityManagerInspector.cs
@@ -34,22 +34,30 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             if (activeProfile.objectReferenceValue == null && currentPickerWindow == -1 && checkChange)
             {
-                EditorUtility.DisplayDialog("Attention!", "You must choose a profile for the Mixed Reality Manager.", "OK");
                 if (allConfigProfiles.Length > 1)
                 {
+                    EditorUtility.DisplayDialog("Attention!", "You must choose a profile for the Mixed Reality Manager.", "OK");
                     currentPickerWindow = GUIUtility.GetControlID(FocusType.Passive);
                     EditorGUIUtility.ShowObjectPicker<MixedRealityConfigurationProfile>(null, false, string.Empty, currentPickerWindow);
                 }
                 else if (allConfigProfiles.Length == 1)
                 {
-                    Debug.Log("No Mixed Reality Configuration Profile was set, so we set the default one for you.");
                     activeProfile.objectReferenceValue = allConfigProfiles[0];
                     changed = true;
+                    Selection.activeObject = allConfigProfiles[0];
+                    EditorGUIUtility.PingObject(allConfigProfiles[0]);
                 }
                 else
                 {
-                    Debug.LogError("No Mixed Reality Configuration Profiles exist!");
-                    // TODO, create one and set it?
+                    if (EditorUtility.DisplayDialog("Attention!", "No profiles were found for the Mixed Reality Manager.\n\n" +
+                                                                  "Would you like to create one now?", "OK", "Later"))
+                    {
+                        ScriptableObject profile = CreateInstance(nameof(MixedRealityConfigurationProfile));
+                        profile.CreateAsset();
+                        activeProfile.objectReferenceValue = profile;
+                        Selection.activeObject = profile;
+                        EditorGUIUtility.PingObject(profile);
+                    }
                 }
 
                 checkChange = false;
@@ -67,6 +75,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                         activeProfile.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
                         currentPickerWindow = -1;
                         changed = true;
+                        Selection.activeObject = activeProfile.objectReferenceValue;
+                        EditorGUIUtility.PingObject(activeProfile.objectReferenceValue);
                         break;
                 }
             }
@@ -77,6 +87,13 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
             {
                 MixedRealityManager.Instance.ResetConfiguration((MixedRealityConfigurationProfile)activeProfile.objectReferenceValue);
             }
+        }
+
+        [MenuItem("Mixed Reality Toolkit/Configure...")]
+        public static void CreateMixedRealityManagerObject()
+        {
+            Selection.activeObject = MixedRealityManager.Instance;
+            EditorGUIUtility.PingObject(MixedRealityManager.Instance);
         }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
@@ -80,6 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
                 DisableAllManagers();
                 DestroyAllManagers();
             }
+
             activeProfile = profile;
             Initialize();
         }
@@ -117,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
         /// </summary>
         private void Initialize()
         {
-            isMixedRealityManagerInitializing = true; 
+            isMixedRealityManagerInitializing = true;
 
             //If the Mixed Reality Manager is not configured, stop.
             if (ActiveProfile == null)
@@ -125,6 +126,9 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
                 Debug.LogError("No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Manager");
                 return;
             }
+
+            Debug.Assert(ActiveProfile.ActiveManagers.Count == 0, "Active Managers were not cleaned up properly.");
+            ActiveProfile.ActiveManagers.Clear();
 
             if (ActiveProfile.EnableCameraProfile)
             {
@@ -139,7 +143,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
             }
 
             #region  Managers Registration
-            
+
             //If the Input system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.EnableInputSystem)
             {
@@ -177,6 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
             //Sort the managers based on Priority
             var orderedManagers = ActiveProfile.ActiveManagers.OrderBy(m => m.Value.Priority).ToArray();
             ActiveProfile.ActiveManagers.Clear();
+
             foreach (var manager in orderedManagers)
             {
                 AddManager(manager.Key, manager.Value);
@@ -185,6 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
             InitializeAllManagers();
 
             #endregion Managers Initialization
+
             isMixedRealityManagerInitializing = false;
         }
 
@@ -326,7 +332,6 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
             }
         }
 
-
         /// <summary>
         /// The MonoBehaviour OnEnable event, which is then circulated to all active managers
         /// </summary>
@@ -404,13 +409,13 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
                 }
                 else
                 {
-                    Debug.LogError($"There's already a {nameof(manager)} registered.");
+                    Debug.LogError($"There's already a {type.Name} registered.");
                 }
             }
             else
             {
                 MixedRealityComponents.Add(new Tuple<Type, IMixedRealityManager>(type, manager));
-                if(!isMixedRealityManagerInitializing) manager.Initialize();
+                if (!isMixedRealityManagerInitializing) { manager.Initialize(); }
                 mixedRealityComponentsCount = MixedRealityComponents.Count;
             }
         }
@@ -801,11 +806,15 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Managers
                 manager.Value.Destroy();
             }
 
+            ActiveProfile.ActiveManagers.Clear();
+
             // Destroy all registered runtime components
             foreach (var manager in MixedRealityComponents)
             {
                 manager.Item2.Destroy();
             }
+
+            MixedRealityComponents.Clear();
         }
 
         #endregion Multiple Managers Management


### PR DESCRIPTION
- We were having issues with active profiles being registered to the Mixed Reality Manager whenever we crated a new scene and selected a config profile.
- I also added a Quickstart menu under Mixed Reality Toolkit menu to generate the Mixed Reality Manager in the scene if none exists.
- Updated how we create profiles.
- Updated Camera Profile Inspector to match the rest of the profiles.
- Fixed Profile Activation crashing if it's null or unset.