### PR TITLE
Fix HTK pointer debug rays

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/InputSourcePointer.cs
@@ -91,7 +91,7 @@ namespace HoloToolkit.Unity.InputModule
                     Vector3 position;
                     Vector3 forward;
 
-                    if (!sourceState.sourcePose.TryGetPosition(out position))
+                    if (!sourceState.sourcePose.TryGetPosition(out position, InteractionSourceNode.Pointer))
                     {
                         return;
                     }


### PR DESCRIPTION
Overview
---
Pointers were getting their start position from the grip position instead of the pointer position. This was causing the debug ray to not match the pointer visualization, which was correctly aligning itself with the pointer position.

Changes
---
- Fixes: #2523.
