### PR TITLE
Config Profile Inspector doesn't update values after change.

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityCameraProfileInspector.cs
@@ -20,12 +20,12 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private SerializedProperty transparentBackgroundColor;
         private SerializedProperty holoLensQualityLevel;
 
-        private GUIContent nearClipTitle = new GUIContent("Near Clip");
-        private GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
+        private readonly GUIContent nearClipTitle = new GUIContent("Near Clip");
+        private readonly GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
 
         private void OnEnable()
         {
-            if (!CheckMixedRealityManager())
+            if (!CheckMixedRealityManager(false))
             {
                 return;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityConfigurationProfileInspector.cs
@@ -25,6 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private SerializedProperty controllersProfile;
         private SerializedProperty enableBoundarySystem;
 
+        private MixedRealityConfigurationProfile configurationProfile;
+
         private void OnEnable()
         {
             // Create The MR Manager if none exists.
@@ -55,6 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                 }
             }
 
+            configurationProfile = target as MixedRealityConfigurationProfile;
             enableCameraProfile = serializedObject.FindProperty("enableCameraProfile");
             cameraProfile = serializedObject.FindProperty("cameraProfile");
             enableInputSystem = serializedObject.FindProperty("enableInputSystem");
@@ -74,6 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             var previousLabelWidth = EditorGUIUtility.labelWidth;
             EditorGUIUtility.labelWidth = 160f;
+            EditorGUI.BeginChangeCheck();
 
             // Camera Profile Configuration
             EditorGUILayout.LabelField("Camera Settings", EditorStyles.boldLabel);
@@ -117,6 +121,11 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
             EditorGUIUtility.labelWidth = previousLabelWidth;
             serializedObject.ApplyModifiedProperties();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                MixedRealityManager.Instance.ResetConfiguration(configurationProfile);
+            }
         }
 
         private static void RenderProfile(SerializedProperty property)


### PR DESCRIPTION
- Fixes #2371's issues with cleaning up profiles after user changes them in the inspector.
- fixed null ref when selecting camera profile when no mixed reality manager is in the scene.