### PR TITLE
Fix BaseFocusHandler's events / interfaces

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseFocusHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseFocusHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// Base Component for handling Focus on <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>s.
     /// </summary>
     [RequireComponent(typeof(Collider))]
-    public abstract class BaseFocusHandler : MonoBehaviour, IMixedRealityFocusHandler
+    public abstract class BaseFocusHandler : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityFocusChangedHandler
     {
         [SerializeField]
         [Tooltip("Is focus enabled for this component?")]


### PR DESCRIPTION
Overview
---
In #3113, `IMixedRealityFocusHandler` was changed to no longer be a `IMixedRealityFocusChangedHandler`, but BaseFocusHandler, which consumes events from both interfaces, didn't have `IMixedRealityFocusChangedHandler` added. Since then, this script has silently not been receiving events it depends on.