### PR TITLE
Mrtk data provider matrix update

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -120,6 +120,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
             Vector3 pointerPosition;
             TryGetPointerPosition(out pointerPosition);
 
+            lineBase.UpdateMatrix();
+
             // Set our first and last points
             lineBase.FirstPoint = pointerPosition;
 

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
@@ -299,13 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.DataProviders
 
         protected virtual void OnEnable()
         {
-            UpdateMatrix();
             distorters.Sort();
-        }
-
-        protected virtual void Update()
-        {
-            UpdateMatrix();
         }
 
         #endregion MonoBehaviour Implementation
@@ -537,7 +531,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.DataProviders
             }
         }
 
-        private void UpdateMatrix()
+        public void UpdateMatrix()
         {
             switch (transformMode)
             {

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
@@ -299,7 +299,13 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.DataProviders
 
         protected virtual void OnEnable()
         {
+            UpdateMatrix();
             distorters.Sort();
+        }
+
+        protected virtual void Update()
+        {
+            UpdateMatrix();
         }
 
         #endregion MonoBehaviour Implementation


### PR DESCRIPTION
Overview
The BaseMixedRealityLineDataProvider was updating its matrices in Update, which did not match the timing of the LinePointer needing the matrix in its PreRaycast phase. Since it's the only class activating this component in OnPostRaycast and is raycasting all the time, I replaced its internal Update with a MatrixUpdate in the LinePointer's PreRaycast phase.

Changes
---
- Fixes: part of #3614.
