### PR TITLE
Update BaseFocusHandler, as being the old focused object does not always mean overall focus was lost

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseFocusHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseFocusHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
         protected static IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityManager.Instance.GetManager<IMixedRealityInputSystem>());
 
         [SerializeField]
-        [Tooltip("Is Focus capabilities enabled for this component?")]
+        [Tooltip("Is focus enabled for this component?")]
         private bool focusEnabled = true;
 
         /// <inheritdoc />
@@ -30,10 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
             set { focusEnabled = value; }
         }
 
-        private bool hasFocus;
-
         /// <inheritdoc />
-        public bool HasFocus => FocusEnabled && hasFocus;
+        public bool HasFocus => FocusEnabled && Focusers.Count > 0;
 
         /// <inheritdoc />
         public List<IMixedRealityPointer> Focusers { get; } = new List<IMixedRealityPointer>(0);
@@ -47,25 +45,17 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
         /// <inheritdoc />
         public virtual void OnBeforeFocusChange(FocusEventData eventData)
         {
-            // If we're the new target object
-            // Add the pointer to the list of focusers
-            // and update our hasFocus flag if focusing is enabled.
+            // If we're the new target object,
+            // add the pointer to the list of focusers.
             if (eventData.NewFocusedObject == gameObject)
             {
                 eventData.Pointer.FocusTarget = this;
                 Focusers.Add(eventData.Pointer);
-
-                if (focusEnabled)
-                {
-                    hasFocus = true;
-                }
             }
-            // If we're the old focused target object
-            // update our flag and remove the pointer from our list.
+            // If we're the old focused target object,
+            // remove the pointer from our list.
             else if (eventData.OldFocusedObject == gameObject)
             {
-                hasFocus = false;
-
                 Focusers.Remove(eventData.Pointer);
 
                 // If there is no new focused target


### PR DESCRIPTION
Overview
---
BaseFocusHandler was assuming that being the `OldFocusedObject` meant that overall focus was lost. Since we're keeping track of the focusers (and there might be multiple), I've updated the locally tracked bool to instead check if any focusers are currently focusing the object.