### PR TITLE
Add ConfigurationProfil connection for Extension Service

### DIFF
--- a/Assets/MixedRealityToolkit-Tests/Core/TestFixture_01_MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit-Tests/Core/TestFixture_01_MixedRealityToolkitTests.cs
@@ -263,11 +263,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test data provider 1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestExtensionService1("Test04-08-1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestExtensionService1("Test04-08-1",10, null));
 
             // Add test data provider 2
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test04-08-2.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test04-08-2.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test04-08-2.1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test04-08-2.2",10, null));
 
             // Retrieve all ITestDataProvider2 services
             var test2DataProviderServices = MixedRealityToolkit.Instance.GetActiveServices(typeof(ITestDataProvider2));
@@ -282,12 +282,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test 1 services
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestExtensionService1("Test16-1.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestExtensionService1("Test16-1.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestExtensionService1("Test16-1.1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestExtensionService1("Test16-1.2",10, null));
 
             // Add test 2 services
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test16-2.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test16-2.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test16-2.1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestExtensionService2("Test16-2.2",10, null));
 
             // Retrieve all extension services.
             var allExtensionServices = MixedRealityToolkit.Instance.GetActiveServices(typeof(IMixedRealityExtensionService));
@@ -306,7 +306,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Register ITestExtensionService1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1",10, null));
 
             // Retrieve ITestExtensionService1
             var extensionService1 = MixedRealityToolkit.Instance.GetService(typeof(ITestExtensionService1));
@@ -323,7 +323,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Register ITestExtensionService1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1",10, null));
 
             // Retrieve ITestExtensionService1
             var extensionService1 = MixedRealityToolkit.Instance.GetService(typeof(ITestExtensionService1));
@@ -352,7 +352,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Register ITestExtensionService1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1",10, null));
 
             // Retrieve ITestExtensionService1
             var extensionService1 = MixedRealityToolkit.Instance.GetService(typeof(ITestExtensionService1));
@@ -381,8 +381,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test ExtensionService
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test ExtensionService 2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test ExtensionService 2",10, null));
             MixedRealityToolkit.Instance.RegisterService(typeof(ITestFailService), new TestFailService());
             LogAssert.Expect(LogType.Error, $"{typeof(ITestFailService).Name} does not implement {typeof(IMixedRealityService).Name}.");
 
@@ -402,8 +402,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test ExtensionService
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test ExtensionService 2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test ExtensionService 2",10, null));
             MixedRealityToolkit.Instance.RegisterService(typeof(ITestFailService), new TestFailService());
             LogAssert.Expect(LogType.Error, $"{typeof(ITestFailService).Name} does not implement {typeof(IMixedRealityService).Name}.");
 
@@ -448,7 +448,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test ExtensionService 1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test ExtensionService 1",10, null));
 
             // Validate non-existent ExtensionService
             var isServiceRegistered = MixedRealityToolkit.Instance.IsServiceRegistered<ITestExtensionService2>();
@@ -466,7 +466,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             const string serviceName = "Test ExtensionService 1";
 
             // Add test ITestExtensionService1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1(serviceName, 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1(serviceName, 10, null));
 
             // Validate non-existent ExtensionService
             MixedRealityToolkit.Instance.GetService(typeof(ITestExtensionService2), serviceName);
@@ -481,10 +481,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test ExtensionService 1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test14-1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test14-1",10, null));
 
             // Add test ExtensionService 2
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test14-2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test14-2",10, null));
 
             // Retrieve Test ExtensionService 2-2
             var extensionService2 = (TestExtensionService2)MixedRealityToolkit.Instance.GetService(typeof(ITestExtensionService2), "Test14-2");
@@ -505,11 +505,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test ExtensionService 1
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test15-1", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test15-1",10, null));
 
             // Add test ExtensionServices 2
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test15-2.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test15-2.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test15-2.1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test15-2.2",10, null));
 
             // Retrieve ExtensionService2
             var extensionServices = MixedRealityToolkit.Instance.GetActiveServices(typeof(ITestExtensionService2));
@@ -524,12 +524,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene();
 
             // Add test 1 services
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test16-1.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test16-1.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test16-1.1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test16-1.2",10, null));
 
             // Add test 2 services
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test16-2.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test16-2.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test16-2.1",10, null));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test16-2.2",10, null));
 
             // Retrieve all extension services.
             var allExtensionServices = MixedRealityToolkit.Instance.GetActiveServices(typeof(IMixedRealityExtensionService));
@@ -547,11 +547,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
 
             // Add test 1 services
             MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestDataProvider1("Test07-01-1.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test07-01-1.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test07-01-1.2",10, null));
 
             // Add test 2 services
             MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestDataProvider2("Test07-01-2.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test07-01-2.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test07-01-2.2",10, null));
 
             // Enable all test services
             MixedRealityToolkit.EnableAllServicesByType(typeof(ITestService));
@@ -573,11 +573,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
 
             // Add test 1 services
             MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider1), new TestDataProvider1("Test07-01-1.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test07-01-1.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService1), new TestExtensionService1("Test07-01-1.2",10, null));
 
             // Add test 2 services
             MixedRealityToolkit.Instance.RegisterService(typeof(ITestDataProvider2), new TestDataProvider2("Test07-01-2.1", 10));
-            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test07-01-2.2", 10));
+            MixedRealityToolkit.Instance.RegisterService(typeof(ITestExtensionService2), new TestExtensionService2("Test07-01-2.2",10, null));
 
             // Enable all test services
             MixedRealityToolkit.EnableAllServicesByType(typeof(ITestService));

--- a/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService1.cs
+++ b/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService1.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.Services;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Services
 {
     internal class TestExtensionService1 : BaseExtensionService, ITestExtensionService1
     {
-        public TestExtensionService1(string name, uint priority) : base(name, priority) { }
+        public TestExtensionService1(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService1.cs
+++ b/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService1.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Services
 {
     internal class TestExtensionService1 : BaseExtensionService, ITestExtensionService1
     {
-        public TestExtensionService1(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public TestExtensionService1(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService2.cs
+++ b/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService2.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Services
 {
     internal class TestExtensionService2 : BaseExtensionService, ITestExtensionService2
     {
-        public TestExtensionService2(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public TestExtensionService2(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService2.cs
+++ b/Assets/MixedRealityToolkit-Tests/Services/TestExtensionService2.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.Services;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Services
 {
     internal class TestExtensionService2 : BaseExtensionService, ITestExtensionService2
     {
-        public TestExtensionService2(string name, uint priority) : base(name, priority) { }
+        public TestExtensionService2(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public BaseDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         /// <inheritdoc />
         public virtual IMixedRealityController[] GetActiveControllers() => new IMixedRealityController[0];

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseDeviceManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseDeviceManager(string name, uint priority) : base(name, priority) { }
+        public BaseDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         /// <inheritdoc />
         public virtual IMixedRealityController[] GetActiveControllers() => new IMixedRealityController[0];

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseSpatialObserver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseSpatialObserver(string name, uint priority) : base(name, priority)
+        public BaseSpatialObserver(string name, uint priority, ScriptableObject profil) : base(name, priority, profil)
         {
             SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();
             SourceName = name;

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseSpatialObserver.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseSpatialObserver(string name, uint priority, ScriptableObject profil) : base(name, priority, profil)
+        public BaseSpatialObserver(string name, uint priority, ScriptableObject profile) : base(name, priority, profile)
         {
             SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();
             SourceName = name;

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public WindowsMixedRealityDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public WindowsMixedRealityDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
 #if UNITY_WSA
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealityDeviceManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
+using UnityEngine;
 
 #if UNITY_WSA
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
@@ -12,7 +13,6 @@ using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Services;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 using UnityEngine.XR.WSA.Input;
 using WsaGestureSettings = UnityEngine.XR.WSA.Input.GestureSettings;
 #endif // UNITY_WSA
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public WindowsMixedRealityDeviceManager(string name, uint priority) : base(name, priority) { }
+        public WindowsMixedRealityDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
 #if UNITY_WSA
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.SpatialAwareness
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public WindowsMixedRealitySpatialObserver(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public WindowsMixedRealitySpatialObserver(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         #region IMixedRealityToolkit implementation
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/MixedReality/WindowsMixedRealitySpatialObserver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.SpatialAwareness
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public WindowsMixedRealitySpatialObserver(string name, uint priority) : base(name, priority) { }
+        public WindowsMixedRealitySpatialObserver(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         #region IMixedRealityToolkit implementation
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDeviceManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.OpenVR
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public OpenVRDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public OpenVRDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         #region Controller Utilities
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/OpenVR/OpenVRDeviceManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.OpenVR
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public OpenVRDeviceManager(string name, uint priority) : base(name, priority) { }
+        public OpenVRDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         #region Controller Utilities
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseDeviceManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
 {
     public class MouseDeviceManager : BaseDeviceManager, IMixedRealityExtensionService
     {
-        public MouseDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public MouseDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         /// <summary>
         /// Current Mouse Controller.

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/MouseDeviceManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
 {
     public class MouseDeviceManager : BaseDeviceManager, IMixedRealityExtensionService
     {
-        public MouseDeviceManager(string name, uint priority) : base(name, priority) { }
+        public MouseDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         /// <summary>
         /// Current Mouse Controller.

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityJoystickManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public UnityJoystickManager(string name, uint priority) : base(name, priority) { }
+        public UnityJoystickManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         private const float DeviceRefreshInterval = 3.0f;
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityJoystickManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public UnityJoystickManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public UnityJoystickManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         private const float DeviceRefreshInterval = 3.0f;
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityTouchDeviceManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public UnityTouchDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public UnityTouchDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         private static readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/UnityInput/UnityTouchDeviceManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public UnityTouchDeviceManager(string name, uint priority) : base(name, priority) { }
+        public UnityTouchDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         private static readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();
 

--- a/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsDictationInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsDictationInputDeviceManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.VoiceInput
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public WindowsDictationInputDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public WindowsDictationInputDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         /// <summary>
         /// Is the Dictation Manager currently running?

--- a/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsDictationInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsDictationInputDeviceManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.VoiceInput
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public WindowsDictationInputDeviceManager(string name, uint priority) : base(name, priority) { }
+        public WindowsDictationInputDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         /// <summary>
         /// Is the Dictation Manager currently running?

--- a/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsSpeechInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsSpeechInputDeviceManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.VoiceInput
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
     public class WindowsSpeechInputDeviceManager : BaseDeviceManager, IMixedRealitySpeechSystem
     {
-        public WindowsSpeechInputDeviceManager(string name, uint priority) : base(name, priority) { }
+        public WindowsSpeechInputDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
 
         /// <summary>
         /// The keywords to be recognized and optional keyboard shortcuts.

--- a/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsSpeechInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/VoiceInput/WindowsSpeechInputDeviceManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.VoiceInput
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
     public class WindowsSpeechInputDeviceManager : BaseDeviceManager, IMixedRealitySpeechSystem
     {
-        public WindowsSpeechInputDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public WindowsSpeechInputDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
 
         /// <summary>
         /// The keywords to be recognized and optional keyboard shortcuts.

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDeviceManager.cs
@@ -8,6 +8,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsGaming
     // TODO - Implement
     public class WindowsGamingDeviceManager : BaseDeviceManager
     {
-        public WindowsGamingDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
+        public WindowsGamingDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/WindowsGaming/WindowsGamingDeviceManager.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using UnityEngine;
+
 namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsGaming
 {
     // TODO - Implement
     public class WindowsGamingDeviceManager : BaseDeviceManager
     {
-        public WindowsGamingDeviceManager(string name, uint priority) : base(name, priority) { }
+        public WindowsGamingDeviceManager(string name, uint priority, ScriptableObject profil) : base(name, priority, profil) { }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Services/BaseExtensionService.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/BaseExtensionService.cs
@@ -17,16 +17,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         /// <summary>
         /// Configuration Profil
         /// </summary>
-        protected ScriptableObject configurationProfil;
+        protected ScriptableObject configurationProfile;
 
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseExtensionService(string name, uint priority, ScriptableObject profil) : base(name, priority)
+        public BaseExtensionService(string name, uint priority, ScriptableObject profile) : base(name, priority)
         {
-            configurationProfil = profil;
+            configurationProfile = profile;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Services/BaseExtensionService.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/BaseExtensionService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Services
 {
@@ -14,10 +15,18 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
     public abstract class BaseExtensionService : BaseServiceWithConstructor, Interfaces.IMixedRealityExtensionService
     {
         /// <summary>
+        /// Configuration Profil
+        /// </summary>
+        protected ScriptableObject configurationProfil;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="priority"></param>
-        public BaseExtensionService(string name, uint priority) : base(name, priority) { }
+        public BaseExtensionService(string name, uint priority, ScriptableObject profil) : base(name, priority)
+        {
+            configurationProfil = profil;
+        }
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/_Core/Services/MixedRealityToolkit.cs
@@ -266,7 +266,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 for (int i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile.Configurations?.Length; i++)
                 {
                     var configuration = ActiveProfile.RegisteredServiceProvidersProfile.Configurations[i];
-                    RegisterService<IMixedRealityExtensionService>(configuration.ComponentType, configuration.RuntimePlatform, configuration.ComponentName, configuration.Priority);
+                    RegisterService<IMixedRealityExtensionService>(configuration.ComponentType, configuration.RuntimePlatform, configuration.ComponentName, configuration.Priority, configuration.ConfigurationProfile);
                 }
             }
 


### PR DESCRIPTION
Overview
---
Add ScriptableObject member as configurationProfil in the BaseExtensionService class to store the profil.
Add the configuration.ConfigurationProfil as additionnal parameter when registering the IMixedRealityExtensionService.

Change all IMixedRealityExtensionService implementation constructor to add ScriptableObject has third parameter to accept the configuration profil.

Changes
---
- Fixes: # .
