### PR TITLE
Fixed a typo that was causing some confusion on the Editor.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Editor/MixedRealityTeleportEditor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/MixedRealityTeleportEditor.cs
@@ -119,7 +119,7 @@ namespace HoloToolkit.Unity.InputModule
                 EditorGUILayout.PropertyField(horizontalStrafeProperty, new GUIContent("Horizontal Strafe"));
                 EditorGUILayout.PropertyField(forwardMovementProperty, new GUIContent("Forward Movement"));
                 EditorGUILayout.PropertyField(horizontalRotationProperty, new GUIContent("Horizontal Rotation"));
-                EditorGUILayout.PropertyField(verticalRotationProperty, new GUIContent("Verizontal Rotation"));
+                EditorGUILayout.PropertyField(verticalRotationProperty, new GUIContent("Vertical Rotation"));
             }
 
             serializedObject.ApplyModifiedProperties();


### PR DESCRIPTION
Overview
---
The text in the Editor property field was wrong.

Changes
---
- Fixes: Fixed the typo error.
