### PR TITLE
Update FocusProvider's UIRaycastCamera logic

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -419,16 +419,17 @@ namespace Microsoft.MixedReality.Toolkit.Services.InputSystem
         /// <returns>The UIRaycastCamera</returns>
         private void EnsureUiRaycastCameraSetup()
         {
+            Transform cameraTransform = CameraCache.Main.transform.Find("UIRaycastCamera");
             GameObject cameraObject;
 
-            if (CameraCache.Main.transform.childCount == 0)
+            if (cameraTransform == null)
             {
                 cameraObject = new GameObject { name = "UIRaycastCamera" };
                 cameraObject.transform.parent = CameraCache.Main.transform;
             }
             else
             {
-                cameraObject = CameraCache.Main.transform.Find("UIRaycastCamera").gameObject;
+                cameraObject = cameraTransform.gameObject;
                 Debug.Assert(cameraObject.transform.parent == CameraCache.Main.transform);
             }
 


### PR DESCRIPTION
Overview
---
As currently written, the FocusProvider assumes that the camera will only ever have more than 0 children if the UIRaycastCamera is already present. This isn't a robust assumption, as devs can place additional children under the Camera, which leads to null refs.