### PR TITLE
Updated Inspectors to apply the playspace at design time

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/MixedRealityToolkitInspector.cs
@@ -93,6 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors
         public static void CreateMixedRealityOrchestratorObject()
         {
             Selection.activeObject = MixedRealityToolkit.Instance;
+            var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
             EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
         }
     }

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -58,6 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                         "Yes",
                         "Later"))
                     {
+                        var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
                         MixedRealityToolkit.Instance.ActiveProfile = configurationProfile;
                     }
                     else


### PR DESCRIPTION
Overview
---
> Take 2 :D 

The MixedRealityPlayspace should be instantiated at Design time, to ensure the developer / adopter understands the default layout of an MRTK scene.

They can change this afterwards, but should be there to begin with to ensure the scene is not tampered with at runtime and introduce unexpected results.
This was how it was in the HTK and how the framework was designed initially to run (Body -> head, until Body was renamed)

Changes
---
- Fixes: #2899
