### PR TITLE
Change the namespace of BoundingBox to the UI one (from Utilities)

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleBoundingBox.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleBoundingBox.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -8,7 +8,7 @@ using UnityEngine.Events;
 using UnityEngine.Serialization;
 using UnityPhysics = UnityEngine.Physics;
 
-namespace Microsoft.MixedReality.Toolkit.Utilities
+namespace Microsoft.MixedReality.Toolkit.UI
 {
     public class BoundingBox : BaseFocusHandler,
         IMixedRealityPointerHandler,

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Utilities
+namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
     /// The BoundingBoxHelper class contains functions for getting geometric info from the non-axis-aligned 


### PR DESCRIPTION
In previous PRs we've gotten feedback that BoundingBox feels like a more
UI concept than a "utilities" concept, so moving this to that namespace.