### PR TITLE
Set minimum distance of stabilization plane to nearclip distance of camera

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
@@ -210,6 +210,8 @@ namespace HoloToolkit.Unity
             if (TryGetGazeHitPosition(out gazeHitPosition))
             {
                 focusPointDistance = (gazeOrigin - gazeHitPosition).magnitude;
+                var nearClipPlane = CameraCache.Main.nearClipPlane;
+                focusPointDistance = Mathf.Max(focusPointDistance, nearClipPlane);
             }
             else
             {


### PR DESCRIPTION
When camera collides with an object, the stabilization plane comes to camera. 
This makes Holograms unstable.

![image](https://user-images.githubusercontent.com/4415085/47761222-ec592500-dcfa-11e8-9136-50e4d19c6ffc.png)

The distance of stabilization plane should be greater than that of near clip.

Maybe this behaviour should be optional so that user can disable it.
