### PR TITLE
Add switch for scripting backend

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildInfo.cs
@@ -51,6 +51,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
         public ColorSpace? ColorSpace { get; set; }
 
         /// <inheritdoc />
+        public ScriptingImplementation? ScriptingBackend { get; set; }
+
+        /// <inheritdoc />
         public bool AutoIncrement { get; set; } = false;
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/IBuildInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/IBuildInfo.cs
@@ -58,6 +58,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
         ColorSpace? ColorSpace { get; set; }
 
         /// <summary>
+        /// Optional parameter to set the scripting backend
+        /// </summary>
+        ScriptingImplementation? ScriptingBackend { get; set; }
+
+        /// <summary>
         /// Should the build auto increment the build version number?
         /// </summary>
         bool AutoIncrement { get; set; }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -84,6 +84,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
                 PlayerSettings.colorSpace = buildInfo.ColorSpace.Value;
             }
 
+            if (buildInfo.ScriptingBackend.HasValue)
+            {
+                PlayerSettings.SetScriptingBackend(buildTargetGroup, buildInfo.ScriptingBackend.Value);
+            }
+
             BuildTarget oldBuildTarget = EditorUserBuildSettings.activeBuildTarget;
             BuildTargetGroup oldBuildTargetGroup = oldBuildTarget.GetGroup();
 
@@ -220,6 +225,9 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Build
                         break;
                     case "-colorSpace":
                         buildInfo.ColorSpace = (ColorSpace)Enum.Parse(typeof(ColorSpace), arguments[++i]);
+                        break;
+                    case "-scriptingBackend":
+                        buildInfo.ScriptingBackend = (ScriptingImplementation)Enum.Parse(typeof(ScriptingImplementation), arguments[++i]);
                         break;
                     case "-x86":
                     case "-x64":


### PR DESCRIPTION
Add command line switch to change the scripting backend in command line builds. This is needed in order to build using .NET backend on CI. 
