### PR TITLE
Resolves null references if the input system is disabled with components relying on Input System

### DIFF
--- a/Assets/MixedRealityToolkit/InputSystem/Focus/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/Focus/FocusProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Focus
     public class FocusProvider : MonoBehaviour, IMixedRealityFocusProvider
     {
         private IMixedRealityInputSystem inputSystem = null;
-        public IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>());
+        public IMixedRealityInputSystem InputSystem => inputSystem ?? (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem ? inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>() : null);
 
         /// <summary>
         /// Maximum distance at which the pointer can collide with an object.
@@ -229,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Focus
         private void Start()
         {
             // Register the FocusProvider as a global listener to get input events.
-            InputSystem.Register(gameObject);
+            InputSystem?.Register(gameObject);
         }
 
         private void Update()

--- a/Assets/MixedRealityToolkit/InputSystem/Gaze/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/Gaze/GazeProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Gaze
         private bool delayInitialization = true;
 
         private IMixedRealityInputSystem inputSystem = null;
-        private IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>());
+        private IMixedRealityInputSystem InputSystem => inputSystem ?? (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem ? inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>() : null);
 
         #region IMixedRealityPointer Implementation
 
@@ -241,8 +241,8 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Gaze
         private void OnDisable()
         {
             GazePointer.BaseCursor?.SetVisibility(false);
-            InputSystem.RaiseSourceLost(GazeInputSource);
-            InputSystem.FocusProvider.UnregisterPointer(GazePointer);
+            InputSystem?.RaiseSourceLost(GazeInputSource);
+            InputSystem?.FocusProvider.UnregisterPointer(GazePointer);
         }
 
         private void OnDestroy()
@@ -264,9 +264,9 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Gaze
 
         private void RaiseSourceDetected()
         {
-            InputSystem.FocusProvider.RegisterPointer(GazePointer);
+            InputSystem?.FocusProvider.RegisterPointer(GazePointer);
             GazePointer.BaseCursor?.SetVisibility(true);
-            InputSystem.RaiseSourceDetected(GazeInputSource);
+            InputSystem?.RaiseSourceDetected(GazeInputSource);
         }
 
         private bool FindGazeTransform()

--- a/Assets/MixedRealityToolkit/InputSystem/Gaze/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/Gaze/GazeProvider.cs
@@ -240,7 +240,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Gaze
 
         private void OnDisable()
         {
-            GazePointer.BaseCursor?.SetVisibility(false);
+            GazePointer?.BaseCursor?.SetVisibility(false);
             InputSystem?.RaiseSourceLost(GazeInputSource);
             InputSystem?.FocusProvider.UnregisterPointer(GazePointer);
         }

--- a/Assets/MixedRealityToolkit/InputSystem/Pointers/GenericPointer.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/Pointers/GenericPointer.cs
@@ -17,8 +17,11 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Pointers
     {
         public GenericPointer(string pointerName, IMixedRealityInputSource inputSourceParent)
         {
-            InputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>();
-            PointerId = InputSystem.FocusProvider.GenerateNewPointerId();
+            if (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem)
+            {
+                InputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>();
+            }
+            PointerId = InputSystem?.FocusProvider.GenerateNewPointerId() ?? 0;
             PointerName = pointerName;
             InputSourceParent = inputSourceParent;
         }

--- a/Assets/MixedRealityToolkit/InputSystem/Sources/BaseGenericInputSource.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/Sources/BaseGenericInputSource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Sources
         /// <summary>
         /// The Current Input System for this Input Source.
         /// </summary>
-        public static IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>());
+        public static IMixedRealityInputSystem InputSystem => inputSystem ?? (MixedRealityManager.Instance.ActiveProfile.EnableInputSystem ? inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>() : null);
         private static IMixedRealityInputSystem inputSystem = null;
 
         /// <summary>
@@ -27,9 +27,9 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Sources
         /// <param name="pointers"></param>
         public BaseGenericInputSource(string name, IMixedRealityPointer[] pointers = null)
         {
-            SourceId = InputSystem.GenerateNewSourceId();
+            SourceId = InputSystem?.GenerateNewSourceId() ?? 0;
             SourceName = name;
-            Pointers = pointers ?? new[] { InputSystem.GazeProvider.GazePointer };
+            Pointers = pointers ?? new[] { InputSystem?.GazeProvider.GazePointer };
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityController.cs
@@ -138,7 +138,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
             interactionSourceState.sourcePose.TryGetPosition(out currentPointerPosition, InteractionSourceNode.Pointer);
             interactionSourceState.sourcePose.TryGetRotation(out currentPointerRotation, InteractionSourceNode.Pointer);
 
-            if (CameraCache.Main.transform.parent != null)
+            if (CameraCache.Main?.transform.parent != null)
             {
                 currentPointerData.Position = CameraCache.Main.transform.parent.TransformPoint(currentPointerPosition);
                 currentPointerData.Rotation = Quaternion.Euler(CameraCache.Main.transform.parent.TransformDirection(currentPointerRotation.eulerAngles));


### PR DESCRIPTION
Overview
---
Currently, if a scene starts that previously was using the InputSystem and the Input System was then disabled.  This caused a bucketload of Null reference checks / errors.

I expect review to consider an alternate way of Null testing or EnableInputSystem testing to ensure this should not generate errors in any manager use.

Changes
---
- Fixes: Null Reference Errors in Getmanager due to the manager not existing when called from GazeProvider
- Fixes: Null Reference Errors in Getmanager due to the manager not existing when called from FocusProvider
- Fixes: Null Reference Errors in Getmanager due to the manager not existing when called from GenericPointer
- Fixes: Input System Null Reference Errors in GenericPointer due to the manager not existing or inputsystem disabled
