### PR TITLE
BaseDeviceManager.cs(91,72): error CS0019: Operator '==' cannot be applied to operands of type 'SystemType' and 'Type'

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices
                 {
                     var pointerProfile = MixedRealityManager.Instance.ActiveProfile.PointerProfile.PointerOptions[i];
 
-                    if ((pointerProfile.ControllerType.Type == null || pointerProfile.ControllerType == controllerType.Type) &&
+                    if ((pointerProfile.ControllerType.Type == null || pointerProfile.ControllerType.Type == controllerType.Type) &&
                         (pointerProfile.Handedness == Handedness.Any || pointerProfile.Handedness == Handedness.Both || pointerProfile.Handedness == controllingHand))
                     {
                         var pointerObject = Object.Instantiate(pointerProfile.PointerPrefab);


### PR DESCRIPTION
Overview
--- UWP build was broken due to comparison of different types.


Changes
---
- Fixes: # Fixed by accessing correct property
