### PR TITLE
Merges the README.md changes from mrtk_release into mrtk_development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,63 @@
 <img src="External/ReadMeImages/MRTK_Logo_Rev.png">
 
-# What is MixedRealityToolkit
+# What is the Mixed Reality Toolkit
 
-MRTK is a Microsoft Driven open source project. MRTK-Unity...
-* Provides the **basic building blocks for unity development on HoloLens, Windows Mixed Reality, and OpenVR**.
-* Showcases UX best practices with **UI controls that match Windows Mixed Reality and HoloLens Shell**. 
-* **Enables rapid prototyping** via in-editor simulation that allows you to see changes immediately.
-* **Supports a wide range of platforms**, including
-  * Microsoft HoloLens
-  * Microsoft HoloLens 2
-  * Microsoft Immersive headsets (IHMD)
-  * Windows Mixed Reality headsets
-  * OpenVR headsets (HTC Vive / Oculus Rift)
-    
-* Is **extensible**. Provides devs ability to swap out core components and extend the framework.
+MRTK is a Microsoft driven open source project. 
 
-# Build Status
+MRTK-Unity provides a set of foundational components and features to accelerate MR app development in Unity. The latest Release of MRTK (V2) supports HoloLens/HoloLens 2, Windows Mixed Reality, and OpenVR platforms.
 
-| Branch | Status |
-|---|---|
-| `mrtk_development` |[![Build status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_development-CI)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=1)|
+# MRTK-Unity goals
+ 
+* Provide basic features as an easy to use SDK and reduce barriers to get started.
+* Enable rapid prototyping by providing the basic building blocks for MR app development. 
+* Showcase best practices in MR with UI controls and interactions that matches the WMR and HoloLens shell. 
+* Support a wide audience, allowing solutions to be built that will run on multiple VR / AR / XR platforms such as Windows Mixed Reality, Steam and Open VR.
+* Ensure an extensive framework for advanced integrators, with the ability to swap out core components with their own should they wish to, or simply extend the framework to add new capabilities.
 
- # Required Software
+ # Required software
+ 
 | [![Windows 10 Creators Update](External/ReadMeImages/MRTK170802_Short_17.png)](https://www.microsoft.com/software-download/windows10) [Windows 10 FCU](https://www.microsoft.com/software-download/windows10)| [![Unity](External/ReadMeImages/MRTK170802_Short_18.png)](https://unity3d.com/get-unity/download/archive) [Unity 3D](https://unity3d.com/get-unity/download/archive)| [![Visual Studio 2017](External/ReadMeImages/MRTK170802_Short_19.png)](http://dev.windows.com/downloads) [Visual Studio 2017](http://dev.windows.com/downloads)| [![Simulator (optional)](External/ReadMeImages/MRTK170802_Short_20.png)](https://go.microsoft.com/fwlink/?linkid=852626) [Simulator (optional)](https://go.microsoft.com/fwlink/?linkid=852626)|
 | :--- | :--- | :--- | :--- |
-| To develop apps for mixed reality headsets, you need the Windows 10 Fall Creators Update | The Unity 3D engine provides support for building mixed reality projects in Windows 10 | Visual Studio is used for code editing, deploying and building UWP app packages | The Emulators allow you test your app without the device in a simulated environment |
+| To develop apps for Windows Mixed Reality headsets, you need the Windows 10 Fall Creators Update | The Unity 3D engine provides support for building mixed reality projects in Windows 10 | Visual Studio is used for code editing, deploying and building UWP app packages | The Emulators allow you test your app without the device in a simulated environment |
 
+# Supported platforms
+
+The Mixed Reality Toolkit V2 will includes many APIs to accelerate the development of MR / XR / VR / AR projects for a range of supported devices, starting with
+
+ - Microsoft HoloLens
+ - Microsoft HoloLens 2
+ - Microsoft Windows Mixed Reality immersive headsets (WMR)
+ - OpenVR (HTC Vive / Oculus Rift)
+ 
 # Feature areas
 
-- Input System
-- Articulated Hands + Gestures (HoloLens 2)
-- Eye Tracking (HoloLens 2)
-- Voice Commanding
-- Gaze + Select (HoloLens)
-- Controller Visualization
-- Teleportation
-- UI Controls
-- Solver and Interactions
-- Spatial Understanding
-- Diagnostic Tool
+* Input System
+
+* Articulated Hands + Gestures (HoloLens 2)
+
+* Eye Tracking (HoloLens 2) 
+
+* Voice Commanding 
+
+* Gaze + Select (HoloLens)
+
+* Controller Visualization 
+
+* Teleportation 
+
+* UI Controls 
+
+* Solver and Interactions 
+
+* Spatial Understanding 
+
+* Diagnostic Tool 
 
 # Getting Started with MRTK 
 1. [Download MRTK](Documentation/DownloadingTheMRTK.md)
 2. Follow this [Getting Started Guide](Documentation/GettingStartedWithTheMRTK.md)
 3. Check out [Mixed Reality Toolkit configuration guide](Documentation/MixedRealityConfigurationGuide.md)
 4. Check out building blocks and example scenes(see the table below)
-
-### More documentation
-Find this readme, other documentation articles and the MRTK api reference on our [MRTK Dev Portal on github.io](https://microsoft.github.io/MixedRealityToolkit-Unity/). 
 
 # Building blocks for UI and Interactions
 |  [![Button](External/ReadMeImages/Button/MRTK_Button_Main.png)](Documentation/README_Button.md) [Button](Documentation/README_Button.md) | [![Bounding Box](External/ReadMeImages/BoundingBox/MRTK_BoundingBox_Main.png)](Documentation/README_BoundingBox.md) [Bounding Box](Documentation/README_BoundingBox.md) | [![Manipulation Handler](External/ReadMeImages/ManipulationHandler/MRTK_Manipulation_Main.png)](Documentation/README_ManipulationHandler.md) [Manipulation Handler](Documentation/README_ManipulationHandler.md) |
@@ -63,21 +73,37 @@ Find this readme, other documentation articles and the MRTK api reference on our
 # Example Scene
 You can find various types of interactions and UI controls in [this example scene](Documentation/README_HandInteractionExamples.md).
 
-[![Button](External/ReadMeImages/MRTK_Examples.png)](Documentation/README_HandInteractionExamples.md)
+Find this document, other documentation articles and the MRTK API reference on our [MRTK Dev Portal on github.io](https://microsoft.github.io/MixedRealityToolkit-Unity/). 
 
-# Engage with the Community
+# Engage with the community
 
 Join the conversation around MRTK on [Slack](https://holodevelopers.slack.com/).
 
 Ask questions about using MRTK on [Stack Overflow](https://stackoverflow.com/questions/tagged/mrtk) using the **MRTK** tag.
 
-Search for solution or file a new issue in [GitHub](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues) if you find something broken in MRTK code.
+Search for solutions or file new issues in [GitHub](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues).
 
-Deep dive into project plan and learn how you can contribute to MRTK in our [wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki).  
+Deep dive into future plans and learn how you can contribute to MRTK in our [wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki).
 
-Join our weekly community shiproom to hear directly from the feature team. (link to come soon) 
+Join our weekly community shiproom to hear directly from the feature team. (link coming soon) 
 
 For issues related to Windows Mixed Reality that aren't directly related to the MRTK, check out the [Windows Mixed Reality Developer Forum](https://forums.hololens.com/).
+
+# Examples and QuickStart scenes
+
+One radical change to the Mixed Reality Toolkit vNext, will be the standards and approaches to real world example scenes.
+
+New examples will follow strict guidelines, such as:
+
+* Each example must have utility and demonstrate a real world test case (no tests).
+* Each example will use a standardized template, so all examples have the same look and feel.
+* Each sample will be fully documented, detailing both the use case it is demonstrating and how to implement the features demonstrated.
+
+> Check the "Work In Progress" section of the [Windows Mixed Reality - vNext SDK](MRTK-SDK.md) for a peek at the first new example.
+
+
+The **External\How To** docs folder contains guides on migrating between versions and process troubleshooting.
+Please feel free to grow all these sections. We can't wait to see your additions!
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). 
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
@@ -87,10 +113,10 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 | :--------------------- | :----------------- | :------------------ | :------------------------ |
 | See code examples. Do a coding tutorial. Watch guest lectures.          | Get design guides. Build user interface. Learn interactions and input.     | Get development guides. Learn the technology. Understand the science.       | Join open source projects. Ask questions on forums. Attend events and meetups. |
 
-### Learn more about MRTK Project 
-You can find our planning material on [our wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki) under Project Management Section. You can always see the items the team is actively working on in the Iteration Plan issue. 
+### Build Status
 
-### How to Contribute
-View the [**How To Contribute**](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/How-to-Contribute) wiki page for the most up to date instructions on contributing to the Mixed Reality Toolkit!
+| Branch | Status |
+|---|---|
+| `mrtk_development` |[![Build status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_development-CI)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=1)|
 
-### For details on the different branches used in the Mixed Reality Toolkit repositories, check this [Branch Guide here](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/Branch-Guide).
+### For details on the different branches used in the Mixed Reality Toolkit repositories, check the [Branch Guide](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/Branch-Guide).


### PR DESCRIPTION
It turns out that we've been checking in conflicting changes to README.md in multiple locations.

This takes most of the changes from mrtk_release (it's been the most active area of change)