### PR TITLE
Updated SystemType deserialization method

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/SystemType.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/SystemType.cs
@@ -59,19 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities
 
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
-            if (!string.IsNullOrEmpty(reference))
-            {
-                type = Type.GetType(reference);
-
-                if (type == null)
-                {
-                    Debug.LogWarning($"'{reference}' was referenced but class or struct type was not found.");
-                }
-            }
-            else
-            {
-                type = null;
-            }
+            type = !string.IsNullOrEmpty(reference) ? Type.GetType(reference) : null;
         }
 
         void ISerializationCallbackReceiver.OnBeforeSerialize() { }


### PR DESCRIPTION
Overview
---
When using different platforms it's guaranteed that certain platform specific types will be missing (As they're not included in the build). So this warning doesn't really need to be raised. Classes utilizing this should be checking if the returned type is null before use.