### PR TITLE
Update BaseCursor to properly respond to source events

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Internal.Definitions.Physics;
 using Microsoft.MixedReality.Toolkit.Internal.EventDatum.Input;
-using Microsoft.MixedReality.Toolkit.Internal.Extensions;
 using Microsoft.MixedReality.Toolkit.Internal.Interfaces.InputSystem;
 using Microsoft.MixedReality.Toolkit.SDK.Input;
 using UnityEngine;
@@ -53,13 +51,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
         [Tooltip("Visual that is displayed when cursor is active normally")]
         protected Transform PrimaryCursorVisual = null;
 
-        protected bool IsHandDetected = false;
+        protected bool IsSourceDetected => visibleSourcesCount > 0;
 
         protected bool IsPointerDown = false;
 
         protected GameObject TargetedObject = null;
 
-        private uint visibleHandsCount = 0;
+        private uint visibleSourcesCount = 0;
         private bool isVisible = true;
 
         private Vector3 targetPosition;
@@ -134,28 +132,38 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
         /// <inheritdoc />
         public virtual void OnSourceDetected(SourceStateEventData eventData)
         {
-            if (eventData.Controller != null && eventData.Controller.Interactions.SupportsInputType(DeviceInputType.Hand))
+            if (eventData.Controller != null)
             {
-                visibleHandsCount++;
-            }
-
-            if (visibleHandsCount > 0)
-            {
-                IsHandDetected = true;
+                for (int i = 0; i < eventData.InputSource.Pointers.Length; i++)
+                {
+                    // If a source is detected that's using this cursor's pointer, we increment the count to set the cursor state properly.
+                    if (eventData.InputSource.Pointers[i].PointerId == Pointer.PointerId)
+                    {
+                        visibleSourcesCount++;
+                        return;
+                    }
+                }
             }
         }
 
         /// <inheritdoc />
         public virtual void OnSourceLost(SourceStateEventData eventData)
         {
-            if (eventData.Controller != null && eventData.Controller.Interactions.SupportsInputType(DeviceInputType.Hand))
+            if (eventData.Controller != null)
             {
-                visibleHandsCount--;
+                for (int i = 0; i < eventData.InputSource.Pointers.Length; i++)
+                {
+                    // If a source is lost that's using this cursor's pointer, we decrement the count to set the cursor state properly.
+                    if (eventData.InputSource.Pointers[i].PointerId == Pointer.PointerId)
+                    {
+                        visibleSourcesCount--;
+                        return;
+                    }
+                }
             }
 
-            if (visibleHandsCount == 0)
+            if (visibleSourcesCount == 0)
             {
-                IsHandDetected = false;
                 IsPointerDown = false;
             }
 
@@ -240,8 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
         {
             // We don't call base.OnDisable because we handle unregistering the global listener a bit differently.
             TargetedObject = null;
-            visibleHandsCount = 0;
-            IsHandDetected = false;
+            visibleSourcesCount = 0;
             OnCursorStateChange(CursorStateEnum.Contextual);
         }
 
@@ -359,8 +366,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
         public virtual void OnInputDisabled()
         {
             // Reset visible hands on disable
-            visibleHandsCount = 0;
-            IsHandDetected = false;
+            visibleSourcesCount = 0;
 
             OnCursorStateChange(CursorStateEnum.Contextual);
         }
@@ -403,7 +409,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
                     return CursorStateEnum.Release;
                 }
 
-                if (IsHandDetected)
+                if (IsSourceDetected)
                 {
                     return TargetedObject != null ? CursorStateEnum.InteractHover : CursorStateEnum.Interact;
                 }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/InteractiveMeshCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/InteractiveMeshCursor.cs
@@ -67,12 +67,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
             base.OnCursorStateChange(state);
 
             // the cursor state has changed, reset the animation timer
-            if (hasHand != IsHandDetected || isDown != IsPointerDown || hasHover != (TargetedObject != null))
+            if (hasHand != IsSourceDetected || isDown != IsPointerDown || hasHover != (TargetedObject != null))
             {
                 timer = 0;
             }
 
-            hasHand = IsHandDetected;
+            hasHand = IsSourceDetected;
             isDown = IsPointerDown;
             hasHover = TargetedObject != null;
 


### PR DESCRIPTION
Overview
---
The source detected and lost logic assumed that pointers and cursors will only care about events from the same input source that they're registered on. That might be the case for most of the controller pointers, but that's not the case for the gaze pointer. The hand is a separate input source from the gaze input source.

This assumption is made in other places in the MRTK as well and will likely need updating as we investigate HoloLens support. In most cases, it's probably more correct to check "am I registered in this input source's list of pointers" instead of checking "is my input source the same input source that the event is coming from".

Additionally, `IsHandDetected` was not intended to specifically filter out hands only in the HTK. Its name was from the time before immersive headsets and controller input sources. I've renamed it to reflect this.

Changes
---
- Related to: #2626

Fixes (mostly):
>Does not show interaction state changes (dot <-> donut)

This does not yet address hand taps not coming through to the cursor properly. That logic is currently located in the controller pointer class, while we want the gaze pointer to also handle them.
This does address the cursor responding to source detected/lost with a hand.
