### PR TITLE
Update the MixedRealityPreferences to explicitly provide a SettingScope

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SettingsProvider]
         private static SettingsProvider Preferences()
         {
-            var provider = new SettingsProvider("Project/MRTK")
+            var provider = new SettingsProvider("Project/MRTK", SettingsScope.Project)
             {
                 label = "MRTK",
 


### PR DESCRIPTION
Interestingly enough this appears to be the only compile-time incompatibility
with Unity 2019.1. 2019.1 support in the MRTK is still highly experiemental
but with this change the UWP should build (and be deployable to HL2)

Also note that this change doesn't affect 2018.3 behavior, see:
https://github.com/Unity-Technologies/UnityCsReference/blob/2018.3/Editor/Mono/Settings/SettingsProvider.cs

vs

https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Editor/Mono/Settings/SettingsProvider.cs

The constructor for this object used to default to SettingsScope.Project
2019.1 removed the default (for the second parameter only).

https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3951