### PR TITLE
Ensured Input System is valid before setting cursor on Gaze Provider.

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -269,9 +269,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             }
         }
 
-        protected override void Start()
+        protected override async void Start()
         {
             base.Start();
+
+            await WaitUntilInputSystemValid;
 
             if (cursorPrefab != null)
             {


### PR DESCRIPTION
Overview
---
Added await to start to make sure the input system is initialized before setting cursor.
