### PR TITLE
Declare mouse controller as 'any' handedness

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
@@ -500,7 +500,7 @@ MonoBehaviour:
   - controllerType:
       reference: Microsoft.MixedReality.Toolkit.Core.Providers.UnityInput.MouseController,
         Microsoft.MixedReality.Toolkit
-    handedness: 0
+    handedness: 7
     interactions:
     - id: 0
       description: Spatial Mouse Position

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Providers.UnityInput
     /// <summary>
     /// Manages the mouse using unity input system.
     /// </summary>
-    [MixedRealityController(SupportedControllerType.Mouse, new[] { Handedness.None })]
+    [MixedRealityController(SupportedControllerType.Mouse, new[] { Handedness.Any })]
     public class MouseController : BaseController
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -54,13 +54,26 @@ namespace Microsoft.MixedReality.Toolkit.Core.Providers.UnityInput
 
             MixedRealityRaycaster.DebugEnabled = true;
 
+            const Handedness handedness = Handedness.Any;
+            System.Type controllerType = typeof(MouseController);
+
+            // Make sure that the handedness declared in the controller attribute matches what we expect
+            {
+                var controllerAttribute = MixedRealityControllerAttribute.Find(controllerType);
+                if (controllerAttribute != null)
+                {
+                    Handedness[] handednesses = controllerAttribute.SupportedHandedness;
+                    Debug.Assert(handednesses.Length == 1 && handednesses[0] == Handedness.Any, "Unexpected mouse handedness declared in MixedRealityControllerAttribute");
+                }
+            }
+
             if (MixedRealityToolkit.InputSystem != null)
             {
-                var pointers = RequestPointers(new SystemType(typeof(MouseController)), Handedness.Any, true);
+                var pointers = RequestPointers(new SystemType(controllerType), handedness, true);
                 mouseInputSource = MixedRealityToolkit.InputSystem.RequestNewGenericInputSource("Mouse Input", pointers);
             }
 
-            Controller = new MouseController(TrackingState.NotApplicable, Handedness.Any, mouseInputSource);
+            Controller = new MouseController(TrackingState.NotApplicable, handedness, mouseInputSource);
 
             if (mouseInputSource != null)
             {


### PR DESCRIPTION
That's what the mouse manager expects, otherwise input action mappings are not applied to mouse events.

Overview
---


Changes
---
- Fixes: # .
