### PR TITLE
Update some of the MRTK-specific .NET scripting backend callouts.

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -455,7 +455,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             if (curScriptingBackend == ScriptingImplementation.WinRTDotNET)
             {
-                EditorGUILayout.HelpBox(".NET Scripting backend is depreciated, please use IL2CPP.", MessageType.Warning);
+                EditorGUILayout.HelpBox(".NET Scripting backend is deprecated in Unity 2018 and is removed in Unity 2019.", MessageType.Warning);
             }
 
             var newScriptingBackend = (ScriptingImplementation)EditorGUILayout.IntPopup("Scripting Backend", (int)curScriptingBackend, scriptingBackendNames, scriptingBackendEnum, GUILayout.Width(HALF_WIDTH));

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -68,13 +68,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     message += "- Force Text Serialization\n";
                 }
 
-                var il2Cpp = PlayerSettings.GetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup) == ScriptingImplementation.IL2CPP;
-
-                if (!il2Cpp)
-                {
-                    message += "- Change the Scripting Backend to use IL2CPP\n";
-                }
-
                 var visibleMetaFiles = EditorSettings.externalVersionControl.Equals("Visible Meta Files");
 
                 if (!visibleMetaFiles)
@@ -89,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                 message += "\nWould you like to make this change?";
 
-                if (!forceTextSerialization || !il2Cpp || !visibleMetaFiles || !PlayerSettings.virtualRealitySupported)
+                if (!forceTextSerialization || !visibleMetaFiles || !PlayerSettings.virtualRealitySupported)
                 {
                     var choice = EditorUtility.DisplayDialogComplex("Apply Mixed Reality Toolkit Default Settings?", message, "Apply", "Ignore", "Later");
 
@@ -98,7 +91,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         case 0:
                             EditorSettings.serializationMode = SerializationMode.ForceText;
                             EditorSettings.externalVersionControl = "Visible Meta Files";
-                            PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.IL2CPP);
                             PlayerSettings.virtualRealitySupported = true;
                             refresh = true;
                             break;


### PR DESCRIPTION
A couple of things here:

BuildDeployWindow.cs - The user already gets .NET backend deprecation warnings in the regular Unity build window. The language of this warning is a bit strong telling people to switch to IL2CPP that may have good reason to stick to .NET (i.e. they actually want a debuggable experience and a faster inner loop). This changes the message to be closer to what Unity says - i.e. it's deprecated, try to use the new thing, but you don't have to. Originally I was going to remove this but then opted to keep it around in case people are only using this build window (in which case they still have some notification that this isn't going to be supported going forward.)

MixedRealityEditorSettings.cs - This was actually a fairly problematic suggestion, because really going to IL2CPP is not actually required in Unity 2018.3.x (whose LTS version we are going to support.) What's worse is pressing "ignore" actually set a UNITY APPLICATION WIDE setting which would disable this prompt in other projects as well, and would also stop you from seeing suggestions to enable XR settings (i.e. if you switched from Standalone -> UWP, you would never see suggestion to enable XR settings). People who are enabling the .NET backend are doing so explicitly (and likely because they want a more debuggable experience) and we shouldn't force them away from that.