### PR TITLE
Fix issue where HoloLens hands were using the same MixedRealityInteractionMapping array

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/MixedRealityInteractionMapping.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/MixedRealityInteractionMapping.cs
@@ -111,6 +111,28 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Devices
             changed = false;
         }
 
+        public MixedRealityInteractionMapping(MixedRealityInteractionMapping mixedRealityInteractionMapping)
+        {
+            id = mixedRealityInteractionMapping.id;
+            description = mixedRealityInteractionMapping.description;
+            axisType = mixedRealityInteractionMapping.axisType;
+            inputType = mixedRealityInteractionMapping.inputType;
+            inputAction = mixedRealityInteractionMapping.inputAction;
+            keyCode = mixedRealityInteractionMapping.keyCode;
+            axisCodeX = mixedRealityInteractionMapping.axisCodeX;
+            axisCodeY = mixedRealityInteractionMapping.axisCodeY;
+            invertXAxis = mixedRealityInteractionMapping.invertXAxis;
+            invertYAxis = mixedRealityInteractionMapping.invertYAxis;
+            rawData = null;
+            boolData = false;
+            floatData = 0f;
+            vector2Data = Vector2.zero;
+            positionData = Vector3.zero;
+            rotationData = Quaternion.identity;
+            poseData = MixedRealityPose.ZeroIdentity;
+            changed = false;
+        }
+
         #region Interaction Properties
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseController.cs
@@ -117,7 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
                         MixedRealityInteractionMapping[] profileInteractions = controllerMappings[i].Interactions;
                         MixedRealityInteractionMapping[] newInteractions = new MixedRealityInteractionMapping[profileInteractions.Length];
 
-                        for (int j = 0; j < profileInteractions.Length; i++)
+                        for (int j = 0; j < profileInteractions.Length; j++)
                         {
                             newInteractions[j] = new MixedRealityInteractionMapping(profileInteractions[j]);
                         }

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseController.cs
@@ -114,7 +114,15 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
                         controllerMappings[i].Handedness == ControllerHandedness &&
                         controllerMappings[i].Interactions.Length > 0)
                     {
-                        AssignControllerMappings(controllerMappings[i].Interactions);
+                        MixedRealityInteractionMapping[] profileInteractions = controllerMappings[i].Interactions;
+                        MixedRealityInteractionMapping[] newInteractions = new MixedRealityInteractionMapping[profileInteractions.Length];
+
+                        for (int j = 0; j < profileInteractions.Length; i++)
+                        {
+                            newInteractions[j] = new MixedRealityInteractionMapping(profileInteractions[j]);
+                        }
+
+                        AssignControllerMappings(newInteractions);
                         break;
                     }
 


### PR DESCRIPTION
Overview
---
Since the controller mapping profile only contains one array for HoloLens hands (since there's no differentiation between handedness), both hands are reusing the same array. This causes their values to overwrite each other, and causes events to fire endlessly when one hand is selecting and the other isn't.

This bug fix instead creates a copy of the profile's array, so we aren't reusing the same structure. This will also fix cases where a source might be lost while selecting, which would cause the state to change when a second, unselecting source is detected.

Changes
---
- Fixes: #3195 
- Fixes: https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3253#issuecomment-446037832
