### PR TITLE
Regenerated input system profile for speech sample so we have the default data providers

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityInputSystemProfile.asset
@@ -13,6 +13,62 @@ MonoBehaviour:
   m_Name: Speech.MixedRealityInputSystemProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
+  dataProviderConfigurations:
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityDeviceManager,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+    componentName: Windows Mixed Reality Device Manager
+    priority: 0
+    runtimePlatform: 8
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.OpenVR.Input.OpenVRDeviceManager,
+        Microsoft.MixedReality.Toolkit.Providers.OpenVR
+    componentName: OpenVR Device Manager
+    priority: 0
+    runtimePlatform: 7
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.UnityInput.UnityJoystickManager,
+        Microsoft.MixedReality.Toolkit
+    componentName: Unity Joystick Manager
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.UnityInput.UnityTouchDeviceManager,
+        Microsoft.MixedReality.Toolkit
+    componentName: Unity Touch Device Manager
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Windows.Input.WindowsSpeechInputProvider,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
+    componentName: Windows Speech Input
+    priority: 0
+    runtimePlatform: 25
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Windows.Input.WindowsDictationInputProvider,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
+    componentName: Windows Dictation Input
+    priority: 0
+    runtimePlatform: 25
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.HandJointService, Microsoft.MixedReality.Toolkit
+    componentName: Hand Joint Service
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation
+    componentName: Input Simulation Service
+    priority: 0
+    runtimePlatform: 16
+    deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
+      type: 2}
   focusProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.FocusProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityInputSystemProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityInputSystemProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 00e306afacaf92a4a88a13bb31a11e4f
+guid: 2a6b327d88d172543b7526be8cb2018e
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityToolkitConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityToolkitConfigurationProfile.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   enableCameraProfile: 1
   cameraProfile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}
   enableInputSystem: 1
-  inputSystemProfile: {fileID: 11400000, guid: 00e306afacaf92a4a88a13bb31a11e4f, type: 2}
+  inputSystemProfile: {fileID: 11400000, guid: 2a6b327d88d172543b7526be8cb2018e, type: 2}
   inputSystemType:
     reference: Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem, Microsoft.MixedReality.Toolkit.Services.InputSystem
   enableBoundarySystem: 1
@@ -34,6 +34,7 @@ MonoBehaviour:
   spatialAwarenessSystemType:
     reference: Microsoft.MixedReality.Toolkit.SpatialAwareness.MixedRealitySpatialAwarenessSystem,
       Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem
+  spatialAwarenessSystemProfile: {fileID: 0}
   diagnosticsSystemProfile: {fileID: 11400000, guid: 478436bd1083882479a52d067e98e537,
     type: 2}
   enableDiagnosticsSystem: 0


### PR DESCRIPTION
Data providers in custom input system profiles were lost when the profile was refactored.
