### PR TITLE
Read the default profile and default platforms from the ExtensionServiceAttribute

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -21,7 +21,8 @@ namespace Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
 {
     [MixedRealityDataProvider(
         typeof(IMixedRealitySpatialAwarenessSystem),
-        SupportedPlatforms.WindowsUniversal)]
+        SupportedPlatforms.WindowsUniversal,
+        "Profiles/DefaultMixedRealitySpatialAwarenessMeshObserverProfile.asset", "MixedRealityToolkit.SDK")]
     public class WindowsMixedRealitySpatialMeshObserver : BaseSpatialObserver, IMixedRealitySpatialAwarenessMeshObserver
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using System;
+using System.Linq;
 using UnityEngine;
 
 #if UNITY_EDITOR
@@ -16,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Attributes
     /// <summary>
     /// Attribute that defines the properties of a Mixed Reality Toolkit extension service.
     /// </summary>
-    [AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class MixedRealityExtensionServiceAttribute : Attribute
     {
         /// <summary>
@@ -27,17 +28,17 @@ namespace Microsoft.MixedReality.Toolkit.Core.Attributes
         /// <summary>
         /// The file path to the default profile asset relative to the package folder.
         /// </summary>
-        public virtual string ProfilePath { get; }
+        public virtual string DefaultProfilePath { get; }
 
         /// <summary>
-        /// The package where the asset resides.
+        /// The package where the default profile asset resides.
         /// </summary>
         public virtual string PackageFolder { get; }
 
         /// <summary>
         /// The default profile.
         /// </summary>
-        public virtual BaseMixedRealityProfile Profile
+        public virtual BaseMixedRealityProfile DefaultProfile
         {
             get
             {
@@ -45,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Attributes
                 string path;
                 if (EditorProjectUtilities.FindRelativeDirectory(PackageFolder, out path))
                 {
-                    return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(path, ProfilePath));
+                    return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(path, DefaultProfilePath));
                 }
 
                 Debug.LogError("Unable to find or load the profile.");
@@ -58,16 +59,24 @@ namespace Microsoft.MixedReality.Toolkit.Core.Attributes
         /// Constructor
         /// </summary>
         /// <param name="runtimePlatforms">The platforms on which the extension service is supported.</param>
-        /// <param name="profilePath">The relative path to the profile asset.</param>
-        /// <param name="packageFolder">The folder to which the path is relative.</param>
+        /// <param name="profilePath">The relative path to the default profile asset.</param>
+        /// <param name="packageFolder">The package folder to which the path is relative.</param>
         public MixedRealityExtensionServiceAttribute(
             SupportedPlatforms runtimePlatforms,
-            string profilePath = "", 
+            string defaultProfilePath = "",
             string packageFolder = "MixedRealityToolkit")
         {
             RuntimePlatforms = runtimePlatforms;
-            ProfilePath = profilePath;
+            DefaultProfilePath = defaultProfilePath;
             PackageFolder = packageFolder;
+        }
+
+        /// <summary>
+        /// Convenience function for retrieving the attribute given a certain class type.
+        /// </summary>
+        public static MixedRealityExtensionServiceAttribute Find(Type type)
+        {
+            return type.GetCustomAttributes(typeof(MixedRealityExtensionServiceAttribute), true).FirstOrDefault() as MixedRealityExtensionServiceAttribute;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                     if (GUILayout.Button(new GUIContent("</>", "Replace with a copy of the default profile."), EditorStyles.miniButton, GUILayout.Width(32f)))
                     {
                         profileToCopy = renderedProfile;
-                        var profileTypeName = property.type.Replace("PPtr<$", string.Empty).Replace(">", string.Empty);
+                        var profileTypeName = property.objectReferenceValue.GetType().Name;
                         Debug.Assert(profileTypeName != null, "No Type Found");
 
                         ScriptableObject instance = CreateInstance(profileTypeName);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -137,11 +137,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                     EditorGUILayout.PropertyField(componentType);
                     if (EditorGUI.EndChangeCheck())
                     {
-                        SystemType configurationComponentType = ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType;
                         // Try to assign default configuration profile when type changes.
                         serializedObject.ApplyModifiedProperties();
-                        AssignDefaultConfigurationProfile(configurationComponentType, configurationProfile);
-                        AssignDefaultPlatformValues(configurationComponentType, runtimePlatform);
+                        AssignDefaultConfigurationValues(((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, configurationProfile, runtimePlatform);
                         changed = true;
 
                         GUILayout.EndVertical();
@@ -174,27 +172,16 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             }
         }
 
-        private void AssignDefaultPlatformValues(System.Type componentType, SerializedProperty runtimePlatform)
+        private void AssignDefaultConfigurationValues(System.Type componentType, SerializedProperty configurationProfile, SerializedProperty runtimePlatform)
         {
+            configurationProfile.objectReferenceValue = null;
             runtimePlatform.intValue = -1;
 
             if (componentType != null &&
                 MixedRealityExtensionServiceAttribute.Find(componentType) is MixedRealityExtensionServiceAttribute attr)
             {
-                runtimePlatform.intValue = (int)attr.RuntimePlatforms;
-            }
-
-            serializedObject.ApplyModifiedProperties();
-        }
-
-        private void AssignDefaultConfigurationProfile(System.Type componentType, SerializedProperty configurationProfile)
-        {
-            configurationProfile.objectReferenceValue = null;
-
-            if (componentType != null &&
-                MixedRealityExtensionServiceAttribute.Find(componentType) is MixedRealityExtensionServiceAttribute attr)
-            {
                 configurationProfile.objectReferenceValue = attr.DefaultProfile;
+                runtimePlatform.intValue = (int)attr.RuntimePlatforms;
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions;
+using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Inspectors.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Services;
 using UnityEditor;
@@ -136,12 +137,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                     EditorGUILayout.PropertyField(componentType);
                     if (EditorGUI.EndChangeCheck())
                     {
+                        SystemType configurationComponentType = ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType;
                         // Try to assign default configuration profile when type changes.
                         serializedObject.ApplyModifiedProperties();
-                        AssignDefaultConfigurationProfile(
-                            ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, configurationProfile);
-                        AssignDefaultPlatformValues(
-                            ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, runtimePlatform);
+                        AssignDefaultConfigurationProfile(configurationComponentType, configurationProfile);
+                        AssignDefaultPlatformValues(configurationComponentType, runtimePlatform);
                         changed = true;
 
                         GUILayout.EndVertical();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -139,7 +139,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                         // Try to assign default configuration profile when type changes.
                         serializedObject.ApplyModifiedProperties();
                         AssignDefaultConfigurationProfile(
-                            ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, managerConfig);
+                            ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, configurationProfile);
+                        AssignDefaultPlatformValues(
+                            ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, runtimePlatform);
                         changed = true;
 
                         GUILayout.EndVertical();
@@ -149,6 +151,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                     EditorGUI.BeginChangeCheck();
                     EditorGUILayout.PropertyField(priority);
                     EditorGUILayout.PropertyField(runtimePlatform);
+
                     changed |= EditorGUI.EndChangeCheck();
 
                     changed |= RenderProfile(configurationProfile);
@@ -171,19 +174,27 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             }
         }
 
-        private void AssignDefaultConfigurationProfile(System.Type componentType, SerializedProperty managerConfig)
+        private void AssignDefaultPlatformValues(System.Type componentType, SerializedProperty runtimePlatform)
         {
-            SerializedProperty configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
+            runtimePlatform.intValue = -1;
+
+            if (componentType != null &&
+                MixedRealityExtensionServiceAttribute.Find(componentType) is MixedRealityExtensionServiceAttribute attr)
+            {
+                runtimePlatform.intValue = (int)attr.RuntimePlatforms;
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void AssignDefaultConfigurationProfile(System.Type componentType, SerializedProperty configurationProfile)
+        {
             configurationProfile.objectReferenceValue = null;
 
             if (componentType != null &&
                 MixedRealityExtensionServiceAttribute.Find(componentType) is MixedRealityExtensionServiceAttribute attr)
             {
                 configurationProfile.objectReferenceValue = attr.DefaultProfile;
-            }
-            else
-            {
-                configurationProfile.objectReferenceValue = null;
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -202,7 +202,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Editor.Setup
 
         private static string MakePathRelativeToProject(string absolutePath)
         {
-            return absolutePath.Replace(Application.dataPath + "\\", "Assets/");
+            return absolutePath.Replace(
+                Application.dataPath + Path.DirectorySeparatorChar,
+                "Assets" + Path.DirectorySeparatorChar);
         }
 
         private static void SetIconTheme()


### PR DESCRIPTION
Overview
---
This PR adds the ability to have the registered service providers profile to auto-set its values based on the already set values in the MixedRealityExtensionServiceAttribute.

To start, it tries to load the default profile from an asset path, and it sets the supported platforms automatically.

(video didn't pick up the service type dropdown)

![service_provider](https://user-images.githubusercontent.com/3580640/53261316-86692280-3688-11e9-98af-6e6b4eb83505.gif)
