### PR TITLE
Fix the broken OpenVR build.

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Playback.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Playback.cs
@@ -113,7 +113,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
             try
             {
+#if WINDOWS_UWP
                 if (!UnityEngine.Windows.File.Exists(filename))
+#else
+                if (!System.IO.File.Exists(filename))
+#endif
                 {
                     txt_LoadingUpdate.text += "Error: Playback log file does not exist! ->>   " + filename + "   <<";
                     Log(("Error: Playback log file does not exist! ->" + filename + "<"));
@@ -271,7 +275,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
 #if UNITY_EDITOR
                 Load();
-#else
+#elif WINDOWS_UWP
                 txt_LoadingUpdate.text = "[Load.2] " + FileName;
                 bool result = AsyncHelpers.RunSync<bool>(() => UWP_Load());
                 txt_LoadingUpdate.text = "[Load.2] Done. ";

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/OpenKeyboard.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/OpenKeyboard.cs
@@ -12,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         public static string keyboardText = "";
         public TextMesh debugMessage;
 
+#if UNITY_WSA
         private void Update()
         {
             if (keyboard != null)
@@ -28,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                 }
             }
         }
+#endif
 
         public void OpenSystemKeyboard()
         {


### PR DESCRIPTION
Some of the new code that was introduced added dependencies on UWP APIs
even when calling from a non-UWP context. (i.e. UserInput_Playback.cs)

Also added a UNITY_WSA check around OpenKeyboard because the touch keyboard
APIs are only documented to work on UWP/IOS/Android/etc locations.