### PR TITLE
Remove non-events from IMixedRealityFocusHandler

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseFocusHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/BaseFocusHandler.cs
@@ -19,17 +19,23 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
         [Tooltip("Is focus enabled for this component?")]
         private bool focusEnabled = true;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Is focus enabled for this <see cref="UnityEngine.Component"/>?
+        /// </summary>
         public virtual bool FocusEnabled
         {
             get { return focusEnabled; }
             set { focusEnabled = value; }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Does this object currently have focus by any <see cref="IMixedRealityPointer"/>?
+        /// </summary>
         public bool HasFocus => FocusEnabled && Focusers.Count > 0;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// The list of <see cref="IMixedRealityPointer"/>s that are currently focused on this <see cref="UnityEngine.GameObject"/>
+        /// </summary>
         public List<IMixedRealityPointer> Focusers { get; } = new List<IMixedRealityPointer>(0);
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/Handlers/IMixedRealityFocusHandler.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/Handlers/IMixedRealityFocusHandler.cs
@@ -12,21 +12,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers
     public interface IMixedRealityFocusHandler : IMixedRealityFocusChangedHandler
     {
         /// <summary>
-        /// Does this object currently have focus by any <see cref="IMixedRealityPointer"/>?
-        /// </summary>
-        bool HasFocus { get; }
-
-        /// <summary>
-        /// Is Focus capabilities enabled for this <see cref="UnityEngine.Component"/>?
-        /// </summary>
-        bool FocusEnabled { get; set; }
-
-        /// <summary>
-        /// The list of <see cref="IMixedRealityPointer"/>s that are currently focused on this <see cref="UnityEngine.GameObject"/>
-        /// </summary>
-        List<IMixedRealityPointer> Focusers { get; }
-
-        /// <summary>
         /// The Focus Enter event is raised on this <see cref="UnityEngine.GameObject"/> whenever a <see cref="IMixedRealityPointer"/>'s focus enters this <see cref="UnityEngine.GameObject"/>'s <see cref="UnityEngine.Collider"/>.
         /// </summary>
         /// <param name="eventData"></param>


### PR DESCRIPTION
Overview
---
This is the only handler interface that contains more than the event handlers. `IMixedRealityFocusHandler` contains three additional properties which added unnecessary overhead for implementing the focus events and are implementation-specific.

If a developer needs access to this information, they can inherit from `BaseFocusHandler`. Either way, we don't pass `I[*]Handler` references around, so there's no need to define them there, and not all interface implementations will need them.