### PR TITLE
Update the MRTK root profile picker to select a reasonable default.

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -35,7 +35,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     EditorUtility.DisplayDialog("Attention!", "You must choose a profile for the Mixed Reality Toolkit.", "OK");
                     currentPickerWindow = GUIUtility.GetControlID(FocusType.Passive);
-                    EditorGUIUtility.ShowObjectPicker<MixedRealityToolkitConfigurationProfile>(null, false, string.Empty, currentPickerWindow);
+                    // Shows the list of MixedRealityToolkitConfigurationProfiles in our project,
+                    // selecting the default profile by default (if it exists).
+                    EditorGUIUtility.ShowObjectPicker<MixedRealityToolkitConfigurationProfile>(GetDefaultProfile(allConfigProfiles), false, string.Empty, currentPickerWindow);
                 }
                 else if (allConfigProfiles.Length == 1)
                 {
@@ -100,6 +102,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             var playspace = MixedRealityToolkit.Instance.MixedRealityPlayspace;
             Debug.Assert(playspace != null);
             EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
+        }
+
+        /// <summary>
+        /// Given a list of MixedRealityToolkitConfigurationProfile objects, returns
+        /// the one that matches the default profile name.
+        /// </summary>
+        private MixedRealityToolkitConfigurationProfile GetDefaultProfile(MixedRealityToolkitConfigurationProfile[] allProfiles)
+        {
+            for (int i = 0; i < allProfiles.Length; i++)
+            {
+                if (allProfiles[i].name == "DefaultMixedRealityToolkitConfigurationProfile")
+                {
+                    return allProfiles[i];
+                }
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
One of the points of customer feedback we've seen internally is that as a new person configuring a scene for the first time, they see a list of ~5 profiles of which they don't know what to pick. We should at least point to a reasonable default (i.e. the default profile), even if we don't want to filter down this list further to avoid breaking advanced user scenarios.