### PR TITLE
Fix exceptions deleting SpeechInputHandler's last keyword

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/SpeechInputHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/SpeechInputHandlerInspector.cs
@@ -113,12 +113,18 @@ namespace Microsoft.MixedReality.Toolkit.SDK.Inspectors.Input.Handlers
                 // the remove element button
                 bool elementRemoved = GUILayout.Button(RemoveButtonContent, EditorStyles.miniButton, MiniButtonWidth);
 
+                EditorGUILayout.EndHorizontal();
+
                 if (elementRemoved)
                 {
                     list.DeleteArrayElementAtIndex(index);
-                }
 
-                EditorGUILayout.EndHorizontal();
+                    if (index == list.arraySize)
+                    {
+                        EditorGUI.indentLevel--;
+                        return;
+                    }
+                }
 
                 SerializedProperty keywordProperty = speechCommandProperty.FindPropertyRelative("keyword");
 


### PR DESCRIPTION
Overview
---
The SpeechInputHandlerInspector doesn't properly delete the last keyword, since it tries to continue through displaying the keyword and ends up throwing exceptions:
![image](https://user-images.githubusercontent.com/3580640/54777237-1ee2bc00-4bcf-11e9-836c-da016a4780cf.png)
