### PR TITLE
Initialized rules to remove build warnings

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputActionRulesProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/InputSystem/MixedRealityInputActionRulesProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     public class MixedRealityInputActionRulesProfile : BaseMixedRealityProfile
     {
         [SerializeField]
-        private InputActionRuleDigital[] inputActionRulesDigital;
+        private InputActionRuleDigital[] inputActionRulesDigital = null;
 
         /// <summary>
         /// All the Input Action Rules for <see cref="bool"/> based <see cref="MixedRealityInputAction"/>s
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
         public InputActionRuleDigital[] InputActionRulesDigital => inputActionRulesDigital;
 
         [SerializeField]
-        private InputActionRuleSingleAxis[] inputActionRulesSingleAxis;
+        private InputActionRuleSingleAxis[] inputActionRulesSingleAxis = null;
 
         /// <summary>
         /// All the Input Action Rules for <see cref="float"/> based <see cref="MixedRealityInputAction"/>s
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
         public InputActionRuleSingleAxis[] InputActionRulesSingleAxis => inputActionRulesSingleAxis;
 
         [SerializeField]
-        private InputActionRuleDualAxis[] inputActionRulesDualAxis;
+        private InputActionRuleDualAxis[] inputActionRulesDualAxis = null;
 
         /// <summary>
         /// All the Input Action Rules for <see cref="Vector2"/> based <see cref="MixedRealityInputAction"/>s
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
         public InputActionRuleDualAxis[] InputActionRulesDualAxis => inputActionRulesDualAxis;
 
         [SerializeField]
-        private InputActionRuleVectorAxis[] inputActionRulesVectorAxis;
+        private InputActionRuleVectorAxis[] inputActionRulesVectorAxis = null;
 
         /// <summary>
         /// All the Input Action Rules for <see cref="Vector3"/> based <see cref="MixedRealityInputAction"/>s
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
         public InputActionRuleVectorAxis[] InputActionRulesVectorAxis => inputActionRulesVectorAxis;
 
         [SerializeField]
-        private InputActionRuleQuaternionAxis[] inputActionRulesQuaternionAxis;
+        private InputActionRuleQuaternionAxis[] inputActionRulesQuaternionAxis = null;
 
         /// <summary>
         /// All the Input Action Rules for <see cref="Quaternion"/> based <see cref="MixedRealityInputAction"/>s
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
         public InputActionRuleQuaternionAxis[] InputActionRulesQuaternionAxis => inputActionRulesQuaternionAxis;
 
         [SerializeField]
-        private InputActionRulePoseAxis[] inputActionRulesPoseAxis;
+        private InputActionRulePoseAxis[] inputActionRulesPoseAxis = null;
 
         /// <summary>
         /// All the Input Action Rules for <see cref="MixedRealityPose"/> based <see cref="MixedRealityInputAction"/>s


### PR DESCRIPTION
Overview
---
Input Action Rule fields were not initialized properly and produced build warnings.
