### PR TITLE
Component extensions use == null instead unity's Object.bool

### DIFF
--- a/Assets/MixedRealityToolkit/Extensions/ComponentExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/ComponentExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit
         public static T EnsureComponent<T>(this GameObject gameObject) where T : Component
         {
             T foundComponent = gameObject.GetComponent<T>();
-            return foundComponent == null ? gameObject.AddComponent<T>() : foundComponent;
+            return foundComponent ? foundComponent : gameObject.AddComponent<T>();
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit
         public static Component EnsureComponent(this GameObject gameObject, Type component)
         {
             var foundComponent = gameObject.GetComponent(component);
-            return foundComponent == null ? gameObject.AddComponent(component) : foundComponent;
+            return foundComponent ? foundComponent : gameObject.AddComponent(component);
         }
     }
 }


### PR DESCRIPTION
Overview
--- After switching to unity 2018.3.9f1 I experienced missing canvas utility scripts on our prefabs. Trying to set them manually didn't work as it seems that EnsureComponent in ComponentExtensions.cs finds already a component but does not check if it is already destroyed.

To be honest, the unity docs about "exists" checks are confusing me.


Changes
---
- Fixes: # .
