### PR TITLE
Update MRTKStandard shader's reference to its custom inspector

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Resources/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/_Core/Resources/Shaders/MixedRealityStandard.shader
@@ -738,5 +738,5 @@ Shader "Mixed Reality Toolkit/Standard"
     }
     
     FallBack "VertexLit"
-    CustomEditor "Microsoft.MixedReality.Toolkit.Inspectors.MixedRealityStandardShaderGUI"
+    CustomEditor "Microsoft.MixedReality.Toolkit.Core.Inspectors.MixedRealityStandardShaderGUI"
 }


### PR DESCRIPTION
Overview
---
The namespace of the shader's inspector was changed in #2783, but the reference in the shader itself wasn't updated, causing:

![image](https://user-images.githubusercontent.com/3580640/45981353-8f869280-c009-11e8-96fc-117bea4e5f20.png)