### PR TITLE
Fixing Teleportation to be visually disabled when the system is disab…

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         {
             base.OnEnable();
 
-            if (MixedRealityToolkit.IsInitialized && MixedRealityToolkit.TeleportSystem != null && !lateRegisterTeleport)
+            if (MixedRealityToolkit.IsInitialized && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled && MixedRealityToolkit.TeleportSystem != null && !lateRegisterTeleport)
             {
                 MixedRealityToolkit.TeleportSystem.Register(gameObject);
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -101,7 +101,8 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         #region IMixedRealityPointer Implementation
 
         /// <inheritdoc />
-        public override bool IsInteractionEnabled => !IsTeleportRequestActive && teleportEnabled;
+        public override bool IsInteractionEnabled => !IsTeleportRequestActive && teleportEnabled
+            && (MixedRealityToolkit.IsInitialized && MixedRealityToolkit.HasActiveProfile && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled);
 
         /// <inheritdoc />
         public override float PointerOrientation
@@ -251,7 +252,11 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         public override void OnInputChanged(InputEventData<Vector2> eventData)
         {
             // Don't process input if we've got an active teleport request in progress.
-            if (IsTeleportRequestActive) { return; }
+            if (IsTeleportRequestActive
+                || !(MixedRealityToolkit.IsInitialized && MixedRealityToolkit.HasActiveProfile && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled))
+            {
+                return;
+            }
 
             if (eventData.SourceId == InputSourceParent.SourceId &&
                 eventData.Handedness == Handedness &&

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -28,6 +28,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
 
         protected virtual void OnEnable()
         {
+            if (target == null)
+            {
+                // Either when we are recompiling, or the inspector window is hidden behind another one, the target can get destroyed (null) and thereby will raise an ArgumentException when accessing serializedObject. For now, just return.
+                return;
+            }
+
             targetProfile = serializedObject;
             profile = target as BaseMixedRealityProfile;
         }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -56,6 +56,12 @@ namespace Microsoft.MixedReality.Toolkit.Core.Inspectors.Profiles
         {
             base.OnEnable();
 
+            if (target == null)
+            {
+                // Either when we are recompiling, or the inspector window is hidden behind another one, the target can get destroyed (null) and thereby will raise an ArgumentException when accessing serializedObject. For now, just return.
+                return;
+            }
+
             configurationProfile = target as MixedRealityToolkitConfigurationProfile;
 
             // Create The MR Manager if none exists.


### PR DESCRIPTION
Overview
---
The bug is that when you disable the Teleport System, the visuals still activate when you try to teleport. The fix here is to check that teleport system is in fact enabled.

This change also contains 2 minor fixes in Profile Editors that hit an ArgumentException when either compiling or the window is behind another window.