### PR TITLE
When we are rendering the profile property, just use the parent targe…

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -63,6 +63,8 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
         private static bool RenderProfileInternal(SerializedProperty property, GUIContent guiContent, bool showAddButton, Type serviceType = null)
         {
+            profile = property.serializedObject.targetObject as BaseMixedRealityProfile;
+
             bool changed = false;
 
             var oldObject = property.objectReferenceValue;


### PR DESCRIPTION
Overview
---
There is a bug that when you first select a custom profile, and then click to choose a sub profile for each of the systems, the clone button disappeares.

The bug fix here is to update the profile being targeted in RenderProfileInternal to the parent serializedObject of the serializedProperty which will always be the object being viewed in the inspector, rather than the target object selected in the editor.