### PR TITLE
Add interface guidelines

### DIFF
--- a/CodingGuidelines.md
+++ b/CodingGuidelines.md
@@ -240,6 +240,26 @@ public class MyClass
 }
  ```
 
+## Public Interface Definitions Should Avoid Concrete Types Where Possible.
+
+Interfaces are designed to provide a public contract devoid of implementation. Where possible, avoid assuming a non-primitive type. 
+
+### Don't:
+```
+public interface IFoo
+{
+    Dictionary<string, object> Objects { get; set; }
+}
+```
+
+### Do:
+```
+public interface IFoo
+{
+    IDictionary<string, object> Objects { get; set; }
+}
+```
+
 ## Initilize Enums.
 
 To ensure all Enum's are initialized correctly starting at 0, .NET gives you a tidy shortcut to automatically initilize the enum by just adding the first (starter) value.

--- a/CodingGuidelines.md
+++ b/CodingGuidelines.md
@@ -120,6 +120,10 @@ protected string MyProperty;
 private string myProperty;
  ```
 
+## Interface Naming Conventions
+
+Follow naming [naming conventions](#naming-conventions) with the exception that interfaces should start with `IMixedReality` if they are a public contract.
+
 ## Access Modifiers
 
 Always declare an access modifier for all fields, properties and methods.
@@ -248,7 +252,7 @@ Interfaces are designed to provide a public contract devoid of implementation. W
 ```
 public interface IMixedRealityFoo
 {
-    Dictionary<string, object> Objects { get; set; }
+    Dictionary<string, object> Objects { get; }
 }
 ```
 
@@ -256,7 +260,7 @@ public interface IMixedRealityFoo
 ```
 public interface IMixedRealityFoo
 {
-    IDictionary<string, object> Objects { get; set; }
+    IDictionary<string, object> Objects { get; }
 }
 ```
 

--- a/CodingGuidelines.md
+++ b/CodingGuidelines.md
@@ -246,7 +246,7 @@ Interfaces are designed to provide a public contract devoid of implementation. W
 
 ### Don't:
 ```
-public interface IFoo
+public interface IMixedRealityFoo
 {
     Dictionary<string, object> Objects { get; set; }
 }
@@ -254,7 +254,7 @@ public interface IFoo
 
 ### Do:
 ```
-public interface IFoo
+public interface IMixedRealityFoo
 {
     IDictionary<string, object> Objects { get; set; }
 }


### PR DESCRIPTION
The coding guidelines don't currently specify interface design recommendations. This adds the recommendation that interface types should avoid concrete types where possible.