### PR TITLE
Updates the default MRTK project settings to use Single Pass Instance Rendering

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -46,7 +46,7 @@ PlayerSettings:
   defaultScreenHeight: 768
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
-  m_StereoRenderingPath: 0
+  m_StereoRenderingPath: 2
   m_ActiveColorSpace: 0
   m_MTRendering: 1
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000


### PR DESCRIPTION
As part of working with a number of customers, we've found that many people are using the default Multi Pass rendering mechanism, which is a slow way of rendering.  We've seen in more complex scenarios that this can lead to slowdowns of 5ms per frame.

We should also author a perf doc to recommend setting this value in customers' projects (along with other things like disabling the included visual profiler when doing perf measurements)