### PR TITLE
[June retarget] Fix for choosing closest grabbable object to grab

### DIFF
--- a/Assets/HoloToolkit-Examples/MotionControllers-GrabMechanics/Scripts/BaseGrabber.cs
+++ b/Assets/HoloToolkit-Examples/MotionControllers-GrabMechanics/Scripts/BaseGrabber.cs
@@ -185,7 +185,7 @@ namespace HoloToolkit.Unity.InputModule.Examples.Grabbables
         {
             contactObjects.Sort(delegate (BaseGrabbable b1, BaseGrabbable b2)
             {
-                return Vector3.Distance(b1.GrabPoint, GrabHandle.position).CompareTo(Vector3.Distance(b1.GrabPoint, GrabHandle.position));
+                return Vector3.Distance(b1.GrabPoint, GrabHandle.position).CompareTo(Vector3.Distance(b2.GrabPoint, GrabHandle.position));
             });
         }
 


### PR DESCRIPTION
Sort method was comparing distance of first object to itself, rather than second object

Overview
---
This PR is a rebase and retarget of the commit from @paulmriordan's PR #2159. That PR had been inactive for a month.
