### PR TITLE
2018.2 code compatability

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/SpatialMapping/Scripts/PlaneFindingTest.cs
+++ b/Assets/MixedRealityToolkit-Examples/SpatialMapping/Scripts/PlaneFindingTest.cs
@@ -112,11 +112,14 @@ namespace MixedRealityToolkit.Examples.SpatialMapping
                     UnityEditor.Handles.DrawLine(corners[1], corners[2]);
                     UnityEditor.Handles.DrawLine(corners[1], corners[3]);
                     UnityEditor.Handles.DrawLine(corners[2], corners[3]);
-                    UnityEditor.Handles.ArrowHandleCap(0, center, Quaternion.FromToRotation(Vector3.forward, normal), 0.4f, EventType.ignore);
-
-                    // If this plane is currently in the center of the camera's field of view, highlight it by drawing a
-                    // solid rectangle, and display the important details about this plane.
-                    float planeHitDistance;
+#if UNITY_2018_2_OR_NEWER
+					UnityEditor.Handles.ArrowHandleCap(0, center, Quaternion.FromToRotation(Vector3.forward, normal), 0.4f, EventType.Ignore);
+#else
+					UnityEditor.Handles.ArrowHandleCap(0, center, Quaternion.FromToRotation(Vector3.forward, normal), 0.4f, EventType.ignore);
+#endif
+					// If this plane is currently in the center of the camera's field of view, highlight it by drawing a
+					// solid rectangle, and display the important details about this plane.
+					float planeHitDistance;
                     if (planes[i].Plane.Raycast(cameraForward, out planeHitDistance))
                     {
                         Vector3 hitPoint = Quaternion.Inverse(rotation) * (cameraForward.GetPoint(planeHitDistance) - center);
@@ -138,5 +141,5 @@ namespace MixedRealityToolkit.Examples.SpatialMapping
             }
         }
 #endif
-    }
+				}
 }

--- a/Assets/MixedRealityToolkit/SpatialMapping/Scripts/SpatialProcessing/Editor/SurfaceMeshesToPlanesEditor.cs
+++ b/Assets/MixedRealityToolkit/SpatialMapping/Scripts/SpatialProcessing/Editor/SurfaceMeshesToPlanesEditor.cs
@@ -26,13 +26,21 @@ namespace MixedRealityToolkit.SpatialMapping.EditorScript
             base.OnInspectorGUI();
             serializedObject.Update();
 
-            drawPlanesMask.intValue = (int)((PlaneTypes)EditorGUILayout.EnumMaskField("Draw Planes",
+#if UNITY_2018_1_OR_NEWER
+			drawPlanesMask.intValue = (int)((PlaneTypes)EditorGUILayout.EnumFlagsField("Draw Planes",
+                (PlaneTypes)drawPlanesMask.intValue));
+
+            destroyPlanesMask.intValue = (int)((PlaneTypes)EditorGUILayout.EnumFlagsField("Destroy Planes",
+                (PlaneTypes)destroyPlanesMask.intValue));
+#else
+			drawPlanesMask.intValue = (int)((PlaneTypes)EditorGUILayout.EnumMaskField("Draw Planes",
                 (PlaneTypes)drawPlanesMask.intValue));
 
             destroyPlanesMask.intValue = (int)((PlaneTypes)EditorGUILayout.EnumMaskField("Destroy Planes",
                 (PlaneTypes)destroyPlanesMask.intValue));
+#endif
 
-            serializedObject.ApplyModifiedProperties();
+			serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Scripts/Editor/EditorGUIExtensions.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scripts/Editor/EditorGUIExtensions.cs
@@ -116,9 +116,13 @@ namespace MixedRealityToolkit.Utilities.EditorScript
             {
                 if (valueType.GetCustomAttributes(typeof(FlagsAttribute), true).Length > 0)
                 {
-                    objValue = EditorGUI.EnumMaskField(position, label, (Enum)objValue);
-                }
-                else
+#if UNITY_2018_1_OR_NEWER
+					objValue = EditorGUI.EnumFlagsField(position, label, (Enum)objValue);
+#else
+					objValue = EditorGUI.EnumMaskField(position, label, (Enum)objValue);
+#endif
+				}
+				else
                 {
                     objValue = EditorGUI.EnumPopup(position, label, (Enum)objValue);
                 }

--- a/Assets/MixedRealityToolkit/Utilities/Scripts/Editor/SetIconsWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scripts/Editor/SetIconsWindow.cs
@@ -308,22 +308,26 @@ namespace MixedRealityToolkit.Utilities.EditorScript
             switch (type)
             {
                 case PlayerSettings.WSAImageType.PackageLogo:
-                case PlayerSettings.WSAImageType.StoreTileLogo:
+#if !UNITY_2018_2_OR_NEWER
+				case PlayerSettings.WSAImageType.StoreTileLogo:
                 case PlayerSettings.WSAImageType.StoreTileSmallLogo:
                 case PlayerSettings.WSAImageType.StoreSmallTile:
                 case PlayerSettings.WSAImageType.StoreLargeTile:
-                case PlayerSettings.WSAImageType.UWPSquare44x44Logo:
+#endif
+				case PlayerSettings.WSAImageType.UWPSquare44x44Logo:
                 case PlayerSettings.WSAImageType.UWPSquare71x71Logo:
                 case PlayerSettings.WSAImageType.UWPSquare150x150Logo:
                 case PlayerSettings.WSAImageType.UWPSquare310x310Logo:
+#if !UNITY_2018_2_OR_NEWER
                 case PlayerSettings.WSAImageType.PhoneAppIcon:
                 case PlayerSettings.WSAImageType.PhoneSmallTile:
                 case PlayerSettings.WSAImageType.PhoneMediumTile:
                 case PlayerSettings.WSAImageType.PhoneWideTile:
                     return _newAppIconPath;
                 case PlayerSettings.WSAImageType.PhoneSplashScreen:
-                case PlayerSettings.WSAImageType.SplashScreenImage:
                 case PlayerSettings.WSAImageType.StoreTileWideLogo:
+#endif
+				case PlayerSettings.WSAImageType.SplashScreenImage:
                 case PlayerSettings.WSAImageType.UWPWide310x150Logo:
                     if (scale != PlayerSettings.WSAImageScale.Target16 &&
                         scale != PlayerSettings.WSAImageScale.Target24 &&
@@ -369,6 +373,7 @@ namespace MixedRealityToolkit.Utilities.EditorScript
             {
                 case PlayerSettings.WSAImageType.PackageLogo:
                     return CreateSquareSize(50, scaleFactor);
+#if !UNITY_2018_2_OR_NEWER
                 case PlayerSettings.WSAImageType.StoreTileLogo:
                     return CreateSquareSize(150, scaleFactor);
                 case PlayerSettings.WSAImageType.StoreTileSmallLogo:
@@ -383,7 +388,8 @@ namespace MixedRealityToolkit.Utilities.EditorScript
                     return CreateSquareSize(71, scaleFactor);
                 case PlayerSettings.WSAImageType.PhoneMediumTile:
                     return CreateSquareSize(150, scaleFactor);
-                case PlayerSettings.WSAImageType.UWPSquare44x44Logo:
+#endif
+				case PlayerSettings.WSAImageType.UWPSquare44x44Logo:
                     return CreateSquareSize(44, scaleFactor);
                 case PlayerSettings.WSAImageType.UWPSquare71x71Logo:
                     return CreateSquareSize(71, scaleFactor);
@@ -392,13 +398,16 @@ namespace MixedRealityToolkit.Utilities.EditorScript
                 case PlayerSettings.WSAImageType.UWPSquare310x310Logo:
                     return CreateSquareSize(310, scaleFactor);
 
-                // WIDE 31:15
+				// WIDE 31:15
+#if !UNITY_2018_2_OR_NEWER
                 case PlayerSettings.WSAImageType.PhoneWideTile:
                 case PlayerSettings.WSAImageType.StoreTileWideLogo:
+#endif
                 case PlayerSettings.WSAImageType.UWPWide310x150Logo:
                     return CreateSize(new Vector2(310, 150), scaleFactor);
                 case PlayerSettings.WSAImageType.SplashScreenImage:
                     return CreateSize(new Vector2(620, 300), scaleFactor);
+#if !UNITY_2018_2_OR_NEWER
                 case PlayerSettings.WSAImageType.PhoneSplashScreen:
                     switch (scale)
                     {
@@ -409,6 +418,7 @@ namespace MixedRealityToolkit.Utilities.EditorScript
                         default:
                             return Vector2.zero;
                     }
+#endif
                 default:
                     Debug.LogWarningFormat("Invalid image size for {0} with scale {1}X{2}", type, scale, scaleFactor);
                     return Vector2.zero;

--- a/Assets/MixedRealityToolkit/Utilities/Scripts/Tagalong.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scripts/Tagalong.cs
@@ -292,10 +292,14 @@ namespace MixedRealityToolkit.Utilities
                             {
                                 Light clonedLight = Instantiate(DebugPointLight, closestHit.point, Quaternion.identity) as Light;
                                 clonedLight.color = Color.red;
-                                DestroyObject(clonedLight, 1.0f);
-                            }
+#if UNITY_2018_2_OR_NEWER
+								Object.Destroy(clonedLight, 1.0f);
+#else
+								DestroyObject(clonedLight, 1.0f);
+#endif
+							}
 #if UNITY_EDITOR
-                            DebugDrawLine(DebugDrawLines, cameraPosition, targetCoord, Color.red);
+							DebugDrawLine(DebugDrawLines, cameraPosition, targetCoord, Color.red);
 #endif // UNITY_EDITOR
                         }
                     }


### PR DESCRIPTION
Overview
---
Added compiler directives to let the code compile successfully with 2018.2 (#if UNITY_2018_2_OR_NEWER)

- Remaining Problem: Previously BuildPlayer returned an error string. BuildReport does not have that so I don't know what the equivalent could be. For now in the case of an error, the string "Error" will be used.
