### PR TITLE
Add initial documentation around package manager

### DIFF
--- a/Documentation/Architecture/Package_Manager/Package_Manager.md
+++ b/Documentation/Architecture/Package_Manager/Package_Manager.md
@@ -8,11 +8,11 @@ Package vetting for showing up in the package manager UI should be done in multi
 
 The main goal is that all packages are contained within the Mixed Reality Toolkit Repo, or some separate repo mantained by the same community. This brings clarity to users about where issues can be filed, where to find more information about specific packages, and how they can get their packages added. This will explicitly not display any packages that are not contained within these constraints; while they may be good packages that work well with Mixed Reality Toolkit, they are not mantained within the community and will not be promoted in the same way. Instead, it will be up to the package owners to promote it's use in another way. We may find other promotion techniques if we as a community believe a package provides value but is not part of our ecosystem. 
 
-### Microsoft Packages
+### Release Packages
 
-Microsoft packages are promoted and mantained by Microsoft, with some promise of stability and support (TBD). These will be packages like Azure integration that we believe work well with Mixed Reality Toolkit and explicitly provide features that Microsoft is promoting. These packages will also have a strict process for submitting code changes.
+Release packages are promoted and mantained with some promise of stability and support (TBD). These will be packages like Azure integration that we believe work well with Mixed Reality Toolkit and explicitly provide features that Microsoft is promoting. These packages will also have a strict process for submitting code changes.
 
-### Community Packages
+### Preview Packages
 
 These packages contain less promise to quality and maintainance, but still exist within the ecosystem. The process for code changes will be much less stringent. However, we still want to celebrate community contributions and will surface packages like this in the package manager UI. 
 

--- a/Documentation/Architecture/Package_Manager/Package_Manager.md
+++ b/Documentation/Architecture/Package_Manager/Package_Manager.md
@@ -1,6 +1,6 @@
 # Package Manager
 
-The package manager is intended to highlight what is available from both Microsoft and the community for Mixed Reality Toolkit. It will suplement Unity's built in package management that is available by highlighting [vetted](#package-vetting) resources for developers.
+The package manager is intended to highlight what is available from both Microsoft and the community for Mixed Reality Toolkit (MRTK). It will suplement Unity's built in package management that is available by highlighting [vetted](#package-vetting) resources for developers. The packages themselves will be NuGet packages that are installed to be consumed in Unity. This provides us with a well developed technology and publishing platform for the ecosystem. 
 
 ## Package Vetting
 
@@ -8,24 +8,14 @@ Package vetting for showing up in the package manager UI should be done in multi
 
 The main goal is that all packages are contained within the Mixed Reality Toolkit Repo, or some separate repo mantained by the same community. This brings clarity to users about where issues can be filed, where to find more information about specific packages, and how they can get their packages added. This will explicitly not display any packages that are not contained within these constraints; while they may be good packages that work well with Mixed Reality Toolkit, they are not mantained within the community and will not be promoted in the same way. Instead, it will be up to the package owners to promote it's use in another way. We may find other promotion techniques if we as a community believe a package provides value but is not part of our ecosystem. 
 
-### Release Packages
+## Toolkit Packages
 
-Release packages are promoted and mantained with some promise of stability and support (TBD). These will be packages like Azure integration that we believe work well with Mixed Reality Toolkit and explicitly provide features that Microsoft is promoting. These packages will also have a strict process for submitting code changes.
+Toolkit packages are promoted and mantained with some promise of stability and support (TBD). These will be packages like Azure integration that we believe work well with Mixed Reality Toolkit and explicitly provide features that the MRTK group is promoting. These packages will also have a strict process for submitting code changes.
 
-### Preview Packages
+## Extension Packages
 
-These packages contain less promise to quality and maintainance, but still exist within the ecosystem. The process for code changes will be much less stringent. However, we still want to celebrate community contributions and will surface packages like this in the package manager UI. 
+These packages extend the provided functionality from MRTK as provided by the community. The process for code changes will be much less stringent. However, we still want to celebrate community contributions and will surface packages like this in the package manager UI. We belive these add value to MRTK, but are not mantained by the toolkit contributors directly.
 
-# Interfaces
+## Prerelease Packages
 
-No interfaces will be added to the core of Mixed Reality Toolkit. Everything in the package manager will not be customizable by users. All modifications to a project will go through the [Unity Package Manager](https://docs.unity3d.com/Packages/com.unity.package-manager-ui@1.8/manual/index.html#PackManRegistry)
-
-# Classes
-
-# Enumerations
-
-# Event Data Types
-
-# Configuration Profile
-
-None
+Packages will be marked as prerelease that are considered in an alpha or beta state, and not committed to being a reliable release. This could be features that have never shipped but are being evaluated, as well as updates to packages that are available for alpha or beta testing. 

--- a/Documentation/Architecture/Package_Manager/Package_Manager.md
+++ b/Documentation/Architecture/Package_Manager/Package_Manager.md
@@ -1,0 +1,31 @@
+# Package Manager
+
+The package manager is intended to highlight what is available from both Microsoft and the community for Mixed Reality Toolkit. It will suplement Unity's built in package management that is available by highlighting [vetted](#package-vetting) resources for developers.
+
+## Package Vetting
+
+Package vetting for showing up in the package manager UI should be done in multiple ways. Naming is subject to change, but the below outlines the general split on how packages will be presented. 
+
+The main goal is that all packages are contained within the Mixed Reality Toolkit Repo, or some separate repo mantained by the same community. This brings clarity to users about where issues can be filed, where to find more information about specific packages, and how they can get their packages added. This will explicitly not display any packages that are not contained within these constraints; while they may be good packages that work well with Mixed Reality Toolkit, they are not mantained within the community and will not be promoted in the same way. Instead, it will be up to the package owners to promote it's use in another way. We may find other promotion techniques if we as a community believe a package provides value but is not part of our ecosystem. 
+
+### Microsoft Packages
+
+Microsoft packages are promoted and mantained by Microsoft, with some promise of stability and support (TBD). These will be packages like Azure integration that we believe work well with Mixed Reality Toolkit and explicitly provide features that Microsoft is promoting. These packages will also have a strict process for submitting code changes.
+
+### Community Packages
+
+These packages contain less promise to quality and maintainance, but still exist within the ecosystem. The process for code changes will be much less stringent. However, we still want to celebrate community contributions and will surface packages like this in the package manager UI. 
+
+# Interfaces
+
+No interfaces will be added to the core of Mixed Reality Toolkit. Everything in the package manager will not be customizable by users. All modifications to a project will go through the [Unity Package Manager](https://docs.unity3d.com/Packages/com.unity.package-manager-ui@1.8/manual/index.html#PackManRegistry)
+
+# Classes
+
+# Enumerations
+
+# Event Data Types
+
+# Configuration Profile
+
+None

--- a/Documentation/Architecture/Readme.md
+++ b/Documentation/Architecture/Readme.md
@@ -14,3 +14,4 @@ TODO Add high level image of MRTK system architecture here
 - [Input System](./Input_System/Input_System.md)
 - [Boundary System](./Boundary_System/Boundary_System.md)
 - [Teleport System](./Teleport_System/Teleport_System.md)
+- [Package Manager](./Package_Manager/Package_Manager.md)


### PR DESCRIPTION
Overview
---

Start documentation for Package Management. This should be used as a basis for conversation in determining policy more than implementation details. I want to make sure the community has the right discussion before I start adding any interfaces, classes, or in depth implementation on how to hook in with Unity. 
