### PR TITLE
Addressing previous inscribed rectangle PR comments

### DIFF
--- a/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/Boundary/Scripts/BoundaryVisualizer.cs
@@ -97,14 +97,16 @@ namespace HoloToolkit.Unity.Boundary.Tests
                     marker.transform.position = position;
                     marker.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
 
+                    var markerRenderer = marker.GetComponent<MeshRenderer>();
+
                     if (BoundaryManager.Instance.ContainsObject(position, UnityEngine.Experimental.XR.Boundary.Type.TrackedArea))
                     {
-                        marker.GetComponent<MeshRenderer>().sharedMaterial = trackedAreaBoundsMaterial;
+                        markerRenderer.sharedMaterial = trackedAreaBoundsMaterial;
                     }
 
                     if (BoundaryManager.Instance.ContainsObject(position, UnityEngine.Experimental.XR.Boundary.Type.PlayArea))
                     {
-                        marker.GetComponent<MeshRenderer>().sharedMaterial = boundsMaterial;
+                        markerRenderer.sharedMaterial = boundsMaterial;
                     }
                 }
             }

--- a/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
@@ -264,16 +264,12 @@ namespace HoloToolkit.Unity.Boundary
             {
                 if (boundaryGeometryPoints.Count > 0)
                 {
-                    boundaryGeometryEdges = new Edge[boundaryGeometryPoints.Count];
-
                     for (int pointIndex = 0; pointIndex < boundaryGeometryPoints.Count; pointIndex++)
                     {
-                        var pointA = boundaryGeometryPoints[pointIndex];
-                        var pointB = boundaryGeometryPoints[(pointIndex + 1) % boundaryGeometryPoints.Count];
-                        boundaryGeometryEdges[pointIndex] = new Edge(pointA.x, pointA.z, pointB.x, pointB.z);
-
-                        boundaryFloor = Math.Min(boundaryFloor, pointA.y);
+                        boundaryFloor = Math.Min(boundaryFloor, boundaryGeometryPoints[pointIndex].y);
                     }
+
+                    boundaryGeometryEdges = EdgeHelpers.ConvertVector3ListToEdgeArray(boundaryGeometryPoints);
 
                     inscribedRectangle = new InscribedRectangle(boundaryGeometryEdges);
                 }

--- a/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/EdgeHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.Boundary
@@ -15,6 +16,23 @@ namespace HoloToolkit.Unity.Boundary
 
         // Sentinel value
         public static readonly Vector2 InvalidPoint = new Vector2(float.NegativeInfinity, float.NegativeInfinity);
+
+        /// <summary>
+        /// Helper to convert a list of Vector3 points into an array of Edges.
+        /// </summary>
+        public static Edge[] ConvertVector3ListToEdgeArray(IList<Vector3> points)
+        {
+            var edges = new Edge[points.Count];
+
+            for (int pointIndex = 0; pointIndex < points.Count; pointIndex++)
+            {
+                var pointA = points[pointIndex];
+                var pointB = points[(pointIndex + 1) % points.Count];
+                edges[pointIndex] = new Edge(pointA.x, pointA.z, pointB.x, pointB.z);
+            }
+
+            return edges;
+        }
 
         /// <summary>
         /// Helper to know when a point is invalid.

--- a/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/InscribedRectangle.cs
@@ -33,33 +33,17 @@ namespace HoloToolkit.Unity.Boundary
         /// <summary>
         /// Constructor that takes in a list of points and generates a seed.
         /// </summary>
-        public InscribedRectangle(IList<Vector3> points) : this(points, (int)DateTime.UtcNow.Ticks)
-        {
-        }
+        public InscribedRectangle(IList<Vector3> points) : this(points, (int)DateTime.UtcNow.Ticks) { }
 
         /// <summary>
         /// Constructor that takes in a list of points and sets a fixed random seed to get repeatable results.
         /// </summary>
-        public InscribedRectangle(IList<Vector3> points, int randomSeed)
-        {
-            var edges = new Edge[points.Count];
-
-            for (int pointIndex = 0; pointIndex < points.Count; ++pointIndex)
-            {
-                var pointA = points[pointIndex];
-                var pointB = points[(pointIndex + 1) % points.Count];
-                edges[pointIndex] = new Edge(pointA.x, pointA.z, pointB.x, pointB.z);
-            }
-
-            FindInscribedRectangle(edges, randomSeed, out center, out angle, out width, out height);
-        }
+        public InscribedRectangle(IList<Vector3> points, int randomSeed) : this(EdgeHelpers.ConvertVector3ListToEdgeArray(points), randomSeed) { }
 
         /// <summary>
         /// Constructor that takes in an array of Edges and generates a seed.
         /// </summary>
-        public InscribedRectangle(Edge[] edges) : this(edges, (int)DateTime.UtcNow.Ticks)
-        {
-        }
+        public InscribedRectangle(Edge[] edges) : this(edges, (int)DateTime.UtcNow.Ticks) { }
 
         /// <summary>
         /// Constructor that takes in an array of Edges and sets a fixed random seed to get repeatable results.


### PR DESCRIPTION
Overview
---
There was an optimization mentioned in #2403 that I'm addressing here.
I also refactored out a method to convert Vector3s into Edges, which needed to happen in (at least) two places. This simplifies the InscribedRectangle constructors slightly as well.

Changes
---
- Addresses https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/2403#discussion_r200541457
