### PR TITLE
Button.cs event firing fixes

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
@@ -11,7 +11,7 @@ namespace HoloToolkit.Unity.Buttons
     /// <summary>
     /// Base class for buttons.
     /// </summary>
-    public abstract class Button : MonoBehaviour, IInputHandler, IPointerSpecificFocusable, IHoldHandler, ISourceStateHandler, IInputClickHandler
+    public abstract class Button : MonoBehaviour, IInputHandler, IPointerSpecificFocusable, IHoldHandler, IInputClickHandler
     {
         #region Public Members and Serialized Fields
 
@@ -100,19 +100,14 @@ namespace HoloToolkit.Unity.Buttons
         private bool lastHandVisible = false;
 
         /// <summary>
-        /// State of gaze/focus being on the button
-        /// </summary>
-        private bool handVisible { get { return handCount > 0; } }
-
-        /// <summary>
         /// State of hands being visible
         /// </summary>
-        private bool focused = false;
+        private bool handVisible { get { return InputManager.Instance.DetectedInputSources.Count > 0; } }
 
         /// <summary>
-        /// Count of visible hands
+        /// State of gaze/focus being on the button
         /// </summary>
-        private int handCount = 0;
+        private bool focused = false;
 
         /// <summary>
         /// Check for disabled state or disabled behavior
@@ -296,37 +291,6 @@ namespace HoloToolkit.Unity.Buttons
             }
         }
 
-        /// <summary>
-        /// On Source detected see if it is a hand and increment hand count and set visibility
-        /// </summary>
-        /// <param name="eventData"></param>
-        public void OnSourceDetected(SourceStateEventData eventData)
-        {
-            InteractionSourceInfo sourceInfo;
-            if (eventData.InputSource.TryGetSourceKind(eventData.SourceId, out sourceInfo))
-            {
-                if (sourceInfo == InteractionSourceInfo.Hand)
-                {
-                    handCount++;
-                }
-            }
-        }
-
-        /// <summary>
-        ///  On Source lost decrement hand count and set visibility
-        /// </summary>
-        /// <param name="eventData"></param>
-        public void OnSourceLost(SourceStateEventData eventData)
-        {
-            InteractionSourceInfo sourceInfo;
-            if (eventData.InputSource.TryGetSourceKind(eventData.SourceId, out sourceInfo))
-            {
-                if (sourceInfo == InteractionSourceInfo.Hand)
-                {
-                    handCount--;
-                }
-            }
-        }
         #endregion Input Interface Functions
 
         #region Button Functions

--- a/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Buttons/Button.cs
@@ -156,9 +156,6 @@ namespace HoloToolkit.Unity.Buttons
                 {
                     DoButtonPressed();
 
-                    // Set state to Pressed
-                    ButtonStateEnum newState = ButtonStateEnum.Pressed;
-                    this.OnStateChange(newState);
                     eventData.Use();
                 }
             }
@@ -175,6 +172,7 @@ namespace HoloToolkit.Unity.Buttons
                 if (ButtonPressFilter == InteractionSourcePressInfo.None || ButtonPressFilter == eventData.PressType)
                 {
                     DoButtonReleased();
+
                     eventData.Use();
                 }
             }
@@ -190,7 +188,8 @@ namespace HoloToolkit.Unity.Buttons
             {
                 if (ButtonPressFilter == InteractionSourcePressInfo.None || ButtonPressFilter == eventData.PressType)
                 {
-                    DoButtonPressed(true);
+                    DoButtonClicked();
+
                     eventData.Use();
                 }
             }
@@ -205,7 +204,8 @@ namespace HoloToolkit.Unity.Buttons
         {
             if (!isDisabled)
             {
-                DoButtonPressed();
+                DoButtonHeld();
+
                 eventData.Use();
             }
         }
@@ -216,15 +216,7 @@ namespace HoloToolkit.Unity.Buttons
         /// <param name="eventData"></param>
         public void OnHoldCompleted(HoldEventData eventData)
         {
-            if (!isDisabled && ButtonState == ButtonStateEnum.Pressed)
-            {
-                DoButtonHeld();
-
-                // Unset state from pressed.
-                ButtonStateEnum newState = ButtonStateEnum.Targeted;
-                this.OnStateChange(newState);
-                eventData.Use();
-            }
+            // No button event for OnHoldCompleted. State will be handled in OnInputUp.
         }
 
         /// <summary>
@@ -252,6 +244,7 @@ namespace HoloToolkit.Unity.Buttons
                 OnStateChange(newState);
 
                 focused = true;
+
                 eventData.Use();
             }
         }
@@ -276,6 +269,7 @@ namespace HoloToolkit.Unity.Buttons
                 }
 
                 focused = false;
+
                 eventData.Use();
             }
         }
@@ -321,6 +315,13 @@ namespace HoloToolkit.Unity.Buttons
             }
         }
 
+        protected void DoButtonClicked()
+        {
+            if (OnButtonClicked != null)
+            {
+                OnButtonClicked(gameObject);
+            }
+        }
 
         /// <summary>
         /// Called once after the button is held down.


### PR DESCRIPTION
Overview
---
Part 2 of #2359. This is a rework of the way the Button.cs events are fired. Previously, duplicate events were fired in both `OnInputDown` and `OnInputClicked` (and `OnHoldStarted`). This cleans those up and makes the state logic a little clearer.

Changes
---
- Fixes: #1879
