### PR TITLE
Remove unneeded/dated artifact build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,36 +60,3 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 | ![Academy](External/ReadMeImages/icon_academy.png) [Academy](https://developer.microsoft.com/en-us/windows/mixed-reality/academy)| ![Design](External/ReadMeImages/icon_design.png) [Design](https://developer.microsoft.com/en-us/windows/mixed-reality/design)| ![Development](External/ReadMeImages/icon_development.png) [Development](https://developer.microsoft.com/en-us/windows/mixed-reality/development)| ![Community)](External/ReadMeImages/icon_community.png) [Community](https://developer.microsoft.com/en-us/windows/mixed-reality/community)|
 | :--------------------- | :----------------- | :------------------ | :------------------------ |
 | See code examples. Do a coding tutorial. Watch guest lectures.          | Get design guides. Build user interface. Learn interactions and input.     | Get development guides. Learn the technology. Understand the science.       | Join open source projects. Ask questions on forums. Attend events and meetups. |
-
-# Building the Artifacts
-
-## Requirements
-
-### NuGet
-[NuGet](https://www.nuget.org/downloads) is the package manager for .Net and you'll need to have it available in the PATH.
-
-### UnitySetup
-The build process leverages [UnitySetup](https://www.powershellgallery.com/packages/UnitySetup), an OSS PowerShell Module from Microsoft. 
-
-Install from PowerShell:
-
-```powershell
-Install-Module UnitySetup -Scope CurrentUser
-```
-
-### Git
-If you do not specify a version, then [Git](https://git-scm.com/downloads) is used to find relevant tags. In this case it will need to be available in the PATH.
-
-## Run the Build
-Simply execute the build script as such:
-
-```powershell
-.\build.ps1 -Version '1.2.3'
-```
-For help and examples simply use the PowerShell help command:
-```
-help .\build.ps1 -Detailed
-```
-
-> Note: If you don't specify `-Version <version>` the script will try to infer it from tags pointing to the current git commit. An error is produced if you don't have a tag and no version is provided.
-| See code examples. Do a coding tutorial. Watch guest lectures.          | Get design guides. Build user interface. Learn interactions and input.     | Get development guides. Learn the technology. Understand the science.       | Join open source projects. Ask questions on forums. Attend events and meet-ups. |


### PR DESCRIPTION
I've never needed to build artifacts for the MRTK. We should remove these steps to remove any confusion

Overview
---

Remove artifact build steps that aren't needed


Changes
---
- Fixes: # .
