### PR TITLE
Fixed issue getting focused GameObject(s) when handling input event

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -252,52 +252,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
         #endregion MonoBehaviour Implementation
 
-        #region Focus Details by EventData
-
-        /// <inheritdoc />
-        public GameObject GetFocusedObject(BaseInputEventData eventData)
-        {
-            Debug.Assert(eventData != null);
-            if (OverrideFocusedObject != null) { return OverrideFocusedObject; }
-
-            IMixedRealityPointer pointer;
-            return TryGetPointingSource(eventData, out pointer) ? GetFocusedObject(pointer) : null;
-        }
-
-        /// <inheritdoc />
-        public bool TryGetFocusDetails(BaseInputEventData eventData, out FocusDetails focusDetails)
-        {
-            foreach (var pointerData in pointers)
-            {
-                if (pointerData.Pointer.InputSourceParent.SourceId == eventData.SourceId)
-                {
-                    focusDetails = pointerData.Details;
-                    return true;
-                }
-            }
-
-            focusDetails = default(FocusDetails);
-            return false;
-        }
-
-        /// <inheritdoc />
-        public bool TryGetPointingSource(BaseInputEventData eventData, out IMixedRealityPointer pointer)
-        {
-            foreach (var pointerData in pointers)
-            {
-                if (pointerData.Pointer.InputSourceParent.SourceId == eventData.SourceId)
-                {
-                    pointer = pointerData.Pointer;
-                    return true;
-                }
-            }
-
-            pointer = null;
-            return false;
-        }
-
-        #endregion Focus Details by EventData
-
         #region Focus Details by IMixedRealityPointer
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/DragAndDropHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/DragAndDropHandler.cs
@@ -135,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
             currentPointer = eventData.Pointer;
 
             FocusDetails focusDetails;
-            Vector3 initialDraggingPosition = MixedRealityManager.InputSystem.FocusProvider.TryGetFocusDetails(eventData.Pointer, out focusDetails)
+            Vector3 initialDraggingPosition = MixedRealityManager.InputSystem.FocusProvider.TryGetFocusDetails(currentPointer, out focusDetails)
                     ? focusDetails.Point
                     : hostTransform.position;
 

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/DragAndDropHandler.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/Handlers/DragAndDropHandler.cs
@@ -135,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
             currentPointer = eventData.Pointer;
 
             FocusDetails focusDetails;
-            Vector3 initialDraggingPosition = MixedRealityManager.InputSystem.FocusProvider.TryGetFocusDetails(eventData, out focusDetails)
+            Vector3 initialDraggingPosition = MixedRealityManager.InputSystem.FocusProvider.TryGetFocusDetails(eventData.Pointer, out focusDetails)
                     ? focusDetails.Point
                     : hostTransform.position;
 

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
@@ -302,6 +302,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
                     if (modalInput != null)
                     {
                         modalEventHandled = true;
+
                         // If there is a focused object in the hierarchy of the modal handler, start the event bubble there
                         if (focusedObject != null && focusedObject.transform.IsChildOf(modalInput.transform))
                         {

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
@@ -262,8 +262,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             Debug.Assert(eventData != null);
             var baseInputEventData = ExecuteEvents.ValidateEventData<BaseInputEventData>(eventData);
             Debug.Assert(baseInputEventData != null);
-            Debug.Assert(baseInputEventData.InputSource != null, $"Failed to find an input source for {baseInputEventData}");
             Debug.Assert(!baseInputEventData.used);
+
+            if (baseInputEventData.InputSource == null)
+            {
+                Debug.LogError($"Failed to find an input source for {baseInputEventData}");
+                return;
+            }
 
             // Send the event to global listeners
             base.HandleEvent(eventData, eventHandler);
@@ -275,7 +280,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
                 return;
             }
 
-            Debug.Assert(baseInputEventData.InputSource.Pointers != null, $"InputSource {baseInputEventData.InputSource.SourceName} doesn't have any registered pointers! Input Sources without pointers should use the GazeProvider's pointer as a default fallback.");
+            if (baseInputEventData.InputSource.Pointers == null)
+            {
+                Debug.LogError($"InputSource {baseInputEventData.InputSource.SourceName} doesn't have any registered pointers! Input Sources without pointers should use the GazeProvider's pointer as a default fallback.");
+                return;
+            }
 
             // Get the focused object for each pointer of the event source
             for (int i = 0; i < baseInputEventData.InputSource.Pointers.Length; i++)

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Physics;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Physics;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
@@ -32,29 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         GameObject OverrideFocusedObject { get; set; }
 
         /// <summary>
-        /// Gets the currently focused object based on specified the event data.
-        /// </summary>
-        /// <param name="eventData"></param>
-        /// <returns>Currently focused <see cref="GameObject"/> for the events input source.</returns>
-        GameObject GetFocusedObject(BaseInputEventData eventData);
-
-        /// <summary>
-        /// Try to get the focus details based on the specified event data.
-        /// </summary>
-        /// <param name="eventData"></param>
-        /// <param name="focusDetails"></param>
-        /// <returns>True, if event data pointer input source is registered.</returns>
-        bool TryGetFocusDetails(BaseInputEventData eventData, out FocusDetails focusDetails);
-
-        /// <summary>
-        /// Try to get the registered pointer source that raised the event.
-        /// </summary>
-        /// <param name="eventData"></param>
-        /// <param name="pointer"></param>
-        /// <returns>True, if event data's pointer input source is registered.</returns>
-        bool TryGetPointingSource(BaseInputEventData eventData, out IMixedRealityPointer pointer);
-
-        /// <summary>
         /// Gets the currently focused object for the pointing source.
         /// <para><remarks>If the pointing source is not registered, then the Gaze's Focused <see cref="GameObject"/> is returned.</remarks></para>
         /// </summary>
@@ -73,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// Get the Graphic Event Data for the specified pointing source.
         /// </summary>
         /// <param name="pointer">The pointer who's graphic event data we're looking for.</param>
-        /// <param name="graphicInputEventData">The graphihc event data for the specified pointer</param>
+        /// <param name="graphicInputEventData">The graphic event data for the specified pointer</param>
         /// <returns>True, if graphic event data exists.</returns>
         bool TryGetSpecificPointerGraphicEventData(IMixedRealityPointer pointer, out GraphicInputEventData graphicInputEventData);
 


### PR DESCRIPTION
Overview
---
Removed eventData methods for getting focus data. Users should instead iterate over the event data's pointers and call on the focus provider's pointer specific methods for getting focus data. This ensures there are not extra allocations while getting focus data and keeps performance in mind.

Changes
---
- Fixes: #2918 