### PR TITLE
Fixing incorrect alpha channel values for channel maps and alpha tested (cutout) materials.

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Resources/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/_Core/Resources/Shaders/MixedRealityStandard.shader
@@ -563,7 +563,7 @@ Shader "Mixed Reality Toolkit/Standard"
 #if defined(_CHANNEL_MAP)
                 fixed4 channel = tex2D(_ChannelMap, i.uv);
                 _Metallic = channel.r;
-                albedo *= channel.g;
+                albedo.rgb *= channel.g;
                 _Smoothness = channel.a * 2.0;
 #else
 #if defined(_METALLIC_TEXTURE_ALBEDO_CHANNEL_A)
@@ -675,6 +675,7 @@ Shader "Mixed Reality Toolkit/Standard"
                 _Cutoff = 0.5;
 #endif
                 clip(albedo.a - _Cutoff);
+                albedo.a = 1.0;
 #endif
 
 #if defined(_NORMAL)


### PR DESCRIPTION
Materials using channel maps or alpha tested (cutout) materials could report incorrect alpha values. This is not something apparent in usual usage, but could present problems during Mixed Reality or BEV capture. 
