### PR TITLE
Changed the order of checks

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -618,6 +618,15 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 return false;
             }
 
+#if !UNITY_EDITOR
+            if (!Application.platform.IsPlatformSupported(supportedPlatforms))
+#else
+            if (!UnityEditor.EditorUserBuildSettings.activeBuildTarget.IsPlatformSupported(supportedPlatforms))
+#endif
+            {
+                return false;
+            }
+
             if (interfaceType == null)
             {
                 Debug.LogError("Unable to register a service with a null concrete type.");
@@ -627,15 +636,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
             if (!typeof(IMixedRealityService).IsAssignableFrom(interfaceType))
             {
                 Debug.LogError($"Unable to register the {interfaceType.Name} service. It does not implement {typeof(IMixedRealityService)}.");
-                return false;
-            }
-
-#if !UNITY_EDITOR
-            if (!Application.platform.IsPlatformSupported(supportedPlatforms))
-#else
-            if (!UnityEditor.EditorUserBuildSettings.activeBuildTarget.IsPlatformSupported(supportedPlatforms))
-#endif
-            {
                 return false;
             }
 


### PR DESCRIPTION
Changed the order of checks since the platform can filter classes that might be null

Overview
While implementing the Oculus Go I received 5 errors every time I started the app. Since Service Providers specific to certain platforms are stripped by their containing ASMDEFs, checking for null first and the supported platform second does not seem very idea.

Changes
Changed the check order