### PR TITLE
removed check for dimension index change which should not be needed.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -18,8 +18,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
     {
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Deselect", Tooltip = "The toggle is deselected")]
         public UnityEvent OnDeselect = new UnityEvent();
-        
-        private int lastIndex;
 
         public InteractableOnToggleReceiver(UnityEvent ev) : base(ev)
         {
@@ -34,20 +32,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         public override void OnClick(InteractableStates state, Interactable source, IMixedRealityPointer pointer = null)
         {
             int currentIndex = source.GetDimensionIndex();
-
-            if (currentIndex != lastIndex)
+            
+            if (currentIndex % 2 == 0)
             {
-                if (currentIndex % 2 == 0)
-                {
-                    OnDeselect.Invoke();
-                }
-                else
-                {
-                    uEvent.Invoke();
-                }
+                OnDeselect.Invoke();
             }
-
-            lastIndex = currentIndex;
+            else
+            {
+                uEvent.Invoke();
+            }
         }
     }
 }


### PR DESCRIPTION
Overview
Removed a check comparing the Interactable's DimensionIndex to a cached index value that was meant to keep the receiver and interactable in sync. The check is not needed and actually caused errors if the interactable's toggled state is set through code using SetDimensioniIndex(1).


Changes
---
- Fixes: # .
