### PR TITLE
MRTK menu ordering fix

### DIFF
--- a/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/BuildAndDeploy/Editor/BuildDeployWindow.cs
@@ -182,7 +182,7 @@ namespace HoloToolkit.Unity
 
         #region Methods
 
-        [MenuItem("Mixed Reality Toolkit/Build Window", false, 0)]
+        [MenuItem("Mixed Reality Toolkit/Build Window", false, 8)]
         public static void OpenWindow()
         {
             // Dock it next to the Scene View.

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SetIconsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SetIconsWindow.cs
@@ -27,7 +27,7 @@ namespace HoloToolkit.Unity
         private static Texture2D _originalSplashImage;
         private static float defaultLabelWidth;
 
-        [MenuItem("Mixed Reality Toolkit/Tile Generator", false, 0)]
+        [MenuItem("Mixed Reality Toolkit/Tile Generator", false, 9)]
         private static void OpenWindow()
         {
             // Dock it next to the inspector.


### PR DESCRIPTION
Overview
---
Multiple menu items had the same priority, so the ordering became inconsistent on launch. This pushes the lower items down in priority, but retains a smaller difference between priorities than the 10 that generates a section separator.

Changes
---
- Fixes: #2071
