### PR TITLE
vNext: InteractionReceiver base class

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -17,10 +17,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
         /// <summary>
         /// Is Focus required to receive input events on this GameObject?
         /// </summary>
-        public bool IsFocusRequired
+        public virtual bool IsFocusRequired
         {
             get { return isFocusRequired; }
-            set { isFocusRequired = value; }
+            protected set { isFocusRequired = value; }
         }
 
         #region MonoBehaviour Implementation

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers.meta
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd737bd28d8472d4dba5eb4ff18424ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -123,7 +123,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             interactables.Add(interactable);
         }
 
-#if UNITY_EDITOR
         /// <summary>
         /// When selected draw lines to all linked interactables
         /// </summary>
@@ -157,7 +156,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
                 }
             }
         }
-#endif
 
         /// <summary>
         /// Function to remove an interactable from the linked list.
@@ -237,17 +235,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 
         public void OnFocusChanged( FocusEventData eventData )
         {
-            FocusEventData newData = new FocusEventData( EventSystem.current );
-            newData.Initialize( eventData.Pointer );
-
             if ( eventData.NewFocusedObject != null && IsInteractable( eventData.NewFocusedObject ) )
             {
-                FocusEnter( eventData.NewFocusedObject, newData );
+                FocusEnter( eventData.NewFocusedObject, eventData );
             }
 
             if ( eventData.OldFocusedObject != null && IsInteractable( eventData.OldFocusedObject ) )
             {
-                FocusExit( eventData.OldFocusedObject, newData );
+                FocusExit( eventData.OldFocusedObject, eventData );
             }
 
             CheckLockFocus( eventData.Pointer );

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -60,15 +60,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 
         #endregion
 
-        #region private variables
         /// <summary>
         /// When true, this interaction receiver will draw connections in the editor to Interactables and Targets
         /// </summary>
         [Tooltip( "When true, this interaction receiver will draw connections in the editor to Interactables and Targets" )]
         [SerializeField]
         private bool drawEditorConnections = true;
-        
-        #endregion
+
+        #region MonoBehaviour implementation
 
         /// <summary>
         /// On enable, set the BaseInputHandler's IsFocusRequired to false to receive all events.
@@ -77,20 +76,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         {
             IsFocusRequired = false;
             base.OnEnable();
-        }
-
-        /// <summary>
-        /// Register an interactable with this receiver.
-        /// </summary>
-        /// <param name="interactable">takes a GameObject as the interactable to register.</param>
-        public virtual void RegisterInteractable( GameObject interactable )
-        {
-            if ( interactable == null || interactables.Contains( interactable ) )
-            {
-                return;
-            }
-
-            interactables.Add( interactable );
         }
 
         /// <summary>
@@ -130,6 +115,21 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        #endregion
+
+        /// <summary>
+        /// Register an interactable with this receiver.
+        /// </summary>
+        /// <param name="interactable">takes a GameObject as the interactable to register.</param>
+        public virtual void RegisterInteractable( GameObject interactable )
+        {
+            if ( interactable == null || interactables.Contains( interactable ) )
+            {
+                return;
+            }
+
+            interactables.Add( interactable );
+        }
 
         /// <summary>
         /// Function to remove an interactable from the linked list.
@@ -166,6 +166,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             return ( interactables != null && interactables.Contains( interactable ) );
         }
 
+        #region Global Listener Callbacks
+
         public void OnBeforeFocusChange( FocusEventData eventData ) { /*Unused*/ }
 
         public void OnFocusChanged( FocusEventData eventData )
@@ -180,8 +182,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
                 FocusExit( eventData.OldFocusedObject, eventData );
             }
         }
-
-        #region Global Listener Callbacks
 
         public void OnGestureStarted( InputEventData eventData )
         {
@@ -244,6 +244,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
 
         }
+
         public void OnGestureCompleted( InputEventData<Vector2> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -270,7 +271,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
 
         }
-
         public void OnGestureCanceled( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -278,6 +278,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
                 GestureCanceled( eventData.selectedObject, eventData );
             }
         }
+
         public void OnInputUp( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -385,6 +385,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         #endregion
 
         #region Protected Virtual Callback Functions
+
         protected virtual void FocusEnter(GameObject obj, FocusEventData eventData ) { }
         protected virtual void FocusExit(GameObject obj, FocusEventData eventData ) { }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -1,0 +1,414 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using System.Collections.Generic;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
+using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
+using Microsoft.MixedReality.Toolkit.Core.Managers;
+using Microsoft.MixedReality.Toolkit.SDK.Input;
+using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
+
+namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
+{
+    /// <summary>
+    /// An interaction receiver is simply a component that attached to a list of interactable objects and does something
+    /// based on events from those interactable objects.  This is the base abstract class to extend from.
+    /// </summary>
+    public abstract class InteractionReceiver : BaseInputHandler,
+        IMixedRealityFocusChangedHandler,
+        IMixedRealityGestureHandler,
+        IMixedRealityInputHandler,
+        IMixedRealityGestureHandler<Vector2>,
+        IMixedRealityGestureHandler<Vector3>,
+        IMixedRealityGestureHandler<Quaternion>
+
+    {
+        #region Public Members
+        /// <summary>
+        /// List of linked interactable objects to receive events for
+        /// </summary>
+        [SerializeField]
+        [ Tooltip("Target interactable Object to receive events for")]
+        private List<GameObject> interactables = new List<GameObject>();
+
+        public List<GameObject> Interactables
+        {
+            get { return interactables; }
+            set { value = interactables; }
+        }
+
+        /// <summary>
+        /// List of linked targets that the receiver affects
+        /// </summary>
+        [Tooltip("Targets for the receiver to ")]
+        private List<GameObject> targets = new List<GameObject>();
+
+        public List<GameObject> Targets
+        {
+            get { return targets; }
+            set { value = targets; }
+        }
+
+        [Tooltip( "If true, this object will remain the prime focus while select is held" )]
+        [SerializeField]
+        private bool lockFocus = false;
+
+        /// <summary>
+        /// Flag for locking focus while selected
+        /// </summary>
+        public bool LockFocus
+        {
+            get
+            {
+                return lockFocus;
+            }
+            set
+            {
+                lockFocus = value;
+                CheckLockFocus(_selectingFocuser);
+            }
+        }
+        
+        #endregion
+
+        #region Private and Protected Members
+
+        /// <summary>
+        /// Protected focuser for the current selecting focuser
+        /// </summary>
+        protected IMixedRealityPointer _selectingFocuser;
+        
+        #endregion
+
+        /// <summary>
+        /// On start subscribe to all interaction events on elements in the interactables list.
+        /// </summary>
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            //Still need to register since focus isn't required
+            if(InputSystem != null && InputSystem.IsInputEnabled)
+            {
+                InputSystem.Register( gameObject );
+            }
+        }
+
+        /// <summary>
+        /// On disable remove all linked interactables from the delegate functions
+        /// </summary>
+        protected override void OnDisable()
+        {
+            //Clean up our event subscription
+            if ( InputSystem != null && InputSystem.IsInputEnabled )
+            {
+                InputSystem.Unregister( gameObject );
+            }
+            base.OnDisable();
+        }
+
+        /// <summary>
+        /// Register an interactable with this receiver.
+        /// </summary>
+        /// <param name="interactable">takes a GameObject as the interactable to register.</param>
+        public virtual void Registerinteractable(GameObject interactable)
+        {
+            if (interactable == null || interactables.Contains(interactable))
+            {
+                return;
+            }
+            interactables.Add(interactable);
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// When selected draw lines to all linked interactables
+        /// </summary>
+        protected virtual void OnDrawGizmosSelected()
+        {
+            if (this.interactables.Count > 0)
+            {
+                GameObject[] bioList = this.interactables.ToArray();
+
+                for (int i = 0; i < bioList.Length; i++)
+                {
+                    if (bioList[i] != null)
+                    {
+                        Gizmos.color = Color.green;
+                        Gizmos.DrawLine(this.transform.position, bioList[i].transform.position);
+                    }
+                }
+            }
+
+            if (this.Targets.Count > 0)
+            {
+                GameObject[] targetList = this.Targets.ToArray();
+
+                for (int i = 0; i < targetList.Length; i++)
+                {
+                    if (targetList[i] != null)
+                    {
+                        Gizmos.color = Color.red;
+                        Gizmos.DrawLine(this.transform.position, targetList[i].transform.position);
+                    }
+                }
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Function to remove an interactable from the linked list.
+        /// </summary>
+        /// <param name="interactable"></param>
+        public virtual void Removeinteractable(GameObject interactable)
+        {
+            if (interactable != null && interactables.Contains(interactable))
+            {
+                interactables.Remove(interactable);
+            }
+        }
+
+        /// <summary>
+        /// Clear the interactables list and unregister them
+        /// </summary>
+        public virtual void ClearInteractables()
+        {
+            GameObject[] _intList = interactables.ToArray();
+
+            for (int i = 0; i < _intList.Length; i++)
+            {
+                this.Removeinteractable(_intList[i]);
+            }
+        }
+
+        /// <summary>
+        /// Is the game object interactable in our list of interactables
+        /// </summary>
+        /// <param name="interactable"></param>
+        /// <returns></returns>
+        protected bool IsInteractable(GameObject interactable)
+        {
+            return (interactables != null && interactables.Contains(interactable));
+        }
+
+        private void CheckLockFocus( IMixedRealityPointer focuser )
+        {
+            // If our previous selecting focuser isn't the same
+            if (_selectingFocuser != null && _selectingFocuser != focuser)
+            {
+                // If our focus is currently locked, unlock it before moving on
+                if (LockFocus)
+                {
+                    _selectingFocuser.IsFocusLocked = false;
+                }
+            }
+
+            // Set to the new focuser
+            _selectingFocuser = focuser;
+            if (_selectingFocuser != null)
+            {
+                _selectingFocuser.IsFocusLocked = LockFocus;
+            }
+        }
+
+        private void LockFocuser( IMixedRealityPointer focuser )
+        {
+            if (focuser != null)
+            {
+                ReleaseFocuser();
+                _selectingFocuser = focuser;
+                _selectingFocuser.IsFocusLocked = true;
+            }
+        }
+
+        private void ReleaseFocuser()
+        {
+            if (_selectingFocuser != null)
+            {
+                _selectingFocuser.IsFocusLocked = false;
+                _selectingFocuser = null;
+            }
+        }
+
+        public void OnBeforeFocusChange( FocusEventData eventData ) { /*Unused*/ }
+
+        public void OnFocusChanged( FocusEventData eventData )
+        {
+            FocusEventData newData = new FocusEventData( EventSystem.current );
+            newData.Initialize( eventData.Pointer );
+
+            if ( eventData.NewFocusedObject != null && IsInteractable( eventData.NewFocusedObject ) )
+            {
+                FocusEnter( eventData.NewFocusedObject, newData );
+            }
+
+            if ( eventData.OldFocusedObject != null && IsInteractable( eventData.OldFocusedObject ) )
+            {
+                FocusExit( eventData.OldFocusedObject, newData );
+            }
+
+            CheckLockFocus( eventData.Pointer );
+        }
+
+        #region Global Listener Callbacks
+
+        public void OnGestureStarted( InputEventData eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureStarted( eventData.selectedObject, eventData );
+            }
+        }
+
+        public void OnGestureUpdated( InputEventData eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureUpdated( eventData.selectedObject, eventData );
+            }
+        }
+
+        public void OnGestureUpdated( InputEventData<float> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureUpdated( eventData.selectedObject, eventData );
+            }
+        }
+        public void OnGestureUpdated( InputEventData<Vector2> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureUpdated( eventData.selectedObject, eventData );
+            }
+        }
+        public void OnGestureUpdated( InputEventData<Vector3> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureUpdated( eventData.selectedObject, eventData );
+            }
+        }
+        public void OnGestureUpdated( InputEventData<Quaternion> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureUpdated( eventData.selectedObject, eventData );
+            }
+        }
+
+        public void OnGestureCompleted( InputEventData eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureCompleted( eventData.selectedObject, eventData );
+            }
+
+        }
+        public void OnGestureCompleted( InputEventData<float> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureCompleted( eventData.selectedObject, eventData );
+            }
+
+        }
+        public void OnGestureCompleted( InputEventData<Vector2> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureCompleted( eventData.selectedObject, eventData );
+            }
+
+        }
+
+        public void OnGestureCompleted( InputEventData<Vector3> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureCompleted( eventData.selectedObject, eventData );
+            }
+
+        }
+
+        public void OnGestureCompleted( InputEventData<Quaternion> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureCompleted( eventData.selectedObject, eventData );
+            }
+
+        }
+        
+        public void OnGestureCanceled( InputEventData eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                GestureCanceled( eventData.selectedObject, eventData );
+            }
+        }
+        public void OnInputUp( InputEventData eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                InputUp( eventData.selectedObject, eventData );
+            }
+        }
+
+        public void OnInputDown( InputEventData eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                InputDown( eventData.selectedObject, eventData );
+            }
+        }
+
+        public void OnInputPressed( InputEventData<float> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                InputPressed( eventData.selectedObject, eventData );
+            }
+        }
+
+        public void OnPositionInputChanged( InputEventData<Vector2> eventData )
+        {
+            if ( IsInteractable( eventData.selectedObject ) )
+            {
+                PositionInputChanged( eventData.selectedObject, eventData );
+            }
+        }
+
+        #endregion
+
+        #region Protected Virtual Callback Functions
+        protected virtual void FocusEnter(GameObject obj, FocusEventData eventData ) { }
+        protected virtual void FocusExit(GameObject obj, FocusEventData eventData ) { }
+
+        protected virtual void InputDown(GameObject obj, InputEventData eventData) { }
+        protected virtual void InputUp(GameObject obj, InputEventData eventData) { }
+        protected virtual void InputClicked(GameObject obj, InputEventData eventData ) { }
+        protected virtual void InputPressed( GameObject obj, InputEventData<float> eventData ) { }
+        protected virtual void PositionInputChanged( GameObject obj, InputEventData<Vector2> eventData ) { }
+
+        protected virtual void GestureStarted( GameObject obj, InputEventData eventData ) { }
+        protected virtual void GestureCanceled( GameObject obj, InputEventData eventData ) { }
+
+        protected virtual void GestureUpdated( GameObject obj, InputEventData eventData ) { }
+        protected virtual void GestureUpdated( GameObject obj, InputEventData<float> eventData ) { }
+        protected virtual void GestureUpdated( GameObject obj, InputEventData<Vector2> eventData ) { }
+        protected virtual void GestureUpdated( GameObject obj, InputEventData<Vector3> eventData ) { }
+        protected virtual void GestureUpdated( GameObject obj, InputEventData<Quaternion> eventData ) { }
+
+        protected virtual void GestureCompleted( GameObject obj, InputEventData eventData ) { }
+        protected virtual void GestureCompleted( GameObject obj, InputEventData<float> eventData ) { }
+        protected virtual void GestureCompleted( GameObject obj, InputEventData<Vector2> eventData ) { }
+        protected virtual void GestureCompleted( GameObject obj, InputEventData<Vector3> eventData ) { }
+        protected virtual void GestureCompleted( GameObject obj, InputEventData<Quaternion> eventData ) { }
+
+        #endregion
+    }
+}

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -41,6 +41,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             set { value = interactables; }
         }
 
+        /// <summary>
+        /// Is Focus required to receive input events on this GameObject?
+        /// InteractionReceivers handle events for objects indirectly, in order for this class work properly, keep this set to false.
+        /// </summary>
         public override bool IsFocusRequired
         {
             get

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -78,7 +78,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         protected override void OnEnable()
         {
             IsFocusRequired = false;
-            InputSystem.D
             base.OnEnable();
         }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             private set { value = targets; }
         }
 
-        #endregion
+        #endregion Public Members
 
         /// <summary>
         /// When true, this interaction receiver will draw connections in the editor to Interactables and Targets
@@ -115,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
-        #endregion
+        #endregion MonoBehaviour implementation
 
         /// <summary>
         /// Register an interactable with this receiver.
@@ -168,8 +168,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 
         #region Global Listener Callbacks
 
+        /// <Ineritdoc/>
         public void OnBeforeFocusChange( FocusEventData eventData ) { /*Unused*/ }
 
+        /// <Ineritdoc/>
         public void OnFocusChanged( FocusEventData eventData )
         {
             if ( eventData.NewFocusedObject != null && IsInteractable( eventData.NewFocusedObject ) )
@@ -183,6 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnGestureStarted( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -191,6 +194,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnGestureUpdated( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -199,6 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnGestureUpdated( InputEventData<float> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -206,6 +211,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
                 GestureUpdated( eventData.selectedObject, eventData );
             }
         }
+
+        /// <Ineritdoc/>
         public void OnGestureUpdated( InputEventData<Vector2> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -213,6 +220,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
                 GestureUpdated( eventData.selectedObject, eventData );
             }
         }
+
+        /// <Ineritdoc/>
         public void OnGestureUpdated( InputEventData<Vector3> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -220,6 +229,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
                 GestureUpdated( eventData.selectedObject, eventData );
             }
         }
+
+        /// <Ineritdoc/>
         public void OnGestureUpdated( InputEventData<Quaternion> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -228,49 +239,52 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnGestureCompleted( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
             {
                 GestureCompleted( eventData.selectedObject, eventData );
             }
-
         }
+
+        /// <Ineritdoc/>
         public void OnGestureCompleted( InputEventData<float> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
             {
                 GestureCompleted( eventData.selectedObject, eventData );
             }
-
         }
 
+        /// <Ineritdoc/>
         public void OnGestureCompleted( InputEventData<Vector2> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
             {
                 GestureCompleted( eventData.selectedObject, eventData );
             }
-
         }
 
+        /// <Ineritdoc/>
         public void OnGestureCompleted( InputEventData<Vector3> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
             {
                 GestureCompleted( eventData.selectedObject, eventData );
             }
-
         }
 
+        /// <Ineritdoc/>
         public void OnGestureCompleted( InputEventData<Quaternion> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
             {
                 GestureCompleted( eventData.selectedObject, eventData );
             }
-
         }
+
+        /// <Ineritdoc/>
         public void OnGestureCanceled( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -279,6 +293,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnInputUp( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -287,6 +302,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnInputDown( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -295,6 +311,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnInputPressed( InputEventData<float> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -303,6 +320,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
+        /// <Ineritdoc/>
         public void OnPositionInputChanged( InputEventData<Vector2> eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -311,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
         }
 
-        #endregion
+        #endregion Global Listener Callbacks
 
         #region Protected Virtual Callback Functions
 
@@ -339,6 +357,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         protected virtual void GestureCompleted( GameObject obj, InputEventData<Vector3> eventData ) { }
         protected virtual void GestureCompleted( GameObject obj, InputEventData<Quaternion> eventData ) { }
 
-        #endregion
+        #endregion Protected Virtual Callback Functions
     }
 }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -41,10 +41,23 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             set { value = interactables; }
         }
 
+        public override bool IsFocusRequired
+        {
+            get
+            {
+                return base.IsFocusRequired;
+            }
+
+            protected set
+            {
+                base.IsFocusRequired = value;
+            }
+        }
+
         /// <summary>
         /// List of linked targets that the receiver affects
         /// </summary>
-        [Tooltip("Targets for the receiver to ")]
+        [Tooltip("Targets for the receiver to affect")]
         private List<GameObject> targets = new List<GameObject>();
 
         public List<GameObject> Targets
@@ -53,35 +66,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             set { value = targets; }
         }
 
-        [Tooltip( "If true, this object will remain the prime focus while select is held" )]
-        [SerializeField]
-        private bool lockFocus = false;
-
-        /// <summary>
-        /// Flag for locking focus while selected
-        /// </summary>
-        public bool LockFocus
-        {
-            get
-            {
-                return lockFocus;
-            }
-            set
-            {
-                lockFocus = value;
-                CheckLockFocus(_selectingFocuser);
-            }
-        }
-        
-        #endregion
-
-        #region Private and Protected Members
-
-        /// <summary>
-        /// Protected focuser for the current selecting focuser
-        /// </summary>
-        protected IMixedRealityPointer _selectingFocuser;
-        
         #endregion
 
         /// <summary>
@@ -89,7 +73,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         protected override void OnEnable()
         {
+            IsFocusRequired = false;
             base.OnEnable();
+
             //Still need to register since focus isn't required
             if(InputSystem != null && InputSystem.IsInputEnabled)
             {
@@ -107,6 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             {
                 InputSystem.Unregister( gameObject );
             }
+
             base.OnDisable();
         }
 
@@ -120,6 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             {
                 return;
             }
+
             interactables.Add(interactable);
         }
 
@@ -192,45 +180,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             return (interactables != null && interactables.Contains(interactable));
         }
 
-        private void CheckLockFocus( IMixedRealityPointer focuser )
-        {
-            // If our previous selecting focuser isn't the same
-            if (_selectingFocuser != null && _selectingFocuser != focuser)
-            {
-                // If our focus is currently locked, unlock it before moving on
-                if (LockFocus)
-                {
-                    _selectingFocuser.IsFocusLocked = false;
-                }
-            }
-
-            // Set to the new focuser
-            _selectingFocuser = focuser;
-            if (_selectingFocuser != null)
-            {
-                _selectingFocuser.IsFocusLocked = LockFocus;
-            }
-        }
-
-        private void LockFocuser( IMixedRealityPointer focuser )
-        {
-            if (focuser != null)
-            {
-                ReleaseFocuser();
-                _selectingFocuser = focuser;
-                _selectingFocuser.IsFocusLocked = true;
-            }
-        }
-
-        private void ReleaseFocuser()
-        {
-            if (_selectingFocuser != null)
-            {
-                _selectingFocuser.IsFocusLocked = false;
-                _selectingFocuser = null;
-            }
-        }
-
         public void OnBeforeFocusChange( FocusEventData eventData ) { /*Unused*/ }
 
         public void OnFocusChanged( FocusEventData eventData )
@@ -244,8 +193,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             {
                 FocusExit( eventData.OldFocusedObject, eventData );
             }
-
-            CheckLockFocus( eventData.Pointer );
         }
 
         #region Global Listener Callbacks

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -79,12 +79,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         {
             IsFocusRequired = false;
             base.OnEnable();
-
-            //Still need to register since focus isn't required
-            if(InputSystem != null && InputSystem.IsInputEnabled)
-            {
-                InputSystem.Register( gameObject );
-            }
         }
 
         /// <summary>
@@ -92,12 +86,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         protected override void OnDisable()
         {
-            //Clean up our event subscription
-            if ( InputSystem != null && InputSystem.IsInputEnabled )
-            {
-                InputSystem.Unregister( gameObject );
-            }
-
             base.OnDisable();
         }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -1,22 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using UnityEngine;
-using UnityEngine.EventSystems;
-using System.Collections.Generic;
-using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
-using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
-using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
-using Microsoft.MixedReality.Toolkit.Core.Managers;
-using Microsoft.MixedReality.Toolkit.SDK.Input;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
 using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 {
     /// <summary>
     /// An interaction receiver is simply a component that attached to a list of interactable objects and does something
-    /// based on events from those interactable objects.  This is the base abstract class to extend from.
+    /// based on events from those interactable objects. This is the base abstract class to extend from.
     /// </summary>
     public abstract class InteractionReceiver : BaseInputHandler,
         IMixedRealityFocusChangedHandler,
@@ -32,13 +27,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// List of linked interactable objects to receive events for
         /// </summary>
         [SerializeField]
-        [ Tooltip("Target interactable Object to receive events for")]
+        [Tooltip( "Target interactable Object to receive events for" )]
         private List<GameObject> interactables = new List<GameObject>();
 
         public List<GameObject> Interactables
         {
             get { return interactables; }
-            set { value = interactables; }
+            private set { value = interactables; }
         }
 
         /// <summary>
@@ -47,29 +42,32 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         public override bool IsFocusRequired
         {
-            get
-            {
-                return base.IsFocusRequired;
-            }
-
-            protected set
-            {
-                base.IsFocusRequired = value;
-            }
+            get { return base.IsFocusRequired; }
+            protected set { base.IsFocusRequired = value; }
         }
 
         /// <summary>
         /// List of linked targets that the receiver affects
         /// </summary>
-        [Tooltip("Targets for the receiver to affect")]
+        [Tooltip( "Targets for the receiver to affect" )]
         private List<GameObject> targets = new List<GameObject>();
 
         public List<GameObject> Targets
         {
             get { return targets; }
-            set { value = targets; }
+            private set { value = targets; }
         }
 
+        #endregion
+
+        #region private variables
+        /// <summary>
+        /// When true, this interaction receiver will draw connections in the editor to Interactables and Targets
+        /// </summary>
+        [Tooltip( "When true, this interaction receiver will draw connections in the editor to Interactables and Targets" )]
+        [SerializeField]
+        private bool drawEditorConnections = true;
+        
         #endregion
 
         /// <summary>
@@ -85,14 +83,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// Register an interactable with this receiver.
         /// </summary>
         /// <param name="interactable">takes a GameObject as the interactable to register.</param>
-        public virtual void RegisterInteractable(GameObject interactable)
+        public virtual void RegisterInteractable( GameObject interactable )
         {
-            if (interactable == null || interactables.Contains(interactable))
+            if ( interactable == null || interactables.Contains( interactable ) )
             {
                 return;
             }
 
-            interactables.Add(interactable);
+            interactables.Add( interactable );
         }
 
         /// <summary>
@@ -100,44 +98,48 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         protected virtual void OnDrawGizmosSelected()
         {
-            if (this.interactables.Count > 0)
+            if ( drawEditorConnections )
             {
-                GameObject[] bioList = this.interactables.ToArray();
-
-                for (int i = 0; i < bioList.Length; i++)
+                if ( interactables.Count > 0 )
                 {
-                    if (bioList[i] != null)
+                    GameObject[] interactableList = interactables.ToArray();
+
+                    for ( int i = 0; i < interactableList.Length; i++ )
                     {
-                        Gizmos.color = Color.green;
-                        Gizmos.DrawLine(this.transform.position, bioList[i].transform.position);
+                        if ( interactableList[ i ] != null )
+                        {
+                            Gizmos.color = Color.green;
+                            Gizmos.DrawLine( transform.position, interactableList[ i ].transform.position );
+                        }
                     }
                 }
-            }
 
-            if (this.Targets.Count > 0)
-            {
-                GameObject[] targetList = this.Targets.ToArray();
-
-                for (int i = 0; i < targetList.Length; i++)
+                if ( Targets.Count > 0 )
                 {
-                    if (targetList[i] != null)
+                    GameObject[] targetList = Targets.ToArray();
+
+                    for ( int i = 0; i < targetList.Length; i++ )
                     {
-                        Gizmos.color = Color.red;
-                        Gizmos.DrawLine(this.transform.position, targetList[i].transform.position);
+                        if ( targetList[ i ] != null )
+                        {
+                            Gizmos.color = Color.red;
+                            Gizmos.DrawLine( transform.position, targetList[ i ].transform.position );
+                        }
                     }
                 }
             }
         }
 
+
         /// <summary>
         /// Function to remove an interactable from the linked list.
         /// </summary>
         /// <param name="interactable"></param>
-        public virtual void RemoveInteractable(GameObject interactable)
+        public virtual void RemoveInteractable( GameObject interactable )
         {
-            if (interactable != null && interactables.Contains(interactable))
+            if ( interactable != null && interactables.Contains( interactable ) )
             {
-                interactables.Remove(interactable);
+                interactables.Remove( interactable );
             }
         }
 
@@ -148,9 +150,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         {
             GameObject[] _intList = interactables.ToArray();
 
-            for (int i = 0; i < _intList.Length; i++)
+            for ( int i = 0; i < _intList.Length; i++ )
             {
-                this.RemoveInteractable(_intList[i]);
+                RemoveInteractable( _intList[ i ] );
             }
         }
 
@@ -159,9 +161,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         /// <param name="interactable"></param>
         /// <returns></returns>
-        protected bool IsInteractable(GameObject interactable)
+        protected bool IsInteractable( GameObject interactable )
         {
-            return (interactables != null && interactables.Contains(interactable));
+            return ( interactables != null && interactables.Contains( interactable ) );
         }
 
         public void OnBeforeFocusChange( FocusEventData eventData ) { /*Unused*/ }
@@ -268,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
             }
 
         }
-        
+
         public void OnGestureCanceled( InputEventData eventData )
         {
             if ( IsInteractable( eventData.selectedObject ) )
@@ -312,12 +314,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 
         #region Protected Virtual Callback Functions
 
-        protected virtual void FocusEnter(GameObject obj, FocusEventData eventData ) { }
-        protected virtual void FocusExit(GameObject obj, FocusEventData eventData ) { }
+        protected virtual void FocusEnter( GameObject obj, FocusEventData eventData ) { }
+        protected virtual void FocusExit( GameObject obj, FocusEventData eventData ) { }
 
-        protected virtual void InputDown(GameObject obj, InputEventData eventData) { }
-        protected virtual void InputUp(GameObject obj, InputEventData eventData) { }
-        protected virtual void InputClicked(GameObject obj, InputEventData eventData ) { }
+        protected virtual void InputDown( GameObject obj, InputEventData eventData ) { }
+        protected virtual void InputUp( GameObject obj, InputEventData eventData ) { }
+        protected virtual void InputClicked( GameObject obj, InputEventData eventData ) { }
         protected virtual void InputPressed( GameObject obj, InputEventData<float> eventData ) { }
         protected virtual void PositionInputChanged( GameObject obj, InputEventData<Vector2> eventData ) { }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -73,27 +73,20 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         #endregion
 
         /// <summary>
-        /// On start subscribe to all interaction events on elements in the interactables list.
+        /// On enable, set the BaseInputHandler's IsFocusRequired to false to receive all events.
         /// </summary>
         protected override void OnEnable()
         {
             IsFocusRequired = false;
+            InputSystem.D
             base.OnEnable();
-        }
-
-        /// <summary>
-        /// On disable remove all linked interactables from the delegate functions
-        /// </summary>
-        protected override void OnDisable()
-        {
-            base.OnDisable();
         }
 
         /// <summary>
         /// Register an interactable with this receiver.
         /// </summary>
         /// <param name="interactable">takes a GameObject as the interactable to register.</param>
-        public virtual void Registerinteractable(GameObject interactable)
+        public virtual void RegisterInteractable(GameObject interactable)
         {
             if (interactable == null || interactables.Contains(interactable))
             {
@@ -141,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// Function to remove an interactable from the linked list.
         /// </summary>
         /// <param name="interactable"></param>
-        public virtual void Removeinteractable(GameObject interactable)
+        public virtual void RemoveInteractable(GameObject interactable)
         {
             if (interactable != null && interactables.Contains(interactable))
             {
@@ -158,7 +151,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 
             for (int i = 0; i < _intList.Length; i++)
             {
-                this.Removeinteractable(_intList[i]);
+                this.RemoveInteractable(_intList[i]);
             }
         }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
-using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
-using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
 using System.Collections.Generic;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 {
@@ -27,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// List of linked interactable objects to receive events for
         /// </summary>
         [SerializeField]
-        [Tooltip( "Target interactable Object to receive events for" )]
+        [Tooltip("Target interactable Object to receive events for")]
         private List<GameObject> interactables = new List<GameObject>();
 
         public List<GameObject> Interactables
@@ -49,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// <summary>
         /// List of linked targets that the receiver affects
         /// </summary>
-        [Tooltip( "Targets for the receiver to affect" )]
+        [Tooltip("Targets for the receiver to affect")]
         private List<GameObject> targets = new List<GameObject>();
 
         public List<GameObject> Targets
@@ -63,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// <summary>
         /// When true, this interaction receiver will draw connections in the editor to Interactables and Targets
         /// </summary>
-        [Tooltip( "When true, this interaction receiver will draw connections in the editor to Interactables and Targets" )]
+        [Tooltip("When true, this interaction receiver will draw connections in the editor to Interactables and Targets")]
         [SerializeField]
         private bool drawEditorConnections = true;
 
@@ -83,32 +79,32 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         protected virtual void OnDrawGizmosSelected()
         {
-            if ( drawEditorConnections )
+            if(drawEditorConnections)
             {
-                if ( interactables.Count > 0 )
+                if(interactables.Count > 0)
                 {
                     GameObject[] interactableList = interactables.ToArray();
 
-                    for ( int i = 0; i < interactableList.Length; i++ )
+                    for(int i = 0; i < interactableList.Length; i++)
                     {
-                        if ( interactableList[ i ] != null )
+                        if(interactableList[i] != null)
                         {
                             Gizmos.color = Color.green;
-                            Gizmos.DrawLine( transform.position, interactableList[ i ].transform.position );
+                            Gizmos.DrawLine(transform.position, interactableList[i].transform.position);
                         }
                     }
                 }
 
-                if ( Targets.Count > 0 )
+                if(Targets.Count > 0)
                 {
                     GameObject[] targetList = Targets.ToArray();
 
-                    for ( int i = 0; i < targetList.Length; i++ )
+                    for(int i = 0; i < targetList.Length; i++)
                     {
-                        if ( targetList[ i ] != null )
+                        if(targetList[i] != null)
                         {
                             Gizmos.color = Color.red;
-                            Gizmos.DrawLine( transform.position, targetList[ i ].transform.position );
+                            Gizmos.DrawLine(transform.position, targetList[i].transform.position);
                         }
                     }
                 }
@@ -121,25 +117,25 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// Register an interactable with this receiver.
         /// </summary>
         /// <param name="interactable">takes a GameObject as the interactable to register.</param>
-        public virtual void RegisterInteractable( GameObject interactable )
+        public virtual void RegisterInteractable(GameObject interactable)
         {
-            if ( interactable == null || interactables.Contains( interactable ) )
+            if(interactable == null || interactables.Contains(interactable))
             {
                 return;
             }
 
-            interactables.Add( interactable );
+            interactables.Add(interactable);
         }
 
         /// <summary>
         /// Function to remove an interactable from the linked list.
         /// </summary>
         /// <param name="interactable"></param>
-        public virtual void RemoveInteractable( GameObject interactable )
+        public virtual void RemoveInteractable(GameObject interactable)
         {
-            if ( interactable != null && interactables.Contains( interactable ) )
+            if(interactable != null && interactables.Contains(interactable))
             {
-                interactables.Remove( interactable );
+                interactables.Remove(interactable);
             }
         }
 
@@ -150,9 +146,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         {
             GameObject[] _intList = interactables.ToArray();
 
-            for ( int i = 0; i < _intList.Length; i++ )
+            for(int i = 0; i < _intList.Length; i++)
             {
-                RemoveInteractable( _intList[ i ] );
+                RemoveInteractable(_intList[i]);
             }
         }
 
@@ -161,171 +157,171 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
         /// </summary>
         /// <param name="interactable"></param>
         /// <returns></returns>
-        protected bool IsInteractable( GameObject interactable )
+        protected bool IsInteractable(GameObject interactable)
         {
-            return ( interactables != null && interactables.Contains( interactable ) );
+            return (interactables != null && interactables.Contains(interactable));
         }
 
         #region Global Listener Callbacks
 
-        /// <Ineritdoc/>
-        public void OnBeforeFocusChange( FocusEventData eventData ) { /*Unused*/ }
+        /// <ineritdoc />
+        public void OnBeforeFocusChange(FocusEventData eventData) { /*Unused*/ }
 
-        /// <Ineritdoc/>
-        public void OnFocusChanged( FocusEventData eventData )
+        /// <ineritdoc />
+        public void OnFocusChanged(FocusEventData eventData)
         {
-            if ( eventData.NewFocusedObject != null && IsInteractable( eventData.NewFocusedObject ) )
+            if(eventData.NewFocusedObject != null && IsInteractable(eventData.NewFocusedObject))
             {
-                FocusEnter( eventData.NewFocusedObject, eventData );
+                FocusEnter(eventData.NewFocusedObject, eventData);
             }
 
-            if ( eventData.OldFocusedObject != null && IsInteractable( eventData.OldFocusedObject ) )
+            if(eventData.OldFocusedObject != null && IsInteractable(eventData.OldFocusedObject))
             {
-                FocusExit( eventData.OldFocusedObject, eventData );
-            }
-        }
-
-        /// <Ineritdoc/>
-        public void OnGestureStarted( InputEventData eventData )
-        {
-            if ( IsInteractable( eventData.selectedObject ) )
-            {
-                GestureStarted( eventData.selectedObject, eventData );
+                FocusExit(eventData.OldFocusedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureUpdated( InputEventData eventData )
+        /// <ineritdoc />
+        public void OnGestureStarted(InputEventData eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureUpdated( eventData.selectedObject, eventData );
+                GestureStarted(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureUpdated( InputEventData<float> eventData )
+        /// <ineritdoc />
+        public void OnGestureUpdated(InputEventData eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureUpdated( eventData.selectedObject, eventData );
+                GestureUpdated(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureUpdated( InputEventData<Vector2> eventData )
+        /// <ineritdoc />
+        public void OnGestureUpdated(InputEventData<float> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureUpdated( eventData.selectedObject, eventData );
+                GestureUpdated(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureUpdated( InputEventData<Vector3> eventData )
+        /// <ineritdoc />
+        public void OnGestureUpdated(InputEventData<Vector2> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureUpdated( eventData.selectedObject, eventData );
+                GestureUpdated(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureUpdated( InputEventData<Quaternion> eventData )
+        /// <ineritdoc />
+        public void OnGestureUpdated(InputEventData<Vector3> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureUpdated( eventData.selectedObject, eventData );
+                GestureUpdated(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureCompleted( InputEventData eventData )
+        /// <ineritdoc />
+        public void OnGestureUpdated(InputEventData<Quaternion> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureCompleted( eventData.selectedObject, eventData );
+                GestureUpdated(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureCompleted( InputEventData<float> eventData )
+        /// <ineritdoc />
+        public void OnGestureCompleted(InputEventData eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureCompleted( eventData.selectedObject, eventData );
+                GestureCompleted(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureCompleted( InputEventData<Vector2> eventData )
+        /// <ineritdoc />
+        public void OnGestureCompleted(InputEventData<float> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureCompleted( eventData.selectedObject, eventData );
+                GestureCompleted(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureCompleted( InputEventData<Vector3> eventData )
+        /// <ineritdoc />
+        public void OnGestureCompleted(InputEventData<Vector2> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureCompleted( eventData.selectedObject, eventData );
+                GestureCompleted(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureCompleted( InputEventData<Quaternion> eventData )
+        /// <ineritdoc />
+        public void OnGestureCompleted(InputEventData<Vector3> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureCompleted( eventData.selectedObject, eventData );
+                GestureCompleted(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnGestureCanceled( InputEventData eventData )
+        /// <ineritdoc />
+        public void OnGestureCompleted(InputEventData<Quaternion> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                GestureCanceled( eventData.selectedObject, eventData );
+                GestureCompleted(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnInputUp( InputEventData eventData )
+        /// <ineritdoc />
+        public void OnGestureCanceled(InputEventData eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                InputUp( eventData.selectedObject, eventData );
+                GestureCanceled(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnInputDown( InputEventData eventData )
+        /// <ineritdoc />
+        public void OnInputUp(InputEventData eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                InputDown( eventData.selectedObject, eventData );
+                InputUp(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnInputPressed( InputEventData<float> eventData )
+        /// <ineritdoc />
+        public void OnInputDown(InputEventData eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                InputPressed( eventData.selectedObject, eventData );
+                InputDown(eventData.selectedObject, eventData);
             }
         }
 
-        /// <Ineritdoc/>
-        public void OnPositionInputChanged( InputEventData<Vector2> eventData )
+        /// <ineritdoc />
+        public void OnInputPressed(InputEventData<float> eventData)
         {
-            if ( IsInteractable( eventData.selectedObject ) )
+            if(IsInteractable(eventData.selectedObject))
             {
-                PositionInputChanged( eventData.selectedObject, eventData );
+                InputPressed(eventData.selectedObject, eventData);
+            }
+        }
+
+        /// <ineritdoc />
+        public void OnPositionInputChanged(InputEventData<Vector2> eventData)
+        {
+            if(IsInteractable(eventData.selectedObject))
+            {
+                PositionInputChanged(eventData.selectedObject, eventData);
             }
         }
 
@@ -333,29 +329,29 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
 
         #region Protected Virtual Callback Functions
 
-        protected virtual void FocusEnter( GameObject obj, FocusEventData eventData ) { }
-        protected virtual void FocusExit( GameObject obj, FocusEventData eventData ) { }
+        protected virtual void FocusEnter(GameObject obj, FocusEventData eventData) { }
+        protected virtual void FocusExit(GameObject obj, FocusEventData eventData) { }
 
-        protected virtual void InputDown( GameObject obj, InputEventData eventData ) { }
-        protected virtual void InputUp( GameObject obj, InputEventData eventData ) { }
-        protected virtual void InputClicked( GameObject obj, InputEventData eventData ) { }
-        protected virtual void InputPressed( GameObject obj, InputEventData<float> eventData ) { }
-        protected virtual void PositionInputChanged( GameObject obj, InputEventData<Vector2> eventData ) { }
+        protected virtual void InputDown(GameObject obj, InputEventData eventData) { }
+        protected virtual void InputUp(GameObject obj, InputEventData eventData) { }
+        protected virtual void InputClicked(GameObject obj, InputEventData eventData) { }
+        protected virtual void InputPressed(GameObject obj, InputEventData<float> eventData) { }
+        protected virtual void PositionInputChanged(GameObject obj, InputEventData<Vector2> eventData) { }
 
-        protected virtual void GestureStarted( GameObject obj, InputEventData eventData ) { }
-        protected virtual void GestureCanceled( GameObject obj, InputEventData eventData ) { }
+        protected virtual void GestureStarted(GameObject obj, InputEventData eventData) { }
+        protected virtual void GestureCanceled(GameObject obj, InputEventData eventData) { }
 
-        protected virtual void GestureUpdated( GameObject obj, InputEventData eventData ) { }
-        protected virtual void GestureUpdated( GameObject obj, InputEventData<float> eventData ) { }
-        protected virtual void GestureUpdated( GameObject obj, InputEventData<Vector2> eventData ) { }
-        protected virtual void GestureUpdated( GameObject obj, InputEventData<Vector3> eventData ) { }
-        protected virtual void GestureUpdated( GameObject obj, InputEventData<Quaternion> eventData ) { }
+        protected virtual void GestureUpdated(GameObject obj, InputEventData eventData) { }
+        protected virtual void GestureUpdated(GameObject obj, InputEventData<float> eventData) { }
+        protected virtual void GestureUpdated(GameObject obj, InputEventData<Vector2> eventData) { }
+        protected virtual void GestureUpdated(GameObject obj, InputEventData<Vector3> eventData) { }
+        protected virtual void GestureUpdated(GameObject obj, InputEventData<Quaternion> eventData) { }
 
-        protected virtual void GestureCompleted( GameObject obj, InputEventData eventData ) { }
-        protected virtual void GestureCompleted( GameObject obj, InputEventData<float> eventData ) { }
-        protected virtual void GestureCompleted( GameObject obj, InputEventData<Vector2> eventData ) { }
-        protected virtual void GestureCompleted( GameObject obj, InputEventData<Vector3> eventData ) { }
-        protected virtual void GestureCompleted( GameObject obj, InputEventData<Quaternion> eventData ) { }
+        protected virtual void GestureCompleted(GameObject obj, InputEventData eventData) { }
+        protected virtual void GestureCompleted(GameObject obj, InputEventData<float> eventData) { }
+        protected virtual void GestureCompleted(GameObject obj, InputEventData<Vector2> eventData) { }
+        protected virtual void GestureCompleted(GameObject obj, InputEventData<Vector3> eventData) { }
+        protected virtual void GestureCompleted(GameObject obj, InputEventData<Quaternion> eventData) { }
 
         #endregion Protected Virtual Callback Functions
     }

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ec6c8ebdb4d4a14f9bd1f95becf627f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Overview
Porting the original InteractionReceiver from HTK. This script registers itself with the `InputSystem` and listens for all events available for GameObjects in the Interactables list. To extend, simply override the virtual methods. This is a core component used by many others (namely App bar). Unfortunately, since InteractionReceiver is not necessarily a "UX" component, I can't make a demo scene - this is more foundational and unblocks other components.

### Changes
-- **InteractionReceiver** now implements `IMixedRealityGestureHandler<T>`

### Note
I put the InteractionReceiver in the `SDK.UX.Receivers` namespace, but it might make more sense in `SDK.Input.Receivers`

### Interaction Receiver in HoloToolkit
https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/master/Assets/HoloToolkit-Examples/UX/Readme/README_InteractableObjectExample.md
![receiver](https://user-images.githubusercontent.com/13754172/45731074-7bb2da80-bb8a-11e8-9f43-b55c6bea587e.png)
https://medium.com/@dongyoonpark/open-source-building-blocks-for-windows-mixed-reality-experiences-hololens-mixedrealitytoolkit-28a0a16ebb61

