### PR TITLE
Fixed script errors related to upgrade to Unity 2019.1

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
         }
 
         /// <summary>
-        /// This enum is used interally to define how an object's bounds are calculated in order to fit the boundingbox
+        /// This enum is used internally to define how an object's bounds are calculated in order to fit the boundingbox
         /// to it.
         /// </summary>
         private enum BoundsCalculationMethod
@@ -297,7 +297,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
         private HandleType currentHandleType;
         #endregion Private Properties
 
-        #region Monobehaviour Methods
+        #region MonoBehaviour Methods
         private void Start()
         {
             targetObject = this.gameObject;
@@ -327,7 +327,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
 
             UpdateRigHandles();
         }
-        #endregion Monobehaviour Methods
+        #endregion MonoBehaviour Methods
 
         #region Private Methods
         private void CreateRig()
@@ -362,7 +362,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             {
                 for (var i = 0; i < balls.Count; i++)
                 {
-                    Destroy(balls[i]);
+                    Destroy(balls[i].gameObject);
                 }
 
                 balls.Clear();
@@ -372,7 +372,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             {
                 for (int i = 0; i < links.Count; i++)
                 {
-                    Destroy(links[i]);
+                    Destroy(links[i].gameObject);
                 }
 
                 links.Clear();
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             {
                 for (var i = 0; i < corners.Count; i++)
                 {
-                    Destroy(corners[i]);
+                    Destroy(corners[i].gameObject);
                 }
 
                 corners.Clear();
@@ -390,7 +390,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
 
             if (rigRoot != null)
             {
-                Destroy(rigRoot);
+                Destroy(rigRoot.gameObject);
             }
         }
 
@@ -496,7 +496,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             targetObject.transform.localScale = newScale;
         }
 
-        private Vector3 GetRotationAxis(GameObject handle)
+        private Vector3 GetRotationAxis(Transform handle)
         {
             for (int i = 0; i < balls.Count; ++i)
             {
@@ -926,10 +926,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             SetHiddenHandles();
         }
 
-        private void ShowOneHandle(GameObject handle)
+        private void ShowOneHandle(Transform handle)
         {
             //turn off all balls
-            if (balls != null)
+            if (ballRenderers != null)
             {
                 for (int i = 0; i < ballRenderers.Count; ++i)
                 {
@@ -938,7 +938,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             }
 
             //turn off all corners
-            if (corners != null)
+            if (cornerRenderers != null)
             {
                 for (int i = 0; i < cornerRenderers.Count; ++i)
                 {
@@ -1043,7 +1043,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             }
         }
 
-        private HandleType GetHandleType(GameObject handle)
+        private HandleType GetHandleType(Transform handle)
         {
             for (int i = 0; i < balls.Count; ++i)
             {
@@ -1201,15 +1201,16 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
                         currentInputSource = eventData.InputSource;
                         currentPointer = pointer;
                         grabbedHandle = grabbedCollider.gameObject;
-                        currentHandleType = GetHandleType(grabbedHandle);
-                        currentRotationAxis = GetRotationAxis(grabbedHandle);
+                        Transform grabbedHandleTransform = grabbedHandle.transform;
+                        currentHandleType = GetHandleType(grabbedHandleTransform);
+                        currentRotationAxis = GetRotationAxis(grabbedHandleTransform);
                         currentPointer.TryGetPointingRay(out initialGrabRay);
                         initialGrabMag = distance;
                         initialGrabbedPosition = grabbedHandle.transform.position;
                         initialGrabbedCentroid = targetObject.transform.position;
                         initialScale = targetObject.transform.localScale;
                         pointer.TryGetPointerPosition(out initialGrabPoint);
-                        ShowOneHandle(grabbedHandle);
+                        ShowOneHandle(grabbedHandleTransform);
                         initialGazePoint = Vector3.zero;
                     }
                 }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -154,6 +154,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             string nugetPath = Path.Combine(unity, @"Data\PlaybackEngines\MetroSupport\Tools\NuGet.exe");
 
             // Before building, need to run a nuget restore to generate a json.lock file. Failing to do this breaks the build in VS RTM
+
+#if !UNITY_2019_1_OR_NEWER
             if (PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA) == ScriptingImplementation.WinRTDotNET)
             {
                 if (!await RestoreNugetPackagesAsync(nugetPath, storePath) ||
@@ -165,6 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
                     return IsBuilding = false;
                 }
             }
+#endif
 
             // Ensure that the generated .appx version increments by modifying Package.appxmanifest
             if (!SetPackageVersion(incrementVersion))

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployWindow.cs
@@ -357,6 +357,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             EditorGUILayout.BeginHorizontal();
 
             // Generate C# Project References for debugging
+#if !UNITY_2019_1_OR_NEWER
             bool generateReferenceProjects = EditorUserBuildSettings.wsaGenerateReferenceProjects;
 
             var curScriptingBackend = PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA);
@@ -371,6 +372,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             }
 
             GUILayout.FlexibleSpace();
+#endif
 
             GUI.enabled = ShouldOpenSLNBeEnabled;
 
@@ -502,7 +504,10 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
                 buildConfigOption = WSABuildType.Debug;
             }
 
+#if !UNITY_2019_1_OR_NEWER
             EditorUserBuildSettings.GetWSADotNetNative(buildConfigOption);
+#endif
+
             buildConfigOption = (WSABuildType)EditorGUILayout.EnumPopup("Build Configuration", buildConfigOption, GUILayout.Width(HalfWidth));
 
             string buildConfigString = buildConfigOption.ToString();
@@ -919,9 +924,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             GUILayout.EndVertical();
         }
 
-        #endregion Methods
+#endregion Methods
 
-        #region Utilities
+#region Utilities
 
         private async void ConnectToDevice(DeviceInfo currentConnection)
         {
@@ -1231,9 +1236,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             return string.Empty;
         }
 
-        #endregion Utilities
+#endregion Utilities
 
-        #region Device Portal Commands
+#region Device Portal Commands
 
         private static async void OpenDevicePortal(DevicePortalConnections targetDevices, DeviceInfo currentConnection)
         {
@@ -1481,6 +1486,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             }
         }
 
-        #endregion Device Portal Commands
+#endregion Device Portal Commands
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -147,12 +147,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
                 EditorUserBuildSettings.wsaUWPBuildType = buildInfo.WSAUWPBuildType.Value;
             }
 
+#if !UNITY_2019_1_OR_NEWER
             var oldWSAGenerateReferenceProjects = EditorUserBuildSettings.wsaGenerateReferenceProjects;
 
             if (buildInfo.WSAGenerateReferenceProjects.HasValue)
             {
                 EditorUserBuildSettings.wsaGenerateReferenceProjects = buildInfo.WSAGenerateReferenceProjects.Value;
             }
+#endif
 
             var oldColorSpace = PlayerSettings.colorSpace;
 
@@ -196,17 +198,20 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
             {
                 OnPostProcessBuild(buildInfo, buildReport);
 
+#if !UNITY_2019_1_OR_NEWER
                 if (buildInfo.BuildTarget == BuildTarget.WSAPlayer && EditorUserBuildSettings.wsaGenerateReferenceProjects)
                 {
                     UwpProjectPostProcess.Execute(buildInfo.OutputDirectory);
                 }
+
+                EditorUserBuildSettings.wsaGenerateReferenceProjects = oldWSAGenerateReferenceProjects;
+#endif
 
                 PlayerSettings.colorSpace = oldColorSpace;
                 PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, oldBuildSymbols);
 
                 EditorUserBuildSettings.wsaUWPBuildType = oldWSAUWPBuildType.Value;
 
-                EditorUserBuildSettings.wsaGenerateReferenceProjects = oldWSAGenerateReferenceProjects;
                 EditorUserBuildSettings.SwitchActiveBuildTarget(oldBuildTargetGroup, oldBuildTarget);
             }
         }


### PR DESCRIPTION
Overview
With Unity 2019.1 the option to generate project references for UWP was removed. The related API calls were therefore removed as well and caused the compilation errors. Since .NET scripting runtime was removed for UWP too, code was futher excluded when combinations of the two appeared. 


Changes
---
- Fixes: #3104
