### PR TITLE
Adds 'Try Repair' to SystemType property drawer with missing class reference

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SelectRepairedTypeWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SelectRepairedTypeWindow.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    public class SelectRepairedTypeWindow : EditorWindow
+    {
+        private static Type[] repairedTypeOptions;
+        private static SerializedProperty property;
+        private static SelectRepairedTypeWindow window;
+
+        public static bool WindowOpen { get { return window != null; } }
+
+        public static void Display(Type[] repairedTypeOptions, SerializedProperty property)
+        {
+            if (window != null)
+            {
+                window.Close();
+            }
+
+            SelectRepairedTypeWindow.repairedTypeOptions = repairedTypeOptions;
+            SelectRepairedTypeWindow.property = property;
+
+            window = ScriptableObject.CreateInstance(typeof(SelectRepairedTypeWindow)) as SelectRepairedTypeWindow;
+            window.titleContent = new GUIContent("Select repaired type");
+            window.ShowUtility();
+        }
+
+        private void OnGUI()
+        {
+            for (int i = 0; i < repairedTypeOptions.Length; i++)
+            {
+                if (GUILayout.Button(repairedTypeOptions[i].FullName, EditorStyles.miniButton))
+                {
+                    property.stringValue = SystemType.GetReference(repairedTypeOptions[i]);
+                    property.serializedObject.ApplyModifiedProperties();
+                    Close();
+                }
+            }
+        }
+
+        private void OnDisable()
+        {
+            window = null;
+        }
+
+        private void OnInspectorUpdate()
+        {
+            Repaint();
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SelectRepairedTypeWindow.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SelectRepairedTypeWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1816cf73665b5c648a1545d130811675
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -233,10 +233,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     }
                     else
                     {
+                        var errorContent = EditorGUIUtility.IconContent("d_console.erroricon.sml");
+                        GUI.Label(new Rect(position.width, position.y, position.width, position.height), errorContent);
+
                         Rect dropdownPosition = new Rect(position.x, position.y, position.width - 90, position.height);
                         Rect buttonPosition = new Rect(position.width - 75, position.y, 75, position.height);
 
                         property.stringValue = DrawTypeSelectionControl(dropdownPosition, label, property.stringValue, filter, false);
+
                         if (GUI.Button(buttonPosition, "Try Repair", EditorStyles.miniButton))
                         {
                             string typeNameWithoutAssembly = property.stringValue.Split(new string[] { "," }, StringSplitOptions.None)[0];
@@ -249,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             }
                             else if (repairedTypeOptions.Length > 0)
                             {
-                                property.stringValue = repairedTypeOptions[0].AssemblyQualifiedName;
+                                property.stringValue = SystemType.GetReference(repairedTypeOptions[0]);
                             }
                             else
                             {
@@ -382,7 +386,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     if (GUILayout.Button(repairedTypeOptions[i].FullName, EditorStyles.miniButton))
                     {
-                        property.stringValue = repairedTypeOptions[i].AssemblyQualifiedName;
+                        property.stringValue = SystemType.GetReference(repairedTypeOptions[i]);
                         property.serializedObject.ApplyModifiedProperties();
                         Close();
                     }

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -356,54 +356,5 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             DrawTypeSelectionControl(position, property.FindPropertyRelative("reference"), label, attribute as SystemTypeAttribute);
         }
-
-        #region popup window definition
-
-        public class SelectRepairedTypeWindow : EditorWindow
-        {
-            private static Type[] repairedTypeOptions;
-            private static SerializedProperty property;
-            private static SelectRepairedTypeWindow window;
-
-            public static bool WindowOpen { get { return window != null; } }
-
-            public static void Display (Type[] repairedTypeOptions, SerializedProperty property)
-            {
-                if (window != null)
-                    window.Close();
-
-                SelectRepairedTypeWindow.repairedTypeOptions = repairedTypeOptions;
-                SelectRepairedTypeWindow.property = property;
-
-                window = ScriptableObject.CreateInstance(typeof(SelectRepairedTypeWindow)) as SelectRepairedTypeWindow;
-                window.titleContent = new GUIContent("Select repaired type");
-                window.ShowUtility();
-            }
-
-            private void OnGUI()
-            {
-                for (int i = 0; i < repairedTypeOptions.Length; i++)
-                {
-                    if (GUILayout.Button(repairedTypeOptions[i].FullName, EditorStyles.miniButton))
-                    {
-                        property.stringValue = SystemType.GetReference(repairedTypeOptions[i]);
-                        property.serializedObject.ApplyModifiedProperties();
-                        Close();
-                    }
-                }
-            }
-
-            private void OnDisable()
-            {
-                window = null;
-            }
-
-            private void OnInspectorUpdate()
-            {
-                Repaint();
-            }
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
Overview
---
![TypeToReference](https://user-images.githubusercontent.com/9789716/55349056-90dbc080-546d-11e9-9d4f-669553f41fc8.PNG)

When a type reference is lost in a SystemType field - common when refactoring namespaces - a 'Try Repair' button is displayed. Clicking it searches filtered types by name. If a matching name is found, that type reference is used.

If no types are found you're altered with a dialog. If multiple types are found, a utility window is launched so you can select which type to use.

- Fixes: #3672 #3693 