### PR TITLE
Fix bug with enableOneHandMovement in TwoHandManipulatable

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/Interactions/TwoHandManipulatable.cs
@@ -237,9 +237,9 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
                     {
                         newState = ManipulationMode.None;
                     }
-                    else if (handsPressedCount == 1 && enableOneHandMovement)
+                    else if (handsPressedCount == 1)
                     {
-                        newState = ManipulationMode.Move;
+                        newState = enableOneHandMovement ? ManipulationMode.Move : ManipulationMode.None;
                     }
                     else if (handsPressedCount > 1)
                     {
@@ -252,14 +252,13 @@ namespace HoloToolkit.Unity.InputModule.Utilities.Interactions
                 case ManipulationMode.MoveAndRotate:
                 case ManipulationMode.RotateAndScale:
                 case ManipulationMode.MoveScaleAndRotate:
-                    // TODO: if < 2, make this go to start state ('drop it')
                     if (handsPressedCount == 0)
                     {
                         newState = ManipulationMode.None;
                     }
                     else if (handsPressedCount == 1)
                     {
-                        newState = ManipulationMode.Move;
+                        newState = enableOneHandMovement ? ManipulationMode.Move : ManipulationMode.None;
                     }
                     break;
             }


### PR DESCRIPTION
Overview
---
Previously, a lost hand would revert to one-handed move even if one-handed move wasn't enabled. Now, it falls back to `None` in that case.

Changes
---
- Fixes #2021