### PR TITLE
Spatial Awareness System Scaffolding

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness.meta
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness.meta
@@ -1,6 +1,7 @@
 fileFormatVersion: 2
-guid: 7ba880f7ef3c44158b6ebbef092a158e
-TextScriptImporter:
+guid: c3cfebcff689d6f44aecd921ab3e6592
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System.meta
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dfef71a74c154989bdebefcd7d0301da
+guid: 280858bde276769409b37bd6fb82d586
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
@@ -63,6 +63,21 @@ public class MixedRealitySpatialAwarenessSystem : MixedRealityEventManager, IMix
     /// <inheritdoc/>
     public float UpdateInterval { get; set; } // todo
 
+    /// <inheritdoc/>
+    public bool IsObserverRunning { get; private set; }
+
+    /// <inheritdoc/>
+    public void StartObserver()
+    {
+        // todo
+    }
+
+    /// <inheritdoc/>
+    public void StopObserver()
+    {
+        // todo
+    }
+
     #region Mesh
 
     /// <inheritdoc/>
@@ -70,6 +85,9 @@ public class MixedRealitySpatialAwarenessSystem : MixedRealityEventManager, IMix
 
     /// <inheritdoc/>
     public bool RecalculateNormals { get; set; } // todo
+
+    /// <inheritdoc/>
+    public bool IsMeshDataSupported { get; private set; } // todo
 
     #endregion Mesh
 

--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness;
+//using Microsoft.MixedReality.Toolkit.Internal.EventDatum.SpatialAwareness;
+using Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSystem;
+using Microsoft.MixedReality.Toolkit.Internal.Managers;
+using Microsoft.MixedReality.Toolkit.Internal.Utilities;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.XR;
+
+public class MixedRealitySpatialAwarenessSystem : MixedRealityEventManager, IMixedRealitySpatialAwarenessSystem
+{
+    #region IMixedRealityManager Implmentation
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        InitializeInternal();
+    }
+
+    /// <summary>
+    /// Performs initialization tasks for the SpatialAwarenessSystem.
+    /// </summary>
+    private void InitializeInternal()
+    {
+        // todo
+    }
+
+    /// <inheritdoc/>
+    public override void Reset()
+    {
+        base.Reset();
+        InitializeInternal();
+    }
+
+    public override void Destroy()
+    {
+        // todo
+    }
+
+    #endregion IMixedRealityManager Implmentation
+
+    #region IMixedRealityEventSystem Implmentation
+    #endregion IMixedRealityEventSystem Implmentation
+
+    #region IMixedRealityEventSystem Implmentation
+    #endregion IMixedRealityEventSystem Implmentation
+
+    #region IMixedRealitySpatialAwarenessSystem Implmentation
+
+    /// <inheritdoc/>
+    public bool AutoStart { get; set; } // todo
+
+    /// <inheritdoc/>
+    public Vector3 Extents { get; set; } // todo
+
+    /// <inheritdoc/>
+    public int PhysicsLayer { get; set; } // todo
+
+    /// <inheritdoc/>
+    public int UpdateInterval { get; set; } // todo
+
+    #region Mesh settings
+
+    /// <inheritdoc/>
+    public int TrianglesPerCubicMeter { get; set; } // todo
+
+    /// <inheritdoc/>
+    public bool RecalculateNormals { get; set; } // todo
+
+    #endregion Mesh settings
+
+    #region Surface settings
+
+    /// <inheritdoc/>
+    public float MinimumSurfaceSize { get; set; } // todo
+
+    /// <inheritdoc/>
+    public SpatialAwarenessSurfaceTypes SurfaceTypes { get; set; } // todo gfs
+
+    #endregion Surface settings
+
+    #endregion IMixedRealitySpatialAwarenessSystem Implmentation
+}

--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
@@ -55,15 +55,15 @@ public class MixedRealitySpatialAwarenessSystem : MixedRealityEventManager, IMix
     public bool AutoStart { get; set; } // todo
 
     /// <inheritdoc/>
-    public Vector3 Extents { get; set; } // todo
+    public Vector3 ObservationExtents { get; set; } // todo
 
     /// <inheritdoc/>
     public int PhysicsLayer { get; set; } // todo
 
     /// <inheritdoc/>
-    public int UpdateInterval { get; set; } // todo
+    public float UpdateInterval { get; set; } // todo
 
-    #region Mesh settings
+    #region Mesh
 
     /// <inheritdoc/>
     public int TrianglesPerCubicMeter { get; set; } // todo
@@ -71,17 +71,14 @@ public class MixedRealitySpatialAwarenessSystem : MixedRealityEventManager, IMix
     /// <inheritdoc/>
     public bool RecalculateNormals { get; set; } // todo
 
-    #endregion Mesh settings
+    #endregion Mesh
 
-    #region Surface settings
-
-    /// <inheritdoc/>
-    public float MinimumSurfaceSize { get; set; } // todo
+    #region Surface
 
     /// <inheritdoc/>
-    public SpatialAwarenessSurfaceTypes SurfaceTypes { get; set; } // todo gfs
+    public float MinimumSurfaceArea { get; set; } // todo
 
-    #endregion Surface settings
+    #endregion Surface
 
     #endregion IMixedRealitySpatialAwarenessSystem Implmentation
 }

--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs.meta
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b99f1d5712b466c4eaae0e7e25519c9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 6eccdbd0228d47ab9ac6ca58258f9112, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
@@ -44,3 +44,7 @@ MonoBehaviour:
     reference: Microsoft.MixedReality.Toolkit.SDK.Teleportation.MixedRealityTeleportManager,
       Microsoft.MixedReality.Toolkit.SDK
   teleportDuration: 0.25
+  enableSpatialAwarenessSystem: 1
+  spatialAwarenessSystemType:
+    reference: 
+  spatialAwarenessProfile: {fileID: 0}

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
@@ -12,9 +12,9 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityConfigurationProfile
   m_EditorClassIdentifier: 
   initialManagerTypes:
-  - reference: Microsoft.MixedReality.Toolkit.SDK.Input.MixedRealityInputManager,
-      Microsoft.MixedReality.Toolkit.SDK
   - reference: Microsoft.MixedReality.Toolkit.SDK.BoundarySystem.MixedRealityBoundaryManager,
+      Microsoft.MixedReality.Toolkit.SDK
+  - reference: Microsoft.MixedReality.Toolkit.SDK.Input.MixedRealityInputManager,
       Microsoft.MixedReality.Toolkit.SDK
   targetExperienceScale: 3
   enableCameraProfile: 1
@@ -46,5 +46,6 @@ MonoBehaviour:
   teleportDuration: 0.25
   enableSpatialAwarenessSystem: 1
   spatialAwarenessSystemType:
-    reference: 
-  spatialAwarenessProfile: {fileID: 0}
+    reference: MixedRealitySpatialAwarenessSystem, Microsoft.MixedReality.Toolkit.SDK
+  spatialAwarenessProfile: {fileID: 11400000, guid: 181cf45975f792744bca61c7d9de23a1,
+    type: 2}

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpatialAwarenessProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpatialAwarenessProfile.asset
@@ -9,10 +9,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f1fe31940c9e844ba1f585020e1cd83, type: 3}
-  m_Name: MixedRealitySpatialAwarenessProfile
+  m_Name: DefaultMixedRealitySpatialAwarenessProfile
   m_EditorClassIdentifier: 
   autoStart: 1
-  extents: {x: 10, y: 10, z: 10}
+  observationExtents: {x: 10, y: 10, z: 10}
   physicsLayer: 31
   updateInterval: 3.5
   trianglesPerCubicMeter: 500

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpatialAwarenessProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpatialAwarenessProfile.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f1fe31940c9e844ba1f585020e1cd83, type: 3}
+  m_Name: MixedRealitySpatialAwarenessProfile
+  m_EditorClassIdentifier: 
+  autoStart: 1
+  extents: {x: 10, y: 10, z: 10}
+  physicsLayer: 31
+  updateInterval: 3.5
+  trianglesPerCubicMeter: 500
+  recalculateNormals: 1
+  minimumSurfaceArea: 0.025

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpatialAwarenessProfile.asset.meta
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpatialAwarenessProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 181cf45975f792744bca61c7d9de23a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Spatial.meta
+++ b/Assets/MixedRealityToolkit/Spatial.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 75f31eb6354e435a8e9c9775a4183799
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Spatial/Mapping/README.md
+++ b/Assets/MixedRealityToolkit/Spatial/Mapping/README.md
@@ -1,3 +1,0 @@
-# Mixed Reality Toolkit - Interfaces - Spatial - Mapping
-
-Spatial mapping system operational functionality

--- a/Assets/MixedRealityToolkit/Spatial/Mapping/README.md.meta
+++ b/Assets/MixedRealityToolkit/Spatial/Mapping/README.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: ca4db44ba5e94d72bf4456905b504364
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Spatial/README.md
+++ b/Assets/MixedRealityToolkit/Spatial/README.md
@@ -1,3 +1,0 @@
-# Mixed Reality Toolkit - Interfaces - Spatial
-
-Spatial system operational functionality and related spatial components

--- a/Assets/MixedRealityToolkit/Spatial/README.md.meta
+++ b/Assets/MixedRealityToolkit/Spatial/README.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 44f04c9c9fc14e17bf201a3ef504611e
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Spatial/Sound/README.md
+++ b/Assets/MixedRealityToolkit/Spatial/Sound/README.md
@@ -1,3 +1,0 @@
-# Mixed Reality Toolkit - Interfaces - Spatial - Sound
-
-Spatial audio system operational functionality

--- a/Assets/MixedRealityToolkit/Spatial/Understanding/README.md
+++ b/Assets/MixedRealityToolkit/Spatial/Understanding/README.md
@@ -1,3 +1,0 @@
-# Mixed Reality Toolkit - Interfaces - Spatial - Understanding
-
-Spatial understanding mapping system operational functionality

--- a/Assets/MixedRealityToolkit/Spatial/Understanding/README.md.meta
+++ b/Assets/MixedRealityToolkit/Spatial/Understanding/README.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9ef7adf4946f4744b02ab30de1e4c239
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -291,7 +291,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         /// </summary>
         public bool IsSpatialAwarenessSystemEnabled
         {
-            get { return boundarySystemType != null && boundarySystemType.Type != null && enableBoundarySystem; }
+            get { return spatialAwarenessSystemType != null && spatialAwarenessSystemType.Type != null && enableSpatialAwarenessSystem; }
             private set { enableSpatialAwarenessSystem = value; }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -5,10 +5,12 @@ using Microsoft.MixedReality.Toolkit.Internal.Attributes;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.BoundarySystem;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem;
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Internal.Interfaces;
 using Microsoft.MixedReality.Toolkit.Internal.Interfaces.BoundarySystem;
 using Microsoft.MixedReality.Toolkit.Internal.Interfaces.InputSystem;
+using Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSystem;
 using Microsoft.MixedReality.Toolkit.Internal.Interfaces.TeleportSystem;
 using System;
 using System.Collections.Generic;
@@ -198,7 +200,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         public bool IsBoundarySystemEnabled
         {
             get { return boundarySystemType != null && boundarySystemType.Type != null && enableBoundarySystem; }
-            private set { enableInputSystem = value; }
+            private set { enableBoundarySystem = value; }
         }
 
         [SerializeField]
@@ -232,7 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         private MixedRealityBoundaryVisualizationProfile boundaryVisualizationProfile;
 
         /// <summary>
-        /// Active profile for controller mapping configuration
+        /// Active profile for boundary visualization configuration
         /// </summary>
         public MixedRealityBoundaryVisualizationProfile BoundaryVisualizationProfile
         {
@@ -278,6 +280,46 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
         {
             get { return teleportDuration; }
             set { teleportDuration = value; }
+        }
+
+        [SerializeField]
+        [Tooltip("Enable the Spatial Awareness System on Startup")]
+        private bool enableSpatialAwarenessSystem = false;
+
+        /// <summary>
+        /// Enable and configure the spatial awareness system.
+        /// </summary>
+        public bool IsSpatialAwarenessSystemEnabled
+        {
+            get { return boundarySystemType != null && boundarySystemType.Type != null && enableBoundarySystem; }
+            private set { enableSpatialAwarenessSystem = value; }
+        }
+
+        [SerializeField]
+        [Tooltip("Spatial Awareness System Class to instantiate at runtime.")]
+        [Implements(typeof(IMixedRealitySpatialAwarenessSystem), TypeGrouping.ByNamespaceFlat)]
+        private SystemType spatialAwarenessSystemType;
+
+        /// <summary>
+        /// Boundary System Script File to instantiate at runtime.
+        /// </summary>
+        public SystemType SpatialAwarenessSystemSystemType
+        {
+            get { return spatialAwarenessSystemType; }
+            private set { spatialAwarenessSystemType = value; }
+        }
+
+        [SerializeField]
+        [Tooltip("Profile for controlling spatial awareness settings.")]
+        private MixedRealitySpatialAwarenessProfile spatialAwarenessProfile;
+
+        /// <summary>
+        /// Active profile for the spatial awareness system
+        /// </summary>
+        public MixedRealitySpatialAwarenessProfile SpatialAwarenessProfile
+        {
+            get { return spatialAwarenessProfile; }
+            private set { spatialAwarenessProfile = value; }
         }
 
         #endregion Mixed Reality Manager configurable properties

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8c07fdc6d84f4f509500d3aa0798d348
+guid: c3baa06205b68bb4eabe641618443042
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessProfile.cs
@@ -1,16 +1,79 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using UnityEngine;
 
-public class MixedRealitySpatialAwarenessProfile : MonoBehaviour {
+namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness
+{
+    /// <summary>
+    /// Configuration profile settings for setting up spatial awareness.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Spatial Awareness Profile", fileName = "MixedRealitySpatialAwarenessProfile", order = 7)]
+    public class MixedRealitySpatialAwarenessProfile : ScriptableObject
+    {
+        [SerializeField]
+        private bool autoStart = true;
 
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
-	}
+        /// <summary>
+        /// Indicates whether or not the spatial awareness system is to be automatically started.
+        /// </summary>
+        public bool AutoStart => autoStart;
+
+        [SerializeField]
+        private Vector3 observationExtents = Vector3.one * 10;
+
+        /// <summary>
+        /// The size of the observation volume.
+        /// </summary>
+        public Vector3 ObservationExtents => observationExtents;
+
+        [SerializeField]
+        private int physicsLayer = 31;
+
+        /// <summary>
+        /// The physics layer to which identified meshes and surfaces should be attached.
+        /// </summary>
+        public int PhysicsLayer => physicsLayer;
+
+        [SerializeField]
+        private float updateInterval = 3.5f;
+
+        /// <summary>
+        /// The interval, in seconds, between observation updates.
+        /// </summary>
+        public float UpdateInterval => updateInterval;
+
+        #region Mesh settings
+
+        [SerializeField]
+        private int trianglesPerCubicMeter = 500;
+
+        /// <summary>
+        /// The number of triangles to calculate per cubic meter. 
+        /// </summary>
+        public int TrianglesPerCubicMeter => trianglesPerCubicMeter;
+
+        [SerializeField]
+        private bool recalculateNormals = true;
+
+        /// <summary>
+        /// Indicates whether or not normals should be recalculated when observations are updated.
+        /// </summary>
+        public bool RecalculateNormals => recalculateNormals;
+
+        #endregion Mesh settings
+
+        #region Surface settings
+
+        [SerializeField]
+        private float minimumSurfaceArea = 0.025f;
+
+        /// <summary>
+        /// The minimum area, in square meters, threshold before a surface plane will be identified.
+        /// </summary>
+        public float MinimumSurfaceArea => minimumSurfaceArea;
+
+        #endregion Surface settings
+
+    }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessProfile.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MixedRealitySpatialAwarenessProfile : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessProfile.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f1fe31940c9e844ba1f585020e1cd83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness
+{
+    /// <summary>
+    /// Flags that indicate the semantic(s) for a surface in the environment.
+    /// </summary>
+    [Flags]
+    public enum SpatialAwarenessSurfaceTypes
+    {
+        /// <summary>
+        /// Catch-all for currently undefined surface types.
+        /// </summary>
+        Unknown = 1 << 0,
+
+        /// <summary>
+        /// The floor of the space.
+        /// </summary>
+        Floor = 1 << 1,
+
+        /// <summary>
+        /// The ceiling of the space.
+        /// </summary>
+        Ceiling = 1 << 2,
+
+        /// <summary>
+        /// A wall within the space.
+        /// </summary>
+        Wall = 1 << 3,
+
+        /// <summary>
+        /// A raised, horizontal surface such as a shelf or a table.
+        /// </summary>
+        /// <remarks>Platforms, like floors, that can be used for placing objects requiring a horizontal surface.</remarks>
+        Platform = 1 << 10,
+
+        /// <summary>
+        /// An angled surface.
+        /// </summary>
+        /// <remarks>Angled surfaces can often be used as ramps.</remarks>
+        Angled = 1 << 31,
+
+        /// <summary>
+        /// A horizontal surface.
+        /// </summary>
+        Horizontal = Floor | Ceiling | Platform,
+
+        /// <summary>
+        /// A horizontal surface upon which an object can be placed.
+        /// </summary>
+        HorizontalPlaceable = Floor | Platform,
+
+        /// <summary>
+        /// A surface from which an object can be hung.
+        /// </summary>
+        /// <remarks>Hangable surfaces can either be horizontal or vertical.</remarks>
+        Hangable = Ceiling | Wall
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs
@@ -1,62 +1,43 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness
 {
     /// <summary>
-    /// Flags that indicate the semantic(s) for a surface in the environment.
+    /// Values that indicate the type of a surface within the environment.
     /// </summary>
-    [Flags]
     public enum SpatialAwarenessSurfaceTypes
     {
         /// <summary>
         /// Catch-all for currently undefined surface types.
         /// </summary>
-        Unknown = 1 << 0,
+        Unknown = 0,
 
         /// <summary>
         /// The floor of the space.
         /// </summary>
-        Floor = 1 << 1,
+        Floor,
 
         /// <summary>
         /// The ceiling of the space.
         /// </summary>
-        Ceiling = 1 << 2,
+        Ceiling,
 
         /// <summary>
         /// A wall within the space.
         /// </summary>
-        Wall = 1 << 3,
+        Wall,
 
         /// <summary>
         /// A raised, horizontal surface such as a shelf or a table.
         /// </summary>
         /// <remarks>Platforms, like floors, that can be used for placing objects requiring a horizontal surface.</remarks>
-        Platform = 1 << 10,
+        Platform,
 
         /// <summary>
         /// An angled surface.
         /// </summary>
         /// <remarks>Angled surfaces can often be used as ramps.</remarks>
-        Angled = 1 << 31,
-
-        /// <summary>
-        /// A horizontal surface.
-        /// </summary>
-        Horizontal = Floor | Ceiling | Platform,
-
-        /// <summary>
-        /// A horizontal surface upon which an object can be placed.
-        /// </summary>
-        HorizontalPlaceable = Floor | Platform,
-
-        /// <summary>
-        /// A surface from which an object can be hung.
-        /// </summary>
-        /// <remarks>Hangable surfaces can either be horizontal or vertical.</remarks>
-        Hangable = Ceiling | Wall
+        Angled,
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/SpatialAwareness/SpatialAwarenessSurfaceTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37a2c6fb61326ed4d9f35eadc9b2c7ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -34,11 +34,14 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
         private SerializedProperty enableBoundarySystem;
         private SerializedProperty boundarySystemType;
         private SerializedProperty boundaryHeight;
+        private SerializedProperty boundaryVisualizationProfile;
         // Teleport system properties
         private SerializedProperty enableTeleportSystem;
         private SerializedProperty teleportSystemType;
         private SerializedProperty teleportDuration;
-        private SerializedProperty boundaryVisualizationProfile;
+        // Spatial awareness system properties
+        private SerializedProperty enableSpatialAwarenessSystem;
+        private SerializedProperty spatialAwarenessProfile;
 
         private MixedRealityConfigurationProfile configurationProfile;
 
@@ -95,11 +98,14 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             enableBoundarySystem = serializedObject.FindProperty("enableBoundarySystem");
             boundarySystemType = serializedObject.FindProperty("boundarySystemType");
             boundaryHeight = serializedObject.FindProperty("boundaryHeight");
+            boundaryVisualizationProfile = serializedObject.FindProperty("boundaryVisualizationProfile");
             // Teleport system configuration
             enableTeleportSystem = serializedObject.FindProperty("enableTeleportSystem");
             teleportSystemType = serializedObject.FindProperty("teleportSystemType");
             teleportDuration = serializedObject.FindProperty("teleportDuration");
-            boundaryVisualizationProfile = serializedObject.FindProperty("boundaryVisualizationProfile");
+            // Spatial awareness system configuration
+            enableSpatialAwarenessSystem = serializedObject.FindProperty("enableSpatialAwarenessSystem");
+            spatialAwarenessProfile = serializedObject.FindProperty("spatialAwarenessProfile");
         }
 
         public override void OnInspectorGUI()
@@ -218,6 +224,16 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             {
                 EditorGUILayout.PropertyField(teleportSystemType);
                 EditorGUILayout.PropertyField(teleportDuration);
+            }
+
+            // Spatial Awareness System configuration
+            GUILayout.Space(12f);
+            EditorGUILayout.LabelField("Spatial Awareness System Settings", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(enableSpatialAwarenessSystem);
+
+            if (enableSpatialAwarenessSystem.boolValue)
+            {
+                RenderProfile(spatialAwarenessProfile);
             }
 
             EditorGUIUtility.labelWidth = previousLabelWidth;

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -41,6 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
         private SerializedProperty teleportDuration;
         // Spatial awareness system properties
         private SerializedProperty enableSpatialAwarenessSystem;
+        private SerializedProperty spatialAwarenessSystemType;
         private SerializedProperty spatialAwarenessProfile;
 
         private MixedRealityConfigurationProfile configurationProfile;
@@ -105,6 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             teleportDuration = serializedObject.FindProperty("teleportDuration");
             // Spatial awareness system configuration
             enableSpatialAwarenessSystem = serializedObject.FindProperty("enableSpatialAwarenessSystem");
+            spatialAwarenessSystemType = serializedObject.FindProperty("spatialAwarenessSystemType");
             spatialAwarenessProfile = serializedObject.FindProperty("spatialAwarenessProfile");
         }
 
@@ -233,6 +235,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
 
             if (enableSpatialAwarenessSystem.boolValue)
             {
+                EditorGUILayout.PropertyField(spatialAwarenessSystemType);
                 RenderProfile(spatialAwarenessProfile);
             }
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//using UnityEngine;
+
+//public class MixedRealitySpatialAwarenessProfileInspector
+//{
+//}

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
@@ -1,8 +1,82 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-//using UnityEngine;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
-//public class MixedRealitySpatialAwarenessProfileInspector
-//{
-//}
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Inspectors
+{
+    [CustomEditor(typeof(MixedRealitySpatialAwarenessProfile))]
+    public class MixedRealitySpatialAwarenessProfileInspector : MixedRealityBaseConfigurationProfileInspector
+    {
+        private SerializedProperty autoStart;
+        private SerializedProperty observationExtents;
+        private SerializedProperty physicsLayer;
+        private SerializedProperty updateInterval;
+
+        private GUIContent updateIntervalContent = new GUIContent("Update Interval (seconds)");
+
+        // Mesh properties
+        private SerializedProperty trianglesPerCubicMeter;
+        private SerializedProperty recalculateNormals;
+
+        // Surface properties
+        private SerializedProperty minimumSurfaceArea;
+
+        private void OnEnable()
+        {
+            if (!CheckMixedRealityManager(false))
+            {
+                return;
+            }
+
+            autoStart = serializedObject.FindProperty("autoStart");
+            observationExtents = serializedObject.FindProperty("observationExtents");
+            physicsLayer = serializedObject.FindProperty("physicsLayer");
+            updateInterval = serializedObject.FindProperty("updateInterval");
+
+            // Mesh properties
+            trianglesPerCubicMeter = serializedObject.FindProperty("trianglesPerCubicMeter");
+            recalculateNormals = serializedObject.FindProperty("recalculateNormals");
+
+            // Surface properties
+            minimumSurfaceArea = serializedObject.FindProperty("minimumSurfaceArea");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            RenderMixedRealityToolkitLogo();
+            EditorGUILayout.LabelField("Spatial Awareness Options", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox("Spatial Awareness brings the real world environment into your experiences.", MessageType.Info);
+            EditorGUILayout.Space();
+
+            if (!CheckMixedRealityManager())
+            {
+                return;
+            }
+
+            serializedObject.Update();
+
+            GUILayout.Space(12f);
+            EditorGUILayout.PropertyField(autoStart);
+            EditorGUILayout.PropertyField(observationExtents);
+            EditorGUILayout.PropertyField(physicsLayer);
+            EditorGUILayout.PropertyField(updateInterval, updateIntervalContent);
+
+            GUILayout.Space(12f);
+            EditorGUILayout.LabelField("Mesh Settings:", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(trianglesPerCubicMeter);
+            EditorGUILayout.PropertyField(recalculateNormals);
+
+            GUILayout.Space(12f);
+            EditorGUILayout.LabelField("Surface Settings:", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(minimumSurfaceArea);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
@@ -8,7 +8,7 @@ using Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness;
 using UnityEditor;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Inspectors
+namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
 {
     [CustomEditor(typeof(MixedRealitySpatialAwarenessProfile))]
     public class MixedRealitySpatialAwarenessProfileInspector : MixedRealityBaseConfigurationProfileInspector

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87a04bd890a951a44951bd40c93c1c14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness.meta
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 311119536b2a493a98a74f0c6936d5cf
+guid: 66c2822d293b1484f8bdaf81a4f171aa
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessHandler.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessHandler.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//using UnityEngine;
+
+//public class IMixedRealitySpatialAwarenessHandler
+//{
+//}

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessHandler.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5354cb7038956134298d6c45d5c46b14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -30,6 +30,21 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSys
         /// </summary>
         float UpdateInterval { get; set; }
 
+        /// <summary>
+        /// Indicates whether or not the spatial observer is currently running.
+        /// </summary>
+        bool IsObserverRunning { get; }
+        
+        /// <summary>
+        /// Starts the spatial observer.
+        /// </summary>
+        void StartObserver();
+
+        /// <summary>
+        /// Stops the spatial observer.
+        /// </summary>
+        void StopObserver();
+
         #region Mesh
 
         /// <summary>
@@ -41,6 +56,11 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSys
         /// Indicates whether or not normals should be recalculated when observations are updated.
         /// </summary>
         bool RecalculateNormals { get; set; }
+
+        /// <summary>
+        /// Indicates whether or not the platform supports returning spatial mesh data.
+        /// </summary>
+        bool IsMeshDataSupported { get; }
 
         #endregion Mesh
 

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.SpatialAwareness;
+//using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
+//using Microsoft.MixedReality.Toolkit.Internal.Interfaces.Events;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSystem
+{
+    public interface IMixedRealitySpatialAwarenessSystem // : IMixedRealityEventSystem, IMixedRealityEventSource
+    {
+        /// <summary>
+        /// Indicates whether or not the spatial awareness system is to be automatically started.
+        /// </summary>
+        bool AutoStart { get; set; }
+
+        /// <summary>
+        /// The size of the observation volume.
+        /// </summary>
+        Vector3 Extents { get; set; }
+
+        /// <summary>
+        /// The physics layer to which identified meshes and surfaces should be attached.
+        /// </summary>
+        int PhysicsLayer { get; set; }
+
+        /// <summary>
+        /// The interval, in seconds, between observation updates.
+        /// </summary>
+        int UpdateInterval { get; set; }
+
+        #region Mesh settings
+
+        /// <summary>
+        /// The number of triangles to calculate per cubic meter. 
+        /// </summary>
+        int TrianglesPerCubicMeter { get; set; }
+
+        /// <summary>
+        /// Indicates whether or not normals should be recalculated when observations are updated.
+        /// </summary>
+        bool RecalculateNormals { get; set; }
+
+        #endregion Mesh settings
+
+        #region Surface settings
+
+        /// <summary>
+        /// The minimum size, in square meters, threshold before a surface plane will be identified.
+        /// </summary>
+        float MinimumSurfaceSize { get; set; }
+
+        /// <summary>
+        /// The types of surfaces to identify.
+        /// </summary>
+        SpatialAwarenessSurfaceTypes SurfaceTypes { get; set; }
+
+        #endregion Surface settings
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSys
         /// <summary>
         /// The size of the observation volume.
         /// </summary>
-        Vector3 Extents { get; set; }
+        Vector3 ObservationExtents { get; set; }
 
         /// <summary>
         /// The physics layer to which identified meshes and surfaces should be attached.
@@ -28,9 +28,9 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSys
         /// <summary>
         /// The interval, in seconds, between observation updates.
         /// </summary>
-        int UpdateInterval { get; set; }
+        float UpdateInterval { get; set; }
 
-        #region Mesh settings
+        #region Mesh
 
         /// <summary>
         /// The number of triangles to calculate per cubic meter. 
@@ -42,20 +42,15 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces.SpatialAwarenessSys
         /// </summary>
         bool RecalculateNormals { get; set; }
 
-        #endregion Mesh settings
+        #endregion Mesh
 
-        #region Surface settings
-
-        /// <summary>
-        /// The minimum size, in square meters, threshold before a surface plane will be identified.
-        /// </summary>
-        float MinimumSurfaceSize { get; set; }
+        #region Surface
 
         /// <summary>
-        /// The types of surfaces to identify.
+        /// The minimum area, in square meters, threshold before a surface plane will be identified.
         /// </summary>
-        SpatialAwarenessSurfaceTypes SurfaceTypes { get; set; }
+        float MinimumSurfaceArea { get; set; }
 
-        #endregion Surface settings
+        #endregion Surface
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bcbf0836cb33aa488c3d6853e59f578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Overview
---
Defines the properties and profile for the spatial awareness system in vNext. This PR covers JUST the scaffolding of the spatial awareness system. It does not provide a full implementation. That will come in a future PR (to keep them smaller and more manageable)

Changes
---
- [x] Define the IMixedRealitySpatialAwarenessSystem interface
- [ ] Define the spatial awareness system events
- [ ] Implement default spatial awareness system
- [x] Implement the spatial awareness system profile
- [x] Implement the profile inspector
- [x] Update the MixedRealityManager to add spatial awareness support

Tasks
---
- #2508 
- #2386 