### PR TITLE
IMixedRealityFocusHandler cleanup

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -543,16 +543,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             SetFocus(pointers.Count > 0);
         }
 
-        public void OnBeforeFocusChange(FocusEventData eventData)
-        {
-            //do nothing
-        }
-
-        public void OnFocusChanged(FocusEventData eventData)
-        {
-            //do nothing
-        }
-
         #endregion MixedRealityFocusHandlers
 
         #region MixedRealityPointerHandlers

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Microsoft.MixedReality.Toolkit.Core.EventDatum.Input;
 using UnityEngine.EventSystems;
 
@@ -12,12 +11,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.Handlers
     /// </summary>
     public interface IMixedRealityFocusHandler : IEventSystemHandler
     {
-        [Obsolete("Use IMixedRealityFocusChangedHandler instead.")]
-        void OnBeforeFocusChange(FocusEventData eventData);
-
-        [Obsolete("Use IMixedRealityFocusChangedHandler instead.")]
-        void OnFocusChanged(FocusEventData eventData);
-
         /// <summary>
         /// The Focus Enter event is raised on this <see cref="UnityEngine.GameObject"/> whenever a <see cref="Microsoft.MixedReality.Toolkit.Core.Interfaces.InputSystem.IMixedRealityPointer"/>'s focus enters this <see cref="UnityEngine.GameObject"/>'s <see cref="UnityEngine.Collider"/>.
         /// </summary>


### PR DESCRIPTION
Overview
There were still traces of the two obsolete methods in IMixedRealityFocusHandler. I removed them along with the methods.