### PR TITLE
Remove extra space from BaseMixedRealityProfileInspector

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 {
                     string showFoldoutKey = GetSubProfileDropdownKey(property);
                     bool showFoldout = SessionState.GetBool(showFoldoutKey, false);
-                    showFoldout = EditorGUILayout.Foldout(showFoldout, showFoldout ? "Hide " + property.displayName + "  contents" : "Show " + property.displayName + " contents");
+                    showFoldout = EditorGUILayout.Foldout(showFoldout, showFoldout ? "Hide " + property.displayName + " contents" : "Show " + property.displayName + " contents");
 
                     if (showFoldout)
                     {


### PR DESCRIPTION
Overview
---
From this:
![image](https://user-images.githubusercontent.com/3580640/53662225-428d9480-3c17-11e9-8fff-938e63691628.png)

to this:
![image](https://user-images.githubusercontent.com/3580640/53662208-36093c00-3c17-11e9-8f7a-aaca8b3e628b.png)

(extra space is between Profile and contents)
