### PR TITLE
Implement SDK Profile Lock

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityBoundaryVisualizationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityBoundaryVisualizationProfile.asset
@@ -11,6 +11,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fd6338e77774badb73a2b1320b41caf, type: 3}
   m_Name: DefaultMixedRealityBoundaryVisualizationProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  boundaryHeight: 3
   showFloor: 1
   floorMaterial: {fileID: 2100000, guid: 47f3c5e1cb6142ba9697cd4c86d74321, type: 2}
   floorScale: {x: 10, y: 10}

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityCameraProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityCameraProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a4a1c93114e9437cb75d8b3ee4e0e1ba, type: 3}
   m_Name: DefaultMixedRealityCameraProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   isCameraPersistent: 0
   nearClipPlaneOpaqueDisplay: 0.1
   cameraClearFlagsOpaqueDisplay: 1

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityConfigurationProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
   m_Name: DefaultMixedRealityConfigurationProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   initialManagerTypes:
   - reference: Microsoft.MixedReality.Toolkit.SDK.Teleportation.MixedRealityTeleportManager,
       Microsoft.MixedReality.Toolkit.SDK
@@ -36,6 +37,5 @@ MonoBehaviour:
   teleportSystemType:
     reference: Microsoft.MixedReality.Toolkit.SDK.Teleportation.MixedRealityTeleportManager,
       Microsoft.MixedReality.Toolkit.SDK
-  teleportDuration: 0.25
   registeredComponentsProfile: {fileID: 11400000, guid: efbaf6ea540c69f4fb75415a5d145a53,
     type: 2}

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a1cf5fd47e548e6a23bdd3ddcc00cf6, type: 3}
   m_Name: DefaultMixedRealityControllerMappingProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   renderMotionControllers: 1
   useDefaultModels: 0
   globalLeftHandModel: {fileID: 1370450866519632, guid: 626257b1a6cd47c2a32a18cf75b2fb23,

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityGesturesProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityGesturesProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7554812f08ec49e694a8d9d4ee235a9c, type: 3}
   m_Name: DefaultMixedRealityGesturesProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   manipulationGestures: 12
   navigationGestures: 112
   useRailsNavigation: 0

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityInputActionsProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityInputActionsProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1a15d870c8b4e52acc4643bd258ed6e, type: 3}
   m_Name: DefaultMixedRealityInputActionsProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   inputActions:
   - id: 1
     description: Select

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db393d206eab4604ab74278cb6cda355, type: 3}
   m_Name: DefaultMixedRealityInputPointerProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   pointerOptions:
   - controllerType:
       reference: 

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b71cb900fa9dec5488df2deb180db58f, type: 3}
   m_Name: DefaultMixedRealityInputSystemProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
     type: 2}
   gesturesProfile: {fileID: 11400000, guid: bd7829a9b29409045a745b5a18299291, type: 2}

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityRegisteredComponentsProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityRegisteredComponentsProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eebbca41bb0b40d298ef201735d08616, type: 3}
   m_Name: DefaultMixedRealityRegisteredComponentsProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   configurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput.UnityJoystickManager,

--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpeechCommandsProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealitySpeechCommandsProfile.asset
@@ -11,6 +11,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f18fec9b55c4f818e284af454161962, type: 3}
   m_Name: DefaultMixedRealitySpeechCommandsProfile
   m_EditorClassIdentifier: 
+  isCustomProfile: 0
   startBehavior: 0
   recognitionConfidenceLevel: 1
   speechCommands:

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BaseMixedRealityProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BaseMixedRealityProfile.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Definitions
+{
+    public abstract class BaseMixedRealityProfile : ScriptableObject
+    {
+        [SerializeField]
+        private bool isCustomProfile = true;
+
+        internal bool IsCustomProfile => isCustomProfile;
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BaseMixedRealityProfile.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BaseMixedRealityProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7bf26942d2da73b49a9ae41a021e6ea6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem
     /// Configuration profile settings for setting up boundary visualizations.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
-    public class MixedRealityBoundaryVisualizationProfile : ScriptableObject
+    public class MixedRealityBoundaryVisualizationProfile : BaseMixedRealityProfile
     {
         [SerializeField]
         [Tooltip("The approximate height of the play space, in meters.")]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Devices
 {
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Controller Configuration Profile", fileName = "MixedRealityControllerConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Controller)]
-    public class MixedRealityControllerMappingProfile : ScriptableObject
+    public class MixedRealityControllerMappingProfile : BaseMixedRealityProfile
     {
         [SerializeField]
         [Tooltip("Enable and configure the controller rendering of the Motion Controllers on Startup.")]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityGesturesProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityGesturesProfile.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Gestures Profile", fileName = "MixedRealityGesturesProfile", order = (int)CreateProfileMenuItemIndices.Gestures)]
-    public class MixedRealityGesturesProfile : ScriptableObject
+    public class MixedRealityGesturesProfile : BaseMixedRealityProfile
     {
         [EnumFlags]
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     /// Configuration profile settings for setting up and consuming Input Actions.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Input Actions Profile", fileName = "MixedRealityInputActionsProfile", order = (int)CreateProfileMenuItemIndices.InputActions)]
-    public class MixedRealityInputActionsProfile : ScriptableObject
+    public class MixedRealityInputActionsProfile : BaseMixedRealityProfile
     {
         private readonly string[] defaultInputActions =
         {

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Input System Profile", fileName = "MixedRealityInputSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
-    public class MixedRealityInputSystemProfile : ScriptableObject
+    public class MixedRealityInputSystemProfile : BaseMixedRealityProfile
     {
         [SerializeField]
         [Tooltip("Input System Action Mapping profile for wiring up Controller input to Actions.")]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Pointer Profile", fileName = "MixedRealityInputPointerProfile", order = (int)CreateProfileMenuItemIndices.Pointer)]
-    public class MixedRealityPointerProfile : ScriptableObject
+    public class MixedRealityPointerProfile : BaseMixedRealityProfile
     {
         [SerializeField]
         private PointerOption[] pointerOptions = new PointerOption[0];

--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     /// Configuration profile settings for setting up and consuming Speech Commands.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Speech Commands Profile", fileName = "MixedRealitySpeechCommandsProfile", order = (int)CreateProfileMenuItemIndices.Speech)]
-    public class MixedRealitySpeechCommandsProfile : ScriptableObject
+    public class MixedRealitySpeechCommandsProfile : BaseMixedRealityProfile
     {
         [SerializeField]
         [Tooltip("Whether the recognizer should be activated on start.")]

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityCameraProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityCameraProfile.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
     /// Based on those values, you can customize your camera and quality settings.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Camera Profile", fileName = "MixedRealityCameraProfile", order = (int)CreateProfileMenuItemIndices.Camera)]
-    public class MixedRealityCameraProfile : ScriptableObject
+    public class MixedRealityCameraProfile : BaseMixedRealityProfile
     {
         private enum DisplayType
         {

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityConfigurationProfile.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
     /// Configuration profile settings for the Mixed Reality Toolkit.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Configuration Profile", fileName = "MixedRealityConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
-    public class MixedRealityConfigurationProfile : ScriptableObject, ISerializationCallbackReceiver
+    public class MixedRealityConfigurationProfile : BaseMixedRealityProfile, ISerializationCallbackReceiver
     {
         #region Manager Registry properties
 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityRegisteredComponentsProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityRegisteredComponentsProfile.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Core.Definitions
 {
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Registered Components Profile", fileName = "MixedRealityRegisteredComponentsProfile", order = (int)CreateProfileMenuItemIndices.RegisteredComponents)]
-    public class MixedRealityRegisteredComponentsProfile : ScriptableObject
+    public class MixedRealityRegisteredComponentsProfile : BaseMixedRealityProfile
     {
         [SerializeField]
         private MixedRealityComponentConfiguration[] configurations = null;

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityPreferences.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Inspectors
+{
+    public static class MixedRealityPreferences
+    {
+        private static readonly GUIContent LockContent = new GUIContent("Lock SDK Profiles", "Locks the SDK profiles from being edited.");
+
+        private static bool prefsLoaded;
+
+        private static bool lockProfiles = true;
+
+        /// <summary>
+        /// Should the default profile inspectors be disabled to prevent editing?
+        /// </summary>
+        public static bool LockProfiles
+        {
+            get
+            {
+                // Load the preferences
+                if (!prefsLoaded)
+                {
+                    lockProfiles = EditorPrefsUtility.GetEditorPref("_LockProfiles", true);
+                    prefsLoaded = true;
+                }
+
+                return lockProfiles;
+            }
+            private set
+            {
+                lockProfiles = value;
+            }
+        }
+
+        [PreferenceItem("Mixed Reality Toolkit")]
+        private static void Preferences()
+        {
+            // Preferences GUI
+            EditorGUI.BeginChangeCheck();
+            LockProfiles = EditorGUILayout.Toggle(LockContent, LockProfiles);
+
+            // Save the preferences
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorPrefs.SetBool("_LockProfiles", LockProfiles);
+            }
+
+            if (!LockProfiles)
+            {
+                EditorGUILayout.HelpBox("This is only to be used to update the default SDK profiles. If any edits are made, and not checked into the MRTK's Github, the changes may be lost next time you update your local copy.", MessageType.Warning);
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityPreferences.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Inspectors
 {
-    public static class MixedRealityPreferences
+    internal static class MixedRealityPreferences
     {
         private static readonly GUIContent LockContent = new GUIContent("Lock SDK Profiles", "Locks the SDK profiles from being edited.");
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityPreferences.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityPreferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8058c4e019382e643834d2c5a819a33d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -82,6 +82,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 EditorGUILayout.HelpBox("Boundary visualization is only supported in Room scale experiences.", MessageType.Warning);
             }
             EditorGUILayout.Space();
+
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             serializedObject.Update();
             EditorGUILayout.PropertyField(boundaryHeight);
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
@@ -83,7 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             }
             EditorGUILayout.Space();
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -61,6 +61,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.LabelField("Camera Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Camera Profile helps tweak camera settings no matter what platform you're building for.", MessageType.Info);
 
+
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             serializedObject.Update();
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.HelpBox("The Camera Profile helps tweak camera settings no matter what platform you're building for.", MessageType.Info);
 
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 EditorGUILayout.HelpBox("The Mixed Reality Toolkit's core SDK profiles can be used to get up and running quickly.\n\nYou can use the default profiles provided or create your own in the context menu:\n'Create/Mixed Reality Toolkit/...'", MessageType.Warning);
                 GUI.enabled = false;

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -103,6 +103,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                EditorGUILayout.HelpBox("The Mixed Reality Toolkit's core SDK profiles can be used to get up and running quickly.\n\nYou can use the default profiles provided or create your own in the context menu:\n'Create/Mixed Reality Toolkit/...'", MessageType.Warning);
+                GUI.enabled = false;
+            }
+
             var previousLabelWidth = EditorGUIUtility.labelWidth;
             EditorGUIUtility.labelWidth = 160f;
             EditorGUI.BeginChangeCheck();

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 Selection.activeObject = MixedRealityManager.Instance.ActiveProfile.InputSystemProfile;
             }
-
+            
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Controller Templates", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("Controller templates define all the controllers your users will be able to use in your application.\n\n" +
@@ -124,6 +124,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input actions found, please specify a input action profile in the main configuration.", MessageType.Error);
                 return;
+            }
+
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
             }
 
             if (controllerButtonStyle == null)

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Devices.OpenVR;
@@ -126,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -80,6 +80,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             serializedObject.Update();
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Windows Gesture Settings", EditorStyles.boldLabel);

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using System.Linq;
@@ -80,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -62,6 +62,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                                     "After defining all your actions, you can then wire up these actions to hardware sensors, controllers, and other input devices.", MessageType.Info);
 
 
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             serializedObject.Update();
             RenderList(inputActionList);
             serializedObject.ApplyModifiedProperties();

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using UnityEditor;
@@ -62,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                                     "After defining all your actions, you can then wire up these actions to hardware sensors, controllers, and other input devices.", MessageType.Info);
 
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -55,6 +55,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.LabelField("Input System Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Input System Profile helps developers configure input no matter what platform you're building for.", MessageType.Info);
 
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             var previousLabelWidth = EditorGUIUtility.labelWidth;
             EditorGUIUtility.labelWidth = 160f;
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information. 
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using UnityEditor;
@@ -55,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.LabelField("Input System Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The Input System Profile helps developers configure input no matter what platform you're building for.", MessageType.Info);
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -56,6 +56,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.HelpBox("Pointers attach themselves onto controllers as they are initialized.", MessageType.Info);
             EditorGUILayout.Space();
 
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             serializedObject.Update();
             currentlySelectedPointerOption = -1;
             pointerOptionList.DoLayoutList();

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using UnityEditor;
@@ -56,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.HelpBox("Pointers attach themselves onto controllers as they are initialized.", MessageType.Info);
             EditorGUILayout.Space();
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs
@@ -44,6 +44,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Registered Components Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("This profile defines any additional systems, features, and managers to register with the Mixed Reality Manager.", MessageType.Info);
+
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
+
             serializedObject.Update();
             RenderList(configurations);
             serializedObject.ApplyModifiedProperties();

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.LabelField("Registered Components Profile", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("This profile defines any additional systems, features, and managers to register with the Mixed Reality Manager.", MessageType.Info);
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityRegisteredComponentsProfileInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using System.Linq;
@@ -67,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 Selection.activeObject = MixedRealityManager.Instance.ActiveProfile.InputSystemProfile;
             }
 
-            if (MixedRealityPreferences.LockProfiles)
+            if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)
             {
                 GUI.enabled = false;
             }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -67,7 +67,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 Selection.activeObject = MixedRealityManager.Instance.ActiveProfile.InputSystemProfile;
             }
 
-            EditorGUILayout.Space();
+            if (MixedRealityPreferences.LockProfiles)
+            {
+                GUI.enabled = false;
+            }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Speech Commands", EditorStyles.boldLabel);


### PR DESCRIPTION
Overview
---
Locked the SDK profiles so consumers cannot edit the default assets in the SDK.
Maintainers can still unlock and edit the profiles in Edit/Preferences/MRTK
![image](https://user-images.githubusercontent.com/13334553/45992833-a09ec600-c040-11e8-861f-f8dc16ab2daa.png)

Changes
---
- Implements part of: #2825 