### PR TITLE
Fixed parenting of cursor

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -272,7 +272,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         {
             if (cursorPrefab != null)
             {
-                var cursorObj = Instantiate(cursorPrefab);
+                var cursorObj = Instantiate(cursorPrefab, transform.parent);
                 GazePointer.BaseCursor = cursorObj.GetComponent<IMixedRealityCursor>();
                 Debug.Assert(GazePointer.BaseCursor != null, "Failed to load cursor");
                 GazePointer.BaseCursor.Pointer = GazePointer;


### PR DESCRIPTION
Overview
---
Cursor was spawned in root node and not in body

Changes
---
Changed parenting on instantiate as @StephenHodgson showed me.
