### PR TITLE
Mouse Pointer Updates

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -147,11 +147,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                 TeleportSystem.Register(gameObject);
             }
 
-            if (InputSystem == null)
-            {
-                await WaitUntilInputSystemValid;
-                SetCursor();
-            }
+            await WaitUntilInputSystemValid;
+            SetCursor();
         }
 
         protected override void OnDisable()
@@ -316,9 +313,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         {
             Vector3 pointerPosition;
             TryGetPointerPosition(out pointerPosition);
-            pointingRay = new Ray(pointerPosition, PointerDirection);
+            pointingRay = pointerRay;
+            pointingRay.origin = pointerPosition;
+            pointingRay.direction = PointerDirection;
             return true;
         }
+
+        private readonly Ray pointerRay = new Ray();
 
         /// <inheritdoc />
         public virtual bool TryGetPointerRotation(out Quaternion rotation)

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -77,7 +77,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         /// <inheritdoc />
         public override void OnPositionInputChanged(InputEventData<Vector2> eventData)
         {
-
             if (eventData.SourceId == Controller?.InputSource.SourceId)
             {
                 if (!UseSourcePoseData &&

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseController.cs
@@ -66,8 +66,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
                 return;
             }
 
-            controllerPose.Position = InputSource.Pointers[0].BaseCursor.Position;
-            controllerPose.Rotation = InputSource.Pointers[0].BaseCursor.Rotation;
+            if (InputSource.Pointers[0].BaseCursor != null)
+            {
+                controllerPose.Position = InputSource.Pointers[0].BaseCursor.Position;
+                controllerPose.Rotation = InputSource.Pointers[0].BaseCursor.Rotation;
+            }
 
             // Don't ask me why it's mapped weird. Bc Unity...
             mouseDelta.x = Input.GetAxis("Mouse X");

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseDeviceManager.cs
@@ -28,6 +28,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
                 return;
             }
 
+#if UNITY_EDITOR
+            UnityEditor.EditorWindow.focusedWindow.ShowNotification(new GUIContent("Press \"ESC\" to regain mouse control"));
+#endif
+
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
 


### PR DESCRIPTION
Overview
---
- Added notification when mouse device manager is started about how to regain mouse control.
- Cached the ray in `BasePointer`
![image](https://user-images.githubusercontent.com/13334553/45994454-98e31f80-c048-11e8-9033-3fafc1a5655c.png)

Changes
---
- Fixes: #2832 
- FIxes: #2756 
