### PR TITLE
fix the default floor plane being too small

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityBoundaryVisualizationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityBoundaryVisualizationProfile.asset
@@ -14,4 +14,4 @@ MonoBehaviour:
   playAreaMaterial: {fileID: 2100000, guid: 30d693ff62c571241b431ef4e206b09a, type: 2}
   trackedAreaMaterial: {fileID: 2100000, guid: 1ab3a050711c97243a200ca653272343, type: 2}
   floorPlaneMaterial: {fileID: 2100000, guid: e106645f46550d54bacf6c82811c99e6, type: 2}
-  floorPlaneScale: {x: 3, y: 3, z: 1}
+  floorPlaneScale: {x: 10, y: 10, z: 1}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.BoundarySystem
         public Material FloorPlaneMaterial => floorPlaneMaterial;
 
         [SerializeField]
-        private Vector3 floorPlaneScale = new Vector3(5f, 5f, 1f);
+        private Vector3 floorPlaneScale = new Vector3(10f, 10f, 1f);
 
         /// <summary>
         /// The the size at which to display the rectangular floor plane <see cref="GameObject"/>.


### PR DESCRIPTION
Overview
---
Based on verbal feedback and additional testing, it was apparent that the default floor size in the boundary profile was too small, as were the default values in the class.

Changes
---
Changed default floor plane to be 10x10m
