### PR TITLE
Mrtk Inspector Upgrade (Part 3)

### DIFF
--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Core.Interfaces;
+using System;
+
+namespace Microsoft.MixedReality.Toolkit.Core.Attributes
+{
+    /// <summary>
+    /// Attribute that defines which service a profile is meant to be consumed by.
+    /// Only applies to profiles that are consumed by types implementing IMixedRealityService.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class MixedRealityServiceProfileAttribute : Attribute
+    {
+        public MixedRealityServiceProfileAttribute(Type serviceType) { ServiceType = serviceType; }
+
+        public Type ServiceType { get; private set; }
+    }
+}

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs.meta
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs.meta
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87d3cb16f49f8b14397e2c89b430f774
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/MixedRealityBoundaryVisualizationProfile.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.BoundarySystem;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem
@@ -11,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.BoundarySystem
     /// Configuration profile settings for setting up boundary visualizations.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Boundary Visualization Profile", fileName = "MixedRealityBoundaryVisualizationProfile", order = (int)CreateProfileMenuItemIndices.BoundaryVisualization)]
+    [MixedRealityServiceProfile(typeof(IMixedRealityBoundarySystem))]
     public class MixedRealityBoundaryVisualizationProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Devices
 {
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Controller Visualization Profile", fileName = "MixedRealityControllerVisualizationProfile", order = (int)CreateProfileMenuItemIndices.ControllerVisualization)]
+    [MixedRealityServiceProfile(typeof(IMixedRealityControllerVisualizer))]
     public class MixedRealityControllerVisualizationProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.Diagnostics;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -11,6 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Diagnostics
     /// Configuration profile settings for setting up diagnostics.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Diagnostics Profile", fileName = "MixedRealityDiagnosticsProfile", order = (int)CreateProfileMenuItemIndices.Diagnostics)]
+    [MixedRealityServiceProfile(typeof(IMixedRealityDiagnosticsSystem))]
     public class MixedRealityDiagnosticsProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem
     /// Configuration profile settings for setting up controller pointers.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Input System Profile", fileName = "MixedRealityInputSystemProfile", order = (int)CreateProfileMenuItemIndices.Input)]
+    [MixedRealityServiceProfile(typeof(IMixedRealityInputSystem))]
     public class MixedRealityInputSystemProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/Definitions/MixedRealityRegisteredServiceProvidersProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/MixedRealityRegisteredServiceProvidersProfile.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using UnityEngine;
 

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.SpatialAwarenessSystem.Observers;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem
@@ -11,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem
     /// Configuration profile settings for spatial awareness mesh observers.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Spatial Awareness Mesh Observer Profile", fileName = "MixedRealitySpatialAwarenessMeshObserverProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwarenessMeshObserver)]
+    [MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessMeshObserver))]
     public class MixedRealitySpatialAwarenessMeshObserverProfile : BaseMixedRealityProfile 
     {
         #region IMixedRealitySpatialAwarenessObserver settings

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -151,7 +151,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 {
                     string showFoldoutKey = GetSubProfileDropdownKey(property);
                     bool showFoldout = SessionState.GetBool(showFoldoutKey, false);
-                    showFoldout = EditorGUILayout.Foldout(showFoldout, showFoldout ? "Hide " + property.displayName + " contents" : "Show " + property.displayName + " contents");
+                    showFoldout = EditorGUILayout.Foldout(showFoldout, showFoldout ? "Hide " + property.displayName + " contents" : "Show " + property.displayName + " contents", true);
 
                     if (showFoldout)
                     {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -84,8 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
                 if (!profileTypeIsValid)
                 {
-                    EditorGUILayout.HelpBox("The profile is not configured to be used with a service of type " + serviceType.Name
-                        + "\nIs your profile missing the " + typeof(MixedRealityServiceProfileAttribute).Name + " attribute?", MessageType.Warning);
+                    EditorGUILayout.HelpBox("This profile is not supported for " + serviceType.Name + ". Using an unsupported service may result in unexpected behavior.", MessageType.Warning);
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions;
 using Microsoft.MixedReality.Toolkit.Core.Extensions.EditorClassExtensions;
 using Microsoft.MixedReality.Toolkit.Core.Services;
@@ -44,9 +45,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         /// <param name="guiContent">The GUIContent for the field.</param>
         /// <param name="showAddButton">Optional flag to hide the create button.</param>
         /// <returns>True, if the profile changed.</returns>
-        protected static bool RenderProfile(SerializedProperty property, GUIContent guiContent, bool showAddButton = true)
+        protected static bool RenderProfile(SerializedProperty property, GUIContent guiContent, bool showAddButton = true, Type serviceType = null)
         {
-            return RenderProfileInternal(property, guiContent, showAddButton);
+            return RenderProfileInternal(property, guiContent, showAddButton, serviceType);
         }
 
         /// <summary>
@@ -55,18 +56,41 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         /// <param name="property">the <see cref="BaseMixedRealityProfile"/> property.</param>
         /// <param name="showAddButton">Optional flag to hide the create button.</param>
         /// <returns>True, if the profile changed.</returns>
-        protected static bool RenderProfile(SerializedProperty property, bool showAddButton = true)
+        protected static bool RenderProfile(SerializedProperty property, bool showAddButton = true, Type serviceType = null)
         {
-            return RenderProfileInternal(property, null, showAddButton);
+            return RenderProfileInternal(property, null, showAddButton, serviceType);
         }
 
-        private static bool RenderProfileInternal(SerializedProperty property, GUIContent guiContent, bool showAddButton)
+        private static bool RenderProfileInternal(SerializedProperty property, GUIContent guiContent, bool showAddButton, Type serviceType = null)
         {
             bool changed = false;
-            EditorGUILayout.BeginHorizontal();
 
             var oldObject = property.objectReferenceValue;
 
+            // If we're constraining this to a service type, check whether the profile is valid
+            // If it isn't, issue a warning.
+            if (serviceType != null && oldObject != null)
+            {
+                bool profileTypeIsValid = false;
+
+                foreach (MixedRealityServiceProfileAttribute serviceProfileAttribute in oldObject.GetType().GetCustomAttributes(typeof(MixedRealityServiceProfileAttribute), true))
+                {
+                    if (serviceProfileAttribute.ServiceType.IsAssignableFrom(serviceType))
+                    {
+                        profileTypeIsValid = true;
+                        break;
+                    }
+                }
+
+                if (!profileTypeIsValid)
+                {
+                    EditorGUILayout.HelpBox("The profile is not configured to be used with a service of type " + serviceType.Name
+                        + "\nIs your profile missing the " + typeof(MixedRealityServiceProfileAttribute).Name + " attribute?", MessageType.Warning);
+                }
+            }
+
+            EditorGUILayout.BeginHorizontal();
+           
             if (guiContent == null)
             {
                 EditorGUILayout.PropertyField(property);
@@ -116,12 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                     }
                 }
             }
-
-            if (oldObject != property.objectReferenceValue)
-            {
-                changed = true;
-            }
-
+            
             EditorGUILayout.EndHorizontal();
 
             // Check fields within profile for other nested profiles
@@ -146,11 +165,15 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                             configProfile.RenderAsSubProfile = true;
                         }
 
-                        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
                         EditorGUI.indentLevel++;
+                        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
                         subProfileEditor.OnInspectorGUI();
-                        EditorGUI.indentLevel--;
+
+                        EditorGUILayout.Space();
+                        EditorGUILayout.Space();
+
                         EditorGUILayout.EndVertical();
+                        EditorGUI.indentLevel--;
                     }
 
                     SessionState.SetBool(showFoldoutKey, showFoldout);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -124,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
                 if (!renderedProfile.IsCustomProfile && profile.IsCustomProfile)
                 {
-                    if (GUILayout.Button(new GUIContent("</>", "Replace with a copy of the default profile."), EditorStyles.miniButton, GUILayout.Width(32f)))
+                    if (GUILayout.Button(new GUIContent("Clone", "Replace with a copy of the default profile."), EditorStyles.miniButton, GUILayout.Width(42f)))
                     {
                         profileToCopy = renderedProfile;
                         var profileTypeName = property.objectReferenceValue.GetType().Name;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -19,19 +19,14 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
     /// </summary>
     public abstract class BaseMixedRealityToolkitConfigurationProfileInspector : BaseMixedRealityProfileInspector
     {
-        public bool RenderAsSubProfile
-        {
-            set { renderAsSubProfile = value; }
-        }
+        public bool RenderAsSubProfile { get; set; }
 
         [SerializeField]
         private Texture2D logoLightTheme = null;
 
         [SerializeField]
         private Texture2D logoDarkTheme = null;
-
-        private bool renderAsSubProfile = false;
-
+        
         protected virtual void Awake()
         {
             string assetPath = $"{MixedRealityEditorSettings.MixedRealityToolkit_RelativeFolderPath}/StandardAssets/Textures";
@@ -53,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         protected void RenderMixedRealityToolkitLogo()
         {
             // If we're being rendered as a sub profile, don't show the logo
-            if (renderAsSubProfile)
+            if (RenderAsSubProfile)
                 return;
 
             GUILayout.BeginHorizontal();
@@ -73,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         protected bool DrawBacktrackProfileButton(string message, UnityEngine.Object activeObject)
         {
             // If we're being rendered as a sub profile, don't show the button
-            if (renderAsSubProfile)
+            if (RenderAsSubProfile)
                 return false;
 
             if (GUILayout.Button(message))

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Inspectors.Utilities;
+using Microsoft.MixedReality.Toolkit.Core.Interfaces.Devices;
 using Microsoft.MixedReality.Toolkit.Core.Services;
 using UnityEditor;
 using UnityEngine;
@@ -118,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
                 {
                     EditorGUILayout.PropertyField(enableControllerMapping);
                     changed |= RenderProfile(controllerMappingProfile);
-                    changed |= RenderProfile(controllerVisualizationProfile);
+                    changed |= RenderProfile(controllerVisualizationProfile, true, typeof(IMixedRealityControllerVisualizer));
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -3,9 +3,9 @@
 
 using Microsoft.MixedReality.Toolkit.Core.Attributes;
 using Microsoft.MixedReality.Toolkit.Core.Definitions;
-using Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Inspectors.Utilities;
 using Microsoft.MixedReality.Toolkit.Core.Services;
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -125,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
                 EditorGUILayout.EndHorizontal();
 
-                if (configFoldouts[i])
+                if (configFoldouts[i] || RenderAsSubProfile)
                 {
                     EditorGUI.indentLevel++;
 
@@ -152,7 +152,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
                     changed |= EditorGUI.EndChangeCheck();
 
-                    changed |= RenderProfile(configurationProfile);
+                    Type serviceType = null;
+                    if (configurationProfile.objectReferenceValue != null)
+                    {
+                        serviceType = (target as MixedRealityRegisteredServiceProvidersProfile).Configurations[i].ComponentType;
+                    }
+
+                    changed |= RenderProfile(configurationProfile, true, serviceType);
 
                     EditorGUI.indentLevel--;
 


### PR DESCRIPTION
Overview
---
This PR adds the MixedRealityServiceProfileAttribute class and adds inspector warnings for incorrectly configured registered services.

The attribute should be used on any profile class that is consumed by an IMixedRealityService.

```
[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
public class MixedRealityServiceProfileAttribute : Attribute
{
    public MixedRealityServiceProfileAttribute(Type serviceType) { ServiceType = serviceType; }
    public Type ServiceType { get; private set; }
}
```
```
[MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessMeshObserver))]
public class MixedRealitySpatialAwarenessMeshObserverProfile : BaseMixedRealityProfile 
{
   ...
}
```
This is intended mostly for registered service providers. But core services profiles have been given the attribute for consistency.

In registered service configurations, if you attempt to set a profile that doesn't match the service type, an error _may_ be thrown by the service. But this is not guaranteed and is easily missed. Now a warning is displayed and remains in place until the problem is fixed:

![profilevalidation](https://user-images.githubusercontent.com/9789716/53996004-c5b55b80-40eb-11e9-87be-0ac4e7d2aef2.PNG)

Issues
---
This is just an inspector warning. The attribute should really be used to enforce correct profile usage.

Next steps
---
Profile attributes are a first step towards automating some tedious profile-related tasks.