### PR TITLE
Remove example scenes list in the Build Settings

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,26 +4,5 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes:
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
-    guid: 3dd4a396b5225f8469b9a1eb608bfa57
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/mrtk_eyes_00_RootScene.unity
-    guid: 27c3fbe0128089f48994cdc6af8668fc
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/mrtk_eyes_01_BasicSetup.unity
-    guid: 3ac2cf3aa0e281340babd2053d8b7d46
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/mrtk_eyes_02_TargetSelection.unity
-    guid: 55643f7e4eceb734784192b162f565e0
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/mrtk_eyes_03_Navigation.unity
-    guid: 5df475f0bf57b1f488d59e0e16040d9a
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/mrtk_eyes_04_TargetPositioning.unity
-    guid: 91ded1f5ef2ae854ba4ac94eca7a2494
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/mrtk_eyes_05_Visualizer.unity
-    guid: 2d6c43a82f3a88c4dbdc3b5e99a68d8a
+  m_Scenes: []
   m_configObjects: {}


### PR DESCRIPTION
Overview
---
Remove example scenes list in the Build Settings for the users without Examples package.

![2019-04-03 14_42_55-Unity 2018 3 8f1 Personal - Untitled - MRTK-Public-Microsoft - PC, Mac   Linux S](https://user-images.githubusercontent.com/13754172/55578131-093ebd80-56ca-11e9-9a5e-2a5623d0b41b.png)

