### PR TITLE
Add multiple GitHub issue templates, to better facilitate MRTK task filing

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,34 @@
+---
+name: "\U0001F41B Bug Report"
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+_(Links to sample GitHub project preferred)_
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what happens instead.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Unity Editor Version**
+Which Unity version(s) you've been able to reproduce the bug in.
+
+**Mixed Reality Toolkit Release Version**
+Which MRTK version(s) you've been able to reproduce the bug in.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,7 +1,6 @@
 ---
 name: "\U0001F41B Bug Report"
-about: Create a report to help us improve
-
+about: Create a report to help us improve. Please label your issue with HoloToolkit or MRTK vNext, depending on which project this affects.
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,7 +1,10 @@
 ---
 name: "\U0001F41B Bug Report"
-about: Create a report to help us improve. Please label your issue with HoloToolkit or MRTK vNext, depending on which project this affects.
+about: Create a report to help us improve.
 ---
+
+**Does this affect the legacy HoloToolkit (master) or the Mixed Reality Toolkit (mrtk_release)?**
+HoloToolkit | Mixed Reality Toolkit
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,7 +1,10 @@
 ---
 name: "\U0001F195 Feature Request"
-about: Suggest an idea for this project. Please label your issue with HoloToolkit or MRTK vNext, depending on which project this affects.
+about: Suggest an idea for this project.
 ---
+
+**Does this affect the legacy HoloToolkit (master) or the Mixed Reality Toolkit (mrtk_release)?**
+HoloToolkit | Mixed Reality Toolkit
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,7 +1,6 @@
 ---
 name: "\U0001F195 Feature Request"
-about: Suggest an idea for this project
-
+about: Suggest an idea for this project. Please label your issue with HoloToolkit or MRTK vNext, depending on which project this affects.
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F195 Feature Request"
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/---mrtk-task.md
+++ b/.github/ISSUE_TEMPLATE/---mrtk-task.md
@@ -1,7 +1,6 @@
 ---
-name: "\U0001F4DD vNext Task"
-about: File an outstanding task for vNext.
-
+name: "\U0001F4DD Mixed Reality Toolkit Task"
+about: File an outstanding task for MRTK vNext.
 ---
 
 **Overview**

--- a/.github/ISSUE_TEMPLATE/---vnext-task.md
+++ b/.github/ISSUE_TEMPLATE/---vnext-task.md
@@ -1,0 +1,18 @@
+---
+name: "\U0001F4DD vNext Task"
+about: File an outstanding task for vNext.
+
+---
+
+**Overview**
+A clear and concise description of what the outstanding task is.
+
+**Requirements**
+A list of the required features this task will implement.
+* Requirement 1
+* Requirement 2
+
+**Acceptance Criteria**
+A list of the specific things that must be done for approval and acceptance here, done in checklist form. This may correspond with the above requirements.
+- [ ] Criterion 1
+- [ ] Criterion 2


### PR DESCRIPTION
Overview
---
![image](https://user-images.githubusercontent.com/3580640/44756250-a60afe00-aade-11e8-93d3-d1ac99791e5b.png)

Adds multiple issue templates for bug reports, feature requests, and MRTK tasks, with specialized templates for each.

See https://github.com/keveleigh/HoloToolkit-Unity/issues/new/choose to see how this looks when filing an issue.

The default, existing issue template is now the fallback and has been left untouched.
