### PR TITLE
Pointer focus dispatch rework

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -244,6 +244,47 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void HandleEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler)
         {
+            Debug.Assert(eventData != null);
+            Debug.Assert(!(eventData is  MixedRealityPointerEventData), "HandleEvent called with a pointer event. All events raised by pointer should call HandlePointerEvent");
+
+            if (disabledRefCount > 0)
+            {
+                return;
+            }
+
+            var baseInputEventData = ExecuteEvents.ValidateEventData<BaseInputEventData>(eventData);
+            DispatchEventToGlobalListeners(baseInputEventData, eventHandler);
+            
+            if (baseInputEventData.used)
+            {
+                // All global listeners get a chance to see the event,
+                // but if any of them marked it used,
+                // we stop the event from going any further.
+                return;
+            }
+
+            Debug.Assert(baseInputEventData.InputSource.Pointers != null, $"InputSource {baseInputEventData.InputSource.SourceName} doesn't have any registered pointers! Input Sources without pointers should use the GazeProvider's pointer as a default fallback.");
+
+            var modalEventHandled = false;
+            // Get the focused object for each pointer of the event source
+            for (int i = 0; i < baseInputEventData.InputSource.Pointers.Length && !baseInputEventData.used; i++)
+            {
+                modalEventHandled = DispatchEventToObjectFocusedByPointer(baseInputEventData.InputSource.Pointers[i], baseInputEventData, modalEventHandled, eventHandler);
+            }
+
+            if (!baseInputEventData.used)
+            {
+                DispatchEventToFallbackHandlers(baseInputEventData, eventHandler);
+            }
+        }
+        
+        /// <summary>
+        /// Handles a pointer event
+        /// Assumption: We only send pointer events to the objects that pointers are focusing, except for global event listeners (which listen to everything)
+        /// In contract, all other events get sent to all other pointers attached to a given input source
+        /// </summary>
+        private void HandlePointerEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler) where T : IMixedRealityPointerHandler
+        {
             if (disabledRefCount > 0)
             {
                 return;
@@ -251,17 +292,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             Debug.Assert(eventData != null);
             var baseInputEventData = ExecuteEvents.ValidateEventData<BaseInputEventData>(eventData);
-            Debug.Assert(baseInputEventData != null);
-            Debug.Assert(!baseInputEventData.used);
-
-            if (baseInputEventData.InputSource == null)
-            {
-                Debug.LogError($"Failed to find an input source for {baseInputEventData}");
-                return;
-            }
-
-            // Send the event to global listeners
-            base.HandleEvent(eventData, eventHandler);
+            DispatchEventToGlobalListeners(baseInputEventData, eventHandler);
 
             if (baseInputEventData.used)
             {
@@ -271,70 +302,86 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            if (baseInputEventData.InputSource.Pointers == null)
+            Debug.Assert(pointerEventData.Pointer != null, "Trying to dispatch event on pointer but pointerEventData is null");
+
+            DispatchEventToObjectFocusedByPointer(pointerEventData.Pointer, baseInputEventData, false, eventHandler);                
+
+            if (!baseInputEventData.used)
             {
-                Debug.LogError($"InputSource {baseInputEventData.InputSource.SourceName} doesn't have any registered pointers! Input Sources without pointers should use the GazeProvider's pointer as a default fallback.");
-                return;
+                DispatchEventToFallbackHandlers(baseInputEventData, eventHandler);
             }
+        }
 
-            var modalEventHandled = false;
+        /// <summary>
+        /// Dispatch an input event to all global event listeners
+        /// Return true if the event has been handled by a global event listener
+        /// </summary>
+        private void DispatchEventToGlobalListeners<T>(BaseInputEventData baseInputEventData, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
+        {
+            Debug.Assert(baseInputEventData != null);
+            Debug.Assert(!baseInputEventData.used);
+            Debug.Assert(baseInputEventData.InputSource != null, $"Failed to find an input source for {baseInputEventData}");
 
-            // Get the focused object for each pointer of the event source
-            for (int i = 0; i < baseInputEventData.InputSource.Pointers.Length; i++)
-            {
-                GameObject focusedObject = FocusProvider?.GetFocusedObject(baseInputEventData.InputSource.Pointers[i]);
+            // Send the event to global listeners
+            base.HandleEvent(baseInputEventData, eventHandler);            
+        }
 
-                // Handle modal input if one exists
-                if (modalInputStack.Count > 0 && !modalEventHandled)
-                {
-                    GameObject modalInput = modalInputStack.Peek();
-
-                    if (modalInput != null)
-                    {
-                        modalEventHandled = true;
-
-                        // If there is a focused object in the hierarchy of the modal handler, start the event bubble there
-                        if (focusedObject != null && focusedObject.transform.IsChildOf(modalInput.transform))
-                        {
-                            if (ExecuteEvents.ExecuteHierarchy(focusedObject, baseInputEventData, eventHandler) && baseInputEventData.used)
-                            {
-                                return;
-                            }
-                        }
-                        // Otherwise, just invoke the event on the modal handler itself
-                        else
-                        {
-                            if (ExecuteEvents.ExecuteHierarchy(modalInput, baseInputEventData, eventHandler) && baseInputEventData.used)
-                            {
-                                return;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        Debug.LogError("ModalInput GameObject reference was null!\nDid this GameObject get destroyed?");
-                    }
-                }
-
-                // If event was not handled by modal, pass it on to the current focused object
-                if (focusedObject != null)
-                {
-                    if (ExecuteEvents.ExecuteHierarchy(focusedObject, baseInputEventData, eventHandler) && baseInputEventData.used)
-                    {
-                        return;
-                    }
-                }
-            }
-
+        private void DispatchEventToFallbackHandlers<T>(BaseInputEventData baseInputEventData, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
+        {
             // If event was not handled by the focused object, pass it on to any fallback handlers
-            if (fallbackInputStack.Count > 0)
+            if (!baseInputEventData.used && fallbackInputStack.Count > 0)
             {
                 GameObject fallbackInput = fallbackInputStack.Peek();
-                if (ExecuteEvents.ExecuteHierarchy(fallbackInput, baseInputEventData, eventHandler) && baseInputEventData.used)
+                ExecuteEvents.ExecuteHierarchy(fallbackInput, baseInputEventData, eventHandler);
+            }
+        }
+
+        
+        /// <summary>
+        /// Dispatch an input event to the object focused by the given IMixedRealityPointer.
+        /// If a modal dialog is active, dispatch the pointer event to that modal dialog
+        /// Returns true if the event was handled by a modal handler
+        private bool DispatchEventToObjectFocusedByPointer<T>(IMixedRealityPointer mixedRealityPointer, BaseInputEventData baseInputEventData, 
+            bool modalEventHandled, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
+        {
+            GameObject focusedObject = FocusProvider?.GetFocusedObject(mixedRealityPointer);
+
+            // Handle modal input if one exists
+            if (modalInputStack.Count > 0 && !modalEventHandled)
+            {
+                GameObject modalInput = modalInputStack.Peek();
+
+                if (modalInput != null)
                 {
-                    // return;
+                    // If there is a focused object in the hierarchy of the modal handler, start the event bubble there
+                    if (focusedObject != null && focusedObject.transform.IsChildOf(modalInput.transform))
+                    {
+                        if (ExecuteEvents.ExecuteHierarchy(focusedObject, baseInputEventData, eventHandler) && baseInputEventData.used)
+                        {
+                            return true;
+                        }
+                    }
+                    // Otherwise, just invoke the event on the modal handler itself
+                    else
+                    {
+                        if (ExecuteEvents.ExecuteHierarchy(modalInput, baseInputEventData, eventHandler) && baseInputEventData.used)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                else
+                {
+                    Debug.LogError("ModalInput GameObject reference was null!\nDid this GameObject get destroyed?");
                 }
             }
+
+            // If event was not handled by modal, pass it on to the current focused object
+            if (focusedObject != null)
+            {
+                ExecuteEvents.ExecuteHierarchy(focusedObject, baseInputEventData, eventHandler);
+            }
+            return modalEventHandled;
         }
 
         /// <summary>
@@ -820,7 +867,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private GraphicInputEventData HandlePointerDown(IMixedRealityPointer pointer)
         {
             // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(pointerEventData, OnPointerDownEventHandler);
+            HandlePointerEvent(pointerEventData, OnPointerDownEventHandler);
+
             GraphicInputEventData graphicEventData;
             FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out graphicEventData);
             return graphicEventData;
@@ -866,7 +914,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private void HandleClick()
         {
             // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(pointerEventData, OnInputClickedEventHandler);
+            HandlePointerEvent(pointerEventData, OnInputClickedEventHandler);
 
             // NOTE: In Unity UI, a "click" happens on every pointer up, so we have RaisePointerUp call the pointerClickHandler.
         }
@@ -917,7 +965,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private GraphicInputEventData HandlePointerUp(IMixedRealityPointer pointer)
         {
             // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(pointerEventData, OnPointerUpEventHandler);
+            HandlePointerEvent(pointerEventData, OnPointerUpEventHandler);
 
             GraphicInputEventData graphicEventData;
             FocusProvider.TryGetSpecificPointerGraphicEventData(pointer, out graphicEventData);

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -244,13 +244,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void HandleEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler)
         {
-            Debug.Assert(eventData != null);
-            Debug.Assert(!(eventData is MixedRealityPointerEventData), "HandleEvent called with a pointer event. All events raised by pointer should call HandlePointerEvent");
-
             if (disabledRefCount > 0)
             {
                 return;
             }
+
+            Debug.Assert(eventData != null);
+            Debug.Assert(!(eventData is MixedRealityPointerEventData), "HandleEvent called with a pointer event. All events raised by pointer should call HandlePointerEvent");
 
             var baseInputEventData = ExecuteEvents.ValidateEventData<BaseInputEventData>(eventData);
             DispatchEventToGlobalListeners(baseInputEventData, eventHandler);

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -245,7 +245,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override void HandleEvent<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> eventHandler)
         {
             Debug.Assert(eventData != null);
-            Debug.Assert(!(eventData is  MixedRealityPointerEventData), "HandleEvent called with a pointer event. All events raised by pointer should call HandlePointerEvent");
+            Debug.Assert(!(eventData is MixedRealityPointerEventData), "HandleEvent called with a pointer event. All events raised by pointer should call HandlePointerEvent");
 
             if (disabledRefCount > 0)
             {
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             var baseInputEventData = ExecuteEvents.ValidateEventData<BaseInputEventData>(eventData);
             DispatchEventToGlobalListeners(baseInputEventData, eventHandler);
-            
+
             if (baseInputEventData.used)
             {
                 // All global listeners get a chance to see the event,
@@ -277,7 +277,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 DispatchEventToFallbackHandlers(baseInputEventData, eventHandler);
             }
         }
-        
+
         /// <summary>
         /// Handles a pointer event
         /// Assumption: We only send pointer events to the objects that pointers are focusing, except for global event listeners (which listen to everything)
@@ -304,7 +304,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             Debug.Assert(pointerEventData.Pointer != null, "Trying to dispatch event on pointer but pointerEventData is null");
 
-            DispatchEventToObjectFocusedByPointer(pointerEventData.Pointer, baseInputEventData, false, eventHandler);                
+            DispatchEventToObjectFocusedByPointer(pointerEventData.Pointer, baseInputEventData, false, eventHandler);
 
             if (!baseInputEventData.used)
             {
@@ -323,7 +323,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Debug.Assert(baseInputEventData.InputSource != null, $"Failed to find an input source for {baseInputEventData}");
 
             // Send the event to global listeners
-            base.HandleEvent(baseInputEventData, eventHandler);            
+            base.HandleEvent(baseInputEventData, eventHandler);
         }
 
         private void DispatchEventToFallbackHandlers<T>(BaseInputEventData baseInputEventData, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
@@ -336,12 +336,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        
         /// <summary>
         /// Dispatch an input event to the object focused by the given IMixedRealityPointer.
         /// If a modal dialog is active, dispatch the pointer event to that modal dialog
         /// Returns true if the event was handled by a modal handler
-        private bool DispatchEventToObjectFocusedByPointer<T>(IMixedRealityPointer mixedRealityPointer, BaseInputEventData baseInputEventData, 
+        private bool DispatchEventToObjectFocusedByPointer<T>(IMixedRealityPointer mixedRealityPointer, BaseInputEventData baseInputEventData,
             bool modalEventHandled, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
         {
             GameObject focusedObject = FocusProvider?.GetFocusedObject(mixedRealityPointer);
@@ -849,10 +848,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void RaisePointerDown(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
-            // Create input event
-            pointerEventData.Initialize(pointer, handedness, inputAction);
-
-            ExecutePointerDown(HandlePointerDown(pointer));
+            RaisePointerDown(pointer, inputAction, handedness);
         }
 
         /// <inheritdoc />
@@ -933,10 +929,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void RaisePointerUp(IMixedRealityPointer pointer, Handedness handedness, MixedRealityInputAction inputAction)
         {
-            // Create input event
-            pointerEventData.Initialize(pointer, handedness, inputAction);
-
-            ExecutePointerUp(HandlePointerUp(pointer));
+            RaisePointerUp(pointer, inputAction, handedness);
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -340,6 +340,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Dispatch an input event to the object focused by the given IMixedRealityPointer.
         /// If a modal dialog is active, dispatch the pointer event to that modal dialog
         /// Returns true if the event was handled by a modal handler
+        /// </summary>
         private bool DispatchEventToObjectFocusedByPointer<T>(IMixedRealityPointer mixedRealityPointer, BaseInputEventData baseInputEventData,
             bool modalEventHandled, ExecuteEvents.EventFunction<T> eventHandler) where T : IEventSystemHandler
         {


### PR DESCRIPTION
Overview
---
From @julenka:

This PR fixes a bug in the input system where pointers are dispatching pointer events to all other pointers attached to an input source, which causes a large number of null pointer exceptions and also duplicate events to be sent to the system.

## Explanation of the Bug
Currently MixedRealityInputSystem dispatches any event `E` to all pointers attached to `E`.InputSource. Therefore, when a Pointer wants to send a PointerDown event to the object it is focusing, instead the following happens when trying to dispatch pointer event `E` from pointer `P`:

1. Initialize `E` with information about pointer `P` so that `eventData.Pointer` returns `P`
1. Get the InputSource `S` attached to pointer `P`
2. For all pointers `P2` on `S`...
  a. If `P2` is focused on some object `O`
  b. Dispatch pointer event `E` to `O`, **even if P2 ~= P.**

This causes two problems when you have multiple pointers on an input source, for example the multiple pointers we have on fully articulated hands:

1. Each PointerDown event will get sent N times, where N = # pointers attached to a source.
2. If one pointer is focused on something, but another is not, then in step 1, `E.Pointer` is set to something that doesn't actually have object focus (`E.Pointer.Result.Object == null`). Then, if something tried to access `E.Pointer.Result.Object` it will get null pointer. This violates an assumption that for any PointerEvent `E2` being dispatched, `E2` is focusing some object.

## Explanation of the Fix
When dispatching a pointer event, this event should only be sent to global event listeners and the object being focused by the pointer, NOT all other pointers attached pointer.InputSource.

Create a new method `HandlePointerEvent` that should be used to dispatch all events for pointers (which are the only things that can provide object focus). This method only dispatched events to global handlers and the object being focused, not to other pointers on the input source.

Also refactor the code a bit to avoid duplicate code.