### PR TITLE
Properly set pointerName at pointer creation

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -172,6 +172,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
             set
             {
                 base.Controller = value;
+                pointerName = gameObject.name;
                 InputSourceParent = base.Controller.InputSource;
             }
         }


### PR DESCRIPTION
Overview
---
Fix bug introduced by #2944, where a backing field was created but it was never populated.

Now, the pointer sets its backing field anywhere its gameObject name is updated (here, it's set in the `base.Controller` setter).