### PR TITLE
profiler sample rate was unbounded in the inspector

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
@@ -36,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         [SerializeField]
         [FormerlySerializedAs("frameRateDuration")]
         [Tooltip("The amount of time, in seconds, to collect frames for frame rate calculation.")]
+        [Range(0, 5)]
         private float frameSampleRate = 0.1f;
 
         /// <summary>


### PR DESCRIPTION
Added a range of 0 (show FPS every frame) to 5 seconds
