### PR TITLE
Focus Provider Update

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -315,13 +315,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         /// <inheritdoc />
         public bool TryGetFocusDetails(IMixedRealityPointer pointer, out FocusDetails focusDetails)
         {
-            foreach (var pointerData in pointers)
+            PointerData pointerData;
+            if (TryGetPointerData(pointer, out pointerData))
             {
-                if (pointerData.Pointer.PointerId == pointer.PointerId)
-                {
-                    focusDetails = pointerData.Details;
-                    return true;
-                }
+                focusDetails = pointerData.Details;
+                return true;
             }
 
             focusDetails = default(FocusDetails);

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -249,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             Debug.Assert(eventData != null);
             IMixedRealityPointer pointer;
             TryGetPointingSource(eventData, out pointer);
-            return GetFocusedObject(pointer);
+            return pointer != null ? GetFocusedObject(pointer) : null;
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -332,7 +332,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         public bool TryGetSpecificPointerGraphicEventData(IMixedRealityPointer pointer, out GraphicInputEventData graphicInputEventData)
         {
             PointerData pointerData;
-            if (GetPointerData(pointer, out pointerData))
+            if (TryGetPointerData(pointer, out pointerData))
             {
                 graphicInputEventData = pointerData.GraphicEventData;
                 return true;
@@ -420,7 +420,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         {
             Debug.Assert(pointer.PointerId != 0, $"{pointer} does not have a valid pointer id!");
             PointerData pointerData;
-            return GetPointerData(pointer, out pointerData);
+            return TryGetPointerData(pointer, out pointerData);
         }
 
         /// <inheritdoc />
@@ -440,7 +440,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             Debug.Assert(pointer.PointerId != 0, $"{pointer} does not have a valid pointer id!");
 
             PointerData pointerData;
-            if (!GetPointerData(pointer, out pointerData)) { return false; }
+            if (!TryGetPointerData(pointer, out pointerData)) { return false; }
 
             // Raise focus events if needed.
             if (pointerData.CurrentPointerTarget != null)
@@ -475,7 +475,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         /// <param name="pointer">the pointer who's data we're looking for</param>
         /// <param name="data">The data associated to the pointer</param>
         /// <returns>Pointer Data if the pointing source is registered.</returns>
-        private bool GetPointerData(IMixedRealityPointer pointer, out PointerData data)
+        private bool TryGetPointerData(IMixedRealityPointer pointer, out PointerData data)
         {
             foreach (var pointerData in pointers)
             {

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -393,9 +393,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         }
 
         /// <summary>
-        /// Helper for assigning world space canvases event cameras.<para/>
-        /// <remarks>Warning! Very expensive. Use sparingly at runtime.</remarks>
+        /// Helper for assigning world space canvases event cameras.
         /// </summary>
+        /// <remarks>Warning! Very expensive. Use sparingly at runtime.</remarks>
         public void UpdateCanvasEventSystems()
         {
             Debug.Assert(UIRaycastCamera != null, "You must assign a UIRaycastCamera on the FocusProvider before updating your canvases.");

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -247,16 +247,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         public GameObject GetFocusedObject(BaseInputEventData eventData)
         {
             Debug.Assert(eventData != null);
-            if (OverrideFocusedObject != null) { return OverrideFocusedObject; }
-
-            FocusDetails focusDetails;
-            if (!TryGetFocusDetails(eventData, out focusDetails)) { return null; }
-
             IMixedRealityPointer pointer;
             TryGetPointingSource(eventData, out pointer);
-            GraphicInputEventData graphicInputEventData = GetSpecificPointerGraphicEventData(pointer);
-            Debug.Assert(graphicInputEventData != null);
-            return graphicInputEventData.selectedObject;
+            return GetFocusedObject(pointer);
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -297,7 +297,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         {
             base.OnDisable();
             GazePointer.BaseCursor?.SetVisibility(false);
-            InputSystem.FocusProvider.UnregisterPointer(GazePointer);
             InputSystem.RaiseSourceLost(GazeInputSource);
         }
 
@@ -318,9 +317,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
         private void RaiseSourceDetected()
         {
-            InputSystem.FocusProvider.RegisterPointer(GazePointer);
-            GazePointer.BaseCursor?.SetVisibility(true);
             InputSystem.RaiseSourceDetected(GazeInputSource);
+            GazePointer.BaseCursor?.SetVisibility(true);
         }
 
         #endregion Utilities

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
@@ -684,8 +684,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
             ExecuteEvents.ExecuteHierarchy(focusedObject, focusEventData, OnFocusEnterEventHandler);
 
-            var graphicEventData = FocusProvider.GetSpecificPointerGraphicEventData(pointer);
-            if (graphicEventData != null)
+            GraphicInputEventData graphicEventData;
+            if (FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out graphicEventData))
             {
                 ExecuteEvents.ExecuteHierarchy(focusedObject, graphicEventData, ExecuteEvents.pointerEnterHandler);
             }
@@ -705,8 +705,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
             ExecuteEvents.ExecuteHierarchy(unfocusedObject, focusEventData, OnFocusExitEventHandler);
 
-            var graphicEventData = FocusProvider.GetSpecificPointerGraphicEventData(pointer);
-            if (graphicEventData != null)
+            GraphicInputEventData graphicEventData;
+            if (FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out graphicEventData))
             {
                 ExecuteEvents.ExecuteHierarchy(unfocusedObject, graphicEventData, ExecuteEvents.pointerExitHandler);
             }
@@ -750,12 +750,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             ExecutePointerDown(HandlePointerDown(pointer));
         }
 
-        private GraphicInputEventData HandlePointerDown(IMixedRealityPointer pointingSource)
+        private GraphicInputEventData HandlePointerDown(IMixedRealityPointer pointer)
         {
             // Pass handler through HandleEvent to perform modal/fallback logic
             HandleEvent(pointerEventData, OnPointerDownEventHandler);
-
-            return FocusProvider.GetSpecificPointerGraphicEventData(pointingSource);
+            GraphicInputEventData graphicEventData;
+            FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out graphicEventData);
+            return graphicEventData;
         }
 
         private static void ExecutePointerDown(GraphicInputEventData graphicInputEventData)
@@ -846,12 +847,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             }
         }
 
-        private GraphicInputEventData HandlePointerUp(IMixedRealityPointer pointingSource)
+        private GraphicInputEventData HandlePointerUp(IMixedRealityPointer pointer)
         {
             // Pass handler through HandleEvent to perform modal/fallback logic
             HandleEvent(pointerEventData, OnPointerUpEventHandler);
 
-            return FocusProvider.GetSpecificPointerGraphicEventData(pointingSource);
+            GraphicInputEventData graphicEventData;
+            FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out graphicEventData);
+            return graphicEventData;
         }
 
         #endregion Pointer Up

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -289,7 +289,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
         /// </summary>
         protected virtual void UpdateCursorTransform()
         {
-            Debug.Assert(Pointer != null, "No Pointer has been assigned!");
+            if (Pointer == null)
+            {
+                Debug.LogError("No Pointer has been assigned!");
+                return;
+            }
 
             FocusDetails focusDetails;
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/CursorModifier.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/CursorModifier.cs
@@ -161,6 +161,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
                 return HostTransform.position + HostTransform.TransformVector(CursorPositionOffset);
             }
 
+            if (cursor.Pointer == null)
+            {
+                Debug.LogError($"{cursor.GameObjectReference.name} has no pointer set in it's cursor component!");
+                return Vector3.zero;
+            }
+
             FocusDetails focusDetails;
             if (InputSystem.FocusProvider.TryGetFocusDetails(cursor.Pointer, out focusDetails))
             {

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
@@ -80,7 +80,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
         /// <inheritdoc />
         protected override void UpdateCursorTransform()
         {
-            Debug.Assert(Pointer != null, "No Pointer has been assigned!");
+            if (Pointer == null)
+            {
+                Debug.LogError($"[TeleportCursor.{name}] No Pointer has been assigned!");
+                return;
+            }
 
             FocusDetails focusDetails;
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -61,8 +61,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
 
         protected bool IsTeleportRequestActive = false;
 
-        private bool delayPointerRegistration = true;
-
         /// <summary>
         /// The forward direction of the targeting ray
         /// </summary>
@@ -116,25 +114,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         protected override void OnEnable()
         {
             base.OnEnable();
-
-            BaseCursor?.SetVisibility(true);
-
-            if (!delayPointerRegistration)
-            {
-                InputSystem.FocusProvider.RegisterPointer(this);
-            }
-
-            TeleportSystem?.Register(gameObject);
-        }
-
-        protected virtual void Start()
-        {
-            Debug.Assert(InputSourceParent != null, "This Pointer must have a Input Source Assigned");
-
-            InputSystem.FocusProvider.RegisterPointer(this);
-            delayPointerRegistration = false;
-
             SetCursor();
+            BaseCursor?.SetVisibility(true);
+            TeleportSystem?.Register(gameObject);
         }
 
         protected override void OnDisable()
@@ -146,7 +128,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
             IsSelectPressed = false;
             HasSelectPressedOnce = false;
             BaseCursor?.SetVisibility(false);
-            InputSystem.FocusProvider.UnregisterPointer(this);
         }
 
         #endregion  MonoBehaviour Implementation

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
@@ -72,9 +72,10 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.InputSystem
         /// <summary>
         /// Get the Graphic Event Data for the specified pointing source.
         /// </summary>
-        /// <param name="pointer"></param>
-        /// <returns></returns>
-        GraphicInputEventData GetSpecificPointerGraphicEventData(IMixedRealityPointer pointer);
+        /// <param name="pointer">The pointer who's graphic event data we're looking for.</param>
+        /// <param name="graphicInputEventData">The graphihc event data for the specified pointer</param>
+        /// <returns>True, if graphic event data exists.</returns>
+        bool TryGetSpecificPointerGraphicEventData(IMixedRealityPointer pointer, out GraphicInputEventData graphicInputEventData);
 
         /// <summary>
         /// Generate a new unique pointer id.


### PR DESCRIPTION
Overview
---
- Removed duplicate faulty logic when getting focused object via event data.
- Removed duplicate calls to register pointers. (they were already being registered by the input source's on detected event)
- Refactored a bit to make the pattern of getting pointer data the same, by passing a pointer, and getting data out.  This makes getting the focused object safer, by first attempting to get the pointer data, if any exists.