### PR TITLE
Fix bug in ResetFocusedObjects where the previous target stayed the same

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -187,10 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
             public void ResetFocusedObjects(bool clearPreviousObject = true)
             {
-                if (clearPreviousObject)
-                {
-                    PreviousPointerTarget = null;
-                }
+                PreviousPointerTarget = clearPreviousObject ? null : CurrentPointerTarget;
 
                 focusDetails.Point = Details.Point;
                 focusDetails.Normal = Details.Normal;


### PR DESCRIPTION
Overview
---
When a pointer is set to [no longer be enabled for interaction](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs#L509), the focused object is reset without the previous object being cleared. Since this line is hit every time the pointer is updated, multiple `FocusLost` events are sent to the previous object, since it never changes.

With this change, on the first call to this method, the previous object will be properly set to the old current focused object. Since the `CurrentPointerTarget` is then set to null, every subsequent call to this method will set the previous target to null and not send another `FocusLost` event.