### PR TITLE
Adds 'Utilities' to Mixed Reality Toolkit menu

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/ChannelPackerWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ChannelPackerWindow.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private const string StandardRoughnessShaderName = "Standard (Roughness setup)";
         private const string StandardSpecularShaderName = "Standard (Specular setup)";
 
-        [MenuItem("Mixed Reality Toolkit/Channel Packer")]
+        [MenuItem("Mixed Reality Toolkit/Utilities/Channel Packer")]
         private static void ShowWindow()
         {
             ChannelPackerWindow window = GetWindow<ChannelPackerWindow>();

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -181,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         #region Methods
 
-        [MenuItem("Mixed Reality Toolkit/Build Window", false, 0)]
+        [MenuItem("Mixed Reality Toolkit/Utilities/Build Window", false, 0)]
         public static void OpenWindow()
         {
             // Dock it next to the Scene View.


### PR DESCRIPTION
Overview
---
Moves _Channel Packer_ and _Build Window_ to a _Utilities_ sub-menu.

A nitpicky change but I feel it's important that _Add to Scene and Configure..._ remain as obvious as possible.

Current:
![OldMenu](https://user-images.githubusercontent.com/9789716/55743214-95145a80-59e6-11e9-8e90-d44fbcbbbfac.png)

New:
![NewMenu](https://user-images.githubusercontent.com/9789716/55743219-980f4b00-59e6-11e9-8e60-77053c50286e.png)
