### PR TITLE
Add rotated transform to Solvers after glTF coordinate system update

### DIFF
--- a/Assets/HoloToolkit-Examples/Utilities/Prefabs/SolverExample/WristWrapper.prefab
+++ b/Assets/HoloToolkit-Examples/Utilities/Prefabs/SolverExample/WristWrapper.prefab
@@ -204,7 +204,7 @@ Transform:
   m_GameObject: {fileID: 1142712698810798}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 4, y: 4, z: 4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4739880715010660}
   - {fileID: 4502422720436818}
@@ -303,7 +303,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 30d693ff62c571241b431ef4e206b09a, type: 2}
   m_StaticBatchInfo:
@@ -338,7 +337,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 30d693ff62c571241b431ef4e206b09a, type: 2}
   m_StaticBatchInfo:
@@ -373,7 +371,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 30d693ff62c571241b431ef4e206b09a, type: 2}
   m_StaticBatchInfo:
@@ -408,7 +405,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 811899e9ec1885f4cabed7937a48efbc, type: 2}
   m_StaticBatchInfo:
@@ -443,7 +439,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 64165286eff98134b82f4a6081c52d0f, type: 2}
   m_StaticBatchInfo:
@@ -478,7 +473,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 30d693ff62c571241b431ef4e206b09a, type: 2}
   m_StaticBatchInfo:
@@ -513,7 +507,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 30d693ff62c571241b431ef4e206b09a, type: 2}
   m_StaticBatchInfo:
@@ -596,6 +589,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   element: 6
+  handedness: 0
   trackedObjectToReference: 1
   additionalOffset: {x: 0, y: 0, z: 0}
   additionalRotation: {x: 0, y: 0, z: 0}
@@ -639,6 +633,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   element: 6
+  handedness: 0
   trackedObjectToReference: 1
   additionalOffset: {x: 0, y: 0, z: 0}
   additionalRotation: {x: 0, y: 0, z: 0}

--- a/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
+++ b/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,7 +39,6 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0.50217825, g: 0.5020953, b: 0.5018046, a: 1}
-  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -55,10 +54,11 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
-    m_AtlasSize: 1024
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
@@ -311,7 +311,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -547,7 +546,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -637,7 +635,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -722,7 +719,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -981,7 +977,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -1066,7 +1061,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -1488,6 +1482,38 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114148732877180316, guid: c484e6b755f90bd4eaa30a97ddeecfc1,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114065663948585220, guid: c484e6b755f90bd4eaa30a97ddeecfc1,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114675429442830900, guid: c484e6b755f90bd4eaa30a97ddeecfc1,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114044496379295336, guid: c484e6b755f90bd4eaa30a97ddeecfc1,
+        type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4379708329699554, guid: c484e6b755f90bd4eaa30a97ddeecfc1, type: 2}
+      propertyPath: m_LocalScale.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4379708329699554, guid: c484e6b755f90bd4eaa30a97ddeecfc1, type: 2}
+      propertyPath: m_LocalScale.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4379708329699554, guid: c484e6b755f90bd4eaa30a97ddeecfc1, type: 2}
+      propertyPath: m_LocalScale.z
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c484e6b755f90bd4eaa30a97ddeecfc1, type: 2}
   m_IsPrefabParent: 0
@@ -1522,7 +1548,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -1719,7 +1744,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -1985,7 +2009,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -2302,7 +2325,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:
@@ -2502,7 +2524,6 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
   m_Materials:
   - {fileID: 2100000, guid: 67dd3ea9a59f8fb48a5a4a7d10f2a97f, type: 2}
   m_StaticBatchInfo:

--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverHandler.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverHandler.cs
@@ -46,7 +46,7 @@ namespace HoloToolkit.Unity
                 if (trackedObjectToReference != value)
                 {
                     trackedObjectToReference = value;
-                    TransformTarget = null;
+                    OnControllerLost();
                     AttachToNewTrackedObject();
                 }
             }
@@ -66,7 +66,7 @@ namespace HoloToolkit.Unity
             set
             {
                 additionalOffset = value;
-                UpdateOffsetTransform();
+                TrackTransform(TransformTarget);
             }
         }
 
@@ -76,7 +76,7 @@ namespace HoloToolkit.Unity
             set
             {
                 additionalRotation = value;
-                UpdateOffsetTransform();
+                TrackTransform(TransformTarget);
             }
         }
 
@@ -202,24 +202,7 @@ namespace HoloToolkit.Unity
 
         private void TrackTransform(Transform newTrackedTransform)
         {
-            if (RequiresOffset())
-            {
-                TransformTarget = MakeOffsetTransform(newTrackedTransform);
-            }
-            else
-            {
-                TransformTarget = newTrackedTransform;
-            }
-        }
-
-        private bool RequiresOffset()
-        {
-            return AdditionalOffset.sqrMagnitude != 0 || AdditionalRotation.sqrMagnitude != 0;
-        }
-
-        private void UpdateOffsetTransform()
-        {
-            TransformTarget = MakeOffsetTransform(TransformTarget);
+            TransformTarget = MakeOffsetTransform(newTrackedTransform);
         }
 
         private Transform MakeOffsetTransform(Transform parentTransform)
@@ -233,6 +216,9 @@ namespace HoloToolkit.Unity
             transformWithOffset.transform.localPosition = AdditionalOffset;
             transformWithOffset.transform.localRotation = Quaternion.Euler(AdditionalRotation);
             transformWithOffset.name = string.Format("{0} on {1} with offset {2}, {3}", gameObject.name, TrackedObjectToReference.ToString(), AdditionalOffset, AdditionalRotation);
+            // In order to account for the reversed normals due to the glTF coordinate system change, we need to provide rotated attachment points.
+            transformWithOffset.transform.Rotate(0, 180, 0);
+
             return transformWithOffset.transform;
         }
 


### PR DESCRIPTION
Overview
---
After the glTF coordinate system update (#2638), the controller model's forward, up, etc vectors are reversed.

In order to account for this in solvers that assume the forward direction is out from the controller, we now expose a transform rotated 180 degrees around the Y axis, so "forward" is "forward" again.

This PR also updates the sample scene a little bit to account for this addition.