### PR TITLE
Removed UWP from OpenVR supported platforms

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityRegisteredComponentsProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityRegisteredComponentsProfile.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
         Microsoft.MixedReality.Toolkit
     componentName: Unity Open VR Device Manager
     priority: 10
-    runtimePlatform: -1
+    runtimePlatform: 7
     configurationProfile: {fileID: 0}
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality.WindowsMixedRealityDeviceManager,


### PR DESCRIPTION
Overview
---
Unity does not include OpenVR as a valid VR SDK on UWP.

![image](https://user-images.githubusercontent.com/3580640/45328883-9e9e1880-b512-11e8-87cc-c95af4b19707.png)
