### PR TITLE
Update WMR source naming to include Voice

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
             }
 
             var pointers = interactionSource.supportsPointing ? RequestPointers(typeof(WindowsMixedRealityController), controllingHand) : null;
-            string nameModifier = controllingHand == Handedness.None ? "Hand" : controllingHand.ToString();
+            string nameModifier = controllingHand == Handedness.None ? interactionSource.kind.ToString() : controllingHand.ToString();
             var inputSource = InputSystem?.RequestNewGenericInputSource($"Mixed Reality Controller {nameModifier}", pointers);
             var detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
 


### PR DESCRIPTION
Overview
---
Currently, the manager assumes that any source without a handedness is a hand. However, it can also be voice, which comes across the `InteractionManager` events as a select press and release when "Select" is spoken.