### PR TITLE
Remove all pointer data on input module deactivation

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -77,10 +77,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 MixedRealityToolkit.InputSystem.Unregister(gameObject);
 
-                foreach (IMixedRealityInputSource inputSource in MixedRealityToolkit.InputSystem.DetectedInputSources)
+                foreach (var p in pointerDataToUpdate)
                 {
-                    OnSourceLost(inputSource);
+                    pointerDataToRemove.Add(p.Value);
                 }
+                pointerDataToUpdate.Clear();
 
                 // Process once more to handle pointer removals.
                 Process();
@@ -281,11 +282,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
-            OnSourceLost(eventData.InputSource);
-        }
+            var inputSource = eventData.InputSource;
 
-        void OnSourceLost(IMixedRealityInputSource inputSource)
-        {
             for (int i = 0; i < inputSource.Pointers.Length; i++)
             {
                 var pointer = inputSource.Pointers[i];


### PR DESCRIPTION
Overview
---
MixedRealityInputModule was only correctly releasing pointer data for input sources currently in the input system. Changed it to release all pointer data instead.

Changes
---
- Fixes: #3944 .
