### PR TITLE
Editor Null Reference Fixes

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -11,6 +11,7 @@ using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.States;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -41,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         /// </summary>
         private static IMixedRealityInputSystem inputSystem = null;
         protected static IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>());
-        
+
         // list of pointers
         protected List<IMixedRealityPointer> pointers = new List<IMixedRealityPointer>();
         public List<IMixedRealityPointer> Focusers => pointers;
@@ -156,23 +157,25 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         }
 
         #region InspectorHelpers
-        /// <summary>
-        /// Gets a list of input actions, used by the inspector
-        /// </summary>
-        /// <returns></returns>
-        public static string[] GetInputActions()
+        public static bool TryGetInputActions(out string[] descriptionsArray)
         {
-            MixedRealityInputAction[] actions = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions;
-
-            List<string> list = new List<string>();
-            for (int i = 0; i < actions.Length; i++)
+            if (MixedRealityToolkit.Instance?.ActiveProfile == null)
             {
-                list.Add(actions[i].Description);
+                descriptionsArray = null;
+                return false;
             }
 
-            return list.ToArray();
+            MixedRealityInputAction[] actions = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions;
+
+            descriptionsArray = new string[actions.Length];
+            for (int i = 0; i < actions.Length; i++)
+            {
+                descriptionsArray[i] = actions[i].Description;
+            }
+
+            return true;
         }
-        
+
         /// <summary>
         /// Returns a list of states assigned to the Interactable
         /// </summary>
@@ -183,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             {
                 return States.GetStates();
             }
-            
+
             return new State[0];
         }
         #endregion InspectorHelpers
@@ -208,17 +211,17 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 
             SetupVoiceCommand();
         }
-        
+
         private void OnDisable()
         {
             if (IsGlobal)
             {
                 InputSystem.Unregister(gameObject);
             }
-            
+
             StopVoiceCommand();
         }
-        
+
         protected virtual void Update()
         {
             if (rollOffTimer < rollOffTime && HasPress)
@@ -289,7 +292,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         protected virtual void SetupEvents()
         {
             InteractableEvent.EventLists lists = InteractableEvent.GetEventTypes();
-            
+
             for (int i = 0; i < Events.Count; i++)
             {
                 Events[i].Receiver = InteractableEvent.GetReceiver(Events[i], lists);
@@ -323,7 +326,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
                             InteractableThemePropertySettings settings = theme.Settings[n];
 
                             settings.Theme = InteractableProfileItem.GetTheme(settings, Profiles[i].Target, lists);
-                            
+
                             // add themes to theme list based on dimension
                             if (j == dimensionIndex)
                             {
@@ -332,7 +335,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 
                             tempSettings.Add(settings);
                         }
-                        
+
                         themeSettings.Settings = tempSettings;
                         themeSettingsList.Add(themeSettings);
                     }
@@ -344,7 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         }
 
         #endregion InteractableInitiation
-        
+
         #region SetButtonStates
 
         /// <summary>
@@ -364,7 +367,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         public virtual void SetFocus(bool focus)
         {
             HasFocus = focus;
-            if(!focus && HasPress)
+            if (!focus && HasPress)
             {
                 rollOffTimer = 0;
             }
@@ -376,14 +379,14 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             StateManager.SetStateValue(InteractableStates.InteractableStateEnum.Focus, focus ? 1 : 0);
             UpdateState();
         }
-        
+
         public virtual void SetPress(bool press)
         {
             HasPress = press;
             StateManager.SetStateValue(InteractableStates.InteractableStateEnum.Pressed, press ? 1 : 0);
             UpdateState();
         }
-        
+
         public virtual void SetDisabled(bool disabled)
         {
             IsDisabled = disabled;
@@ -546,7 +549,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         #endregion MixedRealityFocusHandlers
 
         #region MixedRealityPointerHandlers
-        
+
         /// <summary>
         /// pointer up event has fired
         /// </summary>
@@ -692,7 +695,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             {
                 return;
             }
-            
+
             if (StateManager != null)
             {
                 if (eventData != null && ShouldListen(eventData.MixedRealityInputAction) && (eventData.MixedRealityInputAction != pointerInputAction || pointerInputAction == MixedRealityInputAction.None))
@@ -786,8 +789,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             {
                 dimensionIndex = 0;
             }
-            
-            if(currentIndex != dimensionIndex)
+
+            if (currentIndex != dimensionIndex)
             {
                 FilterThemesByDimensions();
                 forceUpdate = true;
@@ -850,7 +853,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
                 return false;
             }
 
-            if (Dimensions > 1 && ((dimensionIndex != Dimensions -1 & !CanSelect) || (dimensionIndex == Dimensions - 1 & !CanDeselect)) )
+            if (Dimensions > 1 && ((dimensionIndex != Dimensions - 1 & !CanSelect) || (dimensionIndex == Dimensions - 1 & !CanDeselect)))
             {
                 return false;
             }
@@ -914,9 +917,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         protected IEnumerator GlobalVisualReset(float time)
         {
             yield return new WaitForSeconds(time);
-            
+
             StateManager.SetStateValue(InteractableStates.InteractableStateEnum.VoiceCommand, 0);
-            if (!HasFocus) {
+            if (!HasFocus)
+            {
                 StateManager.SetStateValue(InteractableStates.InteractableStateEnum.Focus, 0);
             }
 
@@ -955,7 +959,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             if (Enabled && ShouldListen(eventData.MixedRealityInputAction))
             {
                 StartGlobalVisual(true);
-                
+
                 IncreaseDimensionIndex();
                 SendVoiceCommands(eventData.RecognizedText, 0, 1);
 
@@ -972,7 +976,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
             if (!string.IsNullOrEmpty(VoiceCommand) && VoiceCommand.Length > 2)
             {
-                voiceCommands = new string[] { VoiceCommand }; 
+                voiceCommands = new string[] { VoiceCommand };
                 if (VoiceCommand.IndexOf(",") > -1)
                 {
                     voiceCommands = VoiceCommand.Split(',');
@@ -980,7 +984,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 
                 recognitionConfidenceLevel = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.SpeechCommandsProfile.SpeechRecognitionConfidenceLevel;
 
-                if(keywordRecognizer == null)
+                if (keywordRecognizer == null)
                 {
                     keywordRecognizer = new KeywordRecognizer(voiceCommands, (ConfidenceLevel)recognitionConfidenceLevel);
                     keywordRecognizer.OnPhraseRecognized += KeywordRecognizer_OnPhraseRecognized;
@@ -1015,7 +1019,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         {
             if (args.text == VoiceCommand && (!RequiresFocus || HasFocus) && CanInteract())
             {
-                
+
                 if (CanInteract())
                 {
                     StartGlobalVisual(true);
@@ -1066,11 +1070,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         /// <returns></returns>
         protected int GetVoiceCommandIndex(string command)
         {
-            if(voiceCommands.Length > 1)
+            if (voiceCommands.Length > 1)
             {
                 for (int i = 0; i < voiceCommands.Length; i++)
                 {
-                    if(command == voiceCommands[i])
+                    if (command == voiceCommands[i])
                     {
                         return i;
                     }
@@ -1079,7 +1083,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 
             return 0;
         }
-        
+
         #endregion VoiceCommands
 
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         #region InspectorHelpers
         public static bool TryGetInputActions(out string[] descriptionsArray)
         {
-            if (MixedRealityToolkit.Instance?.ActiveProfile == null)
+            if (!MixedRealityToolkit.IsInitialized || !MixedRealityToolkit.HasActiveProfile)
             {
                 descriptionsArray = null;
                 return false;

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -75,8 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
         {
             if (actionOptions == null && !Interactable.TryGetInputActions(out actionOptions))
             {
-                EditorGUILayout.HelpBox("Mixed Reality Toolkit is uninitialized, configure it by going invoking the 'Mixed Reality Toolkit > Configure...' menu", MessageType.Error);
-                return;
+                EditorGUILayout.HelpBox("Mixed Reality Toolkit is missing, configure it by invoking the 'Mixed Reality Toolkit > Configure...' menu", MessageType.Error);
             }
 
             //RenderBaseInspector()
@@ -173,10 +172,19 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 
             SerializedProperty actionId = serializedObject.FindProperty("InputActionId");
 
-            int newActionId = EditorGUILayout.Popup("Input Actions", actionId.intValue, actionOptions);
-            if (newActionId != actionId.intValue)
+            if (actionOptions == null)
             {
-                actionId.intValue = newActionId;
+                GUI.enabled = false;
+                EditorGUILayout.Popup("Input Actions", 0, new string[] { "Missing Mixed Reality Toolkit" });
+                GUI.enabled = true;
+            }
+            else
+            {
+                int newActionId = EditorGUILayout.Popup("Input Actions", actionId.intValue, actionOptions);
+                if (newActionId != actionId.intValue)
+                {
+                    actionId.intValue = newActionId;
+                }
             }
 
             //selected.enumValueIndex = (int)(MixedRealityInputAction)EditorGUILayout.EnumPopup(new GUIContent("Input Action", "Input source for this Interactable, Default: Select"), (MixedRealityInputAction)selected.enumValueIndex);

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -1,22 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Core.Definitions.InputSystem;
 using Microsoft.MixedReality.Toolkit.Core.Inspectors.Utilities;
-using Microsoft.MixedReality.Toolkit.SDK.Input.Handlers;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Events;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Profile;
 using Microsoft.MixedReality.Toolkit.SDK.UX.Interactable.Themes;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using UnityEditor;
-using UnityEditor.Animations;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.UI;
 
 namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
 {
@@ -71,6 +63,10 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Interactable
             base.OnInspectorGUI();
         }
 
+        /// <remarks>
+        /// There is a check in here that verifies whether or not we can get InputActions, if we can't we show an error help box; otherwise we get them.
+        /// This method is sealed, if you wish to override <see cref="OnInspectorGUI"/>, then override <see cref="RenderCustomInspector"/> method instead.
+        /// </remarks>
         public sealed override void OnInspectorGUI()
         {
             if (actionOptions == null && !Interactable.TryGetInputActions(out actionOptions))

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/InputActionPropertyDrawer.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/InputActionPropertyDrawer.cs
@@ -25,31 +25,33 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.PropertyDrawers
                 actionLabels = new[] { new GUIContent("Missing Mixed Reality Toolkit") };
                 actionIds = new[] { 0 };
             }
-
-            if (profile == null ||
-                (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
-                 profile.InputActions != null &&
-                 profile.InputActions != MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions))
+            else
             {
-                profile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile;
+                if (profile == null ||
+                    (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
+                     profile.InputActions != null &&
+                     profile.InputActions != MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions))
+                {
+                    profile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile;
 
-                if (profile != null)
-                {
-                    actionLabels = profile.InputActions.Select(action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
-                    actionIds = profile.InputActions.Select(action => (int)action.Id).Prepend(0).ToArray();
+                    if (profile != null)
+                    {
+                        actionLabels = profile.InputActions.Select(action => new GUIContent(action.Description)).Prepend(new GUIContent("None")).ToArray();
+                        actionIds = profile.InputActions.Select(action => (int)action.Id).Prepend(0).ToArray();
+                    }
+                    else
+                    {
+                        actionLabels = new[] { new GUIContent("No input action profile found") };
+                        actionIds = new[] { 0 };
+                    }
                 }
-                else
+
+                if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
                 {
-                    actionLabels = new[] { new GUIContent("No input action profile found") };
+                    profile = null;
+                    actionLabels = new[] { new GUIContent("Input System Disabled") };
                     actionIds = new[] { 0 };
                 }
-            }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
-            {
-                profile = null;
-                actionLabels = new[] { new GUIContent("Input System Disabled") };
-                actionIds = new[] { 0 };
             }
 
             var label = EditorGUI.BeginProperty(rect, content, property);

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -332,6 +332,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         #region MonoBehaviour Implementation
 
         private static MixedRealityToolkit instance;
+        private static bool newInstanceBeingInitialized = false;
 
         /// <summary>
         /// Returns the Singleton instance of the classes type.
@@ -355,10 +356,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 var objects = FindObjectsOfType<MixedRealityToolkit>();
                 searchForInstance = false;
                 MixedRealityToolkit newInstance;
+                newInstanceBeingInitialized = false;
 
                 switch (objects.Length)
                 {
                     case 0:
+                        newInstanceBeingInitialized = true;
                         newInstance = new GameObject(nameof(MixedRealityToolkit)).AddComponent<MixedRealityToolkit>();
                         break;
                     case 1:
@@ -380,6 +383,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 {
                     // Don't do any additional setup because the app is quitting.
                     instance = newInstance;
+                    newInstanceBeingInitialized = false;
                 }
 
                 Debug.Assert(instance != null);
@@ -397,7 +401,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         {
             lock (initializedLock)
             {
-                if (IsInitialized) { return; }
+                if (IsInitialized)
+                {
+                    newInstanceBeingInitialized = false;
+                    return;
+                }
 
                 instance = this;
 
@@ -442,6 +450,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                 {
                     InitializeServiceLocator();
                 }
+
+                newInstanceBeingInitialized = false;
             }
         }
 
@@ -528,7 +538,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
 #if UNITY_EDITOR
         private void OnValidate()
         {
-            if (!IsInitialized && !UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
+            if (!newInstanceBeingInitialized && !IsInitialized && !UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
             {
                 ConfirmInitialized();
             }


### PR DESCRIPTION
Overview
---
This change fixes a few null reference bugs in the editor when MRTK is unavailable, and a prefab is opened. The simplest repro is:

1. Create a new scene
2. Open any prefab
3. Observe null reference being thrown.