### PR TITLE
Updated the namespace of BaseCollectionInspector

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Inspectors/UX/Collections/BaseCollectionInspector.cs
+++ b/Assets/MixedRealityToolkit-SDK/Inspectors/UX/Collections/BaseCollectionInspector.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEditor;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Collections;
 
-namespace Microsoft.MixedReality.Toolkit.SDK.UX.Inspectors.Collections
+namespace Microsoft.MixedReality.Toolkit.SDK.Inspectors.UX.Collections
 {
     [CustomEditor( typeof(BaseObjectCollection), true )]
     public class BaseCollectionInspector : Editor


### PR DESCRIPTION
Overview
---
`BaseCollectionInspector`'s namespace wasn't in the normal inspector namespace for SDK inspectors.
