### PR TITLE
Removed variants of methods to raise input events that receive no handedness.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -943,18 +943,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             };
 
         /// <inheritdoc />
-        public void RaiseOnInputDown(IMixedRealityInputSource source, MixedRealityInputAction inputAction)
-        {
-            inputAction = ProcessRules(inputAction, true);
-
-            // Create input event
-            inputEventData.Initialize(source, inputAction);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(inputEventData, OnInputDownEventHandler);
-        }
-
-        /// <inheritdoc />
         public void RaiseOnInputDown(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction)
         {
             inputAction = ProcessRules(inputAction, true);
@@ -976,18 +964,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var casted = ExecuteEvents.ValidateEventData<InputEventData>(eventData);
                 handler.OnInputUp(casted);
             };
-
-        /// <inheritdoc />
-        public void RaiseOnInputUp(IMixedRealityInputSource source, MixedRealityInputAction inputAction)
-        {
-            inputAction = ProcessRules(inputAction, false);
-
-            // Create input event
-            inputEventData.Initialize(source, inputAction);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(inputEventData, OnInputUpEventHandler);
-        }
 
         /// <inheritdoc />
         public void RaiseOnInputUp(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction)
@@ -1013,18 +989,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             };
 
         /// <inheritdoc />
-        public void RaiseFloatInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, float inputValue)
-        {
-            inputAction = ProcessRules(inputAction, inputValue);
-
-            // Create input event
-            floatInputEventData.Initialize(source, inputAction, inputValue);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(floatInputEventData, OnFloatInputChanged);
-        }
-
-        /// <inheritdoc />
         public void RaiseFloatInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, float inputValue)
         {
             inputAction = ProcessRules(inputAction, inputValue);
@@ -1048,18 +1012,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             };
 
         /// <inheritdoc />
-        public void RaisePositionInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, Vector2 inputPosition)
-        {
-            inputAction = ProcessRules(inputAction, inputPosition);
-
-            // Create input event
-            vector2InputEventData.Initialize(source, inputAction, inputPosition);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(vector2InputEventData, OnTwoDoFInputChanged);
-        }
-
-        /// <inheritdoc />
         public void RaisePositionInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Vector2 inputPosition)
         {
             inputAction = ProcessRules(inputAction, inputPosition);
@@ -1077,18 +1029,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var casted = ExecuteEvents.ValidateEventData<InputEventData<Vector3>>(eventData);
                 handler.OnInputChanged(casted);
             };
-
-        /// <inheritdoc />
-        public void RaisePositionInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, Vector3 position)
-        {
-            inputAction = ProcessRules(inputAction, position);
-
-            // Create input event
-            positionInputEventData.Initialize(source, inputAction, position);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(positionInputEventData, OnPositionInputChanged);
-        }
 
         /// <inheritdoc />
         public void RaisePositionInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Vector3 position)
@@ -1114,18 +1054,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             };
 
         /// <inheritdoc />
-        public void RaiseRotationInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, Quaternion rotation)
-        {
-            inputAction = ProcessRules(inputAction, rotation);
-
-            // Create input event
-            rotationInputEventData.Initialize(source, inputAction, rotation);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(positionInputEventData, OnRotationInputChanged);
-        }
-
-        /// <inheritdoc />
         public void RaiseRotationInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Quaternion rotation)
         {
             inputAction = ProcessRules(inputAction, rotation);
@@ -1147,18 +1075,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var casted = ExecuteEvents.ValidateEventData<InputEventData<MixedRealityPose>>(eventData);
                 handler.OnInputChanged(casted);
             };
-
-        /// <inheritdoc />
-        public void RaisePoseInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, MixedRealityPose inputData)
-        {
-            inputAction = ProcessRules(inputAction, inputData);
-
-            // Create input event
-            poseInputEventData.Initialize(source, inputAction, inputData);
-
-            // Pass handler through HandleEvent to perform modal/fallback logic
-            HandleEvent(poseInputEventData, OnPoseInputChanged);
-        }
 
         /// <inheritdoc />
         public void RaisePoseInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, MixedRealityPose inputData)

--- a/Assets/MixedRealityToolkit/EventDatum/Input/HandTrackingInputEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/HandTrackingInputEventData.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="touchedObject">This is a the global position of the HandTrackingInputSource that created the EventData</param>
         public void Initialize(IMixedRealityInputSource inputSource, IMixedRealityController controller, Handedness sourceHandedness, Vector3 touchPoint)
         {
-            Initialize(inputSource, MixedRealityInputAction.None, touchPoint);
+            Initialize(inputSource, Handedness.None, MixedRealityInputAction.None, touchPoint);
             Controller = controller;
         }
     }

--- a/Assets/MixedRealityToolkit/EventDatum/Input/HandTrackingInputEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/HandTrackingInputEventData.cs
@@ -22,15 +22,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// This function is called to fill the HandTrackingIntputEventData object with information
         /// </summary>
-        /// <param name="inputSource">This is a reference to the HandTrackingInputSource that created the EventData</param>
-        /// <param name="controller">This is a reference to the IMixedRealityController that created the EventData</param>
-        /// <param name="grabbing">This is a the state (grabbing or not grabbing) of the HandTrackingInputSource that created the EventData</param>
-        /// <param name="pressing">This is a the state (pressing or not pressing) of the HandTrackingInputSource that created the EventData</param>
-        /// <param name="actionPoint">This is a the global position grabbed by the HandTrackingInputSource that created the EventData</param>
-        /// <param name="touchedObject">This is a the global position of the HandTrackingInputSource that created the EventData</param>
+        /// <param name="inputSource">Reference to the HandTrackingInputSource that created the EventData</param>
+        /// <param name="controller">Reference to the IMixedRealityController that created the EventData</param>
+        /// <param name="sourceHandedness">Handedness of the HandTrackingInputSource that created the EventData</param>
+        /// <param name="touchPoint">Global position of the HandTrackingInputSource that created the EventData</param>
         public void Initialize(IMixedRealityInputSource inputSource, IMixedRealityController controller, Handedness sourceHandedness, Vector3 touchPoint)
         {
-            Initialize(inputSource, Handedness.None, MixedRealityInputAction.None, touchPoint);
+            Initialize(inputSource, sourceHandedness, MixedRealityInputAction.None, touchPoint);
             Controller = controller;
         }
     }

--- a/Assets/MixedRealityToolkit/EventDatum/Input/InputEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/InputEventData.cs
@@ -23,17 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Used to initialize/reset the event and populate the data.
         /// </summary>
         /// <param name="inputSource"></param>
-        /// <param name="inputAction"></param>
-        public void Initialize(IMixedRealityInputSource inputSource, MixedRealityInputAction inputAction)
-        {
-            BaseInitialize(inputSource, inputAction);
-            Handedness = Handedness.None;
-        }
-
-        /// <summary>
-        /// Used to initialize/reset the event and populate the data.
-        /// </summary>
-        /// <param name="inputSource"></param>
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
         public void Initialize(IMixedRealityInputSource inputSource, Handedness handedness, MixedRealityInputAction inputAction)
@@ -56,18 +45,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <inheritdoc />
         public InputEventData(EventSystem eventSystem) : base(eventSystem) { }
-
-        /// <summary>
-        /// Used to initialize/reset the event and populate the data.
-        /// </summary>
-        /// <param name="inputSource"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="data"></param>
-        public void Initialize(IMixedRealityInputSource inputSource, MixedRealityInputAction inputAction, T data)
-        {
-            Initialize(inputSource, inputAction);
-            InputData = data;
-        }
 
         /// <summary>
         /// Used to initialize/reset the event and populate the data.

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -265,13 +265,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Raise the input down event.
         /// </summary>
         /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        void RaiseOnInputDown(IMixedRealityInputSource source, MixedRealityInputAction inputAction);
-
-        /// <summary>
-        /// Raise the input down event.
-        /// </summary>
-        /// <param name="source"></param>
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
         void RaiseOnInputDown(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction);
@@ -284,13 +277,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Raise the input up event.
         /// </summary>
         /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        void RaiseOnInputUp(IMixedRealityInputSource source, MixedRealityInputAction inputAction);
-
-        /// <summary>
-        /// Raise the input up event.
-        /// </summary>
-        /// <param name="source"></param>
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
         void RaiseOnInputUp(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction);
@@ -298,14 +284,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #endregion Input Up
 
         #region Float Input Changed
-
-        /// <summary>
-        /// Raise Float Input Changed.
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="inputValue"></param>
-        void RaiseFloatInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, float inputValue);
 
         /// <summary>
         /// Raise Float Input Changed.
@@ -324,26 +302,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Raise the 2 degrees of freedom input event.
         /// </summary>
         /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="position"></param>
-        void RaisePositionInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, Vector2 position);
-
-        /// <summary>
-        /// Raise the 2 degrees of freedom input event.
-        /// </summary>
-        /// <param name="source"></param>
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
         /// <param name="position"></param>
         void RaisePositionInputChanged(IMixedRealityInputSource source, Handedness handedness, MixedRealityInputAction inputAction, Vector2 position);
-
-        /// <summary>
-        /// Raise the 3 degrees of freedom input event.
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="position"></param>
-        void RaisePositionInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, Vector3 position);
 
         /// <summary>
         /// Raise the 3 degrees of freedom input event.
@@ -362,14 +324,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Raise the 3 degrees of freedom input event.
         /// </summary>
         /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="rotation"></param>
-        void RaiseRotationInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, Quaternion rotation);
-
-        /// <summary>
-        /// Raise the 3 degrees of freedom input event.
-        /// </summary>
-        /// <param name="source"></param>
         /// <param name="handedness"></param>
         /// <param name="inputAction"></param>
         /// <param name="rotation"></param>
@@ -378,14 +332,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #endregion Input Rotation Changed
 
         #region Input Pose Changed
-
-        /// <summary>
-        /// Raise the 6 degrees of freedom input event.
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="inputAction"></param>
-        /// <param name="inputData"></param>
-        void RaisePoseInputChanged(IMixedRealityInputSource source, MixedRealityInputAction inputAction, MixedRealityPose inputData);
 
         /// <summary>
         /// Raise the 6 degrees of freedom input event.

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                     if (Interactions[i].Changed)
                     {
-                        MixedRealityToolkit.InputSystem?.RaisePoseInputChanged(InputSource, Interactions[i].MixedRealityInputAction, Interactions[i].PoseData);
+                        MixedRealityToolkit.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].PoseData);
                     }
                 }
 
@@ -95,7 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                     if (Interactions[i].Changed)
                     {
-                        MixedRealityToolkit.InputSystem?.RaisePositionInputChanged(InputSource, Interactions[i].MixedRealityInputAction, Interactions[i].Vector2Data);
+                        MixedRealityToolkit.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].Vector2Data);
                     }
                 }
 
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                     if (Interactions[i].Changed)
                     {
-                        MixedRealityToolkit.InputSystem?.RaisePositionInputChanged(InputSource, Interactions[i].MixedRealityInputAction, Interactions[i].Vector2Data);
+                        MixedRealityToolkit.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].Vector2Data);
                     }
                 }
 

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchController.cs
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                 if (Interactions[0].Changed)
                 {
-                    MixedRealityToolkit.InputSystem?.RaisePositionInputChanged(InputSource, Interactions[0].MixedRealityInputAction, TouchData.deltaPosition);
+                    MixedRealityToolkit.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[0].MixedRealityInputAction, TouchData.deltaPosition);
                 }
 
                 lastPose.Position = InputSource.Pointers[0].BaseCursor.Position;
@@ -119,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                 if (Interactions[1].Changed)
                 {
-                    MixedRealityToolkit.InputSystem?.RaisePoseInputChanged(InputSource, Interactions[1].MixedRealityInputAction, lastPose);
+                    MixedRealityToolkit.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[1].MixedRealityInputAction, lastPose);
                 }
 
                 if (!isManipulating)


### PR DESCRIPTION
Implemented the changes described in proposal #3791 . As a side effect, this PR changes the handedness of some input events raised by mouse and unity touch controllers from `Handedness.None` to the actual handedness of each controller as defined by `IMixedRealityController.ControllerHandedness`.
