### PR TITLE
Button.cs eventData fixes

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
@@ -246,8 +246,8 @@ namespace HoloToolkit.Unity.Buttons
         /// </summary>
         public void OnFocusExit(PointerSpecificEventData eventData)
         {
-             if (!m_disabled) // && FocusManager.Instance.IsFocused(this))
-             {
+            if (!m_disabled) // && FocusManager.Instance.IsFocused(this))
+            {
                 if (ButtonState == ButtonStateEnum.Pressed)
                 {
                     DoButtonCanceled();

--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
@@ -141,6 +141,7 @@ namespace HoloToolkit.Unity.Buttons
                     // Set state to Pressed
                     ButtonStateEnum newState = ButtonStateEnum.Pressed;
                     this.OnStateChange(newState);
+                    eventData.Use();
                 }
             }
         }
@@ -156,6 +157,7 @@ namespace HoloToolkit.Unity.Buttons
                 if (ButtonPressFilter == InteractionSourcePressInfo.None || ButtonPressFilter == eventData.PressType)
                 {
                     DoButtonReleased();
+                    eventData.Use();
                 }
             }
         }
@@ -171,6 +173,7 @@ namespace HoloToolkit.Unity.Buttons
                 if (ButtonPressFilter == InteractionSourcePressInfo.None || ButtonPressFilter == eventData.PressType)
                 {
                     DoButtonPressed(true);
+                    eventData.Use();
                 }
             }
         }
@@ -185,6 +188,7 @@ namespace HoloToolkit.Unity.Buttons
             if (!m_disabled)
             {
                 DoButtonPressed();
+                eventData.Use();
             }
         }
 
@@ -201,6 +205,7 @@ namespace HoloToolkit.Unity.Buttons
                 // Unset state from pressed.
                 ButtonStateEnum newState = ButtonStateEnum.Targeted;
                 this.OnStateChange(newState);
+                eventData.Use();
             }
         }
 
@@ -217,6 +222,7 @@ namespace HoloToolkit.Unity.Buttons
 
                 ButtonStateEnum newState = ButtonStateEnum.Targeted;
                 this.OnStateChange(newState);
+                eventData.Use();
             }
         }
 
@@ -231,6 +237,7 @@ namespace HoloToolkit.Unity.Buttons
                 this.OnStateChange(newState);
 
                 _bFocused = true;
+                 eventData.Use();
             }
         }
 
@@ -240,7 +247,7 @@ namespace HoloToolkit.Unity.Buttons
         public void OnFocusExit(PointerSpecificEventData eventData)
         {
              if (!m_disabled) // && FocusManager.Instance.IsFocused(this))
-            {
+             {
                 if (ButtonState == ButtonStateEnum.Pressed)
                 {
                     DoButtonCanceled();
@@ -254,7 +261,8 @@ namespace HoloToolkit.Unity.Buttons
                 }
 
                 _bFocused = false;
-            }
+                eventData.Use();
+             }
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs.meta
@@ -1,13 +1,13 @@
 fileFormatVersion: 2
-guid: 1fb6040b8ecac06468282404a86299e4
-timeCreated: 1530168127
-licenseType: Pro
+guid: da8f80956d894644bb62bc848d89ede8
+timeCreated: 1500484825
+licenseType: Free
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 50f52cea2ab53ec4d868ca6837c9a0b8, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs.meta
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs.meta
@@ -1,13 +1,13 @@
 fileFormatVersion: 2
-guid: da8f80956d894644bb62bc848d89ede8
-timeCreated: 1500484825
-licenseType: Free
+guid: 1fb6040b8ecac06468282404a86299e4
+timeCreated: 1530168127
+licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 50f52cea2ab53ec4d868ca6837c9a0b8, type: 3}
+  icon: {instanceID: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Overview
---

Fixed #2295. Marked eventData objects as used inside Button to ensure events do not propagate to downstream handlers.

Changes
---
- Fixes: # 2295.
