### PR TITLE
Move MRTK scene check out of the profile inspector and into a utility class.

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -10,9 +10,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     [CustomEditor(typeof(MixedRealityToolkitConfigurationProfile))]
     public class MixedRealityToolkitConfigurationProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
     {
-        const string HideNoActiveToolkitWarningKey = "MRTK_HideNoActiveToolkitWarningKey";
-        private static bool HideNoActiveToolkitWarning = true;
-
         private static readonly GUIContent TargetScaleContent = new GUIContent("Target Scale:");
 
         // Experience properties
@@ -60,35 +57,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (target == null)
             {
                 // Either when we are recompiling, or the inspector window is hidden behind another one, the target can get destroyed (null) and thereby will raise an ArgumentException when accessing serializedObject. For now, just return.
-                return;
-            }
-
-            configurationProfile = target as MixedRealityToolkitConfigurationProfile;
-
-            // Create The MR Manager if none exists.
-            if (!MixedRealityToolkit.IsInitialized)
-            {
-                // Search the scene for one, in case we've just hot reloaded the assembly.
-                var managerSearch = FindObjectsOfType<MixedRealityToolkit>();
-
-                if (managerSearch.Length == 0)
-                {
-                    HideNoActiveToolkitWarning = SessionState.GetBool(HideNoActiveToolkitWarningKey, false);
-                    if (!HideNoActiveToolkitWarning)
-                    {
-                        NoActiveToolkitWarning.OpenWindow(configurationProfile);
-                    }
-                    return; 
-                }
-            }
-
-            if (!MixedRealityToolkit.ConfirmInitialized())
-            {
-                return;
-            }
-
-            if (!MixedRealityToolkit.Instance.HasActiveProfile)
-            {
                 return;
             }
 
@@ -314,53 +282,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (changed)
             {
                 EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(configurationProfile);
-            }
-        }
-
-        private class NoActiveToolkitWarning : EditorWindow
-        {
-            private static NoActiveToolkitWarning activeWindow;
-            private MixedRealityToolkitConfigurationProfile configurationProfile;
-            private bool hideWarning = false;
-
-            public static void OpenWindow(MixedRealityToolkitConfigurationProfile configurationProfile)
-            {
-                // If we already have an active window, bail
-                if (activeWindow != null)
-                    return;
-
-                activeWindow = EditorWindow.GetWindow<NoActiveToolkitWarning>();
-                activeWindow.configurationProfile = configurationProfile;
-                activeWindow.maxSize = new Vector2(400, 80);
-                activeWindow.minSize = new Vector2(400, 80);
-                activeWindow.titleContent = new GUIContent("No Active Toolkit Found");
-
-                activeWindow.Show(true); 
-            }
-
-            private void OnGUI()
-            {
-                EditorGUILayout.HelpBox("There is no active Mixed Reality Toolkit in your scene. Would you like to create one now?", MessageType.Warning);
-
-                hideWarning = EditorGUILayout.Toggle("Don't show this again", hideWarning);
-
-                EditorGUILayout.BeginHorizontal();
-                if (GUILayout.Button("Yes"))
-                {
-                    var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
-                    Debug.Assert(playspace != null);
-                    MixedRealityToolkit.Instance.ActiveProfile = configurationProfile;
-
-                    SessionState.SetBool(HideNoActiveToolkitWarningKey, hideWarning);
-                    Close();
-                }
-
-                if (GUILayout.Button("No"))
-                {
-                    SessionState.SetBool(HideNoActiveToolkitWarningKey, hideWarning);
-                    Close();
-                }
-                EditorGUILayout.EndHorizontal();
             }
         }
     }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -48,8 +48,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static bool showRegisteredServiceProperties = true;
         private SerializedProperty registeredServiceProvidersProfile;
 
-        private MixedRealityToolkitConfigurationProfile configurationProfile;
-
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -91,6 +89,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void OnInspectorGUI()
         {
+            var configurationProfile = (MixedRealityToolkitConfigurationProfile)target;
+
             serializedObject.Update();
             RenderMixedRealityToolkitLogo();
 

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+// #if UNITY_EDITOR
+
+using Microsoft.MixedReality.Toolkit;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Utility class for checking if a scene has been properly set up for use with MixedRealityToolkit
+    /// </summary>
+    [InitializeOnLoad]
+    public class MixedRealityToolkitSceneChecker
+    {
+        const string HideNoActiveToolkitWarningKey = "MRTK_HideNoActiveToolkitWarningKey";
+        private static bool HideNoActiveToolkitWarning = true;
+
+        static MixedRealityToolkitSceneChecker()
+        {
+            EditorSceneManager.sceneOpened += SceneOpened;
+            EditorSceneManager.newSceneCreated += NewSceneCreated;
+        }
+
+        private static void SceneOpened(Scene scene, OpenSceneMode mode)
+        {
+            CheckMixedRealityToolkitScene();
+        }
+
+        private static void NewSceneCreated(Scene scene, NewSceneSetup setup, NewSceneMode mode)
+        {
+            switch (setup)
+            {
+                case NewSceneSetup.EmptyScene:
+                    break;
+
+                case NewSceneSetup.DefaultGameObjects:
+                    CheckMixedRealityToolkitScene();
+                    break;
+            }
+        }
+
+        private static void CheckMixedRealityToolkitScene()
+        {
+            // configurationProfile = target as MixedRealityToolkitConfigurationProfile;
+
+            // Create The MR Manager if none exists.
+            if (!MixedRealityToolkit.IsInitialized)
+            {
+                // Search the scene for one, in case we've just hot reloaded the assembly.
+                var managerSearch = Object.FindObjectsOfType<MixedRealityToolkit>();
+
+                if (managerSearch.Length == 0)
+                {
+                    HideNoActiveToolkitWarning = SessionState.GetBool(HideNoActiveToolkitWarningKey, false);
+                    if (!HideNoActiveToolkitWarning)
+                    {
+                        NoActiveToolkitWarning.OpenWindow(null);
+                    }
+                    return; 
+                }
+            }
+        }
+
+        internal class NoActiveToolkitWarning : EditorWindow
+        {
+            private static NoActiveToolkitWarning activeWindow;
+            [SerializeField]
+            public MixedRealityToolkitConfigurationProfile configurationProfile;
+            private bool hideWarning = false;
+
+            public static void OpenWindow(MixedRealityToolkitConfigurationProfile configurationProfile)
+            {
+                // If we already have an active window, bail
+                if (activeWindow != null)
+                    return;
+
+                activeWindow = EditorWindow.GetWindow<NoActiveToolkitWarning>();
+                activeWindow.configurationProfile = configurationProfile;
+                activeWindow.maxSize = new Vector2(400, 140);
+                activeWindow.minSize = new Vector2(400, 140);
+                activeWindow.titleContent = new GUIContent("No Active Toolkit Found");
+
+                activeWindow.ShowPopup(); 
+            }
+
+            private void OnGUI()
+            {
+                EditorGUILayout.HelpBox("There is no active Mixed Reality Toolkit in your scene. Would you like to create one now?", MessageType.Warning);
+
+                hideWarning = EditorGUILayout.Toggle("Don't show this again", hideWarning);
+
+                configurationProfile = (MixedRealityToolkitConfigurationProfile)EditorGUILayout.ObjectField(configurationProfile, typeof(MixedRealityToolkitConfigurationProfile), false);
+                if (configurationProfile == null)
+                {
+                    EditorGUILayout.HelpBox("Select a configuration profile.", MessageType.Info);
+                }
+
+                EditorGUILayout.BeginHorizontal();
+                GUI.enabled = (configurationProfile != null);
+                if (GUILayout.Button("Yes"))
+                {
+                    var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
+                    Debug.Assert(playspace != null);
+                    MixedRealityToolkit.Instance.ActiveProfile = configurationProfile;
+
+                    SessionState.SetBool(HideNoActiveToolkitWarningKey, hideWarning);
+                    Close();
+                }
+                GUI.enabled = true;
+
+                if (GUILayout.Button("No"))
+                {
+                    SessionState.SetBool(HideNoActiveToolkitWarningKey, hideWarning);
+                    Close();
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+        }
+    }
+}
+
+// #endif

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
@@ -78,7 +78,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 // If we already have an active window, bail
                 if (activeWindow != null)
+                {
                     return;
+                }
 
                 activeWindow = EditorWindow.GetWindow<NoActiveToolkitWarning>();
                 activeWindow.configurationProfile = configurationProfile;

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
@@ -22,6 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         static MixedRealityToolkitSceneChecker()
         {
+            // Check for a valid MRTK instance when scenes are opened or created.
             EditorSceneManager.sceneOpened += SceneOpened;
             EditorSceneManager.newSceneCreated += NewSceneCreated;
         }
@@ -35,6 +36,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             switch (setup)
             {
+                // Ignore the check when the scene is explicitly empty.
+                // This includes empty scenes in playmode tests.
                 case NewSceneSetup.EmptyScene:
                     break;
 
@@ -46,8 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private static void CheckMixedRealityToolkitScene()
         {
-            // configurationProfile = target as MixedRealityToolkitConfigurationProfile;
-
             // Create The MR Manager if none exists.
             if (!MixedRealityToolkit.IsInitialized)
             {

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-// #if UNITY_EDITOR
+#if UNITY_EDITOR
 
 using Microsoft.MixedReality.Toolkit;
 using UnityEngine;
@@ -125,4 +125,4 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     }
 }
 
-// #endif
+#endif

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebf862aba0d0da944ad46887e6f776b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Overview

This check should not be performed when loading profiles, since it only happens when a profile is actually visible in the inspector, which can happen at arbitrary times in the workflow or not at all. Profiles as separate assets should not be responsible for modifying scene state.

---

Changes

The new utility class will be created on project load (`[InitializeOnLoad]` attribute) and check for a MRTK instance when a new scene is created (with default objects) or when a scene is loaded.

This also solves the problem that the popup would come up when running tests, since these first start from an empty scene before a test scene is loaded. The check will now be ignored in that case, using the `NewSceneSetup.EmptyScene` parameter.

---
- Fixes: #3884 .
