### PR TITLE
Fix overwriting bool in RequestPointers

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
@@ -44,12 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
                 {
                     var pointerProfile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile.PointerOptions[i];
 
-                    if (!useSpecificType)
-                    {
-                        useSpecificType = pointerProfile.ControllerType.Type != null;
-                    }
-
-                    if ((!useSpecificType || pointerProfile.ControllerType.Type == controllerType.Type) &&
+                    if (((useSpecificType && pointerProfile.ControllerType.Type == controllerType.Type) || (!useSpecificType && pointerProfile.ControllerType.Type == null)) &&
                         (pointerProfile.Handedness == Handedness.Any || pointerProfile.Handedness == Handedness.Both || pointerProfile.Handedness == controllingHand))
                     {
                         var pointerObject = Object.Instantiate(pointerProfile.PointerPrefab);


### PR DESCRIPTION
Overview
---
Line 49 was overwriting a method parameter inside a `for` loop.

The result of this was that subsequent pointers in the pointer profile were using the overwritten value instead of their own bool checks.

For example:
Putting a specifically typed pointer above a `None` typed pointer in the pointer profile.
The specifically typed pointer will overwrite `useSpecificType` to true, which will cause all following pointers to keep using `useSpecificType` as true, since line 49 will be skipped.