### PR TITLE
Fix for tile generator quitting if used on a non 2018 build of Unity

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/SetIconsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/SetIconsWindow.cs
@@ -196,9 +196,18 @@ namespace HoloToolkit.Unity
 
                     foreach (var scale in scales)
                     {
-                        PlayerSettings.WSA.SetVisualAssetsImage(CloneAndResizeToFile(type, scale), type, scale);
-
-                        progress++;
+                        try
+                        {
+                            PlayerSettings.WSA.SetVisualAssetsImage(CloneAndResizeToFile(type, scale), type, scale);
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogWarning(e.Message);
+                        }
+                        finally
+                        {
+                            progress++;
+                        }
                         if (EditorUtility.DisplayCancelableProgressBar("Generating images", string.Format("Generating resized images {0} of {1}", progress, progressTotal), progress / progressTotal))
                         {
                             canceled = true;


### PR DESCRIPTION
Overview
---
Carry on processing other images after an unsupported image type is encountered.

Changes
---
- Fixes: #3028 .
