### PR TITLE
fixed NullReference

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -74,17 +74,22 @@ namespace Microsoft.MixedReality.Toolkit.Core.Definitions.SpatialAwarenessSystem
         /// <param name="destroyMeshes"></param>
         public static void Cleanup(SpatialAwarenessMeshObject meshObject, bool destroyGameObject = true, bool destroyMeshes = true)
         {
-            if (destroyGameObject && (meshObject.GameObject != null))
+            if (meshObject.GameObject == null)
+            {
+                return;
+            }
+
+            if (destroyGameObject)
             {
                 UnityEngine.Object.Destroy(meshObject.GameObject);
                 meshObject.GameObject = null;
+                return;
             }
-
-            Mesh filterMesh = meshObject.Filter.sharedMesh;
-            Mesh colliderMesh = meshObject.Collider.sharedMesh;
 
             if (destroyMeshes)
             {
+                Mesh filterMesh = meshObject.Filter.sharedMesh;
+                Mesh colliderMesh = meshObject.Collider.sharedMesh;
 
                 if (filterMesh != null)
                 {


### PR DESCRIPTION
Overview
In case meshObject.GameObject was null or was destroyed, meshObject.Filter and meshObject.Collider were still accessed without null checks. all 3 references were actually referencing the same gameobject with its components