### PR TITLE
Mrtk Inspector Upgrade (Part 2)

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Core.Extensions.EditorClassExtensions;
 using Microsoft.MixedReality.Toolkit.Core.Services;
 using Microsoft.MixedReality.Toolkit.Core.Utilities.Async;
 using System;
+using System.Text;
 using UnityEditor;
 using UnityEngine;
 
@@ -22,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         private static BaseMixedRealityProfile profile;
         private static SerializedObject targetProfile;
         private static BaseMixedRealityProfile profileToCopy;
+        private static StringBuilder dropdownKeyBuilder = new StringBuilder();
 
         protected virtual void OnEnable()
         {
@@ -121,7 +123,54 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             }
 
             EditorGUILayout.EndHorizontal();
+
+            // Check fields within profile for other nested profiles
+            // Draw them when found
+            if (property.objectReferenceValue != null)
+            {
+                Type profileType = property.objectReferenceValue.GetType();
+                if (typeof(BaseMixedRealityProfile).IsAssignableFrom(profileType))
+                {
+                    string showFoldoutKey = GetSubProfileDropdownKey(property);
+                    bool showFoldout = SessionState.GetBool(showFoldoutKey, false);
+                    showFoldout = EditorGUILayout.Foldout(showFoldout, showFoldout ? "Hide " + property.displayName + "  contents" : "Show " + property.displayName + " contents");
+
+                    if (showFoldout)
+                    {
+                        Editor subProfileEditor = Editor.CreateEditor(property.objectReferenceValue);
+
+                        // If this is a default MRTK configuration profile, ask it to render as a sub-profile
+                        if (typeof(BaseMixedRealityToolkitConfigurationProfileInspector).IsAssignableFrom(subProfileEditor.GetType()))
+                        {
+                            BaseMixedRealityToolkitConfigurationProfileInspector configProfile = (BaseMixedRealityToolkitConfigurationProfileInspector)subProfileEditor;
+                            configProfile.RenderAsSubProfile = true;
+                        }
+
+                        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+                        EditorGUI.indentLevel++;
+                        subProfileEditor.OnInspectorGUI();
+                        EditorGUI.indentLevel--;
+                        EditorGUILayout.EndVertical();
+                    }
+
+                    SessionState.SetBool(showFoldoutKey, showFoldout);
+                }
+            }
+
             return changed;
+        }
+
+        private static string GetSubProfileDropdownKey(SerializedProperty property)
+        {
+            if (property.objectReferenceValue == null)
+                throw new Exception("Can't get sub profile dropdown key for a property that is null.");
+
+            dropdownKeyBuilder.Clear();
+            dropdownKeyBuilder.Append("MRTK_SubProfile_ShowDropdown_");
+            dropdownKeyBuilder.Append(property.name);
+            dropdownKeyBuilder.Append("_");
+            dropdownKeyBuilder.Append(property.objectReferenceValue.GetType().Name);
+            return dropdownKeyBuilder.ToString();
         }
 
         [MenuItem("CONTEXT/BaseMixedRealityProfile/Create Copy from Profile Values", false, 0)]

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Core.Definitions;
+using Microsoft.MixedReality.Toolkit.Core.Services;
 using Microsoft.MixedReality.Toolkit.Core.Utilities.Editor.Setup;
 using System;
 using UnityEditor;
@@ -18,11 +19,18 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
     /// </summary>
     public abstract class BaseMixedRealityToolkitConfigurationProfileInspector : BaseMixedRealityProfileInspector
     {
+        public bool RenderAsSubProfile
+        {
+            set { renderAsSubProfile = value; }
+        }
+
         [SerializeField]
         private Texture2D logoLightTheme = null;
 
         [SerializeField]
         private Texture2D logoDarkTheme = null;
+
+        private bool renderAsSubProfile = false;
 
         protected virtual void Awake()
         {
@@ -44,12 +52,36 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         /// </summary>
         protected void RenderMixedRealityToolkitLogo()
         {
+            // If we're being rendered as a sub profile, don't show the logo
+            if (renderAsSubProfile)
+                return;
+
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
             GUILayout.Label(EditorGUIUtility.isProSkin ? logoDarkTheme : logoLightTheme, GUILayout.MaxHeight(128f));
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
             GUILayout.Space(12f);
+        }
+        
+        /// <summary>
+        /// Renders a button that will take user back to a specified profile object
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="activeObject"></param>
+        /// <returns>True if button was clicked</returns>
+        protected bool DrawBacktrackProfileButton(string message, UnityEngine.Object activeObject)
+        {
+            // If we're being rendered as a sub profile, don't show the button
+            if (renderAsSubProfile)
+                return false;
+
+            if (GUILayout.Button(message))
+            {
+                Selection.activeObject = activeObject;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -87,9 +87,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -59,9 +59,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -80,17 +80,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
+                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
 
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
@@ -76,17 +76,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
+                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
 
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -39,9 +39,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                return;
             }
 
             CheckProfileLock(target);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -95,17 +95,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
+                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
 
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -103,10 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
+                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
 
                 return;
             }
@@ -115,17 +112,14 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No Input Actions profile was specified.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Input Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
-                }
+                DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile);
 
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -36,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         public override void OnInspectorGUI()
         {
             RenderMixedRealityToolkitLogo();
+
             if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
             {
                 return;
@@ -45,17 +46,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
+                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
 
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -61,9 +61,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -66,9 +66,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -41,9 +41,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
@@ -78,9 +78,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 return;
             }
 
-            if (GUILayout.Button("Back to Configuration Profile"))
+            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
+                return;
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -60,17 +60,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
 
-                if (GUILayout.Button("Back to Configuration Profile"))
-                {
-                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile;
-                }
+                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
 
                 return;
             }
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                return;
             }
 
             CheckProfileLock(target);


### PR DESCRIPTION
Overview
---
Adds sub-profile inspector rendering. Whenever a profile field is drawn in a default MRTK configuration profile a dropdown is created which lets the user display the contents of the field's profile. This allows users to quickly access and modify all active profiles in a project when they select the MixedRealityToolkit object in the scene.

Configuration profiles are made aware of when they are being drawn as sub-profiles and omit logos and 'Back' buttons in this state.

Dropdown states are stored in editor prefs and will persist across sessions.

Problems
----
- If every nested sub-profile from the main configuration profile is open at once the inspector can become a bit sluggish.
- There's no check for recursive profile inspectors being drawn. I can't imagine what scenario would result in this occurring but in theory it's a problem.

![subprofile](https://user-images.githubusercontent.com/9789716/53515025-e6dbd380-3a7d-11e9-94aa-40e8334d0d83.PNG)