### PR TITLE
Fix GetManager(s) calls in MixedRealityManager

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
@@ -721,14 +721,26 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
             }
             else
             {
-                //If no name provided, return all components of the same type. Else return the type/name combination.
+                // If no name provided, return all components of the same type. Else return the type/name combination.
                 if (string.IsNullOrWhiteSpace(managerName))
                 {
                     for (int i = 0; i < mixedRealityComponentsCount; i++)
                     {
-                        if (MixedRealityComponents[i].Item1.Name == type.Name)
+                        if (MixedRealityComponents[i].Item1.Name == type.Name ||
+                            MixedRealityComponents[i].Item2.GetType().Name == type.Name)
                         {
                             managers.Add(MixedRealityComponents[i].Item2);
+                            continue;
+                        }
+
+                        var interfaces = MixedRealityComponents[i].Item2.GetType().GetInterfaces();
+                        for (int j = 0; j < interfaces.Length; j++)
+                        {
+                            if (interfaces[j].Name == type.Name)
+                            {
+                                managers.Add(MixedRealityComponents[i].Item2);
+                                break;
+                            }
                         }
                     }
                 }
@@ -736,9 +748,22 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
                 {
                     for (int i = 0; i < mixedRealityComponentsCount; i++)
                     {
-                        if (MixedRealityComponents[i].Item1.Name == type.Name && MixedRealityComponents[i].Item2.Name == managerName)
+                        if (MixedRealityComponents[i].Item1.Name == type.Name &&
+                            MixedRealityComponents[i].Item2.Name == managerName)
                         {
                             managers.Add(MixedRealityComponents[i].Item2);
+                            continue;
+                        }
+
+                        var interfaces = MixedRealityComponents[i].Item2.GetType().GetInterfaces();
+                        for (int j = 0; j < interfaces.Length; j++)
+                        {
+                            if (interfaces[j].Name == type.Name &&
+                                MixedRealityComponents[i].Item2.Name == managerName)
+                            {
+                                managers.Add(MixedRealityComponents[i].Item2);
+                                break;
+                            }
                         }
                     }
                 }
@@ -941,6 +966,17 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
                 {
                     manager = MixedRealityComponents[i].Item2;
                     break;
+                }
+
+                var interfaces = MixedRealityComponents[i].Item2.GetType().GetInterfaces();
+                for (int j = 0; j < interfaces.Length; j++)
+                {
+                    if (interfaces[j].Name == type.Name &&
+                        MixedRealityComponents[i].Item2.Name == managerName)
+                    {
+                        manager = MixedRealityComponents[i].Item2;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Overview
---
After #2718, only one GetManager call was updated to actually check all interfaces. The others simply kept checking against the registered type, which is now IMixedRealityComponent for all components (causing them to return empty).

Basically, this is an expansion of the code added in e710233caeadf9238fb180a061e589fa61dfeadb to all component/manager getters.