### PR TITLE
Prevent MRTK instance from being created OnAppQuitting

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -557,6 +557,14 @@ namespace Microsoft.MixedReality.Toolkit
                 switch (objects.Length)
                 {
                     case 0:
+#if UNITY_EDITOR
+                        // Generating a new instance during app shutdown in the editor allows instances to persist into edit mode, which cause unwanted behavior
+                        if (isApplicationQuitting)
+                        {
+                            Debug.LogWarning("Trying to find instance during application shutdown.");
+                            return null;
+                        }
+#endif
                         Debug.Assert(!newInstanceBeingInitialized, "We shouldn't be initializing another MixedRealityToolkit unless we errored on the previous.");
                         newInstanceBeingInitialized = true;
                         newInstance = new GameObject(nameof(MixedRealityToolkit)).AddComponent<MixedRealityToolkit>();

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -558,7 +558,7 @@ namespace Microsoft.MixedReality.Toolkit
                 {
                     case 0:
 #if UNITY_EDITOR
-                        // Generating a new instance during app shutdown in the editor allows instances to persist into edit mode, which cause unwanted behavior
+                        // Generating a new instance during app shutdown in the editor allows instances to persist into edit mode, which may cause unwanted behavior
                         if (isApplicationQuitting)
                         {
                             Debug.LogWarning("Trying to find instance during application shutdown.");


### PR DESCRIPTION
Overview
---
Generating a new instance during app shutdown in the editor allows instances to persist into edit mode, which cause unwanted behavior.

This fix returns a null Instance of the MRTK if none are found in the scene and the app is quitting while running in the editor.

Previously, the editor could attempt to ping the MRTK instance while the app was shutting down, which caused it to generate an instance during shutdown, which it held onto during the transition back to edit mode.

Changes
---
- Fixes: # .
