### PR TITLE
Fix some build warnings

### DIFF
--- a/Assets/HoloToolkit-Examples/SpectatorView/Scripts/SpectatorViewNetworkManager.cs
+++ b/Assets/HoloToolkit-Examples/SpectatorView/Scripts/SpectatorViewNetworkManager.cs
@@ -16,7 +16,7 @@ public class SpectatorViewNetworkManager : NetworkManager
     /// </summary>
     [SerializeField]
     [Tooltip("Component that manages the main flow, events and the main contact point with UNET multilens")]
-    private SpectatorView spectatorView;
+    private SpectatorView spectatorView = null;
 
     // Use this for initialization
     private void Start()

--- a/Assets/HoloToolkit-Preview/SpectatorView/UnityARKitPlugin/Plugins/iOS/UnityARKit/Helpers/UnityARUtility.cs
+++ b/Assets/HoloToolkit-Preview/SpectatorView/UnityARKitPlugin/Plugins/iOS/UnityARKit/Helpers/UnityARUtility.cs
@@ -7,11 +7,15 @@ namespace UnityEngine.XR.iOS
     {
         private MeshCollider meshCollider; //declared to avoid code stripping of class
         private MeshFilter meshFilter; //declared to avoid code stripping of class
+#if UNITY_IOS || UNITY_EDITOR
         private static GameObject planePrefab = null;
+#endif
 
         public static void InitializePlanePrefab(GameObject go)
         {
+#if UNITY_IOS || UNITY_EDITOR
             planePrefab = go;
+#endif
         }
 
 #if UNITY_IOS || UNITY_EDITOR
@@ -49,7 +53,6 @@ namespace UnityEngine.XR.iOS
 
             return plane;
         }
-
 #endif
 
     }

--- a/Assets/HoloToolkit/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/HoloToolkit/UX/Scripts/AppBar/AppBar.cs
@@ -212,7 +212,6 @@ namespace HoloToolkit.Unity.UX
         private BoundingBox boundingBox;
 
         private ButtonTemplate[] defaultButtons;
-        private Vector3[] forwards = new Vector3[4];
         private Vector3 targetBarSize = Vector3.one;
         private float lastTimeTapped = 0f;
         private float coolDownTime = 0.5f;


### PR DESCRIPTION
Overview
---
The `planePrefab` is only used in this script and is only used `#if UNITY_IOS || UNITY_EDITOR`. Without this check when building for Standalone:

![image](https://user-images.githubusercontent.com/3580640/40802062-68e3b432-64c9-11e8-9b30-2fe9d6528ecf.png)

SpectatorViewNetworkManager also shows:

![image](https://user-images.githubusercontent.com/3580640/42063084-f8e044fc-7ae4-11e8-8547-c15eef0e0d80.png)

and AppBar shows:

![image](https://user-images.githubusercontent.com/3580640/42063092-010acd50-7ae5-11e8-9608-24958b675dde.png)

Changes
---
- Fixes: #2068, specifically https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/2068#issuecomment-393639957
