### PR TITLE
Pointer line length bugs

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -173,7 +173,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                         if (i == Result.RayStepIndex)
                         {
                             // Only add the distance between the start point and the hit
-                            clearWorldLength += Vector3.Distance(Result.StartPoint, Result.StartPoint);
+                            clearWorldLength += Vector3.Distance(Rays[i].Origin, Result.Details.Point);
                         }
                         else if (i < Result.RayStepIndex)
                         {

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -182,7 +182,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                         }
                     }
 
-                    // Clamp the end of the parabola to the result hit's point
+                    // Clamp the end of the line to the result hit's point
                     lineBase.LineEndClamp = lineBase.GetNormalizedLengthFromWorldLength(clearWorldLength, LineCastResolution);
 
                     if (FocusTarget != null)

--- a/Assets/MixedRealityToolkit/_Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
@@ -300,20 +300,23 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.DataProviders
             Vector3 lastPoint = GetUnClampedPoint(0f);
             float normalizedLength = 0f;
             float distanceSoFar = 0f;
+            float normalizedSegmentLength = 1f / searchResolution;
 
             for (int i = 1; i < searchResolution; i++)
             {
                 // Get the normalized length of this position along the line
-                normalizedLength = (1f / searchResolution) * i;
+                normalizedLength = normalizedSegmentLength * i;
                 Vector3 currentPoint = GetUnClampedPoint(normalizedLength);
                 distanceSoFar += Vector3.Distance(lastPoint, currentPoint);
-                lastPoint = currentPoint;
 
                 if (distanceSoFar >= worldLength)
                 {
-                    // We've reached the world length
+                    // We've reached the world length, so subtract the amount we overshot
+                    normalizedLength -= (distanceSoFar - worldLength) / Vector3.Distance(lastPoint, currentPoint) * normalizedSegmentLength;
                     break;
                 }
+
+                lastPoint = currentPoint;
             }
 
             return Mathf.Clamp01(normalizedLength);

--- a/Assets/MixedRealityToolkit/_Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/_Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
@@ -297,6 +297,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.DataProviders
         /// <returns></returns>
         public float GetNormalizedLengthFromWorldLength(float worldLength, int searchResolution = 10)
         {
+            if (searchResolution < 1)
+            {
+                return 0;
+            }
+
             Vector3 lastPoint = GetUnClampedPoint(0f);
             float normalizedLength = 0f;
             float distanceSoFar = 0f;


### PR DESCRIPTION
Overview
---
Line 176 in LinePointer was adding 0 (the distance between a point and itself) for the raystep that hit the object. This now properly adds the distance between the start of the raystep and the hit point.

Additionally, `GetNormalizedLengthFromWorldLength` was consistently overshooting and providing a slightly larger value than the true normalized length. This code now subtracts the amount that was overshot.

Changes
---
- Related to #2960 
