### PR TITLE
Some fixes

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -97,11 +97,6 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
                 !MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled ||
                  MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
-
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -93,10 +93,32 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
         {
             RenderMixedRealityToolkitLogo();
 
-            if (!CheckMixedRealityConfigured() ||
-                !MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled ||
-                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
+            if (!CheckMixedRealityConfigured())
             {
+                return;
+            }
+
+            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
+            {
+                EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
+
+                if (GUILayout.Button("Back to Configuration Profile"))
+                {
+                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                }
+
+                return;
+            }
+
+            if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
+            {
+                EditorGUILayout.HelpBox("No Input Actions profile was specified.", MessageType.Error);
+
+                if (GUILayout.Button("Back to Input Profile"))
+                {
+                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                }
+
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
## Changes

- Updated two profile inspector icons

- The `MixedRealityInputActionRulesInspector` had an error where you could see the "Back to Configuration Profile" message even if there was no MixedRealityToolkit in your scene.

