### PR TITLE
Fix pointer line material not being included in the build

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
@@ -395,7 +395,7 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 0
   lineStepCount: 16
-  lineMaterial: {fileID: 0}
+  lineMaterial: {fileID: 2100000, guid: 11727442de02c1d4b8d37a063c748aec, type: 2}
   roundedEdges: 1
   roundedCaps: 1
   lineRenderer: {fileID: 120690711267243118}

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab
@@ -143,7 +143,7 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 0
   lineStepCount: 256
-  lineMaterial: {fileID: 0}
+  lineMaterial: {fileID: 2100000, guid: 11727442de02c1d4b8d37a063c748aec, type: 2}
   roundedEdges: 1
   roundedCaps: 1
   lineRenderer: {fileID: 120827243805602862}

--- a/Assets/MixedRealityToolkit-SDK/StandardAssets/Materials/MRTK_DefaultPointerLine.mat
+++ b/Assets/MixedRealityToolkit-SDK/StandardAssets/Materials/MRTK_DefaultPointerLine.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: MRTK_DefaultPointerLine
+  m_Shader: {fileID: 203, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _InvFade: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _TintColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}

--- a/Assets/MixedRealityToolkit-SDK/StandardAssets/Materials/MRTK_DefaultPointerLine.mat.meta
+++ b/Assets/MixedRealityToolkit-SDK/StandardAssets/Materials/MRTK_DefaultPointerLine.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11727442de02c1d4b8d37a063c748aec
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
@@ -16,13 +16,10 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities.Lines.Renderers
     [RequireComponent(typeof(BaseMixedRealityLineDataProvider))]
     public class MixedRealityLineRenderer : BaseMixedRealityLineRenderer
     {
-        private const string DefaultLineShader = "Particles/Alpha Blended";
-        private const string DefaultLineShaderColor = "_TintColor";
-
         [Header("Mixed Reality Line Renderer Settings")]
 
         [SerializeField]
-        [Tooltip("The material to use for the Unity MixedRealityLineRenderer (will be auto-generated if null)")]
+        [Tooltip("The material to use for the Unity MixedRealityLineRenderer.")]
         private Material lineMaterial = null;
 
         public Material LineMaterial
@@ -61,8 +58,8 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Utilities.Lines.Renderers
 
             if (lineMaterial == null)
             {
-                lineMaterial = new Material(Shader.Find(DefaultLineShader));
-                lineMaterial.SetColor(DefaultLineShaderColor, Color.gray);
+                Debug.LogError("MixedRealityLineRenderer needs a material.");
+                gameObject.SetActive(false);
             }
         }
 


### PR DESCRIPTION
Overview
---
Unity doesn't include shaders that aren't used in materials either referenced in a scene or in a Resources folder. This PR creates a material for the pointer lines with the same settings as the code was doing, instead of trying to create one at runtime and failing when not in the Editor.
