### PR TITLE
Add inscribed rectangle to BoundaryManager

### DIFF
--- a/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
+++ b/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
@@ -601,7 +601,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 851957070}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.23, y: 0.13322008, z: -0.004582405}
+  m_LocalPosition: {x: 0, y: 0.13322008, z: -0.004582405}
   m_LocalScale: {x: 0.013220016, y: 0.71818995, z: 0.61351055}
   m_Children: []
   m_Father: {fileID: 1573948297}
@@ -723,7 +723,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 512.5886, y: 323.03625}
+  m_AnchoredPosition: {x: 512.8186, y: 323.03625}
   m_SizeDelta: {x: 1025, y: 648}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &870996819
@@ -960,84 +960,6 @@ CanvasRenderer:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 920459028}
---- !u!1 &940849994
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1103436554492578, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 940849995}
-  - component: {fileID: 940849997}
-  - component: {fileID: 940849996}
-  m_Layer: 5
-  m_Name: Subtitle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &940849995
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224191356868840390, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 940849994}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
-  m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
-  m_Children: []
-  m_Father: {fileID: 1980833646}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -512.181, y: -322.598}
-  m_SizeDelta: {x: 1107.8, y: 89.1924}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &940849996
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114392904915671634, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 940849994}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
-    m_FontSize: 40
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 4
-    m_MaxSize: 101
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Working with Fonts in Unity
---- !u!222 &940849997
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222624442265456234, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 940849994}
 --- !u!1 &943754118
 GameObject:
   m_ObjectHideFlags: 0
@@ -1318,7 +1240,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1141318931}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.23, y: 0.13322008, z: -0.004582405}
+  m_LocalPosition: {x: 0, y: 0.13322008, z: -0.004582405}
   m_LocalScale: {x: 0.013220016, y: 0.71818995, z: 0.61351055}
   m_Children: []
   m_Father: {fileID: 1335327949}
@@ -1589,7 +1511,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1269249349}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0887143, y: 0.33, z: 2.015}
+  m_LocalPosition: {x: 0, y: 0.33, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1335327949}
@@ -1621,7 +1543,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1335327948}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.3175, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 870996818}
@@ -1740,7 +1662,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1573948296}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.635, y: 0, z: 0}
+  m_LocalPosition: {x: 0.3175, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1980833646}
@@ -1941,7 +1863,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af07a3ddd2d344b4c94aea43ecc16d46, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  boundsMaterial: {fileID: 2100000, guid: e7baa8ff231a0d54aa60430714b6ac83, type: 2}
+  boundsMaterial: {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
 --- !u!4 &1728360663
 Transform:
   m_ObjectHideFlags: 0
@@ -1955,84 +1877,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1839777879
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1005805910615968, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1839777880}
-  - component: {fileID: 1839777882}
-  - component: {fileID: 1839777881}
-  m_Layer: 5
-  m_Name: Subtitle (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1839777880
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 224610327728189076, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1839777879}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
-  m_LocalScale: {x: 0.00049999997, y: 0.00049999997, z: 0.00049999997}
-  m_Children: []
-  m_Father: {fileID: 1980833646}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -512.1811, y: -322.888}
-  m_SizeDelta: {x: 1107.8, y: 89.1924}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1839777881
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114300407264067004, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1839777879}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
-    m_FontSize: 40
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 4
-    m_MaxSize: 101
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Font Scale and Font Sizes
---- !u!222 &1839777882
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 222870682305638952, guid: 42b7699419297d24aa14535697918b4c,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1839777879}
 --- !u!1 &1980833645
 GameObject:
   m_ObjectHideFlags: 0
@@ -2060,18 +1904,16 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1980833645}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -1.3525823}
+  m_LocalPosition: {x: 0, y: 0, z: -0.019086}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2062600409}
-  - {fileID: 940849995}
-  - {fileID: 1839777880}
   m_Father: {fileID: 1573948297}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 511.9536, y: 323.03625}
+  m_AnchoredPosition: {x: 0, y: 0.1354}
   m_SizeDelta: {x: 1025, y: 648}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1980833647
@@ -2160,7 +2002,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2062600408}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1.3334956}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
   m_Children: []
   m_Father: {fileID: 1980833646}
@@ -2168,7 +2010,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -512.181, y: -322.9009}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 1107.8, y: 1303.4058}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2062600410

--- a/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
+++ b/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
@@ -1914,6 +1914,47 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+--- !u!1 &1728360661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1728360663}
+  - component: {fileID: 1728360662}
+  m_Layer: 0
+  m_Name: BoundaryVisualizer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1728360662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728360661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af07a3ddd2d344b4c94aea43ecc16d46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  boundsMaterial: {fileID: 2100000, guid: e7baa8ff231a0d54aa60430714b6ac83, type: 2}
+--- !u!4 &1728360663
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1728360661}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1839777879
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
+++ b/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
@@ -1864,6 +1864,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   boundsMaterial: {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
+  trackedAreaBoundsMaterial: {fileID: 2100000, guid: 693646fbd4009244e9cc6a4cd5b72585,
+    type: 2}
 --- !u!4 &1728360663
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
+++ b/Assets/HoloToolkit-Examples/Boundary/Scenes/BoundaryTest.unity
@@ -88,6 +88,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -112,6 +113,84 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &264961429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1451936078842708, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 264961430}
+  - component: {fileID: 264961432}
+  - component: {fileID: 264961431}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &264961430
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224339627565595316, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 264961429}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.0005000003, y: 0.0005000001, z: 0.0005000003}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.82153, y: -322.73904}
+  m_SizeDelta: {x: 1107.8, y: 244.2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &264961431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114257903654940708, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 264961429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 86574c70442309b45be5a1c37a37a40b, type: 3}
+    m_FontSize: 78
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Boundary
+--- !u!222 &264961432
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222382184650279478, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 264961429}
 --- !u!1 &344604318
 GameObject:
   m_ObjectHideFlags: 0
@@ -210,7 +289,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: ae797726e4af83a49b67dca339693aaf, type: 2}
+  - {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -320,6 +399,84 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3eddd1c29199313478dd3f912bfab2ab, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &529290968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1579474663996116, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 529290969}
+  - component: {fileID: 529290971}
+  - component: {fileID: 529290970}
+  m_Layer: 5
+  m_Name: Subtitle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &529290969
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224867391563566598, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529290968}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.82153, y: -322.849}
+  m_SizeDelta: {x: 1107.8, y: 89.1924}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &529290970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114628746298840300, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529290968}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: FloorQuad prefab
+--- !u!222 &529290971
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222081016692326802, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529290968}
 --- !u!1 &679906049
 GameObject:
   m_ObjectHideFlags: 0
@@ -364,7 +521,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: ae797726e4af83a49b67dca339693aaf, type: 2}
+  - {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -416,6 +573,219 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &851957070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1076840190721308, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 851957071}
+  - component: {fileID: 851957075}
+  - component: {fileID: 851957074}
+  - component: {fileID: 851957073}
+  - component: {fileID: 851957072}
+  m_Layer: 0
+  m_Name: Backpanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &851957071
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4851099024189204, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851957070}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0.23, y: 0.13322008, z: -0.004582405}
+  m_LocalScale: {x: 0.013220016, y: 0.71818995, z: 0.61351055}
+  m_Children: []
+  m_Father: {fileID: 1573948297}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!54 &851957072
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 54652109647812068, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851957070}
+  serializedVersion: 2
+  m_Mass: 100
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
+--- !u!23 &851957073
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23734633781358164, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851957070}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 61c598ddff7a2cc4ea50c285c361691d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &851957074
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 65220125403651066, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851957070}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &851957075
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33521007365351282, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851957070}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &870996817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1835462303943884, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 870996818}
+  - component: {fileID: 870996821}
+  - component: {fileID: 870996820}
+  - component: {fileID: 870996819}
+  m_Layer: 0
+  m_Name: TextContent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &870996818
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224385282562073920, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 870996817}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1.3525823}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 264961430}
+  - {fileID: 1366373657}
+  - {fileID: 1158095041}
+  - {fileID: 943754119}
+  - {fileID: 920459029}
+  - {fileID: 1658767240}
+  - {fileID: 529290969}
+  - {fileID: 1188628801}
+  - {fileID: 952996676}
+  m_Father: {fileID: 1335327949}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 512.5886, y: 323.03625}
+  m_SizeDelta: {x: 1025, y: 648}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &870996819
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114803053854114090, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 870996817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &870996820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114747735679590474, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 870996817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &870996821
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 223269791768138664, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 870996817}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &895193268
 GameObject:
   m_ObjectHideFlags: 0
@@ -460,7 +830,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: ae797726e4af83a49b67dca339693aaf, type: 2}
+  - {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -512,48 +882,318 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &904971170
-Prefab:
+--- !u!1 &920459028
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
-  m_IsPrefabParent: 0
+  m_PrefabParentObject: {fileID: 1113360108618934, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 920459029}
+  - component: {fileID: 920459031}
+  - component: {fileID: 920459030}
+  m_Layer: 5
+  m_Name: DeviceTypes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &920459029
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224644953376245418, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 920459028}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.6625, y: -322.63422}
+  m_SizeDelta: {x: 471.4, y: 140.6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &920459030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114745954840247250, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 920459028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 86574c70442309b45be5a1c37a37a40b, type: 3}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 101
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Immersive headset
+--- !u!222 &920459031
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222889759466084120, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 920459028}
+--- !u!1 &940849994
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1103436554492578, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 940849995}
+  - component: {fileID: 940849997}
+  - component: {fileID: 940849996}
+  m_Layer: 5
+  m_Name: Subtitle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &940849995
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224191356868840390, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 940849994}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
+  m_Children: []
+  m_Father: {fileID: 1980833646}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.181, y: -322.598}
+  m_SizeDelta: {x: 1107.8, y: 89.1924}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &940849996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114392904915671634, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 940849994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Working with Fonts in Unity
+--- !u!222 &940849997
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222624442265456234, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 940849994}
+--- !u!1 &943754118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1485382055181008, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 943754119}
+  - component: {fileID: 943754121}
+  - component: {fileID: 943754120}
+  m_Layer: 5
+  m_Name: WorksOn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &943754119
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224413024187748670, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 943754118}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334956}
+  m_LocalScale: {x: 0.0005000003, y: 0.0005000001, z: 0.0005000003}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.6625, y: -322.61212}
+  m_SizeDelta: {x: 471.4, y: 140.6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &943754120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114544788369345886, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 943754118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 2a056e2bb89e0134daaf49e5f183e5dc, type: 3}
+    m_FontSize: 34
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 101
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Works on
+--- !u!222 &943754121
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222602141398920914, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 943754118}
+--- !u!1 &952996675
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1447413817162332, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 952996676}
+  - component: {fileID: 952996678}
+  - component: {fileID: 952996677}
+  m_Layer: 5
+  m_Name: Subtitle (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &952996676
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224182034455888874, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 952996675}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.00049999997, y: 0.00049999997, z: 0.00049999997}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.82153, y: -323.075}
+  m_SizeDelta: {x: 1107.8, y: 89.1924}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &952996677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114142685639597208, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 952996675}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Test scene
+--- !u!222 &952996678
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222845313865076940, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 952996675}
 --- !u!1 &1061324848
 GameObject:
   m_ObjectHideFlags: 0
@@ -598,7 +1238,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: ae797726e4af83a49b67dca339693aaf, type: 2}
+  - {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -650,6 +1290,464 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1141318931
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1319326335823192, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1141318932}
+  - component: {fileID: 1141318936}
+  - component: {fileID: 1141318935}
+  - component: {fileID: 1141318934}
+  - component: {fileID: 1141318933}
+  m_Layer: 0
+  m_Name: Backpanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1141318932
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4925815908915770, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1141318931}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0.23, y: 0.13322008, z: -0.004582405}
+  m_LocalScale: {x: 0.013220016, y: 0.71818995, z: 0.61351055}
+  m_Children: []
+  m_Father: {fileID: 1335327949}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!54 &1141318933
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 54100405396922970, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1141318931}
+  serializedVersion: 2
+  m_Mass: 100
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
+--- !u!23 &1141318934
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23612074761842514, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1141318931}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 61c598ddff7a2cc4ea50c285c361691d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &1141318935
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 65599234300196070, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1141318931}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1141318936
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33590020163061146, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1141318931}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1158095040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1702150885567096, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1158095041}
+  - component: {fileID: 1158095044}
+  - component: {fileID: 1158095043}
+  - component: {fileID: 1158095042}
+  m_Layer: 0
+  m_Name: Rule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1158095041
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4459327869346566, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158095040}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -512.82007, y: -322.6673, z: 1.3285}
+  m_LocalScale: {x: 0.5497447, y: 0.0030726464, z: 1}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1158095042
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23475067446539832, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158095040}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!64 &1158095043
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 64067504913786168, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158095040}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1158095044
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33070690472620464, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158095040}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1188628800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1072600106012318, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1188628801}
+  - component: {fileID: 1188628803}
+  - component: {fileID: 1188628802}
+  m_Layer: 5
+  m_Name: Subtitle (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1188628801
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224315620099300408, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1188628800}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.00049999997, y: 0.00049999997, z: 0.00049999997}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.82153, y: -322.95}
+  m_SizeDelta: {x: 1107.8, y: 89.1924}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1188628802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114181130579894316, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1188628800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: BoundaryManager script
+--- !u!222 &1188628803
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222628989992007860, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1188628800}
+--- !u!1 &1269249349
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1037805327611902, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1269249350}
+  m_Layer: 0
+  m_Name: SceneDescriptionPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1269249350
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4038737183939630, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1269249349}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.0887143, y: 0.33, z: 2.015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1335327949}
+  - {fileID: 1573948297}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1335327948
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1152677137086646, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1335327949}
+  m_Layer: 0
+  m_Name: Panel1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1335327949
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4579641208005124, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1335327948}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 870996818}
+  - {fileID: 1141318932}
+  m_Father: {fileID: 1269249350}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1366373656
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1344339051826214, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1366373657}
+  - component: {fileID: 1366373659}
+  - component: {fileID: 1366373658}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1366373657
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224856759666131864, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1366373656}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334956}
+  m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.8215, y: -322.98813}
+  m_SizeDelta: {x: 1107.8, y: 1000}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1366373658
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114761561608045154, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1366373656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 86574c70442309b45be5a1c37a37a40b, type: 3}
+    m_FontSize: 34
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "Scripts that leverage boundary APIs in Unity. These are useful for rendering
+    the floor for immersive devices. You can also check if a particular game object
+    is within the established boundary or not.\n\n\n\nA simple quad scaled up to 10x
+    that will be rendered as the floor for an immersive device.\r\n\r\n\n\nPlaces
+    a floor quad to ground the scene. Allows you to check if your GameObject is within
+    setup boundary on the immersive headset. Boundary can be configured via the Mixed
+    Reality Portal.\r\n\r\n\n\nNavigate to the Tests folder.\r\nDouble click on the
+    test scene you wish to explore.\r\nEither click \"Play\" in the unity editor or
+    File -> Build Settings.\r\nAdd Open Scenes, Platform -> Windows Store, SDK ->
+    Universal 10, Build Type -> D3D, Check 'Unity C# Projects'.\r\n"
+--- !u!222 &1366373659
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222334294151603570, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1366373656}
+--- !u!1 &1573948296
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1502550149394970, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1573948297}
+  m_Layer: 0
+  m_Name: Panel2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1573948297
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4706133977960180, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1573948296}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.635, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1980833646}
+  - {fileID: 851957071}
+  m_Father: {fileID: 1269249350}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1584737070
 Prefab:
   m_ObjectHideFlags: 0
@@ -698,3 +1796,382 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1584737070}
   m_Script: {fileID: 11500000, guid: 0decd33ba8702954885a62b5bc1a778e, type: 3}
+--- !u!1001 &1598812497
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4541142303025740, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: d29bc40b7f3df26479d6a0aac211c355, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1 &1658767239
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1857403430107600, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1658767240}
+  - component: {fileID: 1658767241}
+  m_Layer: 0
+  m_Name: MRTK_Logo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1658767240
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4905320192366726, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1658767239}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -512.9825, y: -322.609, z: 1.3330002}
+  m_LocalScale: {x: 0.013813125, y: 0.01381305, z: 0.008287894}
+  m_Children: []
+  m_Father: {fileID: 870996818}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!212 &1658767241
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 212559292570936782, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1658767239}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 10
+  m_Sprite: {fileID: 21300000, guid: f721996453d888a4db83f0f9f1a4eb7c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 7.48}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+--- !u!1 &1839777879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1005805910615968, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1839777880}
+  - component: {fileID: 1839777882}
+  - component: {fileID: 1839777881}
+  m_Layer: 5
+  m_Name: Subtitle (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1839777880
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224610327728189076, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1839777879}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334941}
+  m_LocalScale: {x: 0.00049999997, y: 0.00049999997, z: 0.00049999997}
+  m_Children: []
+  m_Father: {fileID: 1980833646}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.1811, y: -322.888}
+  m_SizeDelta: {x: 1107.8, y: 89.1924}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1839777881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114300407264067004, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1839777879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e3d8348b7d66bae4aa4b1f3ada3ef5fd, type: 3}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Font Scale and Font Sizes
+--- !u!222 &1839777882
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222870682305638952, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1839777879}
+--- !u!1 &1980833645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1750976490984934, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1980833646}
+  - component: {fileID: 1980833649}
+  - component: {fileID: 1980833648}
+  - component: {fileID: 1980833647}
+  m_Layer: 0
+  m_Name: TextContent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1980833646
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224904040068643104, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1980833645}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1.3525823}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2062600409}
+  - {fileID: 940849995}
+  - {fileID: 1839777880}
+  m_Father: {fileID: 1573948297}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 511.9536, y: 323.03625}
+  m_SizeDelta: {x: 1025, y: 648}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1980833647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114247302280288692, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1980833645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1980833648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114119232482227162, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1980833645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1980833649
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 223336420783637346, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1980833645}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &2062600408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1454564949874076, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2062600409}
+  - component: {fileID: 2062600411}
+  - component: {fileID: 2062600410}
+  m_Layer: 5
+  m_Name: Description
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2062600409
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 224058629180668634, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2062600408}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3334956}
+  m_LocalScale: {x: 0.00050000026, y: 0.0005, z: 0.00050000026}
+  m_Children: []
+  m_Father: {fileID: 1980833646}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -512.181, y: -322.9009}
+  m_SizeDelta: {x: 1107.8, y: 1303.4058}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2062600410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114592574472669386, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2062600408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 86574c70442309b45be5a1c37a37a40b, type: 3}
+    m_FontSize: 34
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 101
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "Click 'Build' and create an App folder. When compile is done, open the
+    solution and deploy to device.\r\nBoundaryTest.unity\r\nShows how to check if
+    an object is within boundary and render a floor quad.\r\n\r\nWe render the floor
+    quad at (0,0,-3) in editor. There are 4 different cubes in the test scene which
+    try to demonstrate if an object is within or outside the setup boundary.\r\n\r\n"
+--- !u!222 &2062600411
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 222786115559259628, guid: 42b7699419297d24aa14535697918b4c,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2062600408}

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
@@ -7,7 +7,6 @@ namespace HoloToolkit.Unity.Boundary.Tests
 {
     public class BoundaryTest : MonoBehaviour
     {
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
         private Material[] defaultMaterials = null;
 
         private void Start()
@@ -16,7 +15,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
             BoundaryManager.Instance.RenderFloor = true;
 
             defaultMaterials = GetComponent<Renderer>().materials;
-        
+
             if (BoundaryManager.Instance.ContainsObject(gameObject.transform.position))
             {
                 Debug.LogFormat("Object {0} is within established boundary. Position: {1}", name, gameObject.transform.position);
@@ -46,6 +45,5 @@ namespace HoloToolkit.Unity.Boundary.Tests
                 Destroy(defaultMaterials[i]);
             }
         }
-#endif
     }
 }

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
@@ -16,6 +16,8 @@ namespace HoloToolkit.Unity.Boundary.Tests
 
             defaultMaterials = GetComponent<Renderer>().materials;
 
+            int colorPropertyId = Shader.PropertyToID("_Color");
+
             if (BoundaryManager.Instance.ContainsObject(gameObject.transform.position))
             {
                 Debug.LogFormat("Object {0} is within established boundary. Position: {1}", name, gameObject.transform.position);
@@ -23,7 +25,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
                 for (int i = 0; i < defaultMaterials.Length; i++)
                 {
                     // Color the cube green if object is within specified boundary.
-                    defaultMaterials[i].SetColor("_Color", Color.green);
+                    defaultMaterials[i].SetColor(colorPropertyId, Color.green);
                 }
             }
             else
@@ -33,7 +35,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
                 for (int i = 0; i < defaultMaterials.Length; i++)
                 {
                     // Color the cube red if object is outside specified boundary.
-                    defaultMaterials[i].SetColor("_Color", Color.red);
+                    defaultMaterials[i].SetColor(colorPropertyId, Color.red);
                 }
             }
         }

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
@@ -18,7 +18,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
 
             int colorPropertyId = Shader.PropertyToID("_Color");
 
-            if (BoundaryManager.Instance.ContainsObject(gameObject.transform.position))
+            if (BoundaryManager.Instance.ContainsObject(gameObject.transform.position, UnityEngine.Experimental.XR.Boundary.Type.TrackedArea))
             {
                 Debug.LogFormat("Object {0} is within established boundary. Position: {1}", name, gameObject.transform.position);
 

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryTest.cs
@@ -7,6 +7,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
 {
     public class BoundaryTest : MonoBehaviour
     {
+#if UNITY_2017_2_OR_NEWER
         private Material[] defaultMaterials = null;
 
         private void Start()
@@ -48,4 +49,5 @@ namespace HoloToolkit.Unity.Boundary.Tests
             }
         }
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace HoloToolkit.Unity.Boundary.Tests
+{
+    /// <summary>
+    /// Demo class to show different ways of using the boundary API
+    /// </summary>
+    public class BoundaryVisualizer : MonoBehaviour
+    {
+        [Tooltip("Material used to draw the inscribed rectangle bounds")]
+        [SerializeField]
+        private Material BoundsMaterial;
+
+        private void Start()
+        {
+            AddQuad();
+            AddRectangleBounds();
+            AddIndicators();
+        }
+
+        /// <summary>
+        /// Displays the boundary as a quad primative
+        /// </summary>
+        private void AddQuad()
+        {
+            Vector3 center;
+            float angle;
+            float width;
+            float height;
+            BoundaryManager.Instance.TryGetBoundaryRectangleParams(out center, out angle, out width, out height);
+
+            var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            quad.transform.SetParent(this.transform);
+            quad.transform.Translate(center + new Vector3(0.0f, 0.001f, 0.0f)); // Add fudge factor to avoid z-fighting
+            quad.transform.Rotate(new Vector3(90, -angle, 0));
+            quad.transform.localScale = new Vector3(width, height, 1.0f);
+        }
+
+        /// <summary>
+        /// Displays the boundary as a rectangle using a LineRenderer
+        /// </summary>
+        private void AddRectangleBounds()
+        {
+            var points = BoundaryManager.Instance.TryGetBoundaryRectanglePoints();
+            if (points == null)
+            {
+                return;
+            }
+
+            LineRenderer lr = this.gameObject.AddComponent<LineRenderer>();
+            lr.useWorldSpace = false;
+            lr.loop = true;
+            lr.sharedMaterial = this.BoundsMaterial;
+            lr.startWidth = 0.05f;
+            lr.endWidth = 0.05f;
+            lr.positionCount = points.Length;
+            lr.SetPositions(points);
+        }
+
+        /// <summary>
+        /// Displays the boundary as an array of spheres where spheres in the
+        /// bounds are a different color.
+        /// </summary>
+        private void AddIndicators()
+        {
+            const int indicatorCount = 15;
+            const float indicatorDistance = 0.2f;
+            const float dimension = (float)indicatorCount * indicatorDistance;
+
+            Vector3 center;
+            float angle;
+            float width;
+            float height;
+            if (!BoundaryManager.Instance.TryGetBoundaryRectangleParams(out center, out angle, out width, out height))
+            {
+                return;
+            }
+
+            Vector3 corner = center - (new Vector3(dimension, 0.0f, dimension) / 2.0f);
+            for (int xIndex = 0; xIndex < indicatorCount; ++xIndex)
+            {
+                for (int yIndex = 0; yIndex < indicatorCount; ++yIndex)
+                {
+                    var offset = new Vector3((float)xIndex * indicatorDistance, 0.0f, (float)yIndex * indicatorDistance);
+                    var position = corner + offset;
+                    var marker = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                    marker.transform.SetParent(this.transform);
+                    marker.transform.position = position;
+                    marker.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
+                    if (BoundaryManager.Instance.ContainsObject(position))
+                    {
+                        marker.GetComponent<MeshRenderer>().sharedMaterial = this.BoundsMaterial;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
@@ -84,6 +84,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
             }
 
             Vector3 corner = center - (new Vector3(dimension, 0.0f, dimension) / 2.0f);
+            corner.y = 0.0f;
             for (int xIndex = 0; xIndex < indicatorCount; ++xIndex)
             {
                 for (int yIndex = 0; yIndex < indicatorCount; ++yIndex)

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
     /// </summary>
     public class BoundaryVisualizer : MonoBehaviour
     {
+#if UNITY_2017_2_OR_NEWER
         [SerializeField]
         [Tooltip("Material used to draw the inscribed rectangle bounds.")]
         private Material boundsMaterial = null;
@@ -109,4 +110,5 @@ namespace HoloToolkit.Unity.Boundary.Tests
             }
         }
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
@@ -37,7 +37,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
 
             var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
             quad.transform.SetParent(transform);
-            quad.transform.Translate(center + new Vector3(0.0f, 0.001f, 0.0f)); // Add fudge factor to avoid z-fighting
+            quad.transform.Translate(center + new Vector3(0.0f, 0.005f, 0.0f)); // Add fudge factor to avoid z-fighting
             quad.transform.Rotate(new Vector3(90, -angle, 0));
             quad.transform.localScale = new Vector3(width, height, 1.0f);
         }
@@ -84,7 +84,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
             }
 
             Vector3 corner = center - (new Vector3(dimension, 0.0f, dimension) / 2.0f);
-            corner.y = 0.0f;
+            corner.y += 0.05f;
             for (int xIndex = 0; xIndex < indicatorCount; ++xIndex)
             {
                 for (int yIndex = 0; yIndex < indicatorCount; ++yIndex)

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
@@ -6,23 +6,26 @@ using UnityEngine;
 namespace HoloToolkit.Unity.Boundary.Tests
 {
     /// <summary>
-    /// Demo class to show different ways of using the boundary API
+    /// Demo class to show different ways of using the boundary API.
     /// </summary>
     public class BoundaryVisualizer : MonoBehaviour
     {
-        [Tooltip("Material used to draw the inscribed rectangle bounds")]
         [SerializeField]
-        private Material BoundsMaterial;
+        [Tooltip("Material used to draw the inscribed rectangle bounds.")]
+        private Material boundsMaterial = null;
+
+        [SerializeField]
+        [Tooltip("Material used to draw items in the tracked area bounds.")]
+        private Material trackedAreaBoundsMaterial = null;
 
         private void Start()
         {
             AddQuad();
-            AddRectangleBounds();
             AddIndicators();
         }
 
         /// <summary>
-        /// Displays the boundary as a quad primative
+        /// Displays the boundary as a quad primitive.
         /// </summary>
         private void AddQuad()
         {
@@ -33,14 +36,14 @@ namespace HoloToolkit.Unity.Boundary.Tests
             BoundaryManager.Instance.TryGetBoundaryRectangleParams(out center, out angle, out width, out height);
 
             var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
-            quad.transform.SetParent(this.transform);
+            quad.transform.SetParent(transform);
             quad.transform.Translate(center + new Vector3(0.0f, 0.001f, 0.0f)); // Add fudge factor to avoid z-fighting
             quad.transform.Rotate(new Vector3(90, -angle, 0));
             quad.transform.localScale = new Vector3(width, height, 1.0f);
         }
 
         /// <summary>
-        /// Displays the boundary as a rectangle using a LineRenderer
+        /// Displays the boundary as a rectangle using a LineRenderer.
         /// </summary>
         private void AddRectangleBounds()
         {
@@ -50,10 +53,11 @@ namespace HoloToolkit.Unity.Boundary.Tests
                 return;
             }
 
-            LineRenderer lr = this.gameObject.AddComponent<LineRenderer>();
+            LineRenderer lr = gameObject.AddComponent<LineRenderer>();
+            lr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
             lr.useWorldSpace = false;
             lr.loop = true;
-            lr.sharedMaterial = this.BoundsMaterial;
+            lr.sharedMaterial = boundsMaterial;
             lr.startWidth = 0.05f;
             lr.endWidth = 0.05f;
             lr.positionCount = points.Length;
@@ -68,7 +72,7 @@ namespace HoloToolkit.Unity.Boundary.Tests
         {
             const int indicatorCount = 15;
             const float indicatorDistance = 0.2f;
-            const float dimension = (float)indicatorCount * indicatorDistance;
+            const float dimension = indicatorCount * indicatorDistance;
 
             Vector3 center;
             float angle;
@@ -84,15 +88,21 @@ namespace HoloToolkit.Unity.Boundary.Tests
             {
                 for (int yIndex = 0; yIndex < indicatorCount; ++yIndex)
                 {
-                    var offset = new Vector3((float)xIndex * indicatorDistance, 0.0f, (float)yIndex * indicatorDistance);
+                    var offset = new Vector3(xIndex * indicatorDistance, 0.0f, yIndex * indicatorDistance);
                     var position = corner + offset;
                     var marker = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                    marker.transform.SetParent(this.transform);
+                    marker.transform.SetParent(transform);
                     marker.transform.position = position;
                     marker.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
-                    if (BoundaryManager.Instance.ContainsObject(position))
+
+                    if (BoundaryManager.Instance.ContainsObject(position, UnityEngine.Experimental.XR.Boundary.Type.TrackedArea))
                     {
-                        marker.GetComponent<MeshRenderer>().sharedMaterial = this.BoundsMaterial;
+                        marker.GetComponent<MeshRenderer>().sharedMaterial = trackedAreaBoundsMaterial;
+                    }
+
+                    if (BoundaryManager.Instance.ContainsObject(position, UnityEngine.Experimental.XR.Boundary.Type.PlayArea))
+                    {
+                        marker.GetComponent<MeshRenderer>().sharedMaterial = boundsMaterial;
                     }
                 }
             }

--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs.meta
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: af07a3ddd2d344b4c94aea43ecc16d46
+timeCreated: 1519411268
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/InscribedRectangleTest.cs
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/InscribedRectangleTest.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity.Boundary;
+using NUnit.Framework;
+using System;
+using System.Text;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.Tests
+{
+    /// <summary>
+    /// Some smoke tests to make sure the algorithm at least functioning
+    /// </summary>
+    public class InscribedRectangleTest
+    {
+        private class LargestRectangleTestCase
+        {
+            public string Name { get; set; }
+            public Vector3[] Polygon { get; set; }
+            public Vector2 ExpectedCenter { get; set; }
+            public float ExpectedAngle { get; set; }
+            public float ExpectedWidth { get; set; }
+            public float ExpectedHeight { get; set; }
+        }
+
+        private LargestRectangleTestCase[] cases = new LargestRectangleTestCase[]
+        {
+            new LargestRectangleTestCase
+            {
+                Name = "Trivial 1",
+                Polygon = new Vector3[]
+                {
+                    new Vector3(1, 0, 1),
+                    new Vector3(1, 0, -1),
+                    new Vector3(-1, 0, -1),
+                    new Vector3(1, 0, 1),
+                },
+                ExpectedCenter = new Vector2(0.2895508f,-0.2895508f),
+                ExpectedAngle = 45,
+                ExpectedWidth = 1.203304f,
+                ExpectedHeight = 0.8022028f,
+            },
+
+            new LargestRectangleTestCase
+            {
+                Name = "Actual 1",
+                Polygon = new Vector3[]
+                {
+                    new Vector3(-0.5519378f, -1.206148f, -1.19394f),
+                    new Vector3(0.650895f, -1.20466f, -1.449473f),
+                    new Vector3(0.613879f, -1.205253f, -0.9079847f),
+                    new Vector3(0.7181485f, -1.205405f, -0.6554281f),
+                    new Vector3(0.8714309f, -1.205195f, -0.7076129f),
+                    new Vector3(1.004714f, -1.206064f, 0.2727617f),
+                    new Vector3(0.5489904f, -1.206536f, 0.2807388f),
+                    new Vector3(0.5284376f, -1.206964f, 0.6781269f),
+                    new Vector3(0.07208231f, -1.207793f, 1.033721f),
+                    new Vector3(-0.3179387f, -1.207906f, 0.7551652f)
+                },
+                ExpectedCenter = new Vector2(0.2181969f,-0.4680347f),
+                ExpectedAngle = 75,
+                ExpectedWidth = 1.486504f,
+                ExpectedHeight = 0.9910026f
+            },
+
+            new LargestRectangleTestCase
+            {
+                Name = "Actual 2",
+                Polygon = new Vector3[]
+                {
+                    new Vector3(-0.001732647f, -0.926618f, 1.239084f),
+                    new Vector3(-1.178016f, -0.9283609f, 2.398043f),
+                    new Vector3(-2.164025f, -0.9293305f, 2.676547f),
+                    new Vector3(-2.908203f, -0.9298851f, 2.636722f),
+                    new Vector3(-2.423435f, -0.929828f, 3.091747f),
+                    new Vector3(-1.226971f, -0.9292948f, 3.661167f),
+                    new Vector3(0.2079207f, -0.9281015f, 3.563209f),
+                    new Vector3(0.1217785f, -0.927461f, 2.564639f),
+                    new Vector3(0.5864475f, -0.9265049f, 1.729308f),
+                    new Vector3(0.4944292f, -0.9261689f, 1.15375f),
+                },
+                ExpectedCenter = new Vector2(-0.5751144f,2.364177f),
+                ExpectedAngle = 135,
+                ExpectedWidth = 2.319089f,
+                ExpectedHeight = 0.7730296f
+            },
+        };
+
+        /// <summary>
+        /// Helper to write the code for a polygon.
+        /// </summary>
+        /// <param name="polygon"></param>
+        public static void DumpPolygon(Vector3[] polygon)
+        {
+            var sb = new StringBuilder();
+            foreach(var v in polygon)
+            {
+                sb.AppendFormat("new Vector3({0}f, {1}f, {2}f),\r\n", v.x, v.y, v.z);
+            }
+            Debug.Log(sb.ToString());
+        }
+
+        /// <summary>
+        /// Helper to check if two floating point numbers are close enough
+        /// </summary>
+        private bool FloatsEqual(float expected, float actual)
+        {
+            return Math.Abs((double)(expected - actual)) < 0.0001;
+        }
+
+        /// <summary>
+        /// Run the tests.  Outputs to the unity log the results
+        /// </summary>
+        [Test]
+        public void RunTestCases()
+        {
+            foreach (var testCase in this.cases)
+            {
+                RunCase(testCase);
+            }
+        }
+
+        private void RunCase(LargestRectangleTestCase testCase)
+        {
+            InscribedRectangle inscribedRectangle = new InscribedRectangle(testCase.Polygon, 20);
+            Vector2 actualCenter;
+            float actualAngle;
+            float actualWidth;
+            float actualHeight;
+            inscribedRectangle.GetRectangleParams(out actualCenter, out actualAngle, out actualWidth, out actualHeight);
+
+            bool passed =
+                FloatsEqual(testCase.ExpectedCenter.x, actualCenter.x) &&
+                FloatsEqual(testCase.ExpectedCenter.y, actualCenter.y) &&
+                FloatsEqual(testCase.ExpectedAngle, actualAngle) &&
+                FloatsEqual(testCase.ExpectedWidth, actualWidth) &&
+                FloatsEqual(testCase.ExpectedHeight, actualHeight);
+
+            if(!passed)
+            {
+                var message = string.Format("Test Case \"{0}\" failed\r\nExpected: ({1},{2})  {3}  {4}  {5}\r\nActual: ({6},{7})  {8}  {9}  {10}",
+                    testCase.Name,
+                    testCase.ExpectedCenter.x,
+                    testCase.ExpectedCenter.y,
+                    testCase.ExpectedAngle,
+                    testCase.ExpectedWidth,
+                    testCase.ExpectedHeight,
+                    actualCenter.x,
+                    actualCenter.y,
+                    actualAngle,
+                    actualWidth,
+                    actualHeight
+                    );
+                Assert.Fail(message);
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/InscribedRectangleTest.cs
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/InscribedRectangleTest.cs
@@ -36,7 +36,7 @@ namespace HoloToolkit.Unity.Tests
                     new Vector3(-1, 0, -1),
                     new Vector3(1, 0, 1),
                 },
-                ExpectedCenter = new Vector2(0.2895508f,-0.2895508f),
+                ExpectedCenter = new Vector2(0.2895508f, -0.2895508f),
                 ExpectedAngle = 45,
                 ExpectedWidth = 1.203304f,
                 ExpectedHeight = 0.8022028f,
@@ -58,7 +58,7 @@ namespace HoloToolkit.Unity.Tests
                     new Vector3(0.07208231f, -1.207793f, 1.033721f),
                     new Vector3(-0.3179387f, -1.207906f, 0.7551652f)
                 },
-                ExpectedCenter = new Vector2(0.2181969f,-0.4680347f),
+                ExpectedCenter = new Vector2(0.2181969f, -0.4680347f),
                 ExpectedAngle = 75,
                 ExpectedWidth = 1.486504f,
                 ExpectedHeight = 0.9910026f
@@ -80,10 +80,10 @@ namespace HoloToolkit.Unity.Tests
                     new Vector3(0.5864475f, -0.9265049f, 1.729308f),
                     new Vector3(0.4944292f, -0.9261689f, 1.15375f),
                 },
-                ExpectedCenter = new Vector2(-0.5751144f,2.364177f),
+                ExpectedCenter = new Vector2(-0.5928315f, 2.338437f),
                 ExpectedAngle = 135,
-                ExpectedWidth = 2.319089f,
-                ExpectedHeight = 0.7730296f
+                ExpectedWidth = 2.40228f,
+                ExpectedHeight = 0.6863657f
             },
         };
 
@@ -94,7 +94,7 @@ namespace HoloToolkit.Unity.Tests
         public static void DumpPolygon(Vector3[] polygon)
         {
             var sb = new StringBuilder();
-            foreach(var v in polygon)
+            foreach (var v in polygon)
             {
                 sb.AppendFormat("new Vector3({0}f, {1}f, {2}f),\r\n", v.x, v.y, v.z);
             }
@@ -102,7 +102,7 @@ namespace HoloToolkit.Unity.Tests
         }
 
         /// <summary>
-        /// Helper to check if two floating point numbers are close enough
+        /// Helper to check if two floating point numbers are close enough.
         /// </summary>
         private bool FloatsEqual(float expected, float actual)
         {
@@ -110,12 +110,12 @@ namespace HoloToolkit.Unity.Tests
         }
 
         /// <summary>
-        /// Run the tests.  Outputs to the unity log the results
+        /// Run the tests. Outputs the results to the Unity log.
         /// </summary>
         [Test]
         public void RunTestCases()
         {
-            foreach (var testCase in this.cases)
+            foreach (var testCase in cases)
             {
                 RunCase(testCase);
             }
@@ -137,7 +137,7 @@ namespace HoloToolkit.Unity.Tests
                 FloatsEqual(testCase.ExpectedWidth, actualWidth) &&
                 FloatsEqual(testCase.ExpectedHeight, actualHeight);
 
-            if(!passed)
+            if (!passed)
             {
                 var message = string.Format("Test Case \"{0}\" failed\r\nExpected: ({1},{2})  {3}  {4}  {5}\r\nActual: ({6},{7})  {8}  {9}  {10}",
                     testCase.Name,

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/InscribedRectangleTest.cs.meta
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/InscribedRectangleTest.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 798acbd4d9d4e1c46ac517bbcfffd36e
+timeCreated: 1518204273
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
-using UnityEngine.XR.WSA;
-#endif
 
 namespace HoloToolkit.Unity.Boundary
 {
@@ -16,7 +14,6 @@ namespace HoloToolkit.Unity.Boundary
     /// </summary>
     public class BoundaryManager : Singleton<BoundaryManager>
     {
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
         [Tooltip("Quad prefab to display as the floor.")]
         public GameObject FloorQuad = null;
         private GameObject floorQuadInstance = null;
@@ -25,7 +22,10 @@ namespace HoloToolkit.Unity.Boundary
         [Tooltip("Approximate max Y height of your space.")]
         private float boundaryHeight = 10f;
 
-        private Bounds boundaryBounds;
+        // Minimum boundary Y value
+        private float boundaryFloor = 0.0f;
+
+        private InscribedRectangle inscribedRectangle;
 
         [SerializeField]
         // Defaulting coordinate system to RoomScale in immersive headsets.
@@ -37,6 +37,7 @@ namespace HoloToolkit.Unity.Boundary
         // Defaulting coordinate system to Stationary for transparent headsets, like HoloLens.
         // This puts the origin (0, 0, 0) at the first place where the user started the application.
         //private TrackingSpaceType transparentTrackingSpaceType = TrackingSpaceType.Stationary;
+
         // Testing in the editor found that this moved the floor out of the way enough, and it is only
         // used in the case where a headset isn't attached. Otherwise, the floor is positioned like normal.
         private readonly Vector3 floorPositionInEditor = new Vector3(0f, -3f, 0f);
@@ -70,14 +71,20 @@ namespace HoloToolkit.Unity.Boundary
                 }
             }
         }
-#endif
 
         protected override void Awake()
         {
             base.Awake();
 
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
-            if (HolographicSettings.IsDisplayOpaque)
+#if UNITY_WSA
+            bool isDisplayOpaque = UnityEngine.XR.WSA.HolographicSettings.IsDisplayOpaque;
+#else
+            // Assume displays on non Windows MR platforms are all opaque.
+            // This will likely change as new hardwre comes to market.
+            bool isDisplayOpaque = true;
+#endif
+
+            if (isDisplayOpaque)
             {
                 XRDevice.SetTrackingSpaceType(opaqueTrackingSpaceType);
             }
@@ -106,21 +113,17 @@ namespace HoloToolkit.Unity.Boundary
             {
                 floorQuadInstance.SetActive(renderFloor);
             }
-#endif
         }
 
         private void SetBoundaryRendering()
         {
-#if UNITY_WSA &&  UNITY_2017_2_OR_NEWER
             // TODO: BUG: Unity: configured bool always returns false in 2017.2.0p2-MRTP5.
             if (UnityEngine.Experimental.XR.Boundary.configured)
             {
                 UnityEngine.Experimental.XR.Boundary.visible = renderBoundary;
             }
-#endif
         }
 
-#if UNITY_WSA && UNITY_2017_2_OR_NEWER
         private void RenderFloorQuad()
         {
             if (FloorQuad != null && XRDevice.GetTrackingSpaceType() == TrackingSpaceType.RoomScale)
@@ -146,11 +149,61 @@ namespace HoloToolkit.Unity.Boundary
         /// the specified boundary space.
         /// </summary>
         /// <param name="gameObjectPosition"></param>
-        /// <returns></returns>
+        /// <returns>True if the point is in the cuboid bounds</returns>
         public bool ContainsObject(Vector3 gameObjectPosition)
         {
-            // Check if the supplied game object's position is within the bounds volume.
-            return boundaryBounds.Contains(gameObjectPosition);
+            if (gameObjectPosition.y < this.boundaryFloor || gameObjectPosition.y > this.boundaryHeight)
+            {
+                return false;
+            }
+
+            if (this.inscribedRectangle == null || !this.inscribedRectangle.IsRectangleValid)
+            {
+                return false;
+            }
+
+            return this.inscribedRectangle.IsPointInRectangleBounds(new Vector2(gameObjectPosition.x, gameObjectPosition.z));
+        }
+
+        /// <summary>
+        /// Returns the corner points of a 2D rectangle that is the
+        /// largest rectangle we could find within the geometry of
+        /// the space bounds.
+        /// </summary>
+        /// <returns>Array of 3D points, all with the same y value</returns>
+        public Vector3[] TryGetBoundaryRectanglePoints()
+        {
+            if (this.inscribedRectangle == null || !this.inscribedRectangle.IsRectangleValid)
+            {
+                return null;
+            }
+
+            var points2d = this.inscribedRectangle.GetRectanglePoints();
+
+            var positions = new Vector3[points2d.Length];
+            for (int i = 0; i < points2d.Length; ++i)
+            {
+                positions[i] = new Vector3(points2d[i].x, this.boundaryFloor, points2d[i].y);
+            }
+            return positions;
+        }
+
+        /// <summary>
+        /// Returns parameters describing the boundary rectangle
+        /// </summary>
+        internal bool TryGetBoundaryRectangleParams(out Vector3 center, out float angle, out float width, out float height)
+        {
+            if (this.inscribedRectangle == null || !this.inscribedRectangle.IsRectangleValid)
+            {
+                center = Vector3.zero;
+                angle = width = height = 0.0f;
+                return false;
+            }
+
+            Vector2 center2D;
+            this.inscribedRectangle.GetRectangleParams(out center2D, out angle, out width, out height);
+            center = new Vector3(center2D.x, this.boundaryFloor, center2D.y);
+            return true;
         }
 
         /// <summary>
@@ -158,13 +211,13 @@ namespace HoloToolkit.Unity.Boundary
         /// </summary>
         public void CalculateBoundaryVolume()
         {
-            // TODO: BUG: Unity: Should return true if a floor and boundary has been established by user.
-            // But this always returns false with in 2017.2.0p2-MRTP5.
-            //if (!UnityEngine.Experimental.XR.Boundary.configured)
-            //{
-            //    Debug.Log("Boundary not configured.");
-            //    return;
-            //}
+            if (!UnityEngine.Experimental.XR.Boundary.configured)
+            {
+                Debug.Log("Boundary not configured.");
+                // TODO: BUG: Unity: Should return true if a floor and boundary has been established by user.
+                // But this always returns false with in 2017.2.0p2-MRTP5.
+                //return;
+            }
 
             if (XRDevice.GetTrackingSpaceType() != TrackingSpaceType.RoomScale)
             {
@@ -172,31 +225,25 @@ namespace HoloToolkit.Unity.Boundary
                 return;
             }
 
-            boundaryBounds = new Bounds();
-
             // Get all the bounds setup by the user.
             var boundaryGeometry = new List<Vector3>(0);
-            // TODO: BUG: Unity: Should return true if a floor and boundary has been established by user.
-            // But this always returns false with in 2017.2.0p2-MRTP5.
-            if (UnityEngine.Experimental.XR.Boundary.TryGetGeometry(boundaryGeometry))
+            if (UnityEngine.Experimental.XR.Boundary.TryGetGeometry(boundaryGeometry, UnityEngine.Experimental.XR.Boundary.Type.TrackedArea))
             {
                 if (boundaryGeometry.Count > 0)
                 {
                     // Create a UnityEngine.Bounds volume with those values.
                     foreach (Vector3 boundaryGeo in boundaryGeometry)
                     {
-                        boundaryBounds.Encapsulate(boundaryGeo);
+                        this.boundaryFloor = Math.Min(this.boundaryFloor, boundaryGeo.y);
                     }
+
+                    this.inscribedRectangle = new InscribedRectangle(boundaryGeometry);
                 }
             }
             else
             {
-                Debug.Log("TryGetGeometry always returns false.");
+                Debug.Log("TryGetGeometry returned false.");
             }
-
-            // Ensuring that we set height of the bounds volume to be say 10 feet tall.
-            boundaryBounds.Encapsulate(new Vector3(0, boundaryHeight, 0));
         }
-#endif
     }
 }

--- a/Assets/HoloToolkit/Boundary/Scripts/Edge.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/Edge.cs
@@ -1,0 +1,34 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace HoloToolkit.Unity.Boundary
+{
+    /// <summary>
+    /// Helper struct to hold an edge.
+    /// </summary>
+    public struct Edge
+    {
+        public float Ax;
+        public float Ay;
+        public float Bx;
+        public float By;
+
+        public Edge(float ax, float ay, float bx, float by)
+        {
+            Ax = ax;
+            Ay = ay;
+            Bx = bx;
+            By = by;
+        }
+
+        public Edge(Vector2 pointA, Vector2 pointB)
+        {
+            Ax = pointA.x;
+            Bx = pointB.x;
+            Ay = pointA.y;
+            By = pointB.y;
+        }
+    }
+}

--- a/Assets/HoloToolkit/Boundary/Scripts/Edge.cs.meta
+++ b/Assets/HoloToolkit/Boundary/Scripts/Edge.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 84b2e4678d87a0344b197bbc74ba1f3a
+timeCreated: 1530819263
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity.Boundary;
+using System;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.Boundary
+{
+    public static class EdgeHelpers
+    {
+        // A value that is larger than the widest possible room. We use this
+        // to create line segments that are "guaranteed" to hit a piece of the
+        // room boundary
+        private const float largeValue = 10000;
+        private const float smallValue = -largeValue;
+
+        // Sentinel value
+        public static readonly Vector2 InvalidPoint = new Vector2(float.NegativeInfinity, float.NegativeInfinity);
+
+        /// <summary>
+        /// Helper to know when a point is invalid.
+        /// </summary>
+        public static bool IsValidPoint(Vector2 point)
+        {
+            return !float.IsNegativeInfinity(point.x) && !float.IsNegativeInfinity(point.y);
+        }
+
+        /// <summary>
+        /// Returns true if the given point is within the boundary.
+        /// </summary>
+        public static bool IsInside(Edge[] edges, Vector2 point)
+        {
+            // Check if a ray to the right (X+) intersects with an odd number of edges (inside) or an even number of edges (outside)
+            Vector2 farPoint = point;
+            farPoint.x = largeValue;
+            var rightEdge = new Edge(point, farPoint);
+            int intersections = 0;
+            foreach (var edge in edges)
+            {
+                if (IsValidPoint(GetIntersection(edge, rightEdge)))
+                {
+                    ++intersections;
+                }
+            }
+            return (intersections & 1) == 1;
+        }
+
+        /// <summary>
+        /// Gets the point where two edges intersect. Value is InvalidPoint if they do not.
+        /// </summary>
+        public static Vector2 GetIntersection(Edge edge1, Edge edge2)
+        {
+            float s1_x = edge1.Bx - edge1.Ax;
+            float s1_y = edge1.By - edge1.Ay;
+            float s2_x = edge2.Bx - edge2.Ax;
+            float s2_y = edge2.By - edge2.Ay;
+
+            float s, t;
+            s = (-s1_y * (edge1.Ax - edge2.Ax) + s1_x * (edge1.Ay - edge2.Ay)) / (-s2_x * s1_y + s1_x * s2_y);
+            t = (s2_x * (edge1.Ay - edge2.Ay) - s2_y * (edge1.Ax - edge2.Ax)) / (-s2_x * s1_y + s1_x * s2_y);
+
+            if (s >= 0 && s <= 1 && t >= 0 && t <= 1)
+            {
+                // Collision detected
+                return new Vector2(edge1.Ax + (t * s1_x), edge1.Ay + (t * s1_y));
+            }
+
+            return InvalidPoint;
+        }
+    }
+}

--- a/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using HoloToolkit.Unity.Boundary;
-using System;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.Boundary

--- a/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs.meta
+++ b/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f228d092da8f4ca49af624ed9dbf0a9a
+timeCreated: 1530822321
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
@@ -9,33 +9,6 @@ namespace HoloToolkit.Unity.Boundary
 {
     public class InscribedRectangle
     {
-        /// <summary>
-        /// Helper struct to hold an edge.
-        /// </summary>
-        private struct Edge
-        {
-            public float Ax;
-            public float Ay;
-            public float Bx;
-            public float By;
-
-            public Edge(float ax, float ay, float bx, float by)
-            {
-                Ax = ax;
-                Ay = ay;
-                Bx = bx;
-                By = by;
-            }
-
-            public Edge(Vector2 pointA, Vector2 pointB)
-            {
-                Ax = pointA.x;
-                Bx = pointB.x;
-                Ay = pointA.y;
-                By = pointB.y;
-            }
-        }
-
         // Sentinel value
         private static Vector2 InvalidPoint = new Vector2(float.NegativeInfinity, float.NegativeInfinity);
 

--- a/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
@@ -10,7 +10,7 @@ namespace HoloToolkit.Unity.Boundary
     public class InscribedRectangle
     {
         /// <summary>
-        /// Helper class to hold an edge
+        /// Helper struct to hold an edge.
         /// </summary>
         private struct Edge
         {
@@ -21,18 +21,18 @@ namespace HoloToolkit.Unity.Boundary
 
             public Edge(float ax, float ay, float bx, float by)
             {
-                this.Ax = ax;
-                this.Ay = ay;
-                this.Bx = bx;
-                this.By = by;
+                Ax = ax;
+                Ay = ay;
+                Bx = bx;
+                By = by;
             }
 
             public Edge(Vector2 pointA, Vector2 pointB)
             {
-                this.Ax = pointA.x;
-                this.Bx = pointB.x;
-                this.Ay = pointA.y;
-                this.By = pointB.y;
+                Ax = pointA.x;
+                Bx = pointB.x;
+                Ay = pointA.y;
+                By = pointB.y;
             }
         }
 
@@ -60,12 +60,15 @@ namespace HoloToolkit.Unity.Boundary
         private float width;
         private float height;
 
+        /// <summary>
+        /// Constructor that takes in a list of points and generates a seed.
+        /// </summary>
         public InscribedRectangle(IList<Vector3> points) : this(points, (int)DateTime.UtcNow.Ticks)
         {
         }
 
         /// <summary>
-        /// Constructor that sets a fixed random seed to get repeatable results.
+        /// Constructor that takes in a list of points and sets a fixed random seed to get repeatable results.
         /// </summary>
         public InscribedRectangle(IList<Vector3> points, int randomSeed)
         {
@@ -78,48 +81,48 @@ namespace HoloToolkit.Unity.Boundary
                 edges[pointIndex] = new Edge(pointA.x, pointA.z, pointB.x, pointB.z);
             }
 
-            FindInscribedRectangle(edges, randomSeed, out this.center, out this.angle, out this.width, out this.height);
+            FindInscribedRectangle(edges, randomSeed, out center, out angle, out width, out height);
         }
 
         /// <summary>
-        /// Use this to determine if there is a valid inscribed rectangle
+        /// Use this to determine if there is a valid inscribed rectangle.
         /// </summary>
         public bool IsRectangleValid
         {
-            get { return IsValidPoint(this.center); }
+            get { return IsValidPoint(center); }
         }
 
         /// <summary>
-        /// Retrieves the parameters describing the largest inscribed rectangle
+        /// Retrieves the parameters describing the largest inscribed rectangle.
         /// within the bounds
         /// </summary>
         public void GetRectangleParams(out Vector2 centerOut, out float angleOut, out float widthOut, out float heightOut)
         {
-            if (!this.IsRectangleValid)
+            if (!IsRectangleValid)
             {
                 throw new InvalidOperationException();
             }
 
-            centerOut = this.center;
-            angleOut = this.angle;
-            widthOut = this.width;
-            heightOut = this.height;
+            centerOut = center;
+            angleOut = angle;
+            widthOut = width;
+            heightOut = height;
         }
 
         /// <summary>
-        /// Returns the four points that make up the inscribed rectangle
+        /// Returns the four points that make up the inscribed rectangle.
         /// </summary>
         public Vector2[] GetRectanglePoints()
         {
-            if (!this.IsRectangleValid)
+            if (!IsRectangleValid)
             {
                 throw new InvalidOperationException();
             }
 
             var points = new Vector2[4];
 
-            float x = this.width / 2.0f;
-            float y = this.height / 2.0f;
+            float x = width / 2.0f;
+            float y = height / 2.0f;
             points = new Vector2[]
             {
                 new Vector2(x, y),
@@ -130,26 +133,26 @@ namespace HoloToolkit.Unity.Boundary
 
             for (int i = 0; i < points.Length; ++i)
             {
-                points[i] = RotatePoint(Vector2.zero, DegreesToRadians(this.angle), points[i]);
-                points[i] += this.center;
+                points[i] = RotatePoint(Vector2.zero, DegreesToRadians(angle), points[i]);
+                points[i] += center;
             }
 
             return points;
         }
 
         /// <summary>
-        /// Returns true if the given point is within the inscribed rectangle
+        /// Returns true if the given point is within the inscribed rectangle.
         /// </summary>
         public bool IsPointInRectangleBounds(Vector2 point)
         {
-            if (!this.IsRectangleValid)
+            if (!IsRectangleValid)
             {
                 throw new InvalidOperationException();
             }
 
-            point -= this.center;
-            point = RotatePoint(Vector2.zero, DegreesToRadians(-this.angle), point);
-            return (Math.Abs(point.x) <= (this.width / 2.0f)) && (Math.Abs(point.y) <= this.height / 2.0f);
+            point -= center;
+            point = RotatePoint(Vector2.zero, DegreesToRadians(-angle), point);
+            return (Math.Abs(point.x) <= (width / 2.0f)) && (Math.Abs(point.y) <= height / 2.0f);
         }
 
         /// <summary>
@@ -161,7 +164,7 @@ namespace HoloToolkit.Unity.Boundary
         }
 
         /// <summary>
-        /// Rotate a point about another point by the specified angle in radians
+        /// Rotate a point about another point by the specified angle in radians.
         /// </summary>
         private static Vector2 RotatePoint(Vector2 origin, float angleRad, Vector2 point)
         {
@@ -188,7 +191,7 @@ namespace HoloToolkit.Unity.Boundary
         }
 
         /// <summary>
-        /// Returns true if the given point is within the boundary
+        /// Returns true if the given point is within the boundary.
         /// </summary>
         private static bool IsInside(Edge[] edges, Vector2 point)
         {
@@ -208,7 +211,7 @@ namespace HoloToolkit.Unity.Boundary
         }
 
         /// <summary>
-        /// Gets the point where two edges intersect. Value is InvalidPoint if they do not
+        /// Gets the point where two edges intersect. Value is InvalidPoint if they do not.
         /// </summary>
         private static Vector2 GetIntersection(Edge edge1, Edge edge2)
         {
@@ -233,7 +236,7 @@ namespace HoloToolkit.Unity.Boundary
         /// <summary>
         /// Given a point inside of the boundary, finds the points on the
         /// boundary directly above, below, left and right of the point,
-        /// with respect to the given angle
+        /// with respect to the given angle.
         /// </summary>
         private static bool FindSurroundingCollisionPoints(
             Edge[] edges,
@@ -290,7 +293,7 @@ namespace HoloToolkit.Unity.Boundary
                             bottomCollisionPoint = verticalIntersection;
                         }
                     }
-                }  // If vertial intersection found
+                }  // If vertical intersection found
 
                 Vector2 horizontalIntersection = GetIntersection(edge, horizontalLine);
                 if (IsValidPoint(horizontalIntersection))
@@ -328,11 +331,11 @@ namespace HoloToolkit.Unity.Boundary
         }
 
         /// <summary>
-        /// Tries to fit rectangles using pre-defined aspect ratios in the space
+        /// Tries to fit rectangles using predefined aspect ratios in the space
         /// centered on the given point, and rotated by the given angle.
         /// It will return the maximum rectangle it could fit (its aspect ratio
         /// and dimensions), within a margin of error. Returns false if it could
-        /// not fit any rectangles that meet the criteria
+        /// not fit any rectangles that meet the criteria.
         /// </summary>
         private static bool TryFitMaximumRectangleAtAngle(
             Edge[] edges,
@@ -343,8 +346,8 @@ namespace HoloToolkit.Unity.Boundary
             height = 0;
             aspectRatio = 0;
 
-            float[] aspectRatios = {1,   1.5f, 2,   2.5f, 3,    3.5f, 4,    4.5f, 5,    5.5f, 6,    6.5f, 7,    7.5f, 8,
-                            8.5f, 9,   9.5f, 10,  10.5f, 11,  11.5f, 12,  12.5f, 13,  13.5f, 14,  14.5f, 15};
+            float[] aspectRatios = {1, 1.5f, 2, 2.5f, 3, 3.5f, 4, 4.5f, 5, 5.5f, 6, 6.5f, 7, 7.5f,
+                8, 8.5f, 9, 9.5f, 10, 10.5f, 11, 11.5f, 12, 12.5f, 13, 13.5f, 14, 14.5f, 15};
 
             // Start by calculating max width and height by ray-casting a cross from the point at the given angle
             // and taking the shortest leg of each ray. Width is the longest.
@@ -367,8 +370,7 @@ namespace HoloToolkit.Unity.Boundary
             float maxWidth = Math.Max(verticalMinDistanceToEdge, horizontalMinDistanceToEdge) * 2.0f;
             float maxHeight = Math.Min(verticalMinDistanceToEdge, horizontalMinDistanceToEdge) * 2.0f;
 
-
-            // For each aspect ratio we do a binary search to find the maximum rect that fits, though once we start increasing our area by minimumHeightGain we call it good enough
+            // For each aspect ratio we do a binary search to find the maximum rectangle that fits, though once we start increasing our area by minimumHeightGain we call it good enough
             foreach (var candidateAspectRatio in aspectRatios)
             {
                 // The height is limited by the width. If a height would make our width exceed maxWidth, it can't be used
@@ -416,7 +418,7 @@ namespace HoloToolkit.Unity.Boundary
 
         /// <summary>
         /// Returns true if a rectangle centered at the given point, at the
-        /// given angle and dimensions, will fit in the polygon
+        /// given angle and dimensions, will fit in the polygon.
         /// </summary>
         private static bool WillRectangleFit(Edge[] edges, Vector2 center, float angleRad, float width, float height)
         {
@@ -459,8 +461,8 @@ namespace HoloToolkit.Unity.Boundary
         /// drawn through those points. The midpoints of those lines are
         /// used as the center of various rectangles, using a binary search to
         /// vary the size, until the largest fit-able rectangle is found.
-        /// This is then repeated for pre-defined angles (0-180 in steps of 15)
-        /// and aspect ratios (1 to 15 in steps of 0.5)
+        /// This is then repeated for predefined angles (0-180 in steps of 15)
+        /// and aspect ratios (1 to 15 in steps of 0.5).
         /// </summary>
         private static void FindInscribedRectangle(Edge[] edges, int randomSeed, out Vector2 center, out float angle, out float width, out float height)
         {
@@ -536,7 +538,7 @@ namespace HoloToolkit.Unity.Boundary
                     if (IsValidPoint(topCollisionPoint) && IsValidPoint(bottomCollisionPoint))
                     {
                         var verticalMidpoint = new Vector2((topCollisionPoint.x + bottomCollisionPoint.x) / 2,
-                                    (topCollisionPoint.y + bottomCollisionPoint.y) / 2);
+                            (topCollisionPoint.y + bottomCollisionPoint.y) / 2);
                         float aspectRatio;
                         float w;
                         float h;
@@ -552,12 +554,11 @@ namespace HoloToolkit.Unity.Boundary
                     if (IsValidPoint(leftCollisionPoint) && IsValidPoint(rightCollisionPoint))
                     {
                         var horizontalMidpoint = new Vector2((leftCollisionPoint.x + rightCollisionPoint.x) / 2,
-                                        (leftCollisionPoint.y + rightCollisionPoint.y) / 2);
+                            (leftCollisionPoint.y + rightCollisionPoint.y) / 2);
                         float aspectRatio;
                         float w;
                         float h;
-                        if (TryFitMaximumRectangleAtAngle(edges, horizontalMidpoint, DegreesToRadians(candidateAngle), width * height,
-                            out aspectRatio, out w, out h))
+                        if (TryFitMaximumRectangleAtAngle(edges, horizontalMidpoint, DegreesToRadians(candidateAngle), width * height, out aspectRatio, out w, out h))
                         {
                             center = horizontalMidpoint;
                             angle = candidateAngle;

--- a/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
@@ -1,0 +1,572 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.Boundary
+{
+    public class InscribedRectangle
+    {
+        /// <summary>
+        /// Helper class to hold an edge
+        /// </summary>
+        private struct Edge
+        {
+            public float Ax;
+            public float Ay;
+            public float Bx;
+            public float By;
+
+            public Edge(float ax, float ay, float bx, float by)
+            {
+                this.Ax = ax;
+                this.Ay = ay;
+                this.Bx = bx;
+                this.By = by;
+            }
+
+            public Edge(Vector2 pointA, Vector2 pointB)
+            {
+                this.Ax = pointA.x;
+                this.Bx = pointB.x;
+                this.Ay = pointA.y;
+                this.By = pointB.y;
+            }
+        }
+
+        // Sentinel value
+        private static Vector2 InvalidPoint = new Vector2(float.NegativeInfinity, float.NegativeInfinity);
+
+        // Total number of starting points randomly generated within the boundary
+        private const int randomPointCount = 30;
+
+        // A value that is larger than the widest possible room. We use this
+        // to create line segments that are "guaranteed" to hit a piece of the
+        // room boundary
+        private const float largeValue = 10000;
+        private const float smallValue = -largeValue;
+
+        // The total amount of height we want to gain with each binary search
+        // change before we decide that it's good enough, in meters
+        private const float minimumHeightGain = 0.01f;
+
+        private static float DegreesToRadians(double deg) { return (float)(Math.PI / 180 * deg); }
+
+        // Parameters for the inscribed rectangle
+        private Vector2 center = InvalidPoint;
+        private float angle;
+        private float width;
+        private float height;
+
+        public InscribedRectangle(IList<Vector3> points) : this(points, (int)DateTime.UtcNow.Ticks)
+        {
+        }
+
+        /// <summary>
+        /// Constructor that sets a fixed random seed to get repeatable results.
+        /// </summary>
+        public InscribedRectangle(IList<Vector3> points, int randomSeed)
+        {
+            var edges = new Edge[points.Count + 1];
+
+            for (int pointIndex = 0; pointIndex < points.Count; ++pointIndex)
+            {
+                var pointA = points[pointIndex];
+                var pointB = points[(pointIndex + 1) % points.Count];
+                edges[pointIndex] = new Edge(pointA.x, pointA.z, pointB.x, pointB.z);
+            }
+
+            FindInscribedRectangle(edges, randomSeed, out this.center, out this.angle, out this.width, out this.height);
+        }
+
+        /// <summary>
+        /// Use this to determine if there is a valid inscribed rectangle
+        /// </summary>
+        public bool IsRectangleValid
+        {
+            get { return IsValidPoint(this.center); }
+        }
+
+        /// <summary>
+        /// Retrieves the parameters describing the largest inscribed rectangle
+        /// within the bounds
+        /// </summary>
+        public void GetRectangleParams(out Vector2 centerOut, out float angleOut, out float widthOut, out float heightOut)
+        {
+            if (!this.IsRectangleValid)
+            {
+                throw new InvalidOperationException();
+            }
+
+            centerOut = this.center;
+            angleOut = this.angle;
+            widthOut = this.width;
+            heightOut = this.height;
+        }
+
+        /// <summary>
+        /// Returns the four points that make up the inscribed rectangle
+        /// </summary>
+        public Vector2[] GetRectanglePoints()
+        {
+            if (!this.IsRectangleValid)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var points = new Vector2[4];
+
+            float x = this.width / 2.0f;
+            float y = this.height / 2.0f;
+            points = new Vector2[]
+            {
+                new Vector2(x, y),
+                new Vector2(x, -y),
+                new Vector2(-x, -y),
+                new Vector2(-x, y)
+            };
+
+            for (int i = 0; i < points.Length; ++i)
+            {
+                points[i] = RotatePoint(Vector2.zero, DegreesToRadians(this.angle), points[i]);
+                points[i] += this.center;
+            }
+
+            return points;
+        }
+
+        /// <summary>
+        /// Returns true if the given point is within the inscribed rectangle
+        /// </summary>
+        public bool IsPointInRectangleBounds(Vector2 point)
+        {
+            if (!this.IsRectangleValid)
+            {
+                throw new InvalidOperationException();
+            }
+
+            point -= this.center;
+            point = RotatePoint(Vector2.zero, DegreesToRadians(-this.angle), point);
+            return (Math.Abs(point.x) <= (this.width / 2.0f)) && (Math.Abs(point.y) <= this.height / 2.0f);
+        }
+
+        /// <summary>
+        /// Helper to know when a point is invalid.
+        /// </summary>
+        private static bool IsValidPoint(Vector2 point)
+        {
+            return !float.IsNegativeInfinity(point.x) && !float.IsNegativeInfinity(point.y);
+        }
+
+        /// <summary>
+        /// Rotate a point about another point by the specified angle in radians
+        /// </summary>
+        private static Vector2 RotatePoint(Vector2 origin, float angleRad, Vector2 point)
+        {
+            Vector2 retval = point;
+            if (0.0f == angleRad)
+            {
+                return retval;
+            }
+
+            // Translate to origin of rotation
+            retval.x -= origin.x;
+            retval.y -= origin.y;
+
+            // Rotate the point
+            float s = (float)Math.Sin(angleRad);
+            float c = (float)Math.Cos(angleRad);
+            float rotatedX = retval.x * c - retval.y * s;
+            float rotatedY = retval.x * s + retval.y * c;
+
+            // Translate back and return
+            retval.x = rotatedX + origin.x;
+            retval.y = rotatedY + origin.y;
+            return retval;
+        }
+
+        /// <summary>
+        /// Returns true if the given point is within the boundary
+        /// </summary>
+        private static bool IsInside(Edge[] edges, Vector2 point)
+        {
+            // Check if a ray to the right (X+) intersects with an odd number of edges (inside) or an even number of edges (outside)
+            Vector2 farPoint = point;
+            farPoint.x = largeValue;
+            var rightEdge = new Edge(point, farPoint);
+            int intersections = 0;
+            foreach (var edge in edges)
+            {
+                if (IsValidPoint(GetIntersection(edge, rightEdge)))
+                {
+                    ++intersections;
+                }
+            }
+            return (intersections & 1) == 1;
+        }
+
+        /// <summary>
+        /// Gets the point where two edges intersect. Value is InvalidPoint if they do not
+        /// </summary>
+        private static Vector2 GetIntersection(Edge edge1, Edge edge2)
+        {
+            float s1_x = edge1.Bx - edge1.Ax;
+            float s1_y = edge1.By - edge1.Ay;
+            float s2_x = edge2.Bx - edge2.Ax;
+            float s2_y = edge2.By - edge2.Ay;
+
+            float s, t;
+            s = (-s1_y * (edge1.Ax - edge2.Ax) + s1_x * (edge1.Ay - edge2.Ay)) / (-s2_x * s1_y + s1_x * s2_y);
+            t = (s2_x * (edge1.Ay - edge2.Ay) - s2_y * (edge1.Ax - edge2.Ax)) / (-s2_x * s1_y + s1_x * s2_y);
+
+            if (s >= 0 && s <= 1 && t >= 0 && t <= 1)
+            {
+                // Collision detected
+                return new Vector2(edge1.Ax + (t * s1_x), edge1.Ay + (t * s1_y));
+            }
+
+            return InvalidPoint;
+        }
+
+        /// <summary>
+        /// Given a point inside of the boundary, finds the points on the
+        /// boundary directly above, below, left and right of the point,
+        /// with respect to the given angle
+        /// </summary>
+        private static bool FindSurroundingCollisionPoints(
+            Edge[] edges,
+            Vector2 point, float angleRad, out Vector2 topCollisionPoint,
+            out Vector2 bottomCollisionPoint, out Vector2 leftCollisionPoint,
+            out Vector2 rightCollisionPoint)
+        {
+            topCollisionPoint = InvalidPoint;
+            bottomCollisionPoint = InvalidPoint;
+            leftCollisionPoint = InvalidPoint;
+            rightCollisionPoint = InvalidPoint;
+
+            bool isInside = IsInside(edges, point);
+            if (!isInside)
+            {
+                return false;
+            }
+
+            // Find the top and bottom collision points by creating a large line segment that goes through the point to MAX and MIN values on Y
+            var topEndpoint = new Vector2(point.x, largeValue);
+            var bottomEndpoint = new Vector2(point.x, smallValue);
+            topEndpoint = RotatePoint(point, angleRad, topEndpoint);
+            bottomEndpoint = RotatePoint(point, angleRad, bottomEndpoint);
+            var verticalLine = new Edge(topEndpoint, bottomEndpoint);
+            // Find the left and right collision points by creating a large line segment that goes through the point to MAX and Min values on X
+            var rightEndpoint = new Vector2(largeValue, point.y);
+            var leftEndpoint = new Vector2(smallValue, point.y);
+            rightEndpoint = RotatePoint(point, angleRad, rightEndpoint);
+            leftEndpoint = RotatePoint(point, angleRad, leftEndpoint);
+            var horizontalLine = new Edge(rightEndpoint, leftEndpoint);
+
+            // Loop the edges and find the nearest intersection point
+            foreach (var edge in edges)
+            {
+                Vector2 verticalIntersection = GetIntersection(edge, verticalLine);
+                if (IsValidPoint(verticalIntersection))
+                {
+                    // Is this intersection above or below the point?
+                    bool isAbove = RotatePoint(point, -angleRad, verticalIntersection).y > point.y;
+                    if (isAbove)
+                    {
+                        // If this collision point is closer than the previous one
+                        if (!IsValidPoint(topCollisionPoint) ||
+                            Vector2.Distance(point, verticalIntersection) < Vector2.Distance(point, topCollisionPoint))
+                        {
+                            topCollisionPoint = verticalIntersection;
+                        }
+                    }
+                    else
+                    {
+                        if (!IsValidPoint(bottomCollisionPoint) ||
+                            Vector2.Distance(point, verticalIntersection) < Vector2.Distance(point, bottomCollisionPoint))
+                        {
+                            bottomCollisionPoint = verticalIntersection;
+                        }
+                    }
+                }  // If vertial intersection found
+
+                Vector2 horizontalIntersection = GetIntersection(edge, horizontalLine);
+                if (IsValidPoint(horizontalIntersection))
+                {
+                    // Is this intersection left or right of the point?
+                    bool isLeft = RotatePoint(point, -angleRad, horizontalIntersection).x < point.x;
+                    if (isLeft)
+                    {
+                        // Is it closer than the previous intersection?
+                        if (!IsValidPoint(leftCollisionPoint) ||
+                            Vector2.Distance(point, horizontalIntersection) < Vector2.Distance(point, leftCollisionPoint))
+                        {
+                            leftCollisionPoint = horizontalIntersection;
+                        }
+                    }
+                    else
+                    {
+                        // Is it closer than the previous intersection?
+                        if (!IsValidPoint(rightCollisionPoint) ||
+                            Vector2.Distance(point, horizontalIntersection) < Vector2.Distance(point, rightCollisionPoint))
+                        {
+                            rightCollisionPoint = horizontalIntersection;
+                        }
+                    }
+                }
+            }
+
+            // Assert that any point inside should have intersection points on all sides with the polygon
+            if (!IsValidPoint(topCollisionPoint) || !IsValidPoint(bottomCollisionPoint) ||
+                !IsValidPoint(leftCollisionPoint) || !IsValidPoint(rightCollisionPoint))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Tries to fit rectangles using pre-defined aspect ratios in the space
+        /// centered on the given point, and rotated by the given angle.
+        /// It will return the maximum rectangle it could fit (its aspect ratio
+        /// and dimensions), within a margin of error. Returns false if it could
+        /// not fit any rectangles that meet the criteria
+        /// </summary>
+        private static bool TryFitMaximumRectangleAtAngle(
+            Edge[] edges,
+            Vector2 center, float angleRad, float minArea,
+            out float aspectRatio, out float width, out float height)
+        {
+            width = 0;
+            height = 0;
+            aspectRatio = 0;
+
+            float[] aspectRatios = {1,   1.5f, 2,   2.5f, 3,    3.5f, 4,    4.5f, 5,    5.5f, 6,    6.5f, 7,    7.5f, 8,
+                            8.5f, 9,   9.5f, 10,  10.5f, 11,  11.5f, 12,  12.5f, 13,  13.5f, 14,  14.5f, 15};
+
+            // Start by calculating max width and height by ray-casting a cross from the point at the given angle
+            // and taking the shortest leg of each ray. Width is the longest.
+            Vector2 topCollisionPoint;
+            Vector2 bottomCollisionPoint;
+            Vector2 leftCollisionPoint;
+            Vector2 rightCollisionPoint;
+            if (!FindSurroundingCollisionPoints(edges, center, angleRad,
+                out topCollisionPoint, out bottomCollisionPoint, out leftCollisionPoint, out rightCollisionPoint))
+            {
+                return false;
+            }
+
+            float verticalMinDistanceToEdge =
+                Math.Min(Vector2.Distance(center, topCollisionPoint), Vector2.Distance(center, bottomCollisionPoint));
+            float horizontalMinDistanceToEdge =
+                Math.Min(Vector2.Distance(center, leftCollisionPoint), Vector2.Distance(center, rightCollisionPoint));
+
+            // Width is the largest of the possible dimensions (doubled of course)
+            float maxWidth = Math.Max(verticalMinDistanceToEdge, horizontalMinDistanceToEdge) * 2.0f;
+            float maxHeight = Math.Min(verticalMinDistanceToEdge, horizontalMinDistanceToEdge) * 2.0f;
+
+
+            // For each aspect ratio we do a binary search to find the maximum rect that fits, though once we start increasing our area by minimumHeightGain we call it good enough
+            foreach (var candidateAspectRatio in aspectRatios)
+            {
+                // The height is limited by the width. If a height would make our width exceed maxWidth, it can't be used
+                float searchHeightUpperBound = Math.Max(maxHeight, maxWidth / candidateAspectRatio);
+
+                // Set to the min height that will out perform our previous area at the given aspect ratio. This is 0 the first time.
+                // Derived from biggestAreaSoFar=height*(height*aspctRatio)
+                float searchHeightLowerBound = (float)Math.Sqrt(Math.Max((width * height), minArea) / candidateAspectRatio);
+
+                // If the lowest value needed to outperform the previous best is greater than our max, this aspect ratio can't outperform what we've already calculated
+                if (searchHeightLowerBound > searchHeightUpperBound || searchHeightLowerBound * candidateAspectRatio > maxWidth)
+                {
+                    continue;
+                }
+
+                float currentTestingHeight = Math.Max(searchHeightLowerBound, maxHeight / 2);
+
+                // Do the binary search until continuing to search will not give us a significant win
+                do
+                {
+                    if (WillRectangleFit(edges, center, angleRad, candidateAspectRatio * currentTestingHeight, currentTestingHeight))
+                    {
+                        // Binary search up-ward
+
+                        // If the rectangle will fit, increase the lower bounds of our binary search
+                        searchHeightLowerBound = currentTestingHeight;
+
+                        width = currentTestingHeight * candidateAspectRatio;
+                        height = currentTestingHeight;
+                        aspectRatio = candidateAspectRatio;
+                        currentTestingHeight = (searchHeightUpperBound + currentTestingHeight) / 2;
+                    }
+                    else
+                    {
+                        // If the rectangle won't fit, update our upper bound and lower our binary search
+                        searchHeightUpperBound = currentTestingHeight;
+                        currentTestingHeight = (currentTestingHeight + searchHeightLowerBound) / 2;
+                    }
+                }
+                while ((searchHeightUpperBound - searchHeightLowerBound) > minimumHeightGain);
+            }
+
+            return aspectRatio > 0;
+        }
+
+        /// <summary>
+        /// Returns true if a rectangle centered at the given point, at the
+        /// given angle and dimensions, will fit in the polygon
+        /// </summary>
+        private static bool WillRectangleFit(Edge[] edges, Vector2 center, float angleRad, float width, float height)
+        {
+            float halfWidth = width / 2;
+            float halfHeight = height / 2;
+
+            var topLeft = new Vector2(center.x - halfWidth, center.y + halfHeight);
+            var topRight = new Vector2(center.x + halfWidth, center.y + halfHeight);
+            var bottomLeft = new Vector2(center.x - halfWidth, center.y - halfHeight);
+            var bottomRight = new Vector2(center.x + halfWidth, center.y - halfHeight);
+
+            topLeft = RotatePoint(center, angleRad, topLeft);
+            topRight = RotatePoint(center, angleRad, topRight);
+            bottomLeft = RotatePoint(center, angleRad, bottomLeft);
+            bottomRight = RotatePoint(center, angleRad, bottomRight);
+
+            var top = new Edge(topLeft, topRight);
+            var right = new Edge(topRight, bottomRight);
+            var bottom = new Edge(bottomLeft, bottomRight);
+            var left = new Edge(topLeft, bottomLeft);
+
+            // If any edges of the polygon intersect with any of our edges, it won't fit
+            foreach (var edge in edges)
+            {
+                if (IsValidPoint(GetIntersection(edge, top)) || IsValidPoint(GetIntersection(edge, right)) ||
+                    IsValidPoint(GetIntersection(edge, bottom)) || IsValidPoint(GetIntersection(edge, left)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Finds a large inscribed rectangle. Tries to be maximal but this is
+        /// best effort. The algorithm used was inspired by the blog post
+        /// https://d3plus.org/blog/behind-the-scenes/2014/07/08/largest-rect/
+        /// Random points within the polygon are chosen, and then 2 lines are
+        /// drawn through those points. The midpoints of those lines are
+        /// used as the center of various rectangles, using a binary search to
+        /// vary the size, until the largest fit-able rectangle is found.
+        /// This is then repeated for pre-defined angles (0-180 in steps of 15)
+        /// and aspect ratios (1 to 15 in steps of 0.5)
+        /// </summary>
+        private static void FindInscribedRectangle(Edge[] edges, int randomSeed, out Vector2 center, out float angle, out float width, out float height)
+        {
+            center = InvalidPoint;
+            angle = width = height = 0;
+
+            // Find min x, min y, max x, max y and generate random
+            // points in this range until we have randomPointCount
+            // random starting points
+            float minX = largeValue;
+            float minY = largeValue;
+            float maxX = smallValue;
+            float maxY = smallValue;
+
+            foreach (var edge in edges)
+            {
+                if (edge.Ax < minX || edge.Bx < minX)
+                {
+                    minX = Math.Min(edge.Ax, edge.Bx);
+                }
+                if (edge.Ay < minY || edge.By < minY)
+                {
+                    minY = Math.Min(edge.Ay, edge.By);
+                }
+                if (edge.Ax > maxX || edge.Bx > maxX)
+                {
+                    maxX = Math.Max(edge.Ax, edge.Bx);
+                }
+                if (edge.Ay > maxY || edge.By > maxY)
+                {
+                    maxY = Math.Max(edge.Ay, edge.By);
+                }
+            }
+
+            // Generate random points
+            Vector2[] startingPoints = new Vector2[randomPointCount];
+            {
+                var random = new System.Random(randomSeed);
+
+                for (int pointIndex = 0; pointIndex < randomPointCount; ++pointIndex)
+                {
+                    Vector2 candidatePoint;
+
+                    do
+                    {
+                        candidatePoint.x = ((float)random.NextDouble() * (maxX - minX)) + minX;
+                        candidatePoint.y = ((float)random.NextDouble() * (maxY - minY)) + minY;
+                    }
+                    while (!IsInside(edges, candidatePoint));
+
+                    startingPoints[pointIndex] = candidatePoint;
+                }
+            }
+
+            float[] angles = { 0, 15, 30, 45, 60, 75, 90, 105, 120, 135, 150, 165 };
+
+            foreach (var candidateAngle in angles)
+            {
+                // For each randomly generated starting point
+                foreach (var startingPoint in startingPoints)
+                {
+                    // Find the collision point of a cross through the given point at the given angle
+                    // Ignore the return value. A return value of false indicates one of the points is bad.
+                    // We will check each point's validity ourselves anyway.
+                    Vector2 topCollisionPoint;
+                    Vector2 bottomCollisionPoint;
+                    Vector2 leftCollisionPoint;
+                    Vector2 rightCollisionPoint;
+                    FindSurroundingCollisionPoints(edges, startingPoint, DegreesToRadians(candidateAngle),
+                        out topCollisionPoint, out bottomCollisionPoint, out leftCollisionPoint, out rightCollisionPoint);
+
+                    // Now calculate the midpoint between top and bottom (the "vertical midpoint") and left and right (the "horizontal midpoint")
+                    if (IsValidPoint(topCollisionPoint) && IsValidPoint(bottomCollisionPoint))
+                    {
+                        var verticalMidpoint = new Vector2((topCollisionPoint.x + bottomCollisionPoint.x) / 2,
+                                    (topCollisionPoint.y + bottomCollisionPoint.y) / 2);
+                        float aspectRatio;
+                        float w;
+                        float h;
+                        if (TryFitMaximumRectangleAtAngle(edges, verticalMidpoint, DegreesToRadians(candidateAngle), width * height, out aspectRatio, out w, out h))
+                        {
+                            center = verticalMidpoint;
+                            angle = candidateAngle;
+                            width = w;
+                            height = h;
+                        }
+                    }
+
+                    if (IsValidPoint(leftCollisionPoint) && IsValidPoint(rightCollisionPoint))
+                    {
+                        var horizontalMidpoint = new Vector2((leftCollisionPoint.x + rightCollisionPoint.x) / 2,
+                                        (leftCollisionPoint.y + rightCollisionPoint.y) / 2);
+                        float aspectRatio;
+                        float w;
+                        float h;
+                        if (TryFitMaximumRectangleAtAngle(edges, horizontalMidpoint, DegreesToRadians(candidateAngle), width * height,
+                            out aspectRatio, out w, out h))
+                        {
+                            center = horizontalMidpoint;
+                            angle = candidateAngle;
+                            width = w;
+                            height = h;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
@@ -214,7 +214,7 @@ namespace HoloToolkit.Unity.Boundary
                     {
                         // If this collision point is closer than the previous one
                         if (!EdgeHelpers.IsValidPoint(topCollisionPoint) ||
-                            Vector2.Distance(point, verticalIntersection) < Vector2.Distance(point, topCollisionPoint))
+                            Vector2.SqrMagnitude(point - verticalIntersection) < Vector2.SqrMagnitude(point - topCollisionPoint))
                         {
                             topCollisionPoint = verticalIntersection;
                         }
@@ -222,7 +222,7 @@ namespace HoloToolkit.Unity.Boundary
                     else
                     {
                         if (!EdgeHelpers.IsValidPoint(bottomCollisionPoint) ||
-                            Vector2.Distance(point, verticalIntersection) < Vector2.Distance(point, bottomCollisionPoint))
+                            Vector2.SqrMagnitude(point - verticalIntersection) < Vector2.SqrMagnitude(point - bottomCollisionPoint))
                         {
                             bottomCollisionPoint = verticalIntersection;
                         }
@@ -238,7 +238,7 @@ namespace HoloToolkit.Unity.Boundary
                     {
                         // Is it closer than the previous intersection?
                         if (!EdgeHelpers.IsValidPoint(leftCollisionPoint) ||
-                            Vector2.Distance(point, horizontalIntersection) < Vector2.Distance(point, leftCollisionPoint))
+                            Vector2.SqrMagnitude(point - horizontalIntersection) < Vector2.SqrMagnitude(point - leftCollisionPoint))
                         {
                             leftCollisionPoint = horizontalIntersection;
                         }
@@ -247,7 +247,7 @@ namespace HoloToolkit.Unity.Boundary
                     {
                         // Is it closer than the previous intersection?
                         if (!EdgeHelpers.IsValidPoint(rightCollisionPoint) ||
-                            Vector2.Distance(point, horizontalIntersection) < Vector2.Distance(point, rightCollisionPoint))
+                            Vector2.SqrMagnitude(point - horizontalIntersection) < Vector2.SqrMagnitude(point - rightCollisionPoint))
                         {
                             rightCollisionPoint = horizontalIntersection;
                         }

--- a/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs.meta
+++ b/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f5e5f24bf960548469bd89ceed6cf646
+timeCreated: 1518204273
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/UX/Materials/MRTK_Standard_Charcoal.mat
+++ b/Assets/HoloToolkit/UX/Materials/MRTK_Standard_Charcoal.mat
@@ -8,10 +8,10 @@ Material:
   m_PrefabInternal: {fileID: 0}
   m_Name: MRTK_Standard_Charcoal
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
-  m_ShaderKeywords: _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _DIRECTIONAL_LIGHT
-    _DISABLE_ALBEDO_MAP _LIGHTMAPPING_REALTIME _SPECULAR_HIGHLIGHTS
+  m_ShaderKeywords: _BORDER_LIGHT_USES_HOVER_COLOR _DIRECTIONAL_LIGHT _DISABLE_ALBEDO_MAP
+    _LIGHTMAPPING_REALTIME _SPECULAR_HIGHLIGHTS
   m_LightmapFlags: 1
-  m_EnableInstancingVariants: 1
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2000
   stringTagMap:
@@ -63,7 +63,7 @@ Material:
     m_Floats:
     - _AlbedoAlphaMode: 0
     - _BlendOp: 0
-    - _BorderLight: 1
+    - _BorderLight: 0
     - _BorderLightOpaque: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.108


### PR DESCRIPTION
Overview
---
This is a port of @KevinKennedy's inscribed rectangle code from his PR #1759.

I also removed the old Bounds creation for checking if an object was inside the boundary, since that wasn't doing what we expected (Bounds are rectangular, not the shape of the boundary's polygon). Instead, I refactored out some code that was included here to properly check against the edges of the boundary.

![image](https://user-images.githubusercontent.com/3580640/42352488-a50b413e-806f-11e8-9fea-2b4a1a3e6152.png)

Purple is inside the boundary. Cyan is inside the inscribed rectangle, also pictured as a quad.

Changes
---
- Fixes: #1709, fixes #2138.
