### PR TITLE
fixed hand mesh loading on hl2

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private MixedRealityPose currentGripPose = MixedRealityPose.ZeroIdentity;
 
         private bool controllerModelInitialized = false;
-        private bool failedToObtainControllerModel = false;
+        private bool isControllerModelLoaded = false;
 
         #region Update data functions
 
@@ -543,7 +543,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             // Note: Obtaining models from the driver will require access to the InteractionSource.
             // It's unclear whether the interaction source will be available during setup, so we attempt to create
             // the controller model on an input update
-            if (failedToObtainControllerModel ||
+            if (!isControllerModelLoaded ||
                 GetControllerVisualizationProfile() == null ||
                 !GetControllerVisualizationProfile().GetUseDefaultModelsOverride(GetType(), ControllerHandedness))
             {
@@ -607,10 +607,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 }
             }
 
-            if (gltfGameObject == null)
+            if (gltfGameObject != null)
+            {
+                isControllerModelLoaded = true;
+            }
+            else
             {
                 Debug.LogWarning("Failed to create controller model from driver, defaulting to BaseController behavior");
-                failedToObtainControllerModel = true;
                 TryRenderControllerModel(GetType(), InputSourceType.Controller);
             }
         }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -607,11 +607,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 }
             }
 
-            if (gltfGameObject != null)
-            {
-                isControllerModelLoaded = true;
-            }
-            else
+
+            isControllerModelLoaded = (gltfGameObject != null);
+            if (!isControllerModelLoaded)
             {
                 Debug.LogWarning("Failed to create controller model from driver, defaulting to BaseController behavior");
                 TryRenderControllerModel(GetType(), InputSourceType.Controller);


### PR DESCRIPTION
changed flag for gltf model load fail - default case is now that we load the model by calling the base class TryRenderControllerModel. 
fixes model loading for devices that use the articulated hands controller