### PR TITLE
Add WindowsEditor as a supported platform

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/SupportedPlatforms.cs
@@ -15,5 +15,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities
         MacStandalone = 1 << 1,
         LinuxStandalone = 1 << 2,
         WindowsUniversal = 1 << 3,
+        WindowsEditor = 1 << 4,
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
 
         private static bool IsPlatformSupported(SupportedPlatforms target, SupportedPlatforms supported)
         {
-            return ((target & supported) == target);
+            return (target & supported) > 0;
         }
 
 #if UNITY_EDITOR
@@ -58,6 +58,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
         private static SupportedPlatforms GetSupportedPlatformMask(UnityEditor.BuildTarget editorBuildTarget)
         {
             SupportedPlatforms supportedPlatforms = 0;
+
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                supportedPlatforms |= SupportedPlatforms.WindowsStandalone;
+            }
 
             switch (editorBuildTarget)
             {

--- a/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities
 
             if (Application.platform == RuntimePlatform.WindowsEditor)
             {
-                supportedPlatforms |= SupportedPlatforms.WindowsStandalone;
+                supportedPlatforms |= SupportedPlatforms.WindowsEditor;
             }
 
             switch (editorBuildTarget)


### PR DESCRIPTION
Overview
---
This will help enable systems / services that are only meant for editor simulation or otherwise not intended to run on an actual device.