### PR TITLE
Add base.OnEnable to Spatial Awareness inspector

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealitySpatialAwarenessProfileInspector.cs
@@ -57,6 +57,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
         protected override void OnEnable()
         {
+            base.OnEnable();
+
             if (!CheckMixedRealityConfigured(false))
             {
                 return;


### PR DESCRIPTION
Overview
---
This inspector was missing the base call, so some expected values weren't being set properly. In particular, this broke copy + paste.