### PR TITLE
Removed obsolete assert in FocusProvider

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -654,7 +654,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         /// <param name="prioritizedLayerMasks"></param>
         private void RaycastGraphics(PointerData pointer, LayerMask[] prioritizedLayerMasks)
         {
-            Debug.Assert(pointer.Details.Point != Vector3.zero, "Invalid pointer source start point found to raycast from!");
             Debug.Assert(UIRaycastCamera != null, "You must assign a UIRaycastCamera on the FocusProvider before you can process uGUI raycasting.");
 
             RaycastResult raycastResult = default(RaycastResult);


### PR DESCRIPTION
Migrated https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/2456 from master (with #2450 being the Issue).

It also doesn't look like the assert was doing what it thought it did, since it's checking against the focused point, not the start point.