### PR TITLE
replaced error with comment for platforms that don't have a controller visualization

### DIFF
--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -229,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (controllerModel == null)
             {
-                Debug.LogError("Unable to locate controller model");
+                // no controller model available
                 return false;
             }
 


### PR DESCRIPTION
- removed the error for no controller model available as there's platforms that don't have a controller visualization like xbox controller and touch input

fixes: 
#3685 
#3710 