### PR TITLE
Fixed some null refs when no input action profile exists

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -42,6 +42,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
 
         private MixedRealityConfigurationProfile configurationProfile;
 
+        private static bool skipReset = false;
+
         private void OnEnable()
         {
             configurationProfile = target as MixedRealityConfigurationProfile;
@@ -223,10 +225,12 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             EditorGUIUtility.labelWidth = previousLabelWidth;
             serializedObject.ApplyModifiedProperties();
 
-            if (EditorGUI.EndChangeCheck())
+            if (!skipReset && EditorGUI.EndChangeCheck())
             {
                 MixedRealityManager.Instance.ResetConfiguration(configurationProfile);
             }
+
+            skipReset = false;
         }
 
         private static void RenderProfile(SerializedProperty property)
@@ -243,6 +247,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
                     ScriptableObject profile = CreateInstance(profileTypeName);
                     profile.CreateAsset(AssetDatabase.GetAssetPath(Selection.activeObject));
                     property.objectReferenceValue = profile;
+                    skipReset = true;
                 }
             }
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -31,6 +31,9 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
                 return;
             }
 
+            if (!MixedRealityManager.Instance.ActiveProfile.IsInputSystemEnabled ||
+                MixedRealityManager.Instance.ActiveProfile.InputActionsProfile == null) { return; }
+
             speechCommands = serializedObject.FindProperty("speechCommands");
             actionLabels = MixedRealityManager.Instance.ActiveProfile.InputActionsProfile.InputActions.Select(
                 action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
@@ -49,6 +52,20 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             }
 
             EditorGUILayout.HelpBox("Speech Commands are any/all spoken keywords your users will be able say to raise an Input Action in your application.", MessageType.Info);
+
+            if (!MixedRealityManager.Instance.ActiveProfile.IsInputSystemEnabled)
+            {
+
+                EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
+                return;
+            }
+
+            if (MixedRealityManager.Instance.ActiveProfile.InputActionsProfile == null)
+            {
+
+                EditorGUILayout.HelpBox("No input actions found, please specify a input action profile in the main configuration.", MessageType.Error);
+                return;
+            }
 
             serializedObject.Update();
             RenderList(speechCommands);

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -55,14 +55,12 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
 
             if (!MixedRealityManager.Instance.ActiveProfile.IsInputSystemEnabled)
             {
-
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
                 return;
             }
 
             if (MixedRealityManager.Instance.ActiveProfile.InputActionsProfile == null)
             {
-
                 EditorGUILayout.HelpBox("No input actions found, please specify a input action profile in the main configuration.", MessageType.Error);
                 return;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/PropertyDrawers/InputActionPropertyDrawer.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/PropertyDrawers/InputActionPropertyDrawer.cs
@@ -28,11 +28,21 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Inspectors.PropertyDrawers
 
             if (profile == null ||
                 (MixedRealityManager.Instance.ActiveProfile.IsInputSystemEnabled &&
+                 profile.InputActions != null &&
                  profile.InputActions != MixedRealityManager.Instance.ActiveProfile.InputActionsProfile.InputActions))
             {
                 profile = MixedRealityManager.Instance.ActiveProfile.InputActionsProfile;
-                actionLabels = profile.InputActions.Select(action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
-                actionIds = profile.InputActions.Select(action => (int)action.Id).Prepend(0).ToArray();
+
+                if (profile != null)
+                {
+                    actionLabels = profile.InputActions.Select(action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
+                    actionIds = profile.InputActions.Select(action => (int)action.Id).Prepend(0).ToArray();
+                }
+                else
+                {
+                    actionLabels = new[] { new GUIContent("No input action profile found") };
+                    actionIds = new[] { 0 };
+                }
             }
 
             if (!MixedRealityManager.Instance.ActiveProfile.IsInputSystemEnabled)


### PR DESCRIPTION
Overview
---

- Speech input source would throw a null ref if created out of order and no input system nor input action profile existed. Added error dialog and safe returns.
- Fixed an issue making a new profile via add button in main config.
