### PR TITLE
Adding EventRouting for Camera events, added option to ClippingPrimitive

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/CameraEventRouter.cs
+++ b/Assets/MixedRealityToolkit/Utilities/CameraEventRouter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// A helper class to provide hooks into the Unity camera exclusive Lifecycle events
+    /// </summary>
+    public class CameraEventRouter : MonoBehaviour
+    {
+        /// <summary>
+        /// A callback to act upon <see cref="MonoBehaviour.OnPreRender()"/> without a script needing to exist on a <see cref="Camera"/> component
+        /// </summary>
+        public event Action<CameraEventRouter> OnCameraPreRender;
+
+        private void OnPreRender()
+        {
+            OnCameraPreRender?.Invoke(this);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/CameraEventRouter.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/CameraEventRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b9c599bb8dcccf448a8788e94533644
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/ClippingPrimitive.cs
+++ b/Assets/MixedRealityToolkit/Utilities/ClippingPrimitive.cs
@@ -1,4 +1,4 @@
-﻿  // Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -36,6 +36,39 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { clippingSide = value; }
         }
 
+
+        /// <summary>
+        /// Toggles whether the primitive will use the Camera OnPreRender event 
+        /// </summary>
+        /// <remarks>This is especially helpful if you're trying to clip dynamically created objects that may be added to the scene after LateUpdate such as OnWillRender</remarks>
+        [SerializeField]
+        [Tooltip("Toggles whether the primitive will use the Camera OnPreRender event")]
+        private bool useOnPreRender;
+
+        public bool UseOnPreRender
+        {
+            get { return useOnPreRender; }
+            set
+            {
+                if (cameraMethods == null)
+                {
+                    cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
+                }
+
+                if (value)
+                {
+                    cameraMethods.OnCameraPreRender += OnCameraPreRender;
+                }
+                else
+                {
+                    cameraMethods.OnCameraPreRender -= OnCameraPreRender;
+                }
+
+                useOnPreRender = value;
+            }
+        }
+
+
         protected abstract string Keyword { get; }
         protected abstract string KeywordProperty { get; }
         protected abstract string ClippingSideProperty { get; }
@@ -45,6 +78,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         protected List<Material> allocatedMaterials = new List<Material>();
 
         private int clippingSideID;
+
+        [SerializeField]
+        [HideInInspector]
+        private CameraEventRouter cameraMethods;
 
         public void AddRenderer(Renderer _renderer)
         {
@@ -93,6 +130,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             UpdateRenderers();
             ToggleClippingFeature(false);
+
+            if(cameraMethods != null)
+            {
+                cameraMethods.OnCameraPreRender -= OnCameraPreRender;
+            }
+        }
+
+        protected void Start()
+        {
+            if (useOnPreRender)
+            {
+                cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
+                cameraMethods.OnCameraPreRender += OnCameraPreRender;
+            }
         }
 
 #if UNITY_EDITOR
@@ -113,6 +164,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 #endif
 
         protected void LateUpdate()
+        {
+            UpdateRenderers();
+        }
+
+        protected void OnCameraPreRender(CameraEventRouter router)
         {
             UpdateRenderers();
         }


### PR DESCRIPTION
**Overview**
Adding a helper script to Utilities that enables components to subscribe to `OnPreRender()` without living on a Camera component. We can add more as needed.

**Context**
I ran into an issue with TextMeshPro objects dynamically creating a sub TMP object at `OnWillRenderObject()`. This means any check for new objects that may exist in `Update()` or `LateUpdate()` will have to wait a minimum of a frame to catch the newly created TMP object.

**Changes**
--- Updated `ClippingPrimitive`. Now has an option to subscribe to  `OnPreRender()`.
