### PR TITLE
Fix NRE when custom controller has no visualizer

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Utilities.Solvers
         /// <param name="newController">The new controller to be tracked.</param>
         protected virtual void AddControllerTransform(IMixedRealityController newController)
         {
-            if (newController.ControllerHandedness == handedness && newController.Visualizer.GameObjectProxy.transform != null && !newController.Visualizer.GameObjectProxy.transform.Equals(ControllerTransform))
+            if (newController.ControllerHandedness == handedness && newController.Visualizer != null && newController.Visualizer.GameObjectProxy.transform != null && !newController.Visualizer.GameObjectProxy.transform.Equals(ControllerTransform))
             {
                 ControllerTransform = newController.Visualizer.GameObjectProxy.transform;
 


### PR DESCRIPTION
Overview
---
When implementing a custom controller without a visualizer (Keyboard controller) a NRE occurred in check when accessing GameObjectProxy

Changes
---
- Fixes: # .
