### PR TITLE
Delay trying to load controller models to enable Editor loading

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/MotionControllerVisualizer.cs
@@ -108,6 +108,11 @@ namespace HoloToolkit.Unity.InputModule
             InteractionManager.InteractionSourceDetected -= InteractionManager_InteractionSourceDetected;
             InteractionManager.InteractionSourceLost -= InteractionManager_InteractionSourceLost;
             Application.onBeforeRender -= Application_onBeforeRender;
+
+            foreach (MotionControllerInfo controllerInfo in controllerDictionary.Values)
+            {
+                Destroy(controllerInfo.ControllerParent);
+            }
 #endif
         }
 


### PR DESCRIPTION
Overview
---
When launching in the editor, there's a race condition between sources being present in the `DetectedSources` list and the editor's holographic window being available, which is needed to get the platform sources to load the model.

To resolve this, I moved the initial attempt to load out of both `Awake` and `onBeforeRender`, so it now only tries to load in `Update` or `SourceDetected`. I've found this to fix controller model loading in the editor in all my tests.

Changes
---
- Fixes: #1645
- Fixes: #2682
- Fixes: #2805
- Fixes: #2861