### PR TITLE
Update the default location that profiles are cloned to.

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -37,8 +38,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public System.Type ProfileType;
         }
 
+        private const string DefaultCustomProfileFolder = "Assets/MixedRealityToolkit.Generated/CustomProfiles";
         private const string IsCustomProfileProperty = "isCustomProfile";
-        private static readonly Vector2 MinWindowSizeBasic = new Vector2(500, 140);
+        private static readonly Vector2 MinWindowSizeBasic = new Vector2(500, 170);
         private const float SubProfileSizeMultiplier = 70f;
         private static MixedRealityProfileCloneWindow cloneWindow;
 
@@ -188,14 +190,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUILayout.FlexibleSpace();
 
             // Get the selected folder in the project window
-            GetSelectedPathOrFallback(ref targetFolder);
-            targetFolder = EditorGUILayout.ObjectField("Target Folder", targetFolder, typeof(Object), false);
+            targetFolder = EditorGUILayout.ObjectField("Target Folder", targetFolder, typeof(DefaultAsset), false);
+            EditorGUILayout.HelpBox("If no folder is provided, the profile will be cloned to the Assets/MixedRealityToolkit.Generated/CustomProfiles folder.", MessageType.Info);
             childProfileAssetName = EditorGUILayout.TextField("Profile Name", childProfileAssetName);
 
             EditorGUILayout.BeginHorizontal();
 
             if (GUILayout.Button("Clone"))
             {
+                targetFolder = EnsureTargetFolder(targetFolder);
                 CloneMainProfile();
             }
             if (GUILayout.Button("Cancel"))
@@ -298,24 +301,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             AssetDatabase.SaveAssets();
         }
 
-        public static void GetSelectedPathOrFallback(ref Object folderObject)
-        {
-            foreach (Object obj in Selection.GetFiltered(typeof(Object), SelectionMode.Assets))
-            {
-                string path = AssetDatabase.GetAssetPath(obj);
-                if (!string.IsNullOrEmpty(path) && System.IO.Directory.Exists(path))
-                {
-                    folderObject = obj;
-                    return;
-                }
-            }
-
-            if (folderObject == null)
-            {
-                folderObject = AssetDatabase.LoadAssetAtPath("Assets", typeof(Object));
-            }
-        }
-
         private static System.Type FindProfileType(string profileTypeName)
         {
             System.Type type = null;
@@ -332,6 +317,29 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             return type;
+        }
+
+        /// <summary>
+        /// If the targetFolder is invalid asset folder, this will create the CustomProfiles
+        /// folder and use that as the default target.
+        /// </summary>
+        private static Object EnsureTargetFolder(Object targetFolder)
+        {
+            if (targetFolder != null && AssetDatabase.IsValidFolder(AssetDatabase.GetAssetPath(targetFolder)))
+            {
+                return targetFolder;
+            }
+
+            if (!AssetDatabase.IsValidFolder(DefaultCustomProfileFolder))
+            {
+                // AssetDatabase.CreateFolder must be called to create each child of the asset folder
+                // path individually. 
+                // Calling AssetDatabase.CreateFolder("Assets", "MixedRealityToolkit.Generated/CustomProfiles")
+                // generates a folder that looks like "Assets/MixedRealityToolkit.Generated_CustomProfiles".
+                AssetDatabase.CreateFolder("Assets", "MixedRealityToolkit.Generated");
+                AssetDatabase.CreateFolder("Assets/MixedRealityToolkit.Generated", "CustomProfiles");
+            }
+            return AssetDatabase.LoadAssetAtPath(DefaultCustomProfileFolder, typeof(Object));
         }
     }
 }


### PR DESCRIPTION
Currently there place where we clone profiles is somewhat inconsistent - if you clone default root MRTK profile it will go into the CustomProfiles by default. If you use the clone button for the other profiles, they will get dumped in the root Assets folder, which isn't optimal. This makes it so that we at least default to a reasonable thing (the CustomProfiles) while providing a way to override that if so desired.