### PR TITLE
remove IMixedRealityInputHandler from IMixedRealityInputHandler<T>

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DragAndDropHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DragAndDropHandler.cs
@@ -18,7 +18,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Input.Handlers
     /// Dragging is done by calculating the angular delta and z-delta between the current and previous hand positions,
     /// and then repositioning the object based on that.
     /// </summary>
-    public class DragAndDropHandler : BaseFocusHandler, IMixedRealitySourceStateHandler, IMixedRealityPointerHandler, IMixedRealityInputHandler<MixedRealityPose>
+    public class DragAndDropHandler : BaseFocusHandler,
+        IMixedRealityInputHandler,
+        IMixedRealityInputHandler<MixedRealityPose>,
+        IMixedRealityPointerHandler,
+        IMixedRealitySourceStateHandler
     {
         private enum RotationModeEnum
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -22,7 +22,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Utilities
     /// for instructions on how to use the script.
     /// </summary>
     /// 
-    public class ManipulationHandler : BaseFocusHandler, IMixedRealityInputHandler<MixedRealityPose>, IMixedRealitySourceStateHandler
+    public class ManipulationHandler : BaseFocusHandler,
+        IMixedRealityInputHandler,
+        IMixedRealityInputHandler<MixedRealityPose>, 
+        IMixedRealitySourceStateHandler
     {
         #region Private Enums
         private enum HandMovementType

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -13,7 +13,11 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.UX
 {
-    public class BoundingBox : BaseFocusHandler, IMixedRealityPointerHandler, IMixedRealityInputHandler<MixedRealityPose>, IMixedRealitySourceStateHandler
+    public class BoundingBox : BaseFocusHandler, 
+        IMixedRealityInputHandler,
+        IMixedRealityInputHandler<MixedRealityPose>,
+        IMixedRealityPointerHandler,
+        IMixedRealitySourceStateHandler
     {
         #region Enums
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Receivers/InteractionReceiver.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Receivers
     /// </summary>
     public abstract class InteractionReceiver : BaseInputHandler,
         IMixedRealityFocusChangedHandler,
+        IMixedRealityInputHandler,
         IMixedRealityInputHandler<float>,
         IMixedRealityInputHandler<Vector2>,
         IMixedRealityGestureHandler<Vector2>,

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/GazeHandHelper.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/GazeHandHelper.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Utilities
 {
     /// <summary>
-    /// This class must be instantiated by a script that implements the IMixedRealitySourceStateHandler and IMixedRealityInputHandler<MixedRealityPose> interfaces.
+    /// This class must be instantiated by a script that implements the IMixedRealitySourceStateHandler, IMixedRealityInputHandler and IMixedRealityInputHandler<MixedRealityPose> interfaces.
     /// 
     /// ***It must receive EventData arguments from OnInputDown(), OnInputUp(), OnInputChanged() and OnSourceLost().***
     /// 

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityControllerPoseSynchronizer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityControllerPoseSynchronizer.cs
@@ -12,11 +12,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices
     /// Basic interface for synchronizing to a controller pose.
     /// </summary>
     public interface IMixedRealityControllerPoseSynchronizer : IMixedRealitySourcePoseHandler,
-            IMixedRealityInputHandler<float>,
-            IMixedRealityInputHandler<Vector2>,
-            IMixedRealityInputHandler<Vector3>,
-            IMixedRealityInputHandler<Quaternion>,
-            IMixedRealityInputHandler<MixedRealityPose>
+        IMixedRealityInputHandler,
+        IMixedRealityInputHandler<float>,
+        IMixedRealityInputHandler<Vector2>,
+        IMixedRealityInputHandler<Vector3>,
+        IMixedRealityInputHandler<Quaternion>,
+        IMixedRealityInputHandler<MixedRealityPose>
     {
         /// <summary>
         /// The controller handedness to synchronize with.

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityInputHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityInputHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers
     /// <remarks>
     /// Valid input types:
     /// </remarks>
-    public interface IMixedRealityInputHandler<T> : IMixedRealityInputHandler
+    public interface IMixedRealityInputHandler<T> : IEventSystemHandler
     {
         /// <summary>
         /// Raised input event updates from the type of input specified in the interface handler implementation.


### PR DESCRIPTION
Overview
---
Not every class that implements `IMixedRealityInputHandler < T >` needs the methods from `IMixedRealityInputHandler`. This change removes the dependency and allows code that so desires to implement one or both without need for empty method implementations.

Changes
---
Fixes: #3295 
