### PR TITLE
PopupMenu options fix

### DIFF
--- a/Assets/HoloToolkit-Examples/Input/Scenes/InputManagerTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/InputManagerTest.unity
@@ -5915,7 +5915,7 @@ TextMesh:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1906609830}
-  m_Text: 'All other input is disabled
+  m_Text: 'All other clicks are disabled
 
     until this popup is closed!'
   m_OffsetZ: 0

--- a/Assets/HoloToolkit-Examples/Input/Scenes/InputManagerTest.unity
+++ b/Assets/HoloToolkit-Examples/Input/Scenes/InputManagerTest.unity
@@ -1811,9 +1811,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Convex: 0
-  m_InflateMesh: 0
+  m_CookingOptions: 14
   m_SkinWidth: 0.01
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &481840526
@@ -2716,9 +2716,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Convex: 0
-  m_InflateMesh: 0
+  m_CookingOptions: 14
   m_SkinWidth: 0.01
   m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &718516062
@@ -4259,7 +4259,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Activating this button, creates a popup that disables all other input until
+  m_Text: Activating this button, creates a popup that disables all other clicks until
     the popup is dismissed.
 --- !u!222 &1309489392
 CanvasRenderer:

--- a/Assets/HoloToolkit-Examples/Input/Scripts/PopupMenu.cs
+++ b/Assets/HoloToolkit-Examples/Input/Scripts/PopupMenu.cs
@@ -35,6 +35,8 @@ namespace HoloToolkit.Unity.InputModule.Tests
         /// </summary>
         private Action deactivatedCallback;
 
+        private int dehydrateButtonId;
+
         public PopupState CurrentPopupState = PopupState.Closed;
 
         public enum PopupState { Open, Closed }
@@ -42,6 +44,11 @@ namespace HoloToolkit.Unity.InputModule.Tests
         private void Awake()
         {
             gameObject.SetActive(false);
+
+            if (dehydrateButtonId == 0)
+            {
+                dehydrateButtonId = Animator.StringToHash("Dehydrate");
+            }
         }
 
         private void OnEnable()
@@ -118,9 +125,9 @@ namespace HoloToolkit.Unity.InputModule.Tests
             }
 
             // Deactivates the game object
-            if (rootAnimator.isInitialized)
+            if (rootAnimator != null && rootAnimator.isInitialized)
             {
-                rootAnimator.SetTrigger("Dehydrate");
+                rootAnimator.SetTrigger(dehydrateButtonId);
             }
             else
             {

--- a/Assets/HoloToolkit-Examples/Input/Scripts/PopupMenu.cs
+++ b/Assets/HoloToolkit-Examples/Input/Scripts/PopupMenu.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
-    public class PopupMenu : MonoBehaviour, IInputHandler
+    public class PopupMenu : MonoBehaviour
     {
         [SerializeField]
         private TestButton cancelButton = null;
@@ -21,17 +21,17 @@ namespace HoloToolkit.Unity.InputModule.Tests
         private bool closeOnNonTargetedTap = false;
 
         /// <summary>
-        /// Called when 'place' is selected
+        /// Called when 'place' is selected.
         /// </summary>
         private Action activatedCallback;
 
         /// <summary>
-        /// Called when 'back' or 'hide' is selected
+        /// Called when 'back' or 'hide' is selected.
         /// </summary>
         private Action cancelledCallback;
 
         /// <summary>
-        /// Called when the user clicks outside of the menu
+        /// Called when the user clicks outside of the menu.
         /// </summary>
         private Action deactivatedCallback;
 
@@ -71,15 +71,15 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
             if (isModal)
             {
-                InputManager.Instance.PushModalInputHandler(gameObject);
+                InputManager.Instance.PushModalInputHandler(cancelButton.gameObject);
             }
 
             if (closeOnNonTargetedTap)
             {
-                InputManager.Instance.PushFallbackInputHandler(gameObject);
+                InputManager.Instance.PushFallbackInputHandler(cancelButton.gameObject);
             }
 
-            // the visual was activated via an interaction outside of the menu, let anyone who cares know
+            // The visual was activated via an interaction outside of the menu. Let anyone who cares know.
             if (activatedCallback != null)
             {
                 activatedCallback();
@@ -87,7 +87,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         }
 
         /// <summary>
-        /// Dismiss the details pane
+        /// Dismiss the details pane.
         /// </summary>
         public void Dismiss()
         {
@@ -130,32 +130,15 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
         private void OnCancelPressed(TestButton source)
         {
-            if (cancelledCallback != null)
+            if (cancelButton.Focused || closeOnNonTargetedTap)
             {
-                cancelledCallback();
-            }
+                if (cancelledCallback != null)
+                {
+                    cancelledCallback();
+                }
 
-            Dismiss();
-        }
-
-        void IInputHandler.OnInputDown(InputEventData eventData)
-        {
-            if (closeOnNonTargetedTap)
-            {
                 Dismiss();
             }
-
-            eventData.Use(); // Mark the event as used, so it doesn't fall through to other handlers.
-        }
-
-        void IInputHandler.OnInputUp(InputEventData eventData)
-        {
-            if (closeOnNonTargetedTap)
-            {
-                Dismiss();
-            }
-
-            eventData.Use(); // Mark the event as used, so it doesn't fall through to other handlers.
         }
     }
 }

--- a/Assets/HoloToolkit-Examples/Input/Scripts/TestButton.cs
+++ b/Assets/HoloToolkit-Examples/Input/Scripts/TestButton.cs
@@ -22,10 +22,11 @@ namespace HoloToolkit.Unity.InputModule.Tests
         [SerializeField]
         protected Animator ButtonAnimator;
 
-        private static int focusedButtonId;
-        private static int selectedButtonId;
-        private static int deHydrateButtonId;
-        private static int stayFocusedButtonId;
+        private int focusedButtonId;
+        private int selectedButtonId;
+        private int dehydrateButtonId;
+        private int stayFocusedButtonId;
+        private int colorPropertyId;
 
         public delegate void ActivateDelegate(TestButton source);
         public event ActivateDelegate Activated;
@@ -89,27 +90,34 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 selectedButtonId = Animator.StringToHash("Selected");
             }
 
-            if (deHydrateButtonId == 0)
+            if (dehydrateButtonId == 0)
             {
-                deHydrateButtonId = Animator.StringToHash("Dehydrate");
+                dehydrateButtonId = Animator.StringToHash("Dehydrate");
             }
 
             if (stayFocusedButtonId == 0)
             {
                 stayFocusedButtonId = Animator.StringToHash("StayFocused");
             }
+
+            if (colorPropertyId == 0)
+            {
+                colorPropertyId = Shader.PropertyToID("_Color");
+            }
         }
 
         protected virtual void OnEnable()
         {
+            Focused = false;
+
             // Set the initial alpha
             if (ToolTipRenderer != null)
             {
                 cachedToolTipMaterial = ToolTipRenderer.material;
 
-                Color tipColor = cachedToolTipMaterial.GetColor("_Color");
+                Color tipColor = cachedToolTipMaterial.GetColor(colorPropertyId);
                 tipColor.a = 0.0f;
-                cachedToolTipMaterial.SetColor("_Color", tipColor);
+                cachedToolTipMaterial.SetColor(colorPropertyId, tipColor);
                 toolTipTimer = 0.0f;
             }
 
@@ -137,9 +145,9 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 // Update the new opacity
                 if (ToolTipRenderer != null)
                 {
-                    Color tipColor = cachedToolTipMaterial.GetColor("_Color");
+                    Color tipColor = cachedToolTipMaterial.GetColor(colorPropertyId);
                     tipColor.a = Mathf.Clamp(toolTipTimer, 0, ToolTipFadeTime) / ToolTipFadeTime;
-                    cachedToolTipMaterial.SetColor("_Color", tipColor);
+                    cachedToolTipMaterial.SetColor(colorPropertyId, tipColor);
                 }
             }
         }
@@ -155,9 +163,9 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
                 for (int i = 0; i < animatorHashes.Length; i++)
                 {
-                    if (animatorHashes[i].nameHash == deHydrateButtonId)
+                    if (animatorHashes[i].nameHash == dehydrateButtonId)
                     {
-                        ButtonAnimator.SetTrigger(deHydrateButtonId);
+                        ButtonAnimator.SetTrigger(dehydrateButtonId);
                     }
                 }
             }


### PR DESCRIPTION
Overview
---
The PopupMenu was consuming `OnInputDown` and `OnInputUp` events, while it seemed like it should consume (and other similar components were using) `OnInputClicked`. I reworded the example scene to be clearer, and also decreased the number of places states were being handled. The PopupMenu routes its "close" input handling through a button, but was also receiving its own input. Now, everything goes through the button.

Changes
---
- Fixes: #2040, fixes #1535
