### PR TITLE
Keep the transform from the mesh objects when loading into the scene

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/ObjectSurfaceObserver.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/ObjectSurfaceObserver.cs
@@ -52,12 +52,19 @@ namespace HoloToolkit.Unity.SpatialMapping
 
                 for (int iMesh = 0; iMesh < roomFilters.Length; iMesh++)
                 {
-                    AddSurfaceObject(CreateSurfaceObject(
-                        mesh: roomFilters[iMesh].sharedMesh,
+                    MeshFilter meshFilter = roomFilters[iMesh];
+
+                    SurfaceObject newSurfaceObject = CreateSurfaceObject(
+                        mesh: meshFilter.sharedMesh,
                         objectName: "roomMesh-" + iMesh,
                         parentObject: transform,
                         meshID: iMesh
-                        ));
+                        );
+
+                    newSurfaceObject.Object.transform.localPosition = meshFilter.transform.position;
+                    newSurfaceObject.Object.transform.localRotation = meshFilter.transform.rotation;
+
+                    AddSurfaceObject(newSurfaceObject);
                 }
             }
             catch


### PR DESCRIPTION
Overview
---
ObjectSurfaceObserver currently loads in the mesh filters while ignoring the transforms of the GameObjects they're attached to. This change allows meshes to be placed at specific spots and have them load as expected.

Changes
---
- Fixes: #2324
