### PR TITLE
Prevent solver targets from rotating when the target is the head

### DIFF
--- a/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
+++ b/Assets/HoloToolkit-Examples/Utilities/Scenes/SolverExamples.unity
@@ -1700,6 +1700,11 @@ Prefab:
       propertyPath: hideThisObject
       value: 
       objectReference: {fileID: 37845493}
+    - target: {fileID: 114459743357777030, guid: 687094229f7a92743bd68e3e190259ae,
+        type: 2}
+      propertyPath: updateSolverTargetToClickSource
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 687094229f7a92743bd68e3e190259ae, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SolverHandlerEditor.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SolverHandlerEditor.cs
@@ -50,13 +50,13 @@ namespace HoloToolkit.Unity.UX
 
             serializedObject.ApplyModifiedProperties();
 
-            if (trackedObjectChanged)
+            if (Application.isPlaying && trackedObjectChanged)
             {
                 solverHandler.TransformTarget = null;
                 solverHandler.AttachToNewTrackedObject();
             }
 
-            if (additionalOffsetChanged)
+            if (Application.isPlaying && additionalOffsetChanged)
             {
                 solverHandler.AdditionalOffset = additionalOffsetProperty.vector3Value;
                 solverHandler.AdditionalRotation = additionalRotationProperty.vector3Value;

--- a/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverHandler.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Solvers/SolverHandler.cs
@@ -216,8 +216,12 @@ namespace HoloToolkit.Unity
             transformWithOffset.transform.localPosition = AdditionalOffset;
             transformWithOffset.transform.localRotation = Quaternion.Euler(AdditionalRotation);
             transformWithOffset.name = string.Format("{0} on {1} with offset {2}, {3}", gameObject.name, TrackedObjectToReference.ToString(), AdditionalOffset, AdditionalRotation);
-            // In order to account for the reversed normals due to the glTF coordinate system change, we need to provide rotated attachment points.
-            transformWithOffset.transform.Rotate(0, 180, 0);
+
+            if (TrackedObjectToReference != TrackedObjectToReferenceEnum.Head)
+            {
+                // In order to account for the reversed normals due to the glTF coordinate system change, we need to provide rotated attachment points.
+                transformWithOffset.transform.Rotate(0, 180, 0);
+            }
 
             return transformWithOffset.transform;
         }


### PR DESCRIPTION
Overview
---
The fix in #2898 didn't properly account for when the solver was targeting the head. In that case, we don't want to add the 180 degree rotation, as that's only needed for the platform controller models.

Changes
---
- Fixes: #2933
