### PR TITLE
Gate the articulated hand update loop behind a platform check.

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using Windows.Perception;
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
+using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
@@ -220,6 +221,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             base.UpdateControllerData(interactionSourceState);
 
 #if WINDOWS_UWP
+            // The articulated hand support is only present in the 18361 version and beyond Windows
+            // SDK (which contains the V8 drop of the Universal API Contract). In particular,
+            // the HandPose related APIs are only present on this version and above.
+            if (!WindowsApiChecker.UniversalApiContractV8_IsAvailable)
+            {
+                return;
+            }
+
             PerceptionTimestamp perceptionTimestamp = PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now);
             IReadOnlyList<SpatialInteractionSourceState> sources = spatialInteractionManager?.GetDetectedSourcesAtTimestamp(perceptionTimestamp);
             foreach (SpatialInteractionSourceState sourceState in sources)


### PR DESCRIPTION
The new hand pose information is only present on universal contract version 8 and up.

This was found by looking at ildasm against the previous SDK (i.e. version 7) and the latest drops of the new one (version 8). Note that other things in this file still exist in previous versions (i.e. version 2 actually has the SpatialInteractionManager defined).

This is primarily to ensure that we don't try to exercise an unsupported API if we end up getting this far (we also shouldn't because this object should only get instantiated in cases where hands are detected).

It probably makes sense to restructure this in the future, however, to make it so that we never try to call UpdateControllerData in the case that the underlying APIs this file requires aren't supported (so maybe each controller can optionally expose a overloadable method which configures whether or not they will even work against the current platform).

The idea above is a slightly larger change than I think we want to do for RC1.