### PR TITLE
Hide the base InputSystemGlobalListener Start call if isFocusRequired is checked

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -33,6 +33,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
             }
         }
 
+        protected override void Start()
+        {
+            if (!isFocusRequired)
+            {
+                base.Start();
+            }
+        }
+
         protected override void OnDisable()
         {
             if (!isFocusRequired)


### PR DESCRIPTION
Overview
---
`InputSystemGlobalListener` registers as a global listener in `Start`, `OnEnable`, and `OnDisable`. `BaseInputHandler` properly hides the registration in `OnEnable` and `OnDisable`, but did not in `Start`.

Changes
---
- Fixes: #2786
