### PR TITLE
Add option to enable / disable pressableButton back press detection

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/PianoKey.prefab
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/PianoKey.prefab
@@ -67,6 +67,7 @@ MonoBehaviour:
   pressDistance: 0.008
   releaseDistanceDelta: 0.001
   returnRate: 10
+  enforceForwardPush: 0
   TouchBegin:
     m_PersistentCalls:
       m_Calls:
@@ -160,7 +161,7 @@ MonoBehaviour:
   eventsToReceive: 0
   touchableSurface: 0
   bounds: {x: 0.004711149, y: 0.024825739}
-  collider: {fileID: 6113324524881885153}
+  touchableCollider: {fileID: 6113324524881885153}
 --- !u!82 &6132438213147574949
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -42,6 +42,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("Speed of the object movement on release.")]
         private float returnRate = 25.0f;
 
+        [SerializeField]
+        [Tooltip("Ensures that the button can only be pushed from the front. Touching the button from the back or side is prevented.")]
+        private bool enforceForwardPush = true;
+
         [Header("Position markers")]
         [Tooltip("Used to mark where button movement begins. If null, it will be automatically generated.")]
         [SerializeField]
@@ -160,15 +164,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             FindOrCreatePathMarkers();
 
-            // Back-Press Detection:
-            // Accept touch only if controller pushed from the front.
-            // Extrapolate to get previous position.
-            Vector3 previousPosition = eventData.InputData - eventData.Controller.Velocity * Time.deltaTime;
-            float previousDistance = GetProjectedDistance(initialTransform.position, WorldSpacePressDirection, previousPosition);
-
-            if (previousDistance > 0.0f)
+            if (enforceForwardPush)
             {
-                return;
+                // Back-Press Detection:
+                // Accept touch only if controller pushed from the front.
+                // Extrapolate to get previous position.
+                Vector3 previousPosition = eventData.InputData - eventData.Controller.Velocity * Time.deltaTime;
+                float previousDistance = GetProjectedDistance(initialTransform.position, WorldSpacePressDirection, previousPosition);
+
+                if (previousDistance > 0.0f)
+                {
+                    return;
+                }
             }
 
             Debug.Assert(!touchPoints.ContainsKey(eventData.Controller));

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -61,9 +61,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (Selection.activeObject != button.gameObject)
                 return;
 
-            // Instruct the button to create its path markers
-            button.FindOrCreatePathMarkers();
-
             Vector3 touchCageSize = touchCage.size;
             Vector3 touchCageCenter = touchCage.center;
             Bounds touchCageLocalBounds = new Bounds(touchCageCenter, touchCageSize);


### PR DESCRIPTION
Overview
---
Add option to enable / disable back-press detection.

Handle back-press detection differently by only using a check in OnTouchStarted: Test whether the controller was pushing from the front by taking into account its velocity. 