### PR TITLE
update dispose pattern implementation, spatial mesh observer now uses dispose

### DIFF
--- a/Assets/MixedRealityToolkit/Services/BaseService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseService.cs
@@ -40,22 +40,33 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
 
         #region IDisposable Implementation
 
-        private bool disposed;
-
+        /// <summary>
+        /// Finalizer
+        /// </summary>
         ~BaseService()
         {
-            OnDispose(true);
+            Dispose();
         }
 
+        /// <summary>
+        /// Cleanup resources used by this object.
+        /// </summary>
         public void Dispose()
         {
-            if (disposed) { return; }
-            disposed = true;
+            // Clean up our resources (managed and unmanaged resources)
+            Dispose(true);
+
+            // Suppress finalization as the  the finalizer also calls our cleanup code.
             GC.SuppressFinalize(this);
-            OnDispose(false);
         }
 
-        protected virtual void OnDispose(bool finalizing) { }
+        /// <summary>
+        /// Cleanup resources used by the object
+        /// </summary>
+        /// <param name="disposing">Are we fully disposing the object? 
+        /// True will release all managed resources, unmanaged resources are always released.
+        /// </param>
+        protected virtual void Dispose(bool disposing) { }
 
         #endregion IDisposable Implementation
     }

--- a/Assets/MixedRealityToolkit/Services/BaseService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseService.cs
@@ -41,6 +41,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         #region IDisposable Implementation
 
         /// <summary>
+        /// Value indicating if the object has completed disposal.
+        /// </summary>
+        /// <remarks>
+        /// Set by derived classes to indicate that disposal has been completed.
+        /// </remarks>
+        protected bool disposed = false;
+
+        /// <summary>
         /// Finalizer
         /// </summary>
         ~BaseService()
@@ -67,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         /// True will release all managed resources, unmanaged resources are always released.
         /// </param>
         protected virtual void Dispose(bool disposing) { }
-
+    
         #endregion IDisposable Implementation
     }
 }


### PR DESCRIPTION
Overview
---
This change updates the dispose pattern implementation in BaseService.cs to better match the documented sample ( https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose ).

As part of this change, the WindowsMixedRealitySpatialMeshObserver's cleanup code was modified to use Dispose internally and some UNITY_WSA #ifs were consolidated for readability.