### PR TITLE
Fixes an InteractionInputSource bug where data was removed too soon

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InteractionInputSource.cs
@@ -946,10 +946,10 @@ namespace HoloToolkit.Unity.InputModule
 
         private void InteractionManager_InteractionSourceLost(InteractionSourceLostEventArgs args)
         {
+            InputManager.Instance.RaiseSourceLost(this, args.state.source.id);
+
             // NOTE: We don't care whether the source ID previously existed or not, so we blindly call Remove:
             sourceIdToData.Remove(args.state.source.id);
-
-            InputManager.Instance.RaiseSourceLost(this, args.state.source.id);
         }
 
         private void InteractionManager_InteractionSourceDetected(InteractionSourceDetectedEventArgs args)


### PR DESCRIPTION
Overview
---

Previously, the data was removed before the event was fired. This caused any queries back about the data while handling the event to fail.

This was found during Button.cs investigation, and subsequent PRs will be opened following this change.