### PR TITLE
Controller mapping profile and controller attribute fixes

### DIFF
--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityControllerAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityControllerAttribute.cs
@@ -6,6 +6,10 @@ using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using System;
 using System.Linq;
 
+#if WINDOWS_UWP && !ENABLE_IL2CPP
+using Microsoft.MixedReality.Toolkit.Core.Extensions;
+#endif // WINDOWS_UWP && !ENABLE_IL2CPP
+
 namespace Microsoft.MixedReality.Toolkit.Core.Attributes
 {
     /// <summary>

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -19,17 +19,19 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Devices
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Controller Mapping Profile", fileName = "MixedRealityControllerMappingProfile", order = (int)CreateProfileMenuItemIndices.ControllerMapping)]
     public class MixedRealityControllerMappingProfile : BaseMixedRealityProfile
     {
-        private static Type[] controllerMappingTypes;
-
-        public static Type[] ControllerMappingTypes { get { CollectControllerTypes(); return controllerMappingTypes; } }
-
-        public static Type[] CustomControllerMappingTypes { get => (from type in ControllerMappingTypes where UsesCustomInteractionMapping(type) select type).ToArray(); }
-
         [SerializeField]
         [Tooltip("The list of controller templates your application can use.")]
         private MixedRealityControllerMapping[] mixedRealityControllerMappingProfiles = new MixedRealityControllerMapping[0];
 
         public MixedRealityControllerMapping[] MixedRealityControllerMappingProfiles => mixedRealityControllerMappingProfiles;
+
+#if UNITY_EDITOR
+
+        private static Type[] controllerMappingTypes;
+
+        public static Type[] ControllerMappingTypes { get { CollectControllerTypes(); return controllerMappingTypes; } }
+
+        public static Type[] CustomControllerMappingTypes { get => (from type in ControllerMappingTypes where UsesCustomInteractionMapping(type) select type).ToArray(); }
 
         private static void CollectControllerTypes()
         {
@@ -120,6 +122,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Devices
                 return isOptional1 ? 1 : -1; // Put custom mappings at the end. These can be added / removed in the inspector.
             });
         }
+
+#endif // UNITY_EDITOR
 
         private static bool UsesCustomInteractionMapping(Type controllerType)
         {

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -37,8 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Devices
         {
             if (controllerMappingTypes == null)
             {
-                var tmp = new List<Type>();
-                // todo: not supported on uwp/.net
+                List<Type> tmp = new List<Type>();
                 foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
                     try


### PR DESCRIPTION
Overview
---
- Wrap editor specific code in the controller mapping profile in #if / #endif.
- Add "using Microsoft.MixedReality.Toolkit.Core.Extensions" when building UWP on .net backend

This does not 100% resolve .net backend build breaks. There are some changes needed in interactables to work around AppDomain usage