### PR TITLE
Fix: detaching children before DestroyImmediate causes Errors in the Editor

### DIFF
--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -81,7 +81,6 @@ namespace Microsoft.MixedReality.Toolkit.Services.BoundarySystem
             // and clean up the parent.
             if (boundaryVisualizationParent != null)
             {
-                boundaryVisualizationParent.transform.DetachChildren();
 
                 if (Application.isEditor)
                 {
@@ -89,6 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Services.BoundarySystem
                 }
                 else
                 {
+                    boundaryVisualizationParent.transform.DetachChildren();
                     Object.Destroy(boundaryVisualizationParent);
                 }
 

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -62,13 +62,13 @@ namespace Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
         {
             if (diagnosticVisualizationParent != null)
             {
-                diagnosticVisualizationParent.transform.DetachChildren();
                 if (Application.isEditor)
                 {
                     Object.DestroyImmediate(diagnosticVisualizationParent);
                 }
                 else
                 {
+                    diagnosticVisualizationParent.transform.DetachChildren();
                     Object.Destroy(diagnosticVisualizationParent);
                 }
 

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -83,13 +83,13 @@ namespace Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem
                 // Detach the child objects and clean up the parent.
                 if (spatialAwarenessObjectParent != null)
                 {
-                    spatialAwarenessObjectParent.transform.DetachChildren();
                     if (Application.isEditor)
                     {
                         Object.DestroyImmediate(spatialAwarenessObjectParent);
                     }
                     else
                     {
+                        spatialAwarenessObjectParent.transform.DetachChildren();
                         Object.Destroy(spatialAwarenessObjectParent);
                     }
                     spatialAwarenessObjectParent = null;


### PR DESCRIPTION
Overview
Sometimes the Editor throws a lot of errors about destroying transforms and other components that are not allowed to be Destroyed, even though there's no code doing this.
That's because altering a gameobjects hierarchy (detaching children) before calling DestroyImmediate on it is not supported.

Only detach children if the call is Destroy

Unity Case 1136869