### PR TITLE
Add support for non-0 min values in SliderGestureControl

### DIFF
--- a/Assets/HoloToolkit-Examples/UX/Prefabs/Slider.prefab
+++ b/Assets/HoloToolkit-Examples/UX/Prefabs/Slider.prefab
@@ -371,6 +371,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -386,12 +387,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012509494062
 MeshRenderer:
@@ -402,6 +405,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -417,12 +421,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012600065236
 MeshRenderer:
@@ -433,6 +439,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -448,12 +455,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012779802454
 MeshRenderer:
@@ -464,6 +473,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -479,12 +489,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013866804616
 MeshRenderer:
@@ -495,6 +507,7 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -510,12 +523,14 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
   m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &33000010600070742
 MeshFilter:
@@ -646,7 +661,7 @@ MonoBehaviour:
   GestureData: 1
   MaxGestureDistance: 0.25
   AlignmentVector: {x: 1, y: 1, z: 1}
-  FlipDirecationOnCameraForward: 0
+  FlipDirectionOnCameraForward: 0
   SliderBar: {fileID: 1000010121767078}
   Knob: {fileID: 1000012031565074}
   SliderFill: {fileID: 1000011534470254}
@@ -655,9 +670,9 @@ MonoBehaviour:
   OnUpdateEvent:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
-  SliderValue: 0
+    m_TypeName: HoloToolkit.Unity.UnityEventFloat, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  sliderValue: 0
   MinSliderValue: 0
   MaxSliderValue: 10
   Centered: 0
@@ -683,18 +698,18 @@ MonoBehaviour:
   OnSelectEvents:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
   OnDownEvent:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
   OnHoldEvent:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
   StartDelay: 0
   Control: {fileID: 114000013369595812}
   HideCursorOnManipulation: 0
@@ -809,8 +824,8 @@ MonoBehaviour:
   OnComplete:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114425133298623510
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -897,8 +912,8 @@ MonoBehaviour:
   OnComplete:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114672892898193146
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -968,7 +983,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac8d5b128a1d8204fb76c86f47b75912, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PivotAxis: 1
+  pivotAxis: 0
+  targetTransform: {fileID: 0}
 --- !u!114 &114922840319301710
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/HoloToolkit-Examples/UX/Scenes/SliderSamples.unity
+++ b/Assets/HoloToolkit-Examples/UX/Scenes/SliderSamples.unity
@@ -88,6 +88,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 0
 --- !u!196 &4
@@ -256,8 +257,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac8d5b128a1d8204fb76c86f47b75912, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PivotAxis: 1
-  TargetTransform: {fileID: 0}
+  pivotAxis: 0
+  targetTransform: {fileID: 0}
 --- !u!4 &611374906 stripped
 Transform:
   m_PrefabParentObject: {fileID: 4000011864058216, guid: a61fbf52f79ff5b479d7c59ec56dd0bc,
@@ -694,8 +695,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac8d5b128a1d8204fb76c86f47b75912, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PivotAxis: 1
-  TargetTransform: {fileID: 0}
+  pivotAxis: 0
+  targetTransform: {fileID: 0}
 --- !u!4 &1660733758 stripped
 Transform:
   m_PrefabParentObject: {fileID: 4000011864058216, guid: a61fbf52f79ff5b479d7c59ec56dd0bc,
@@ -898,6 +899,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 906323c940a3fad4f8f7e9e4fcd747f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  containerObject: {fileID: 0}
+  alignmentType: 0
+  stationarySpaceTypePosition: {x: 0, y: 0, z: 0}
+  roomScaleSpaceTypePosition: {x: 0, y: 0, z: 0}
 --- !u!4 &1713238780
 Transform:
   m_ObjectHideFlags: 0
@@ -1006,6 +1011,11 @@ Prefab:
         type: 2}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000013369595812, guid: a61fbf52f79ff5b479d7c59ec56dd0bc,
+        type: 2}
+      propertyPath: MinSliderValue
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a61fbf52f79ff5b479d7c59ec56dd0bc, type: 2}

--- a/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace HoloToolkit.Examples.InteractiveElements
 {
     /// <summary>
-    /// updates slider UI based on gesture input
+    /// Updates slider UI based on gesture input
     /// </summary>
     public class SliderGestureControl : GestureInteractiveControl
     {
@@ -72,9 +72,9 @@ namespace HoloToolkit.Examples.InteractiveElements
         private Vector3 mSliderFillScale;
         private float mSliderWidth;
 
-        private float AutoSliderTime = 0.25f;
-        private float AutoSliderTimerCounter = 0.5f;
-        private float AutoSliderValue = 0;
+        private float autoSliderTime = 0.25f;
+        private float autoSliderTimerCounter = 0.5f;
+        private float autoSliderValue = 0;
 
         private Vector3 mSliderVector;
         private Quaternion mCachedRotation;
@@ -188,16 +188,16 @@ namespace HoloToolkit.Examples.InteractiveElements
             switch (gestureValue)
             {
                 case 0:
-                    AutoSliderValue = 0;
+                    autoSliderValue = 0;
                     break;
                 case 1:
-                    AutoSliderValue = 0.5f;
+                    autoSliderValue = 0.5f;
                     break;
                 case 2:
-                    AutoSliderValue = 1;
+                    autoSliderValue = 1;
                     break;
             }
-            AutoSliderTimerCounter = 0;
+            autoSliderTimerCounter = 0;
         }
 
         /// <summary>
@@ -298,22 +298,22 @@ namespace HoloToolkit.Examples.InteractiveElements
         {
             base.Update();
 
-            if (AutoSliderTimerCounter < AutoSliderTime)
+            if (autoSliderTimerCounter < autoSliderTime)
             {
                 if (GestureStarted)
                 {
-                    AutoSliderTimerCounter = AutoSliderTime;
+                    autoSliderTimerCounter = autoSliderTime;
                     return;
                 }
 
-                AutoSliderTimerCounter += Time.deltaTime;
-                if (AutoSliderTimerCounter >= AutoSliderTime)
+                autoSliderTimerCounter += Time.deltaTime;
+                if (autoSliderTimerCounter >= autoSliderTime)
                 {
-                    AutoSliderTimerCounter = AutoSliderTime;
-                    mCachedValue = AutoSliderValue;
+                    autoSliderTimerCounter = autoSliderTime;
+                    mCachedValue = autoSliderValue;
                 }
 
-                mDeltaValue = (AutoSliderValue - mCachedValue) * AutoSliderTimerCounter / AutoSliderTime + mCachedValue;
+                mDeltaValue = (autoSliderValue - mCachedValue) * autoSliderTimerCounter / autoSliderTime + mCachedValue;
 
                 if (!Centered)
                 {
@@ -325,7 +325,6 @@ namespace HoloToolkit.Examples.InteractiveElements
                 }
 
                 UpdateVisuals();
-
             }
         }
     }

--- a/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
@@ -88,14 +88,14 @@ namespace HoloToolkit.Examples.InteractiveElements
             if (MinSliderValue >= MaxSliderValue)
             {
                 Debug.LogError("Your SliderGestureControl has a min value that's greater than or equal to its max value.");
-                Destroy(this);
+                gameObject.SetActive(false);
                 return;
             }
 
             if (Centered && MinSliderValue != -MaxSliderValue)
             {
                 Debug.LogError("A centered SliderGestureControl requires that the min and max values have the same absolute value, one positive and one negative.");
-                Destroy(this);
+                gameObject.SetActive(false);
                 return;
             }
 

--- a/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
@@ -121,7 +121,7 @@ namespace HoloToolkit.Examples.InteractiveElements
 
             if (!Centered)
             {
-                mDeltaValue = SliderValue / mValueSpan;
+                mDeltaValue = (SliderValue - MinSliderValue) / mValueSpan;
             }
             else
             {
@@ -172,7 +172,7 @@ namespace HoloToolkit.Examples.InteractiveElements
 
             if (!Centered)
             {
-                SliderValue = mDeltaValue * mValueSpan;
+                SliderValue = mDeltaValue * mValueSpan + MinSliderValue;
             }
             else
             {
@@ -288,20 +288,14 @@ namespace HoloToolkit.Examples.InteractiveElements
             // set the label
             if (Label != null)
             {
-                float displayValue = SliderValue;
-                if (Centered)
-                {
-                    displayValue = SliderValue * 2 - SliderValue;
-                }
-
                 if (LabelFormat.IndexOf('.') > -1)
                 {
-                    Label.text = displayValue.ToString(LabelFormat);
+                    Label.text = SliderValue.ToString(LabelFormat);
 
                 }
                 else
                 {
-                    Label.text = Mathf.Round(displayValue).ToString(LabelFormat);
+                    Label.text = Mathf.Round(SliderValue).ToString(LabelFormat);
                 }
             }
         }
@@ -332,7 +326,7 @@ namespace HoloToolkit.Examples.InteractiveElements
 
                 if (!Centered)
                 {
-                    SliderValue = mDeltaValue * mValueSpan;
+                    SliderValue = mDeltaValue * mValueSpan + MinSliderValue;
                 }
                 else
                 {

--- a/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
+++ b/Assets/HoloToolkit-Examples/UX/Scripts/Controls/SliderGestureControl.cs
@@ -33,17 +33,21 @@ namespace HoloToolkit.Examples.InteractiveElements
         {
             private set
             {
-                if (mSliderValue != value)
+                if (sliderValue != value)
                 {
-                    mSliderValue = value;
-                    OnUpdateEvent.Invoke(mSliderValue);
+                    sliderValue = value;
+                    OnUpdateEvent.Invoke(sliderValue);
                 }
             }
             get
             {
-                return mSliderValue;
+                return sliderValue;
             }
         }
+
+        [SerializeField]
+        [Tooltip("Set the starting value for the slider here.")]
+        private float sliderValue = 0;
 
         [Tooltip("Min numeric value to display in the slider label")]
         public float MinSliderValue = 0;
@@ -56,8 +60,6 @@ namespace HoloToolkit.Examples.InteractiveElements
 
         [Tooltip("Format the slider value and control decimal places if needed")]
         public string LabelFormat = "#.##";
-
-        private float mSliderValue;
 
         // calculation variables
         private float mValueSpan;
@@ -83,6 +85,20 @@ namespace HoloToolkit.Examples.InteractiveElements
         {
             base.Awake();
 
+            if (MinSliderValue >= MaxSliderValue)
+            {
+                Debug.LogError("Your SliderGestureControl has a min value that's greater than or equal to its max value.");
+                Destroy(this);
+                return;
+            }
+
+            if (Centered && MinSliderValue != -MaxSliderValue)
+            {
+                Debug.LogError("A centered SliderGestureControl requires that the min and max values have the same absolute value, one positive and one negative.");
+                Destroy(this);
+                return;
+            }
+
             if (Knob != null)
             {
                 mStartCenter.z = Knob.transform.localPosition.z;
@@ -101,7 +117,7 @@ namespace HoloToolkit.Examples.InteractiveElements
             mStartSliderPosition = mStartCenter + Vector3.left * mSliderMagnitude / 2;
 
             mValueSpan = MaxSliderValue - MinSliderValue;
-            mSliderValue = Mathf.Clamp(SliderValue, MinSliderValue, MaxSliderValue);
+            sliderValue = Mathf.Clamp(SliderValue, MinSliderValue, MaxSliderValue);
 
             if (!Centered)
             {
@@ -223,11 +239,10 @@ namespace HoloToolkit.Examples.InteractiveElements
                 return;
             }
 
-            mSliderValue = Mathf.Clamp(value, MinSliderValue, MaxSliderValue);
+            SliderValue = Mathf.Clamp(value, MinSliderValue, MaxSliderValue);
             mDeltaValue = SliderValue / MaxSliderValue;
             UpdateVisuals();
             mCachedValue = mDeltaValue;
-
         }
 
         // update visuals


### PR DESCRIPTION
Overview
---
Currently, a non-centered SliderGestureControl assumes it will always have a min value of 0. If the min value is not zero, it will slide the range down until it starts at 0, decreasing the max value by the same amount.

This change also re-exposes a starting SliderValue in the editor, which was (inadvertently?) removed in #816, when the public float was turned into a property without serializing its backing field.

Changes
---
- Fixes: #1712
