### PR TITLE
Fix in TryGetBoundaryRectanglePoints after teleport

### DIFF
--- a/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
+++ b/Assets/HoloToolkit/Boundary/Scripts/BoundaryManager.cs
@@ -215,7 +215,7 @@ namespace HoloToolkit.Unity.Boundary
             var positions = new Vector3[points2d.Length];
             for (int i = 0; i < points2d.Length; ++i)
             {
-                positions[i] = new Vector3(points2d[i].x, boundaryFloor, points2d[i].y);
+                positions[i] = CameraCache.Main.transform.parent.TransformPoint(new Vector3(points2d[i].x, boundaryFloor, points2d[i].y));
             }
             return positions;
         }


### PR DESCRIPTION
Overview
---
After a teleport, the boundary APIs still return positions around the origin, as though the camera has not moved.

I previously updated the RectangleParams method, but did not transform the RectanglePoints method. This fixes that.

Changes
---
- Related to #2469 
