### PR TITLE
Mrtk development serialization fix

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit-SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset
@@ -13,12 +13,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isCustomProfile: 0
   initialServiceTypes:
-  - reference: Microsoft.MixedReality.Toolkit.SDK.Teleportation.MixedRealityTeleportManager,
-      Microsoft.MixedReality.Toolkit.SDK
-  - reference: Microsoft.MixedReality.Toolkit.SDK.BoundarySystem.MixedRealityBoundaryManager,
-      Microsoft.MixedReality.Toolkit.SDK
-  - reference: Microsoft.MixedReality.Toolkit.SDK.Input.MixedRealityInputManager,
-      Microsoft.MixedReality.Toolkit.SDK
   targetExperienceScale: 3
   enableCameraProfile: 1
   cameraProfile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -25,9 +25,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
     {
         #region Service Registry properties
 
-        [SerializeField]
-        private SystemType[] initialServiceTypes = null;
-
         /// <summary>
         /// Dictionary list of active Systems used by the Mixed Reality Toolkit at runtime
         /// </summary>

--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
     /// Configuration profile settings for the Mixed Reality Toolkit.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Toolkit Configuration Profile", fileName = "MixedRealityToolkitConfigurationProfile", order = (int)CreateProfileMenuItemIndices.Configuration)]
-    public class MixedRealityToolkitConfigurationProfile : BaseMixedRealityProfile, ISerializationCallbackReceiver
+    public class MixedRealityToolkitConfigurationProfile : BaseMixedRealityProfile
     {
         #region Service Registry properties
 
@@ -238,33 +238,5 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         public MixedRealityRegisteredServiceProvidersProfile RegisteredServiceProvidersProfile => registeredServiceProvidersProfile;
 
         #endregion Mixed Reality Toolkit configurable properties
-
-        #region ISerializationCallbackReceiver Implementation
-
-        /// <inheritdoc />
-        void ISerializationCallbackReceiver.OnBeforeSerialize()
-        {
-            var count = ActiveServices.Count;
-            initialServiceTypes = new SystemType[count];
-
-            foreach (var service in ActiveServices)
-            {
-                --count;
-                initialServiceTypes[count] = new SystemType(service.Value.GetType());
-            }
-        }
-
-        /// <inheritdoc />
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
-        {
-            if (ActiveServices.Count == 0)
-            {
-                for (int i = 0; i < initialServiceTypes?.Length; i++)
-                {
-                    ActiveServices.Add(initialServiceTypes[i], Activator.CreateInstance(initialServiceTypes[i]) as IMixedRealityService);
-                }
-            }
-        }
     }
-    #endregion  ISerializationCallbackReceiver Implementation
 }

--- a/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
@@ -1028,10 +1028,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 return false;
             }
 
-            return type == typeof(IMixedRealityInputSystem) ||
-                   type == typeof(IMixedRealityTeleportSystem) ||
-                   type == typeof(IMixedRealityBoundarySystem) ||
-                   type == typeof(IMixedRealityDiagnosticsSystem);
+            return typeof(IMixedRealityInputSystem).IsAssignableFrom(type) ||
+                   typeof(IMixedRealityTeleportSystem).IsAssignableFrom(type) ||
+                   typeof(IMixedRealityBoundarySystem).IsAssignableFrom(type) ||
+                   typeof(IMixedRealityDiagnosticsSystem).IsAssignableFrom(type);
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
@@ -177,9 +177,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 Utilities.Editor.InputMappingAxisUtility.CheckUnityInputManagerMappings(Definitions.Devices.ControllerMappingLibrary.UnityInputManagerAxes);
 #endif
 
-                RegisterService(typeof(IMixedRealityInputSystem), Activator.CreateInstance(ActiveProfile.InputSystemType) as IMixedRealityInputSystem);
-
-                if (InputSystem == null)
+                if (!RegisterService(typeof(IMixedRealityInputSystem), Activator.CreateInstance(ActiveProfile.InputSystemType) as IMixedRealityInputSystem) ||
+                    InputSystem == null)
                 {
                     Debug.LogError("Failed to start the Input System!");
                 }
@@ -188,9 +187,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
             // If the Boundary system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.IsBoundarySystemEnabled)
             {
-                RegisterService(typeof(IMixedRealityBoundarySystem), Activator.CreateInstance(ActiveProfile.BoundarySystemSystemType) as IMixedRealityBoundarySystem);
-
-                if (BoundarySystem == null)
+                if (!RegisterService(typeof(IMixedRealityBoundarySystem), Activator.CreateInstance(ActiveProfile.BoundarySystemSystemType) as IMixedRealityBoundarySystem) ||
+                    BoundarySystem == null)
                 {
                     Debug.LogError("Failed to start the Boundary System!");
                 }
@@ -200,9 +198,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
             // If the Teleport system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.IsTeleportSystemEnabled)
             {
-                RegisterService(typeof(IMixedRealityTeleportSystem), Activator.CreateInstance(ActiveProfile.TeleportSystemSystemType) as IMixedRealityTeleportSystem);
-
-                if (TeleportSystem == null)
+                if (!RegisterService(typeof(IMixedRealityTeleportSystem), Activator.CreateInstance(ActiveProfile.TeleportSystemSystemType) as IMixedRealityTeleportSystem) ||
+                    TeleportSystem == null)
                 {
                     Debug.LogError("Failed to start the Teleport System!");
                 }
@@ -210,9 +207,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
 
             if (ActiveProfile.IsDiagnosticsSystemEnabled)
             {
-                RegisterService(typeof(IMixedRealityDiagnosticsSystem), Activator.CreateInstance(ActiveProfile.DiagnosticsSystemSystemType) as IMixedRealityDiagnosticsSystem);
-
-                if (DiagnosticsSystem == null)
+                if (!RegisterService(typeof(IMixedRealityDiagnosticsSystem), Activator.CreateInstance(ActiveProfile.DiagnosticsSystemSystemType) as IMixedRealityDiagnosticsSystem) ||
+                    DiagnosticsSystem == null)
                 {
                     Debug.LogError("Failed to start the Diagnostics System!");
                 }
@@ -231,7 +227,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                     {
                         if (configuration.ComponentType.Type != null)
                         {
-                            RegisterService(typeof(IMixedRealityExtensionService), Activator.CreateInstance(configuration.ComponentType, configuration.ComponentName, configuration.Priority) as IMixedRealityExtensionService);
+                            if(!RegisterService(typeof(IMixedRealityExtensionService), Activator.CreateInstance(configuration.ComponentType, configuration.ComponentName, configuration.Priority) as IMixedRealityExtensionService))
+                            {
+                                Debug.LogError($"Failed to register the {configuration.ComponentType.Type} Extension Service!");
+                            }
                         }
                     }
                 }
@@ -489,50 +488,55 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         /// </summary>
         /// <param name="type">The interface type for the system to be managed.  E.G. InputSystem, BoundarySystem</param>
         /// <param name="service">The Instance of the service class to register</param>
-        public void RegisterService(Type type, IMixedRealityService service)
+        public bool RegisterService(Type type, IMixedRealityService service)
         {
             if (ActiveProfile == null)
             {
                 Debug.LogError($"Unable to add a new {type.Name} Service as the Mixed Reality Toolkit has to Active Profile");
+                return false;
             }
 
             if (type == null)
             {
                 Debug.LogWarning("Unable to add a manager of type null.");
-                return;
+                return false;
             }
             if (service == null)
             {
                 Debug.LogWarning("Unable to add a manager with a null instance.");
-                return;
+                return false;
             }
 
             if (IsCoreSystem(type))
             {
                 IMixedRealityService preExistingService;
-                if (IsCoreSystem(type))
-                {
-                    ActiveProfile.ActiveServices.TryGetValue(type, out preExistingService);
-                }
-                else
-                {
-                    GetService(type, out preExistingService);
-                }
+
+                ActiveProfile.ActiveServices.TryGetValue(type, out preExistingService);
 
                 if (preExistingService == null)
                 {
                     ActiveProfile.ActiveServices.Add(type, service);
+                    return true;
                 }
                 else
                 {
                     Debug.LogError($"There's already a {type.Name} registered.");
+                    return false;
                 }
             }
             else
             {
-                MixedRealityComponents.Add(new Tuple<Type, IMixedRealityExtensionService>(type, (IMixedRealityExtensionService)service));
-                if (!isInitializing) { service.Initialize(); }
-                mixedRealityComponentsCount = MixedRealityComponents.Count;
+                try
+                {
+                    MixedRealityComponents.Add(new Tuple<Type, IMixedRealityExtensionService>(type, (IMixedRealityExtensionService)service));
+                    if (!isInitializing) { service.Initialize(); }
+                    mixedRealityComponentsCount = MixedRealityComponents.Count;
+                    return true;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
@@ -526,7 +526,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
             }
             else
             {
-                if (typeof(IMixedRealityExtensionService).IsAssignableFrom(type))
+                if (!typeof(IMixedRealityExtensionService).IsAssignableFrom(type))
                 {
                     Debug.LogError($"Unable to register {service}. Concrete type does not implement the IMixedRealityExtensionService implementation.");
                     return false;

--- a/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
@@ -526,17 +526,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
             }
             else
             {
-                try
+                if (typeof(IMixedRealityExtensionService).IsAssignableFrom(type))
                 {
-                    MixedRealityComponents.Add(new Tuple<Type, IMixedRealityExtensionService>(type, (IMixedRealityExtensionService)service));
-                    if (!isInitializing) { service.Initialize(); }
-                    mixedRealityComponentsCount = MixedRealityComponents.Count;
-                    return true;
-                }
-                catch (Exception)
-                {
+                    Debug.LogError($"Unable to register {service}. Concrete type does not implement the IMixedRealityExtensionService implementation.");
                     return false;
                 }
+
+                MixedRealityComponents.Add(new Tuple<Type, IMixedRealityExtensionService>(type, (IMixedRealityExtensionService)service));
+                if (!isInitializing) { service.Initialize(); }
+                mixedRealityComponentsCount = MixedRealityComponents.Count;
+                return true;
             }
         }
 


### PR DESCRIPTION
# Overview
---
@davidkline-ms noted an exception that was being raised in a UWP build on both Windows10 and HoloLens in #2979.  

On investigation, this was actually caused by poorly serialised data in the DefaultMixedRealityConfigurationProfile asset.  When the Core Services get reordered for Initialization, these serialised versions were also being detected and as they were being serialized by their concrete types and not their interface, the system failed to identify them as core systems.

This had two effects:

* The core system were duplicated in the service registry, one as a concrete type and another as a system interface
* The concrete type, being not seen as a core system, was attempted to be registered as a Registered service, causing a type cast failure.

It was also noted by others that there was some duplicated core system type checking, which needs cleaning up

# Resolution
---
Several changes have been made to resolve and reduce the risk of this happening in the future

* Serialisation of the Active Managers has been removed (we weren't using it anyway, the use case will need to be revalidated in the future)
* The Default config asset has been cleaned up
* The duplicate CoreSystemType check has been cleaned up
* The RegisterService function now also returns whether the system was indeed added or if an error was caused through a Boolean
* Use of the RegisterService call on initialisation now also listens for the Boolean result for extra protection
* Waves have been parted and many life cycles of my dev PC have been used up trying to figure out why Unity is so bad at building dev builds (and C++ is a huge drain on my life, I missed two meetings fixing this)

# Changes
---
- Fixes: #2979
- Reduces: sanity

# Tested on
---
* Via Unity debug
* UWP Dev .NET build 
* AppX generated from UWP .NET build
* IL2CPP build in VS
* Appx generated from IL2CPP build