### PR TITLE
Prefer DateTime.UtcNow over DateTime.Now

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 {
                     if (UInput.GetKeyDown(Commands[i].KeyCode))
                     {
-                        OnPhraseRecognized((ConfidenceLevel)RecognitionConfidenceLevel, TimeSpan.Zero, DateTime.Now, Commands[i].Keyword);
+                        OnPhraseRecognized((ConfidenceLevel)RecognitionConfidenceLevel, TimeSpan.Zero, DateTime.UtcNow, Commands[i].Keyword);
                     }
                 }
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/Audio/Influencers/AudioInfluencerController.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Audio/Influencers/AudioInfluencerController.cs
@@ -167,7 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
 
         private void Update() 
         {
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
 
             // Audio influences are not updated every frame.
             if ((UpdateInterval * 1000.0f) <= (now - lastUpdate).TotalMilliseconds)

--- a/Assets/MixedRealityToolkit/EventDatum/GenericBaseEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/GenericBaseEventData.cs
@@ -17,11 +17,8 @@ namespace Microsoft.MixedReality.Toolkit
         public IMixedRealityEventSource EventSource { get; private set; }
 
         /// <summary>
-        /// The time at which the event occurred.
+        /// The UTC time at which the event occurred.
         /// </summary>
-        /// <remarks>
-        /// The value will be in the device's configured time zone.
-        /// </remarks>
         public DateTime EventTime { get; private set; }
 
         /// <summary>
@@ -37,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit
         protected void BaseInitialize(IMixedRealityEventSource eventSource)
         {
             Reset();
-            EventTime = DateTime.Now;
+            EventTime = DateTime.UtcNow;
             EventSource = eventSource;
         }
     }

--- a/Assets/MixedRealityToolkit/EventDatum/Input/BaseInputEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/BaseInputEventData.cs
@@ -12,11 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public abstract class BaseInputEventData : BaseEventData
     {
         /// <summary>
-        /// The time at which the event occurred.
+        /// The UTC time at which the event occurred.
         /// </summary>
-        /// <remarks>
-        /// The value will be in the device's configured time zone.
-        /// </remarks>
         public DateTime EventTime { get; private set; }
 
         /// <summary>
@@ -48,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected void BaseInitialize(IMixedRealityInputSource inputSource, MixedRealityInputAction inputAction)
         {
             Reset();
-            EventTime = DateTime.Now;
+            EventTime = DateTime.UtcNow;
             InputSource = inputSource;
             MixedRealityInputAction = inputAction;
             SourceId = InputSource.SourceId;

--- a/Assets/MixedRealityToolkit/EventDatum/Input/SpeechEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/SpeechEventData.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public TimeSpan PhraseDuration { get; private set; }
 
         /// <summary>
-        /// The moment in time when uttering of the phrase began.
+        /// The moment in UTC time when uttering of the phrase began.
         /// </summary>
         public DateTime PhraseStartTime { get; private set; }
 

--- a/Assets/MixedRealityToolkit/Utilities/FastSimplexNoise.cs
+++ b/Assets/MixedRealityToolkit/Utilities/FastSimplexNoise.cs
@@ -219,7 +219,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return x < xi ? xi - 1 : xi;
         }
 
-        public FastSimplexNoise() : this(DateTime.Now.Ticks) { }
+        public FastSimplexNoise() : this(DateTime.UtcNow.Ticks) { }
 
         public FastSimplexNoise(long seed)
         {

--- a/CodingGuidelines.md
+++ b/CodingGuidelines.md
@@ -600,3 +600,9 @@ This chart can help you decide which `#if` to use, depending on your use cases a
 | `UNITY_WSA && !UNITY_EDITOR` | True | True | False |
 | `ENABLE_WINMD_SUPPORT` | True | True | False |
 | `NETFX_CORE` | False | True | False |
+
+## Prefer DateTime.UtcNow over DateTime.Now
+
+DateTime.UtcNow is faster than DateTime.Now. In previous performance investigations we've found that using DateTime.Now adds significant overhead especially when used in the Update() loop. [Others have hit the same issue](https://stackoverflow.com/questions/1561791/optimizing-alternatives-to-datetime-now).
+
+Prefer using DateTime.UtcNow unless you actually need the localized times (a legitmate reason may be you wanting to show the current time in the user's time zone). If you are dealing with relative times (i.e. the delta between some last update and now), it's best to use DateTime.UtcNow to avoid the overhead of doing timezone conversions.


### PR DESCRIPTION
Overview
---
In previous performance investigations we've found that using DateTime.Now adds significant overhead especially when used in the Update() loop. [Others have hit the same issue](https://stackoverflow.com/questions/1561791/optimizing-alternatives-to-datetime-now).

Prefer using DateTime.UtcNow unless you actually need the localized times (a reason may be wanting to show the current time in the user's time zone). If you are dealing with relative times (i.e. the delta between some last update and now), it's best to use DateTime.UtcNow to avoid the overhead of doing timezone conversions.