### PR TITLE
Make FloorScale's type match floorScale's type

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Boundary/MixedRealityBoundaryManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Boundary/MixedRealityBoundaryManager.cs
@@ -523,7 +523,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.BoundarySystem
                 return null;
             }
 
-            Vector3 floorScale = MixedRealityToolkit.Instance.ActiveProfile.BoundaryVisualizationProfile.FloorScale;
+            Vector2 floorScale = MixedRealityToolkit.Instance.ActiveProfile.BoundaryVisualizationProfile.FloorScale;
 
             // Render the floor.
             currentFloorObject = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem
         /// <summary>
         /// The size at which to display the rectangular floor plane <see cref="GameObject"/>.
         /// </summary>
-        public Vector3 FloorScale => floorScale;
+        public Vector2 FloorScale => floorScale;
 
         #endregion Floor settings
 


### PR DESCRIPTION
Overview
---
Changes the return type from Vector3 -> Vector2. We were only using `x` and `y` in the manager anyway.

Changes
---
- Fixes: #2706
