### PR TITLE
Added #if blocks to QR code preview feature

### DIFF
--- a/Assets/HoloToolkit-Preview/QRTracker/Scripts/AttachToQRCode.cs
+++ b/Assets/HoloToolkit-Preview/QRTracker/Scripts/AttachToQRCode.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using QRCodesTrackerPlugin;
 
 namespace HoloToolkit.Unity.QRTracking
 {
@@ -18,6 +16,7 @@ namespace HoloToolkit.Unity.QRTracking
         private bool updatedId = false;
 
         private SpatialGraphCoordinateSystem coordSystem = null;
+
         /// <summary>
         /// Data of the QR code to which we want to attach the game object."
         /// </summary>
@@ -39,9 +38,11 @@ namespace HoloToolkit.Unity.QRTracking
                     {
                         qRCodeData = string.Empty;
                     }
-                    
+
+#if UNITY_EDITOR || UNITY_WSA
                     qrCodeId = QRCodesManager.Instance.GetIdForQRCode(qRCodeData);
                     updatedId = true;
+#endif // UNITY_EDITOR || UNITY_WSA
                 }
             }
         }
@@ -50,9 +51,11 @@ namespace HoloToolkit.Unity.QRTracking
 
         private void Awake()
         {
+#if UNITY_EDITOR || UNITY_WSA
             QRCodesManager.Instance.QRCodeAdded += Instance_QRCodeAdded;
             QRCodesManager.Instance.QRCodeUpdated += Instance_QRCodeUpdated;
             QRCodesManager.Instance.QRCodeRemoved += Instance_QRCodeRemoved;
+#endif // UNITY_EDITOR || UNITY_WSA
         }
 
         private void Start()
@@ -62,10 +65,14 @@ namespace HoloToolkit.Unity.QRTracking
                 // default use the scripts object
                 gameObjectToAttach = gameObject;
             }
+
+#if UNITY_EDITOR || UNITY_WSA
             qrCodeId = QRCodesManager.Instance.GetIdForQRCode(qRCodeData);
             updatedId = true;
+#endif // UNITY_EDITOR || UNITY_WSA
         }
 
+#if UNITY_EDITOR || UNITY_WSA
         private void Instance_QRCodeAdded(object sender, QRCodeEventArgs<QRCodesTrackerPlugin.QRCode> e)
         {
             if (qrCodeId == System.Guid.Empty)
@@ -115,5 +122,6 @@ namespace HoloToolkit.Unity.QRTracking
                 updatedId = false;
             }
         }
+#endif // UNITY_EDITOR || UNITY_WSA
     }
 }

--- a/Assets/HoloToolkit-Preview/QRTracker/Scripts/QRCode.cs
+++ b/Assets/HoloToolkit-Preview/QRTracker/Scripts/QRCode.cs
@@ -1,22 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-
-#if WINDOWS_UWP
-using Windows.Perception.Spatial;
-#endif
 
 namespace HoloToolkit.Unity.QRTracking
 {
-    [RequireComponent(typeof(HoloToolkit.Unity.SpatialGraphCoordinateSystem))]
+    [RequireComponent(typeof(SpatialGraphCoordinateSystem))]
     public class QRCode : MonoBehaviour
     {
+#if UNITY_EDITOR || UNITY_WSA
         public QRCodesTrackerPlugin.QRCode qrCode;
-        private GameObject qrCodeCube;
-
+#endif // UNITY_EDITOR || UNITY_WSA
         public float PhysicalSize;
         public string CodeText { get; set; }
 
@@ -26,6 +20,7 @@ namespace HoloToolkit.Unity.QRTracking
         private TextMesh QRTimeStamp;
         private TextMesh QRSize;
         private GameObject QRInfo;
+        private GameObject qrCodeCube;
 
         private long lastTimeStamp = 0;
 
@@ -33,6 +28,8 @@ namespace HoloToolkit.Unity.QRTracking
         {
             PhysicalSize = 0.1f;
             CodeText = "Dummy";
+
+#if UNITY_EDITOR || UNITY_WSA
             if (qrCode == null)
             {
                 throw new System.Exception("QR Code Empty");
@@ -55,7 +52,15 @@ namespace HoloToolkit.Unity.QRTracking
             QRSize.text = "Size:" + qrCode.PhysicalSizeMeters.ToString("F04") + "m";
             QRTimeStamp.text = "Time:" + qrCode.LastDetectedQPCTicks;
             Debug.Log("Id= " + qrCode.Id + " PhysicalSize = " + PhysicalSize + " TimeStamp = " + qrCode.LastDetectedQPCTicks + " QRVersion = " + qrCode.Version + " QRData = " + CodeText);
+#endif // UNITY_EDITOR || UNITY_WSA
         }
+
+        private void Update()
+        {
+#if UNITY_EDITOR || UNITY_WSA
+            UpdatePropertiesDisplay();
+        }
+
         private void UpdatePropertiesDisplay()
         {
             // Update properties that change
@@ -79,11 +84,7 @@ namespace HoloToolkit.Unity.QRTracking
                 lastTimeStamp = qrCode.LastDetectedQPCTicks;
                 QRInfo.transform.localScale = new Vector3(PhysicalSize/0.2f, PhysicalSize / 0.2f, PhysicalSize / 0.2f);
             }
-        }
-
-        private void Update()
-        {
-            UpdatePropertiesDisplay();
+#endif // UNITY_EDITOR || UNITY_WSA
         }
     }
 }

--- a/Assets/HoloToolkit-Preview/QRTracker/Scripts/QRCodesManager.cs
+++ b/Assets/HoloToolkit-Preview/QRTracker/Scripts/QRCodesManager.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections;
-
 using System.Collections.Generic;
-
 using UnityEngine;
 
+#if UNITY_EDITOR || UNITY_WSA
 using QRCodesTrackerPlugin;
+#endif // UNITY_EDITOR || UNITY_WSA
+
 namespace HoloToolkit.Unity.QRTracking
 {
     public static class QRCodeEventArgs
@@ -36,18 +36,19 @@ namespace HoloToolkit.Unity.QRTracking
         public bool AutoStartQRTracking = true;
 
         public bool IsTrackerRunning { get; private set; }
-        public QRCodesTrackerPlugin.QRTrackerStartResult StartResult { get; private set; }
 
+#if UNITY_EDITOR || UNITY_WSA
+        public QRTrackerStartResult StartResult { get; private set; }
 
         public event EventHandler<QRCodeEventArgs<QRCodesTrackerPlugin.QRCode>> QRCodeAdded;
         public event EventHandler<QRCodeEventArgs<QRCodesTrackerPlugin.QRCode>> QRCodeUpdated;
         public event EventHandler<QRCodeEventArgs<QRCodesTrackerPlugin.QRCode>> QRCodeRemoved;
 
-        private System.Collections.Generic.SortedDictionary<System.Guid, QRCodesTrackerPlugin.QRCode> qrCodesList = new SortedDictionary<System.Guid, QRCodesTrackerPlugin.QRCode>();
+        private SortedDictionary<Guid, QRCodesTrackerPlugin.QRCode> qrCodesList = new SortedDictionary<Guid, QRCodesTrackerPlugin.QRCode>();
 
         private QRTracker qrTracker;
 
-        public System.Guid GetIdForQRCode(string qrCodeData)
+        public Guid GetIdForQRCode(string qrCodeData)
         {
             lock (qrCodesList)
             {
@@ -59,16 +60,17 @@ namespace HoloToolkit.Unity.QRTracking
                     }
                 }
             }
-            return System.Guid.Empty;
+            return Guid.Empty;
         }
 
-        public System.Collections.Generic.IList<QRCodesTrackerPlugin.QRCode> GetList()
+        public IList<QRCodesTrackerPlugin.QRCode> GetList()
         {
             lock (qrCodesList)
             {
                 return new List<QRCodesTrackerPlugin.QRCode>(qrCodesList.Values);
             }
         }
+#endif // UNITY_EDITOR || UNITY_WSA
 
         protected override void Awake()
         {
@@ -78,6 +80,7 @@ namespace HoloToolkit.Unity.QRTracking
 
         protected virtual void Start()
         {
+#if UNITY_EDITOR || UNITY_WSA
             qrTracker = new QRTracker();
             qrTracker.Added += QrTracker_Added;
             qrTracker.Updated += QrTracker_Updated;
@@ -87,8 +90,10 @@ namespace HoloToolkit.Unity.QRTracking
             {
                 StartQRTracking();
             }
+#endif // UNITY_EDITOR || UNITY_WSA
         }
 
+#if UNITY_EDITOR || UNITY_WSA
         public QRTrackerStartResult StartQRTracking()
         {
             if (!IsTrackerRunning)
@@ -150,7 +155,6 @@ namespace HoloToolkit.Unity.QRTracking
                 handlers(this, QRCodeEventArgs.Create(args.Code));
             }
         }
-
+#endif // UNITY_EDITOR || UNITY_WSA
     }
-
 }

--- a/Assets/HoloToolkit-Preview/QRTracker/Scripts/QRCodesVisualizer.cs
+++ b/Assets/HoloToolkit-Preview/QRTracker/Scripts/QRCodesVisualizer.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-
 using System.Collections.Generic;
-
 using UnityEngine;
 
-using QRCodesTrackerPlugin;
 namespace HoloToolkit.Unity.QRTracking
 {
     public class QRCodesVisualizer : MonoBehaviour
@@ -15,8 +11,9 @@ namespace HoloToolkit.Unity.QRTracking
         public GameObject qrCodePrefab;
 
         private SortedDictionary<System.Guid, GameObject> qrCodesObjectsList;
-
-        struct ActionData
+        
+#if UNITY_EDITOR || UNITY_WSA
+        private struct ActionData
         {
             public enum Type
             {
@@ -35,12 +32,16 @@ namespace HoloToolkit.Unity.QRTracking
         }
 
         private Queue<ActionData> pendingActions = new Queue<ActionData>();
+#endif // UNITY_EDITOR || UNITY_WSA
+
         private void Awake()
         {
+#if UNITY_EDITOR || UNITY_WSA
             qrCodesObjectsList = new SortedDictionary<System.Guid, GameObject>();
             QRCodesManager.Instance.QRCodeAdded += Instance_QRCodeAdded;
             QRCodesManager.Instance.QRCodeUpdated += Instance_QRCodeUpdated;
             QRCodesManager.Instance.QRCodeRemoved += Instance_QRCodeRemoved;
+#endif // UNITY_EDITOR || UNITY_WSA
         }
 
         private void Start()
@@ -49,6 +50,12 @@ namespace HoloToolkit.Unity.QRTracking
             {
                 throw new System.Exception("Prefab not assigned");
             }
+        }
+
+#if UNITY_EDITOR || UNITY_WSA
+        private void Update()
+        {
+            HandleEvents();
         }
 
         private void Instance_QRCodeAdded(object sender, QRCodeEventArgs<QRCodesTrackerPlugin.QRCode> e)
@@ -105,11 +112,6 @@ namespace HoloToolkit.Unity.QRTracking
                 }
             }
         }
-
-        private void Update()
-        {
-            HandleEvents();
-        }
+#endif // UNITY_EDITOR || UNITY_WSA
     }
-
 }

--- a/Assets/HoloToolkit-Preview/QRTracker/Scripts/SpatialGraphCoordinateSystem.cs
+++ b/Assets/HoloToolkit-Preview/QRTracker/Scripts/SpatialGraphCoordinateSystem.cs
@@ -1,66 +1,70 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+
 #if WINDOWS_UWP
 using Windows.Perception.Spatial;
 #endif
+
 namespace HoloToolkit.Unity
 {
     public class SpatialGraphCoordinateSystem : MonoBehaviour
     {
 #if WINDOWS_UWP
         private SpatialCoordinateSystem CoordinateSystem = null;
-#endif
-        private System.Guid id;
+#endif // WINDOWS_UWP
+
+#if UNITY_EDITOR || UNITY_WSA
         private UnityEngine.XR.WSA.PositionalLocatorState CurrentState { get; set; }
+#endif // UNITY_EDITOR || UNITY_WSA
+
+        private System.Guid id;
         public System.Guid Id
         {
-            get
-            {
-                return id;
-            }
-
+            get { return id; }
             set
             {
                 id = value;
 #if WINDOWS_UWP
                 CoordinateSystem = Windows.Perception.Spatial.Preview.SpatialGraphInteropPreview.CreateCoordinateSystemForNode(id);
-#endif
+#endif // WINDOWS_UWP
             }
         }
 
         private void Awake()
         {
+#if UNITY_EDITOR || UNITY_WSA
             CurrentState = UnityEngine.XR.WSA.PositionalLocatorState.Unavailable;
+#endif // UNITY_EDITOR || UNITY_WSA
         }
 
         private void Start()
         {
+#if UNITY_EDITOR || UNITY_WSA
             UnityEngine.XR.WSA.WorldManager.OnPositionalLocatorStateChanged += WorldManager_OnPositionalLocatorStateChanged;
             CurrentState = UnityEngine.XR.WSA.WorldManager.state;
+
 #if WINDOWS_UWP
             if (CoordinateSystem == null)
             {
                 CoordinateSystem = Windows.Perception.Spatial.Preview.SpatialGraphInteropPreview.CreateCoordinateSystemForNode(id);
             }
-#endif
+#endif // WINDOWS_UWP
+#endif // UNITY_EDITOR || UNITY_WSA
+        }
+
+        private void Update()
+        {
+#if UNITY_EDITOR || UNITY_WSA
+            UpdateLocation();
         }
 
         private void WorldManager_OnPositionalLocatorStateChanged(UnityEngine.XR.WSA.PositionalLocatorState oldState, UnityEngine.XR.WSA.PositionalLocatorState newState)
         {
             CurrentState = newState;
-            if (newState == UnityEngine.XR.WSA.PositionalLocatorState.Active)
-            {
-                // This simply activates/deactivates this object and all children when tracking changes
-                gameObject.SetActive(true);
-            }
-            else
-            {
-                gameObject.SetActive(false);
-            }
+            // This simply activates/deactivates this object and all children when tracking changes.
+            gameObject.SetActive(newState == UnityEngine.XR.WSA.PositionalLocatorState.Active);
         }
 
         private void UpdateLocation()
@@ -122,13 +126,9 @@ namespace HoloToolkit.Unity
                 {
                    gameObject.SetActive(false);
                 }
-#endif
+#endif // WINDOWS_UWP
             }
-        }
-
-        private void Update()
-        {
-            UpdateLocation();
+#endif // UNITY_EDITOR || UNITY_WSA
         }
     }
 }


### PR DESCRIPTION
Overview
---
The QR code plugin is only provided for UWP and the editor, so all references to it (and other Unity WSA specific APIs) needed to be wrapped with `#if UNITY_EDITOR || UNITY_WSA`. This also led to some minor clean-up to better wrap the contents.

Changes
---
- Fixes: https://github.com/Microsoft/MixedRealityToolkit/issues/183
