### PR TITLE
Fixed jump in SolverBodyLock rotation tether

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverBodyLock.cs
@@ -37,9 +37,10 @@ namespace HoloToolkit.Unity
         public int TetherAngleSteps = 6;
         #endregion
 
+        Quaternion desiredRot = Quaternion.identity;
+
         public override void SolverUpdate()
         {
-            Quaternion desiredRot = Quaternion.identity;
 
             if (RotationTether)
             {
@@ -52,9 +53,9 @@ namespace HoloToolkit.Unity
                 {
                     int numSteps = Mathf.RoundToInt(targetYRotation / tetherAngleLimit);
                     tetherYRotation = numSteps * tetherAngleLimit;
+                    desiredRot = Quaternion.Euler(0f, tetherYRotation, 0f);
                 }
 
-                desiredRot = Quaternion.Euler(0f, tetherYRotation, 0f);
             }
 
             Vector3 desiredPos = solverHandler.TransformTarget != null ? solverHandler.TransformTarget.position + (desiredRot * offset) : Vector3.zero;


### PR DESCRIPTION
Overview
---
Fixed jump in SolverBodyLock rotation tether by keeping the value of "desiredRot" between updates. Before, desiredRot was reset to Quaternion.identity in every updated which caused a bigger lock area around the zero rotation, and irregular jumps when the initial angle limit was exceeded.

Changes
---
- Fixes: # .
