### PR TITLE
When activating MixedRealityInputModule, handle input sources already present

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     OnSourceDetected(inputSource);
                 }
 
-                MixedRealityToolkit.InputSystem?.Register(gameObject);
+                MixedRealityToolkit.InputSystem.Register(gameObject);
             }
         }
 
@@ -75,6 +75,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (MixedRealityToolkit.InputSystem != null)
             {
+                MixedRealityToolkit.InputSystem.Unregister(gameObject);
+
                 foreach (IMixedRealityInputSource inputSource in MixedRealityToolkit.InputSystem.DetectedInputSources)
                 {
                     OnSourceLost(inputSource);
@@ -82,8 +84,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 // Process once more to handle pointer removals.
                 Process();
-
-                MixedRealityToolkit.InputSystem.Unregister(gameObject);
             }
 
             RaycastCamera = null;


### PR DESCRIPTION
Overview
For instance, the mouse input source is available before activating the input module