### PR TITLE
Billboard.cs up vector bug fix

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
@@ -55,8 +55,6 @@ namespace HoloToolkit.Unity
             {
                 TargetTransform = CameraCache.Main.transform;
             }
-
-            Update();
         }
 
         /// <summary>
@@ -71,19 +69,20 @@ namespace HoloToolkit.Unity
 
             // Get a Vector that points from the target to the main camera.
             Vector3 directionToTarget = TargetTransform.position - transform.position;
-            Vector3 targetUpVector = CameraCache.Main.transform.up;
+
+            bool useCameraAsUpVector = true;
 
             // Adjust for the pivot axis.
             switch (PivotAxis)
             {
                 case PivotAxis.X:
                     directionToTarget.x = 0.0f;
-                    targetUpVector = transform.up;
+                    useCameraAsUpVector = false;
                     break;
 
                 case PivotAxis.Y:
                     directionToTarget.y = 0.0f;
-                    targetUpVector = transform.up;
+                    useCameraAsUpVector = false;
                     break;
 
                 case PivotAxis.Z:
@@ -92,7 +91,7 @@ namespace HoloToolkit.Unity
                     break;
 
                 case PivotAxis.XY:
-                    targetUpVector = transform.up;
+                    useCameraAsUpVector = false;
                     break;
 
                 case PivotAxis.XZ:
@@ -116,7 +115,14 @@ namespace HoloToolkit.Unity
             }
 
             // Calculate and apply the rotation required to reorient the object
-            transform.rotation = Quaternion.LookRotation(-directionToTarget, targetUpVector);
+            if (useCameraAsUpVector)
+            {
+                transform.rotation = Quaternion.LookRotation(-directionToTarget, CameraCache.Main.transform.up);
+            }
+            else
+            {
+                transform.rotation = Quaternion.LookRotation(-directionToTarget);
+            }
         }
     }
 }


### PR DESCRIPTION
Overview
---
LookRotation wants the two vectors to be orthogonal. Giving it the
object's current up vector caused some drift in the z angle in some
cases (since the resulting up vector sometimes cannot be what we pass in). Now, we
don't pass any up vector in and let Unity handle it in cases where we
don't want z touched.