### PR TITLE
Alternate implementation for Solver Handler Scene Object attachment

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
         /// <summary>
         /// Is Focus required to receive input events on this GameObject?
         /// </summary>
-        public bool IsFocusRequired
+        public virtual bool IsFocusRequired
         {
             get { return isFocusRequired; }
             set { isFocusRequired = value; }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Controllers/MixedRealityControllerVisualizer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Controllers/MixedRealityControllerVisualizer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces;
 using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
 using UnityEngine;
 
@@ -11,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Controllers
     /// The Mixed Reality Visualization component is primarily responsible for synchronizing the user's current input with controller models.
     /// </summary>
     /// <seealso cref="Core.Definitions.Devices.MixedRealityControllerMappingProfile"/>
-    public class MixedRealityControllerVisualizer : ControllerPoseSynchronizer
+    public class MixedRealityControllerVisualizer : ControllerPoseSynchronizer, IMixedRealitySceneObject
     {
         // TODO wire up input actions to controller transform nodes / animations
 
@@ -70,5 +71,36 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Controllers
         }
 
         #endregion IMixedRealityInputHandler Implementation
+
+        #region IMixedRealitySceneObject Implementation 
+
+        /// <inheritdoc />
+        public void RegisterSceneObject()
+        {
+            Core.Managers.MixedRealityManager.Instance.MixedRealitySceneObjects.Add(this);
+        }
+
+        /// <inheritdoc />
+        public void UnregisterSceneObject()
+        {
+            Core.Managers.MixedRealityManager.Instance.MixedRealitySceneObjects.Remove(this);
+        }
+
+        #endregion IMixedRealitySceneObject Implementation 
+
+        #region MonoBehaviour Implementation
+
+        protected override void OnEnable()
+        {
+            RegisterSceneObject();
+            base.OnEnable();
+        }
+        protected override void OnDisable()
+        {
+            UnregisterSceneObject();
+            base.OnDisable();
+        }
+
+        #endregion MonoBehaviour Implementation
     }
 }

--- a/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -2,7 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
+using Microsoft.MixedReality.Toolkit.Core.Managers;
 using Microsoft.MixedReality.Toolkit.Core.Utilities;
+using Microsoft.MixedReality.Toolkit.SDK.UX.Controllers;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -11,11 +16,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
     /// <summary>
     /// This class handles the solver components that are attached to this <see cref="GameObject"/>
     /// </summary>
-    public class SolverHandler : MonoBehaviour
+    public class SolverHandler : MonoBehaviour, IMixedRealitySourceStateHandler
     {
         [SerializeField]
         [Tooltip("Tracked object to calculate position and orientation from. If you want to manually override and use a scene object, use the TransformTarget field.")]
-        private TrackedObjectType trackedObjectToReference = TrackedObjectType.Head;
+        private TrackedObjectType trackedObjectToReference = TrackedObjectType.None;
 
         /// <summary>
         /// Tracked object to calculate position and orientation from. If you want to manually override and use a scene object, use the TransformTarget field.
@@ -129,6 +134,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
 
         private void Awake()
         {
+            //Register this GameObject to receive Input System Events.
+            MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>()?.Register(this.gameObject);
+
             GoalScale = Vector3.one;
             AltScale = new Vector3Smoothed(Vector3.one, 0.1f);
             DeltaTime = 0.0f;
@@ -136,7 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
             solvers.AddRange(GetComponents<Solver>());
 
             // TransformTarget overrides TrackedObjectToReference
-            if (!TransformTarget)
+            if (trackedObjectToReference != TrackedObjectType.None)
             {
                 AttachToNewTrackedObject();
             }
@@ -190,8 +198,35 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
                 case TrackedObjectType.Head:
                     TrackTransform(CameraCache.Main.transform);
                     break;
-                // Other cases will come online as ControllerFinder is ported appropriately.
+                case TrackedObjectType.LeftController:
+                    var leftController = GetVisualizerForHand(Handedness.Left);
+                    if (leftController != null)
+                    {
+                        TrackTransform(leftController.gameObject.transform);
+                    }
+                    break;
+                case TrackedObjectType.RightController:
+                    var rightController = GetVisualizerForHand(Handedness.Right);
+                    if (rightController != null)
+                    {
+                        TrackTransform(rightController.gameObject.transform);
+                    }
+                    break;
+
+                    // Other cases will come online as ControllerFinder is ported appropriately.
             }
+        }
+
+        private MixedRealityControllerVisualizer GetVisualizerForHand(Handedness hand)
+        {
+            foreach (MixedRealityControllerVisualizer controller in MixedRealityManager.Instance.MixedRealitySceneObjects)
+            {
+                if (controller.Handedness == hand)
+                {
+                    return controller;
+                }
+            }
+            return null;
         }
 
         private void TrackTransform(Transform newTrackedTransform)
@@ -212,5 +247,29 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
             transformWithOffset.name = string.Format("{0} on {1} with offset {2}, {3}", gameObject.name, TrackedObjectToReference.ToString(), AdditionalOffset, AdditionalRotation);
             return transformWithOffset.transform;
         }
+
+        #region IMixedRealitySourceStateHandler implementation
+
+        public void OnSourceDetected(SourceStateEventData eventData)
+        {
+            if (trackedObjectToReference != TrackedObjectType.None)
+            {
+                AttachToNewTrackedObject();
+            }
+        }
+
+        public void OnSourceLost(SourceStateEventData eventData)
+        {
+            if (transformWithOffset != null)
+            {
+                Destroy(transformWithOffset);
+            }
+            if (trackedObjectToReference != TrackedObjectType.None)
+            {
+                TransformTarget = null;
+            }
+        }
+
+        #endregion IMixedRealitySourceStateHandler implementation
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/TrackedObjectType.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/TrackedObjectType.cs
@@ -3,19 +3,26 @@
 
 namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities
 {
+    /// <summary>
+    /// Defines the types of automatic objects that can be tracked
+    /// </summary>
     public enum TrackedObjectType
     {
         /// <summary>
+        /// Do not automatically track an object, use the manual reference instead.
+        /// </summary>
+        None = 0,
+        /// <summary>
         /// Calculates position and orientation from the main camera.
         /// </summary>
-        Head = 0,
+        Head,
         /// <summary>
-        /// Calculates position and orientation from the left motion-tracked controller.
+        /// Calculates position and orientation from the left tracked controller.
         /// </summary>
-        MotionControllerLeft,
+        LeftController,
         /// <summary>
-        /// Calculates position and orientation from the right motion-tracked controller.
+        /// Calculates position and orientation from the right tracked controller.
         /// </summary>
-        MotionControllerRight
+        RightController
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealitySceneObject.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealitySceneObject.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.MixedReality.Toolkit.Core.Interfaces
+{
+    /// <summary>
+    /// Generic interface for all optional Mixed Reality systems, components, or features that can be added to the <see cref="Definitions.MixedRealityComponentConfiguration"/>
+    /// </summary>
+    public interface IMixedRealitySceneObject 
+    {
+        /// <summary>
+        /// Register the gameobject with the Mixed Reality Manager Scene Object registry
+        /// </summary>
+        void RegisterSceneObject();
+
+        /// <summary>
+        /// Unregister the gameobject with the Mixed Reality Manager Scene Object registry
+        /// </summary>
+        void UnregisterSceneObject();
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealitySceneObject.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/IMixedRealitySceneObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 476f4b965873e624e9f2b429267c16ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
@@ -115,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
         #endregion Mixed Reality runtime component registry
 
         #region Mixed Reality scene object registry
-        public List<IMixedRealitySceneObject> MixedRealitySceneObjects { get; set; } = new List<IMixedRealitySceneObject>();
+        public List<IMixedRealitySceneObject> MixedRealitySceneObjects { get; } = new List<IMixedRealitySceneObject>();
         #endregion Mixed Reality scene object registry
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
@@ -114,6 +114,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
 
         #endregion Mixed Reality runtime component registry
 
+        #region Mixed Reality scene object registry
+        public List<IMixedRealitySceneObject> MixedRealitySceneObjects { get; set; } = new List<IMixedRealitySceneObject>();
+        #endregion Mixed Reality scene object registry
+
         /// <summary>
         /// Function called when the instance is assigned.
         /// Once all managers are registered and properties updated, the Mixed Reality Manager will initialize all active managers.


### PR DESCRIPTION
Overview
---
This implementation enables the Mixed Reality manager to keep a track of any Scene Objects created in the scene by devices and makes them available for Scene components.

This is a preliminary check-in for review

It's critical that devices are not polled or "part" of a scene.  The Current MixedRealityControllerVisualizer is a representation of a controller in a scene, the GameObject of the controller.
To this the device layer appends the SourcePoseController to enable input events from the controller to manipulate the Controller Game object.

This implementation has enabled the Visualizer to register it's existence with the MixedRealityManager, so that other scripts can easily query for the gameobjects for the controllers in the scene.  Scene objects interacting with scene objects.

*Note* **No parts of the device layer have been modified for this implementation**.

Please review and comment where further changes are needed, 

> Additionally, this solves issue #2790 

Changes
---
- Adds new Scene Object Registration system to the Mixed Reality manager (currently "limited to" MotionControllerVisualizers)
 - Adds functionality to the SolverHandler to grab the correct handed controller from the Scene Object Registration
- Added the ISourceStatehandler implementation to the SolverHandler, so it can refresh the solver when a controller is attached / detached.

TODO
---
This is a preliminary implementation, Ideally the Scene Object Registry should be able to handle any game object, but this requires a fair amount of additional design.

# Registry notes

This brings the registry count up to 3, the distinct registries and their purpose are as follows:

* Core manager Registry - Unique registry for managers where there can only ever ne a single instance in operation (e.g. InputSystem, BoundarySystem). Each manager receives all Unity events coordinated through the MR Manager.
* Component Registry - Emulates the managers registry, except allows multiple components to be added.  Each manager receives all Unity events coordinated through the MR Manager.
* Scene Object Registry - List of referencable Scene objects, to avoid use of "FindObjectOfType" lookups.  Used for regularly queries scene objects critical to a project (e.g. VR Controllers represented in a scene)