### PR TITLE
Ignore DocFX generated doc/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ Assets/StreamingAssets/GltfModels.meta
 Assets/StreamingAssets.meta
 
 /mrtk_log_mostRecentET.csv
+
+# =============== #
+# DocFX Generated #
+# =============== #
+doc/


### PR DESCRIPTION
Added to .gitignore the 'doc' folder generated when running DocFX