### PR TITLE
Add support for controllers/sources without pointers to use the GazePointer

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -227,7 +227,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             #endregion IMixedRealityPointer Implementation
 
             /// <summary>
-            /// 
+            /// Press this pointer. This sends a pointer down event across the input system.
             /// </summary>
             /// <param name="mixedRealityInputAction">The input action that corresponds to the pressed button or axis.</param>
             /// <param name="handedness">Optional handedness of the source that pressed the pointer.</param>
@@ -237,7 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             }
 
             /// <summary>
-            /// 
+            /// Release this pointer. This sends pointer clicked and pointer up events across the input system.
             /// </summary>
             /// <param name="mixedRealityInputAction">The input action that corresponds to the released button or axis.</param>
             /// <param name="handedness">Optional handedness of the source that released the pointer.</param>

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -231,7 +231,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             /// </summary>
             /// <param name="mixedRealityInputAction">The input action that corresponds to the pressed button or axis.</param>
             /// <param name="handedness">Optional handedness of the source that pressed the pointer.</param>
-            public void PressPointer(MixedRealityInputAction mixedRealityInputAction, Handedness handedness = Handedness.None)
+            public void RaisePointerDown(MixedRealityInputAction mixedRealityInputAction, Handedness handedness = Handedness.None)
             {
                 InputSystem.RaisePointerDown(this, handedness, mixedRealityInputAction);
             }
@@ -241,7 +241,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             /// </summary>
             /// <param name="mixedRealityInputAction">The input action that corresponds to the released button or axis.</param>
             /// <param name="handedness">Optional handedness of the source that released the pointer.</param>
-            public void ReleasePointer(MixedRealityInputAction mixedRealityInputAction, Handedness handedness = Handedness.None)
+            public void RaisePointerUp(MixedRealityInputAction mixedRealityInputAction, Handedness handedness = Handedness.None)
             {
                 InputSystem.RaisePointerClicked(this, handedness, mixedRealityInputAction, 0);
                 InputSystem.RaisePointerUp(this, handedness, mixedRealityInputAction);
@@ -348,7 +348,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             {
                 if (eventData.InputSource.Pointers[i].PointerId == GazePointer.PointerId)
                 {
-                    gazePointer.ReleasePointer(eventData.MixedRealityInputAction, eventData.Handedness);
+                    gazePointer.RaisePointerUp(eventData.MixedRealityInputAction, eventData.Handedness);
                     return;
                 }
             }
@@ -360,7 +360,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             {
                 if (eventData.InputSource.Pointers[i].PointerId == GazePointer.PointerId)
                 {
-                    gazePointer.PressPointer(eventData.MixedRealityInputAction, eventData.Handedness);
+                    gazePointer.RaisePointerDown(eventData.MixedRealityInputAction, eventData.Handedness);
                     return;
                 }
             }

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
@@ -1121,7 +1121,7 @@ MonoBehaviour:
       axisCodeY: 
       invertYAxis: 0
   - id: 8
-    description: WMR Source Unknown Handedness
+    description: WMR Hand No Handedness
     controllerType:
       reference: Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality.WindowsMixedRealityController,
         Microsoft.MixedReality.Toolkit

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerConfigurationProfile.asset
@@ -1120,3 +1120,157 @@ MonoBehaviour:
       axisCodeX: 
       axisCodeY: 
       invertYAxis: 0
+  - id: 8
+    description: WMR Source Unknown Handedness
+    controllerType:
+      reference: Microsoft.MixedReality.Toolkit.Internal.Devices.WindowsMixedReality.WindowsMixedRealityController,
+        Microsoft.MixedReality.Toolkit
+    handedness: 0
+    useDefaultModel: 0
+    overrideModel: {fileID: 0}
+    useCustomInteractionMappings: 0
+    interactions:
+    - id: 0
+      description: Spatial Pointer
+      axisType: 7
+      inputType: 3
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 1
+      description: Spatial Grip
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 2
+      description: Grip Press
+      axisType: 2
+      inputType: 7
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 3
+      description: Touchpad Position
+      axisType: 4
+      inputType: 21
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 4
+      description: Touchpad Touch
+      axisType: 2
+      inputType: 22
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 5
+      description: Touchpad Press
+      axisType: 2
+      inputType: 24
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 6
+      description: Thumbstick Position
+      axisType: 4
+      inputType: 17
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 7
+      description: Thumbstick Press
+      axisType: 2
+      inputType: 18
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 8
+      description: Trigger Position
+      axisType: 3
+      inputType: 10
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 9
+      description: Trigger Pressed (Select)
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 10
+      description: Trigger Touched
+      axisType: 2
+      inputType: 11
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0
+    - id: 11
+      description: Menu Pressed
+      axisType: 2
+      inputType: 27
+      inputAction:
+        id: 0
+        description: None
+        axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertYAxis: 0


### PR DESCRIPTION
Overview
---
Adds a new mapping for unhanded WMR controllers, as HoloLens hands come through with an unknown handedness.

Also adds `IMixedRealityInputHandler` to the `GazeProvider` in order to properly route input events into pointer events. This enables both HoloLens hands and immersive apps that choose not to use controller-based pointers.

Changes
---
- Related to #2626 

Fixes:
>Does not trigger input events.

for PointerDown/Click/Up.
