### PR TITLE
Shader updates from Dev

### DIFF
--- a/Assets/HoloToolkit-Examples/StandardShader/Animations/RoundedCorner.anim
+++ b/Assets/HoloToolkit-Examples/StandardShader/Animations/RoundedCorner.anim
@@ -44,34 +44,6 @@ AnimationClip:
     path: 
     classID: 23
     script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 2
-        time: 0
-        value: 0.1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-      - serializedVersion: 2
-        time: 2.5
-        value: 0.02
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-      - serializedVersion: 2
-        time: 5
-        value: 0.1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: material._BorderWidth
-    path: 
-    classID: 23
-    script: {fileID: 0}
   m_PPtrCurves: []
   m_SampleRate: 60
   m_WrapMode: 0
@@ -83,13 +55,6 @@ AnimationClip:
     - serializedVersion: 2
       path: 0
       attribute: 2352964247
-      script: {fileID: 0}
-      typeID: 23
-      customType: 22
-      isPPtrCurve: 0
-    - serializedVersion: 2
-      path: 0
-      attribute: 2241588077
       script: {fileID: 0}
       typeID: 23
       customType: 22
@@ -141,34 +106,6 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: material._RoundCornerRadius
-    path: 
-    classID: 23
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 2
-        time: 0
-        value: 0.1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-      - serializedVersion: 2
-        time: 2.5
-        value: 0.02
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-      - serializedVersion: 2
-        time: 5
-        value: 0.1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: material._BorderWidth
     path: 
     classID: 23
     script: {fileID: 0}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/CubeBorderRoundedOpaque.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/CubeBorderRoundedOpaque.mat
@@ -83,7 +83,7 @@ Material:
     - _ColorWriteMask: 15
     - _CullMode: 0
     - _CustomMode: 1
-    - _Cutoff: 0.5
+    - _Cutoff: 1
     - _DetailNormalMapScale: 1
     - _DirectionalLight: 1
     - _DstBlend: 0
@@ -104,7 +104,7 @@ Material:
     - _HoverLight: 1
     - _HoverLightOpaque: 0
     - _InnerGlow: 0
-    - _Metallic: 1
+    - _Metallic: 0.5
     - _Mode: 1
     - _NearPlaneFade: 0
     - _OcclusionStrength: 1
@@ -117,9 +117,9 @@ Material:
     - _RimPower: 3
     - _RoundCornerMargin: 0.1
     - _RoundCornerPower: 0.4
-    - _RoundCornerRadius: 0.25
+    - _RoundCornerRadius: 0.16
     - _RoundCorners: 1
-    - _Smoothness: 0
+    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
@@ -137,6 +137,6 @@ Material:
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
     - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
-    - _HoverColorOverride: {r: 0.8206897, g: 0, b: 1, a: 1}
+    - _HoverColorOverride: {r: 0.1397059, g: 0.14563891, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
     - _RimColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/CubeEnvironmentColor.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/CubeEnvironmentColor.mat
@@ -90,8 +90,8 @@ Material:
     - _EnableHoverColorOverride: 0
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
-    - _EnvironmentColorIntensity: 0.46
-    - _EnvironmentColorThreshold: 1.46
+    - _EnvironmentColorIntensity: 0.5
+    - _EnvironmentColorThreshold: 3
     - _EnvironmentColoring: 1
     - _FadeBeginDistance: 0.85
     - _FadeCompleteDistance: 0.5

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorder.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorder.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorder
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_LIGHT
-    _INNER_GLOW
+    _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 0
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderBlue.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderBlue.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderBlue
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0, g: 0.25517225, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderCyan.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderCyan.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderCyan
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0, g: 0.4044118, b: 0.3709433, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderGreen.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderGreen.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderGreen
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0, g: 0.44852942, b: 0.05877288, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderOrange.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderOrange.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderOrange
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0.6911765, g: 0.38610548, b: 0, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderPink.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderPink.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderPink
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,10 +114,10 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
+    - _RoundCornerMargin: 0.01
     - _RoundCornerPower: 0.4
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -133,6 +135,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0.3455882, g: 0, b: 0.2788538, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderPurple.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderPurple.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderPurple
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0.24137926, g: 0, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderRed.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderRed.mat
@@ -9,7 +9,7 @@ Material:
   m_Name: PanelBorderRed
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
   m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_USES_HOVER_COLOR _HOVER_COLOR_OVERRIDE
-    _HOVER_LIGHT _INNER_GLOW
+    _HOVER_LIGHT _INNER_GLOW _ROUND_CORNERS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -112,9 +114,9 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 3
-    - _RoundCornerMargin: 0
-    - _RoundCornerRadius: 0.25
-    - _RoundCorners: 0
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.01
+    - _RoundCorners: 1
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 0
@@ -132,6 +134,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0.66176474, g: 0.041075055, b: 0, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderRoundedBlue.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/PanelBorderRoundedBlue.mat
@@ -72,7 +72,7 @@ Material:
     - _BorderLightOpaque: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
-    - _BorderWidth: 0.05
+    - _BorderWidth: 0.1
     - _BorderWidthHorizontal: 0.048
     - _BorderWidthVertical: 0.1
     - _BumpScale: 1
@@ -88,6 +88,7 @@ Material:
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 1
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
@@ -100,6 +101,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 1
     - _Metallic: 0
     - _Mode: 2
@@ -133,6 +135,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 0, g: 0.25517225, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _RimColor: {r: 0.33088237, g: 0.33088237, b: 0.33088237, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallGlass.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallGlass.mat
@@ -8,7 +8,8 @@ Material:
   m_PrefabInternal: {fileID: 0}
   m_Name: ShaderBallGlass
   m_Shader: {fileID: 4800000, guid: d45c0efca53019e43891b0f610f8146e, type: 3}
-  m_ShaderKeywords: _ALPHABLEND_ON _HOVER_LIGHT _REFLECTIONS _REFRACTION _SPECULAR_HIGHLIGHTS
+  m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT_USES_HOVER_COLOR _DIRECTIONAL_LIGHT
+    _DISABLE_ALBEDO_MAP _REFLECTIONS _REFRACTION _RIM_LIGHT _SPECULAR_HIGHLIGHTS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -19,31 +20,7 @@ Material:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailAlbedoMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailMask:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailNormalMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 761728b4c11af5748aebdd0023b2d500, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -51,39 +28,26 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _ParallaxMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     m_Floats:
     - _AlbedoAlphaMode: 0
-    - _AlbedoAlphaSmoothness: 0
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightUsesHoverColor: 0
-    - _BorderMinValue: 0.02
+    - _BorderLightUsesHoverColor: 1
+    - _BorderMinValue: 0.1
     - _BorderWidth: 0.1
-    - _BorderWidthHorizontal: 0.1
-    - _BorderWidthVertical: 0.1
-    - _BumpScale: 1
     - _ClippingPlane: 0
     - _ClippingPlaneBorder: 0
     - _ClippingPlaneBorderWidth: 0.025
     - _ColorWriteMask: 15
-    - _Cull: 2
     - _CullMode: 2
     - _CustomMode: 2
     - _Cutoff: 0.5
-    - _DetailNormalMapScale: 1
-    - _DirectionalLight: 0
+    - _DirectionalLight: 1
     - _DstBlend: 10
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 0
     - _EnableNormalMap: 0
     - _EnvironmentColorIntensity: 0.5
@@ -91,43 +55,35 @@ Material:
     - _EnvironmentColoring: 0
     - _FadeBeginDistance: 0.85
     - _FadeCompleteDistance: 0.5
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _HoverLight: 1
+    - _HoverLight: 0
+    - _HoverLightOpaque: 0
     - _InnerGlow: 0
-    - _Metallic: 0
+    - _Metallic: 0.5
     - _Mode: 2
-    - _MyCullVariable: 1
     - _NearPlaneFade: 0
-    - _OcclusionStrength: 1
-    - _Parallax: 0.02
     - _Reflections: 1
     - _Refraction: 1
-    - _RefractiveIndex: 0
+    - _RefractiveIndex: 0.1
     - _RenderQueueOverride: -1
-    - _RimLight: 0
-    - _RimPower: 3
-    - _RoundCornerMargin: 0
+    - _RimLight: 1
+    - _RimPower: 8
+    - _RoundCornerMargin: 0.01
     - _RoundCornerRadius: 0.25
     - _RoundCorners: 0
-    - _Smoothness: 1
-    - _SmoothnessTextureChannel: 0
+    - _Smoothness: 0.5
     - _SpecularHighlights: 1
     - _SrcBlend: 5
-    - _UVSec: 0
     - _ZTest: 4
     - _ZWrite: 0
     m_Colors:
     - _ClipPlane: {r: 0, g: 1, b: 0, a: 0}
     - _ClippingPlaneBorderColor: {r: 1, g: 0.2, b: 0, a: 1}
-    - _Color: {r: 0.5882353, g: 0.5882353, b: 0.5882353, a: 0.7058824}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.5019608}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
     - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
     - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
-    - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
     - _RimColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallNearPlaneFade.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallNearPlaneFade.mat
@@ -89,11 +89,12 @@ Material:
     - _DstBlend: 1
     - _EdgeSmoothingValue: 0.002
     - _EnableEmission: 0
+    - _EnableHoverColorOpaqueOverride: 0
     - _EnableHoverColorOverride: 0
     - _EnableLightMap: 0
     - _EnableNormalMap: 0
     - _EnvironmentColorIntensity: 1
-    - _EnvironmentColorThreshold: 1.5
+    - _EnvironmentColorThreshold: 3
     - _EnvironmentColoring: 1
     - _FadeBeginDistance: 3
     - _FadeCompleteDistance: 1
@@ -101,6 +102,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _HoverLight: 1
+    - _HoverLightOpaque: 0
     - _InnerGlow: 0
     - _Metallic: 0
     - _Mode: 4
@@ -134,6 +136,7 @@ Material:
     - _EnvironmentColorY: {r: 0, g: 0.91724133, b: 1, a: 1}
     - _EnvironmentColorZ: {r: 0, g: 0.03438126, b: 0.8308824, a: 1}
     - _HoverColor: {r: 1, g: 0, b: 0, a: 1}
+    - _HoverColorOpaqueOverride: {r: 1, g: 1, b: 1, a: 1}
     - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
     - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
     - _RimColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallNormalMap.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallNormalMap.mat
@@ -103,7 +103,7 @@ Material:
     - _HoverLight: 1
     - _HoverLightOpaque: 0
     - _InnerGlow: 0
-    - _Metallic: 0
+    - _Metallic: 0.5
     - _Mode: 0
     - _MyCullVariable: 1
     - _NearPlaneFade: 0

--- a/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallNormalMapTransparent.mat
+++ b/Assets/HoloToolkit-Examples/StandardShader/Materials/ShaderBallNormalMapTransparent.mat
@@ -103,7 +103,7 @@ Material:
     - _HoverLight: 1
     - _HoverLightOpaque: 0
     - _InnerGlow: 0
-    - _Metallic: 0
+    - _Metallic: 0.5
     - _Mode: 2
     - _MyCullVariable: 1
     - _NearPlaneFade: 0

--- a/Assets/HoloToolkit-Examples/StandardShader/Prefabs/Placard.prefab
+++ b/Assets/HoloToolkit-Examples/StandardShader/Prefabs/Placard.prefab
@@ -224,5 +224,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac8d5b128a1d8204fb76c86f47b75912, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PivotAxis: 1
-  TargetTransform: {fileID: 0}
+  pivotAxis: 1
+  targetTransform: {fileID: 0}

--- a/Assets/HoloToolkit/Common/Scripts/Editor/StandardShaderGUI.cs
+++ b/Assets/HoloToolkit/Common/Scripts/Editor/StandardShaderGUI.cs
@@ -67,8 +67,8 @@ namespace HoloToolkit.Unity
             public static readonly string[] albedoAlphaModeNames = Enum.GetNames(typeof(AlbedoAlphaMode));
             public static readonly string[] depthWriteNames = Enum.GetNames(typeof(DepthWrite));
             public static GUIContent sourceBlend = new GUIContent("Source Blend", "Blend Mode of Newly Calculated Color");
-            public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Exisiting Color");
-            public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Exisiting Color");
+            public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Existing Color");
+            public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Existing Color");
             public static GUIContent depthTest = new GUIContent("Depth Test", "How Should Depth Testing Be Performed.");
             public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Object Are Written to the Depth Buffer");
             public static GUIContent colorWriteMask = new GUIContent("Color Write Mask", "Color Channel Writing Mask");
@@ -100,9 +100,9 @@ namespace HoloToolkit.Unity
             public static GUIContent fadeCompleteDistance = new GUIContent("Fade Complete", "Distance From Camera When Fade is Fully In");
             public static GUIContent hoverLight = new GUIContent("Hover Light", "Enable utilization of a Hover Light");
             public static GUIContent enableHoverColorOverride = new GUIContent("Override Color", "Override Global Hover Color");
-            public static GUIContent hoverLightOpaque = new GUIContent("Hover Light Opaque", "Enable Hover Light on Transparent pixels");
+            public static GUIContent hoverLightOpaque = new GUIContent("Hover Light Opaque", "Enable Hover Light on Transparent Pixels");
             public static GUIContent enableHoverColorOpaqueOverride = new GUIContent("Override Color", "Override Opaque Hover Color");
-            public static GUIContent hoverColorOpaqueOverride = new GUIContent("Color", "Override Hover Color for Trasnparent Pixels");
+            public static GUIContent hoverColorOpaqueOverride = new GUIContent("Color", "Override Hover Color for Transparent Pixels");
             public static GUIContent hoverColorOverride = new GUIContent("Color", "Override Hover Color");
             public static GUIContent roundCorners = new GUIContent("Round Corners", "(Assumes UVs Specify Borders)");
             public static GUIContent roundCornerRadius = new GUIContent("Unit Radius", "Rounded Rectangle Corner Unit Sphere Radius");
@@ -118,12 +118,12 @@ namespace HoloToolkit.Unity
             public static GUIContent environmentColoring = new GUIContent("Environment Coloring", "Change Color Based on View");
             public static GUIContent environmentColorThreshold = new GUIContent("Threshold", "Threshold When Environment Coloring Should Appear Based on Surface Normal");
             public static GUIContent environmentColorIntensity = new GUIContent("Intensity", "Intensity (or Brightness) of the Environment Coloring");
-            public static GUIContent environmentColorX = new GUIContent("X-Axis Color", "Color Along the Worldspace X-Axis");
-            public static GUIContent environmentColorY = new GUIContent("Y-Axis Color", "Color Along the Worldspace Y-Axis");
-            public static GUIContent environmentColorZ = new GUIContent("Z-Axis Color", "Color Along the Worldspace Z-Axis");
+            public static GUIContent environmentColorX = new GUIContent("X-Axis Color", "Color Along the World Space X-Axis");
+            public static GUIContent environmentColorY = new GUIContent("Y-Axis Color", "Color Along the World Space Y-Axis");
+            public static GUIContent environmentColorZ = new GUIContent("Z-Axis Color", "Color Along the World Space Z-Axis");
         }
 
-        protected bool initilized;
+        protected bool initialized;
 
         protected MaterialProperty renderingMode;
         protected MaterialProperty customRenderingMode;
@@ -253,7 +253,7 @@ namespace HoloToolkit.Unity
             Material material = (Material)materialEditor.target;
 
             FindProperties(props);
-            Initilize(material);
+            Initialize(material);
 
             RenderingModeOptions(materialEditor);
             MainMapOptions(materialEditor, material);
@@ -339,12 +339,12 @@ namespace HoloToolkit.Unity
             }
         }
 
-        protected void Initilize(Material material)
+        protected void Initialize(Material material)
         {
-            if (!initilized)
+            if (!initialized)
             {
                 MaterialChanged(material);
-                initilized = true;
+                initialized = true;
             }
         }
 
@@ -614,7 +614,7 @@ namespace HoloToolkit.Unity
             materialEditor.RenderQueueField();
 
             // When round corner or border light features are used, enable instancing to disable batching. Static and dynamic 
-            // batching will normalize the object scale, which breakes border realted features.
+            // batching will normalize the object scale, which breaks border related features.
             GUI.enabled = !PropertyEnabled(roundCorners) && !PropertyEnabled(borderLight);
 
             if (!GUI.enabled && !material.enableInstancing)

--- a/Assets/HoloToolkit/Common/Shaders/Standard.shader
+++ b/Assets/HoloToolkit/Common/Shaders/Standard.shader
@@ -44,7 +44,7 @@ Shader "MixedRealityToolkit/Standard"
         _HoverColorOpaqueOverride("Hover Color Override for Transparent Pixels", Color) = (1.0, 1.0, 1.0, 1.0)
         [Toggle(_ROUND_CORNERS)] _RoundCorners("Round Corners", Float) = 0.0
         _RoundCornerRadius("Round Corner Radius", Range(0.01, 0.5)) = 0.25
-        _RoundCornerMargin("Round Corner Margin", Range(0.0, 0.5)) = 0.0
+        _RoundCornerMargin("Round Corner Margin", Range(0.0, 0.5)) = 0.01
         [Toggle(_BORDER_LIGHT)] _BorderLight("Border Light", Float) = 0.0
         [Toggle(_BORDER_LIGHT_USES_HOVER_COLOR)] _BorderLightUsesHoverColor("Border Light Uses Hover Color", Float) = 1.0
         [Toggle(_BORDER_LIGHT_OPAQUE)] _BorderLightOpaque("Border Light Opaque", Float) = 0.0
@@ -88,12 +88,15 @@ Shader "MixedRealityToolkit/Standard"
 
             CGPROGRAM
 
+#if defined(SHADER_API_D3D11)
             #pragma target 5.0
-            #pragma only_renderers d3d11
-            #pragma multi_compile_instancing
-            #pragma multi_compile _ LIGHTMAP_ON
+#endif
             #pragma vertex vert
             #pragma fragment frag
+
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ _MULTI_HOVER_LIGHT
 
             #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
             #pragma shader_feature _DISABLE_ALBEDO_MAP
@@ -118,7 +121,7 @@ Shader "MixedRealityToolkit/Standard"
             #pragma shader_feature _BORDER_LIGHT_OPAQUE
             #pragma shader_feature _INNER_GLOW
             #pragma shader_feature _ENVIRONMENT_COLORING
-            
+
             #define IF(a, b, c) lerp(b, c, step((fixed) (a), 0.0));
 
             #include "UnityCG.cginc"
@@ -161,6 +164,12 @@ Shader "MixedRealityToolkit/Standard"
             #undef _FRESNEL
 #endif
 
+#if defined(_ROUND_CORNERS) || defined(_BORDER_LIGHT) || defined(_INNER_GLOW)
+            #define _DISTANCE_TO_EDGE
+#else
+            #undef _DISTANCE_TO_EDGE
+#endif
+
             struct appdata_t
             {
                 float4 vertex : POSITION;
@@ -180,7 +189,7 @@ Shader "MixedRealityToolkit/Standard"
                 float4 position : SV_POSITION;
 #if defined(_BORDER_LIGHT)
                 float4 uv : TEXCOORD0;
-#else
+#elif !defined(_DISABLE_ALBEDO_MAP) || defined(_NORMAL_MAP) || defined(_DISTANCE_TO_EDGE)
                 float2 uv : TEXCOORD0;
 #endif
 #if defined(LIGHTMAP_ON)
@@ -252,9 +261,12 @@ Shader "MixedRealityToolkit/Standard"
 #endif
 
 #if defined(_HOVER_LIGHT)
-            float3 _HoverPosition;
-            float _HoverRadius;
-            fixed4 _HoverColor;
+            float4 _HoverLight0;
+            fixed4 _HoverLightColor0;
+#if defined(_MULTI_HOVER_LIGHT)
+            float4 _HoverLight1;
+            fixed4 _HoverLightColor1;
+#endif
 #if defined(_HOVER_COLOR_OVERRIDE)
             fixed3 _HoverColorOverride;
 #endif
@@ -289,18 +301,28 @@ Shader "MixedRealityToolkit/Standard"
             fixed3 _EnvironmentColorZ;
 #endif
 
+#if defined(_DIRECTIONAL_LIGHT)
+            static const fixed3 _Ambient = fixed3(0.25, 0.25, 0.25);
+#endif
+
 #if defined(_SPECULAR_HIGHLIGHTS)
             static const fixed _Shininess = 800.0;
 #endif
 
 #if defined(_FRESNEL)
-            static const fixed _FresnelPower = 4.0;
-            static const fixed _FresnelPowerInverse = 1.0 / _FresnelPower;
+            static const fixed _FresnelPower = 8.0;
 #endif
 
 #if defined(_BORDER_LIGHT)
             static const fixed _BorderPower = 10.0;
             static const fixed _InverseBorderPower = 1.0 / _BorderPower;
+#endif
+
+#if defined(_HOVER_LIGHT)
+            inline fixed HoverLight(float4 hoverLight, float3 worldPosition, float alpha)
+            {
+                return (1.0 - saturate(length(hoverLight.xyz - worldPosition) / hoverLight.w)) * alpha;
+            }
 #endif
 
 #if defined(_CLIPPING_PLANE)
@@ -319,7 +341,7 @@ Shader "MixedRealityToolkit/Standard"
 #if defined(_TRANSPARENT)
                 return smoothstep(1.0, 0.0, distance / _EdgeSmoothingValue);
 #else
-                return step(distance, 0.0);
+                return (distance < 0.0);
 #endif
             }
 #endif
@@ -346,58 +368,70 @@ Shader "MixedRealityToolkit/Standard"
                 o.scale.z = length(mul(unity_ObjectToWorld, float4(0.0, 0.0, 1.0, 0.0)));
 #endif
 
-#if defined(_BORDER_LIGHT)
+#if defined(_BORDER_LIGHT) || defined(_ROUND_CORNERS)
                 o.uv.xy = TRANSFORM_TEX(v.uv, _MainTex);
    
                 float minScale = min(min(o.scale.x, o.scale.y), o.scale.z);
+
+#if defined(_BORDER_LIGHT) 
                 float maxScale = max(max(o.scale.x, o.scale.y), o.scale.z);
                 float minOverMiddleScale = minScale / (o.scale.x + o.scale.y + o.scale.z - minScale - maxScale);
 
                 float areaYZ = o.scale.y * o.scale.z;
                 float areaXZ = o.scale.z * o.scale.x;
                 float areaXY = o.scale.x * o.scale.y;
+
                 float borderWidth = _BorderWidth;
+#endif
 
                 if (abs(v.normal.x) == 1.0) // Y,Z plane.
                 {
                     o.scale.x = o.scale.z;
                     o.scale.y = o.scale.y;
 
+#if defined(_BORDER_LIGHT) 
                     if (areaYZ > areaXZ && areaYZ > areaXY)
                     {
                         borderWidth *= minOverMiddleScale;
                     }
+#endif
                 }
                 else if (abs(v.normal.y) == 1.0) // X,Z plane.
                 {
                     o.scale.x = o.scale.x;
                     o.scale.y = o.scale.z;
 
+#if defined(_BORDER_LIGHT) 
                     if (areaXZ > areaXY && areaXZ > areaYZ)
                     {
                         borderWidth *= minOverMiddleScale;
                     }
+#endif
                 }
                 else  // X,Y plane.
                 {
                     o.scale.x = o.scale.x;
                     o.scale.y = o.scale.y;
 
+#if defined(_BORDER_LIGHT) 
                     if (areaXY > areaYZ && areaXY > areaXZ)
                     {
                         borderWidth *= minOverMiddleScale;
                     }
+#endif
                 }
 
                 o.scale.z = minScale;
+
+#if defined(_BORDER_LIGHT) 
                 float scaleRatio = min(o.scale.x, o.scale.y) / max(o.scale.x, o.scale.y);
-                
+
                 o.uv.z = IF(o.scale.x > o.scale.y, 1.0 - (borderWidth * scaleRatio), 1.0 - borderWidth);
                 o.uv.w = IF(o.scale.x > o.scale.y, 1.0 - borderWidth, 1.0 - (borderWidth * scaleRatio));
-#else
+#endif
+#elif !defined(_DISABLE_ALBEDO_MAP) || defined(_NORMAL_MAP) || defined(_DISTANCE_TO_EDGE)
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
 #endif
-
 
 #if defined(LIGHTMAP_ON)
                 o.lightMapUV.xy = v.lightMapUV.xy * unity_LightmapST.xy + unity_LightmapST.zw;
@@ -421,7 +455,7 @@ Shader "MixedRealityToolkit/Standard"
                 return o;
             }
 
-#if !defined(_ALPHA_CLIP) && !defined(_TRANSPARENT)
+#if defined(SHADER_API_D3D11) && !defined(_ALPHA_CLIP) && !defined(_TRANSPARENT)
             [earlydepthstencil]
 #endif
             fixed4 frag(v2f i) : SV_Target
@@ -450,16 +484,16 @@ Shader "MixedRealityToolkit/Standard"
                 float planeDistance = PointVsPlane(i.worldPosition.xyz, _ClipPlane);
 #if defined(_CLIPPING_PLANE_BORDER)
                 fixed3 planeBorderColor = lerp(_ClippingPlaneBorderColor, fixed3(0.0, 0.0, 0.0), planeDistance / _ClippingPlaneBorderWidth);
-                albedo.rgb += step(planeDistance, _ClippingPlaneBorderWidth) * planeBorderColor;
+                albedo.rgb += planeBorderColor * ((planeDistance < _ClippingPlaneBorderWidth) ? 1.0 : 0.0);
 #endif
 #if defined(_ALPHA_CLIP)
-                albedo *= step(0.0, planeDistance);
+                albedo *= (planeDistance > 0.0);
 #else
                 albedo *= saturate(planeDistance);
 #endif
 #endif
 
-#if defined(_ROUND_CORNERS) || defined(_BORDER_LIGHT) || defined(_INNER_GLOW)
+#if defined(_DISTANCE_TO_EDGE)
                 fixed2 distanceToEdge;
                 distanceToEdge.x = abs(i.uv.x - 0.5) * 2.0;
                 distanceToEdge.y = abs(i.uv.y - 0.5) * 2.0;
@@ -467,9 +501,12 @@ Shader "MixedRealityToolkit/Standard"
 
                 // Rounded corner clipping.
 #if defined(_ROUND_CORNERS)
-                fixed cornerCircleRadius = (_RoundCornerRadius - _RoundCornerMargin) * i.scale.z;
-                fixed2 roundCornerPosition = distanceToEdge * 0.5 * i.scale.xy;
-                fixed2 cornerCircleDistance = (i.scale.xy * 0.5) - cornerCircleRadius - _RoundCornerMargin * i.scale.xy;
+                fixed2 halfScale = i.scale.xy * 0.5;
+                fixed2 roundCornerPosition = distanceToEdge * halfScale;
+
+                fixed cornerCircleRadius = saturate(_RoundCornerRadius - _RoundCornerMargin) * i.scale.z;
+                fixed2 cornerCircleDistance = halfScale - (_RoundCornerMargin * i.scale.z) - cornerCircleRadius;
+
                 fixed roundCornerClip = RoundCorners(roundCornerPosition, cornerCircleDistance, cornerCircleRadius);
 #endif
 
@@ -477,19 +514,31 @@ Shader "MixedRealityToolkit/Standard"
 
                 // Hover light.
 #if defined(_HOVER_LIGHT)
-                fixed pointToHover = (1.0 - saturate(length(_HoverPosition - i.worldPosition.xyz) / _HoverRadius)) * _HoverColor.a;
+                fixed pointToHover0 = HoverLight(_HoverLight0, i.worldPosition.xyz, _HoverLightColor0.a);
+#if defined(_MULTI_HOVER_LIGHT)
+                fixed pointToHover1 = HoverLight(_HoverLight1, i.worldPosition.xyz, _HoverLightColor1.a);
+#endif
 #if defined(_HOVER_COLOR_OVERRIDE)
-                _HoverColor.rgb = _HoverColorOverride.rgb;
+                fixed3 hoverColor = _HoverColorOverride.rgb;
+#else
+                fixed3 hoverColor = lerp(fixed3(0.0, 0.0, 0.0), _HoverLightColor0.rgb, pointToHover0);
+#if defined(_MULTI_HOVER_LIGHT)
+                hoverColor += lerp(fixed3(0.0, 0.0, 0.0), _HoverLightColor1.rgb, pointToHover1);
+#endif
+#endif
+                fixed pointToHover = pointToHover0;
+#if defined(_MULTI_HOVER_LIGHT)
+                pointToHover += pointToHover1;
 #endif
 #if defined(_HOVER_LIGHT_OPAQUE)
 #if defined(_HOVER_COLOR_OPAQUE_OVERRIDE)
-                _HoverColor.rgb = lerp(_HoverColorOpaqueOverride, _HoverColor.rgb, albedo.a);
+                hoverColor = lerp(_HoverColorOpaqueOverride, hoverColor, albedo.a);
 #endif
                 fixed baseBlend = 1.0 + (albedo.a - 1.0) * saturate(pointToHover / (pointToHover + albedo.a));
-                albedo.rgb += -(1.0 - baseBlend) * albedo.rgb + _HoverColor.rgb * max(pointToHover, 1.0 - baseBlend);
+                albedo.rgb += -(1.0 - baseBlend) * albedo.rgb + hoverColor * max(pointToHover, 1.0 - baseBlend);
                 albedo.a = (albedo.a + pointToHover);
 #else
-                albedo.rgb = saturate(albedo.rgb + _HoverColor.rgb * pointToHover);
+                albedo.rgb = saturate(albedo.rgb + hoverColor * pointToHover);
 #endif
 #endif
 
@@ -498,14 +547,18 @@ Shader "MixedRealityToolkit/Standard"
                 fixed3 borderColor = albedo.rgb * _BorderPower;
 #if defined(_HOVER_LIGHT)
 #if defined(_BORDER_LIGHT_USES_HOVER_COLOR)
-                borderColor *= _HoverColor.rgb;
+                borderColor *= hoverColor;
 #endif
 #else
                 fixed pointToHover = 1.0;
 #endif
                 fixed borderValue;
 #if defined(_ROUND_CORNERS)
-                borderValue = 1.0 - RoundCorners(roundCornerPosition, cornerCircleDistance, cornerCircleRadius * (1.0 - (_BorderWidth * 2.0)));
+                fixed borderMargin = _RoundCornerMargin  + _BorderWidth * 0.5;
+                cornerCircleRadius = saturate(_RoundCornerRadius - borderMargin) * i.scale.z;
+                cornerCircleDistance = halfScale - (borderMargin * i.scale.z) - cornerCircleRadius;
+
+                borderValue =  1.0 - RoundCorners(roundCornerPosition, cornerCircleDistance, cornerCircleRadius);
 #else
                 borderValue = max(smoothstep(i.uv.z - _EdgeSmoothingValue, i.uv.z + _EdgeSmoothingValue, distanceToEdge.x),
                                   smoothstep(i.uv.w - _EdgeSmoothingValue, i.uv.w + _EdgeSmoothingValue, distanceToEdge.y));
@@ -553,7 +606,7 @@ Shader "MixedRealityToolkit/Standard"
 
 #if defined(_SPECULAR_HIGHLIGHTS)
                 fixed halfVector = max(0.0, dot(worldNormal, normalize(_WorldSpaceLightPos0 + worldViewDir)));
-                fixed specular = saturate(pow(halfVector, _Shininess * pow(_Smoothness, 4)) * _Smoothness);
+                fixed specular = saturate(pow(halfVector, _Shininess * pow(_Smoothness, 4.0)) * _Smoothness);
 #else
                 fixed specular = 0.0;
 #endif
@@ -567,7 +620,9 @@ Shader "MixedRealityToolkit/Standard"
 #if defined(_REFRACTION)
                 fixed4 refractColor = UNITY_SAMPLE_TEXCUBE(unity_SpecCube0, refract(incident, worldNormal, _RefractiveIndex));
                 ibl *= DecodeHDR(refractColor, unity_SpecCube0_HDR);
-#endif 
+#endif
+#else
+                fixed3 ibl = unity_IndirectSpecColor.rgb;
 #endif
 
                 // Fresnel lighting.
@@ -576,23 +631,17 @@ Shader "MixedRealityToolkit/Standard"
 #if defined(_RIM_LIGHT)
                 fixed3 fresnelColor = _RimColor * pow(fresnel, _RimPower);
 #else
-                fixed3 fresnelColor = unity_AmbientSky.rgb * _FresnelPowerInverse * pow(fresnel, _FresnelPower);
+                fixed3 fresnelColor = unity_IndirectSpecColor.rgb * (pow(fresnel, _FresnelPower) * _Smoothness);
 #endif
 #endif
                 // Final lighting mix.
                 fixed4 output = albedo;
 
-#if defined(_REFLECTIONS) || defined(_DIRECTIONAL_LIGHT)
+#if defined(_DIRECTIONAL_LIGHT)
                 fixed minProperty = min(_Smoothness, _Metallic);
-#endif
-
-#if defined(_REFLECTIONS)
                 output.rgb += ibl * min((1.0 - _Metallic), 0.5);
                 output.rgb = lerp(output.rgb, ibl, minProperty);
-#endif
-
-#if defined(_DIRECTIONAL_LIGHT)
-                output.rgb *= lerp(unity_AmbientSky.rgb * 1.5 + (albedo.rgb *_LightColor0.rgb * diffuse + _LightColor0.rgb * specular), albedo, minProperty);
+                output.rgb *= lerp(_Ambient + glstate_lightmodel_ambient + (albedo.rgb *_LightColor0.rgb * diffuse + _LightColor0.rgb * specular), albedo, minProperty);
                 output.rgb += (_LightColor0.rgb * albedo * specular) + (_LightColor0.rgb * specular * _Smoothness);
 #endif
 
@@ -600,7 +649,7 @@ Shader "MixedRealityToolkit/Standard"
 #if defined(_RIM_LIGHT)
                 output.rgb += fresnelColor;
 #else
-                output.rgb += fresnelColor * (1 - minProperty);
+                output.rgb += fresnelColor * (1.0 - minProperty);
 #endif
 #endif
 


### PR DESCRIPTION
Overview
---
From original PR:
>Integrating the latest work to improve the MRTK/Standard shader. Improvements include:
>
>- Support for non-D3D11 APIs (tested on iOS and Android devices using OpenGL ES and Metal)
>- Support for three hover lights (useful with IHMDs with multi-pointers)
>- Improved rounded corner algorithm
>- Closer match to the Unity/Standard shader
>- Improved shader based anti-aliasing support
>- Minor optimizations
>
>
>![aa](https://user-images.githubusercontent.com/13305729/40255071-b4227e3a-5a9a-11e8-9d01-5ff0b0a807c6.png)
>(Shader based anti-aliasing example.)

Changes
---
- Migrates over #2129.
- Part of #2423.
