### PR TITLE
Diagnostics settings updates

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityDiagnosticsProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityDiagnosticsProfile.asset
@@ -13,5 +13,6 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityDiagnosticsProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  showDiagnostics: 0
+  showDiagnostics: 1
   showProfiler: 1
+  frameRateDuration: 0.1

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -119,6 +119,31 @@ namespace Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
             }
         }
 
+        private float frameRateDuration = 0.1f;
+        private readonly float minFrameRateDuration = 0.01f;
+        private readonly float maxFrameRateDuration = 1.0f;
+
+        /// <inheritdoc />
+        public float FrameRateDuration
+        {
+            get
+            {
+                return frameRateDuration;
+            }
+
+            set
+            {
+                if (!Mathf.Approximately(frameRateDuration, value))
+                {
+                    frameRateDuration = Mathf.Clamp(value, minFrameRateDuration, maxFrameRateDuration);
+                    if (visualProfiler != null)
+                    {
+                        visualProfiler.FrameSampleRate = frameRateDuration;
+                    }
+                }
+            }
+        }
+
         #endregion IMixedRealityDiagnosticsSystem
 
         #region IMixedRealityEventSource

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -42,6 +42,12 @@ namespace Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
         [Range(0.0f, 1.0f)]
         private float frameSampleRate = 0.1f;
 
+        public float FrameSampleRate
+        {
+            get { return frameSampleRate; }
+            set { frameSampleRate = Mathf.Clamp(value, 0.0f, 1.0f); }
+        }
+
         [Header("UI Settings")]
         [SerializeField]
         [Range(0.0f, 100.0f)]

--- a/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
@@ -16,20 +16,30 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Diagnostics
         [SerializeField]
         [FormerlySerializedAs("visible")]
         [Tooltip("Display all enabled diagnostics")]
-        private bool showDiagnostics = false;
+        private bool showDiagnostics = true;
 
         /// <summary>
-        /// Show or hide diagnostic visualizations
+        /// Show or hide diagnostic visualizations.
         /// </summary>
         public bool ShowDiagnostics => showDiagnostics;
 
         [SerializeField]
         [Tooltip("Display profiler")]
-        private bool showProfiler = false;
+        private bool showProfiler = true;
 
         /// <summary>
-        /// Show or hide the profiler UI
+        /// Show or hide the profiler UI.
         /// </summary>
         public bool ShowProfiler => showProfiler;
+
+        [SerializeField]
+        [Tooltip("The amount of time, in seconds, to collect frames for frame rate calculation.")]
+        [Range(0.01f, 1.0f)]
+        private float frameRateDuration = 0.1f;
+
+        /// <summary>
+        /// The amount of time, in seconds, to collect frames for frame rate calculation.
+        /// </summary>
+        public float FrameRateDuration => frameRateDuration;
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -14,8 +14,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
     {
         private static bool showGeneralSettings = true;
         private SerializedProperty showDiagnostics;
+
+        private static bool showProfilerSettings = true;
         private SerializedProperty showProfiler;
+        private SerializedProperty frameRateDuration;
+
         // todo: coming soon
+        // private static bool showDebugPanelSettings = true;
         // private SerializedProperty isDebugPanelVisible;
 
         protected override void OnEnable()
@@ -29,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
             showDiagnostics = serializedObject.FindProperty("showDiagnostics");
             showProfiler = serializedObject.FindProperty("showProfiler");
+            frameRateDuration = serializedObject.FindProperty("frameRateDuration");
         }
 
         public override void OnInspectorGUI()
@@ -65,8 +71,17 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                         EditorGUILayout.HelpBox("Diagnostic visualizations have been globally disabled.", MessageType.Info);
                         EditorGUILayout.Space();
                     }
+                }
+            }
 
+            EditorGUILayout.Space();
+            showProfilerSettings = EditorGUILayout.Foldout(showProfilerSettings, "Profiler Settings", true);
+            if (showProfilerSettings)
+            {
+                using (new EditorGUI.IndentLevelScope())
+                {
                     EditorGUILayout.PropertyField(showProfiler);
+                    EditorGUILayout.PropertyField(frameRateDuration);
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -285,6 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
             {
                 using (new EditorGUI.IndentLevelScope())
                 {
+                    EditorGUILayout.HelpBox("It is recommended to enable the Diagnostics system during development. Be sure to disable prior to building your shipping product.", MessageType.Warning);
                     EditorGUILayout.PropertyField(enableDiagnosticsSystem);
                     EditorGUILayout.PropertyField(diagnosticsSystemType);
                     changed |= RenderProfile(diagnosticsSystemProfile);

--- a/Assets/MixedRealityToolkit/Interfaces/Diagnostics/IMixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Diagnostics/IMixedRealityDiagnosticsSystem.cs
@@ -22,8 +22,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.Diagnostics
         bool ShowDiagnostics { get; set; }
 
         /// <summary>
-        /// Enable / disable the profiler display
+        /// Enable / disable the profiler display.
         /// </summary>
         bool ShowProfiler { get; set; }
+
+        /// <summary>
+        /// The amount of time, in seconds, to collect frames for frame rate calculation.
+        /// </summary>
+        float FrameRateDuration { get; }
     }
 }


### PR DESCRIPTION
Enable diagnostic visualization by default.
Add ability to configure frameRateDuration (time span to collect frames for calculation)
Update visual profiler to allow setting sample duration via code
Add diagnostics recommendation in toolkit config inspector

Fixes #3536
