### PR TITLE
Fix gaze pointer being lost on hand lost

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -848,16 +848,18 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             for (var i = 0; i < eventData.InputSource.Pointers.Length; i++)
             {
                 // Special unregistration for Gaze
-                if (eventData.InputSource.SourceId == InputSystem.GazeProvider.GazeInputSource.SourceId)
+                if (gazeProviderPointingData != null && eventData.InputSource.Pointers[i].PointerId == gazeProviderPointingData.Pointer.PointerId)
                 {
-                    Debug.Log("UnRegistering focus pointer");
-                    Debug.Assert(gazeProviderPointingData != null);
-
                     // If the source lost is the gaze input source, then reset it.
-                    if (eventData.InputSource.Pointers[i].PointerId == gazeProviderPointingData.Pointer.PointerId)
+                    if (eventData.InputSource.SourceId == InputSystem.GazeProvider.GazeInputSource.SourceId)
                     {
                         gazeProviderPointingData.ResetFocusedObjects();
                         gazeProviderPointingData = null;
+                    }
+                    // Otherwise, don't unregister the gaze pointer, since the gaze input source is still active.
+                    else
+                    {
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
Overview
---
Previously, the source lost handling checked to see if the lost source was the gaze input source, and special-cased some logic to clear the pointing data.

We also need to special case if the gaze pointer was being used by a lost non-gaze input source (in the discovered case, this would be a hand source on HoloLens). In this case, we should not remove the gaze pointer, since the gaze input source still exists and other sources might be using it.

Changes
---
- Related to: #2626 

Fixes:
>Head tracking stops working when a hand is raised and lost. Cursor does not follow head movement anymore. It follows head movement only when a hand is raised.
