### PR TITLE
Corrected assignment of the initial rotation in BoundingBoxGizmoHandle

### DIFF
--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBox.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBox.cs
@@ -370,7 +370,6 @@ namespace HoloToolkit.Unity.UX
 
             // Store the local scale of the target bb
             targetBoundsLocalScale = localTargetBounds.size;
-            targetBoundsLocalScale.Scale(target.transform.localScale);
 
             // Now check our flatten behavior
             UpdateFlattenedAxis();
@@ -442,6 +441,8 @@ namespace HoloToolkit.Unity.UX
             // Get position of object based on renderers
             transform.position = targetBoundsWorldCenter;
             Vector3 scale = targetBoundsLocalScale;
+            scale = target.transform.TransformVector(scale);  // transform the target's local scale to world scale
+            scale = transform.InverseTransformVector(scale);  // transform world scale to the local scale of the bounding box
 
             // Use absolute value when determining smallest axis
             // so we don't get fooled by inverted scales

--- a/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
+++ b/Assets/HoloToolkit/UX/Scripts/BoundingBoxes/BoundingBoxGizmoHandle.cs
@@ -387,7 +387,7 @@ namespace HoloToolkit.Unity.UX
             initialScale            = transformToAffect.localScale;
             initialPosition         = transformToAffect.position;
             initialOrientation      = transformToAffect.rotation.eulerAngles;
-            initialRotation         = transformToAffect.rotation;
+            initialRotation         = transformToAffect.localRotation;
             initialHandOrientation  = GetHandOrientation(eventData.SourceId);
             initialScaleOrigin      = transformToAffect.position - this.transform.position;
 


### PR DESCRIPTION
Variable initialRotation is used only in calculations where the rotation coordinate system is local.
So it needs to be initialized with the local instead of the global rotation.
(The previous code version works only as long as none of the parents of transformToAffect were rotated.)