### PR TITLE
Properly initialize pointerEventData in the input manager

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
@@ -772,7 +772,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         public void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction)
         {
             // Create input event
-            pointerEventData.Initialize(pointer.InputSourceParent, inputAction);
+            pointerEventData.Initialize(pointer, inputAction);
 
             ExecutePointerDown(HandlePointerDown(pointer));
         }
@@ -781,7 +781,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         public void RaisePointerDown(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
             // Create input event
-            pointerEventData.Initialize(pointer.InputSourceParent, handedness, inputAction);
+            pointerEventData.Initialize(pointer, handedness, inputAction);
 
             ExecutePointerDown(HandlePointerDown(pointer));
         }
@@ -855,7 +855,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         public void RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction)
         {
             // Create input event
-            pointerEventData.Initialize(pointer.InputSourceParent, inputAction);
+            pointerEventData.Initialize(pointer, inputAction);
 
             ExecutePointerUp(HandlePointerUp(pointer));
         }
@@ -864,7 +864,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
         public void RaisePointerUp(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
             // Create input event
-            pointerEventData.Initialize(pointer.InputSourceParent, handedness, inputAction);
+            pointerEventData.Initialize(pointer, handedness, inputAction);
 
             ExecutePointerUp(HandlePointerUp(pointer));
         }

--- a/Assets/MixedRealityToolkit/_Core/EventDatum/Input/MixedRealityPointerEventData.cs
+++ b/Assets/MixedRealityToolkit/_Core/EventDatum/Input/MixedRealityPointerEventData.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Input
         /// <param name="pointer"></param>
         /// <param name="inputAction"></param>
         /// <param name="count"></param>
-        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count)
+        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count = 0)
         {
             Initialize(pointer.InputSourceParent, inputAction);
             Pointer = pointer;
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Input
         /// <param name="count"></param>
         /// <param name="inputAction"></param>
         /// <param name="handedness"></param>
-        public void Initialize(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction, int count)
+        public void Initialize(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction, int count = 0)
         {
             Initialize(pointer.InputSourceParent, handedness, inputAction);
             Pointer = pointer;


### PR DESCRIPTION
Overview
---
`RaisePointerDown` and `RaisePointerUp` were using `InputEventData`'s `Initialize` instead of `MixedRealityPointerEventData`'s, so the pointer stored inside the event data wasn't being updated. This caused the pointer to always be the pointer that last fired a click event (or `null`, initially), as that was the only method properly updating the pointer.