### PR TITLE
Updated isOpaque check to be part of the camera profile #2826

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityCameraProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityCameraProfile.cs
@@ -63,9 +63,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         [Tooltip("Set the desired quality for your application for HoloLens.")]
         private int holoLensQualityLevel = 0;
 
-        private static DisplayType currentDisplayType;
+        [HideInInspector]
+        private DisplayType currentDisplayType;
 
-        public static bool IsOpaque
+        /// <summary>
+        /// Is the current camera displaying on an Opaque (AR) device or a VR / immersive device
+        /// </summary>
+        public bool IsOpaque
         {
             get
             {

--- a/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Managers/MixedRealityManager.cs
@@ -154,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Managers
                     CameraCache.Main.transform.root.DontDestroyOnLoad();
                 }
 
-                if (MixedRealityCameraProfile.IsOpaque)
+                if (ActiveProfile.CameraProfile.IsOpaque)
                 {
                     ActiveProfile.CameraProfile.ApplySettingsForOpaqueDisplay();
                 }


### PR DESCRIPTION
Overview
---
Resolution for Task #2826

Changes
---
- Changes IsOpaque property to be non-static
- MRManager check updated to match.

IsOpaque option now accessible through the profile with
```
MixedRealityManager.ActiveProfile.CameraProfile.IsOpaque
```
