### PR TITLE
Updating HTK gitignore to match MRTK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,16 @@ obj/
 *.idb
 *.opendb
 
+# ============================ #
+# Visual Studio Code Generated #
+# ============================ #
+.vscode/
+
+# ===================== #
+# Project Specific List #
+# ===================== #
+artifacts/
 Assets/ThirdParty/
 Assets/ThirdParty.meta
+Assets/TextMesh Pro.meta
+Assets/TextMesh Pro/


### PR DESCRIPTION
Overview
---
Otherwise, when switching between the projects, the TextMesh Pro folders show up in the changelist.
This also brings over support for the VSCode generated folder.