### PR TITLE
Fixed pointer registration.

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -18,8 +18,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
     {
         public CursorStateEnum CursorState { get; private set; } = CursorStateEnum.None;
 
-        public bool SetVisibilityOnSourceDetected { get; set; } = false;
-
         /// <summary>
         /// Surface distance to place the cursor off of the surface at
         /// </summary>
@@ -110,6 +108,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Cursors
                 PrimaryCursorVisual.gameObject.SetActive(visible);
             }
         }
+
+        /// <inheritdoc />
+        public bool SetVisibilityOnSourceDetected { get; set; } = false;
 
         /// <inheritdoc />
         public GameObject GameObjectReference => gameObject;

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -11,9 +11,9 @@ using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.Physics;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.TeleportSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
 using System.Collections;
-using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
@@ -129,7 +129,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         protected override void OnEnable()
         {
             base.OnEnable();
-            SetCursor();
 
             if (MixedRealityManager.IsInitialized && TeleportSystem != null && !lateRegisterTeleport)
             {
@@ -146,6 +145,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                 await new WaitUntil(() => TeleportSystem != null);
                 lateRegisterTeleport = false;
                 TeleportSystem.Register(gameObject);
+            }
+
+            if (InputSystem == null)
+            {
+                await WaitUntilInputSystemValid;
+                SetCursor();
             }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityCursor.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityCursor.cs
@@ -42,6 +42,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// <param name="visible">True if cursor should be visible, false if not.</param>
         void SetVisibility(bool visible);
 
+        /// <summary>
+        /// Sets the visibility of the <see cref="IMixedRealityCursor"/> when the source is detected.
+        /// </summary>
         bool SetVisibilityOnSourceDetected { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Overview
---
- Also waited until the input system is valid before setting the cursor.
- We should only be setting the cursor once in Start, not on each Enable.
- Added documentation to cursor interface and moved the property into the cursor implementation region of the class.

Changes
---
- Fixes: https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/2752
