### PR TITLE
Make IMixedRealityControllerVisualizer less implementation-specific

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Interfaces/Devices/IMixedRealityControllerVisualizer.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/Devices/IMixedRealityControllerVisualizer.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices
 {
-    public interface IMixedRealityControllerVisualizer : IMixedRealityControllerPoseSynchronizer
+    public interface IMixedRealityControllerVisualizer
     {
         /// <summary>
         /// The <see cref="GameObject"/> reference for this controller.
@@ -14,6 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices
         /// This reference may not always be available when called.
         /// </remarks>
         GameObject GameObjectProxy { get; }
+
+        /// <summary>
+        /// The current controller reference.
+        /// </summary>
+        IMixedRealityController Controller { get; set; }
 
         // TODO add defined elements or transforms?
     }


### PR DESCRIPTION
Overview
---
Not all visualizers will be driven by a pose synchronizer. Implementations that want to be (like `MixedRealityControllerVisualizer`) are still able to implement both interfaces.