### PR TITLE
[Solver PR 3.5] SolverHandler bug fixes

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -11,7 +11,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
     /// <summary>
     /// This class handles the solver components that are attached to this <see cref="GameObject"/>
     /// </summary>
-    [DisallowMultipleComponent]
     public class SolverHandler : MonoBehaviour
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -28,8 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
                 if (trackedObjectToReference != value)
                 {
                     trackedObjectToReference = value;
-                    TransformTarget = null;
-                    AttachToNewTrackedObject();
+                    RefreshTrackedObject();
                 }
             }
         }
@@ -174,6 +173,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
         }
 
         #endregion MonoBehaviour Implementation
+
+        /// <summary>
+        /// Clears the transform target and attaches to the current <see cref="TrackedObjectToReference"/>.
+        /// </summary>
+        public void RefreshTrackedObject()
+        {
+            transformTarget = null;
+            AttachToNewTrackedObject();
+        }
 
         protected virtual void AttachToNewTrackedObject()
         {

--- a/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -207,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
                 transformWithOffset.transform.parent = parentTransform;
             }
 
-            transformWithOffset.transform.localPosition = AdditionalOffset;
+            transformWithOffset.transform.localPosition = Vector3.Scale(AdditionalOffset, transformWithOffset.transform.localScale);
             transformWithOffset.transform.localRotation = Quaternion.Euler(AdditionalRotation);
             transformWithOffset.name = string.Format("{0} on {1} with offset {2}, {3}", gameObject.name, TrackedObjectToReference.ToString(), AdditionalOffset, AdditionalRotation);
             return transformWithOffset.transform;


### PR DESCRIPTION
Overview
---
Removed `[DisallowMultipleComponent]` as it shouldn't have been added in the first place and the InBetween solver depends on multiple handlers.
Refactored out `RefreshTrackedObject()` as a public method to facilitate runtime refreshes.
Fixed a bug where a solver's parent's scale wasn't being accounted for in the desired solver offset, so offsets could be larger or smaller in world space than expected.