### PR TITLE
Config Profile SystemType null check.

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -197,7 +197,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool IsBoundarySystemEnabled
         {
-            get { return boundarySystemType.Type != null && enableBoundarySystem; }
+            get { return boundarySystemType != null && boundarySystemType.Type != null && enableBoundarySystem; }
             private set { enableInputSystem = value; }
         }
 
@@ -249,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool IsTeleportSystemEnabled
         {
-            get { return teleportSystemType.Type != null && enableTeleportSystem; }
+            get { return teleportSystemType != null && teleportSystemType.Type != null && enableTeleportSystem; }
             private set { enableTeleportSystem = value; }
         }
 


### PR DESCRIPTION
Overview
---
Made sure we're checking if the `SystemType` is not null before attempting to check if that `SystemType`'s resolved Type was not null.

This was causing our unit tests to fail.

Unit Tests now pass with flying colors.
