### PR TITLE
Add items to .gitignore file to avoid checking in nuget packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,16 @@ Assets/ThirdParty.meta
 Assets/TextMesh Pro.meta
 Assets/TextMesh Pro/
 --Version/
+
+# ===== #
+# NuGet #
+# ===== #
+Assets/NuGet.config
+Assets/NuGet.config.meta
+Assets/NuGet/
+Assets/NuGet.meta
+Assets/packages.config
+Assets/packages.config.meta
+Assets/Packages/
+Assets/Packages.meta
+Packages/


### PR DESCRIPTION
Overview
---
Spectator View will likely begin to start consuming NuGet packages. This change is intended to avoid checking in any nuget related helpers or nuget package obtained dlls.

Changes
---
- Fixes: # .
