### PR TITLE
Fix See-it, Say-it label delay timing regression: Easing was unchecked. Interactable theme updated.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel.asset
@@ -515,7 +515,7 @@ MonoBehaviour:
         Animation: {fileID: 0}
       ShaderName: 
     Easing:
-      Enabled: 0
+      Enabled: 1
       Curve:
         serializedVersion: 2
         m_Curve:


### PR DESCRIPTION
Overview
---
Fix See-it, Say-it label delay timing regression: Easing was unchecked. 
Interactable theme updated to have easing timing for 1 sec.

Changes
---
See-it, Say-it label profile updated. No code change.

![2019-04-04 11_23_12-Unity 2018 3 8f1 Personal - HandInteractionExamples unity - MRTK-Public-RC1 - PC](https://user-images.githubusercontent.com/13754172/55583750-81f84680-56d7-11e9-8848-6e57d365fb6a.png)
