### PR TITLE
Update #if wrappings around speech providers

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -13,8 +13,6 @@ using UnityEngine.Windows.Speech;
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Input
 {
-#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-
     [MixedRealityExtensionService(SupportedPlatforms.WindowsStandalone | SupportedPlatforms.WindowsUniversal | SupportedPlatforms.WindowsEditor)]
     public class WindowsDictationInputProvider : BaseDeviceManager, IMixedRealityDictationSystem
     {
@@ -31,11 +29,10 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(registrar, name, priority, profile) { }
 
-        /// <summary>
-        /// Is the Dictation Manager currently running?
-        /// </summary>
+        /// <inheritdoc />
         public bool IsListening { get; private set; } = false;
 
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
         private bool hasFailed;
         private bool hasListener;
         private bool isTransitioning;
@@ -130,6 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             }
         }
 
+        /// <inheritdoc />
         public override void Destroy()
         {
             if (Application.isPlaying)

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -295,6 +295,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             textSoFar = null;
             dictationResult = string.Empty;
         }
-    }
 #endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+    }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -13,8 +13,6 @@ using UnityEngine.Windows.Speech;
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Input
 {
-#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-
     [MixedRealityExtensionService(SupportedPlatforms.WindowsStandalone | SupportedPlatforms.WindowsUniversal | SupportedPlatforms.WindowsEditor)]
     public class WindowsSpeechInputProvider : BaseDeviceManager, IMixedRealitySpeechSystem
     {
@@ -41,6 +39,12 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// </summary>
         public IMixedRealityInputSource InputSource = null;
 
+        /// <summary>
+        /// The minimum confidence level for the recognizer to fire an event.
+        /// </summary>
+        public RecognitionConfidenceLevel RecognitionConfidenceLevel { get; set; }
+
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
         private KeywordRecognizer keywordRecognizer;
 
         /// <inheritdoc />
@@ -48,8 +52,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         {
             get { return keywordRecognizer != null && keywordRecognizer.IsRunning; }
         }
-
-        public RecognitionConfidenceLevel RecognitionConfidenceLevel { get; set; }
 
         /// <inheritdoc />
         public override void Enable()

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -3,12 +3,12 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using System;
-using UnityEngine;
-using UInput = UnityEngine.Input;
 
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+using System;
+using UnityEngine;
 using UnityEngine.Windows.Speech;
+using UInput = UnityEngine.Input;
 #endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Input
@@ -24,9 +24,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public WindowsSpeechInputProvider(
-            IMixedRealityServiceRegistrar registrar, 
-            string name = null, 
-            uint priority = DefaultPriority, 
+            IMixedRealityServiceRegistrar registrar,
+            string name = null,
+            uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(registrar, name, priority, profile) { }
 
         /// <summary>
@@ -137,6 +137,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 }
             }
         }
-    }
 #endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+    }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityDictationSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityDictationSystem.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public interface IMixedRealityDictationSystem : IMixedRealityDeviceManager, IMixedRealityExtensionService
     {
         /// <summary>
-        /// Is the system currently listing to dictation input?
+        /// Is the system currently listing for dictation input?
         /// </summary>
         bool IsListening { get; }
 


### PR DESCRIPTION
Overview
---
The speech and dictation providers had their constructors wrapped inside `#if` statements, which seemed to be preventing their docs from being properly generated. I moved the statements around to reduce the scope they were wrapping.