### PR TITLE
Fixed ParabolaConstrainedLineDataProvider's SetPointInternal

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Utilities/Lines/DataProviders/ParabolaConstrainedLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/Lines/DataProviders/ParabolaConstrainedLineDataProvider.cs
@@ -87,13 +87,19 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.DataProviders
         /// <inheritdoc />
         protected override void SetPointInternal(int pointIndex, Vector3 point)
         {
-            if (pointIndex == 1)
+            switch (pointIndex)
             {
-                endPoint.Position = point;
-            }
-            else
-            {
-                Debug.LogError("Invalid point index!");
+                case 0:
+                    // We do nothing with this case. Parabola lines start at 0,0,0
+                    // Case 0's point is (0,0,0)
+                    // 10/25/2018 - VNext Refactoring of Tooltips
+                    break;
+                case 1:
+                    endPoint.Position = point;
+                    break;
+                default:
+                    Debug.LogError("Invalid point index!");
+                    break;
             }
         }
 


### PR DESCRIPTION
Overview
---Fixed the unclear behavior of the ParabolaConstrainedLineDataProvider's SetPointInternal
If a function called it with a 0 value (for the origin point of the parabola), it would report with a vague error.
Added a comment explaining why nothing was done.
Needed for Tooltip refactor.

Changes
---
- Fixes: # .
