### PR TITLE
Fixed the folder name for the Invisible Shader

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Resources/Shaders/InvisibleShader.shader
+++ b/Assets/MixedRealityToolkit/_Core/Resources/Shaders/InvisibleShader.shader
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-Shader "MixedRealityToolkit/InvisibleShader" {
+Shader "Mixed Reality Toolkit/InvisibleShader" {
 
 	Subshader
 	{


### PR DESCRIPTION
Overview
---
Currently, the Standard shader and the Invisible shader appear in different folders in the shader query tree.
This fixes this so that both MRTK shaders now appear in the same folder, matching what the Standard shader was using

Changes
---
- Fixes: Folder names for shaders
