### PR TITLE
Add check to prevent trying to instantiate null gaze cursor

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -403,7 +403,8 @@ namespace Microsoft.MixedReality.Toolkit.Services.InputSystem
 
             if (GazeCursor == null &&
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile != null)
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile != null &&
+                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile.GazeCursorPrefab != null)
             {
                 var cursor = Instantiate(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile.GazeCursorPrefab, MixedRealityToolkit.Instance.MixedRealityPlayspace);
                 SetGazeCursor(cursor);


### PR DESCRIPTION
Overview
---
Makes the gaze cursor optional. Otherwise, if no gaze cursor is set in the profile (a valid state), the system setup will fail out when trying to `Instantiate` null.