### PR TITLE
Fix error when auto-configuring input data provider

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset
@@ -50,6 +50,13 @@ MonoBehaviour:
     runtimePlatform: 25
     deviceManagerProfile: {fileID: 0}
   - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Windows.Input.WindowsDictationInputProvider,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
+    componentName: Windows Dictation Input
+    priority: 0
+    runtimePlatform: 25
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
       reference: Microsoft.MixedReality.Toolkit.Input.HandJointService, Microsoft.MixedReality.Toolkit
     componentName: Hand Joint Service
     priority: 0

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -269,6 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                                     serializedObject.ApplyModifiedProperties();
                                     System.Type type = ((MixedRealityInputSystemProfile)serializedObject.targetObject).DataProviderConfigurations[i].ComponentType.Type;
                                     ApplyDataProviderConfiguration(type, providerName, configurationProfile, runtimePlatform);
+                                    break;
                                 }
 
                                 EditorGUI.BeginChangeCheck();


### PR DESCRIPTION
There was a missing "break;" statement that was causing the input provider to fall through and execute code at the wrong time, resulting in an ArgumentException related to "control 4'2 position".

As part of the validation, the input profile was updated to add back the dictation provider.
