### PR TITLE
MeshLineRenderer improvement

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/BaseMixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/BaseMixedRealityLineRenderer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
     /// <summary>
     /// Base class for Mixed Reality Line Renderers.
     /// </summary>
-    [ExecuteInEditMode]
+    [ExecuteAlways]
     public abstract class BaseMixedRealityLineRenderer : MonoBehaviour
     {
         [SerializeField]
@@ -138,6 +138,27 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
         [Tooltip("Number of steps to interpolate along line in Interpolated step mode")]
         private int lineStepCount = 16;
 
+        [SerializeField]
+        [Tooltip("Method for distributing rendered points along line. Auto lets the implementation decide. None means normalized distribution. DistanceSingleValue ensures uniform distribution. DistanceCurveValue enables custom distribution.")]
+        private PointDistributionMode pointDistributionMode = PointDistributionMode.Auto;
+
+        /// <summary>
+        /// Method for distributing rendered points along line.
+        /// </summary>
+        public PointDistributionMode PointDistributionMode
+        {
+            get { return pointDistributionMode; }
+            set { pointDistributionMode = value; }
+        }
+
+        [SerializeField]
+        [Tooltip("Minimum distance between points distributed along curve. Used when PointDistributionMode is set to DistanceSingleValue. Total points capped by LineStepCount.")]
+        private float customPointDistributionLength = 0.1f;
+
+        [SerializeField]
+        [Tooltip("Custom function for distribing points along curve.Used when DistanceCurveValue is set to Distance. Total points set by LineStepCount.")]
+        private AnimationCurve customPointDistributionCurve = AnimationCurve.Linear(0,0,1,1);
+
         /// <summary>
         /// Number of steps to interpolate along line in Interpolated step mode
         /// </summary>
@@ -177,7 +198,35 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
             return lineWidth.Evaluate(Mathf.Repeat(normalizedLength + widthOffset, 1f)) * widthMultiplier;
         }
 
-        public virtual void Update()
+        protected virtual float GetNormalizedPointAlongLine(int stepNum)
+        {
+            float normalizedDistance = 0;
+
+            switch (pointDistributionMode)
+            {
+                case PointDistributionMode.None:
+                case PointDistributionMode.Auto:
+                    // Normalized length along line
+                    normalizedDistance = (1f / (LineStepCount - 1)) * stepNum;
+                    break;
+
+                case PointDistributionMode.DistanceCurveValue:
+                    // Use curve to interpret value
+                    normalizedDistance = (1f / (LineStepCount - 1)) * stepNum;
+                    normalizedDistance = customPointDistributionCurve.Evaluate(normalizedDistance);
+                    break;
+
+                case PointDistributionMode.DistanceSingleValue:
+                    // Get the normalized distance along curve
+                    float totalWorldLength = customPointDistributionLength * stepNum;
+                    normalizedDistance = lineDataSource.GetNormalizedLengthFromWorldLength(totalWorldLength);
+                    break;
+            }
+
+            return normalizedDistance;
+        }
+
+        private void LateUpdate()
         {
             UpdateLine();
         }

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MeshLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MeshLineRenderer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
             lineMaterial.enableInstancing = true;
         }
 
-        private void LateUpdate()
+        protected override void UpdateLine()
         {
             if (LineDataSource.enabled)
             {                

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MeshLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MeshLineRenderer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
 {
@@ -12,8 +11,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
     /// </summary>
     public class MeshLineRenderer : BaseMixedRealityLineRenderer
     {
-        private const string InvisibleShaderName = "MixedRealityToolkit/InvisibleShader";
-
         [Header("Instanced Mesh Settings")]
 
         [SerializeField]
@@ -47,6 +44,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
         [SerializeField]
         private string colorProperty = "_Color";
 
+        [SerializeField]
+        [Tooltip("How many line steps to skip before a mesh is drawn")]
+        [Range(0,10)]
+        private int lineStepSkip = 0;
+        
         public string ColorProperty
         {
             get { return colorProperty; }
@@ -69,40 +71,20 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
         {
             get
             {
+                if (lineMaterial != null && lineMesh != null && lineMaterial.HasProperty(colorProperty))
+                    return true;
+
                 Debug.Assert(lineMesh != null, "Missing assigned line mesh.");
                 Debug.Assert(lineMaterial != null, "Missing assigned line material.");
-                Debug.Assert(lineMaterial.HasProperty(colorProperty), $"Unable to find the property \"{colorProperty}\" for the line material");
-                return lineMaterial != null && lineMesh != null && lineMaterial.HasProperty(colorProperty);
+                Debug.Assert((lineMaterial != null && lineMaterial.HasProperty(colorProperty)), $"Unable to find the property \"{colorProperty}\" for the line material");
+                return false;
             }
         }
 
-        #region Command buffer properties
-
-        private readonly Dictionary<Camera, CommandBuffer> cameras = new Dictionary<Camera, CommandBuffer>();
-
         private int colorId;
-        private Vector4[] colorValues;
-        private Matrix4x4[] meshTransforms;
-        private bool executeCommandBuffer = false;
+        private List<Vector4> colorValues = new List<Vector4>();
+        private List<Matrix4x4> meshTransforms = new List<Matrix4x4>();
         private MaterialPropertyBlock linePropertyBlock;
-
-        #endregion
-
-        #region OnWillRenderObject helpers
-
-        private readonly Vector3[] meshVertices = new Vector3[3];
-
-        [SerializeField]
-        [HideInInspector]
-        private Material renderedMaterial = null;
-
-        [SerializeField]
-        [HideInInspector]
-        private Mesh renderedMesh = null;
-
-        private MeshRenderer meshRenderer;
-
-        #endregion OnWillRenderObject helpers
 
         private void OnValidate()
         {
@@ -110,22 +92,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
             {
                 enabled = false;
                 return;
-            }
-
-            if (renderedMaterial == null)
-            {
-                // Create an 'invisible' material so the mesh doesn't show up pink
-                renderedMaterial = new Material(Shader.Find(InvisibleShaderName));
-            }
-
-            if (renderedMesh == null)
-            {
-                // create a simple 1-triangle mesh to ensure OnWillRenderObject is always called.
-                renderedMesh = new Mesh
-                {
-                    vertices = meshVertices,
-                    triangles = new[] { 0, 1, 2 }
-                };
             }
         }
 
@@ -139,99 +105,42 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
 
             if (linePropertyBlock == null)
             {
-                lineMaterial.enableInstancing = true;
                 linePropertyBlock = new MaterialPropertyBlock();
-                colorId = Shader.PropertyToID(colorProperty);
             }
 
-            if (meshRenderer == null)
-            {
-                // HACK: OnWillRenderObject won't be called unless there's a renderer attached and its bounds are visible.
-                meshRenderer = gameObject.AddComponent<MeshRenderer>();
-                meshRenderer.receiveShadows = false;
-                meshRenderer.shadowCastingMode = ShadowCastingMode.Off;
-                meshRenderer.lightProbeUsage = LightProbeUsage.Off;
-                meshRenderer.motionVectorGenerationMode = MotionVectorGenerationMode.ForceNoMotion;
-                meshRenderer.sharedMaterial = renderedMaterial;
-
-                var meshFilter = gameObject.AddComponent<MeshFilter>();
-                meshFilter.sharedMesh = renderedMesh;
-            }
+            lineMaterial.enableInstancing = true;
         }
 
-        protected override void UpdateLine()
+        private void LateUpdate()
         {
-            executeCommandBuffer = false;
-
             if (LineDataSource.enabled)
-            {
-                if (meshTransforms == null || meshTransforms.Length != LineStepCount)
-                {
-                    meshTransforms = new Matrix4x4[LineStepCount];
-                }
+            {                
+                meshTransforms.Clear();
+                colorValues.Clear();
 
-                if (colorValues == null || colorValues.Length != LineStepCount)
-                {
-                    colorValues = new Vector4[LineStepCount];
-                    linePropertyBlock.Clear();
-                }
+                int skipCount = 0;
 
                 for (int i = 0; i < LineStepCount; i++)
                 {
-                    float normalizedDistance = (1f / (LineStepCount - 1)) * i;
-                    colorValues[i] = GetColor(normalizedDistance);
-                    meshTransforms[i] = Matrix4x4.TRS(LineDataSource.GetPoint(normalizedDistance), LineDataSource.GetRotation(normalizedDistance), Vector3.one * GetWidth(normalizedDistance));
+                    if (lineStepSkip > 0)
+                    {
+                        skipCount++;
+                        if (skipCount < lineStepSkip)
+                            continue;
+
+                        skipCount = 0;
+                    }
+
+                    float normalizedDistance = GetNormalizedPointAlongLine(i);
+                    colorValues.Add(GetColor(normalizedDistance));
+                    meshTransforms.Add(Matrix4x4.TRS(LineDataSource.GetPoint(normalizedDistance), LineDataSource.GetRotation(normalizedDistance), Vector3.one * GetWidth(normalizedDistance)));
                 }
 
+                colorId = Shader.PropertyToID(colorProperty);
+                linePropertyBlock.Clear();
                 linePropertyBlock.SetVectorArray(colorId, colorValues);
-
-                executeCommandBuffer = true;
+                Graphics.DrawMeshInstanced(lineMesh, 0, lineMaterial, meshTransforms, linePropertyBlock);
             }
-
-            UpdateHelperMesh();
-        }
-
-        private void OnDisable()
-        {
-            foreach (KeyValuePair<Camera, CommandBuffer> bufferCamera in cameras)
-            {
-                if (bufferCamera.Key != null)
-                {
-                    bufferCamera.Key.RemoveCommandBuffer(CameraEvent.AfterForwardOpaque, bufferCamera.Value);
-                }
-            }
-
-            cameras.Clear();
-        }
-
-        private void OnWillRenderObject()
-        {
-            Camera currentCamera = Camera.current;
-            CommandBuffer buffer;
-
-            if (!cameras.TryGetValue(currentCamera, out buffer))
-            {
-                buffer = new CommandBuffer { name = $"LineDataProvider Mesh Renderer {currentCamera.name}" };
-                currentCamera.AddCommandBuffer(CameraEvent.AfterForwardOpaque, buffer);
-                cameras.Add(currentCamera, buffer);
-            }
-
-            buffer.Clear();
-
-            if (executeCommandBuffer)
-            {
-                buffer.DrawMeshInstanced(lineMesh, 0, lineMaterial, 0, meshTransforms, meshTransforms.Length, linePropertyBlock);
-            }
-        }
-
-        private void UpdateHelperMesh()
-        {
-            // Update our helper mesh so OnWillRenderObject will be called
-            meshVertices[0] = transform.InverseTransformPoint(LineDataSource.GetPoint(0.0f)); // - transform.position;
-            meshVertices[1] = transform.InverseTransformPoint(LineDataSource.GetPoint(0.5f)); // - transform.position;
-            meshVertices[2] = transform.InverseTransformPoint(LineDataSource.GetPoint(1.0f)); // - transform.position;
-            renderedMesh.vertices = meshVertices;
-            renderedMesh.RecalculateBounds();
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
                 }
                 else
                 {
-                    float normalizedDistance = (1f / (LineStepCount - 1)) * i;
+                    float normalizedDistance = GetNormalizedPointAlongLine(i);
                     positions[i] = lineDataSource.GetPoint(normalizedDistance);
                 }
             }

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/ParticleSystemLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/ParticleSystemLineRenderer.cs
@@ -203,7 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
             {
                 for (int i = 0; i < LineStepCount; i++)
                 {
-                    float normalizedDistance = (1f / (LineStepCount - 1)) * i;
+                    float normalizedDistance = GetNormalizedPointAlongLine(i);
                     ParticleSystem.Particle particle = mainParticleArray[i];
                     particle.position = LineDataSource.GetPoint(normalizedDistance);
                     particle.startColor = GetColor(normalizedDistance);

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
@@ -121,7 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.Core.Utilities.Lines.Renderers
             
             for (int i = 0; i <= LineStepCount; i++)
             {
-                float normalizedDistance = (1f / (LineStepCount - 1)) * i;
+                float normalizedDistance = GetNormalizedPointAlongLine(i);
                 positions.Add(LineDataSource.GetPoint(normalizedDistance));
                 colors.Add(GetColor(normalizedDistance));
                 widths.Add(GetWidth(normalizedDistance));


### PR DESCRIPTION
Overview
---
Uses a different method to render instanced meshes in MeshLineRenderer. Less finicky both at runtime and in editor.

- Removed command buffers
- Removed hidden mesh / OnWillRenderObject call
- Adds point distribution mode to base line renderer class