### PR TITLE
Fixed a race condition with BaseInputHandler

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -268,8 +268,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             }
         }
 
-        protected virtual void Start()
+        protected override void Start()
         {
+            base.Start();
+
             if (cursorPrefab != null)
             {
                 var cursorObj = Instantiate(cursorPrefab, transform.parent);

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.InputSystem.Pointers;
-using Microsoft.MixedReality.Toolkit.InputSystem.Sources;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
@@ -10,7 +8,10 @@ using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
 using Microsoft.MixedReality.Toolkit.Core.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using Microsoft.MixedReality.Toolkit.Core.Utilities.Physics;
+using Microsoft.MixedReality.Toolkit.InputSystem.Pointers;
+using Microsoft.MixedReality.Toolkit.InputSystem.Sources;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.Input
@@ -337,7 +338,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         {
             base.OnDisable();
             GazePointer.BaseCursor?.SetVisibility(false);
-            InputSystem.RaiseSourceLost(GazeInputSource);
+            InputSystem?.RaiseSourceLost(GazeInputSource);
         }
 
         #endregion MonoBehaviour Implementation
@@ -387,8 +388,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             return gazePointer = new InternalGazePointer(this, "Gaze Pointer", null, raycastLayerMasks, maxGazeCollisionDistance, gazeTransform, stabilizer);
         }
 
-        private void RaiseSourceDetected()
+        private async void RaiseSourceDetected()
         {
+            await WaitUntilInputSystemValid;
             InputSystem.RaiseSourceDetected(GazeInputSource);
             GazePointer.BaseCursor?.SetVisibility(true);
         }

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/SpeechInputHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/SpeechInputHandler.cs
@@ -33,8 +33,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
 
         #region MonoBehaviour Implementation
 
-        private void Start()
+        protected override void Start()
         {
+            base.Start();
+
             if (persistentKeywords)
             {
                 Debug.Assert(gameObject.transform.parent == null, "Persistent keyword GameObject must be at the root level of the scene hierarchy.");

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.Input
@@ -17,30 +18,21 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
         private bool lateInitialize = true;
 
+        protected readonly WaitUntil WaitUntilInputSystemValid = new WaitUntil(() => InputSystem != null);
+
         protected virtual void OnEnable()
         {
-            if (!MixedRealityManager.IsInitialized)
-            {
-                Debug.LogError("Missing Mixed Reality Manager!");
-                return;
-            }
-
-            if (InputSystem != null && !lateInitialize)
+            if (MixedRealityManager.IsInitialized && InputSystem != null && !lateInitialize)
             {
                 InputSystem.Register(gameObject);
             }
         }
 
-        protected virtual void Start()
+        protected virtual async void Start()
         {
             if (lateInitialize)
             {
-                if (InputSystem == null)
-                {
-                    Debug.LogError("Unable to find Input System!");
-                    return;
-                }
-
+                await WaitUntilInputSystemValid;
                 lateInitialize = false;
                 InputSystem.Register(gameObject);
             }

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
@@ -15,16 +15,40 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         private static IMixedRealityInputSystem inputSystem = null;
         protected static IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>());
 
+        private bool lateInitialize = true;
+
         protected virtual void OnEnable()
         {
-            Debug.Assert(MixedRealityManager.IsInitialized, "No Mixed Reality Manager found in the scene.  Be sure to run the Mixed Reality Configuration.");
-            Debug.Assert(InputSystem != null, "No Input System found, Did you set it up in your configuration profile?");
-            InputSystem.Register(gameObject);
+            if (!MixedRealityManager.IsInitialized)
+            {
+                Debug.LogError("Missing Mixed Reality Manager!");
+                return;
+            }
+
+            if (InputSystem != null && !lateInitialize)
+            {
+                InputSystem.Register(gameObject);
+            }
+        }
+
+        protected virtual void Start()
+        {
+            if (lateInitialize)
+            {
+                if (InputSystem == null)
+                {
+                    Debug.LogError("Unable to find Input System!");
+                    return;
+                }
+
+                lateInitialize = false;
+                InputSystem.Register(gameObject);
+            }
         }
 
         protected virtual void OnDisable()
         {
-            InputSystem.Unregister(gameObject);
+            InputSystem?.Unregister(gameObject);
         }
     }
 }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -316,7 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
                 {
                     Debug.LogError($"{name}: Unable to get focus details for {pointer.GetType().Name}!");
                 }
-                else
+                else if (pointer.GetType() != typeof(TouchPointer))
                 {
                     Debug.LogWarning($"{pointer.GetType().Name} not registered!");
                 }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -316,6 +316,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
                 {
                     Debug.LogError($"{name}: Unable to get focus details for {pointer.GetType().Name}!");
                 }
+                else
+                {
+                    Debug.LogWarning($"{pointer.GetType().Name} not registered!");
+                }
 
                 return;
             }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -316,10 +316,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
                 {
                     Debug.LogError($"{name}: Unable to get focus details for {pointer.GetType().Name}!");
                 }
-                else if (pointer.GetType() != typeof(TouchPointer))
-                {
-                    Debug.LogWarning($"{pointer.GetType().Name} not registered!");
-                }
 
                 return;
             }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -13,6 +13,7 @@ using Microsoft.MixedReality.Toolkit.Core.Interfaces.TeleportSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
 using System.Collections;
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
@@ -61,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
 
         protected bool IsTeleportRequestActive = false;
 
-        private bool lateRegisterTeleport = false;
+        private bool lateRegisterTeleport = true;
 
         /// <summary>
         /// The forward direction of the targeting ray
@@ -119,31 +120,21 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
             SetCursor();
             BaseCursor?.SetVisibility(true);
 
-            if (TeleportSystem == null)
-            {
-                lateRegisterTeleport = true;
-            }
-            else if (!lateRegisterTeleport)
+            if (MixedRealityManager.IsInitialized && TeleportSystem != null && !lateRegisterTeleport)
             {
                 TeleportSystem.Register(gameObject);
             }
         }
 
-        protected override void Start()
+        protected override async void Start()
         {
             base.Start();
 
             if (lateRegisterTeleport)
             {
-                if (TeleportSystem == null)
-                {
-                    Debug.LogError("Failed to find the Teleport System!");
-                }
-                else
-                {
-                    lateRegisterTeleport = false;
-                    TeleportSystem.Register(gameObject);
-                }
+                await new WaitUntil(() => TeleportSystem != null);
+                lateRegisterTeleport = false;
+                TeleportSystem.Register(gameObject);
             }
         }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -61,6 +61,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
 
         protected bool IsTeleportRequestActive = false;
 
+        private bool lateRegisterTeleport = false;
+
         /// <summary>
         /// The forward direction of the targeting ray
         /// </summary>
@@ -116,7 +118,33 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
             base.OnEnable();
             SetCursor();
             BaseCursor?.SetVisibility(true);
-            TeleportSystem?.Register(gameObject);
+
+            if (TeleportSystem == null)
+            {
+                lateRegisterTeleport = true;
+            }
+            else if (!lateRegisterTeleport)
+            {
+                TeleportSystem.Register(gameObject);
+            }
+        }
+
+        protected override void Start()
+        {
+            base.Start();
+
+            if (lateRegisterTeleport)
+            {
+                if (TeleportSystem == null)
+                {
+                    Debug.LogError("Failed to find the Teleport System!");
+                }
+                else
+                {
+                    lateRegisterTeleport = false;
+                    TeleportSystem.Register(gameObject);
+                }
+            }
         }
 
         protected override void OnDisable()
@@ -171,7 +199,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         }
 
         /// <inheritdoc />
-        public IMixedRealityInputSource InputSourceParent { get; private set; }
+        public IMixedRealityInputSource InputSourceParent { get; protected set; }
 
         /// <inheritdoc />
         public IMixedRealityCursor BaseCursor { get; set; }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -290,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                     {
                         teleportEnabled = true;
 
-                        TeleportSystem.RaiseTeleportRequest(this, TeleportHotSpot);
+                        TeleportSystem?.RaiseTeleportRequest(this, TeleportHotSpot);
                     }
                     else if (canMove)
                     {
@@ -356,7 +356,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                     if (TeleportSurfaceResult == TeleportSurfaceResult.Valid ||
                         TeleportSurfaceResult == TeleportSurfaceResult.HotSpot)
                     {
-                        TeleportSystem.RaiseTeleportStarted(this, TeleportHotSpot);
+                        TeleportSystem?.RaiseTeleportStarted(this, TeleportHotSpot);
                     }
                 }
 
@@ -364,7 +364,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                 {
                     canTeleport = false;
                     teleportEnabled = false;
-                    TeleportSystem.RaiseTeleportCanceled(this, TeleportHotSpot);
+                    TeleportSystem?.RaiseTeleportCanceled(this, TeleportHotSpot);
                 }
             }
 


### PR DESCRIPTION
Overview
---
There was a race condition we needed to check against in the BaseInputHandler.  If the Input System isn't valid by the time we get OnEnable called we could drop registration of listeners. 

BaseControllerPointer also had the same issue for the Teleport System, and was updated to accommodate that as well.

These changes make the handlers more robust and is lazy initialized, waiting until the systems are valid before doing any action.