### PR TITLE
Partially removed if-branching from _BORDER_LIGHT

### DIFF
--- a/Assets/HoloToolkit/Common/Shaders/Standard.shader
+++ b/Assets/HoloToolkit/Common/Shaders/Standard.shader
@@ -118,6 +118,8 @@ Shader "MixedRealityToolkit/Standard"
             #pragma shader_feature _BORDER_LIGHT_OPAQUE
             #pragma shader_feature _INNER_GLOW
             #pragma shader_feature _ENVIRONMENT_COLORING
+            
+            #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0));
 
             #include "UnityCG.cginc"
             #include "UnityStandardConfig.cginc"
@@ -389,17 +391,9 @@ Shader "MixedRealityToolkit/Standard"
 
                 o.scale.z = minScale;
                 float scaleRatio = min(o.scale.x, o.scale.y) / max(o.scale.x, o.scale.y);
-
-                if (o.scale.x > o.scale.y)
-                {
-                    o.uv.z = 1.0 - (borderWidth * scaleRatio);
-                    o.uv.w = 1.0 - borderWidth;
-                }
-                else
-                {
-                    o.uv.z = 1.0 - borderWidth;
-                    o.uv.w = 1.0 - (borderWidth * scaleRatio);
-                }
+                
+				o.uv.z = IF(o.scale.x > o.scale.y, 1.0 - (borderWidth * scaleRatio), 1.0 - borderWidth);
+				o.uv.w = IF(o.scale.x > o.scale.y, 1.0 - borderWidth, 1.0 - (borderWidth * scaleRatio));
 #else
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
 #endif


### PR DESCRIPTION
Overview
---
I have followed the documentation on here:

https://shadowmint.gitbooks.io/unity-material-shaders/support/syntax/step.html

Branching in shaders are usually undesirable because of the GPU-architecture (as far as I have read), but sometimes they can be useful in edge-cases. For this case I could have eliminated the if-else ifs in the block above the one I worked on, but on second thought I decided to leave it as to be honest I have not yet spent that much time looking into this shader.

Changes
---
- I have removed the 2nd branching in the _BORDER__LIGHT-definition that wrote to o.uv.z and o.uv.w and replaced with a custom #define IF at line 122 . 
