### PR TITLE
Fix bug where GazeCursor was never being set

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -99,13 +99,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
         /// <inheritdoc />
         public IMixedRealityPointer GazePointer => gazePointer ?? InitializeGazePointer();
-
-        private IMixedRealityCursor gazeCursor = null;
+        private InternalGazePointer gazePointer = null;
 
         /// <inheritdoc />
-        public IMixedRealityCursor GazeCursor => gazeCursor;
-
-        private InternalGazePointer gazePointer = null;
+        public IMixedRealityCursor GazeCursor => GazePointer.BaseCursor;
 
         /// <inheritdoc />
         public GameObject GazeTarget { get; private set; }
@@ -396,7 +393,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
             gazePointer = new InternalGazePointer(this, "Gaze Pointer", null, raycastLayerMasks, maxGazeCollisionDistance, gazeTransform, stabilizer);
 
-            if (gazeCursor == null &&
+            if (GazeCursor == null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile != null)
             {


### PR DESCRIPTION
Overview
---
After #3113, the new `GazeCursor` property (and its underlying field) were never being set, thus causing all references to them to be null.

Now, the `GazeCursor` property will return the `GazePointer`'s cursor.

Changes
---
- Related to #2960 
