### PR TITLE
Updated pointer events

### DIFF
--- a/Assets/MixedRealityToolkit-Examples/Demos/Solvers/Scripts/SwapVolume.cs
+++ b/Assets/MixedRealityToolkit-Examples/Demos/Solvers/Scripts/SwapVolume.cs
@@ -3,7 +3,9 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers;
+using Microsoft.MixedReality.Toolkit.Core.Services;
 using Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers;
 using UnityEngine;
 
@@ -64,13 +66,18 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 
                 if (updateSolverTargetToClickSource && solverHandler != null)
                 {
-                    if (eventData.Handedness == Handedness.Right)
+                    IMixedRealityController controller;
+
+                    if (MixedRealityToolkit.InputSystem.TryGetController(eventData.InputSource, out controller))
                     {
-                        solverHandler.TrackedObjectToReference = TrackedObjectType.MotionControllerRight;
-                    }
-                    else if (eventData.Handedness == Handedness.Left)
-                    {
-                        solverHandler.TrackedObjectToReference = TrackedObjectType.MotionControllerLeft;
+                        if (controller.ControllerHandedness == Handedness.Right)
+                        {
+                            solverHandler.TrackedObjectToReference = TrackedObjectType.MotionControllerRight;
+                        }
+                        else if (controller.ControllerHandedness == Handedness.Left)
+                        {
+                            solverHandler.TrackedObjectToReference = TrackedObjectType.MotionControllerLeft;
+                        }
                     }
                 }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/GazeProvider.cs
@@ -233,27 +233,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             }
 
             #endregion IMixedRealityPointer Implementation
-
-            /// <summary>
-            /// Press this pointer. This sends a pointer down event across the input system.
-            /// </summary>
-            /// <param name="mixedRealityInputAction">The input action that corresponds to the pressed button or axis.</param>
-            /// <param name="handedness">Optional handedness of the source that pressed the pointer.</param>
-            public void RaisePointerDown(MixedRealityInputAction mixedRealityInputAction, Handedness handedness = Handedness.None)
-            {
-                MixedRealityToolkit.InputSystem.RaisePointerDown(this, handedness, mixedRealityInputAction);
-            }
-
-            /// <summary>
-            /// Release this pointer. This sends pointer clicked and pointer up events across the input system.
-            /// </summary>
-            /// <param name="mixedRealityInputAction">The input action that corresponds to the released button or axis.</param>
-            /// <param name="handedness">Optional handedness of the source that released the pointer.</param>
-            public void RaisePointerUp(MixedRealityInputAction mixedRealityInputAction, Handedness handedness = Handedness.None)
-            {
-                MixedRealityToolkit.InputSystem.RaisePointerClicked(this, handedness, mixedRealityInputAction, 0);
-                MixedRealityToolkit.InputSystem.RaisePointerUp(this, handedness, mixedRealityInputAction);
-            }
         }
 
         #endregion InternalGazePointer Class
@@ -354,7 +333,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             {
                 if (eventData.InputSource.Pointers[i].PointerId == GazePointer.PointerId)
                 {
-                    gazePointer.RaisePointerUp(eventData.MixedRealityInputAction, eventData.Handedness);
+                    MixedRealityToolkit.InputSystem.RaisePointerClicked(gazePointer, eventData.MixedRealityInputAction, 0);
+                    MixedRealityToolkit.InputSystem.RaisePointerUp(gazePointer, eventData.MixedRealityInputAction);
                     return;
                 }
             }
@@ -366,7 +346,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             {
                 if (eventData.InputSource.Pointers[i].PointerId == GazePointer.PointerId)
                 {
-                    gazePointer.RaisePointerDown(eventData.MixedRealityInputAction, eventData.Handedness);
+                    MixedRealityToolkit.InputSystem.RaisePointerDown(gazePointer, eventData.MixedRealityInputAction, eventData.InputSource);
                     return;
                 }
             }

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
@@ -791,7 +791,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             ExecutePointerDown(HandlePointerDown(pointer));
         }
 
-        [Obsolete]
+        [Obsolete("Use RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)")]
         public void RaisePointerDown(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
             // Create input event
@@ -837,7 +837,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             HandleClick();
         }
 
-        [Obsolete]
+        [Obsolete("Use RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count, IMixedRealityInputSource inputSource = null)")]
         public void RaisePointerClicked(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction, int count)
         {
             // Create input event
@@ -874,7 +874,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             ExecutePointerUp(HandlePointerUp(pointer));
         }
 
-        [Obsolete]
+        [Obsolete("Use RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)")]
         public void RaisePointerUp(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
             // Create input event

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/MixedRealityInputManager.cs
@@ -783,15 +783,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             };
 
         /// <inheritdoc />
-        public void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction)
+        public void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)
         {
             // Create input event
-            pointerEventData.Initialize(pointer, inputAction);
+            pointerEventData.Initialize(pointer, inputAction, inputSource);
 
             ExecutePointerDown(HandlePointerDown(pointer));
         }
 
-        /// <inheritdoc />
+        [Obsolete]
         public void RaisePointerDown(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
             // Create input event
@@ -829,15 +829,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
                 };
 
         /// <inheritdoc />
-        public void RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count)
+        public void RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count, IMixedRealityInputSource inputSource = null)
         {
             // Create input event
-            pointerEventData.Initialize(pointer, inputAction, count);
+            pointerEventData.Initialize(pointer, inputAction, inputSource, count);
 
             HandleClick();
         }
 
-        /// <inheritdoc />
+        [Obsolete]
         public void RaisePointerClicked(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction, int count)
         {
             // Create input event
@@ -866,7 +866,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             };
 
         /// <inheritdoc />
-        public void RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction)
+        public void RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)
         {
             // Create input event
             pointerEventData.Initialize(pointer, inputAction);
@@ -874,7 +874,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             ExecutePointerUp(HandlePointerUp(pointer));
         }
 
-        /// <inheritdoc />
+        [Obsolete]
         public void RaisePointerUp(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
             // Create input event

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -411,8 +411,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                 if (eventData.MixedRealityInputAction == pointerAction)
                 {
                     IsSelectPressed = false;
-                    MixedRealityToolkit.InputSystem.RaisePointerClicked(this, Handedness, pointerAction, 0);
-                    MixedRealityToolkit.InputSystem.RaisePointerUp(this, Handedness, pointerAction);
+                    MixedRealityToolkit.InputSystem.RaisePointerClicked(this, pointerAction, 0);
+                    MixedRealityToolkit.InputSystem.RaisePointerUp(this, pointerAction);
                 }
             }
         }
@@ -433,7 +433,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                 {
                     IsSelectPressed = true;
                     HasSelectPressedOnce = true;
-                    MixedRealityToolkit.InputSystem.RaisePointerDown(this, Handedness, pointerAction);
+                    MixedRealityToolkit.InputSystem.RaisePointerDown(this, pointerAction);
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/_Core/EventDatum/Input/MixedRealityPointerEventData.cs
+++ b/Assets/MixedRealityToolkit/_Core/EventDatum/Input/MixedRealityPointerEventData.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
@@ -31,10 +32,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Input
         /// </summary>
         /// <param name="pointer"></param>
         /// <param name="inputAction"></param>
+        /// <param name="inputSource"></param>
         /// <param name="count"></param>
-        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count = 0)
+        public void Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null, int count = 0)
         {
-            Initialize(pointer.InputSourceParent, inputAction);
+            Initialize(inputSource ?? pointer.InputSourceParent, inputAction);
             Pointer = pointer;
             Count = count;
         }
@@ -46,6 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.Input
         /// <param name="count"></param>
         /// <param name="inputAction"></param>
         /// <param name="handedness"></param>
+        [Obsolete("Use Initialize(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null, int count = 0)")]
         public void Initialize(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction, int count = 0)
         {
             Initialize(pointer.InputSourceParent, handedness, inputAction);

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -221,7 +221,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// </summary>
         /// <param name="pointer">The pointer where the event originates.</param>
         /// <param name="inputAction"></param>
-        void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction);
+        /// <param name="inputSource"></param>
+        void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null);
 
         /// <summary>
         /// Raise the pointer down event.
@@ -229,6 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// <param name="pointer">The pointer where the event originates.</param>
         /// <param name="handedness">The handedness of the event.</param>
         /// <param name="inputAction"></param>
+        [Obsolete("Use RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)")]
         void RaisePointerDown(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction);
 
         #endregion Pointer Down
@@ -241,7 +243,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// <param name="pointer"></param>
         /// <param name="inputAction"></param>
         /// <param name="count"></param>
-        void RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count);
+        /// <param name="inputSource"></param>
+        void RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, int count, IMixedRealityInputSource inputSource = null);
 
         /// <summary>
         /// Raise the pointer clicked event.
@@ -250,6 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
         /// <param name="count"></param>
+        [Obsolete("Use RaisePointerClicked(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)")]
         void RaisePointerClicked(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction, int count);
 
         #endregion Pointer Click
@@ -261,7 +265,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// </summary>
         /// <param name="pointer"></param>
         /// <param name="inputAction"></param>
-        void RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction);
+        /// <param name="inputSource"></param>
+        void RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null);
 
         /// <summary>
         /// Raise the pointer up event.
@@ -269,6 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem
         /// <param name="pointer"></param>
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
+        [Obsolete("Use RaisePointerUp(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)")]
         void RaisePointerUp(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction);
 
         #endregion Pointer Up


### PR DESCRIPTION
Overview
---
Removes handedness from pointer events, as pointers do not have handedness properties.

Handedness can only be determined from `IMixedRealityController.ControllerHandedness`

Fixes #3298
Fixes #3299

Breaking Changes
---
- `PointerEventData` now inherits from `BaseInputEventData`