### PR TITLE
Minor keyboard fixes

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UX/Scripts/Keyboard.cs
@@ -253,7 +253,7 @@ namespace HoloToolkit.UI.Keyboard
 
             // Setting the keyboardType to an undefined TouchScreenKeyboardType,
             // which prevents the MRTK keyboard from triggering the system keyboard itself.
-            InputField.keyboardType = (TouchScreenKeyboardType)(-1);
+            InputField.keyboardType = (TouchScreenKeyboardType)(int.MaxValue);
 
             // Keep keyboard deactivated until needed
             gameObject.SetActive(false);

--- a/Assets/HoloToolkit/UX/Scripts/KeyboardInputField.cs
+++ b/Assets/HoloToolkit/UX/Scripts/KeyboardInputField.cs
@@ -34,21 +34,24 @@ namespace HoloToolkit.UI.Keyboard
         {
             base.OnPointerClick(eventData);
 
-            Keyboard.Instance.Close();
-            Keyboard.Instance.PresentKeyboard(text, KeyboardLayout);
-
-            if (KeyboardSpawnPoint != null)
+            if (!TouchScreenKeyboard.isSupported)
             {
-                Keyboard.Instance.RepositionKeyboard(KeyboardSpawnPoint, null, KeyBoardPositionOffset);
-            }
-            else
-            {
-                Keyboard.Instance.RepositionKeyboard(transform, null, KeyBoardPositionOffset);
-            }
+                Keyboard.Instance.Close();
+                Keyboard.Instance.PresentKeyboard(text, KeyboardLayout);
 
-            // Subscribe to keyboard delegates
-            Keyboard.Instance.OnTextUpdated += Keyboard_OnTextUpdated;
-            Keyboard.Instance.OnClosed += Keyboard_OnClosed;
+                if (KeyboardSpawnPoint != null)
+                {
+                    Keyboard.Instance.RepositionKeyboard(KeyboardSpawnPoint, null, KeyBoardPositionOffset);
+                }
+                else
+                {
+                    Keyboard.Instance.RepositionKeyboard(transform, null, KeyBoardPositionOffset);
+                }
+
+                // Subscribe to keyboard delegates
+                Keyboard.Instance.OnTextUpdated += Keyboard_OnTextUpdated;
+                Keyboard.Instance.OnClosed += Keyboard_OnClosed;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Overview
---
Instead of trying to case a negative int and failing on XAML, now we cast a large, still invalid, number.

Also, disables the Toolkit keyboard on platforms that support a system keyboard.

Changes
---
- Fixes: #2384 
