### PR TITLE
Add update to serializedObject in diagnostic inspector 

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -48,6 +48,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 GUI.enabled = false;
             }
 
+            serializedObject.Update();
+
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Diagnostic Visualization Options", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("Diagnostic visualizations can help monitor system resources and performance inside an application.", MessageType.Info);
@@ -59,6 +61,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             EditorGUILayout.PropertyField(showCpu);
             EditorGUILayout.PropertyField(showFps);
             EditorGUILayout.PropertyField(showMemory);
+
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }


### PR DESCRIPTION
Inspector changes weren't ever being saved from the diagnostic profile UI, which would cause it to never be enabled. 
