### PR TITLE
Remove broken hyper link - current development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,3 @@ help .\build.ps1 -Detailed
 ```
 
 > Note: If you don't specify `-Version <version>` the script will try to infer it from tags pointing to the current git commit. An error is produced if you don't have a tag and no version is provided.
-| See code examples. Do a coding tutorial. Watch guest lectures.          | Get design guides. Build user interface. Learn interactions and input.     | Get development guides. Learn the technology. Understand the science.       | Join open source projects. Ask questions on forums. Attend events and meet-ups. |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The Mixed Reality Toolkit vNext will includes many APIs to accelerate the develo
 | To develop apps for mixed reality headsets, you need the Windows 10 Fall Creators Update | The Unity 3D engine provides support for building mixed reality projects in Windows 10 | Visual Studio is used for code editing, deploying and building UWP app packages | The Emulators allow you test your app without the device in a simulated environment |
 
 # Getting started with MRTK-vNext
-MRTK-vNext is currently under heavy development, utilizing the current state of the [Dev_Working_Branch](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/Dev_Working_Branch) as a starting point. Refer to this branch for working examples and experimental code.
+MRTK-vNext is currently under heavy development. To determine the best branch for starting out, please view the [Branch Guide](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/Branch-Guide) wiki page.
 
 > Learn more about the approach behind the [Windows Mixed Reality - vNext SDK](/MRTK-SDK.md) here.  Which aims to help on-board developers quicker when building solutions.
 


### PR DESCRIPTION
Overview
---

The main hyperlink calling out the a MRTK-vnext development branch is broken. This review redirects developers to our branch guide wiki page, which should remain regardless of branching name changes


Changes
---
- Fixes: #3335 .
