### PR TITLE
Billboard camera tolerance

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
@@ -53,7 +53,7 @@ namespace HoloToolkit.Unity
         {
             if (TargetTransform == null)
             {
-                TargetTransform = CameraCache.Main.transform;
+                TargetTransform = CameraCache.Main?.transform;
             }
         }
 
@@ -64,6 +64,7 @@ namespace HoloToolkit.Unity
         {
             if (TargetTransform == null)
             {
+                TargetTransform = CameraCache.Main?.transform;
                 return;
             }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
@@ -53,19 +53,28 @@ namespace HoloToolkit.Unity
         {
             if (TargetTransform == null)
             {
-                TargetTransform = CameraCache.Main?.transform;
+                if (CameraCache.Main != null)
+                {
+                    TargetTransform = CameraCache.Main.transform;
+                }
             }
         }
 
         /// <summary>
         /// Keeps the object facing the camera.
         /// </summary>
-        private void Update()
+        private void LateUpdate()
         {
             if (TargetTransform == null)
             {
-                TargetTransform = CameraCache.Main?.transform;
-                return;
+                if (CameraCache.Main != null)
+                {
+                    TargetTransform = CameraCache.Main.transform;
+                }
+                else
+                {
+                    return;
+                }
             }
 
             // Get a Vector that points from the target to the main camera.


### PR DESCRIPTION
Overview
---
Two small changes to help Billboard cope with the lack of, or late setup of, a cached camera instance. 

Changes
---
1. null check in OnEnable
2. per-frame attempt to obtain the main camera transfer within the existing null-transform test