### PR TITLE
Fix marker assignment by checking local cache of spectator information

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
@@ -41,7 +41,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SpectatorView.MarkerDetectio
         {
             if (_detecting)
             {
-                if(!_holoLensCamera.TakeSingle())
+                if(_holoLensCamera.State == CameraState.Ready &&
+                    !_holoLensCamera.TakeSingle())
                 {
                     Debug.LogError("Failed to take photo with HoloLensCamera, Camera State: " + _holoLensCamera.State.ToString());
                 }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialCoordinates/MarkerSpatialCoordinateService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialCoordinates/MarkerSpatialCoordinateService.cs
@@ -400,7 +400,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SpectatorView.SpatialCoordin
                         _cachedSelfUser.Spectators[spectator.Id] = new Spectator(spectator.Id);
                     }
 
-                    if (!spectator.HasValidMarkerId())
+                    if (!_cachedSelfUser.Spectators[spectator.Id].HasValidMarkerId() &&
+                        !spectator.HasValidMarkerId())
                     {
                         _cachedSelfUser.Spectators[spectator.Id].MarkerId = _cachedSelfUser.AvailableMarkerId;
                         _cachedSelfUser.AvailableMarkerId += 1;
@@ -677,6 +678,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SpectatorView.SpatialCoordin
         {
             if (_actAsUser)
             {
+                Debug.Log("Generating state payload for cached self user: " + _cachedSelfUser.ToString());
                 var output = SerializationHelper.Serialize(_cachedSelfUser);
                 return output;
             }


### PR DESCRIPTION
Overview
---
We could get into a weird state where the assigned marker to a spectator was rapidly increased based on the delay in sending the assigned marker over the network. 

Changes
---
We now check our local cache of the spectator marker value on the main user device. If its assigned, we don't reassign a new number in instances where the spectator has not yet registered that its had a marker assigned.
