### PR TITLE
 Add link to Azure hosted Slack invitation sender

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ For larger submissions, we have drafted contribution guidelines to ensure a smoo
 
 All changes be they small or large, need to adhere to the [MRTK Coding Standards](/CodingGuidelines.md), so please ensure you are familiar with these while developing to avoid delays when the change is being reviewed.
 
-If you have any questions, please reach out on the [HoloLens forums](https://forums.hololens.com/) or the [HoloDevelopers slack](https://holodevelopers.slack.com/). You can easily be granted access the Slack community via the [automatic invitation sender](https://holodevelopersslack.azurewebsites.net/).
+If you have any questions, please reach out on the [HoloLens forums](https://forums.hololens.com/) or the [HoloDevelopers slack](https://holodevelopers.slack.com/). You can easily be granted access to the Slack community via the [automatic invitation sender](https://holodevelopersslack.azurewebsites.net/).
 
 # Submission process
 We provide several paths to enable developers to contribute to the Mixed Reality Toolkit, all starting with [creating a new Issue](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ For larger submissions, we have drafted contribution guidelines to ensure a smoo
 
 All changes be they small or large, need to adhere to the [MRTK Coding Standards](/CodingGuidelines.md), so please ensure you are familiar with these while developing to avoid delays when the change is being reviewed.
 
-If you have any questions, please reach out on the [HoloLens forums](https://forums.hololens.com/) or the [HoloDevelopers slack](https://holodevelopers.slack.com/).
+If you have any questions, please reach out on the [HoloLens forums](https://forums.hololens.com/) or the [HoloDevelopers slack](https://holodevelopers.slack.com/). You can easily be granted access the Slack community via the [automatic invitation sender](https://holodevelopersslack.azurewebsites.net/).
 
 # Submission process
 We provide several paths to enable developers to contribute to the Mixed Reality Toolkit, all starting with [creating a new Issue](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose)


### PR DESCRIPTION
The current documentation mention to join HoloLens dedicated forum, or Slack. If you are not member of HoloDevelopers on Slack, you need someone to send you an invitation.

An automatic invitation sender has been hosted on Azure for a while now, and can provide a quick and easy access to anybody without manual intervention.

Since the Contribution guide was providing the Slack address, I suggest we also provide a link to the automatic invitation sender.