### PR TITLE
[June retarget] Fix for dragging of rotation handles of BoundBoxRig

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
@@ -213,7 +213,7 @@ namespace HoloToolkit.Unity.UX
 
                 Vector3 newScale = changeScale;
                 newScale.Scale(initialScale);
-               
+
                 //scale from object center
                 transformToAffect.localScale = newScale;
 
@@ -261,7 +261,7 @@ namespace HoloToolkit.Unity.UX
             }
             else
             {
-                Vector3 axis = (Axis == BoundingBoxGizmoHandleAxisToAffect.X ? new Vector3(1,0,0) : Axis == BoundingBoxGizmoHandleAxisToAffect.Y ? new Vector3(0,1,0) : new Vector3(0,0,1) );
+                Vector3 axis = (Axis == BoundingBoxGizmoHandleAxisToAffect.X ? new Vector3(1, 0, 0) : Axis == BoundingBoxGizmoHandleAxisToAffect.Y ? new Vector3(0, 1, 0) : new Vector3(0, 0, 1));
                 transformToAffect.localRotation = initialRotation;
                 transformToAffect.Rotate(axis, angle * 5.0f);
             }
@@ -270,9 +270,13 @@ namespace HoloToolkit.Unity.UX
         private void ApplyRotation(Vector3 currentHandPosition)
         {
             if (RotateAroundPivot)
+            {
                 ApplyRotationPivot(currentHandPosition);
+            }
             else
+            {
                 ApplyRotationContinuous(currentHandPosition);
+            }
         }
 
         private void ApplyRotationContinuous(Vector3 currentHandPosition)
@@ -311,7 +315,7 @@ namespace HoloToolkit.Unity.UX
             }
             else
             {
-                Vector3 axis = (Axis == BoundingBoxGizmoHandleAxisToAffect.X ? new Vector3(1, 0, 0) : Axis == BoundingBoxGizmoHandleAxisToAffect.Y ? new Vector3(0, 1, 0) : new Vector3(0, 0,1));
+                Vector3 axis = (Axis == BoundingBoxGizmoHandleAxisToAffect.X ? new Vector3(1, 0, 0) : Axis == BoundingBoxGizmoHandleAxisToAffect.Y ? new Vector3(0, 1, 0) : new Vector3(0, 0, 1));
                 transformToAffect.localRotation = initialRotation;
                 float angle = newEulers.x != 0 ? newEulers.x : newEulers.y != 0 ? newEulers.y : newEulers.z;
                 transformToAffect.Rotate(axis, angle * 2.0f);
@@ -322,8 +326,7 @@ namespace HoloToolkit.Unity.UX
         {
             Vector3 delta = currentHandPosition - lastHandWorldPos;
 
-            if (delta.sqrMagnitude == 0)
-                return;
+            if (delta.sqrMagnitude == 0) { return; }
 
             delta.Scale(rotationFromPositionScale);
 

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
@@ -35,6 +35,7 @@ namespace HoloToolkit.Unity.UX
         private float maxScale = 10.0f;
         private BoundingBoxGizmoHandleRotationType rotationCoordinateSystem;
         private BoundingBoxGizmoHandleHandMotionType handMotionForRotation;
+        private Vector3 lastHandWorldPos = Vector3.zero;
 
         public BoundingBoxGizmoHandleTransformType AffineType
         {
@@ -140,6 +141,7 @@ namespace HoloToolkit.Unity.UX
                 rig = value;
             }
         }
+        public bool RotateAroundPivot { get; set; }
 
         private void Start()
         {
@@ -183,6 +185,8 @@ namespace HoloToolkit.Unity.UX
                         ApplyRotation(currentHandPosition);
                     }
                 }
+
+                lastHandWorldPos = currentHandPosition;
             }
         }
 
@@ -265,6 +269,14 @@ namespace HoloToolkit.Unity.UX
         }
         private void ApplyRotation(Vector3 currentHandPosition)
         {
+            if (RotateAroundPivot)
+                ApplyRotationPivot(currentHandPosition);
+            else
+                ApplyRotationContinuous(currentHandPosition);
+        }
+
+        private void ApplyRotationContinuous(Vector3 currentHandPosition)
+        {
             Vector3 initialRay = initialHandPosition - transformToAffect.position;
             initialRay.Normalize();
 
@@ -305,6 +317,32 @@ namespace HoloToolkit.Unity.UX
                 transformToAffect.Rotate(axis, angle * 2.0f);
             }
         }
+
+        private void ApplyRotationPivot(Vector3 currentHandPosition)
+        {
+            Vector3 delta = currentHandPosition - lastHandWorldPos;
+
+            if (delta.sqrMagnitude == 0)
+                return;
+
+            delta.Scale(rotationFromPositionScale);
+
+            var pivotToHandleDir = (transform.position - transformToAffect.position).normalized;
+            switch (Axis)
+            {
+                default:
+                case BoundingBoxGizmoHandleAxisToAffect.X:
+                    transformToAffect.Rotate(Vector3.right, Vector3.Dot(delta, Vector3.Cross(pivotToHandleDir, transformToAffect.right)), Space.Self);
+                    break;
+                case BoundingBoxGizmoHandleAxisToAffect.Y:
+                    transformToAffect.Rotate(Vector3.up, Vector3.Dot(delta, Vector3.Cross(pivotToHandleDir, transformToAffect.up)), Space.Self);
+                    break;
+                case BoundingBoxGizmoHandleAxisToAffect.Z:
+                    transformToAffect.Rotate(Vector3.forward, Vector3.Dot(delta, Vector3.Cross(pivotToHandleDir, transformToAffect.forward)), Space.Self);
+                    break;
+            }
+        }
+
         private Vector3 GetBoundedScaleChange(Vector3 scale)
         {
             Vector3 maximumScale = new Vector3(initialScale.x * maxScale, initialScale.y * maxScale, initialScale.z * maxScale);
@@ -342,6 +380,7 @@ namespace HoloToolkit.Unity.UX
             inputDownEventData = eventData;
 
             initialHandPosition     = GetHandPosition(eventData.SourceId);
+            lastHandWorldPos        = initialHandPosition;
             initialScale            = transformToAffect.localScale;
             initialPosition         = transformToAffect.position;
             initialOrientation      = transformToAffect.rotation.eulerAngles;

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
@@ -530,7 +530,7 @@ namespace HoloToolkit.Unity.UX
             {
                 return BoundingBox.FlattenModeEnum.FlattenZ;
             }
-          
+
             return BoundingBox.FlattenModeEnum.DoNotFlatten;
         }
     }

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxRig.cs
@@ -44,6 +44,9 @@ namespace HoloToolkit.Unity.UX
         [SerializeField]
         private BoundingBoxGizmoHandleHandMotionType handMotionToRotate = BoundingBoxGizmoHandleHandMotionType.handRotatesToRotateObject;
 
+        [SerializeField]
+        private bool rotateAroundPivot = false;
+
         [Header("Preset Components")]
         [SerializeField]
         [Tooltip("To visualize the object bounding box, drop the MixedRealityToolkit/UX/Prefabs/BoundingBoxes/BoundingBoxBasic.prefab here.")]
@@ -269,6 +272,7 @@ namespace HoloToolkit.Unity.UX
                     rotateHandles[i].transform.localScale = rotateHandleSize;
                     rotateHandles[i].name = "Middle " + i.ToString();
                     rigRotateGizmoHandles[i] = rotateHandles[i].AddComponent<BoundingBoxGizmoHandle>();
+                    rigRotateGizmoHandles[i].RotateAroundPivot = rotateAroundPivot;
                     rigRotateGizmoHandles[i].Rig = this;
                     rigRotateGizmoHandles[i].HandMotionForRotation = handMotionToRotate;
                     rigRotateGizmoHandles[i].RotationCoordinateSystem = rotationType;


### PR DESCRIPTION
Overview
---
This PR is a rebase and retarget of the commit from @paulmriordan's PR #2160. That PR had been inactive for a month.

To quote @paulmriordan in #2160:

>Current method of rotation is not consistent; the object is rotated different directions
>depending on orientation of object.

>This commit adds an option (rotateAroundPivot) which allows the user to rotate an object in a more >natural way.

>To avoid breaking existing usage, this new rotation is enabled via a bool in BoundingBoxRig.

> Existing behaviour:
> ![boundingboxgizmoold](https://user-images.githubusercontent.com/4314853/40498945-6573e890-5f78-11e8-9268-0dd08701ffd2.gif)
> 
> New behaviour:
> ![boundingboxgizmonew](https://user-images.githubusercontent.com/4314853/40498949-68375396-5f78-11e8-82d1-36e322d07808.gif)
