### PR TITLE
Fix FocusProvider bug where the pointer was comparing to itself

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -483,7 +483,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
                 foreach (var otherPointer in pointers)
                 {
-                    if (otherPointer.CurrentPointerTarget == unfocusedObject)
+                    if (otherPointer.Pointer != pointer && otherPointer.CurrentPointerTarget == unfocusedObject)
                     {
                         objectIsStillFocusedByOtherPointer = true;
                         break;


### PR DESCRIPTION
Overview
---
Since the pointer being unregistered is still in the list of pointers at this point in the code, it was comparing against itself, making this statement always true. This was causing focus lost events to not be fired in cases where they should be.