### PR TITLE
Small Performance Tweaks Round 2

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBorder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBorder.cs
@@ -8,20 +8,20 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Layout
 {
     /// <summary>
-    /// Use a Unity primitive Cube or cylindar as a border segment relative to the scale of the AnchorTransform
+    /// Use a Unity primitive Cube or cylinder as a border segment relative to the scale of the AnchorTransform
     /// Use with ButtonSize on the component and the Anchor for consistent results
-    /// Works best when using with ButtonSize, but not requied - See ButtonSize for more info.
+    /// Works best when using with ButtonSize, but not required - See ButtonSize for more info.
     /// </summary>
     [ExecuteInEditMode]
     public class ButtonBorder : MonoBehaviour
     {
         /// <summary>
         /// A scale factor for button layouts, default is based on 2048 pixels to 1 meter.
-        /// Similar to values used in designer and 2D art programs and helps create consistancy across teams.
+        /// Similar to values used in designer and 2D art programs and helps create consistency across teams.
         /// 
         /// Use Case:
         /// A designer created a basic button background using a Cube and ButtonSize
-        /// Add some more borders, using more cubes or cylenders, that will scale to the edges of the background size
+        /// Add some more borders, using more cubes or cylinders, that will scale to the edges of the background size
         /// </summary>
         [Tooltip("A pixel to Unity unit conversion, Default: 2048x2048 pixels covers a 1x1 Unity Unit or default primitive size")]
         [SerializeField]
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Layout
         /// </summary>
         [Tooltip("The transform this object should be linked and aligned to")]
         [SerializeField]
-        private Transform AnchorTransform;
+        private Transform AnchorTransform = null;
 
         /// <summary>
         /// Width of the border
@@ -55,14 +55,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Layout
         /// </summary>
         [Tooltip("Where to set this object's center point in relation to the Anchor's center point")]
         [SerializeField]
-        private Vector3 Alignment;
+        private Vector3 Alignment = Vector3.zero;
 
         /// <summary>
         /// An absolute value to offset the border from the Anchor's edge
         /// </summary>
         [Tooltip("That absolute amount to offset the position")]
         [SerializeField]
-        private Vector3 PositionOffset;
+        private Vector3 PositionOffset = Vector3.zero;
 
         /// <summary>
         /// Overlap the edge it is assigned to so there are not gaps in the corners
@@ -80,13 +80,29 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Layout
         [SerializeField]
         private bool OnlyInEditMode = true;
 
+        private Vector3 scale;
+        private Vector3 startPosition;
+        private Vector3 weighDirection;
+        private Vector3 localPosition;
+        private Vector3 anchorTransformLocalPosition;
+        private Vector3 anchorTransformLocalScale;
+
         /// <summary>
         /// Set the size and position
         /// </summary>
         private void UpdateSize()
         {
-            Vector3 weighDireciton = new Vector3(Mathf.Abs(Alignment.x), Mathf.Abs(Alignment.y), Mathf.Abs(Alignment.z));
-            Vector3 scale = weighDireciton * (Weight / BasePixelScale);// Vector3.Scale(Alignment, Scale) + Offset / BasePixelScale;
+            // Vector3 weighDireciton = new Vector3(Mathf.Abs(Alignment.x), Mathf.Abs(Alignment.y), Mathf.Abs(Alignment.z));
+            // Vector3 scale = weighDireciton * (Weight / BasePixelScale);// Vector3.Scale(Alignment, Scale) + Offset / BasePixelScale;
+
+            weighDirection.x = Mathf.Abs(Alignment.x);
+            weighDirection.y = Mathf.Abs(Alignment.y);
+            weighDirection.z = Mathf.Abs(Alignment.z);
+
+            scale.x = weighDirection.x * (Weight / BasePixelScale);
+            scale.y = weighDirection.y * (Weight / BasePixelScale);
+            scale.z = weighDirection.z * (Weight / BasePixelScale);
+
             float size = ((Weight * 2) / BasePixelScale);
             if (scale.x > scale.y)
             {
@@ -100,14 +116,24 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Layout
 
             transform.localScale = scale;
 
-            Vector3 startPosition = AnchorTransform.localPosition;
+            anchorTransformLocalPosition = AnchorTransform.localPosition;
+            anchorTransformLocalScale = AnchorTransform.localScale;
+
+            startPosition = anchorTransformLocalPosition;
 
             if (AnchorTransform != this.transform)
             {
-                startPosition = AnchorTransform.localPosition + (Vector3.Scale(AnchorTransform.localScale * 0.5f, Alignment));
+                // startPosition = AnchorTransform.localPosition + (Vector3.Scale(AnchorTransform.localScale * 0.5f, Alignment));
+                startPosition.x = anchorTransformLocalPosition.x + ((anchorTransformLocalScale.x * 0.5f) * Alignment.x);
+                startPosition.y = anchorTransformLocalPosition.y + ((anchorTransformLocalScale.y * 0.5f) * Alignment.y);
+                startPosition.z = anchorTransformLocalPosition.z + ((anchorTransformLocalScale.z * 0.5f) * Alignment.z);
             }
 
-            transform.localPosition = startPosition + (Alignment * Weight * 0.5f / BasePixelScale) + (PositionOffset / BasePixelScale);
+            // transform.localPosition = startPosition + (Alignment * Weight * 0.5f / BasePixelScale) + (PositionOffset / BasePixelScale);
+            localPosition.x = startPosition.x + (Alignment.x * Weight * 0.5f / BasePixelScale) + (PositionOffset.x / BasePixelScale);
+            localPosition.y = startPosition.y + (Alignment.y * Weight * 0.5f / BasePixelScale) + (PositionOffset.y / BasePixelScale);
+            localPosition.z = startPosition.z + (Alignment.z * Weight * 0.5f / BasePixelScale) + (PositionOffset.z / BasePixelScale);
+            transform.localPosition = localPosition;
         }
 
         // Update is called once per frame

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAnimatorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAnimatorTheme.cs
@@ -14,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     public class InteractableAnimatorTheme : InteractableThemeBase
     {
         private int lastIndex = 0;
+        private Animator controller;
 
         public InteractableAnimatorTheme()
         {
@@ -29,6 +30,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                 });
         }
 
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+            controller = Host.GetComponent<Animator>();
+        }
+
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -40,7 +47,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         {
             if(lastIndex != index)
             {
-                Animator controller = Host.GetComponent<Animator>();
                 if(controller != null)
                 {
                     controller.SetTrigger(property.Values[index].String);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAudioTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAudioTheme.cs
@@ -10,6 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 {
     public class InteractableAudioTheme : InteractableThemeBase
     {
+        private AudioSource audioSource;
 
         public InteractableAudioTheme()
         {
@@ -26,6 +27,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                 });
         }
 
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+            audioSource = Host.GetComponentInChildren<AudioSource>();
+        }
+
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -39,7 +46,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
-            AudioSource audioSource = Host.GetComponentInChildren<AudioSource>();
             if (audioSource == null)
             {
                 audioSource = Host.AddComponent<AudioSource>();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -11,6 +11,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 {
     public class InteractableColorTheme : InteractableShaderTheme
     {
+        private TextMesh mesh;
+        private Text text;
+
         public InteractableColorTheme()
         {
             Types = new Type[] { typeof(Renderer), typeof(TextMesh), typeof(Text) };
@@ -26,17 +29,23 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                 });
         }
 
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+            mesh = Host.GetComponent<TextMesh>();
+            text = Host.GetComponent<Text>();
+        }
+
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue color = new InteractableThemePropertyValue();
-            TextMesh mesh = Host.GetComponent<TextMesh>();
+
             if (mesh != null)
             {
                 color.Color = mesh.color;
                 return color;
             }
 
-            Text text = Host.GetComponent<Text>();
             if (text != null)
             {
                 color.Color = text.color;
@@ -49,14 +58,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             Color color = Color.Lerp(property.StartValue.Color, property.Values[index].Color, percentage);
-            TextMesh mesh = Host.GetComponent<TextMesh>();
+
             if (mesh != null)
             {
                 mesh.color = color;
                 return;
             }
 
-            Text text = Host.GetComponent<Text>();
             if (text != null)
             {
                 text.color = color;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableMaterialTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableMaterialTheme.cs
@@ -11,6 +11,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     public class InteractableMaterialTheme : InteractableThemeBase
     {
         private Material material = null;
+        private Renderer renderer;
+
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+
+            renderer = Host.GetComponent<Renderer>();
+        }
 
         public InteractableMaterialTheme()
         {
@@ -30,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
-            Renderer renderer = Host.GetComponent<Renderer>();
+
             material = renderer.material;
             start.Material = material;
             return start;
@@ -40,7 +48,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         {
             Host.SetActive(property.Values[index].Bool);
 
-            Renderer renderer = Host.GetComponent<Renderer>();
             material = property.Values[index].Material;
             renderer.material = material;
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableOffsetTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableOffsetTheme.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     public class InteractableOffsetTheme : InteractableThemeBase
     {
         private Vector3 startPosition;
+        private Transform hostTransform;
 
         public InteractableOffsetTheme()
         {
@@ -29,19 +30,20 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
-            startPosition = Host.transform.localPosition;
+            hostTransform = Host.transform;
+            startPosition = hostTransform.localPosition;
         }
 
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
-            start.Vector3 = Host.transform.localPosition;
+            start.Vector3 = hostTransform.localPosition;
             return start;
         }
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
-            Host.transform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);
+            hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableRotationTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableRotationTheme.cs
@@ -10,6 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 {
     public class InteractableRotationTheme : InteractableThemeBase
     {
+        private Transform hostTransform;
 
         public InteractableRotationTheme()
         {
@@ -25,16 +26,23 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                 });
         }
 
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+
+            hostTransform = Host.transform;
+        }
+
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
-            start.Vector3 = Host.transform.eulerAngles;
+            start.Vector3 = hostTransform.eulerAngles;
             return start;
         }
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
-            Host.transform.localRotation = Quaternion.Euler( Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage));
+            hostTransform.localRotation = Quaternion.Euler( Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage));
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableScaleTheme.cs
@@ -10,6 +10,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 {
     public class InteractableScaleTheme : InteractableThemeBase
     {
+        private Transform hostTransform;
+
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+
+            hostTransform = Host.transform;
+        }
 
         public InteractableScaleTheme()
         {
@@ -28,13 +36,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
-            start.Vector3 = Host.transform.localScale;
+            start.Vector3 = hostTransform.localScale;
             return start;
         }
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
-            Host.transform.localScale = Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage);
+            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs
@@ -11,8 +11,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 {
     public class InteractableShaderTheme : InteractableThemeBase
     {
+        private static InteractableThemePropertyValue emptyValue = new InteractableThemePropertyValue();
+
         protected MaterialPropertyBlock propertyBlock;
         protected List<ShaderProperties> shaderProperties;
+        protected Renderer renderer;
+
+        private InteractableThemePropertyValue startValue = new InteractableThemePropertyValue();
 
         public InteractableShaderTheme()
         {
@@ -43,6 +48,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
             }
 
             propertyBlock = InteractableThemeShaderUtils.GetMaterialPropertyBlock(host, shaderProperties.ToArray());
+
+            renderer = Host.GetComponent<Renderer>();
         }
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
@@ -70,32 +77,33 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                     break;
             }
 
-            SetPropertyBlock(Host, propertyBlock);
+            renderer.SetPropertyBlock(propertyBlock);
         }
 
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             if (Host == null)
-                return new InteractableThemePropertyValue();
+                return emptyValue;
 
-            InteractableThemePropertyValue start = new InteractableThemePropertyValue();
+            startValue.Reset();
+
             string propId = property.GetShaderPropId();
             switch (property.Type)
             {
                 case InteractableThemePropertyValueTypes.Color:
-                    start.Color = propertyBlock.GetVector(propId);
+                    startValue.Color = propertyBlock.GetVector(propId);
                     break;
                 case InteractableThemePropertyValueTypes.ShaderFloat:
-                    start.Float = propertyBlock.GetFloat(propId);
+                    startValue.Float = propertyBlock.GetFloat(propId);
                     break;
                 case InteractableThemePropertyValueTypes.shaderRange:
-                    start.Float = propertyBlock.GetFloat(propId);
+                    startValue.Float = propertyBlock.GetFloat(propId);
                     break;
                 default:
                     break;
             }
 
-            return start;
+            return startValue;
         }
 
         public static float GetFloat(GameObject host, string propId)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
@@ -14,6 +14,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     /// </summary>
     public class InteractableStringTheme : InteractableThemeBase
     {
+        private TextMesh mesh;
+        private Text text;
+
         public InteractableStringTheme()
         {
             Types = new Type[] { typeof(TextMesh), typeof(Text) };
@@ -30,18 +33,25 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                 });
         }
 
+        public override void Init(GameObject host, InteractableThemePropertySettings settings)
+        {
+            base.Init(host, settings);
+
+            mesh = Host.GetComponent<TextMesh>();
+            text = Host.GetComponent<Text>();
+        }
+
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
             start.String = "";
-            TextMesh mesh = Host.GetComponentInChildren<TextMesh>();
+
             if (mesh != null)
             {
                 start.String = mesh.text;
                 return start;
             }
 
-            Text text = Host.GetComponentInChildren<Text>();
             if (mesh != null)
             {
                 start.String = text.text;
@@ -51,14 +61,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
-            TextMesh mesh = Host.GetComponentInChildren<TextMesh>();
             if(mesh != null)
             {
                 mesh.text = property.Values[index].String;
                 return;
             }
-
-            Text text = Host.GetComponentInChildren<Text>();
             if (mesh != null)
             {
                 text.text = property.Values[index].String;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableTextureTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableTextureTheme.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     public class InteractableTextureTheme : InteractableThemeBase
     {
         private MaterialPropertyBlock propertyBlock;
+        private Renderer renderer;
 
         public InteractableTextureTheme()
         {
@@ -31,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         {
             base.Init(host, settings);
             propertyBlock = InteractableThemeShaderUtils.GetMaterialPropertyBlock(host, new ShaderProperties[0]);
+            renderer = Host.GetComponent<Renderer>();
         }
 
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
@@ -43,8 +45,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             propertyBlock.SetTexture("_MainTex", property.Values[index].Texture);
-
-            Renderer renderer = Host.GetComponent<Renderer>();
             renderer.SetPropertyBlock(propertyBlock);
         }
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeBase.cs
@@ -81,7 +81,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         {
             if(state != lastState || force)
             {
-                for (int i = 0; i < ThemeProperties.Count; i++)
+                int themePropCount = ThemeProperties.Count;
+                for (int i = 0; i < themePropCount; i++)
                 {
                     InteractableThemeProperty current = ThemeProperties[i];
                     current.StartValue = GetProperty(current);
@@ -94,7 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
                     else
                     {
                         SetValue(current, state, 1);
-                        if(i >= ThemeProperties.Count - 1)
+                        if(i >= themePropCount - 1)
                         {
                             hasFirstState = true;
                         }
@@ -107,7 +108,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
             else if(Ease.Enabled && Ease.IsPlaying())
             {
                 Ease.OnUpdate();
-                for (int i = 0; i < ThemeProperties.Count; i++)
+                int themePropCount = ThemeProperties.Count;
+                for (int i = 0; i < themePropCount; i++)
                 {
                     InteractableThemeProperty current = ThemeProperties[i];
                     SetValue(current, state, Ease.GetCurved());

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertyValue.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertyValue.cs
@@ -30,6 +30,25 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
         public Quaternion Quaternion;
         public AudioClip AudioClip;
         public Animation Animation;
+
+        public void Reset()
+        {
+            Name = string.Empty;
+            String = string.Empty;
+            Bool = false;
+            Int = 0;
+            Float = 0;
+            Texture = null;
+            Material = null;
+            GameObject = null;
+            Vector2 = default(Vector2);
+            Vector3 = default(Vector3);
+            Vector4 = default(Vector4);
+            Color = default(Color);
+            Quaternion = default(Quaternion);
+            AudioClip = null;
+            Animation = null;
+        }
     }
 }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ScaleOffsetColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ScaleOffsetColorTheme.cs
@@ -12,12 +12,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
     {
         protected Vector3 startPosition;
         protected Vector3 startScale;
+        protected Transform hostTransform;
 
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
-            startPosition = Host.transform.localPosition;
-            startScale = Host.transform.localScale;
+            hostTransform = Host.transform;
+            startPosition = hostTransform.localPosition;
+            startScale = hostTransform.localScale;
         }
 
         public ScaleOffsetColorTheme()
@@ -58,10 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
             switch (property.Name)
             {
                 case "Scale":
-                    start.Vector3 = Host.transform.localScale;
+                    start.Vector3 = hostTransform.localScale;
                     break;
                 case "Offset":
-                    start.Vector3 = Host.transform.localPosition;
+                    start.Vector3 = hostTransform.localPosition;
                     break;
                 case "Color":
                     start = base.GetProperty(property);
@@ -77,10 +79,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes
             switch (property.Name)
             {
                 case "Scale":
-                    Host.transform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(startScale, property.Values[index].Vector3), percentage);
+                    hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(startScale, property.Values[index].Vector3), percentage);
                     break;
                 case "Offset":
-                    Host.transform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);
+                    hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);
                     break;
                 case "Color":
                     base.SetValue(property, index, percentage);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTip.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTip.cs
@@ -257,14 +257,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
         public Vector2 LocalContentSize => localContentSize;
 
         private Vector3 localAttachPoint;
-
         private Vector3 attachPointOffset;
-
         private Vector3[] localAttachPointPositions;
-
         private List<IToolTipBackground> backgrounds = new List<IToolTipBackground>();
-
         private List<IToolTipHighlight> highlights = new List<IToolTipHighlight>();
+        private TextMesh cachedLabelText;
+        private int prevTextLength = -1;
+        private int prevTextHash = -1;
 
         /// <summary>
         /// point about which ToolTip pivots to face camera
@@ -443,27 +442,45 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
             // Set the content using a text mesh by default
             // This function can be overridden for tooltips that use Unity UI
 
-            TextMesh text = label.GetComponent<TextMesh>();
-            if (text != null && !string.IsNullOrEmpty(toolTipText))
+            // Has content changed?
+            int currentTextLength = toolTipText.Length;
+            int currentTextHash = toolTipText.GetHashCode();
+
+            // If it has, update the content
+            if (currentTextLength != prevTextLength || currentTextHash != prevTextHash)
             {
-                text.fontSize = fontSize;
-                text.text = toolTipText.Trim();
-                text.lineSpacing = 1;
-                text.anchor = TextAnchor.MiddleCenter;
-                // Get the world scale of the text
-                // Convert that to local scale using the content parent
-                Vector3 localScale = GetTextMeshLocalScale(text);
-                localContentSize.x = localScale.x + backgroundPadding.x;
-                localContentSize.y = localScale.y + backgroundPadding.y;
+                prevTextHash = currentTextHash;
+                prevTextLength = currentTextLength;
+
+                if (cachedLabelText == null)
+                    cachedLabelText = label.GetComponent<TextMesh>();
+
+                if (cachedLabelText != null && !string.IsNullOrEmpty(toolTipText))
+                {
+                    cachedLabelText.fontSize = fontSize;
+                    cachedLabelText.text = toolTipText.Trim();
+                    cachedLabelText.lineSpacing = 1;
+                    cachedLabelText.anchor = TextAnchor.MiddleCenter;
+                    // Get the world scale of the text
+                    // Convert that to local scale using the content parent
+                    Vector3 localScale = GetTextMeshLocalScale(cachedLabelText);
+                    localContentSize.x = localScale.x + backgroundPadding.x;
+                    localContentSize.y = localScale.y + backgroundPadding.y;
+                }
+
+                // Now that we have the size of our content, get our pivots
+                ToolTipUtility.GetAttachPointPositions(ref localAttachPointPositions, localContentSize);
+                localAttachPoint = ToolTipUtility.FindClosestAttachPointToAnchor(anchor.transform, contentParent.transform, localAttachPointPositions, PivotType);
+
+                foreach (IToolTipBackground background in backgrounds)
+                {
+                    background.OnContentChange(localContentSize, LocalContentOffset, contentParent.transform);
+                }
             }
-            // Now that we have the size of our content, get our pivots
-            ToolTipUtility.GetAttachPointPositions(ref localAttachPointPositions, localContentSize);
-            localAttachPoint = ToolTipUtility.FindClosestAttachPointToAnchor(anchor.transform, contentParent.transform, localAttachPointPositions, PivotType);
 
             foreach (IToolTipBackground background in backgrounds)
             {
                 background.IsVisible = showBackground;
-                background.OnContentChange(localContentSize, LocalContentOffset, contentParent.transform);
             }
 
             foreach (IToolTipHighlight highlight in highlights)
@@ -532,7 +549,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
         {
             Vector3 localScale = Vector3.zero;
 
-            if (textMesh.text == null)
+            if (string.IsNullOrEmpty(textMesh.text))
                 return localScale;
 
             string[] splitStrings = textMesh.text.Split(new string[] { System.Environment.NewLine, "\n" }, System.StringSplitOptions.RemoveEmptyEntries);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTipConnector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTipConnector.cs
@@ -34,7 +34,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
         {
             get
             {
-                toolTip = gameObject.EnsureComponent<ToolTip>();
+                if (toolTip == null)
+                    toolTip = gameObject.EnsureComponent<ToolTip>();
+
                 return toolTip != null;
             }
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTipUtility.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTipUtility.cs
@@ -44,10 +44,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
                     for (int i = 0; i < localPivotPositions.Length; i++)
                     {
                         currentPivot = localPivotPositions[i];
-                        float dist = Vector3.Distance(anchorPosition, contentParent.TransformPoint(currentPivot));
-                        if (dist < nearDist)
+                        float sqrDist = (anchorPosition - contentParent.TransformPoint(currentPivot)).sqrMagnitude;
+                        if (sqrDist < nearDist)
                         {
-                            nearDist = dist;
+                            nearDist = sqrDist;
                             nearPivot = currentPivot;
                         }
                     }
@@ -58,10 +58,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
                     for (int i = (int)ToolTipAttachPoint.BottomRightCorner; i < (int)ToolTipAttachPoint.TopLeftCorner; i++)
                     {
                         currentPivot = localPivotPositions[i];
-                        float dist = Vector3.Distance(anchorPosition, contentParent.TransformPoint(currentPivot));
-                        if (dist < nearDist)
+                        float sqrDist = (anchorPosition - contentParent.TransformPoint(currentPivot)).sqrMagnitude;
+                        if (sqrDist < nearDist)
                         {
-                            nearDist = dist;
+                            nearDist = sqrDist;
                             nearPivot = currentPivot;
                         }
                     }
@@ -72,10 +72,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.ToolTips
                     for (int i = (int)ToolTipAttachPoint.BottomMiddle; i < (int)ToolTipAttachPoint.LeftMiddle; i++)
                     {
                         currentPivot = localPivotPositions[i];
-                        float dist = Vector3.Distance(anchorPosition, contentParent.TransformPoint(currentPivot));
-                        if (dist < nearDist)
+                        float sqrDist = (anchorPosition - contentParent.TransformPoint(currentPivot)).sqrMagnitude;
+                        if (sqrDist < nearDist)
                         {
-                            nearDist = dist;
+                            nearDist = sqrDist;
                             nearPivot = currentPivot;
                         }
                     }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Easing.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Easing.cs
@@ -49,15 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
         /// </summary>
         public void OnUpdate()
         {
-#if UNITY_EDITOR
-            if (!Application.isPlaying)
-            {
-                // If we're in the editor and we're not playing
-                // always update the cached keys to reflect recent changes
-                cachedKeys = Curve.keys;
-            }
-#endif
-
             if (timer < LerpTime)
             {
                 timer = Mathf.Min(timer + Time.deltaTime, LerpTime);
@@ -113,8 +104,18 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
 
         protected bool IsLinear()
         {
-            if (cachedKeys == null)
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                // If we're in the editor and we're not playing
+                // always update the cached keys to reflect recent changes
                 cachedKeys = Curve.keys;
+            }
+#endif
+            if (cachedKeys == null)
+            {
+                cachedKeys = Curve.keys;
+            }
 
             if (cachedKeys.Length > 1)
             {
@@ -147,6 +148,9 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
             }
 
             Curve = animation;
+
+            // Update the cached keys
+            cachedKeys = Curve.keys;
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Easing.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Easing.cs
@@ -30,12 +30,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
         /// </summary>
         public AnimationCurve Curve = AnimationCurve.Linear(0, 1, 1, 1);
 
+
         /// <summary>
         /// The amounnt of time the ease should run
         /// </summary>
         public float LerpTime = 0.5f;
 
         private float timer = 0.5f;
+        private Keyframe[] cachedKeys;
 
         public Easing()
         {
@@ -47,6 +49,15 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
         /// </summary>
         public void OnUpdate()
         {
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                // If we're in the editor and we're not playing
+                // always update the cached keys to reflect recent changes
+                cachedKeys = Curve.keys;
+            }
+#endif
+
             if (timer < LerpTime)
             {
                 timer = Mathf.Min(timer + Time.deltaTime, LerpTime);
@@ -102,9 +113,12 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX
 
         protected bool IsLinear()
         {
-            if (Curve.keys.Length > 1)
+            if (cachedKeys == null)
+                cachedKeys = Curve.keys;
+
+            if (cachedKeys.Length > 1)
             {
-                return (Curve.keys[0].value == 1 && Curve.keys[1].value == 1);
+                return (cachedKeys[0].value == 1 && cachedKeys[1].value == 1);
             }
 
             return false;


### PR DESCRIPTION
Overview
---
Small performance tweaks - we stuck to changes that didn't require much refactoring. Primary test case was a scene with 50 HoloButtons and 50 Unity UI Canvas buttons. Tested using HoloLens and VR devices.

Changes
---
- Removed allocations from Interactable components (~5k per frame in test case)
- Shaved a few milliseconds off hot Interactable profile code
- Cached Interactable host components using Init wherever possible
- Small improvement in VectorRollingStatistics (but they add up)
- ToolTips only update content borders when content is changed