### PR TITLE
Fix issue where some event data wasn't having its handedness properly reset

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/EventDatum/Input/InputEventData.cs
+++ b/Assets/MixedRealityToolkit/_Core/EventDatum/Input/InputEventData.cs
@@ -29,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Input
         public void Initialize(IMixedRealityInputSource inputSource, MixedRealityInputAction inputAction)
         {
             BaseInitialize(inputSource, inputAction);
+            Handedness = Handedness.None;
         }
 
         /// <summary>


### PR DESCRIPTION
Overview
---
Since we reuse a single event data object for each type of event data, it sometimes contained stale handedness data when the non-handed `Initialize` was used.

Changes
---
- Related to #2960 
