### PR TITLE
UI Ray-cast distances should take into account the near clip plane

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Focus/FocusManager.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+#if UNITY_2017_4_OR_NEWER && !UNITY_2017_4_0 && !UNITY_2017_4_1 && !UNITY_2017_4_2
+#define UNITY_2017_4_3_OR_NEWER
+#endif
+
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -639,7 +643,11 @@ namespace HoloToolkit.Unity.InputModule
             {
                 newUiRaycastPosition.x = uiRaycastResult.screenPosition.x;
                 newUiRaycastPosition.y = uiRaycastResult.screenPosition.y;
+                #if UNITY_2017_4_3_OR_NEWER
+                newUiRaycastPosition.z = uiRaycastResult.distance + UIRaycastCamera.nearClipPlane;
+                #else
                 newUiRaycastPosition.z = uiRaycastResult.distance;
+                #endif
 
                 Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
 
@@ -686,7 +694,11 @@ namespace HoloToolkit.Unity.InputModule
                         }
                         else if (threeDLayerIndex == uiLayerIndex)
                         {
+                            #if UNITY_2017_4_3_OR_NEWER
+                            if (pointer.LastRaycastHit.distance > uiRaycastResult.distance + UIRaycastCamera.nearClipPlane)
+                            #else
                             if (pointer.LastRaycastHit.distance > uiRaycastResult.distance)
+                            #endif
                             {
                                 overridePhysicsRaycast = true;
                             }
@@ -694,7 +706,11 @@ namespace HoloToolkit.Unity.InputModule
                     }
                     else
                     {
+                        #if UNITY_2017_4_3_OR_NEWER
+                        if (pointer.LastRaycastHit.distance > uiRaycastResult.distance + UIRaycastCamera.nearClipPlane)
+                        #else
                         if (pointer.LastRaycastHit.distance > uiRaycastResult.distance)
+                        #endif
                         {
                             overridePhysicsRaycast = true;
                         }


### PR DESCRIPTION
Ray-cast distance calculations should take into account that ray-casts from the UI camera originate from the near clipping plane of the camera since Unity 2017.4.3 and newer versions.

Overview
---

MRTK/HTK does not currently calculate the distance to a UI canvas correctly (#3359) or correctly work out the depth of UI objects when trying to determine if a UI or physics object should get focus (#3322). This is only an issue in Unity 2017.4.3 and later versions due to the introduction of the Unity fix [934908](https://issuetracker.unity3d.com/issues/using-canvas-on-world-space-or-camera-buttons-are-not-clickable-if-pos-z-is-set-less-than-zero)

Changes
---
Currently the original MRTK claims to support Unity 2017.2+ so I have assumed we need to variant the code based on the version of Unity to only fix affected versions.

I added the definition of UNITY_2017_4_3_OR_NEWER so that the existing behavior can be preserved for unaffected Unity versions. Unity only includes _OR_NEWER macros for year.x versions but this change appeared in Unity 2017.4.3 so I have added a definition for UNITY_2017_4_3_OR_NEWER combining existing definitions.

Lines 646 - 650 resolves issue #3359 
Lines 697 - 701 and 709 - 713 are also needed to resolve issue #3322

- Fixes: #3359 & #3322
