### PR TITLE
Fix copy+paste errors in diagnostic code

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Diagnostics/MixedRealityDiagnosticsManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Diagnostics/MixedRealityDiagnosticsManager.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.MixedReality.Toolkit.Core.Definitions.Diagnostics;
-using Microsoft.MixedReality.Toolkit.Core.EventDatum.Boundary;
+using Microsoft.MixedReality.Toolkit.Core.EventDatum.Diagnostics;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.Diagnostics;
 using Microsoft.MixedReality.Toolkit.Core.Managers;
 using Microsoft.MixedReality.Toolkit.Core.Utilities;
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
         }
 
         /// <summary>
-        /// Event sent whenever the boundary visualization changes.
+        /// Event sent whenever the diagnostics visualization changes.
         /// </summary>
         private static readonly ExecuteEvents.EventFunction<IMixedRealityDiagnosticsHandler> OnDiagnosticsChanged =
             delegate (IMixedRealityDiagnosticsHandler handler, BaseEventData eventData)

--- a/Assets/MixedRealityToolkit/_Core/EventDatum/Diagnostics/DiagnosticsEventData.cs
+++ b/Assets/MixedRealityToolkit/_Core/EventDatum/Diagnostics/DiagnosticsEventData.cs
@@ -5,7 +5,7 @@ using Microsoft.MixedReality.Toolkit.Core.Definitions.Diagnostics;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.Diagnostics;
 using UnityEngine.EventSystems;
 
-namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Boundary
+namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Diagnostics
 {
     public class DiagnosticsEventData : GenericBaseEventData
     {

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Diagnostic Visualization Options", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Diagnostic vidualizations can help monitor system resources and performance inside an application.", MessageType.Info);
+            EditorGUILayout.HelpBox("Diagnostic visualizations can help monitor system resources and performance inside an application.", MessageType.Info);
             EditorGUILayout.Space();
 
             EditorGUILayout.PropertyField(visible);

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -43,8 +43,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Boundary Visualization Options", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Boundary visualizations can help users stay oriented and comfortable in the experience.", MessageType.Info);
+            EditorGUILayout.LabelField("Diagnostic Visualization Options", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox("Diagnostic vidualizations can help monitor system resources and performance inside an application.", MessageType.Info);
             EditorGUILayout.Space();
 
             EditorGUILayout.PropertyField(visible);

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/Diagnostics/IMixedRealityDiagnosticsHandler.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/Diagnostics/IMixedRealityDiagnosticsHandler.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Core.EventDatum.Boundary;
+using Microsoft.MixedReality.Toolkit.Core.EventDatum.Diagnostics;
 using UnityEngine.EventSystems;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Diagnostics


### PR DESCRIPTION
Overview
---

There were remaining boundary comments, namespaces, and text in the diagnostic code. Scrub that out

Changes
---
- Fixes: #2863 
