### PR TITLE
fix bug : Null Exception occur in WorldAnchorManager 

### DIFF
--- a/Assets/HoloToolkit/Common/Scripts/WorldAnchorManager.cs
+++ b/Assets/HoloToolkit/Common/Scripts/WorldAnchorManager.cs
@@ -324,7 +324,7 @@ namespace HoloToolkit.Unity
             for (var i = 0; i < anchors.Length; i++)
             {
                 // Don't remove SpatialMapping anchors if exists
-                if (spatialMappingManager != null && anchors[i].gameObject.transform.parent.gameObject == spatialMappingManager.gameObject)
+                if (spatialMappingManager != null && anchors[i].gameObject.transform.parent != null && anchors[i].gameObject.transform.parent.gameObject == spatialMappingManager.gameObject)
                 { continue; }
 
                 // Let's check to see if there are anchors we weren't accounting for.


### PR DESCRIPTION
Overview
---
if WorldAnchor component dont have parent, null exception occur.
change to check to be anchor.gameobject.transform.parent null

---
- Fixes: #1781


