### PR TITLE
MRTK relative folder matching fix.

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Utilities/Editor/Setup/EnforceEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/Editor/Setup/EnforceEditorSettings.cs
@@ -174,7 +174,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Editor.Setup
 
             for (int i = 0; i < directories.Length; i++)
             {
-                if (directories[i].Contains(directoryName))
+                var name = Path.GetFileName(directories[i]);
+
+                if (name != null && name.Equals(directoryName))
                 {
                     path = directories[i];
                     return true;


### PR DESCRIPTION
Made sure to get the folder name only and make sure it exactly equals the folder name we're searching for.