### PR TITLE
Fixed errors when stopping editor playmode.

### DIFF
--- a/Assets/MixedRealityToolkit/InputSystem/Focus/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/Focus/FocusProvider.cs
@@ -390,6 +390,8 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem.Focus
         /// <returns>The UIRaycastCamera</returns>
         private void CreateUiRaycastCamera()
         {
+            if (!enabled) { return; }
+
             var cameraObject = new GameObject { name = "UIRaycastCamera" };
             cameraObject.transform.parent = transform;
             cameraObject.transform.localPosition = Vector3.zero;

--- a/Assets/MixedRealityToolkit/InputSystem/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/MixedRealityInputManager.cs
@@ -102,7 +102,6 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
             {
                 if (Application.isEditor)
                 {
-#if UNITY_EDITOR
                     bool addedComponents = false;
                     var eventSystems = UnityEngine.Object.FindObjectsOfType<EventSystem>();
                     var standaloneInputModules = UnityEngine.Object.FindObjectsOfType<StandaloneInputModule>();
@@ -121,6 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
                         addedComponents = true;
                     }
 
+#if UNITY_EDITOR
                     if (addedComponents) { UnityEditor.EditorGUIUtility.PingObject(FocusProvider.UIRaycastCamera); }
 #endif
                 }

--- a/Assets/MixedRealityToolkit/InputSystem/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit/InputSystem/MixedRealityInputManager.cs
@@ -166,21 +166,21 @@ namespace Microsoft.MixedReality.Toolkit.InputSystem
         {
             InputDisabled?.Invoke();
 
-            if (FocusProvider.UIRaycastCamera != null)
-            {
-                if (Application.isEditor)
-                {
-                    UnityEngine.Object.DestroyImmediate(FocusProvider.UIRaycastCamera.gameObject);
-                }
-                else
-                {
-                    UnityEngine.Object.Destroy(FocusProvider.UIRaycastCamera.gameObject);
-                }
-            }
-
             if (focusProvider != null)
             {
                 focusProvider.enabled = false;
+
+                if (FocusProvider.UIRaycastCamera != null)
+                {
+                    if (Application.isEditor)
+                    {
+                        UnityEngine.Object.DestroyImmediate(FocusProvider.UIRaycastCamera.gameObject);
+                    }
+                    else
+                    {
+                        UnityEngine.Object.Destroy(FocusProvider.UIRaycastCamera.gameObject);
+                    }
+                }
 
                 if (Application.isEditor)
                 {

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -82,14 +82,19 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
         /// </summary>
         /// <param name="interactionSourceState">Source State provided by the SDK</param>
         /// <returns>New or Existing Controller Input Source</returns>
-        private WindowsMixedRealityController GetOrAddController(InteractionSourceState interactionSourceState)
+        private WindowsMixedRealityController GetOrAddController(InteractionSourceState interactionSourceState, bool updateControllerData = true)
         {
             //If a device is already registered with the ID provided, just return it.
             if (activeControllers.ContainsKey(interactionSourceState.source.id))
             {
                 var controller = activeControllers[interactionSourceState.source.id] as WindowsMixedRealityController;
                 Debug.Assert(controller != null);
-                controller.UpdateController(interactionSourceState);
+
+                if (updateControllerData)
+                {
+                    controller.UpdateController(interactionSourceState);
+                }
+
                 return controller;
             }
 
@@ -124,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality
         /// <param name="interactionSourceState">Source State provided by the SDK to remove</param>
         private void RemoveController(InteractionSourceState interactionSourceState)
         {
-            var controller = GetOrAddController(interactionSourceState);
+            var controller = GetOrAddController(interactionSourceState, false);
             InputSystem?.RaiseSourceLost(controller?.InputSource, controller);
             activeControllers.Remove(interactionSourceState.source.id);
         }


### PR DESCRIPTION
- Disabled focus provider and added a check in the `UIRaycastCamera` creation to return if it's disabled.
- Added a flag to `GetOrAddController` to skip updating the controller when we remove it.