### PR TITLE
Saving the default ConfigurationProfile axes

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
@@ -35,7 +35,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 1
       description: Spatial Grip
       axisType: 7
@@ -45,7 +46,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 2
       description: Grip Press
       axisType: 2
@@ -55,7 +57,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 3
       description: Touchpad Position
       axisType: 4
@@ -65,7 +68,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 4
       description: Touchpad Touch
       axisType: 2
@@ -75,7 +79,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 5
       description: Touchpad Press
       axisType: 2
@@ -85,7 +90,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 6
       description: Thumbstick Position
       axisType: 4
@@ -95,7 +101,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 7
       description: 'Thumbstick Press '
       axisType: 2
@@ -105,7 +112,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 8
       description: Trigger Position
       axisType: 3
@@ -115,7 +123,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 9
       description: Trigger Pressed (Select)
       axisType: 2
@@ -125,7 +134,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 10
       description: Trigger Touched
       axisType: 2
@@ -135,7 +145,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 11
       description: Menu Pressed
       axisType: 2
@@ -145,7 +156,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
   - id: 2
     description: MotionController Right
     controller:
@@ -165,7 +177,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 1
       description: Spatial Grip
       axisType: 7
@@ -175,7 +188,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 2
       description: Grip Press
       axisType: 2
@@ -185,7 +199,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 3
       description: Touchpad Position
       axisType: 4
@@ -195,7 +210,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 4
       description: Touchpad Touch
       axisType: 2
@@ -205,7 +221,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 5
       description: Touchpad Press
       axisType: 2
@@ -215,7 +232,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 6
       description: Thumbstick Position
       axisType: 4
@@ -225,7 +243,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 7
       description: 'Thumbstick Press '
       axisType: 2
@@ -235,7 +254,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 8
       description: Trigger Position
       axisType: 3
@@ -245,7 +265,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 9
       description: Trigger Pressed (Select)
       axisType: 2
@@ -255,7 +276,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 10
       description: Trigger Touched
       axisType: 2
@@ -265,7 +287,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 11
       description: Menu Pressed
       axisType: 2
@@ -275,7 +298,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
   - id: 3
     description: OpenVR Controller Left
     controller:
@@ -295,7 +319,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 1
       description: Trigger Position
       axisType: 3
@@ -305,7 +330,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS9
+      axisCodeX: MIXEDREALITY_AXIS9
+      axisCodeY: 
     - id: 2
       description: Trigger Touch
       axisType: 2
@@ -315,7 +341,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 345
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 3
       description: Trigger Press
       axisType: 2
@@ -325,7 +352,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS9
+      axisCodeX: MIXEDREALITY_AXIS9
+      axisCodeY: 
     - id: 4
       description: Grip
       axisType: 3
@@ -335,7 +363,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS11
+      axisCodeX: MIXEDREALITY_AXIS11
+      axisCodeY: 
     - id: 5
       description: Trackpad-Thumbstick Position
       axisType: 4
@@ -345,7 +374,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: MIXEDREALITY_AXIS1
+      axisCodeY: MIXEDREALITY_AXIS2
     - id: 6
       description: Trackpad-Thumbstick Touch
       axisType: 2
@@ -355,7 +385,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 346
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 7
       description: Trackpad-Thumbstick Press
       axisType: 2
@@ -365,7 +396,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 338
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 8
       description: Unity Button Id 2
       axisType: 2
@@ -375,7 +407,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 332
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 9
       description: Unity Button Id 3
       axisType: 2
@@ -385,7 +418,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 333
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
   - id: 4
     description: OpenVR Controller Right
     controller:
@@ -405,7 +439,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 1
       description: Trigger Position
       axisType: 3
@@ -415,7 +450,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS10
+      axisCodeX: MIXEDREALITY_AXIS10
+      axisCodeY: 
     - id: 2
       description: Trigger Touch
       axisType: 2
@@ -425,7 +461,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 345
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 3
       description: Trigger Press
       axisType: 2
@@ -435,7 +472,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS10
+      axisCodeX: MIXEDREALITY_AXIS10
+      axisCodeY: 
     - id: 4
       description: Grip
       axisType: 3
@@ -445,7 +483,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS12
+      axisCodeX: MIXEDREALITY_AXIS12
+      axisCodeY: 
     - id: 5
       description: Trackpad-Thumbstick Position
       axisType: 4
@@ -455,7 +494,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: MIXEDREALITY_AXIS4
+      axisCodeY: MIXEDREALITY_AXIS5
     - id: 6
       description: Trackpad-Thumbstick Touch
       axisType: 2
@@ -465,7 +505,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 347
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 7
       description: Trackpad-Thumbstick Press
       axisType: 2
@@ -475,7 +516,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 339
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 8
       description: Unity Button Id 0
       axisType: 2
@@ -485,7 +527,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 330
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 9
       description: Unity Button Id 1
       axisType: 2
@@ -495,7 +538,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 331
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
   - id: 5
     description: Oculus Touch Left
     controller:
@@ -515,7 +559,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 1
       description: Axis1D.PrimaryIndexTrigger
       axisType: 3
@@ -525,7 +570,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS9
+      axisCodeX: MIXEDREALITY_AXIS9
+      axisCodeY: 
     - id: 2
       description: Axis1D.PrimaryIndexTrigger Touch
       axisType: 2
@@ -535,7 +581,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 344
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 3
       description: Axis1D.PrimaryIndexTrigger Near Touch
       axisType: 2
@@ -545,7 +592,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS13
+      axisCodeX: MIXEDREALITY_AXIS13
+      axisCodeY: 
     - id: 4
       description: Axis1D.PrimaryIndexTrigger Press
       axisType: 2
@@ -555,7 +603,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS9
+      axisCodeX: MIXEDREALITY_AXIS9
+      axisCodeY: 
     - id: 5
       description: Axis1D.PrimaryHandTrigger Press
       axisType: 3
@@ -565,7 +614,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS11
+      axisCodeX: MIXEDREALITY_AXIS11
+      axisCodeY: 
     - id: 6
       description: Axis2D.PrimaryThumbstick
       axisType: 4
@@ -575,7 +625,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: MIXEDREALITY_AXIS1
+      axisCodeY: MIXEDREALITY_AXIS2
     - id: 7
       description: Button.PrimaryThumbstick Touch
       axisType: 2
@@ -585,7 +636,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 346
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 8
       description: Button.PrimaryThumbstick Near Touch
       axisType: 2
@@ -595,7 +647,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS15
+      axisCodeX: MIXEDREALITY_AXIS15
+      axisCodeY: 
     - id: 9
       description: Button.PrimaryThumbstick Press
       axisType: 2
@@ -605,7 +658,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 338
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 10
       description: Button.Three Press
       axisType: 2
@@ -615,7 +669,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 332
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 11
       description: Button.Four Press
       axisType: 2
@@ -625,7 +680,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 333
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 12
       description: Button.Start Press
       axisType: 2
@@ -635,7 +691,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 337
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 13
       description: Button.Three Touch
       axisType: 2
@@ -645,7 +702,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 342
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 14
       description: Button.Four Touch
       axisType: 2
@@ -655,7 +713,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 343
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 15
       description: Touch.PrimaryThumbRest Touch
       axisType: 2
@@ -665,7 +724,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 348
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 16
       description: Touch.PrimaryThumbRest Near Touch
       axisType: 2
@@ -675,7 +735,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS17
+      axisCodeX: MIXEDREALITY_AXIS17
+      axisCodeY: 
   - id: 6
     description: Oculus Touch Right
     controller:
@@ -695,7 +756,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 1
       description: Axis1D.SecondaryIndexTrigger
       axisType: 3
@@ -705,7 +767,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS10
+      axisCodeX: MIXEDREALITY_AXIS10
+      axisCodeY: 
     - id: 2
       description: Axis1D.SecondaryIndexTrigger Touch
       axisType: 2
@@ -715,7 +778,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 345
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 3
       description: Axis1D.SecondaryIndexTrigger Near Touch
       axisType: 2
@@ -725,7 +789,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS14
+      axisCodeX: MIXEDREALITY_AXIS14
+      axisCodeY: 
     - id: 4
       description: Axis1D.SecondaryIndexTrigger Press
       axisType: 2
@@ -735,7 +800,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS10
+      axisCodeX: MIXEDREALITY_AXIS10
+      axisCodeY: 
     - id: 5
       description: Axis1D.SecondaryHandTrigger Press
       axisType: 3
@@ -745,7 +811,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS12
+      axisCodeX: MIXEDREALITY_AXIS12
+      axisCodeY: 
     - id: 6
       description: Axis2D.SecondaryThumbstick
       axisType: 4
@@ -755,7 +822,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: 
+      axisCodeX: MIXEDREALITY_AXIS4
+      axisCodeY: MIXEDREALITY_AXIS5
     - id: 7
       description: Button.SecondaryThumbstick Touch
       axisType: 2
@@ -765,7 +833,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 347
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 8
       description: Button.SecondaryThumbstick Near Touch
       axisType: 2
@@ -775,7 +844,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS16
+      axisCodeX: MIXEDREALITY_AXIS16
+      axisCodeY: 
     - id: 9
       description: Button.SecondaryThumbstick Press
       axisType: 2
@@ -785,7 +855,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 339
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 10
       description: Button.One Press
       axisType: 2
@@ -795,7 +866,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 330
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 11
       description: Button.Two Press
       axisType: 2
@@ -805,7 +877,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 331
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 12
       description: Button.One Touch
       axisType: 2
@@ -815,7 +888,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 340
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 13
       description: Button.Two Touch
       axisType: 2
@@ -825,7 +899,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 341
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 14
       description: Touch.SecondaryThumbRest Touch
       axisType: 2
@@ -835,7 +910,8 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 349
-      axisCode: 
+      axisCodeX: 
+      axisCodeY: 
     - id: 15
       description: Touch.SecondaryThumbRest Near Touch
       axisType: 2
@@ -845,4 +921,5 @@ MonoBehaviour:
         description: None
         axisConstraint: 0
       keyCode: 0
-      axisCode: MIXEDREALITY_AXIS18
+      axisCodeX: MIXEDREALITY_AXIS18
+      axisCodeY: 


### PR DESCRIPTION
Overview
---
Looks like the axes weren't updated/saved properly, resulting in:

![image](https://user-images.githubusercontent.com/3580640/43165160-1abc7bdc-8f48-11e8-93dd-c83f12a8a463.png)
