### PR TITLE
Add a null input parent check in DefaultPointerMediator

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -36,13 +36,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     farInteractPointers.Add(pointer);
                 }
 
-                HashSet<IMixedRealityPointer> children;
-                if (!pointerByInputSourceParent.TryGetValue(pointer.InputSourceParent, out children))
+                if (pointer.InputSourceParent != null)
                 {
-                    children = new HashSet<IMixedRealityPointer>();
-                    pointerByInputSourceParent.Add(pointer.InputSourceParent, children);
+                    HashSet<IMixedRealityPointer> children;
+                    if (!pointerByInputSourceParent.TryGetValue(pointer.InputSourceParent, out children))
+                    {
+                        children = new HashSet<IMixedRealityPointer>();
+                        pointerByInputSourceParent.Add(pointer.InputSourceParent, children);
+                    }
+                    children.Add(pointer);
                 }
-                children.Add(pointer);
             }
         }
 
@@ -99,15 +102,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     pointer.IsActive = true;
                     unassignedPointers.Remove(pointer);
 
-                    foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
+                    if (pointer.InputSourceParent != null)
                     {
-                        if (!unassignedPointers.Contains(otherPointer))
+                        foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
                         {
-                            continue;
-                        }
+                            if (!unassignedPointers.Contains(otherPointer))
+                            {
+                                continue;
+                            }
 
-                        otherPointer.IsActive = false;
-                        unassignedPointers.Remove(otherPointer);
+                            otherPointer.IsActive = false;
+                            unassignedPointers.Remove(otherPointer);
+                        }
                     }
                 }
             }
@@ -126,15 +132,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     pointer.IsActive = true;
                     unassignedPointers.Remove(pointer);
 
-                    foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
+                    if (pointer.InputSourceParent != null)
                     {
-                        if (!unassignedPointers.Contains(otherPointer))
+                        foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
                         {
-                            continue;
-                        }
+                            if (!unassignedPointers.Contains(otherPointer))
+                            {
+                                continue;
+                            }
 
-                        otherPointer.IsActive = false;
-                        unassignedPointers.Remove(otherPointer);
+                            otherPointer.IsActive = false;
+                            unassignedPointers.Remove(otherPointer);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The parent->child enumeration currently throws an exception for input
sources that don't have a parent set. Add a null check around those
references so that we don't throw an exception in those cases.

https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3802