### PR TITLE
Updated config profiles

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Boundary/MixedRealityBoundaryManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Boundary/MixedRealityBoundaryManager.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.BoundarySystem
             boundaryEventData = new BoundaryEventData(EventSystem.current);
 
             Scale = MixedRealityManager.Instance.ActiveProfile.TargetExperienceScale;
-            BoundaryHeight = MixedRealityManager.Instance.ActiveProfile.BoundaryHeight;
+            BoundaryHeight = MixedRealityManager.Instance.ActiveProfile.BoundaryVisualizationProfile.BoundaryHeight;
 
             SetTrackingSpace();
             CalculateBoundaryBounds();

--- a/Assets/MixedRealityToolkit-SDK/Features/Teleportation/MixedRealityTeleportManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Teleportation/MixedRealityTeleportManager.cs
@@ -74,7 +74,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Teleportation
             }
 #endif // UNITY_EDITOR
 
-            TeleportDuration = MixedRealityManager.Instance.ActiveProfile.TeleportDuration;
             teleportEventData = new TeleportEventData(EventSystem.current);
         }
 

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
@@ -12,9 +12,11 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityConfigurationProfile
   m_EditorClassIdentifier: 
   initialManagerTypes:
-  - reference: Microsoft.MixedReality.Toolkit.SDK.Input.MixedRealityInputManager,
+  - reference: Microsoft.MixedReality.Toolkit.SDK.Teleportation.MixedRealityTeleportManager,
       Microsoft.MixedReality.Toolkit.SDK
   - reference: Microsoft.MixedReality.Toolkit.SDK.BoundarySystem.MixedRealityBoundaryManager,
+      Microsoft.MixedReality.Toolkit.SDK
+  - reference: Microsoft.MixedReality.Toolkit.SDK.Input.MixedRealityInputManager,
       Microsoft.MixedReality.Toolkit.SDK
   targetExperienceScale: 3
   enableCameraProfile: 1
@@ -28,7 +30,6 @@ MonoBehaviour:
   boundarySystemType:
     reference: Microsoft.MixedReality.Toolkit.SDK.BoundarySystem.MixedRealityBoundaryManager,
       Microsoft.MixedReality.Toolkit.SDK
-  boundaryHeight: 3
   boundaryVisualizationProfile: {fileID: 11400000, guid: 6d28cce596b44bd3897ca86f8b24e076,
     type: 2}
   enableTeleportSystem: 1

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -12,6 +12,18 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
     public class MixedRealityBoundaryVisualizationProfile : ScriptableObject
     {
+        [SerializeField]
+        [Tooltip("The approximate height of the play space, in meters.")]
+        private float boundaryHeight = 3.0f;
+
+        /// <summary>
+        /// The developer defined height of the boundary, in meters.
+        /// </summary>
+        /// <remarks>
+        /// The BoundaryHeight property is used to create a three dimensional volume for the play space.
+        /// </remarks>
+        public float BoundaryHeight => boundaryHeight;
+
         #region Floor settings
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -150,18 +150,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         }
 
         [SerializeField]
-        [Tooltip("The approximate height of the play space, in meters.")]
-        private float boundaryHeight = 3.0f;
-
-        /// <summary>
-        /// The developer defined height of the boundary, in meters.
-        /// </summary>
-        /// <remarks>
-        /// The BoundaryHeight property is used to create a three dimensional volume for the play space.
-        /// </remarks>
-        public float BoundaryHeight => boundaryHeight;
-
-        [SerializeField]
         [Tooltip("Profile for wiring up boundary visualization assets.")]
         private MixedRealityBoundaryVisualizationProfile boundaryVisualizationProfile;
 
@@ -199,19 +187,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         {
             get { return teleportSystemType; }
             private set { teleportSystemType = value; }
-        }
-
-        [SerializeField]
-        [Tooltip("The duration of the teleport in seconds.")]
-        private float teleportDuration = 0.25f;
-
-        /// <summary>
-        /// The duration of the teleport in seconds.
-        /// </summary>
-        public float TeleportDuration
-        {
-            get { return teleportDuration; }
-            set { teleportDuration = value; }
         }
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem;
+using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using UnityEditor;
 using UnityEngine;
@@ -11,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
     [CustomEditor(typeof(MixedRealityBoundaryVisualizationProfile))]
     public class MixedRealityBoundaryVisualizationProfileInspector : MixedRealityBaseConfigurationProfileInspector
     {
+        private SerializedProperty boundaryHeight;
         private SerializedProperty showFloor;
         private SerializedProperty floorMaterial;
         private SerializedProperty floorScale;
@@ -37,6 +39,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 return;
             }
+
+            boundaryHeight = serializedObject.FindProperty("boundaryHeight");
 
             showFloor = serializedObject.FindProperty("showFloor");
             floorMaterial = serializedObject.FindProperty("floorMaterial");
@@ -71,8 +75,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Boundary Visualization Options", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("Boundary visualizations can help users stay oriented and comfortable in the experience.", MessageType.Info);
+            // Boundary settings depend on the experience scale
+            if (MixedRealityManager.Instance.ActiveProfile.TargetExperienceScale != ExperienceScale.Room)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.HelpBox("Boundary visualization is only supported in Room scale experiences.", MessageType.Warning);
+            }
             EditorGUILayout.Space();
             serializedObject.Update();
+            EditorGUILayout.PropertyField(boundaryHeight);
+            EditorGUILayout.Space();
             EditorGUILayout.LabelField("Floor Settings:", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(showFloor, showContent);
             EditorGUILayout.PropertyField(floorMaterial, materialContent);

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -26,11 +26,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         // Boundary system properties
         private SerializedProperty enableBoundarySystem;
         private SerializedProperty boundarySystemType;
-        private SerializedProperty boundaryHeight;
         // Teleport system properties
         private SerializedProperty enableTeleportSystem;
         private SerializedProperty teleportSystemType;
-        private SerializedProperty teleportDuration;
         private SerializedProperty boundaryVisualizationProfile;
 
         private SerializedProperty registeredComponentsProfile;
@@ -87,11 +85,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             // Boundary system configuration
             enableBoundarySystem = serializedObject.FindProperty("enableBoundarySystem");
             boundarySystemType = serializedObject.FindProperty("boundarySystemType");
-            boundaryHeight = serializedObject.FindProperty("boundaryHeight");
             // Teleport system configuration
             enableTeleportSystem = serializedObject.FindProperty("enableTeleportSystem");
             teleportSystemType = serializedObject.FindProperty("teleportSystemType");
-            teleportDuration = serializedObject.FindProperty("teleportDuration");
             boundaryVisualizationProfile = serializedObject.FindProperty("boundaryVisualizationProfile");
             registeredComponentsProfile = serializedObject.FindProperty("registeredComponentsProfile");
         }
@@ -166,17 +162,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.LabelField("Boundary System Settings", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(enableBoundarySystem);
             EditorGUILayout.PropertyField(boundarySystemType);
+            changed |= RenderProfile(boundaryVisualizationProfile);
 
             // Boundary settings depend on the experience scale
-            if (scale == ExperienceScale.Room)
-            {
-                EditorGUILayout.PropertyField(boundaryHeight);
-                changed |= RenderProfile(boundaryVisualizationProfile);
-            }
-            else
+            if (scale != ExperienceScale.Room)
             {
                 GUILayout.Space(6f);
-                EditorGUILayout.HelpBox("Boundary visualization is only supported in Room scale experiences.", MessageType.Info);
+                EditorGUILayout.HelpBox("Boundary visualization is only supported in Room scale experiences.", MessageType.Warning);
             }
 
             // Teleport System configuration
@@ -184,7 +176,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.LabelField("Teleport System Settings", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(enableTeleportSystem);
             EditorGUILayout.PropertyField(teleportSystemType);
-            EditorGUILayout.PropertyField(teleportDuration);
 
             GUILayout.Space(12f);
             changed |= RenderProfile(registeredComponentsProfile);


### PR DESCRIPTION
Overview
---
We want to make sure that all feature specific settings are encapsulated in the feature's profile. Boundary height should have been part of the boundary viz profile.

- moved boundary height into boundary visualization profile.
- made sure boundary profile wasn't hidden when experience setting wasn't set to room.
- removed teleport duration from main config profile, as it's currently unimplemented anyway.
