### PR TITLE
replace ScriptableObject with BaseMixedRealityProfile

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
@@ -22,9 +23,10 @@ namespace Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public WindowsDictationInputProvider(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public WindowsDictationInputProvider(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <summary>
         /// Is the Dictation Manager currently running?

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public WindowsDictationInputProvider(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Devices;
@@ -19,7 +20,13 @@ namespace Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
     public class WindowsSpeechInputProvider : BaseDeviceManager, IMixedRealitySpeechSystem
     {
-        public WindowsSpeechInputProvider(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public WindowsSpeechInputProvider(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <summary>
         /// The keywords to be recognized and optional keyboard shortcuts.

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public WindowsSpeechInputProvider(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/Services/TestExtensionService1.cs
+++ b/Assets/MixedRealityToolkit.Tests/Services/TestExtensionService1.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Services;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Services
 {
     internal class TestExtensionService1 : BaseExtensionService, ITestExtensionService1
     {
-        public TestExtensionService1(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        public TestExtensionService1(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/Assets/MixedRealityToolkit.Tests/Services/TestExtensionService2.cs
+++ b/Assets/MixedRealityToolkit.Tests/Services/TestExtensionService2.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Services;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Services
 {
     internal class TestExtensionService2 : BaseExtensionService, ITestExtensionService2
     {
-        public TestExtensionService2(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        public TestExtensionService2(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         public bool IsEnabled { get; private set; }
 

--- a/Assets/MixedRealityToolkit/Definitions/MixedRealityServiceConfiguration.cs
+++ b/Assets/MixedRealityToolkit/Definitions/MixedRealityServiceConfiguration.cs
@@ -22,8 +22,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         /// <param name="componentName">The simple, human readable name for the system, feature, or manager.</param>
         /// <param name="priority">The priority this system, feature, or manager will be initialized in.</param>
         /// <param name="runtimePlatform">The runtime platform(s) to run this system, feature, or manager on.</param>
-        /// <param name="configurationProfile">The configuration profile for the system, feature, or manager.</param>
-        public MixedRealityServiceConfiguration(SystemType componentType, string componentName, uint priority, SupportedPlatforms runtimePlatform, ScriptableObject configurationProfile)
+        /// <param name="configurationProfile">The configuration profile for the service.</param>
+        public MixedRealityServiceConfiguration(
+            SystemType componentType, 
+            string componentName, 
+            uint priority, 
+            SupportedPlatforms runtimePlatform, 
+            BaseMixedRealityProfile configurationProfile)
         {
             this.componentType = componentType;
             this.componentName = componentName;
@@ -62,16 +67,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions
         private SupportedPlatforms runtimePlatform;
 
         /// <summary>
-        /// The runtime platform(s) to run this system, feature, or manager on.
+        /// The runtime platform(s) to run this service.
         /// </summary>
         public SupportedPlatforms RuntimePlatform => runtimePlatform;
 
         [SerializeField]
-        private ScriptableObject configurationProfile;
+        private BaseMixedRealityProfile configurationProfile;
 
         /// <summary>
-        /// The configuration profile for the system, feature, or manager.
+        /// The configuration profile for the service.
         /// </summary>
-        public ScriptableObject ConfigurationProfile => configurationProfile;
+        public BaseMixedRealityProfile ConfigurationProfile => configurationProfile;
     }
 }

--- a/Assets/MixedRealityToolkit/Devices/BaseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/BaseDeviceManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem;
@@ -18,9 +19,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public BaseDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public BaseDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <inheritdoc />
         public virtual IMixedRealityController[] GetActiveControllers() => new IMixedRealityController[0];

--- a/Assets/MixedRealityToolkit/Devices/BaseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/BaseDeviceManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public BaseDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Devices/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Devices/BaseSpatialObserver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem;
 using Microsoft.MixedReality.Toolkit.Core.Services;
@@ -12,6 +13,18 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
 {
     public class BaseSpatialObserver : BaseExtensionService, IMixedRealitySpatialAwarenessObserver
     {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public BaseSpatialObserver(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile)
+        {
+            SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();
+            SourceName = name;
+        }
+
         #region IMixedRealityEventSource Implementation
 
         /// <inheritdoc />
@@ -56,17 +69,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         public string SourceName { get; }
 
         #endregion IMixedRealityEventSource Implementation
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public BaseSpatialObserver(string name, uint priority, ScriptableObject profile) : base(name, priority, profile)
-        {
-            SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();
-            SourceName = name;
-        }
 
         #region IMixedRealitySpatialAwarenessObserver implementation
 

--- a/Assets/MixedRealityToolkit/Devices/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Devices/BaseSpatialObserver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public BaseSpatialObserver(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile)
         {
             SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();

--- a/Assets/MixedRealityToolkit/Devices/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/OpenVR/OpenVRDeviceManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.OpenVR
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public OpenVRDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         #region Controller Utilities

--- a/Assets/MixedRealityToolkit/Devices/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/OpenVR/OpenVRDeviceManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput;
@@ -18,9 +19,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.OpenVR
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public OpenVRDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public OpenVRDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         #region Controller Utilities
 

--- a/Assets/MixedRealityToolkit/Devices/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/UnityInput/MouseDeviceManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
@@ -13,7 +14,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
 {
     public class MouseDeviceManager : BaseDeviceManager, IMixedRealityExtensionService
     {
-        public MouseDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public MouseDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <summary>
         /// Current Mouse Controller.

--- a/Assets/MixedRealityToolkit/Devices/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/UnityInput/MouseDeviceManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public MouseDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Devices/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/UnityInput/UnityJoystickManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public UnityJoystickManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         private const float DeviceRefreshInterval = 3.0f;

--- a/Assets/MixedRealityToolkit/Devices/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/UnityInput/UnityJoystickManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
@@ -21,9 +22,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public UnityJoystickManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public UnityJoystickManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         private const float DeviceRefreshInterval = 3.0f;
 

--- a/Assets/MixedRealityToolkit/Devices/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/UnityInput/UnityTouchDeviceManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
@@ -20,9 +21,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public UnityTouchDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public UnityTouchDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         private static readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();
 

--- a/Assets/MixedRealityToolkit/Devices/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/UnityInput/UnityTouchDeviceManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.UnityInput
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public UnityTouchDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         private static readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();

--- a/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public WindowsMixedRealityDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
 #if UNITY_WSA

--- a/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
-using UnityEngine;
 
 #if UNITY_WSA
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Devices;
@@ -13,6 +13,7 @@ using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Services;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 using UnityEngine.XR.WSA.Input;
 using WsaGestureSettings = UnityEngine.XR.WSA.Input.GestureSettings;
 #endif // UNITY_WSA
@@ -24,9 +25,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public WindowsMixedRealityDeviceManager(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public WindowsMixedRealityDeviceManager(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
 #if UNITY_WSA
 

--- a/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealitySpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealitySpatialObserver.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem;
-using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem;
 using Microsoft.MixedReality.Toolkit.Core.Services;
-using Microsoft.MixedReality.Toolkit.Core.Utilities;
-using UnityEngine;
 using System.Collections.Generic;
+using UnityEngine;
 
 #if UNITY_WSA
+using Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem;
+using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Utilities;
 using UnityEngine.XR.WSA;
 #endif // UNITY_WSA
 
@@ -20,9 +21,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public WindowsMixedRealitySpatialObserver(string name, uint priority, ScriptableObject profile) : base(name, priority, profile) { }
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public WindowsMixedRealitySpatialObserver(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         #region IMixedRealityToolkit implementation
 

--- a/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealitySpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Devices/WindowsMixedReality/WindowsMixedRealitySpatialObserver.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Devices.WindowsMixedReality
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public WindowsMixedRealitySpatialObserver(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority, profile) { }
 
         #region IMixedRealityToolkit implementation

--- a/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         /// </summary>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
-        /// <param name="profile">The service's con</param>
+        /// <param name="profile">The service's configuration profile.</param>
         public BaseExtensionService(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority)
         {
             ConfigurationProfile = profile;

--- a/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Interfaces;
 using UnityEngine;
 
@@ -15,18 +16,19 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
     public abstract class BaseExtensionService : BaseServiceWithConstructor, Interfaces.IMixedRealityExtensionService
     {
         /// <summary>
-        /// Configuration Profil
+        /// Configuration Profile
         /// </summary>
-        protected ScriptableObject configurationProfile;
+        protected BaseMixedRealityProfile ConfigurationProfile { get; set; } = null;
 
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="priority"></param>
-        public BaseExtensionService(string name, uint priority, ScriptableObject profile) : base(name, priority)
+        /// <param name="name">Friendly name of the service.</param>
+        /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The service's con</param>
+        public BaseExtensionService(string name, uint priority, BaseMixedRealityProfile profile) : base(name, priority)
         {
-            configurationProfile = profile;
+            ConfigurationProfile = profile;
         }
     }
 }


### PR DESCRIPTION
Overview
---
#3318 was a fantastic change that had one minor flaw. Rather than pass a ScriptableObject as the profile, BaseMixedRealityProfile should have been used.

This change also updates the summary tags for the relevant constructors

Client code / profiles should not encounter any breaking changes with this PR.