### PR TITLE
Fixed diagnostics null ref when disabling at edit time

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/MixedRealityToolkitConfigurationProfile.cs
@@ -249,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
 
         public bool IsDiagnosticsSystemEnabled
         {
-            get { return enableDiagnosticsSystem && DiagnosticsSystemSystemType?.Type != null; }
+            get { return enableDiagnosticsSystem && DiagnosticsSystemSystemType?.Type != null && diagnosticsSystemProfile != null; }
             private set { enableDiagnosticsSystem = value; }
         }
 

--- a/Assets/MixedRealityToolkit/_Core/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -60,7 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services.DiagnosticsSystem
             showFps = false;
             showMemory = false;
 
-            RaiseDiagnosticsChanged();
+            if (Application.isPlaying)
+            {
+                RaiseDiagnosticsChanged();
+            }
         }
 
         #endregion IMixedRealityService


### PR DESCRIPTION
Overview
---
- Fixed a null ref when disabling diagnostics system at edit time.
- Only enable diagnostics system if a valid profile is assigned.