### PR TITLE
Release frame after its been used for aruco marker detection

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/PhotoCapture/HoloLensCamera.cs
+++ b/Assets/MixedRealityToolkit.Extensions/PhotoCapture/HoloLensCamera.cs
@@ -1308,18 +1308,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.PhotoCapture
                     latestFrame = frame;
                 }
 
-                int numCallbacks = OnFrameCaptured.GetInvocationList().Length;
-                if (getFrame && OnFrameCaptured != null && numCallbacks > 0)
-                {
-                    /// TODO: add refs
-                    for (int i = 0; i < numCallbacks; ++i)
-                    {
-                        frame.AddRef();
-                    }
-
-                    // callback any registered listeners
-                    OnFrameCaptured?.Invoke(this, frame);
-                }
+                // callback any registered listeners
+                OnFrameCaptured?.Invoke(this, frame);
             }
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
@@ -153,7 +153,6 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.M
                 var extrinsics = frame.Extrinsics;
 
                 var dictionary = _api.ProcessImage(imageData, imageWidth, imageHeight, pixelFormat, intrinsics, extrinsics);
-
                 if (_markerObservations != null)
                 {
                     foreach (var markerPair in dictionary)
@@ -181,7 +180,6 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.M
                 }
             }
 #endif
-            frame.Release();
         }
 
         private static Marker CalcAverageMarker(List<Marker> markers)

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
@@ -153,6 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.M
                 var extrinsics = frame.Extrinsics;
 
                 var dictionary = _api.ProcessImage(imageData, imageWidth, imageHeight, pixelFormat, intrinsics, extrinsics);
+
                 if (_markerObservations != null)
                 {
                     foreach (var markerPair in dictionary)
@@ -180,6 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.M
                 }
             }
 #endif
+            frame.Release();
         }
 
         private static Marker CalcAverageMarker(List<Marker> markers)


### PR DESCRIPTION
Overview
---
Its better to not expect users to release a frame. They should have to opt in to incrementing the reference count for said frame.

Changes
---
- Fixes: # .
