### PR TITLE
Improve how menu item order is specified

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.BoundarySystem
@@ -8,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.BoundarySystem
     /// <summary>
     /// Configuration profile settings for setting up boundary visualizations.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = 6)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
     public class MixedRealityBoundaryVisualizationProfile : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Controller Configuration Profile", fileName = "MixedRealityControllerConfigurationProfile", order = 4)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Controller Configuration Profile", fileName = "MixedRealityControllerConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Controller)]
     public class MixedRealityControllerMappingProfile : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem
     /// <summary>
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = 4)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = (int)CreateProfileMenuItemIndices.InputActions)]
     public class MixedRealityInputActionsProfile : ScriptableObject
     {
         private readonly string[] defaultInputActions =

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem
@@ -8,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem
     /// <summary>
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = 3)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = (int)CreateProfileMenuItemIndices.Pointer)]
     public class MixedRealityPointerProfile : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem
@@ -8,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem
     /// <summary>
     /// Configuration profile settings for setting up and consuming Speech Commands.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = 5)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = (int)CreateProfileMenuItemIndices.Speech)]
     public class MixedRealitySpeechCommandsProfile : ScriptableObject
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityCameraProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityCameraProfile.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Internal.Utilities;
 using UnityEngine;
 
@@ -11,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
     /// is a transparent device or an occluded device.
     /// Based on those values, you can customize your camera and quality settings.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = 1)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = (int)CreateProfileMenuItemIndices.Camera)]
     public class MixedRealityCameraProfile : ScriptableObject
     {
         private enum DisplayType

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions
     /// <summary>
     /// Configuration profile settings for the Mixed Reality Toolkit.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Configuration Profile", fileName = "MixedRealityConfigurationProfile", order = 0)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Configuration Profile", fileName = "MixedRealityConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
     public class MixedRealityConfigurationProfile : ScriptableObject, ISerializationCallbackReceiver
     {
         #region Manager Registry properties

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/ProfileMenuItemIndices.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/ProfileMenuItemIndices.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities
+{
+    /// <summary>
+    /// Defines the display order of the Assets > Create > Mixed Reality Toolkit > Profiles menu items.
+    /// </summary>
+    public enum CreateProfileMenuItemIndices
+    {
+        Configuration = 0,
+        Camera,
+        Input,
+        Pointer,
+        Controller,
+        InputActions,
+        Speech,
+        BoundaryVisualization,
+        SpatialAwareness,
+
+        Assembly = 99
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/ProfileMenuItemIndices.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/ProfileMenuItemIndices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87707e41c37bc4848a02261a1c24e8ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Overview
---
It is hard to know what value you should use when adding a new menu item and reordering a menu requires modifying multiple files.

To add a new menu item:
- Add an entry in the ProfileMenuItemIndices enum
- Cast the enum value to an in in the CreateAssetMenu attribute (order property)

To reorder the menu:
- Change the value(s) in the ProfileMenuItemIndices enum

Changes
---
- [x] Add an enum to the Internal.Definitions.Utilities namespace that specifies the menu item index for our Assets > Create > Mixed Reality Toolkit menu.
- [x] Update the MixedReality*Profile classes to use the appropriate enum value vs a hard-coded "magic" number.
