### PR TITLE
MRTK Raystep fix and cleanup

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Physics/RayStep.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Physics/RayStep.cs
@@ -137,31 +137,15 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Physics
             Debug.Assert(steps != null);
             Debug.Assert(steps.Length > 0);
 
-            Vector3 point = Vector3.zero;
-            float remainingDistance = distance;
-            int numSteps = steps.Length;
-
-            for (int i = 0; i < numSteps; i++)
-            {
-                if (remainingDistance > numSteps)
-                {
-                    remainingDistance -= numSteps;
-                }
-                else
-                {
-                    point = Vector3.Lerp(steps[i].Origin, steps[i].Terminus, remainingDistance / steps[i].Length);
-                    remainingDistance = 0;
-                    break;
-                }
-            }
-
+            var (rayStep, remainingDistance) = GetStepByDistance(steps, distance);
             if (remainingDistance > 0)
             {
-                // If we reach the end and still have distance left, set the point to the terminus of the last step
-                point = steps[numSteps - 1].Terminus;
+                return Vector3.Lerp(rayStep.Origin, rayStep.Terminus, remainingDistance / rayStep.Length);
             }
-
-            return point;
+            else
+            {
+                return rayStep.Terminus;
+            }
         }
 
         /// <summary>
@@ -170,36 +154,31 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Physics
         /// <param name="steps"></param>
         /// <param name="distance"></param>
         /// <returns></returns>
-        public static RayStep GetStepByDistance(RayStep[] steps, float distance)
+        public static (RayStep rayStep, float traveledDistance) GetStepByDistance(RayStep[] steps, float distance)
         {
             Debug.Assert(steps != null);
             Debug.Assert(steps.Length > 0);
 
-            RayStep step = new RayStep();
             float remainingDistance = distance;
+
             int numSteps = steps.Length;
+            float stepLength = 0;
 
             for (int i = 0; i < numSteps; i++)
             {
-                if (remainingDistance > steps[i].Length)
+                stepLength = steps[i].Length;
+
+                if (remainingDistance > stepLength)
                 {
-                    remainingDistance -= steps[i].Length;
+                    remainingDistance -= stepLength;
                 }
                 else
                 {
-                    step = steps[i];
-                    remainingDistance = 0;
-                    break;
+                    return (steps[i], remainingDistance);
                 }
             }
 
-            if (remainingDistance > 0)
-            {
-                // If we reach the end and still have distance left, return the last step
-                step = steps[steps.Length - 1];
-            }
-
-            return step;
+            return (steps[steps.Length - 1], remainingDistance);
         }
 
         /// <summary>
@@ -213,7 +192,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.Physics
             Debug.Assert(steps != null);
             Debug.Assert(steps.Length > 0);
 
-            return GetStepByDistance(steps, distance).Direction;
+            return GetStepByDistance(steps, distance).rayStep.Direction;
         }
 
         #endregion


### PR DESCRIPTION
Overview
The code in GetPointByDistance compared and subtracted the remainingDistance with the raystep's array length, not with the individual length of the current raystep.
I fixed that and also reduced the code, making GetPointByDistance use GetStepByDistance introducing a returning tuple.


Changes
---
- Fixes: #3571 .
