### PR TITLE
Updated Inspectors to apply the playspace at design time

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityManagerInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityManagerInspector.cs
@@ -93,6 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors
         public static void CreateMixedRealityManagerObject()
         {
             Selection.activeObject = MixedRealityManager.Instance;
+            var playspace = MixedRealityManager.Instance.MixedRealityPlayspace;
             EditorGUIUtility.PingObject(MixedRealityManager.Instance);
         }
     }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -58,7 +58,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                         "Yes",
                         "Later"))
                     {
-                        MixedRealityManager.Instance.ActiveProfile = configurationProfile;
+                       var playspace = MixedRealityManager.Instance.MixedRealityPlayspace;
+                       MixedRealityManager.Instance.ActiveProfile = configurationProfile;
                     }
                     else
                     {

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                         "Yes",
                         "Later"))
                     {
-                       var playspace = MixedRealityManager.Instance.MixedRealityPlayspace;
+                       var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
                        MixedRealityToolkit.Instance.ActiveProfile = configurationProfile;
                     }
                     else

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityConfigurationProfileInspector.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                         "Later"))
                     {
                        var playspace = MixedRealityManager.Instance.MixedRealityPlayspace;
-                       MixedRealityManager.Instance.ActiveProfile = configurationProfile;
+                       MixedRealityToolkit.Instance.ActiveProfile = configurationProfile;
                     }
                     else
                     {


### PR DESCRIPTION
Overview
---
The MixedRealityPlayspace should be instantiated at Design time, to ensure the developer / adopter understands the default layout of an MRTK scene.

They can change this afterwards, but should be there to begin with to ensure the scene is not tampered with at runtime and introduce unexpected results.
This was how it was in the HTK and how the framework was designed initially to run (Body -> head, until Body was renamed)

Changes
---
- Fixes: #2899
