### PR TITLE
Fix dotnet runtime for UWP

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Diagnostics/CpuUseTracker.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Diagnostics/CpuUseTracker.cs
@@ -10,9 +10,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
     internal class CpuUseTracker
     {
         private TimeSpan? processorTime;
-        private Process currentProcess = Process.GetCurrentProcess();
         private TimeSpan[] readings = new TimeSpan[20];
-        int index = 0;
+        private int index = 0;
+
+#if !WINDOWS_UWP || ENABLE_IL2CPP
+        private Process currentProcess = Process.GetCurrentProcess();
+#endif
 
         public void Reset()
         {
@@ -21,6 +24,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
 
         public double GetReadingInMs()
         {
+#if WINDOWS_UWP && !ENABLE_IL2CPP
+            // UWP doesn't support process with dotnet runtime, so we can't get CPU readings with the current pattern. 
+            return -1;
+#else
             if (!processorTime.HasValue)
             {
                 processorTime = currentProcess.TotalProcessorTime;
@@ -35,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
             index = (index + 1) % readings.Length;
 
             return Math.Round(readings.Average(t => t.TotalMilliseconds), 2);
+#endif
         }
     }
 }

--- a/Assets/MixedRealityToolkit-SDK/Features/Diagnostics/MemoryUseTracker.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Diagnostics/MemoryUseTracker.cs
@@ -9,7 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
 {
     internal class MemoryUseTracker
     {
-        private Process currentProcess = Process.GetCurrentProcess();
         private readonly MemoryReading[] memoryReadings;
         private int index = 0;
 
@@ -29,9 +28,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
         public MemoryReading GetReading()
         {
             var reading = memoryReadings[index];
-
-            reading.VirtualMemoryInBytes = currentProcess.VirtualMemorySize64;
-            reading.WorkingSetMemoryInBytes = currentProcess.WorkingSet64;
             reading.GCMemoryInBytes = GC.GetTotalMemory(false);
 
             index = (index + 1) % memoryReadings.Length;
@@ -41,14 +37,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
 
         public struct MemoryReading
         {
-            public long VirtualMemoryInBytes { get; set; }
-            public long WorkingSetMemoryInBytes { get; set; }
             public long GCMemoryInBytes { get; set; }
 
             public MemoryReading Reset()
             {
-                VirtualMemoryInBytes = 0;
-                WorkingSetMemoryInBytes = 0;
                 GCMemoryInBytes = 0;
 
                 return this;
@@ -56,8 +48,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
 
             public static MemoryReading operator +(MemoryReading a, MemoryReading b)
             {
-                a.VirtualMemoryInBytes += b.VirtualMemoryInBytes;
-                a.WorkingSetMemoryInBytes += b.WorkingSetMemoryInBytes;
                 a.GCMemoryInBytes += b.GCMemoryInBytes;
 
                 return a;
@@ -65,8 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.DiagnosticsSystem
 
             public static MemoryReading operator /(MemoryReading a, int b)
             {
-                a.VirtualMemoryInBytes /= b;
-                a.WorkingSetMemoryInBytes /= b;
                 a.GCMemoryInBytes /= b;
 
                 return a;


### PR DESCRIPTION
Overview
---
Add pragma restrictions on use of System.Diagnostics.Process for cases where UWP and dotnet backend are used, since they don't use netstandard 2.0

Changes
---
- Fixes: #2874
