### PR TITLE
Fix for #2438 . Force components to initialize in the right order

### DIFF
--- a/Assets/HoloToolkit-Preview/SpectatorView/Scripts/Networking/NewDeviceDiscovery.cs
+++ b/Assets/HoloToolkit-Preview/SpectatorView/Scripts/Networking/NewDeviceDiscovery.cs
@@ -44,7 +44,7 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
             set { spectatorView = value; }
         }
 
-        private void Awake()
+        private void Start()
         {
             string[] errors;
             if (!DependenciesValid(out errors))

--- a/Assets/HoloToolkit-Preview/SpectatorView/Scripts/Networking/SpectatorView.cs
+++ b/Assets/HoloToolkit-Preview/SpectatorView/Scripts/Networking/SpectatorView.cs
@@ -130,6 +130,11 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
             private set {isHost = value; }
         }
 
+        private void Awake()
+        {
+            isHost = FindObjectOfType<PlatformSwitcher>().TargetPlatform == PlatformSwitcher.Platform.Hololens;
+        }
+
         private void Start()
         {
             string[] errors;
@@ -151,7 +156,6 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
                 return;
             }
 #endif
-            isHost = FindObjectOfType<PlatformSwitcher>().TargetPlatform == PlatformSwitcher.Platform.Hololens;
 
             // The host needs an aditional component
             if (isHost)

--- a/Assets/HoloToolkit-Preview/SpectatorView/Scripts/SpatialSync/CameraCaptureHololens.cs
+++ b/Assets/HoloToolkit-Preview/SpectatorView/Scripts/SpatialSync/CameraCaptureHololens.cs
@@ -133,6 +133,7 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
             {
                 Debug.LogException(e);
             }
+
         }
 
         /// <summary>
@@ -163,6 +164,8 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
             {
                 Debug.LogError("Failed to capturing image");
             }
+
+            photoCaptureFrame.Dispose();
 
             photoCaptureObject.TakePhotoAsync(OnCapturedPhotoToMemory);
         }

--- a/Assets/HoloToolkit-Preview/SpectatorView/Scripts/SpatialSync/CameraCaptureHololens.cs
+++ b/Assets/HoloToolkit-Preview/SpectatorView/Scripts/SpatialSync/CameraCaptureHololens.cs
@@ -50,7 +50,7 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
         /// Texture to which the photo will be saved to
         /// </summary>
         private Texture2D targetTexture;
-        
+
         /// <summary>
         /// Vertical resolution of the capture camera image
         /// </summary>
@@ -118,13 +118,20 @@ namespace HoloToolkit.Unity.Preview.SpectatorView
         /// <param name="result">Result of the intent of starting the camera</param>
         private void OnPhotoModeStarted(PhotoCapture.PhotoCaptureResult result)
         {
-            if (result.success)
+            try
             {
-                photoCaptureObject.TakePhotoAsync(OnCapturedPhotoToMemory);
+                if (result.success)
+                {
+                    photoCaptureObject.TakePhotoAsync(OnCapturedPhotoToMemory);
+                }
+                else
+                {
+                    Debug.LogError("Unable to start photo mode!");
+                }
             }
-            else
+            catch (System.Exception e)
             {
-                Debug.LogError("Unable to start photo mode!");
+                Debug.LogException(e);
             }
         }
 


### PR DESCRIPTION
Overview
---
As a fix to #2438 we have now forced SpectatorView's `isHost` field to initialize on the `Awake`. That will allow `SpectatorViewNetworkManager` to make use of that field without risking getting into script execution order issues. 



@davidkline-ms I have created this PR against `Master` because I wasn't sure which branch should I create it of. Could you please redirect the PR or let me know what you would like me to do? 

Changes
---
- Fixes: #2438

- Some exception handling has been added on `OnPhotoModeStarted`. There were some instances when if the iPhone stopped broadcasting while the HoloLens was still taking pictures, it would throw an exception.
- We're now manually disposing of the pictures taken to avoid the GC kicking in more often
- `NewDeviceDiscovery` initialization moved to the `Start` to make sure that `SpectatorView` has been initialized by then 
