### PR TITLE
The finger cursor should align the inverse surface normal

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -250,7 +250,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void RotateToSurfaceNormal(Transform target, float deltaTime, Vector3 surfaceNormal)
         {
-            Quaternion targetRotation = Quaternion.LookRotation(surfaceNormal);
+            Quaternion targetRotation = Quaternion.LookRotation(-surfaceNormal);
             target.rotation = Quaternion.Lerp(target.rotation, targetRotation, deltaTime / RotationLerpTime);
         }
     }


### PR DESCRIPTION
Overview
---
The finger cursor was aligning with the surface normal rather than the inverse surface normal. Normally not an issue because the cursor looks the same front & back but when the cursor moves from finger alignment to surface alignment it does some extra rotation.
