### PR TITLE
Remove OverrideFocusedObject

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -95,9 +95,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        /// <inheritdoc />
-        public GameObject OverrideFocusedObject { get; set; }
-
         #endregion IFocusProvider Properties
 
         /// <summary>
@@ -379,8 +376,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public GameObject GetFocusedObject(IMixedRealityPointer pointingSource)
         {
-            if (OverrideFocusedObject != null) { return OverrideFocusedObject; }
-
             if (pointingSource == null)
             {
                 Debug.LogError("No Pointer passed to get focused object");

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
@@ -28,13 +28,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         Camera UIRaycastCamera { get; }
 
         /// <summary>
-        /// To tap on a hologram even when not focused on,
-        /// set OverrideFocusedObject to desired game object.
-        /// If it's null, then focused object will be used.
-        /// </summary>
-        GameObject OverrideFocusedObject { get; set; }
-
-        /// <summary>
         /// Gets the currently focused object for the pointing source.
         /// <para><remarks>If the pointing source is not registered, then the Gaze's Focused <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> is returned.</remarks></para>
         /// </summary>


### PR DESCRIPTION
Overview
---
`OverrideFocusedObject` was a holdover from one of the original HoloToolkits' input dispatch.
With the (long ago) additions of global listeners, the modal listener stack, etc, this isn't really needed anymore (open to disagreements though!).