### PR TITLE
Move eventsource functionality from SpatialAwarenessSystem to observer(s)

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/SpatialAwareness/System/MixedRealitySpatialAwarenessSystem.cs
@@ -183,14 +183,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
         #region Mesh Events
 
         /// <inheritdoc />
-        public void RaiseMeshAdded(int meshId, GameObject mesh)
+        public void RaiseMeshAdded(IMixedRealitySpatialAwarenessObserver observer, int meshId, GameObject mesh)
         {
             if (!UseMeshSystem) { return; }
 
             // Parent the mesh object
             mesh.transform.parent = MeshParent.transform;
 
-            meshEventData.Initialize(this, meshId, mesh);
+            meshEventData.Initialize(observer, meshId, mesh);
             HandleEvent(meshEventData, OnMeshAdded);
         }
 
@@ -205,14 +205,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
             };
 
         /// <inheritdoc />
-        public void RaiseMeshUpdated(int meshId, GameObject mesh)
+        public void RaiseMeshUpdated(IMixedRealitySpatialAwarenessObserver observer, int meshId, GameObject mesh)
         {
             if (!UseMeshSystem) { return; }
 
             // Parent the mesh object
             mesh.transform.parent = MeshParent.transform;
 
-            meshEventData.Initialize(this, meshId, mesh);
+            meshEventData.Initialize(observer, meshId, mesh);
             HandleEvent(meshEventData, OnMeshUpdated);
         }
 
@@ -228,11 +228,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
 
 
         /// <inheritdoc />
-        public void RaiseMeshRemoved(int meshId)
+        public void RaiseMeshRemoved(IMixedRealitySpatialAwarenessObserver observer, int meshId)
         {
             if (!UseMeshSystem) { return; }
 
-            meshEventData.Initialize(this, meshId, null);
+            meshEventData.Initialize(observer, meshId, null);
             HandleEvent(meshEventData, OnMeshRemoved);
         }
 
@@ -251,11 +251,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
         #region Surface Finding Events
 
         /// <inheritdoc />
-        public void RaiseSurfaceAdded(int surfaceId, GameObject surfaceObject)
+        public void RaiseSurfaceAdded(IMixedRealitySpatialAwarenessObserver observer, int surfaceId, GameObject surfaceObject)
         {
             if (!UseSurfaceFindingSystem) { return; }
 
-            surfaceFindingEventData.Initialize(this, surfaceId, surfaceObject);
+            surfaceFindingEventData.Initialize(observer, surfaceId, surfaceObject);
             HandleEvent(surfaceFindingEventData, OnSurfaceAdded);
         }
 
@@ -270,11 +270,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
             };
 
         /// <inheritdoc />
-        public void RaiseSurfaceUpdated(int surfaceId, GameObject surfaceObject)
+        public void RaiseSurfaceUpdated(IMixedRealitySpatialAwarenessObserver observer, int surfaceId, GameObject surfaceObject)
         {
             if (!UseSurfaceFindingSystem) { return; }
 
-            surfaceFindingEventData.Initialize(this, surfaceId, surfaceObject);
+            surfaceFindingEventData.Initialize(observer, surfaceId, surfaceObject);
             HandleEvent(surfaceFindingEventData, OnSurfaceUpdated);
         }
 
@@ -289,11 +289,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
             };
 
         /// <inheritdoc />
-        public void RaiseSurfaceRemoved(int surfaceId)
+        public void RaiseSurfaceRemoved(IMixedRealitySpatialAwarenessObserver observer, int surfaceId)
         {
             if (!UseSurfaceFindingSystem) { return; }
 
-            surfaceFindingEventData.Initialize(this, surfaceId, null);
+            surfaceFindingEventData.Initialize(observer, surfaceId, null);
             HandleEvent(surfaceFindingEventData, OnSurfaceRemoved);
         }
 
@@ -310,57 +310,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
         #endregion Surface Finding Events
 
         #endregion IMixedRealityToolkit Implementation
-
-        #region IMixedRealtyEventSystem Implementation
-
-        /// <inheritdoc />
-        public override void HandleEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler)
-        {
-            base.HandleEvent(eventData, eventHandler);
-        }
-
-        /// <summary>
-        /// Registers the <see cref="GameObject"/> to listen for boundary events.
-        /// </summary>
-        /// <param name="listener"></param>
-        public override void Register(GameObject listener)
-        {
-            base.Register(listener);
-        }
-
-        /// <summary>
-        /// UnRegisters the <see cref="GameObject"/> to listen for boundary events.
-        /// /// </summary>
-        /// <param name="listener"></param>
-        public override void Unregister(GameObject listener)
-        {
-            base.Unregister(listener);
-        }
-
-        #endregion
-
-        #region IMixedRealityEventSource Implementation
-
-        /// <inheritdoc />
-        bool IEqualityComparer.Equals(object x, object y)
-        {
-            // There shouldn't be other Spatial Awareness Managers to compare to.
-            return false;
-        }
-
-        /// <inheritdoc />
-        public int GetHashCode(object obj)
-        {
-            return Mathf.Abs(SourceName.GetHashCode());
-        }
-
-        /// <inheritdoc />
-        public uint SourceId { get; } = 0;
-
-        /// <inheritdoc />
-        public string SourceName { get; } = "Mixed Reality Spatial Awareness System";
-
-        #endregion IMixedRealityEventSource Implementation
 
         #region IMixedRealitySpatialAwarenessSystem Implementation
 
@@ -399,6 +348,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.SpatialAwarenessSystem
         public void SuspendObserver()
         {
             SpatialAwarenessObserver?.StopObserving();
+        }
+
+        private uint nextSourceId = 0;
+
+        /// <inheritdoc />
+        public uint GenerateNewSourceId()
+        {
+            return nextSourceId++;
         }
 
         #region Mesh Handling implementation

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseSpatialObserver.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem;
 using Microsoft.MixedReality.Toolkit.Core.Services;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -11,12 +12,63 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
 {
     public class BaseSpatialObserver : BaseExtensionService, IMixedRealitySpatialAwarenessObserver
     {
+        #region IMixedRealityEventSource Implementation
+
+        /// <inheritdoc />
+        bool IEqualityComparer.Equals(object x, object y)
+        {
+            return x.Equals(y);
+        }
+
+        /// <inheritdoc /> 
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) { return false; }
+            if (ReferenceEquals(this, obj)) { return true; }
+            if (obj.GetType() != GetType()) { return false; }
+
+            return Equals((IMixedRealitySpatialAwarenessObserver)obj);
+        }
+
+        private bool Equals(IMixedRealitySpatialAwarenessObserver other)
+        {
+            return ((other != null) &&
+                (SourceId == other.SourceId) &&
+                string.Equals(SourceName, other.SourceName));
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(object obj)
+        {
+            return obj.GetHashCode();
+        }
+
+        /// <inheritdoc /> 
+        public override int GetHashCode()
+        {
+            return Mathf.Abs(SourceName.GetHashCode());
+        }
+
+        /// <inheritdoc />
+        public uint SourceId { get; }
+
+        /// <inheritdoc />
+        public string SourceName { get; }
+
+        #endregion IMixedRealityEventSource Implementation
+
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseSpatialObserver(string name, uint priority) : base(name, priority) { }
+        public BaseSpatialObserver(string name, uint priority) : base(name, priority)
+        {
+            SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();
+            SourceName = name;
+        }
+
+        #region IMixedRealitySpatialAwarenessObserver implementation
 
         /// <summary>
         /// Is the observer running (actively accumulating spatial data)?
@@ -141,5 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
                 }
             }
         }
+
+        #endregion IMixedRealitySpatialAwarenessObserver implementation
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs
@@ -153,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.SpatialAwareness
                 Debug.LogWarning("The Windows Mixed Reality spatial observer is currently running.");
                 return;
             }
-
+            
             // We want the first update immediately.
             lastUpdated = 0;
 
@@ -346,7 +346,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.SpatialAwareness
                 ReclaimMeshObject(mesh);
 
                 // Send the mesh removed event
-                SpatialAwarenessSystem.RaiseMeshRemoved(id);
+                SpatialAwarenessSystem.RaiseMeshRemoved(this, id);
             }
         }
 
@@ -482,11 +482,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.SpatialAwareness
 
             if (sendUpdatedEvent)
             {
-                SpatialAwarenessSystem.RaiseMeshUpdated(cookedData.id.handle, meshObject.GameObject);
+                SpatialAwarenessSystem.RaiseMeshUpdated(this, cookedData.id.handle, meshObject.GameObject);
             }
             else
             {
-                SpatialAwarenessSystem.RaiseMeshAdded(cookedData.id.handle, meshObject.GameObject);
+                SpatialAwarenessSystem.RaiseMeshAdded(this, cookedData.id.handle, meshObject.GameObject);
             }
         }
 #endif // UNITY_WSA

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/EventDatum/SpatialAwareness/MixedRealitySpatialAwarenessEventData.cs
+++ b/Assets/MixedRealityToolkit/_Core/EventDatum/SpatialAwareness/MixedRealitySpatialAwarenessEventData.cs
@@ -30,11 +30,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.EventDatum.SpatialAwarenessSystem
 
         /// <inheritdoc />
         public void Initialize(
-            IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
+            IMixedRealitySpatialAwarenessObserver observer,
             int id,
             GameObject gameObject)
         {
-            BaseInitialize(spatialAwarenessSystem);
+            BaseInitialize(observer);
             Id = id;
             GameObject = gameObject;
         }

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessObserver.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Core.Interfaces;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.Events;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem
 {
-    public interface IMixedRealitySpatialAwarenessObserver : IMixedRealityExtensionService
+    public interface IMixedRealitySpatialAwarenessObserver : IMixedRealityExtensionService, IMixedRealityEventSource
     {
         /// <summary>
         /// Is the observer running (actively accumulating spatial data)?

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem
 {
-    public interface IMixedRealitySpatialAwarenessSystem : IMixedRealityEventSystem, IMixedRealityEventSource
+    public interface IMixedRealitySpatialAwarenessSystem : IMixedRealityEventSystem
     {
         /// <summary>
         /// Indicates the developer's intended startup behavior.
@@ -67,6 +67,15 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem
         /// <remarks>This will cause spatial awareness events to be suspended until ResumeObserver is called.</remarks>
         void SuspendObserver();
 
+        /// <summary>
+        /// Generates a new source identifier for an <see cref="IMixedRealitySpatialAwarenessObserver"/> implementation.
+        /// </summary>
+        /// <returns>The source identifier to be used by the <see cref="IMixedRealitySpatialAwarenessObserver"/> implementation.</returns>
+        /// <remarks>
+        /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
+        /// </remarks>
+        uint GenerateNewSourceId();
+
         #region Mesh Handling
 
         /// <summary>
@@ -92,7 +101,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem
         /// Gets or sets the level of detail, as a MixedRealitySpatialAwarenessMeshLevelOfDetail value, for the returned spatial mesh.
         /// Setting this value to Custom, implies that the developer is specifying a custom value for MeshTrianglesPerCubicMeter. 
         /// </summary>
-        /// <remarks>Specifying any other value will cause <see cref="MeshTrianglesPerCubicMeter"/> to be overwritten.</remarks>
+        /// <remarks>
+        /// Specifying any other value will cause <see cref="MeshTrianglesPerCubicMeter"/> to be overwritten.
+        /// </remarks>
         SpatialAwarenessMeshLevelOfDetail MeshLevelOfDetail { get; set; }
 
         /// <summary>
@@ -137,31 +148,34 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem
         /// <summary>
         /// The spatial awareness system will call the <see cref="IMixedRealitySpatialAwarenessMeshHandler.OnMeshAdded"/> method to indicate a mesh has been added.
         /// </summary>
+        /// <param name="observer">The observer raising the event.</param>
         /// <param name="meshId">Value identifying the mesh.</param>
         /// <param name="meshObject">The mesh <see cref="GameObject"/>.</param>
         /// <remarks>
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
         /// </remarks>
-        void RaiseMeshAdded(int meshId, GameObject meshObject);
+        void RaiseMeshAdded(IMixedRealitySpatialAwarenessObserver observer, int meshId, GameObject meshObject);
 
         /// <summary>
         /// The spatial awareness system will call the <see cref="IMixedRealitySpatialAwarenessMeshHandler.OnMeshUpdated"/> method to indicate an existing mesh has been updated.
         /// </summary>
+        /// <param name="observer">The observer raising the event.</param>
         /// <param name="meshId">Value identifying the mesh.</param>
         /// <param name="meshObject">The mesh <see cref="GameObject"/>.</param>
         /// <remarks>
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
         /// </remarks>
-        void RaiseMeshUpdated(int meshId, GameObject meshObject);
+        void RaiseMeshUpdated(IMixedRealitySpatialAwarenessObserver observer, int meshId, GameObject meshObject);
 
         /// <summary>
         /// The spatial awareness system will call the <see cref="IMixedRealitySpatialAwarenessMeshHandler.OnMeshUpdated"/> method to indicate an existing mesh has been removed.
         /// </summary>
+        /// <param name="observer">The observer raising the event.</param>
         /// <param name="meshId">Value identifying the mesh.</param>
         /// <remarks>
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
         /// </remarks>
-        void RaiseMeshRemoved(int meshId);
+        void RaiseMeshRemoved(IMixedRealitySpatialAwarenessObserver observer, int meshId);
 
         #endregion Mesh Events
 
@@ -251,31 +265,34 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem
         /// <summary>
         /// The spatial awareness system will call the <see cref="IMixedRealitySpatialAwarenessSurfaceFindingHandler.OnSurfaceAdded"/> method to indicate a planar surface has been added.
         /// </summary>
+        /// <param name="observer">The observer raising the event.</param>
         /// <param name="surfaceId">Value identifying the surface.</param>
         /// <param name="surfaceObject">The surface <see cref="GameObject"/>.</param>
         /// <remarks>
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
         /// </remarks>
-        void RaiseSurfaceAdded(int surfaceId, GameObject surfaceObject);
+        void RaiseSurfaceAdded(IMixedRealitySpatialAwarenessObserver observer, int surfaceId, GameObject surfaceObject);
 
         /// <summary>
         /// The spatial awareness system will call the <see cref="IMixedRealitySpatialAwarenessSurfaceFindingHandler.OnSurfaceUpdated"/> method to indicate an existing planar surface has been updated.
         /// </summary>
+        /// <param name="observer">The observer raising the event.</param>
         /// <param name="surfaceId">Value identifying the surface.</param>
         /// <param name="surfaceObject">The surface <see cref="GameObject"/>.</param>
         /// <remarks>
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
         /// </remarks>
-        void RaiseSurfaceUpdated(int surfaceId, GameObject surfaceObject);
+        void RaiseSurfaceUpdated(IMixedRealitySpatialAwarenessObserver observer, int surfaceId, GameObject surfaceObject);
 
         /// <summary>
         /// The spatial awareness system will call the <see cref="IMixedRealitySpatialAwarenessSurfaceFindingHandler.OnSurfaceUpdated"/> method to indicate an existing planar surface has been removed.
         /// </summary>
+        /// <param name="observer">The observer raising the event.</param>
         /// <param name="surfaceId">Value identifying the surface.</param>
         /// <remarks>
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialObserver"/> interface, and not by application code.
         /// </remarks>
-        void RaiseSurfaceRemoved(int surfaceId);
+        void RaiseSurfaceRemoved(IMixedRealitySpatialAwarenessObserver observer, int surfaceId);
 
         #endregion Surface Finding Events
 


### PR DESCRIPTION
Overview
---
This change moves the implementation of IMixedRealityEventSource from the spatial awareness system and adds it to the spatial awareness observer. This enables client code to determine / access the source of the events.

This is a breaking change for any concrete implementations of IMixedRealitySpatialAwarenessSystem and/or IMixedRealitySpatialAwarenessObserver.

Changes
---
- Fixes: #3190
