### PR TITLE
Update Spatial Awareness system cleanup

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -304,10 +304,11 @@ namespace Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
             if (Application.isPlaying)
             {
                 // Cleanup the scene objects are managing
-                if (ObservedObjectParent != null)
+                if (observedObjectParent != null)
                 {
-                    ObservedObjectParent.transform.DetachChildren();
+                    observedObjectParent.transform.DetachChildren();
                 }
+                
                 foreach (SpatialAwarenessMeshObject meshObject in meshes.Values)
                 {
                     if (meshObject != null)


### PR DESCRIPTION
Call observedObjectParent instead of ObservedObjectParent, so we don't create GameObjects on cleanup.