### PR TITLE
Add TargetPositionLockedOnFocusLock for pointers

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -261,6 +261,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool IsFocusLocked { get; set; }
 
+        /// <inheritdoc />
+        public bool IsTargetPositionLockedOnFocusLock { get; set; }
+
         [SerializeField]
         private bool overrideGlobalPointerExtent = false;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -90,6 +90,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool IsFocusLocked { get; set; }
 
+        /// <inheritdoc />
+        public bool IsTargetPositionLockedOnFocusLock { get; set; }
+
         public RayStep[] Rays { get; protected set; } = { new RayStep(Vector3.zero, Vector3.forward) };
 
         public LayerMask[] PrioritizedLayerMasksOverride { get; set; }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             lineBase.UpdateMatrix();
 
             // Set our first and last points
-            if (IsFocusLocked && Result?.Details != null)
+            if (IsFocusLocked && IsTargetPositionLockedOnFocusLock && Result != null)
             {
                 // Make the final point 'stick' to the target at the distance of the target
                 SetLinePoints(Position, Result.Details.Point, Result.Details.RayDistance);
@@ -191,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             // If focus is locked, we're sticking to the target
             // So don't clamp the world length
-            if (IsFocusLocked)
+            if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
             {
                 float cursorOffsetLocalLength = LineBase.GetNormalizedLengthFromWorldLength(cursorOffsetWorldLength);
                 LineBase.LineEndClamp = 1 - cursorOffsetLocalLength;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -98,9 +98,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 lineRenderer.LineColor = lineColor;
             }
 
-            // If focus is locked, we're sticking to the target
+            // If focus and target point is locked, we're sticking to the target
             // So don't clamp the world length
-            if (IsFocusLocked)
+            if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
             {
                 float cursorOffsetLocalLength = LineBase.GetNormalizedLengthFromWorldLength(cursorOffsetWorldLength);
                 LineBase.LineEndClamp = 1 - cursorOffsetLocalLength;
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             LineBase.FirstPoint = startPoint;
             LineBase.LastPoint = endPoint;
 
-            if (IsFocusLocked)
+            if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
             {
                 inertia.enabled = false;
                 // Project forward based on pointer direction to get an 'expected' position of the first control point

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointerVisual.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointerVisual.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
@@ -34,7 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public void OnEnable()
         {
             CheckInitialization();
-
         }
 
         public void OnDestroy()
@@ -79,7 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public void Update()
         {
             bool tetherVisualsEnabled = false;
-            if (pointer.IsFocusLocked)
+            if (pointer.IsFocusLocked && pointer.IsTargetPositionLockedOnFocusLock && pointer.Result != null)
             {
                 NearInteractionGrabbable grabbedObject = GetGrabbedObject();
                 if (grabbedObject != null && grabbedObject.ShowTetherWhenManipulating)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Physics;
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
@@ -150,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             public Vector3 hitNormalOnObject = Vector3.zero;
 
             public RayStep ray;
-            public int rayStepIndex;
+            public int rayStepIndex = -1;
             public float rayDistance;
 
             public void Clear()
@@ -163,7 +162,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 hitNormalOnObject = Vector3.zero;
 
                 ray = default(RayStep);
-                rayStepIndex = 0;
+                rayStepIndex = -1;
                 rayDistance = 0.0f;
             }
 
@@ -270,26 +269,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (hitResult.hitObject != CurrentPointerTarget)
                 {
                     Pointer.OnPreCurrentPointerTargetChange();
+
+                    // Set to default:
+                    Pointer.IsTargetPositionLockedOnFocusLock = true; 
                 }
 
                 PreviousPointerTarget = CurrentPointerTarget;
 
-                if (hitResult.hitObject != null)
+                focusDetails.Object = hitResult.hitObject;
+                focusDetails.LastRaycastHit = hitResult.raycastHit;
+                focusDetails.LastGraphicsRaycastResult = hitResult.graphicsRaycastResult;
+
+                if (hitResult.rayStepIndex >= 0)
                 {
                     RayStepIndex = hitResult.rayStepIndex;
                     StartPoint = hitResult.ray.Origin;
 
-                    focusDetails.LastRaycastHit = hitResult.raycastHit;
-                    focusDetails.LastGraphicsRaycastResult = hitResult.graphicsRaycastResult;
-                    focusDetails.Object = hitResult.hitObject;
                     focusDetails.RayDistance = hitResult.rayDistance;
                     focusDetails.Point = hitResult.hitPointOnObject;
                     focusDetails.Normal = hitResult.hitNormalOnObject;
-                    focusDetails.PointLocalSpace = hitResult.hitObject.transform.InverseTransformPoint(focusDetails.Point);
-                    focusDetails.NormalLocalSpace = hitResult.hitObject.transform.InverseTransformPoint(focusDetails.Normal);
                 }
                 else
                 {
+                    // If we don't have a valid ray cast, use the whole pointer ray.
                     RayStep firstStep = Pointer.Rays[0];
                     RayStep finalStep = Pointer.Rays[Pointer.Rays.Length - 1];
                     RayStepIndex = 0;
@@ -302,12 +304,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         rayDist += Pointer.Rays[i].Length;
                     }
 
-                    focusDetails.LastRaycastHit = default(RaycastHit);
-                    focusDetails.LastGraphicsRaycastResult = default(RaycastResult);
-                    focusDetails.Object = null;
                     focusDetails.RayDistance = rayDist;
                     focusDetails.Point = finalStep.Terminus;
                     focusDetails.Normal = -finalStep.Direction;
+                }
+
+                if (hitResult.hitObject != null)
+                {
+                    focusDetails.PointLocalSpace = hitResult.hitObject.transform.InverseTransformPoint(focusDetails.Point);
+                    focusDetails.NormalLocalSpace = hitResult.hitObject.transform.InverseTransformPoint(focusDetails.Normal);
+                }
+                else
+                {
                     focusDetails.PointLocalSpace = Vector3.zero;
                     focusDetails.NormalLocalSpace = Vector3.zero;
                 }
@@ -326,6 +334,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // In case the focused object is moving, we need to update the focus point based on the object's new transform.
                     focusDetails.Point = focusDetails.Object.transform.TransformPoint(focusDetails.PointLocalSpace);
                     focusDetails.Normal = focusDetails.Object.transform.TransformDirection(focusDetails.NormalLocalSpace);
+                    focusDetails.PointLocalSpace = focusDetails.Object.transform.InverseTransformPoint(focusDetails.Point);
+                    focusDetails.NormalLocalSpace = focusDetails.Object.transform.InverseTransformPoint(focusDetails.Normal);
                 }
 
                 StartPoint = Pointer.Rays[0].Origin;
@@ -722,13 +732,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             else
             {
-                // If the pointer is locked
-                // Keep the focus objects the same
+                // If the pointer is locked, keep the focused object the same.
                 // This will ensure that we execute events on those objects
-                // even if the pointer isn't pointing at them
-                if (!pointer.Pointer.IsFocusLocked)
+                // even if the pointer isn't pointing at them.
+                if (pointer.Pointer.IsFocusLocked && pointer.Pointer.IsTargetPositionLockedOnFocusLock)
                 {
-                    // Otherwise, continue
+                    pointer.UpdateFocusLockedHit();
+                }
+                else
+                {
                     LayerMask[] prioritizedLayerMasks = (pointer.Pointer.PrioritizedLayerMasksOverride ?? FocusLayerMasks);
 
                     // Perform raycast to determine focused object
@@ -746,15 +758,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         hit = GetPrioritizedHitResult(hit, hitResultUi, prioritizedLayerMasks);
                     }
 
+                    // Make sure to keep focus on the previous object if focus is locked (no target position lock here).
+                    if (pointer.Pointer.IsFocusLocked && pointer.Pointer.Result?.CurrentPointerTarget != null)
+                    {
+                        hit.hitObject = pointer.Pointer.Result.CurrentPointerTarget;
+                    }
+
                     // Apply the hit result only now so changes in the current target are detected only once per frame.
                     pointer.UpdateHit(hit);
 
                     // Set the pointer's result last
                     pointer.Pointer.Result = pointer;
-                }
-                else
-                {
-                    pointer.UpdateFocusLockedHit();
                 }
             }
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -359,7 +359,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             // If flagged to do so (setCursorInvisibleWhenFocusLocked) and active (IsInteractionEnabled), set the visibility to !IsFocusLocked,
             // but don't touch the visibility when not active or not flagged.
-            if (setCursorInvisibleWhenFocusLocked && (GazePointer?.IsInteractionEnabled ?? false) && GazePointer?.IsFocusLocked == GazeCursor?.IsVisible)
+            if (setCursorInvisibleWhenFocusLocked && GazePointer != null && 
+                GazePointer.IsInteractionEnabled && GazePointer.IsFocusLocked  == GazeCursor.IsVisible)
             {
                 GazeCursor.SetVisibility(!GazePointer.IsFocusLocked);
             }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -868,14 +868,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, Handedness handedness = Handedness.None, IMixedRealityInputSource inputSource = null)
         {
+            pointer.IsFocusLocked = (pointer.Result?.Details.Object != null);
+
             pointerEventData.Initialize(pointer, inputAction, handedness, inputSource);
             
             HandlePointerEvent(pointerEventData, OnPointerDownEventHandler);
-            
-            if (pointer.Result?.Details.Object != null)
-            {
-                pointer.IsFocusLocked = true;
-            }
         }
 
         #endregion Pointer Down
@@ -923,7 +920,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             pointerEventData.Initialize(pointer, inputAction, handedness, inputSource);
 
             HandlePointerEvent(pointerEventData, OnPointerUpEventHandler);
-            
+
             pointer.IsFocusLocked = false;
         }
 

--- a/Assets/MixedRealityToolkit/Definitions/Physics/FocusDetails.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Physics/FocusDetails.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -41,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// The last raycast hit info for graphic raycast
         /// </summary>
         public RaycastResult LastGraphicsRaycastResult { get; set; }
+
         public Vector3 PointLocalSpace { get; set; }
         public Vector3 NormalLocalSpace { get; set; }
     }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityPointerHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityPointerHandler.cs
@@ -11,16 +11,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public interface IMixedRealityPointerHandler : IEventSystemHandler
     {
         /// <summary>
-        /// When a pointer up event is raised, this method is used to pass along the event data to the input handler.
-        /// </summary>
-        /// <param name="eventData"></param>
-        void OnPointerUp(MixedRealityPointerEventData eventData);
-
-        /// <summary>
         /// When a pointer down event is raised, this method is used to pass along the event data to the input handler.
         /// </summary>
         /// <param name="eventData"></param>
         void OnPointerDown(MixedRealityPointerEventData eventData);
+
+        /// <summary>
+        /// When a pointer up event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        /// <param name="eventData"></param>
+        void OnPointerUp(MixedRealityPointerEventData eventData);
 
         /// <summary>
         /// When a pointer clicked event is raised, this method is used to pass along the event data to the input handler.

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
@@ -58,6 +58,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         bool IsFocusLocked { get; set; }
 
         /// <summary>
+        /// Specifies whether the pointer's target position (cursor) is locked to the target object when focus is locked.
+        /// </summary>
+        bool IsTargetPositionLockedOnFocusLock { get; set; }
+
+        /// <summary>
         /// The scene query rays.
         /// </summary>
         RayStep[] Rays { get; }

--- a/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
+++ b/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
@@ -87,6 +87,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool IsFocusLocked { get; set; }
 
+        /// <inheritdoc />
+        public bool IsTargetPositionLockedOnFocusLock { get; set; }
+
         /// <summary>
         /// The pointer's maximum extent when raycasting.
         /// </summary>

--- a/Assets/MixedRealityToolkit/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/MixedRealityRaycaster.cs
@@ -122,6 +122,25 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         }
 
         /// <summary>
+        /// Intersection test of ray step with given plane.
+        /// </summary>
+        /// <returns>Whether the ray step intersects the ray step.</returns>
+        public static bool RaycastPlanePhysicsStep(RayStep step, Plane plane, out Vector3 hitPoint)
+        {
+            if (plane.Raycast(step, out float intersectDistance))
+            {
+                if (intersectDistance <= step.Length)
+                {
+                    hitPoint = ((Ray)step).GetPoint(intersectDistance);
+                    return true;
+                }
+            }
+
+            hitPoint = Vector3.zero;
+            return false;
+        }
+
+        /// <summary>
         /// Sphere raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/> within a specified maximum distance.
         /// </summary>
         /// <param name="step"></param>


### PR DESCRIPTION
Add `TargetPositionLockedOnFocusLock ` for pointers to to allow the cursor to not be position-locked on HandInteractionPan surfaces

Overview
---
In order for the pannable texture to be fixed to the pointer target position, the pointer target position needs to be movable when focus is locked. This change ensures that the focused object is maintained, even if the pointer ray cast may not be hitting the focused object anymore. This only happens when `IMixedRealityPointer.IsTargetPositionLockedOnFocusLock` is set to false (usually in an event handler). The default setting is to keep the position locked on focus lock.

Since focus lock is handled per pointer, target position lock needs to be handled on the same level.

The initial idea was to only allow a `FocusSessionConfiguration` object to be modified in the FocusEnter event. But since the FocusEnter event is not pointer specific, as it is only raised for the first pointer entering the focus, this is currently not possible.