### PR TITLE
Remove usage of the non-overloaded null operator on the camera cache.

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/CameraCache.cs
+++ b/Assets/MixedRealityToolkit/Utilities/CameraCache.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             get
             {
-                var mainCamera = cachedCamera ?? Refresh(Camera.main);
+                var mainCamera = cachedCamera == null ? Refresh(Camera.main) : cachedCamera;
 
                 if (mainCamera == null)
                 {


### PR DESCRIPTION
The Camera object is a unity object, which actually must be checked using the == null or != null operator explicitly (because Unity) overloads that operator. It's possible for a camera to be destroyed but not yet null (i.e. the unity concept of the the camera is dead but the object is still non-null). The ?? operator skips Unity's overloading, and will sometimes return "it's not null" which is technically true but still not safe to use from a Unity perspective.