### PR TITLE
Prevent MRTK From repeatedly creating profile-less instance automatically

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit
             get
             {
 #if UNITY_EDITOR
-                if (!Application.isPlaying && activeProfile == null)
+                if (!Application.isPlaying && activeProfile == null && Instance != null)
                 {
                     UnityEditor.Selection.activeObject = Instance;
                     UnityEditor.EditorGUIUtility.PingObject(Instance);

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit
     [DisallowMultipleComponent]
     public class MixedRealityToolkit : MonoBehaviour, IMixedRealityServiceRegistrar
     {
-#region Mixed Reality Toolkit Profile configuration
+        #region Mixed Reality Toolkit Profile configuration
 
         private const string MixedRealityPlayspaceName = "MixedRealityPlayspace";
 
@@ -74,7 +74,9 @@ namespace Microsoft.MixedReality.Toolkit
             get
             {
 #if UNITY_EDITOR
-                if (!Application.isPlaying && activeProfile == null && Instance != null)
+                // Search for existing instance without invoking automatically generating one
+                bool hasActiveInstance = instance != null || FindObjectOfType<MixedRealityToolkit>();
+                if (!Application.isPlaying && activeProfile == null && hasActiveInstance)
                 {
                     UnityEditor.Selection.activeObject = Instance;
                     UnityEditor.EditorGUIUtility.PingObject(Instance);
@@ -123,9 +125,9 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#endregion Mixed Reality Toolkit Profile configuration
+        #endregion Mixed Reality Toolkit Profile configuration
 
-#region Mixed Reality runtime service registry
+        #region Mixed Reality runtime service registry
 
         private static readonly Dictionary<Type, IMixedRealityService> activeSystems = new Dictionary<Type, IMixedRealityService>();
 
@@ -144,9 +146,9 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices => new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices) as IReadOnlyList<Tuple<Type, IMixedRealityService>>;
 
-#endregion Mixed Reality runtime service registry
+        #endregion Mixed Reality runtime service registry
 
-#region IMixedRealityServiceRegistrar implementation
+        #region IMixedRealityServiceRegistrar implementation
 
         /// <inheritdoc />
         public bool RegisterService<T>(T serviceInstance) where T : IMixedRealityService
@@ -156,8 +158,8 @@ namespace Microsoft.MixedReality.Toolkit
 
         /// <inheritdoc />
         public bool RegisterService<T>(
-            Type concreteType, 
-            SupportedPlatforms supportedPlatforms = (SupportedPlatforms)(-1), 
+            Type concreteType,
+            SupportedPlatforms supportedPlatforms = (SupportedPlatforms)(-1),
             params object[] args) where T : IMixedRealityService
         {
             if (isApplicationQuitting)
@@ -205,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit
         public bool UnregisterService<T>(string name = null) where T : IMixedRealityService
         {
             T serviceInstance = GetServiceByName<T>(name);
-            
+
             if (serviceInstance == null) { return false; }
 
             return UnregisterService<T>(serviceInstance);
@@ -318,7 +320,7 @@ namespace Microsoft.MixedReality.Toolkit
             throw new NotImplementedException();
         }
 
-#endregion IMixedRealityServiceRegistrar implementation
+        #endregion IMixedRealityServiceRegistrar implementation
 
         /// <summary>
         /// Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active services.
@@ -367,7 +369,7 @@ namespace Microsoft.MixedReality.Toolkit
                 }
             }
 
-#region Services Registration
+            #region Services Registration
 
             // If the Input system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.IsInputSystemEnabled)
@@ -382,7 +384,7 @@ namespace Microsoft.MixedReality.Toolkit
                 {
                     Debug.LogError("Failed to start the Input System!");
                 }
-                
+
                 args = new object[] { this, InputSystem, ActiveProfile.InputSystemProfile };
                 if (!RegisterDataProvider<IMixedRealityFocusProvider>(ActiveProfile.InputSystemProfile.FocusProviderType, args: args))
                 {
@@ -456,9 +458,9 @@ namespace Microsoft.MixedReality.Toolkit
                 }
             }
 
-#endregion Service Registration
+            #endregion Service Registration
 
-#region Services Initialization
+            #region Services Initialization
 
             var orderedCoreSystems = activeSystems.OrderBy(m => m.Value.Priority).ToArray();
             activeSystems.Clear();
@@ -478,7 +480,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             InitializeAllServices();
 
-#endregion Services Initialization
+            #endregion Services Initialization
 
             isInitializing = false;
         }
@@ -525,7 +527,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#region MonoBehaviour Implementation
+        #region MonoBehaviour Implementation
 
         private static MixedRealityToolkit instance;
         private static bool newInstanceBeingInitialized = false;
@@ -801,11 +803,11 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#endregion MonoBehaviour Implementation
+        #endregion MonoBehaviour Implementation
 
-#region Service Container Management
+        #region Service Container Management
 
-#region Registration
+        #region Registration
         private bool RegisterServiceInternal(Type interfaceType, IMixedRealityService serviceInstance)
         {
             if (serviceInstance == null)
@@ -860,9 +862,9 @@ namespace Microsoft.MixedReality.Toolkit
             return RegisterServiceInternal(interfaceType, serviceInstance);
         }
 
-#endregion Registration
+        #endregion Registration
 
-#region Multiple Service Management
+        #region Multiple Service Management
 
         /// <summary>
         /// Enable all services in the Mixed Reality Toolkit active service registry for a given type
@@ -999,9 +1001,9 @@ namespace Microsoft.MixedReality.Toolkit
             return true;
         }
 
-#endregion Multiple Service Management
+        #endregion Multiple Service Management
 
-#region Service Utilities
+        #region Service Utilities
 
         /// <summary>
         /// Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core system.
@@ -1180,11 +1182,11 @@ namespace Microsoft.MixedReality.Toolkit
             return true;
         }
 
-#endregion Service Utilities
+        #endregion Service Utilities
 
-#endregion Service Container Management
+        #endregion Service Container Management
 
-#region Core System Accessors
+        #region Core System Accessors
 
         private static IMixedRealityInputSystem inputSystem = null;
 
@@ -1342,6 +1344,6 @@ namespace Microsoft.MixedReality.Toolkit
 
         private static bool logDiagnosticsSystem = true;
 
-#endregion Core System Accessors
+        #endregion Core System Accessors
     }
 }


### PR DESCRIPTION
Overview
---
- Previously, if you clicked on any MRTK profile with an open scene lacking an MRTK instance, the MRTK Active profile getter would attempt to request an editor ping to an instance that did not exist, thus creating one in your scene without prompt. 

- This behavior led to the MRTK modifying scenes that shouldn't have been modified.

Changes
---
- Fixes: # .
