### PR TITLE
Added better platform checking

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityRegisteredComponentsProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityRegisteredComponentsProfile.asset
@@ -19,39 +19,34 @@ MonoBehaviour:
     priority: 10
     runtimePlatform: -1
     configurationProfile: {fileID: 0}
-    editorPlatform: -1
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.OpenVR.OpenVRDeviceManager,
         Microsoft.MixedReality.Toolkit
     componentName: Unity Open VR Device Manager
     priority: 10
-    runtimePlatform: 20548
+    runtimePlatform: -1
     configurationProfile: {fileID: 0}
-    editorPlatform: 2884080
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality.WindowsMixedRealityDeviceManager,
         Microsoft.MixedReality.Toolkit
     componentName: Mixed Reality Device Manager
     priority: 10
-    runtimePlatform: 2752512
+    runtimePlatform: 8
     configurationProfile: {fileID: 0}
-    editorPlatform: 131204
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.VoiceInput.WindowsSpeechInputDeviceManager,
         Microsoft.MixedReality.Toolkit
     componentName: Windows Speech Input Manager
     priority: 10
-    runtimePlatform: 2752580
+    runtimePlatform: 9
     configurationProfile: {fileID: 0}
-    editorPlatform: 131204
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.VoiceInput.WindowsDictationInputDeviceManager,
         Microsoft.MixedReality.Toolkit
     componentName: Windows Dictation Input Manager
     priority: 10
-    runtimePlatform: 2752580
+    runtimePlatform: 9
     configurationProfile: {fileID: 0}
-    editorPlatform: 131204
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput.UnityTouchDeviceManager,
         Microsoft.MixedReality.Toolkit
@@ -59,4 +54,3 @@ MonoBehaviour:
     priority: 10
     runtimePlatform: -1
     configurationProfile: {fileID: 0}
-    editorPlatform: -1

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityComponentConfiguration.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityComponentConfiguration.cs
@@ -23,21 +23,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         /// <param name="priority">The priority this system, feature, or manager will be initialized in.</param>
         /// <param name="runtimePlatform">The runtime platform(s) to run this system, feature, or manager on.</param>
         /// <param name="configurationProfile">The configuration profile for the system, feature, or manager.</param>
-        /// <param name="editorPlatform">The editor platform(s) to run this system, feature, or manager on.</param>
-        public MixedRealityComponentConfiguration(SystemType componentType, string componentName, uint priority, RuntimePlatform runtimePlatform, ScriptableObject configurationProfile
-#if UNITY_EDITOR
-            , UnityEditor.BuildTarget editorPlatform
-#endif
-        )
+        public MixedRealityComponentConfiguration(SystemType componentType, string componentName, uint priority, SupportedPlatforms runtimePlatform, ScriptableObject configurationProfile)
         {
             this.componentType = componentType;
             this.componentName = componentName;
             this.priority = priority;
             this.runtimePlatform = runtimePlatform;
             this.configurationProfile = configurationProfile;
-#if UNITY_EDITOR
-            this.editorPlatform = editorPlatform;
-#endif
         }
 
         [SerializeField]
@@ -67,12 +59,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
 
         [EnumFlags]
         [SerializeField]
-        private RuntimePlatform runtimePlatform;
+        private SupportedPlatforms runtimePlatform;
 
         /// <summary>
         /// The runtime platform(s) to run this system, feature, or manager on.
         /// </summary>
-        public RuntimePlatform RuntimePlatform => runtimePlatform;
+        public SupportedPlatforms RuntimePlatform => runtimePlatform;
 
         [SerializeField]
         private ScriptableObject configurationProfile;
@@ -81,16 +73,5 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         /// The configuration profile for the system, feature, or manager.
         /// </summary>
         public ScriptableObject ConfigurationProfile => configurationProfile;
-
-#if UNITY_EDITOR
-        [EnumFlags]
-        [SerializeField]
-        private UnityEditor.BuildTarget editorPlatform;
-
-        /// <summary>
-        /// The editor platform(s) to run this system, feature, or manager on.
-        /// </summary>
-        public UnityEditor.BuildTarget EditorPlatform => editorPlatform;
-#endif
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/SupportedPlatforms.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities
+{
+    /// <summary>
+    /// The supported platforms for Mixed Reality Toolkit Components and Features.
+    /// </summary>
+    [Flags]
+    public enum SupportedPlatforms
+    {
+        WindowsStandalone = 1 << 0,
+        MacStandalone = 1 << 1,
+        LinuxStandalone = 1 << 2,
+        WindowsUniversal = 1 << 3,
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/SupportedPlatforms.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/SupportedPlatforms.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dca6753a2924f5d9301605e4f662702
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs
@@ -63,11 +63,9 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
                 var priority = managerConfig.FindPropertyRelative("priority");
                 priority.intValue = 10;
                 var runtimePlatform = managerConfig.FindPropertyRelative("runtimePlatform");
-                runtimePlatform.intValue = (int)Application.platform;
+                runtimePlatform.intValue = -1;
                 var configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
                 configurationProfile.objectReferenceValue = null;
-                var editorPlatform = managerConfig.FindPropertyRelative("editorPlatform");
-                editorPlatform.intValue = (int)EditorUserBuildSettings.activeBuildTarget;
                 serializedObject.ApplyModifiedProperties();
                 var componentType = ((MixedRealityRegisteredComponentsProfile)serializedObject.targetObject).Configurations[list.arraySize - 1].ComponentType;
                 componentType.Type = null;
@@ -98,7 +96,6 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
                 var componentType = managerConfig.FindPropertyRelative("componentType");
                 var priority = managerConfig.FindPropertyRelative("priority");
                 var runtimePlatform = managerConfig.FindPropertyRelative("runtimePlatform");
-                var editorPlatform = managerConfig.FindPropertyRelative("editorPlatform");
                 var configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
 
                 GUILayout.BeginVertical();
@@ -125,11 +122,11 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
                     EditorGUILayout.PropertyField(componentType);
                     EditorGUILayout.PropertyField(priority);
                     EditorGUILayout.PropertyField(runtimePlatform);
-                    EditorGUILayout.PropertyField(editorPlatform);
                     EditorGUILayout.PropertyField(configurationProfile);
 
                     if (EditorGUI.EndChangeCheck())
                     {
+                        serializedObject.ApplyModifiedProperties();
                         MixedRealityManager.Instance.ResetConfiguration(MixedRealityManager.Instance.ActiveProfile);
                     }
 

--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
@@ -192,21 +192,18 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
                 for (int i = 0; i < ActiveProfile.RegisteredComponentsProfile.Configurations?.Length; i++)
                 {
                     var configuration = ActiveProfile.RegisteredComponentsProfile.Configurations[i];
+
 #if UNITY_EDITOR
-                    if ((UnityEditor.EditorUserBuildSettings.activeBuildTarget & configuration.EditorPlatform) != 0 &&
-                        configuration.ComponentType.Type != null)
-                    {
-                        AddManager(typeof(IMixedRealityComponent), Activator.CreateInstance(configuration.ComponentType, configuration.ComponentName, configuration.Priority) as IMixedRealityComponent);
-                    }
+                    if (UnityEditor.EditorUserBuildSettings.activeBuildTarget.IsPlatformSupported(configuration.RuntimePlatform))
 #else
-                    if ((Application.platform & configuration.RuntimePlatform) != 0)
+                    if (Application.platform.IsPlatformSupported(configuration.RuntimePlatform))
+#endif
                     {
                         if (configuration.ComponentType.Type != null)
                         {
                             AddManager(typeof(IMixedRealityComponent), Activator.CreateInstance(configuration.ComponentType, configuration.ComponentName, configuration.Priority) as IMixedRealityComponent);
                         }
                     }
-#endif
                 }
             }
 

--- a/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
@@ -10,11 +10,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
     {
         public static bool IsPlatformSupported(this RuntimePlatform runtimePlatform, SupportedPlatforms platform)
         {
-            if (platform == (SupportedPlatforms)(-1))
-            {
-                return true;
-            }
-
             if (platform == 0)
             {
                 return false;
@@ -37,18 +32,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
                 case RuntimePlatform.LinuxEditor:
                     return (platform & SupportedPlatforms.LinuxStandalone) != 0;
                 default:
-                    return false;
+                    return true;
             }
         }
 
 #if UNITY_EDITOR
         public static bool IsPlatformSupported(this UnityEditor.BuildTarget editorBuildTarget, SupportedPlatforms platform)
         {
-            if (platform == (SupportedPlatforms)(-1))
-            {
-                return true;
-            }
-
             if (platform == 0)
             {
                 return false;
@@ -69,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
                 case UnityEditor.BuildTarget.StandaloneLinuxUniversal:
                     return (platform & SupportedPlatforms.LinuxStandalone) != 0;
                 default:
-                    return false;
+                    return true;
             }
         }
 #endif

--- a/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
@@ -12,17 +12,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
         {
             if (platform < 0)
             {
-                Debug.Log("All platforms supported!");
                 return true;
             }
 
             if (platform == 0)
             {
-                Debug.Log("No platforms supported");
                 return false;
             }
-
-            Debug.Log($"Supported {platform}");
 
             switch (runtimePlatform)
             {
@@ -41,7 +37,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
                 case RuntimePlatform.LinuxEditor:
                     return (platform & SupportedPlatforms.LinuxStandalone) != 0;
                 default:
-                    Debug.Log("No platforms supported");
                     return false;
             }
         }
@@ -51,17 +46,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
         {
             if (platform < 0)
             {
-                Debug.Log("All platforms supported!");
                 return true;
             }
 
             if (platform == 0)
             {
-                Debug.Log("No platforms supported");
                 return false;
             }
-
-            Debug.Log($"Supported {platform}");
 
             switch (editorBuildTarget)
             {
@@ -78,7 +69,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
                 case UnityEditor.BuildTarget.StandaloneLinuxUniversal:
                     return (platform & SupportedPlatforms.LinuxStandalone) != 0;
                 default:
-                    Debug.Log("No platforms supported");
                     return false;
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
@@ -10,9 +10,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
     {
         public static bool IsPlatformSupported(this RuntimePlatform runtimePlatform, SupportedPlatforms platform)
         {
-            if (platform == 0)
+            if (platform == (SupportedPlatforms)(-1))
             {
-                return false;
+                return true;
             }
 
             switch (runtimePlatform)
@@ -32,16 +32,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
                 case RuntimePlatform.LinuxEditor:
                     return (platform & SupportedPlatforms.LinuxStandalone) != 0;
                 default:
-                    return true;
+                    return false;
             }
         }
 
 #if UNITY_EDITOR
         public static bool IsPlatformSupported(this UnityEditor.BuildTarget editorBuildTarget, SupportedPlatforms platform)
         {
-            if (platform == 0)
+            if (platform == (SupportedPlatforms)(-1))
             {
-                return false;
+                return true;
             }
 
             switch (editorBuildTarget)
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
                 case UnityEditor.BuildTarget.StandaloneLinuxUniversal:
                     return (platform & SupportedPlatforms.LinuxStandalone) != 0;
                 default:
-                    return true;
+                    return false;
             }
         }
 #endif

--- a/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Utilities
+{
+    public static class PlatformUtility
+    {
+        public static bool IsPlatformSupported(this RuntimePlatform runtimePlatform, SupportedPlatforms platform)
+        {
+            if (platform < 0)
+            {
+                Debug.Log("All platforms supported!");
+                return true;
+            }
+
+            if (platform == 0)
+            {
+                Debug.Log("No platforms supported");
+                return false;
+            }
+
+            Debug.Log($"Supported {platform}");
+
+            switch (runtimePlatform)
+            {
+                case RuntimePlatform.WindowsPlayer:
+                case RuntimePlatform.WindowsEditor:
+                    return (platform & SupportedPlatforms.WindowsStandalone) != 0;
+                case RuntimePlatform.WSAPlayerARM:
+                case RuntimePlatform.WSAPlayerX86:
+                case RuntimePlatform.WSAPlayerX64:
+                case RuntimePlatform.XboxOne:
+                    return (platform & SupportedPlatforms.WindowsUniversal) != 0;
+                case RuntimePlatform.OSXEditor:
+                case RuntimePlatform.OSXPlayer:
+                    return (platform & SupportedPlatforms.MacStandalone) != 0;
+                case RuntimePlatform.LinuxPlayer:
+                case RuntimePlatform.LinuxEditor:
+                    return (platform & SupportedPlatforms.LinuxStandalone) != 0;
+                default:
+                    Debug.Log("No platforms supported");
+                    return false;
+            }
+        }
+
+#if UNITY_EDITOR
+        public static bool IsPlatformSupported(this UnityEditor.BuildTarget editorBuildTarget, SupportedPlatforms platform)
+        {
+            if (platform < 0)
+            {
+                Debug.Log("All platforms supported!");
+                return true;
+            }
+
+            if (platform == 0)
+            {
+                Debug.Log("No platforms supported");
+                return false;
+            }
+
+            Debug.Log($"Supported {platform}");
+
+            switch (editorBuildTarget)
+            {
+                case UnityEditor.BuildTarget.StandaloneWindows:
+                case UnityEditor.BuildTarget.StandaloneWindows64:
+                    return (platform & SupportedPlatforms.WindowsStandalone) != 0;
+                case UnityEditor.BuildTarget.WSAPlayer:
+                case UnityEditor.BuildTarget.XboxOne:
+                    return (platform & SupportedPlatforms.WindowsUniversal) != 0;
+                case UnityEditor.BuildTarget.StandaloneOSX:
+                    return (platform & SupportedPlatforms.MacStandalone) != 0;
+                case UnityEditor.BuildTarget.StandaloneLinux:
+                case UnityEditor.BuildTarget.StandaloneLinux64:
+                case UnityEditor.BuildTarget.StandaloneLinuxUniversal:
+                    return (platform & SupportedPlatforms.LinuxStandalone) != 0;
+                default:
+                    Debug.Log("No platforms supported");
+                    return false;
+            }
+        }
+#endif
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
     {
         public static bool IsPlatformSupported(this RuntimePlatform runtimePlatform, SupportedPlatforms platform)
         {
-            if (platform < 0)
+            if (platform == (SupportedPlatforms)(-1))
             {
                 return true;
             }
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
 #if UNITY_EDITOR
         public static bool IsPlatformSupported(this UnityEditor.BuildTarget editorBuildTarget, SupportedPlatforms platform)
         {
-            if (platform < 0)
+            if (platform == (SupportedPlatforms)(-1))
             {
                 return true;
             }

--- a/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/PlatformUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a77dca6c5c89447ca4330f72438bc150
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Overview
---
New registered component profile wasn't saving the platforms correctly bc unity's build targets and runtime platform enums were not bit flags.  

I added an enum with our supported platforms and added a little utility to check if the runtime time platform or build target matches our own supported mask.

I also fixed an issue where we were not saving our new values before resetting the profile.