### PR TITLE
Add ability to update the PointerData for a pointer with locked focus

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -246,6 +246,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             {
                 if (!pointerWasLocked)
                 {
+                    PreviousPointerTarget = focusDetails.Object;
                     pointLocalSpace = focusDetails.Object.transform.InverseTransformPoint(focusDetails.Point);
                     normalLocalSpace = focusDetails.Object.transform.InverseTransformDirection(focusDetails.Normal);
                     pointerWasLocked = true;
@@ -254,6 +255,17 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
                 // In case the focused object is moving, we need to update the focus point based on the object's new transform.
                 focusDetails.Point = focusDetails.Object.transform.TransformPoint(pointLocalSpace);
                 focusDetails.Normal = focusDetails.Object.transform.TransformDirection(normalLocalSpace);
+
+                StartPoint = Pointer.Rays[0].Origin;
+
+                for (int i = 0; i < Pointer.Rays.Length; i++)
+                {
+                    if (Pointer.Rays[i].Contains(focusDetails.Point))
+                    {
+                        RayStepIndex = i;
+                        break;
+                    }
+                }
             }
 
             public void ResetFocusedObjects(bool clearPreviousObject = true)

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -179,6 +179,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
             private GraphicInputEventData graphicData;
 
             private FocusDetails focusDetails = new FocusDetails();
+            private Vector3 pointLocalSpace;
+            private Vector3 normalLocalSpace;
+            private bool pointerWasLocked;
 
             public PointerData(IMixedRealityPointer pointer)
             {
@@ -198,6 +201,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
                 focusDetails.Point = hit.point;
                 focusDetails.Normal = hit.normal;
                 focusDetails.Object = hit.transform.gameObject;
+
+                pointerWasLocked = false;
             }
 
             /// <summary>
@@ -229,6 +234,26 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
                 focusDetails.Point = finalStep.Terminus;
                 focusDetails.Normal = -finalStep.Direction;
                 focusDetails.Object = null;
+
+                pointerWasLocked = false;
+            }
+
+            /// <summary>
+            /// Update focus information while focus is locked. If the object is moving,
+            /// this updates the hit point to its new world transform.
+            /// </summary>
+            public void UpdateFocusLockedHit()
+            {
+                if (!pointerWasLocked)
+                {
+                    pointLocalSpace = focusDetails.Object.transform.InverseTransformPoint(focusDetails.Point);
+                    normalLocalSpace = focusDetails.Object.transform.InverseTransformDirection(focusDetails.Normal);
+                    pointerWasLocked = true;
+                }
+
+                // In case the focused object is moving, we need to update the focus point based on the object's new transform.
+                focusDetails.Point = focusDetails.Object.transform.TransformPoint(pointLocalSpace);
+                focusDetails.Normal = focusDetails.Object.transform.TransformDirection(normalLocalSpace);
             }
 
             public void ResetFocusedObjects(bool clearPreviousObject = true)
@@ -589,6 +614,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
                     // Set the pointer's result last
                     pointer.Pointer.Result = pointer;
+                }
+                else
+                {
+                    pointer.UpdateFocusLockedHit();
                 }
             }
 

--- a/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/Input/FocusProvider.cs
@@ -258,6 +258,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input
 
                 StartPoint = Pointer.Rays[0].Origin;
 
+                // In order to provide a correct RayStepIndex, we
+                // need to check to see which RayStep now contains the hit point.
+                // This is needed if the object moved closer or further away.
                 for (int i = 0; i < Pointer.Rays.Length; i++)
                 {
                     if (Pointer.Rays[i].Contains(focusDetails.Point))

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -121,7 +121,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
 
             // Set our first and last points
             lineBase.FirstPoint = pointerPosition;
-            lineBase.LastPoint = pointerPosition + (PointerDirection * PointerExtent);
+
+            if (IsFocusLocked)
+            {
+                lineBase.LastPoint = pointerPosition + ((Result.Details.Point - pointerPosition).normalized * PointerExtent);
+            }
+            else
+            {
+                lineBase.LastPoint = pointerPosition + (PointerDirection * PointerExtent);
+            }
 
             // Make sure our array will hold
             if (Rays == null || Rays.Length != LineCastResolution)
@@ -193,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                     if (IsFocusLocked)
                     {
                         gravityDistorter.enabled = true;
-                        gravityDistorter.WorldCenterOfGravity = Result.CurrentPointerTarget.transform.position;
+                        gravityDistorter.WorldCenterOfGravity = Result.Details.Point;
                     }
                 }
                 else

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Physics/RayStep.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Physics/RayStep.cs
@@ -15,12 +15,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Physics
             Terminus = terminus;
             Length = Vector3.Distance(origin, terminus);
             Direction = (Terminus - Origin).normalized;
+
+            epsilon = 0.01f;
         }
 
         public Vector3 Origin { get; private set; }
         public Vector3 Terminus { get; private set; }
         public Vector3 Direction { get; private set; }
         public float Length { get; private set; }
+
+        private readonly float epsilon;
 
         public Vector3 GetPoint(float distance)
         {
@@ -41,6 +45,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Physics
             Origin = ray.origin;
             Direction = ray.direction;
             Terminus = Origin + (Direction * Length);
+        }
+
+        public bool Contains(Vector3 point)
+        {
+            return Vector3.Distance(Origin, point) + Vector3.Distance(point, Terminus) - Length < epsilon;
         }
 
         public static implicit operator Ray(RayStep r)


### PR DESCRIPTION
Overview
---
Previously, a pointer with locked focus wasn't being updated. Its data was stale from the moment focus became locked. This leads to strange visualizations when the locked object or the pointer is moved, leaving the cursor behind or rendering the pointer line to the wrong point.

Changes
---
- Related to #2960, #3294 
