### PR TITLE
Fix MRTK Pointer Unity UI interaction 

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Audio/Scenes/AudioLoFiEffectDemo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Audio/Scenes/AudioLoFiEffectDemo.unity
@@ -694,7 +694,7 @@ GameObject:
   - component: {fileID: 1701341181}
   - component: {fileID: 1701341185}
   - component: {fileID: 1701341188}
-  - component: {fileID: 1701341187}
+  - component: {fileID: 1701341186}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -796,7 +796,7 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
---- !u!114 &1701341187
+--- !u!114 &1701341186
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -805,16 +805,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1701341180}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &1701341188
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Audio/Scenes/AudioOcclusionDemo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Audio/Scenes/AudioOcclusionDemo.unity
@@ -498,7 +498,7 @@ GameObject:
   - component: {fileID: 1460686211}
   - component: {fileID: 1460686215}
   - component: {fileID: 1460686217}
-  - component: {fileID: 1460686218}
+  - component: {fileID: 1460686216}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -600,6 +600,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1460686216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460686210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1460686217
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -615,25 +627,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &1460686218
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1460686210}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &1552166284
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Boundary/Scenes/BoundaryVisualization.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Boundary/Scenes/BoundaryVisualization.unity
@@ -715,7 +715,7 @@ GameObject:
   - component: {fileID: 1491404207}
   - component: {fileID: 1491404211}
   - component: {fileID: 1491404205}
-  - component: {fileID: 1491404210}
+  - component: {fileID: 1491404206}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -759,6 +759,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1491404206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491404203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!81 &1491404207
 AudioListener:
   m_ObjectHideFlags: 0
@@ -817,25 +829,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!114 &1491404210
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1491404203}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &1491404211
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Diagnostics/Scenes/DiagnosticsDemo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Diagnostics/Scenes/DiagnosticsDemo.unity
@@ -199,7 +199,7 @@ GameObject:
   - component: {fileID: 469757470}
   - component: {fileID: 469757468}
   - component: {fileID: 469757473}
-  - component: {fileID: 469757472}
+  - component: {fileID: 469757469}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -243,6 +243,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &469757469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 469757466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!81 &469757470
 AudioListener:
   m_ObjectHideFlags: 0
@@ -293,25 +305,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!114 &469757472
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 469757466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &469757473
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -558,16 +551,6 @@ PrefabInstance:
       propertyPath: m_Text
       value: DiagnosticDemoControls.cs
       objectReference: {fileID: 0}
-    - target: {fileID: 114121190672569774, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: '    Toggle Diagnostics'
-      objectReference: {fileID: 0}
-    - target: {fileID: 114186135864427680, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: '    Toggle Profiler'
-      objectReference: {fileID: 0}
     - target: {fileID: 224849082003076088, guid: a900c08743a94c328074df8bbe3eb63c,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -582,6 +565,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0.055
+      objectReference: {fileID: 0}
+    - target: {fileID: 114186135864427680, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: '    Toggle Profiler'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114121190672569774, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: '    Toggle Diagnostics'
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scenes/Glb-Loading-Demo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scenes/Glb-Loading-Demo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -143,6 +143,79 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &732588822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 732588823}
+  - component: {fileID: 732588824}
+  m_Layer: 0
+  m_Name: UIRaycastCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &732588823
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732588822}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1292482201}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &732588824
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732588822}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &907065543
 GameObject:
   m_ObjectHideFlags: 0
@@ -262,7 +335,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 732588823}
   m_Father: {fileID: 553589746}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scenes/Gltf-Loading-Demo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scenes/Gltf-Loading-Demo.unity
@@ -174,7 +174,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1551200070}
   m_Father: {fileID: 218353309}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -397,6 +398,79 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1551200069
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1551200070}
+  - component: {fileID: 1551200071}
+  m_Layer: 0
+  m_Name: UIRaycastCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1551200070
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1551200069}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 290616756}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &1551200071
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1551200069}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &1618579155
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -9178,7 +9178,6 @@ GameObject:
   - component: {fileID: 1087739259}
   - component: {fileID: 1087739258}
   - component: {fileID: 1087739257}
-  - component: {fileID: 1087739262}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -9235,6 +9234,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
 --- !u!114 &1087739259
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9300,25 +9306,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!114 &1087739262
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1087739255}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &1131124965
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionGestureEventsExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionGestureEventsExample.unity
@@ -914,8 +914,8 @@ GameObject:
   - component: {fileID: 1806536909}
   - component: {fileID: 1806536908}
   - component: {fileID: 1806536907}
+  - component: {fileID: 1806536906}
   - component: {fileID: 1806536905}
-  - component: {fileID: 1806536910}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -959,6 +959,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1806536906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1806536903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1806536907
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1024,25 +1036,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!114 &1806536910
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1806536903}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &1830316601
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionUnityUIExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionUnityUIExample.unity
@@ -772,6 +772,11 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114948745459632076, guid: 655521c3560b40f40b75cd30857eae84,
+        type: 3}
+      propertyPath: m_Text
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 114946447199427632, guid: 655521c3560b40f40b75cd30857eae84,
         type: 3}
       propertyPath: m_havePropertiesChanged
@@ -807,11 +812,6 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 114948745459632076, guid: 655521c3560b40f40b75cd30857eae84,
-        type: 3}
-      propertyPath: m_Text
-      value: 
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 655521c3560b40f40b75cd30857eae84, type: 3}
 --- !u!224 &736941836 stripped
@@ -833,8 +833,8 @@ GameObject:
   - component: {fileID: 911672742}
   - component: {fileID: 911672741}
   - component: {fileID: 911672744}
+  - component: {fileID: 911672740}
   - component: {fileID: 911672739}
-  - component: {fileID: 911672745}
   m_Layer: 0
   m_Name: Camera
   m_TagString: MainCamera
@@ -878,6 +878,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &911672740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 911672737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!81 &911672741
 AudioListener:
   m_ObjectHideFlags: 0
@@ -951,25 +963,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &911672745
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 911672737}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &988292642
 GameObject:
   m_ObjectHideFlags: 1

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/HandJointChaserExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/HandJointChaserExample.unity
@@ -2959,7 +2959,7 @@ GameObject:
   - component: {fileID: 1066499001}
   - component: {fileID: 1066499008}
   - component: {fileID: 1066499005}
-  - component: {fileID: 1066499007}
+  - component: {fileID: 1066499006}
   m_Layer: 0
   m_Name: Camera
   m_TagString: MainCamera
@@ -3061,7 +3061,7 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
---- !u!114 &1066499007
+--- !u!114 &1066499006
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3070,16 +3070,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1066499000}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &1066499008
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Scenes/SolverExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Scenes/SolverExamples.unity
@@ -989,7 +989,7 @@ GameObject:
   - component: {fileID: 624307632}
   - component: {fileID: 624307636}
   - component: {fileID: 624307638}
-  - component: {fileID: 624307639}
+  - component: {fileID: 624307637}
   m_Layer: 0
   m_Name: Camera
   m_TagString: MainCamera
@@ -1091,6 +1091,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &624307637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 624307631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &624307638
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1106,25 +1118,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &624307639
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 624307631}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &651759642
 GameObject:
   m_ObjectHideFlags: 0
@@ -2937,12 +2930,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1054075472835142, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 114107642412081004, guid: a900c08743a94c328074df8bbe3eb63c,
         type: 3}
       propertyPath: m_Text
       value: 'Solvers
 
 '
+      objectReference: {fileID: 0}
+    - target: {fileID: 114713125240876806, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: Immersive headset
       objectReference: {fileID: 0}
     - target: {fileID: 114995780653097258, guid: a900c08743a94c328074df8bbe3eb63c,
         type: 3}
@@ -2961,16 +2963,6 @@ PrefabInstance:
         that selected on it. Select the sphere again to deactivate it. You can tap
         on multiple spheres in a row to activate more than one solver at a time.'
       objectReference: {fileID: 0}
-    - target: {fileID: 114713125240876806, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: Immersive headset
-      objectReference: {fileID: 0}
-    - target: {fileID: 114125765304321574, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: How to use
-      objectReference: {fileID: 0}
     - target: {fileID: 224849082003076088, guid: a900c08743a94c328074df8bbe3eb63c,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2981,13 +2973,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -0.021
       objectReference: {fileID: 0}
-    - target: {fileID: 1054075472835142, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1149545904682892, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114125765304321574, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: How to use
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/MaterialGallery.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/MaterialGallery.unity
@@ -6134,7 +6134,7 @@ GameObject:
   - component: {fileID: 1491404207}
   - component: {fileID: 1491404211}
   - component: {fileID: 1491404205}
-  - component: {fileID: 1491404210}
+  - component: {fileID: 1491404206}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -6179,6 +6179,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1491404206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491404203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!81 &1491404207
 AudioListener:
   m_ObjectHideFlags: 0
@@ -6240,25 +6252,6 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!114 &1491404210
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1491404203}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &1491404211
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterialComparison.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterialComparison.unity
@@ -187,7 +187,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -234,13 +233,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -1296,7 +1293,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -1343,13 +1339,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -2038,7 +2032,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -2085,13 +2078,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -2204,7 +2195,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -2251,13 +2241,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -3159,7 +3147,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -3206,13 +3193,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 1
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -3676,7 +3661,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -3723,13 +3707,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -4984,7 +4966,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -5031,13 +5012,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 1
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -5409,7 +5388,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -5456,13 +5434,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -6093,7 +6069,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -6140,13 +6115,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 1
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -7036,7 +7009,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -7083,13 +7055,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -7202,7 +7172,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -7249,13 +7218,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -7368,7 +7335,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -7415,13 +7381,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -7793,7 +7757,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -7840,13 +7803,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -8126,7 +8087,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -8173,13 +8133,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -8849,7 +8807,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -8896,13 +8853,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -9182,7 +9137,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -9229,13 +9183,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 1
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -9440,7 +9392,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -9487,13 +9438,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -10000,7 +9949,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -10047,13 +9995,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -10442,7 +10388,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -10489,13 +10434,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -10867,7 +10810,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -10914,13 +10856,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -11185,7 +11125,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -11232,13 +11171,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -11426,7 +11363,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -11473,13 +11409,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -11667,7 +11601,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -11714,13 +11647,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -12000,7 +11931,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -12047,13 +11977,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -12398,7 +12326,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -12445,13 +12372,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -13050,7 +12975,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -13097,13 +13021,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -13419,7 +13341,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -13466,13 +13387,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 1
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -14018,7 +13937,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -14065,13 +13983,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -14368,7 +14284,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -14415,13 +14330,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -14834,7 +14747,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -14881,13 +14793,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -16269,7 +16179,7 @@ GameObject:
   - component: {fileID: 1491404207}
   - component: {fileID: 1491404205}
   - component: {fileID: 1491404210}
-  - component: {fileID: 1491404211}
+  - component: {fileID: 1491404206}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -16315,6 +16225,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1491404206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491404203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!81 &1491404207
 AudioListener:
   m_ObjectHideFlags: 0
@@ -16391,25 +16313,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &1491404211
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1491404203}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &1499090606
 GameObject:
   m_ObjectHideFlags: 0
@@ -16652,7 +16555,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -16699,13 +16601,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -17399,7 +17299,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -17446,13 +17345,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 1
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -18083,7 +17980,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -18130,13 +18026,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -18249,7 +18143,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -18296,13 +18189,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -18447,7 +18338,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -18494,13 +18384,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -18797,7 +18685,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -18844,13 +18731,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -19055,7 +18940,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -19102,13 +18986,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -19221,7 +19103,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -19268,13 +19149,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.5
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -19976,7 +19855,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -20023,13 +19901,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -21178,7 +21054,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -21225,13 +21100,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -21507,7 +21380,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -21554,13 +21426,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.25
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 0
     - _Refraction: 0
     - _RefractiveIndex: 0
@@ -22484,7 +22354,6 @@ Material:
     - _BlendOp: 0
     - _BorderLight: 0
     - _BorderLightOpaque: 0
-    - _BorderLightOpaqueAlpha: 1
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 0.1
@@ -22531,13 +22400,11 @@ Material:
     - _IridescenceThreshold: 0.05
     - _Metallic: 0.75
     - _Mode: 0
-    - _NearLightFade: 0
     - _NearPlaneFade: 0
     - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _ProximityLight: 0
-    - _ProximityLightTwoSided: 0
     - _Reflections: 1
     - _Refraction: 0
     - _RefractiveIndex: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterials.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterials.unity
@@ -5371,7 +5371,7 @@ GameObject:
   - component: {fileID: 1491404207}
   - component: {fileID: 1491404210}
   - component: {fileID: 1491404205}
-  - component: {fileID: 1491404211}
+  - component: {fileID: 1491404206}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -5416,6 +5416,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1491404206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491404203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!81 &1491404207
 AudioListener:
   m_ObjectHideFlags: 0
@@ -5492,25 +5504,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &1491404211
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1491404203}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1001 &1513985206
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Collections/Scenes/ObjectCollectionExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Collections/Scenes/ObjectCollectionExamples.unity
@@ -1626,6 +1626,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 45
       objectReference: {fileID: 0}
+    - target: {fileID: 1054075472835142, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114186135864427680, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: ClipPlane.cs
+      objectReference: {fileID: 0}
     - target: {fileID: 114107642412081004, guid: a900c08743a94c328074df8bbe3eb63c,
         type: 3}
       propertyPath: m_Text
@@ -1647,25 +1656,6 @@ PrefabInstance:
         items don't display properly\n\u2022 Scatter \u2013 random layout within a
         defined radius"
       objectReference: {fileID: 0}
-    - target: {fileID: 114125765304321574, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: MixedRealityStandard.shader
-      objectReference: {fileID: 0}
-    - target: {fileID: 114121190672569774, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: HoverLight.cs
-      objectReference: {fileID: 0}
-    - target: {fileID: 114186135864427680, guid: a900c08743a94c328074df8bbe3eb63c,
-        type: 3}
-      propertyPath: m_Text
-      value: ClipPlane.cs
-      objectReference: {fileID: 0}
-    - target: {fileID: 1054075472835142, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1149545904682892, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1673,6 +1663,16 @@ PrefabInstance:
     - target: {fileID: 1171793634254456, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114121190672569774, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: HoverLight.cs
+      objectReference: {fileID: 0}
+    - target: {fileID: 114125765304321574, guid: a900c08743a94c328074df8bbe3eb63c,
+        type: 3}
+      propertyPath: m_Text
+      value: MixedRealityStandard.shader
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a900c08743a94c328074df8bbe3eb63c, type: 3}
@@ -5460,7 +5460,7 @@ GameObject:
   - component: {fileID: 1524062330}
   - component: {fileID: 1524062336}
   - component: {fileID: 1524062334}
-  - component: {fileID: 1524062337}
+  - component: {fileID: 1524062335}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -5562,6 +5562,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1524062335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524062329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1524062336
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5577,25 +5589,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &1524062337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1524062329}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &1537287404
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Lines/Scenes/LineExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Lines/Scenes/LineExamples.unity
@@ -216,32 +216,6 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 0
   lineStepCount: 32
-  pointDistributionMode: 1
-  customPointDistributionLength: 0.1
-  customPointDistributionCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 1
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 1
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
   lineMaterial: {fileID: 1720015152}
   roundedEdges: 1
   roundedCaps: 1
@@ -407,7 +381,6 @@ MonoBehaviour:
   - {x: 0, y: 1, z: 0}
   velocitySearchRange: 0.02
   distorters: []
-  distortionEnabled: 1
   distortionMode: 0
   distortionStrength:
     serializedVersion: 2
@@ -837,32 +810,6 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 0
   lineStepCount: 32
-  pointDistributionMode: 1
-  customPointDistributionLength: 0.1
-  customPointDistributionCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 1
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 1
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
   lineMaterial: {fileID: 1189006756}
   roundedEdges: 1
   roundedCaps: 0
@@ -1028,7 +975,6 @@ MonoBehaviour:
   - {x: 0, y: 1, z: 0}
   velocitySearchRange: 0.02
   distorters: []
-  distortionEnabled: 1
   distortionMode: 0
   distortionStrength:
     serializedVersion: 2
@@ -1337,32 +1283,6 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 0
   lineStepCount: 16
-  pointDistributionMode: 1
-  customPointDistributionLength: 0.1
-  customPointDistributionCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 1
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 1
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
   lineMaterial: {fileID: 1734310451}
   roundedEdges: 0
   roundedCaps: 0
@@ -1521,7 +1441,6 @@ MonoBehaviour:
   - {x: 0, y: 1, z: 0}
   velocitySearchRange: 0.02
   distorters: []
-  distortionEnabled: 1
   distortionMode: 0
   distortionStrength:
     serializedVersion: 2
@@ -1549,7 +1468,7 @@ MonoBehaviour:
     m_RotationOrder: 4
   uniformDistortionStrength: 1
   startPoint:
-    position: {x: 0, y: 0, z: -0.000000059604645}
+    position: {x: 0, y: 0, z: 0}
     rotation: {x: 0, y: 0, z: 0, w: 1}
   endPoint:
     position: {x: 1, y: 0, z: 0}
@@ -1846,7 +1765,7 @@ GameObject:
   - component: {fileID: 1524062330}
   - component: {fileID: 1524062336}
   - component: {fileID: 1524062334}
-  - component: {fileID: 1524062337}
+  - component: {fileID: 1524062335}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1948,6 +1867,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &1524062335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1524062329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1524062336
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1963,25 +1894,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &1524062337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1524062329}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1 &1528404276
 GameObject:
   m_ObjectHideFlags: 0
@@ -2509,32 +2421,6 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 1
   lineStepCount: 4
-  pointDistributionMode: 1
-  customPointDistributionLength: 0.1
-  customPointDistributionCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 1
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 1
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
   lineMaterial: {fileID: 204203605}
   roundedEdges: 1
   roundedCaps: 1
@@ -2676,7 +2562,6 @@ MonoBehaviour:
   - {x: 0, y: 1, z: 0}
   velocitySearchRange: 0.02
   distorters: []
-  distortionEnabled: 1
   distortionMode: 0
   distortionStrength:
     serializedVersion: 2
@@ -2760,7 +2645,6 @@ MonoBehaviour:
   - {x: 0, y: 1, z: 0}
   velocitySearchRange: 0.02
   distorters: []
-  distortionEnabled: 1
   distortionMode: 0
   distortionStrength:
     serializedVersion: 2
@@ -2888,32 +2772,6 @@ MonoBehaviour:
   widthOffset: 0
   stepMode: 0
   lineStepCount: 32
-  pointDistributionMode: 1
-  customPointDistributionLength: 0.1
-  customPointDistributionCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 1
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 1
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
   lineMaterial: {fileID: 347146117}
   roundedEdges: 1
   roundedCaps: 1

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity
@@ -714,21 +714,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Pressable Button With Backplate (1)
       objectReference: {fileID: 0}
-    - target: {fileID: 2204069621878992557, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
-        type: 3}
-      propertyPath: m_havePropertiesChanged
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
-        type: 3}
-      propertyPath: m_isInputParsingRequired
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2204069623020599746, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -799,15 +784,20 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 2204069621878992557, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
-      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1761586768}
-    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
-      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: Increment
+      propertyPath: m_havePropertiesChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: m_isInputParsingRequired
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2204069620958546074, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
@@ -815,6 +805,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1761586768}
     - target: {fileID: 2204069620958546074, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Increment
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1761586768}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: Increment
@@ -926,8 +926,8 @@ GameObject:
   - component: {fileID: 534669904}
   - component: {fileID: 534669903}
   - component: {fileID: 534669908}
+  - component: {fileID: 534669907}
   - component: {fileID: 534669906}
-  - component: {fileID: 534669909}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1021,6 +1021,18 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+--- !u!114 &534669907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 534669902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &534669908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1036,25 +1048,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!114 &534669909
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 534669902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!1001 &1119914264
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1647,21 +1640,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Pressable Button With Backplate
       objectReference: {fileID: 0}
-    - target: {fileID: 2204069621878992557, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
-        type: 3}
-      propertyPath: m_havePropertiesChanged
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
-        type: 3}
-      propertyPath: m_isInputParsingRequired
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2204069623020599746, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1732,15 +1710,20 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 2204069621878992557, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
-      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1761586768}
-    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
-      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: Increment
+      propertyPath: m_havePropertiesChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204069621878992595, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: m_isInputParsingRequired
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2204069620958546074, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
@@ -1748,6 +1731,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1761586768}
     - target: {fileID: 2204069620958546074, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Increment
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+        type: 3}
+      propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1761586768}
+    - target: {fileID: 8779034279059886464, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: Increment

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity
@@ -5044,23 +5044,23 @@ MonoBehaviour:
   OnManipulationStarted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Microsoft.MixedReality.Toolkit.UI.ManipulationEvent, Microsoft.MixedReality.Toolkit.SDK,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Microsoft.MixedReality.Toolkit.SDK.Input.Events.ManipulationEvent,
+      Microsoft.MixedReality.Toolkit.SDK, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   OnManipulationEnded:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Microsoft.MixedReality.Toolkit.UI.ManipulationEvent, Microsoft.MixedReality.Toolkit.SDK,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Microsoft.MixedReality.Toolkit.SDK.Input.Events.ManipulationEvent,
+      Microsoft.MixedReality.Toolkit.SDK, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   OnHoverEntered:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Microsoft.MixedReality.Toolkit.UI.ManipulationEvent, Microsoft.MixedReality.Toolkit.SDK,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Microsoft.MixedReality.Toolkit.SDK.Input.Events.ManipulationEvent,
+      Microsoft.MixedReality.Toolkit.SDK, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   OnHoverExited:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Microsoft.MixedReality.Toolkit.UI.ManipulationEvent, Microsoft.MixedReality.Toolkit.SDK,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Microsoft.MixedReality.Toolkit.SDK.Input.Events.ManipulationEvent,
+      Microsoft.MixedReality.Toolkit.SDK, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!65 &836834072
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -8670,7 +8670,7 @@ GameObject:
   - component: {fileID: 1524062330}
   - component: {fileID: 1524062334}
   - component: {fileID: 1524062337}
-  - component: {fileID: 1524062336}
+  - component: {fileID: 1524062335}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -8772,7 +8772,7 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
---- !u!114 &1524062336
+--- !u!114 &1524062335
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8781,16 +8781,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1524062329}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &1524062337
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Scenes/InspectorFieldsExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Scenes/InspectorFieldsExamples.unity
@@ -295,7 +295,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 0}
+  m_Camera: {fileID: 409268363}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -306,6 +306,79 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1 &409268359
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 409268360}
+  - component: {fileID: 409268363}
+  m_Layer: 0
+  m_Name: UIRaycastCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &409268360
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409268359}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1428889684}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &409268363
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409268359}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 3
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 0.5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 1
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
 --- !u!1 &817150417
 GameObject:
   m_ObjectHideFlags: 0
@@ -906,7 +979,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 409268360}
   m_Father: {fileID: 1386039203}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -344,6 +344,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnPostSceneQuery() { }
 
+        ///  <inheritdoc />
+        public virtual void OnCurrentPointerTargetAboutToChange() { }
+
         #endregion IMixedRealityPointer Implementation
 
         #region IEquality Implementation

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -345,7 +345,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public virtual void OnPostSceneQuery() { }
 
         ///  <inheritdoc />
-        public virtual void OnCurrentPointerTargetAboutToChange() { }
+        public virtual void OnPreCurrentPointerTargetChange() { }
 
         #endregion IMixedRealityPointer Implementation
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -169,6 +169,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Rays[0].UpdateRayStep(ref newGazeOrigin, ref endPoint);
         }
 
+        public void OnCurrentPointerTargetAboutToChange()
+        {
+        }
+
         /// <inheritdoc />
         public virtual Vector3 Position
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Rays[0].UpdateRayStep(ref newGazeOrigin, ref endPoint);
         }
 
-        public void OnCurrentPointerTargetAboutToChange()
+        public void OnPreCurrentPointerTargetChange()
         {
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private float closestDistance = 0.0f;
 
         // The closest touchable component limits the set of objects which are currently touchable.
-        // These are all the game objects in the subtree of the clostest touchable component's owner object.
+        // These are all the game objects in the subtree of the closest touchable component's owner object.
         private NearInteractionTouchable closestProximityTouchable = null;
         // The current object that is being touched. We need to make sure to consistently fire 
         // poke-down / poke-up events for this object. This is also the case when the object within

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        public override void OnCurrentPointerTargetAboutToChange()
+        public override void OnPreCurrentPointerTargetChange()
         {
             if (currentTouchableObjectDown != null)
             {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -134,6 +134,75 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private Vector3 newUiRaycastPosition = Vector3.zero;
 
+        /// <summary>
+        /// Helper class for storing intermediate hit results. Should be applied to the PointerData once all
+        /// possible hits of a pointer have been processed.
+        /// </summary>
+        private class PointerHitResult
+        {
+            public RaycastHit raycastHit;
+            public RaycastResult graphicsRaycastResult;
+
+            public GameObject hitObject;
+            public Vector3 hitPointOnObject = Vector3.zero;
+            public Vector3 hitNormalOnObject = Vector3.zero;
+
+            public RayStep ray;
+            public int rayStepIndex;
+            public float rayDistance;
+
+            /// <summary>
+            /// Set hit focus information from a closest-colliders-to pointer check.
+            /// </summary>
+            public void Set(GameObject hitObject, in Vector3 hitPointOnObject, in Vector4 hitNormalOnObject, in RayStep ray, int rayStepIndex, float rayDistance)
+            {
+                raycastHit = default(RaycastHit);
+                graphicsRaycastResult = default(RaycastResult);
+
+                this.hitObject = hitObject;
+                this.hitPointOnObject = hitPointOnObject;
+                this.hitNormalOnObject = hitNormalOnObject;
+
+                this.ray = ray;
+                this.rayStepIndex = rayStepIndex;
+                this.rayDistance = rayDistance;
+            }
+
+            /// <summary>
+            /// Set hit focus information from a physics raycast.
+            /// </summary>
+            public void Set(in RaycastHit hit, in RayStep ray, int rayStepIndex, float rayDistance)
+            {
+                raycastHit = hit;
+                graphicsRaycastResult = default(RaycastResult);
+
+                hitObject = hit.transform.gameObject;
+                hitPointOnObject = hit.point;
+                hitNormalOnObject = hit.normal;
+
+                this.ray = ray;
+                this.rayStepIndex = rayStepIndex;
+                this.rayDistance = rayDistance;
+            }
+
+            /// <summary>
+            /// Set hit information from a canvas raycast.
+            /// </summary>
+            public void Set(in RaycastResult result, in Vector3 hitPointOnObject, in Vector4 hitNormalOnObject, in RayStep ray, int rayStepIndex, float rayDistance)
+            {
+                raycastHit = default(RaycastHit);
+                graphicsRaycastResult = result;
+
+                this.hitObject = result.gameObject;
+                this.hitPointOnObject = hitPointOnObject;
+                this.hitNormalOnObject = hitNormalOnObject;
+
+                this.ray = ray;
+                this.rayStepIndex = rayStepIndex;
+                this.rayDistance = rayDistance;
+            }
+        }
+
         [Serializable]
         private class PointerData : IPointerResult, IEquatable<PointerData>
         {
@@ -174,130 +243,67 @@ namespace Microsoft.MixedReality.Toolkit.Input
             private PointerEventData graphicData;
 
             private FocusDetails focusDetails = new FocusDetails();
-            private bool pointerWasLocked;
 
             public PointerData(IMixedRealityPointer pointer)
             {
                 Pointer = pointer;
             }
 
-            /// <summary>
-            /// Update focus information from a closest-colliders-to pointer check
-            /// </summary>
-            public void UpdateHit(GameObject hitObject, RayStep sourceRay, int rayStepIndex, float rayDistance, Vector3 hitPointOnObject)
+            public void UpdateHit(PointerHitResult hitResult)
             {
-                RayStepIndex = rayStepIndex;
-                StartPoint = sourceRay.Origin;
-
-                focusDetails.RayDistance = rayDistance;
-                focusDetails.Object = hitObject;
-                focusDetails.Point = hitPointOnObject;
-                if (hitObject != null)
+                if (hitResult.hitObject != CurrentPointerTarget)
                 {
-                    focusDetails.PointLocalSpace = hitObject.transform.InverseTransformPoint(hitPointOnObject);
+                    Pointer.OnCurrentPointerTargetAboutToChange();
+                }
+
+                PreviousPointerTarget = CurrentPointerTarget;
+
+                if (hitResult.hitObject != null)
+                {
+                    RayStepIndex = hitResult.rayStepIndex;
+                    StartPoint = hitResult.ray.Origin;
+
+                    focusDetails.LastRaycastHit = hitResult.raycastHit;
+                    focusDetails.LastGraphicsRaycastResult = hitResult.graphicsRaycastResult;
+                    focusDetails.Object = hitResult.hitObject;
+                    focusDetails.RayDistance = hitResult.rayDistance;
+                    focusDetails.Point = hitResult.hitPointOnObject;
+                    focusDetails.Normal = hitResult.hitNormalOnObject;
+                    focusDetails.PointLocalSpace = hitResult.hitObject.transform.InverseTransformPoint(focusDetails.Point);
+                    focusDetails.NormalLocalSpace = hitResult.hitObject.transform.InverseTransformPoint(focusDetails.Normal);
                 }
                 else
                 {
+                    RayStep firstStep = Pointer.Rays[0];
+                    RayStep finalStep = Pointer.Rays[Pointer.Rays.Length - 1];
+                    RayStepIndex = 0;
+
+                    StartPoint = firstStep.Origin;
+
+                    float rayDist = 0.0f;
+                    for (int i = 0; i < Pointer.Rays.Length; i++)
+                    {
+                        rayDist += Pointer.Rays[i].Length;
+                    }
+
+                    focusDetails.LastRaycastHit = default(RaycastHit);
+                    focusDetails.LastGraphicsRaycastResult = default(RaycastResult);
+                    focusDetails.Object = null;
+                    focusDetails.RayDistance = rayDist;
+                    focusDetails.Point = finalStep.Terminus;
+                    focusDetails.Normal = -finalStep.Direction;
                     focusDetails.PointLocalSpace = Vector3.zero;
+                    focusDetails.NormalLocalSpace = Vector3.zero;
                 }
-                // TODO: compute normal of hit point closest to the pointer
-                focusDetails.NormalLocalSpace = Vector3.zero;
-                focusDetails.Normal = Vector3.zero;
             }
-
-            /// <summary>
-            /// Update focus information from a physics raycast
-            /// </summary>
-            public void UpdateHit(RaycastHit hit, RayStep sourceRay, int rayStepIndex, float rayDistance)
-            {
-                RayStepIndex = rayStepIndex;
-                StartPoint = sourceRay.Origin;
-
-                focusDetails.LastRaycastHit = hit;
-                focusDetails.Point = hit.point;
-                focusDetails.Normal = hit.normal;
-                focusDetails.RayDistance = rayDistance;
-
-                Debug.Assert(hit.transform != null);
-                focusDetails.Object = hit.transform.gameObject;
-                focusDetails.PointLocalSpace = hit.transform.InverseTransformPoint(hit.point);
-                focusDetails.NormalLocalSpace = hit.transform.InverseTransformDirection(hit.normal);
-
-                pointerWasLocked = false;
-            }
-
-            /// <summary>
-            /// Update focus information from a Canvas raycast 
-            /// </summary>
-            public void UpdateHit(RaycastResult result, RaycastHit hit, RayStep sourceRay, int rayStepIndex, float rayDistance)
-            {
-                RayStepIndex = rayStepIndex;
-                StartPoint = sourceRay.Origin;
-
-                focusDetails.LastGraphicsRaycastResult = result;
-                focusDetails.Point = hit.point;
-                focusDetails.RayDistance = rayDistance;
-                focusDetails.Normal = hit.normal;
-                focusDetails.Object = result.gameObject;
-                focusDetails.PointLocalSpace = result.gameObject.transform.InverseTransformPoint(hit.point);
-                focusDetails.NormalLocalSpace = result.gameObject.transform.InverseTransformDirection(hit.normal);
-            }
-
-            public void UpdateHit()
-            {
-                PreviousPointerTarget = Details.Object;
-
-                RayStep firstStep = Pointer.Rays[0];
-                RayStep finalStep = Pointer.Rays[Pointer.Rays.Length - 1];
-                RayStepIndex = 0;
-
-                StartPoint = firstStep.Origin;
-
-                focusDetails.Point = finalStep.Terminus;
-                focusDetails.Normal = -finalStep.Direction;
-                focusDetails.Object = null;
-
-                pointerWasLocked = false;
-            }
-
-            public void ClearHits()
-            {
-                PreviousPointerTarget = Details.Object;
-
-                RayStep firstStep = Pointer.Rays[0];
-                RayStep finalStep = Pointer.Rays[Pointer.Rays.Length - 1];
-                RayStepIndex = 0;
-
-                StartPoint = firstStep.Origin;
-
-                float rayDist = 0;
-                for (int i = 0; i < Pointer.Rays.Length; i++)
-                {
-                    rayDist += Pointer.Rays[i].Length;
-                }
-
-                focusDetails.LastGraphicsRaycastResult = new RaycastResult();
-                focusDetails.Point = finalStep.Terminus;
-                focusDetails.Normal = -finalStep.Direction;
-                focusDetails.RayDistance = rayDist;
-                focusDetails.Object = null;
-                focusDetails.NormalLocalSpace = Vector3.zero;
-                focusDetails.PointLocalSpace = Vector3.zero;
-
-                pointerWasLocked = false;
-            }
-
+            
             /// <summary>
             /// Update focus information while focus is locked. If the object is moving,
             /// this updates the hit point to its new world transform.
             /// </summary>
             public void UpdateFocusLockedHit()
             {
-                if (!pointerWasLocked)
-                {
-                    PreviousPointerTarget = focusDetails.Object;
-                    pointerWasLocked = true;
-                }
+                PreviousPointerTarget = focusDetails.Object;
 
                 if (focusDetails.Object != null && focusDetails.Object.transform != null)
                 {
@@ -306,7 +312,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     focusDetails.Normal = focusDetails.Object.transform.TransformDirection(focusDetails.NormalLocalSpace);
                 }
 
-                StartPoint = Pointer.Rays[0].Origin;                
+                StartPoint = Pointer.Rays[0].Origin;
 
                 for (int i = 0; i < Pointer.Rays.Length; i++)
                 {
@@ -321,6 +327,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             public void ResetFocusedObjects(bool clearPreviousObject = true)
             {
+                if (focusDetails.Object != null)
+                {
+                    Pointer.OnCurrentPointerTargetAboutToChange();
+                }
+
                 PreviousPointerTarget = clearPreviousObject ? null : CurrentPointerTarget;
 
                 focusDetails.Point = Details.Point;
@@ -594,9 +605,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (!objectIsStillFocusedByOtherPointer)
                 {
                     // Policy: only raise focus exit if no other pointers are still focusing the object
-                    MixedRealityToolkit.InputSystem.RaiseFocusExit(pointer, unfocusedObject);
+                    MixedRealityToolkit.InputSystem?.RaiseFocusExit(pointer, unfocusedObject);
                 }
-                MixedRealityToolkit.InputSystem.RaisePreFocusChanged(pointer, unfocusedObject, null);
+                MixedRealityToolkit.InputSystem?.RaisePreFocusChanged(pointer, unfocusedObject, null);
             }
 
             pointers.Remove(pointerData);
@@ -704,18 +715,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // Otherwise, continue
                     LayerMask[] prioritizedLayerMasks = (pointer.Pointer.PrioritizedLayerMasksOverride ?? FocusLayerMasks);
 
-                    // Clear the hit
-                    pointer.ClearHits();
-
                     // Perform raycast to determine focused object
-                    QueryScene(pointer, prioritizedLayerMasks);
+                    PointerHitResult hit = new PointerHitResult(); // TODO: cache and clear
+                    QueryScene(pointer.Pointer, prioritizedLayerMasks, hit);
 
                     // If we have a unity event system, perform graphics raycasts as well to support Unity UI interactions
                     if (EventSystem.current != null)
                     {
                         // NOTE: We need to do this AFTER RaycastPhysics so we use the current hit point to perform the correct 2D UI Raycast.
-                        RaycastGraphics(pointer, prioritizedLayerMasks);
+                        PointerHitResult hitUi = new PointerHitResult();
+                        RaycastGraphics(pointer.Pointer, pointer.GraphicEventData, prioritizedLayerMasks, hitUi);
+
+                        hit = GetPrioritizedHitResult(hit, hitUi, prioritizedLayerMasks);
                     }
+
+                    // Apply the hit result only now so changes in the current target are detected only once per frame.
+                    pointer.UpdateHit(hit);
 
                     // Set the pointer's result last
                     pointer.Pointer.Result = pointer;
@@ -726,10 +741,34 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            // Call the pointer's OnPostSceneQuery function
+            // Call the pointer's OnPostSceneQuery function.
             // This will give it a chance to respond to raycast results
-            // e.g., by updating its appearance
+            // e.g., by updating its appearance.
             pointer.Pointer.OnPostSceneQuery();
+        }
+
+        PointerHitResult GetPrioritizedHitResult(PointerHitResult hit1, PointerHitResult hit2, LayerMask[] prioritizedLayerMasks)
+        {
+            if (hit1.hitObject != null && hit2.hitObject != null)
+            {
+                // Check layer prioritization.
+                if (prioritizedLayerMasks.Length > 1)
+                {
+                    // Get the index in the prioritized layer masks
+                    int layerIndex1 = hit1.hitObject.layer.FindLayerListIndex(prioritizedLayerMasks);
+                    int layerIndex2 = hit2.hitObject.layer.FindLayerListIndex(prioritizedLayerMasks);
+
+                    if (layerIndex1 != layerIndex2)
+                    {
+                        return (layerIndex1 < layerIndex2) ? hit1 : hit2;
+                    }
+                }
+
+                // Check which hit is closer.
+                return (hit1.rayDistance < hit2.rayDistance) ? hit1 : hit2;
+            }
+
+            return (hit1.hitObject != null) ? hit1 : hit2;
         }
 
         /// <summary>
@@ -772,33 +811,33 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         /// <param name="pointerData"></param>
         /// <param name="prioritizedLayerMasks"></param>
-        private static void QueryScene(PointerData pointerData, LayerMask[] prioritizedLayerMasks)
+        private static void QueryScene(IMixedRealityPointer pointer, LayerMask[] prioritizedLayerMasks, PointerHitResult hit)
         {
             float rayStartDistance = 0;
             RaycastHit physicsHit;
-            RayStep[] pointerRays = pointerData.Pointer.Rays;
+            RayStep[] pointerRays = pointer.Rays;
 
             if (pointerRays == null)
             {
-                Debug.LogError($"No valid rays for {pointerData.Pointer.PointerName} pointer.");
+                Debug.LogError($"No valid rays for {pointer.PointerName} pointer.");
                 return;
             }
 
             if (pointerRays.Length <= 0)
             {
-                Debug.LogError($"No valid rays for {pointerData.Pointer.PointerName} pointer");
+                Debug.LogError($"No valid rays for {pointer.PointerName} pointer");
                 return;
             }
 
             // Perform query for each step in the pointing source
             for (int i = 0; i < pointerRays.Length; i++)
             {
-                switch (pointerData.Pointer.SceneQueryType)
+                switch (pointer.SceneQueryType)
                 {
                     case SceneQueryType.SimpleRaycast:
                         if (MixedRealityRaycaster.RaycastSimplePhysicsStep(pointerRays[i], prioritizedLayerMasks, out physicsHit))
                         {
-                            UpdatePointerRayOnHit(pointerData, pointerRays, physicsHit, i, rayStartDistance);
+                            UpdatePointerRayOnHit(pointerRays, physicsHit, i, rayStartDistance, hit);
                             return;
                         }
                         break;
@@ -806,18 +845,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         Debug.LogWarning("Box Raycasting Mode not supported for pointers.");
                         break;
                     case SceneQueryType.SphereCast:
-                        if (MixedRealityRaycaster.RaycastSpherePhysicsStep(pointerRays[i], pointerData.Pointer.SphereCastRadius, prioritizedLayerMasks, out physicsHit))
+                        if (MixedRealityRaycaster.RaycastSpherePhysicsStep(pointerRays[i], pointer.SphereCastRadius, prioritizedLayerMasks, out physicsHit))
                         {
-                            UpdatePointerRayOnHit(pointerData, pointerRays, physicsHit, i, rayStartDistance);
+                            UpdatePointerRayOnHit(pointerRays, physicsHit, i, rayStartDistance, hit);
                             return;
                         }
                         break;
                     case SceneQueryType.SphereOverlap:
-                        Collider[] colliders = UnityEngine.Physics.OverlapSphere(pointerData.Pointer.Rays[i].Origin, pointerData.Pointer.SphereCastRadius, ~UnityEngine.Physics.IgnoreRaycastLayer);
+                        Collider[] colliders = UnityEngine.Physics.OverlapSphere(pointer.Rays[i].Origin, pointer.SphereCastRadius, ~UnityEngine.Physics.IgnoreRaycastLayer);
 
                         if (colliders.Length > 0)
                         {
-                            Vector3 testPoint = pointerData.Pointer.Rays[i].Origin;
+                            Vector3 testPoint = pointer.Rays[i].Origin;
                             GameObject closest = null;
                             float closestDistance = Mathf.Infinity;
                             Vector3 objectHitPoint = testPoint;
@@ -825,7 +864,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             foreach (Collider collider in colliders)
                             {
                                 // Policy: in order for an collider to be near interactable it must have
-                                // a NearIneractionGrabbable component on it
+                                // a NearInteractionGrabbable component on it.
+                                // FIXME: This is assuming only the grab pointer is using SceneQueryType.SphereOverlap. 
                                 if (collider.GetComponent<NearInteractionGrabbable>() == null)
                                 {
                                     continue;
@@ -841,25 +881,28 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                     objectHitPoint = closestPointToCollider;
                                 }
                             }
-                            pointerData.UpdateHit(closest, pointerData.Pointer.Rays[i], 0, closestDistance, objectHitPoint);
-                            return;
+                            if (closest != null)
+                            {
+                                hit.Set(closest, objectHitPoint, Vector3.zero, pointer.Rays[i], 0, closestDistance);
+                                return;
+                            }
                         }
                         break;
                     default:
-                        Debug.LogError($"Invalid raycast mode {pointerData.Pointer.SceneQueryType} for {pointerData.Pointer.PointerName} pointer.");
+                        Debug.LogError($"Invalid raycast mode {pointer.SceneQueryType} for {pointer.PointerName} pointer.");
                         break;
                 }
 
-                rayStartDistance += pointerData.Pointer.Rays[i].Length;
+                rayStartDistance += pointer.Rays[i].Length;
             }
         }
 
-        private static void UpdatePointerRayOnHit(PointerData pointerData, RayStep[] raySteps, RaycastHit physicsHit, int hitRayIndex, float rayStartDistance)
+        private static void UpdatePointerRayOnHit(RayStep[] raySteps, RaycastHit physicsHit, int hitRayIndex, float rayStartDistance, PointerHitResult hit)
         {
             Vector3 origin = raySteps[hitRayIndex].Origin;
             Vector3 terminus = physicsHit.point;
             raySteps[hitRayIndex].UpdateRayStep(ref origin, ref terminus);
-            pointerData.UpdateHit(physicsHit, raySteps[hitRayIndex], hitRayIndex, rayStartDistance + physicsHit.distance);
+            hit.Set(physicsHit, raySteps[hitRayIndex], hitRayIndex, rayStartDistance + physicsHit.distance);
         }
 
         #endregion Physics Raycasting
@@ -867,98 +910,59 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #region uGUI Graphics Raycasting
 
         /// <summary>
-        /// Perform a Unity Graphics Raycast to determine which uGUI element is currently being gazed at, if any.
+        /// Perform a Unity Graphics Raycast to determine which uGUI element is currently being pointed at, if any.
         /// </summary>
-        /// <param name="pointerData"></param>
-        /// <param name="prioritizedLayerMasks"></param>
-        private void RaycastGraphics(PointerData pointerData, LayerMask[] prioritizedLayerMasks)
+        private void RaycastGraphics(IMixedRealityPointer pointer, PointerEventData graphicEventData, LayerMask[] prioritizedLayerMasks, PointerHitResult hit)
         {
             Debug.Assert(UIRaycastCamera != null, "Missing UIRaycastCamera!");
 
             RaycastResult raycastResult = default(RaycastResult);
-            bool overridePhysicsRaycast = false;
-            RayStep rayStep = default(RayStep);
-            int rayStepIndex = 0;
 
-            if (pointerData.Pointer.Rays == null)
+            if (pointer.Rays == null)
             {
-                Debug.LogError($"No valid rays for {pointerData.Pointer.PointerName} pointer.");
+                Debug.LogError($"No valid rays for {pointer.PointerName} pointer.");
                 return;
             }
 
-            if (pointerData.Pointer.Rays.Length <= 0)
+            if (pointer.Rays.Length <= 0)
             {
-                Debug.LogError($"No valid rays for {pointerData.Pointer.PointerName} pointer");
+                Debug.LogError($"No valid rays for {pointer.PointerName} pointer");
                 return;
             }
 
             // Cast rays for every step until we score a hit
-            float totalDistance = 0;
-            for (int i = 0; i < pointerData.Pointer.Rays.Length; i++)
+            float totalDistance = 0.0f;
+            for (int i = 0; i < pointer.Rays.Length; i++)
             {
-                if (RaycastGraphicsStep(pointerData, pointerData.Pointer.Rays[i], prioritizedLayerMasks, out overridePhysicsRaycast, out raycastResult))
+                if (RaycastGraphicsStep(graphicEventData, pointer.Rays[i], prioritizedLayerMasks, out raycastResult))
                 {
-                    if (raycastResult.distance < pointerData.Pointer.Rays[i].Length)
+                    if (raycastResult.isValid &&
+                        raycastResult.distance < pointer.Rays[i].Length &&
+                        raycastResult.module != null &&
+                        raycastResult.module.eventCamera == UIRaycastCamera)
                     {
                         totalDistance += raycastResult.distance;
 
-                        rayStepIndex = i;
-                        rayStep = pointerData.Pointer.Rays[i];
-                        break;
-                    }
-                    else
-                    {
-                        // Hit, but need to terminate graphics raycasts based on distance.  Reset RaycastResult
-                        raycastResult = default(RaycastResult);
-                    }
+                        newUiRaycastPosition.x = raycastResult.screenPosition.x;
+                        newUiRaycastPosition.y = raycastResult.screenPosition.y;
+                        newUiRaycastPosition.z = raycastResult.distance;
 
-                    totalDistance += pointerData.Pointer.Rays[i].Length;
+                        Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
+                        Vector3 normal = -raycastResult.gameObject.transform.forward;
 
-                    if (totalDistance > pointerData.Details.RayDistance)
-                    {
-                        break;
+                        hit.Set(raycastResult, worldPos, normal, pointer.Rays[i], i, totalDistance);
+                        return;
                     }
                 }
-            }
 
-            if (totalDistance > pointerData.Details.RayDistance)
-            {
-                // Hit, but farther than last hit.  Reset RaycastResult
-                raycastResult = default(RaycastResult);
-            }
-
-            // Check if we need to overwrite the physics raycast info
-            if ((pointerData.CurrentPointerTarget == null || overridePhysicsRaycast) &&
-                raycastResult.isValid &&
-                raycastResult.module != null &&
-                raycastResult.module.eventCamera == UIRaycastCamera)
-            {
-                newUiRaycastPosition.x = raycastResult.screenPosition.x;
-                newUiRaycastPosition.y = raycastResult.screenPosition.y;
-                newUiRaycastPosition.z = raycastResult.distance;
-
-                Vector3 worldPos = UIRaycastCamera.ScreenToWorldPoint(newUiRaycastPosition);
-
-                var hitInfo = new RaycastHit
-                {
-                    point = worldPos,
-                    normal = -raycastResult.gameObject.transform.forward
-                };
-
-                pointerData.UpdateHit(raycastResult, hitInfo, rayStep, rayStepIndex, totalDistance);
+                totalDistance += pointer.Rays[i].Length;
             }
         }
 
         /// <summary>
-        /// Raycasts each graphic <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>
+        /// Raycasts a single graphic <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>
         /// </summary>
-        /// <param name="pointerData"></param>
-        /// <param name="step"></param>
-        /// <param name="prioritizedLayerMasks"></param>
-        /// <param name="overridePhysicsRaycast"></param>
-        /// <param name="uiRaycastResult"></param>
-        /// <returns></returns>
-        private bool RaycastGraphicsStep(PointerData pointerData, RayStep step, LayerMask[] prioritizedLayerMasks, out bool overridePhysicsRaycast, out RaycastResult uiRaycastResult)
+        private bool RaycastGraphicsStep(PointerEventData graphicEventData, RayStep step, LayerMask[] prioritizedLayerMasks, out RaycastResult uiRaycastResult)
         {
             Debug.Assert(step.Direction != Vector3.zero, "RayStep Direction is Invalid.");
 
@@ -967,57 +971,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             UIRaycastCamera.transform.rotation = Quaternion.LookRotation(step.Direction, Vector3.up);
 
             // We always raycast from the center of the camera.
-            pointerData.GraphicEventData.position = new Vector2(UIRaycastCamera.pixelWidth * 0.5f, UIRaycastCamera.pixelHeight * 0.5f);
+            graphicEventData.position = new Vector2(UIRaycastCamera.pixelWidth * 0.5f, UIRaycastCamera.pixelHeight * 0.5f);
 
             // Graphics raycast
-            uiRaycastResult = EventSystem.current.Raycast(pointerData.GraphicEventData, prioritizedLayerMasks);
-            pointerData.GraphicEventData.pointerCurrentRaycast = uiRaycastResult;
+            uiRaycastResult = EventSystem.current.Raycast(graphicEventData, prioritizedLayerMasks);
+            graphicEventData.pointerCurrentRaycast = uiRaycastResult;
 
-            overridePhysicsRaycast = false;
-
-            // If we have a raycast result, check if we need to overwrite the physics raycast info
-            if (uiRaycastResult.gameObject != null)
-            {
-                if (pointerData.CurrentPointerTarget != null)
-                {
-                    float distance = 0f;
-                    for (int i = 0; i <= pointerData.RayStepIndex; i++)
-                    {
-                        distance += pointerData.Pointer.Rays[i].Length;
-                    }
-
-                    // Check layer prioritization
-                    if (prioritizedLayerMasks.Length > 1)
-                    {
-                        // Get the index in the prioritized layer masks
-                        int uiLayerIndex = uiRaycastResult.gameObject.layer.FindLayerListIndex(prioritizedLayerMasks);
-                        int threeDLayerIndex = pointerData.Details.LastRaycastHit.collider.gameObject.layer.FindLayerListIndex(prioritizedLayerMasks);
-
-                        if (threeDLayerIndex > uiLayerIndex)
-                        {
-                            overridePhysicsRaycast = true;
-                        }
-                        else if (threeDLayerIndex == uiLayerIndex)
-                        {
-                            if (distance > uiRaycastResult.distance)
-                            {
-                                overridePhysicsRaycast = true;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (distance > uiRaycastResult.distance)
-                        {
-                            overridePhysicsRaycast = true;
-                        }
-                    }
-                }
-                // If we've hit something, no need to go further
-                return true;
-            }
-            // If we haven't hit something, keep going
-            return false;
+            return (uiRaycastCamera.gameObject != null);
         }
 
         #endregion uGUI Graphics Raycasting

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -257,7 +257,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            public override void OnCurrentPointerTargetAboutToChange()
+            public override void OnPreCurrentPointerTargetChange()
             {
             }
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -257,6 +257,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
+            public override void OnCurrentPointerTargetAboutToChange()
+            {
+            }
+
             /// <inheritdoc />
             public override Vector3 Position
             {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c9877a3079e968a4e97a2b371a0df9de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityInputModuleInspector.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityInputModuleInspector.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    [UnityEditor.CustomEditor(typeof(MixedRealityInputModule))]
+    public class MixedRealityInputModuleEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            MixedRealityInputModule inputModule = (MixedRealityInputModule)target;
+            if (Application.isPlaying && inputModule.RaycastCamera != null)
+            {
+                foreach (var pointer in inputModule.ActiveMixedRealityPointers)
+                {
+                    if (pointer.Rays != null && pointer.Rays.Length > 0)
+                    {
+                        inputModule.RaycastCamera.transform.position = pointer.Rays[0].Origin;
+                        inputModule.RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction, Vector3.up);
+
+                        inputModule.RaycastCamera.Render();
+
+                        GUILayout.Label(pointer.PointerName);
+                        GUILayout.Label(pointer.ToString());
+                        GUILayout.Label(pointer.PointerId.ToString());
+                        GUILayout.Label(inputModule.RaycastCamera.targetTexture);
+                    }
+                }
+            }
+        }
+
+        public override bool RequiresConstantRepaint()
+        {
+            MixedRealityInputModule inputModule = (MixedRealityInputModule)target;
+            if (Application.isPlaying && inputModule.RaycastCamera != null)
+            {
+                return true;
+            }
+
+            return base.RequiresConstantRepaint();
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityInputModuleInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityInputModuleInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 732a086bd5e619443baf1720542c1b70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityToolkit.Services.Inspectors.asmdef
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityToolkit.Services.Inspectors.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "Microsoft.MixedReality.Toolkit.Services.InputSystem.Inspectors",
+    "references": [
+        "Microsoft.MixedReality.Toolkit",
+        "Microsoft.MixedReality.Toolkit.Services.InputSystem"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityToolkit.Services.Inspectors.asmdef.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityToolkit.Services.Inspectors.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8eb5c41a66d79584997ac78c84bd18fb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -1,0 +1,317 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    [RequireComponent(typeof(Camera))]
+    public class MixedRealityInputModule : StandaloneInputModule, IMixedRealityPointerHandler, IMixedRealitySourceStateHandler
+    {
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(MixedRealityInputModule))]
+        public class Editor : UnityEditor.Editor
+        {
+            public override void OnInspectorGUI()
+            {
+                MixedRealityInputModule t = (MixedRealityInputModule)target;
+
+                base.OnInspectorGUI();
+
+                if (Application.isPlaying && t.RaycastCamera != null)
+                {
+                    foreach (var pointerData in t.pointerDataToUpdate)
+                    {
+                        IMixedRealityPointer pointer = pointerData.Value.pointer;
+                        if (pointer.Rays != null && pointer.Rays.Length > 0)
+                        {
+                            t.RaycastCamera.transform.position = pointer.Rays[0].Origin;
+                            t.RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction, Vector3.up);
+
+                            t.RaycastCamera.Render();
+
+                            GUILayout.Label(pointer.PointerName);
+                            GUILayout.Label(pointer.ToString());
+                            GUILayout.Label(pointer.PointerId.ToString());
+                            GUILayout.Label(t.RaycastCamera.targetTexture);
+                        }
+                    }
+                }
+            }
+
+            public override bool RequiresConstantRepaint()
+            {
+                return true;
+            }
+        }
+#endif
+
+        // TODO: Make sure Unity UI input capturing participates in MRTK focus locking correctly.
+        // TODO: Consider simulating touch events rather than mouse events for PokePointer. What are the tradeoffs?
+
+        protected class PointerData
+        {
+            public IMixedRealityPointer pointer;
+
+            public Vector3? lastMousePoint3d = null; // Last position of the pointer for the input in 3D.
+            public PointerEventData.FramePressState nextClickState = PointerEventData.FramePressState.NotChanged;
+
+            public MouseState mouseState = new MouseState();
+            public PointerEventData eventDataLeft;
+            public PointerEventData eventDataMiddle; // Middle and right are placeholders to simulate mouse input.
+            public PointerEventData eventDataRight;
+
+            public PointerData(IMixedRealityPointer pointer, EventSystem eventSystem)
+            {
+                this.pointer = pointer;
+                eventDataLeft = new PointerEventData(eventSystem);
+                eventDataMiddle = new PointerEventData(eventSystem);
+                eventDataRight = new PointerEventData(eventSystem);
+            }
+        }
+
+        /// <summary>
+        /// Mapping from pointer id to event data and click state
+        /// </summary>
+        protected readonly Dictionary<int, PointerData> pointerDataToUpdate = new Dictionary<int, PointerData>();
+
+        /// <summary>
+        /// List of pointers that need one last frame of updates to remove
+        /// </summary>
+        protected readonly List<PointerData> pointerDataToRemove = new List<PointerData>();
+
+        protected Camera RaycastCamera { get; private set; }
+
+        public override void ActivateModule()
+        {
+            base.ActivateModule();
+
+            RaycastCamera = MixedRealityToolkit.InputSystem?.FocusProvider.UIRaycastCamera;
+
+            MixedRealityToolkit.InputSystem?.Register(gameObject);
+        }
+
+        public override void DeactivateModule()
+        {
+            MixedRealityToolkit.InputSystem?.Unregister(gameObject);
+
+            RaycastCamera = null;
+
+            base.DeactivateModule();
+        }
+
+        public override bool ShouldActivateModule()
+        {
+            return pointerDataToUpdate.Count > 0 || pointerDataToRemove.Count > 0 || base.ShouldActivateModule();
+        }
+
+        /// <summary>
+        /// Process the active pointers from MixedRealityInputManager and all other Unity input.
+        /// </summary>
+        public override void Process()
+        {
+            CursorLockMode cursorLockStateBackup = Cursor.lockState;
+
+            try
+            {
+                // Disable cursor lock for MRTK pointers.
+                Cursor.lockState = CursorLockMode.None;
+
+                // Process pointer events as mouse events.
+                foreach(var p in pointerDataToUpdate)
+                {
+                    PointerData pointerData = p.Value;
+                    IMixedRealityPointer pointer = pointerData.pointer;
+
+                    if (pointer.IsInteractionEnabled
+                        && pointer.Rays != null
+                        && pointer.Rays.Length > 0
+                        && pointer.SceneQueryType == Physics.SceneQueryType.SimpleRaycast)
+                    {
+                        ProcessMouseEvent((int)pointer.PointerId);
+                    }
+                    else
+                    {
+                        // Remove Unity pointer if it exists, but leave the MRTK pointer in pointersData unless/until the pointer's source device is lost/disconnected.
+                        ProcessMrtkPointerLost(pointerData);
+                    }
+                }
+
+                for (int i = 0; i < pointerDataToRemove.Count; i++)
+                {
+                    ProcessMrtkPointerLost(pointerDataToRemove[i]);
+                }
+                pointerDataToRemove.Clear();
+            }
+            finally
+            {
+                Cursor.lockState = cursorLockStateBackup;
+            }
+
+            base.Process();
+        }
+
+        private void ProcessMrtkPointerLost(PointerData pointerData)
+        {
+            if (pointerData.lastMousePoint3d != null)
+            {
+                IMixedRealityPointer pointer = pointerData.pointer;
+
+                pointer.Result = null;
+                ProcessMouseEvent((int)pointer.PointerId);
+
+                pointerData.lastMousePoint3d = null; // Mark last mouse position invalid.
+            }
+        }
+
+        /// <summary>
+        /// Adds MRTK pointer support as mouse input for Unity UI.
+        /// </summary>
+        protected override MouseState GetMousePointerEventData(int id)
+        {
+            // Search for MRTK pointer with given id.
+            // If found, generate mouse event data for pointer, otherwise call base implementation.
+            PointerData pointerData;
+            if (pointerDataToUpdate.TryGetValue(id, out pointerData))
+            {
+                return GetMousePointerEventDataForMrtkPointer(pointerData);
+            }
+
+            return base.GetMousePointerEventData(id);
+        }
+
+        protected MouseState GetMousePointerEventDataForMrtkPointer(PointerData pointerData)
+        {
+            IMixedRealityPointer pointer = pointerData.pointer;
+
+            // Reset the RaycastCamera for projecting (used in calculating deltas)
+            Debug.Assert(pointer.Rays != null && pointer.Rays.Length > 0);
+            RaycastCamera.transform.position = pointer.Rays[0].Origin;
+            RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction);
+
+            // Populate data
+            pointerData.eventDataLeft.Reset();
+
+            Vector3 viewportPos = new Vector3(0.5f, 0.5f, 1.0f);
+            Vector2 newPos = RaycastCamera.ViewportToScreenPoint(viewportPos);
+
+            // Populate initial data or drag data
+            Vector2 lastPosition;
+            if (pointerData.lastMousePoint3d == null)
+            {
+                // For the first event, use the same position for 'last' and 'new'.
+                lastPosition = newPos;
+            }
+            else
+            {
+                // Otherwise, re-project the last pointer position.
+                lastPosition = RaycastCamera.WorldToScreenPoint(pointerData.lastMousePoint3d.Value);
+            }
+
+            // Save off the 3D position of the cursor.
+            pointerData.lastMousePoint3d = RaycastCamera.ViewportToWorldPoint(viewportPos);
+
+            // Calculate delta
+            pointerData.eventDataLeft.delta = newPos - lastPosition;
+            pointerData.eventDataLeft.position = newPos;
+
+            // Move the press position to allow dragging
+            pointerData.eventDataLeft.pressPosition += pointerData.eventDataLeft.delta;
+
+            // Populate raycast data
+            pointerData.eventDataLeft.pointerCurrentRaycast = (pointer.Result?.Details.Object != null) ? pointer.Result.Details.LastGraphicsRaycastResult : new RaycastResult();
+            // TODO: Simulate raycast for 3D objects?
+
+            // Populate the data for the buttons
+            pointerData.eventDataLeft.button = PointerEventData.InputButton.Left;
+            pointerData.mouseState.SetButtonState(PointerEventData.InputButton.Left, StateForPointer(pointerData), pointerData.eventDataLeft);
+
+            // Need to provide data for middle and right button for MouseState, although not used by MRTK pointers.
+            CopyFromTo(pointerData.eventDataLeft, pointerData.eventDataRight);
+            pointerData.eventDataRight.button = PointerEventData.InputButton.Right;
+            pointerData.mouseState.SetButtonState(PointerEventData.InputButton.Right, PointerEventData.FramePressState.NotChanged, pointerData.eventDataRight);
+
+            CopyFromTo(pointerData.eventDataLeft, pointerData.eventDataMiddle);
+            pointerData.eventDataMiddle.button = PointerEventData.InputButton.Middle;
+            pointerData.mouseState.SetButtonState(PointerEventData.InputButton.Middle, PointerEventData.FramePressState.NotChanged, pointerData.eventDataMiddle);
+
+            return pointerData.mouseState;
+        }
+
+        protected PointerEventData.FramePressState StateForPointer(PointerData pointerData)
+        {
+            PointerEventData.FramePressState ret = pointerData.nextClickState;
+
+            // Reset state
+            pointerData.nextClickState = PointerEventData.FramePressState.NotChanged;
+
+            return ret;
+        }
+
+        #region IMixedRealityPointerHandler
+
+        void IMixedRealityPointerHandler.OnPointerUp(MixedRealityPointerEventData eventData)
+        {
+            int id = (int)eventData.Pointer.PointerId;
+            Debug.Assert(pointerDataToUpdate.ContainsKey(id));
+            pointerDataToUpdate[id].nextClickState = PointerEventData.FramePressState.Released;
+        }
+
+        void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
+        {
+            int id = (int)eventData.Pointer.PointerId;
+            Debug.Assert(pointerDataToUpdate.ContainsKey(id));
+            pointerDataToUpdate[id].nextClickState = PointerEventData.FramePressState.Pressed;
+        }
+
+        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
+        {
+        }
+
+        #endregion
+
+        #region IMixedRealitySourceStateHandler
+
+        void IMixedRealitySourceStateHandler.OnSourceDetected(SourceStateEventData eventData)
+        {
+            var inputSource = eventData.InputSource;
+            for (int i = 0; i < inputSource.Pointers.Length; i++)
+            {
+                var pointer = inputSource.Pointers[i];
+                if (pointer.InputSourceParent == inputSource)
+                {
+                    int id = (int)pointer.PointerId;
+                    Debug.Assert(!pointerDataToUpdate.ContainsKey(id));
+                    pointerDataToUpdate.Add(id, new PointerData(pointer, eventSystem));
+                }
+            }
+        }
+
+        void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
+        {
+            var inputSource = eventData.InputSource;
+            for (int i = 0; i < eventData.InputSource.Pointers.Length; i++)
+            {
+                var pointer = inputSource.Pointers[i];
+                if (pointer.InputSourceParent == inputSource)
+                {
+                    int id = (int)pointer.PointerId;
+                    Debug.Assert(pointerDataToUpdate.ContainsKey(id));
+
+                    PointerData pointerData = null;
+                    if (pointerDataToUpdate.TryGetValue(id, out pointerData))
+                    {
+                        Debug.Assert(!pointerDataToRemove.Contains(pointerData));
+                        pointerDataToRemove.Add(pointerData);
+
+                        pointerDataToUpdate.Remove(id);
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -10,44 +10,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [RequireComponent(typeof(Camera))]
     public class MixedRealityInputModule : StandaloneInputModule, IMixedRealityPointerHandler, IMixedRealitySourceStateHandler
     {
-#if UNITY_EDITOR
-        [UnityEditor.CustomEditor(typeof(MixedRealityInputModule))]
-        public class Editor : UnityEditor.Editor
-        {
-            public override void OnInspectorGUI()
-            {
-                MixedRealityInputModule inputModule = (MixedRealityInputModule)target;
-
-                base.OnInspectorGUI();
-
-                if (Application.isPlaying && inputModule.RaycastCamera != null)
-                {
-                    foreach (var pointerData in inputModule.pointerDataToUpdate)
-                    {
-                        IMixedRealityPointer pointer = pointerData.Value.pointer;
-                        if (pointer.Rays != null && pointer.Rays.Length > 0)
-                        {
-                            inputModule.RaycastCamera.transform.position = pointer.Rays[0].Origin;
-                            inputModule.RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction, Vector3.up);
-
-                            inputModule.RaycastCamera.Render();
-
-                            GUILayout.Label(pointer.PointerName);
-                            GUILayout.Label(pointer.ToString());
-                            GUILayout.Label(pointer.PointerId.ToString());
-                            GUILayout.Label(inputModule.RaycastCamera.targetTexture);
-                        }
-                    }
-                }
-            }
-
-            public override bool RequiresConstantRepaint()
-            {
-                return true;
-            }
-        }
-#endif
-
         protected class PointerData
         {
             public IMixedRealityPointer pointer;
@@ -79,7 +41,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         protected readonly List<PointerData> pointerDataToRemove = new List<PointerData>();
 
-        protected Camera RaycastCamera { get; private set; }
+        public Camera RaycastCamera { get; private set; }
+
+        public IEnumerable<IMixedRealityPointer> ActiveMixedRealityPointers
+        {
+            get
+            {
+                foreach (var pointerDataEntry in pointerDataToUpdate)
+                {
+                    yield return pointerDataEntry.Value.pointer;
+                }
+            }
+        }
 
         public override void ActivateModule()
         {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a21b486d0bb44444b1418aaa38b44de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -122,16 +122,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (inputModules.Length == 0)
                 {
-                    Debug.LogWarning($"Automatically adding a {typeof(StandaloneInputModule).Name} to main camera. You should save this change to the scene.", CameraCache.Main);
-                    CameraCache.Main.gameObject.AddComponent<StandaloneInputModule>();
+                    Debug.LogWarning($"Automatically adding a {typeof(MixedRealityInputModule).Name} to main camera. You should save this change to the scene.", CameraCache.Main);
+                    CameraCache.Main.gameObject.AddComponent<MixedRealityInputModule>();
                 }
-                else if ((inputModules.Length == 1) && (inputModules[0] is StandaloneInputModule))
+                else if ((inputModules.Length == 1) && (inputModules[0] is MixedRealityInputModule))
                 {
                     // Nothing. Input module is setup correctly.
                 }
                 else
                 {
-                    Debug.LogError($"For Mixed Reality Toolkit input to work properly, please remove your other input module(s) and add a {typeof(StandaloneInputModule).Name} to your main camera.", inputModules[0]);
+                    Debug.LogError($"For Mixed Reality Toolkit input to work properly, please remove your other input module(s) and add a {typeof(MixedRealityInputModule).Name} to your main camera.", inputModules[0]);
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
@@ -120,6 +120,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Called during the scene query just before the current pointer target changes.
         /// </summary>
-        void OnCurrentPointerTargetAboutToChange();
+        void OnPreCurrentPointerTargetChange();
     }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
@@ -116,5 +116,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Called after performing the scene query.
         /// </summary>
         void OnPostSceneQuery();
+
+        /// <summary>
+        /// Called during the scene query just before the current pointer target changes.
+        /// </summary>
+        void OnCurrentPointerTargetAboutToChange();
     }
 }

--- a/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
+++ b/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
@@ -128,7 +128,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public abstract void OnPostSceneQuery();
 
         /// <inheritdoc />
-        public abstract void OnCurrentPointerTargetAboutToChange();
+        public abstract void OnPreCurrentPointerTargetChange();
 
         #region IEquality Implementation
 

--- a/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
+++ b/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
@@ -127,6 +127,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public abstract void OnPostSceneQuery();
 
+        /// <inheritdoc />
+        public abstract void OnCurrentPointerTargetAboutToChange();
+
         #region IEquality Implementation
 
         public static bool Equals(IMixedRealityPointer left, IMixedRealityPointer right)


### PR DESCRIPTION
Overview
---
- Add MixedRealityInputModule inheriting from StandaloneInputModule to add MRTK pointer events for Unity UI.

- Introduce reliable mechanism for a pointer to detect when its current pointer target is about to change.
    - Remove raycast code-duplication (and thus knowledge about FocusProvider implementation) in PokePointer. We need to make sure to also take into account Unity UI graphics raycasts.

- Make all objects of a NearInteractionTouchable subtree touchable (needed for Unity UI).
    
