### PR TITLE
Fix pointer line visibility when switching the active controller

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ControllerFinder.cs
@@ -149,10 +149,7 @@ namespace HoloToolkit.Unity.InputModule
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             if (oldController.Handedness == handedness)
             {
-                OnControllerLost();
-
-                ControllerInfo = null;
-                ElementTransform = null;
+                ResetControllerTransform();
             }
 #endif
         }
@@ -162,7 +159,7 @@ namespace HoloToolkit.Unity.InputModule
 #if UNITY_WSA && UNITY_2017_2_OR_NEWER
             if (ControllerInfo != null)
             {
-                RemoveControllerTransform(ControllerInfo);
+                ResetControllerTransform();
             }
 
             TryAndAddControllerTransform();
@@ -182,5 +179,17 @@ namespace HoloToolkit.Unity.InputModule
         /// without the overhead of needing to check that handedness matches.
         /// </summary>
         protected virtual void OnControllerLost() { }
+
+        /// <summary>
+        /// Lets all listeners know that the controller was lost, then resets the cached info
+        /// and transform, potentially in preparation of a new controller.
+        /// </summary>
+        private void ResetControllerTransform()
+        {
+            OnControllerLost();
+
+            ControllerInfo = null;
+            ElementTransform = null;
+        }
     }
 }


### PR DESCRIPTION
Overview
---
When one controller is using the glTF controller model and the other isn't, the pointing ray doesn't properly disable itself when it doesn't find anything to attach to. This is because we update the handedness, then in the refresh code check to make sure the handedness is the same as the currently tracked controller before sending the controller lost event.

This change forces the previous controller to be lost, regardless of the current handedness.

Changes
---
- Fixes: #2669
