### PR TITLE
Extracted the TeleportSystem enabled check into a property. Also, mad…

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         {
             base.OnEnable();
 
-            if (MixedRealityToolkit.IsInitialized && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled && MixedRealityToolkit.TeleportSystem != null && !lateRegisterTeleport)
+            if (MixedRealityToolkit.IsTeleportSystemEnabled && MixedRealityToolkit.TeleportSystem != null && !lateRegisterTeleport)
             {
                 MixedRealityToolkit.TeleportSystem.Register(gameObject);
             }
@@ -139,7 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         {
             base.Start();
 
-            if (lateRegisterTeleport && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled)
+            if (lateRegisterTeleport && MixedRealityToolkit.IsTeleportSystemEnabled)
             {
                 if (MixedRealityToolkit.TeleportSystem == null)
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -101,8 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         #region IMixedRealityPointer Implementation
 
         /// <inheritdoc />
-        public override bool IsInteractionEnabled => !IsTeleportRequestActive && teleportEnabled
-            && (MixedRealityToolkit.IsInitialized && MixedRealityToolkit.HasActiveProfile && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled);
+        public override bool IsInteractionEnabled => !IsTeleportRequestActive && teleportEnabled && MixedRealityToolkit.IsTeleportSystemEnabled;
 
         /// <inheritdoc />
         public override float PointerOrientation
@@ -252,8 +251,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
         public override void OnInputChanged(InputEventData<Vector2> eventData)
         {
             // Don't process input if we've got an active teleport request in progress.
-            if (IsTeleportRequestActive
-                || !(MixedRealityToolkit.IsInitialized && MixedRealityToolkit.HasActiveProfile && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled))
+            if (IsTeleportRequestActive || !MixedRealityToolkit.IsTeleportSystemEnabled)
             {
                 return;
             }

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -353,21 +353,24 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
                     return null;
                 }
 
+
                 var objects = FindObjectsOfType<MixedRealityToolkit>();
                 searchForInstance = false;
                 MixedRealityToolkit newInstance;
-                newInstanceBeingInitialized = false;
 
                 switch (objects.Length)
                 {
                     case 0:
+                        Debug.Assert(!newInstanceBeingInitialized, "We shouldn't be initializing another MixedRealityToolkit unless we errored on the previous.");
                         newInstanceBeingInitialized = true;
                         newInstance = new GameObject(nameof(MixedRealityToolkit)).AddComponent<MixedRealityToolkit>();
                         break;
                     case 1:
+                        newInstanceBeingInitialized = false;
                         newInstance = objects[0];
                         break;
                     default:
+                        newInstanceBeingInitialized = false;
                         Debug.LogError($"Expected exactly 1 {nameof(MixedRealityToolkit)} but found {objects.Length}.");
                         return null;
                 }
@@ -1361,6 +1364,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Services
         private static bool logSpatialAwarenessSystem = true;
 
         private static IMixedRealityTeleportSystem teleportSystem = null;
+
+        /// <summary>
+        /// Returns true if the MixedRealityToolkit exists and has an active profile that has Teleport system enabled.
+        /// </summary>
+        public static bool IsTeleportSystemEnabled => IsInitialized && HasActiveProfile && Instance.ActiveProfile.IsTeleportSystemEnabled;
 
         /// <summary>
         /// The current Teleport System registered with the Mixed Reality Toolkit.


### PR DESCRIPTION
Overview
---
This is a follow up to the previous PR with one more change based on Will's comment:

Extracted the TeleportSystem enabled check into a property. Also, made use of newInstanceBeingInitiali
zed in MRTK in Debug.Assert to both get rid of build warning and also have an appropriate assert.