### PR TITLE
Build and deploy window fixes

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -162,7 +162,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private static float timeLastUpdatedBuilds;
 
         private string[] targetIps;
-        private string[] windowsSdkPaths;
+        private List<Version> windowsSdkVersions = new List<Version>();
 
         private Vector2 scrollPosition;
 
@@ -195,13 +195,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             titleContent = new GUIContent("Build Window");
             minSize = new Vector2(512, 256);
 
-            windowsSdkPaths = Directory.GetDirectories(@"C:\Program Files (x86)\Windows Kits\10\Lib");
-
-            for (int i = 0; i < windowsSdkPaths.Length; i++)
-            {
-                windowsSdkPaths[i] = windowsSdkPaths[i].Substring(windowsSdkPaths[i].LastIndexOf(@"\", StringComparison.Ordinal) + 1);
-            }
-
+            LoadWindowsSdkPaths();
             UpdateBuilds();
 
             currentConnectionInfoIndex = lastSessionConnectionInfoIndex;
@@ -406,30 +400,24 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             GUILayout.BeginVertical();
 
-            // SDK and MS Build Version(and save setting, if it's changed)
+            // SDK and MS Build Version (and save setting, if it's changed)
             string currentSDKVersion = EditorUserBuildSettings.wsaMinUWPSDK;
 
-            int currentSDKVersionIndex = -1;
-
-            for (var i = 0; i < windowsSdkPaths.Length; i++)
+            Version chosenSDKVersion = null;
+            for (var i = 0; i < windowsSdkVersions.Count; i++)
             {
-                if (string.IsNullOrEmpty(currentSDKVersion))
+                // windowsSdkVersions is sorted in ascending order, so we always take
+                // the highest SDK version that is above our minimum.
+                if (windowsSdkVersions[i] >= UwpBuildDeployPreferences.MIN_SDK_VERSION)
                 {
-                    currentSDKVersionIndex = windowsSdkPaths.Length - 1;
-                }
-                else
-                {
-                    if (windowsSdkPaths[i].Equals(UwpBuildDeployPreferences.MIN_SDK_VERSION))
-                    {
-                        currentSDKVersionIndex = i;
-                    }
+                    chosenSDKVersion = windowsSdkVersions[i];
                 }
             }
 
-            EditorGUILayout.HelpBox($"Minimum Required SDK Version: {currentSDKVersion}", MessageType.Info);
+            EditorGUILayout.HelpBox($"Windows SDK Version: {currentSDKVersion}", MessageType.Info);
 
             // Throw exception if user has no Windows 10 SDK installed
-            if (currentSDKVersionIndex < 0)
+            if (chosenSDKVersion == null)
             {
                 if (IsValidSdkInstalled)
                 {
@@ -444,8 +432,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             IsValidSdkInstalled = true;
 
-            string newSDKVersion = windowsSdkPaths[currentSDKVersionIndex];
-
+            string newSDKVersion = chosenSDKVersion.ToString();
             if (!newSDKVersion.Equals(currentSDKVersion))
             {
                 EditorUserBuildSettings.wsaMinUWPSDK = newSDKVersion;
@@ -1242,6 +1229,19 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             Debug.LogError($"Unable to find PackageFamilyName in manifest file ({manifest})");
             return string.Empty;
+        }
+
+        private void LoadWindowsSdkPaths()
+        {
+            var windowsSdkPaths = Directory.GetDirectories(@"C:\Program Files (x86)\Windows Kits\10\Lib");
+            for (int i = 0; i < windowsSdkPaths.Length; i++)
+            {
+                windowsSdkVersions.Add(new Version(windowsSdkPaths[i].Substring(windowsSdkPaths[i].LastIndexOf(@"\", StringComparison.Ordinal) + 1)));
+            }
+
+            // There is no well-defined enumeration of Directory.GetDirectories, so the list
+            // is sorted prior to use later in this class.
+            windowsSdkVersions.Sort();
         }
 
         #endregion Utilities

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -260,7 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             if (string.IsNullOrWhiteSpace(EditorUserBuildSettings.wsaMinUWPSDK))
             {
-                EditorUserBuildSettings.wsaMinUWPSDK = UwpBuildDeployPreferences.MIN_SDK_VERSION;
+                EditorUserBuildSettings.wsaMinUWPSDK = UwpBuildDeployPreferences.MIN_SDK_VERSION.ToString();
             }
 
             string minVersion = EditorUserBuildSettings.wsaMinUWPSDK;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -3,13 +3,14 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using Microsoft.MixedReality.Toolkit.WindowsDevicePortal;
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Build.Editor
 {
     public static class UwpBuildDeployPreferences
     {
-        public const string MIN_SDK_VERSION = "10.0.17134.0";
+        public static Version MIN_SDK_VERSION = new Version("10.0.17134.0");
         private const string EDITOR_PREF_BUILD_CONFIG = "BuildDeployWindow_BuildConfig";
         private const string EDITOR_PREF_FORCE_REBUILD = "BuildDeployWindow_ForceRebuild";
         private const string EDITOR_PREF_CONNECT_INFOS = "BuildDeployWindow_DeviceConnections";


### PR DESCRIPTION
While looking into other build related issues (i.e. IL2CPP vs .NET) I noticed that there were some issues with the build window (with respect to SDK versioning and chosing the right SDK).

There were a couple of issues:
1) There was a concept of a "min" SDK, but the code was actually doing an equality comparison to look for it. That is, if you had GREATER than the min SDK it would fall over.
2) It looks like even if you set a different target SDK than you current (i.e. if you had a higher target SDK than the current min one specified by the MRTK), it would lower your target.

This does change things a bit in that this will now prefer the latest SDK (over always the min SDK). It's a marginal improvement over the old in that now future progress (where new SDK version drops occur) don't cause you to fall over because you didn't detect the "minimum" (because you actually have higher than the minimum).

Also switches to using the Version type instead of doing string comparisons (as this allows us to properly sort and reason over versions instead of strings)