### PR TITLE
Interactable startup performance fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
@@ -92,11 +92,28 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
         }
 
         /// <summary>
+        /// True when event types have been compiled once by GetEventTypes
+        /// </summary>
+        private static bool eventListsCompiled = false;
+
+        /// <summary>
+        /// The shared list of compiled event types
+        /// </summary>
+        private static EventLists eventLists;
+
+        /// <summary>
         /// Get the recieverBase types that contain event logic
         /// </summary>
         /// <returns></returns>
         public static EventLists GetEventTypes()
         {
+            // This only needs to be done once.
+            // Recompilation will reset this value.
+            if (eventListsCompiled)
+            {
+                return eventLists;
+            }
+
             List<Type> eventTypes = new List<Type>();
             List<string> names = new List<string>();
             
@@ -114,10 +131,13 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events
                 }
             }
 
-            EventLists lists = new EventLists();
-            lists.EventTypes = eventTypes;
-            lists.EventNames = names;
-            return lists;
+            eventLists = new EventLists();
+            eventLists.EventTypes = eventTypes;
+            eventLists.EventNames = names;
+
+            eventListsCompiled = true;
+
+            return eventLists;
         }
         
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs
@@ -29,13 +29,30 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile
         public GameObject Target;
         public List<Theme> Themes;
         public bool HadDefaultTheme;
-        
+
+        /// <summary>
+        /// True when theme types have been compiled once by GetThemeTypes
+        /// </summary>
+        private static bool themeListsCompiled = false;
+
+        /// <summary>
+        /// The shared list of compiled theme types
+        /// </summary>
+        private static ThemeLists themeLists;
+
         /// <summary>
         /// Get a list of themes
         /// </summary>
         /// <returns></returns>
         public static ThemeLists GetThemeTypes()
         {
+            // This only needs to be done once.
+            // Recompilation will reset this value.
+            if (themeListsCompiled)
+            {
+                return themeLists;
+            }
+
             List<Type> themeTypes = new List<Type>();
             List<string> names = new List<string>();
 
@@ -52,11 +69,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile
                     }
                 }
             }
-            
-            ThemeLists lists = new ThemeLists();
-            lists.Types = themeTypes;
-            lists.Names = names;
-            return lists;
+
+            themeLists = new ThemeLists();
+            themeLists.Types = themeTypes;
+            themeLists.Names = names;
+
+            themeListsCompiled = true;
+
+            return themeLists;
         }
 
         /// <summary>


### PR DESCRIPTION
Overview
---
InteractableEvent and InteractableProfileItem now store the results of the static GetEventTypes() and GetThemeTypes() functions in static vars. (These results are cleared on recompile.)

Changes
---
- Fixes: #3562
