### PR TITLE
Update the Getting Started page to mention the required windows SDK.

### DIFF
--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -11,6 +11,7 @@ To get started with the Mixed Reality Toolkit you will need:
 
 * [Unity 2018.2.13f1 +](https://unity3d.com/get-unity/download/archive)
 * [Latest MRTK release (Beta)](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases)
+* [Windows SDK 18362+](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewSDK)
 * A dream
 
 ## Upgrading from the HoloToolkit (HTK)


### PR DESCRIPTION
Due to the new HL2 payload, in order to build against new MRTK you need
to have the latest windows SDK (as of right now it's still in the
insider state).

While we have an issue open to see if we can disentangle this (https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3801) in the interim we should at least document the actual requirements