### PR TITLE
Gazeprovider input system issue due to scene loads

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
@@ -8,7 +9,6 @@ using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
 using Microsoft.MixedReality.Toolkit.Core.Utilities;
-using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using Microsoft.MixedReality.Toolkit.Core.Utilities.Physics;
 using Microsoft.MixedReality.Toolkit.InputSystem.Pointers;
 using Microsoft.MixedReality.Toolkit.InputSystem.Sources;
@@ -389,9 +389,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             return gazePointer = new InternalGazePointer(this, "Gaze Pointer", null, raycastLayerMasks, maxGazeCollisionDistance, gazeTransform, stabilizer);
         }
 
-        private async void RaiseSourceDetected()
+        private void RaiseSourceDetected() 
         {
-            await WaitUntilInputSystemValid;
+            StartCoroutine(RaiseSource());
+        }
+
+        private IEnumerator RaiseSource() 
+        {
+            while (InputSystem == null) yield return null;
             InputSystem.RaiseSourceDetected(GazeInputSource);
             GazePointer.BaseCursor?.SetVisibility(true);
         }

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
@@ -18,8 +18,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
         private bool lateInitialize = true;
 
-//        protected readonly WaitUntil WaitUntilInputSystemValid = new WaitUntil(() => InputSystem != null);
-
         protected virtual void OnEnable()
         {
             if (MixedRealityManager.IsInitialized && InputSystem != null && !lateInitialize)

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/InputSystemGlobalListener.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
-using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.Input
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
         private bool lateInitialize = true;
 
-        protected readonly WaitUntil WaitUntilInputSystemValid = new WaitUntil(() => InputSystem != null);
+//        protected readonly WaitUntil WaitUntilInputSystemValid = new WaitUntil(() => InputSystem != null);
 
         protected virtual void OnEnable()
         {
@@ -28,19 +28,24 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             }
         }
 
-        protected virtual async void Start()
-        {
-            if (lateInitialize)
-            {
-                await WaitUntilInputSystemValid;
-                lateInitialize = false;
-                InputSystem.Register(gameObject);
-            }
-        }
-
         protected virtual void OnDisable()
         {
             InputSystem?.Unregister(gameObject);
+        }
+        
+        protected virtual void Start()
+        {
+            if (lateInitialize)
+            {
+                StartCoroutine(Register());
+            }
+        }
+
+        private IEnumerator Register() 
+        {
+            while (InputSystem == null) yield return null;
+            lateInitialize = false;
+            InputSystem.Register(gameObject);
         }
     }
 }


### PR DESCRIPTION
Overview
---
WaitUntil() InputSystem is active did not work for multiple scene setup. It did not continue despite the InputSystem was !=null from the beginning.
Workaround for: https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/2744

Changes
---
- Fixes: # .
