### PR TITLE
Fixes controller mapping profile serialization for HoloLens gestures

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
@@ -606,8 +606,8 @@ MonoBehaviour:
       invertYAxis: 0
     - id: 2
       description: Grip Press
-      axisType: 2
-      inputType: 7
+      axisType: 3
+      inputType: 13
       inputAction:
         id: 0
         description: None


### PR DESCRIPTION
Overview
---
#2639 checked in the default controller mapping profile with stale axes for the HoloLens gestures mappings. The Grip interaction was updated to be a single axis trigger, but those values weren't updated in the profile. When running on HoloLens, the controller was getting a mapping error, which then [shuts down the entire controller](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityController.cs#L136), causing input on HoloLens to be broken.

![image](https://user-images.githubusercontent.com/3580640/45240216-ace2ff00-b29c-11e8-9165-d7f9265acebd.png)
