### PR TITLE
Simple state sharing

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Interfaces/Sharing.meta
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/Sharing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cac6d374b0509c24089b46bdd5e66a05
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/Sharing/ISimpleState.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/Sharing/ISimpleState.cs
@@ -8,6 +8,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Sharing
     /// </summary>
     public interface ISimpleState : IMixedRealityService
     {
+        bool IsConnected { get; }
+
         Task<bool> HasKey(string key);
         Task SetState<T>(string key, T state);
         Task<T> GetState<T>(string key);

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/Sharing/ISimpleState.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/Sharing/ISimpleState.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Sharing
+{
+    /// <summary>
+    /// Simplest possible non-automatic state sharing.
+    /// Will typically be networked but could also plug into a file system or local database.
+    /// </summary>
+    public interface ISimpleState : IMixedRealityService
+    {
+        Task<bool> HasKey(string key);
+        Task SetState<T>(string key, T state);
+        Task<T> GetState<T>(string key);
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Sharing.meta
+++ b/Assets/MixedRealityToolkit/_Core/Sharing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8765d81112d916642a2b87febff9332a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs
+++ b/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.Sharing;
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Async.AwaitYieldInstructions;
+using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
@@ -12,10 +14,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
     /// </summary>
     public class SimpleStatePlayerPrefs : BaseService, ISimpleState
     {
-        public override void Initialize()
-        {
-            Name = "SimpleStatePlayerPrefs";
-        }
+        /// <inheritdoc />
+        public override string Name { get { return "SimpleStatePlayerPrefs"; } }
+
+        public bool IsConnected { get; set; }
 
         public int SimulatedLatency { get; set; }
 
@@ -26,6 +28,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
 
             await Task.Delay(SimulatedLatency);
 
+            await new WaitForUpdate();
+
             return PlayerPrefs.HasKey(key);
         }
         
@@ -35,6 +39,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
                 throw new Exception("Key cannot be empty.");
 
             await Task.Delay(SimulatedLatency);
+
+            await new WaitForUpdate();
 
             if (PlayerPrefs.HasKey(key))
             {
@@ -64,7 +70,19 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
 
             await Task.Delay(SimulatedLatency);
 
-            string serializedObject = JsonUtility.ToJson(state);
+            await new WaitForUpdate();
+
+            string serializedObject = string.Empty;
+            try
+            {
+                serializedObject = JsonUtility.ToJson(state);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Failed to serialize object of type " + typeof(T) + ": " + e.ToString());
+                return;
+            }
+
             PlayerPrefs.SetString(key, serializedObject);
         }
     }

--- a/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs
+++ b/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs
@@ -10,23 +10,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
     /// Uses JSON to store and retrieve serialized objects from PlayerPrefs
     /// Useful for testing state sharing without a connection
     /// </summary>
-    public class SimpleStatePlayerPrefs : ISimpleState
+    public class SimpleStatePlayerPrefs : BaseService, ISimpleState
     {
-        public string Name { get { return "SimpleStatePlayerPrefs"; } }
-
-        public uint Priority { get { return 0; } }
-
-        public void Destroy() { }
-
-        public void Disable() { }
-
-        public void Enable() { }
-
-        public void Initialize() { }
-
-        public void Reset() { }
-
-        public void Update() { }
+        public override void Initialize()
+        {
+            Name = "SimpleStatePlayerPrefs";
+        }
 
         public int SimulatedLatency { get; set; }
 

--- a/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs
+++ b/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.Sharing;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Services.Sharing
+{
+    /// <summary>
+    /// A local simulation of state sharing
+    /// Uses JSON to store and retrieve serialized objects from PlayerPrefs
+    /// Useful for testing state sharing without a connection
+    /// </summary>
+    public class SimpleStatePlayerPrefs : ISimpleState
+    {
+        public string Name { get { return "SimpleStatePlayerPrefs"; } }
+
+        public uint Priority { get { return 0; } }
+
+        public void Destroy() { }
+
+        public void Disable() { }
+
+        public void Enable() { }
+
+        public void Initialize() { }
+
+        public void Reset() { }
+
+        public void Update() { }
+
+        public int SimulatedLatency { get; set; }
+
+        public async Task<bool> HasKey(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new Exception("Key cannot be empty.");
+
+            await Task.Delay(SimulatedLatency);
+
+            return PlayerPrefs.HasKey(key);
+        }
+        
+        public async Task<T> GetState<T>(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new Exception("Key cannot be empty.");
+
+            await Task.Delay(SimulatedLatency);
+
+            if (PlayerPrefs.HasKey(key))
+            {
+                try
+                {
+                    string jsonString = PlayerPrefs.GetString(key);
+                    T deserializedObject = JsonUtility.FromJson<T>(jsonString);
+                    return deserializedObject;
+                } 
+                catch (Exception e)
+                {
+                    Debug.LogError("Error when attempting to deserialize object from key " + key);
+                }
+            }
+            else
+            {
+                Debug.LogError("Key " + key + " does not exist in state.");
+            }
+
+            return default(T);
+        }
+
+        public async Task SetState<T>(string key, T state)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new Exception("Key cannot be empty.");
+
+            await Task.Delay(SimulatedLatency);
+
+            string serializedObject = JsonUtility.ToJson(state);
+            PlayerPrefs.SetString(key, serializedObject);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Sharing/SimpleStatePlayerPrefs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9651f5443bd56cb42be1c1e3f1f05024
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Simple state sharing service
---
Baseline for a simple, flexible state sharing service.

On a continuum between POC apps and robust, enterprise-ready apps this service should fall somewhere in the middle. It doesn't try to guide you down an 'optimal' path like [advanced state sharing](https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/3210), but it's not an automatic drag-and-drop solution either.

```
public interface ISimpleState : IMixedRealityService
{
    Task<bool> HasKey(string key);
    Task SetState<T>(string key, T state);
    Task<T> GetState<T>(string key);
}
```

This service could be implemented using:
- a remote database
- a local database
- a local file
- an MRTK network connection service
- Photon
- etc. 

Tasks make it easy to deal with varying amounts of latency in these approaches.

SimpleStatePlayerPrefs
----
Wraps PlayerPrefs in the SimpleState interface. Used for testing.