### PR TITLE
Fixed mrtk missing instance bug creating new instances without consent

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -557,6 +557,13 @@ namespace Microsoft.MixedReality.Toolkit
                 switch (objects.Length)
                 {
                     case 0:
+#if UNITY_EDITOR
+                        if (!Application.isPlaying && instance == null)
+                        {
+                            Debug.LogWarning("No MRTK instance found in scene");
+                            return null;
+                        }
+#endif
                         Debug.Assert(!newInstanceBeingInitialized, "We shouldn't be initializing another MixedRealityToolkit unless we errored on the previous.");
                         newInstanceBeingInitialized = true;
                         newInstance = new GameObject(nameof(MixedRealityToolkit)).AddComponent<MixedRealityToolkit>();


### PR DESCRIPTION
Overview
---
- Previously the MRTK would load instances into open scenes without consent, even if  the user responded no to the popup asking for one to be created. This caused large scale scene modifications in scenes without any previous MRTK presence.

- This fix prevents new instances from being created if the application is not playing and no existing instances are found.

Resolves issue https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3921

Changes
---
- Fixes: # .
