### PR TITLE
Fix the doc build

### DIFF
--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -1,7 +1,5 @@
 ﻿- name: About MRTK
   items:
-  - name: MRTK-SDK
-    href: ../MRTK-SDK.md
   - name: MRTK-vNext
     href: ../MRTK-vNext.md
   - name: Mixed Reality Services
@@ -82,8 +80,6 @@
       href: TODO.md
 - name: Planning
   items:
-  - name: MRTK-WorkRoadmap
-    href: ../MRTK-WorkRoadmap.md
   - name: Roadmap
     href: ../Roadmap.md
 - name: Notice


### PR DESCRIPTION
Previous PR https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/3731/files didn't update the toc.yml, but the build didn't catch the issue because it was broken due to SDK versioning issues (and then scene rename issues).

Basically there were a chain of things that were broken and we only now got to the point where we can see it working.