### PR TITLE
Fix mismapped OpenVR trigger axis

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
@@ -342,7 +342,7 @@ MonoBehaviour:
         id: 1
         description: Select
         axisConstraint: 2
-      keyCode: 345
+      keyCode: 344
       axisCodeX: 
       axisCodeY: 
     - id: 3

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/GenericOpenVRController.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices.OpenVR
             // HTC Vive Controller - Left Controller Trigger (7)
             // Oculus Touch Controller - Axis1D.PrimaryIndexTrigger
             // Valve Knuckles Controller - Left Controller Trigger
-            new MixedRealityInteractionMapping(2, "Trigger Touch", AxisType.Digital, DeviceInputType.TriggerTouch, MixedRealityInputAction.None, KeyCode.JoystickButton15),
+            new MixedRealityInteractionMapping(2, "Trigger Touch", AxisType.Digital, DeviceInputType.TriggerTouch, MixedRealityInputAction.None, KeyCode.JoystickButton14),
             // HTC Vive Controller - Left Controller Trigger (7)
             // Oculus Touch Controller - Axis1D.PrimaryIndexTrigger
             // Valve Knuckles Controller - Left Controller Trigger


### PR DESCRIPTION
Left and right triggers were defined as the same axis.