### PR TITLE
Modified input system to keep track of last pointer down

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -60,6 +60,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public IMixedRealityEyeGazeProvider EyeGazeProvider { get; private set; }
 
+        /// <inheritdoc />
+        public IMixedRealityPointer LastPointerDown { get; private set; }
+
         private readonly Stack<GameObject> modalInputStack = new Stack<GameObject>();
         private readonly Stack<GameObject> fallbackInputStack = new Stack<GameObject>();
 
@@ -868,6 +871,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, Handedness handedness = Handedness.None, IMixedRealityInputSource inputSource = null)
         {
+            LastPointerDown = pointer;
             pointer.IsFocusLocked = (pointer.Result?.Details.Object != null);
 
             pointerEventData.Initialize(pointer, inputAction, handedness, inputSource);

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -53,6 +53,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         IMixedRealityEyeGazeProvider EyeGazeProvider { get; }
 
         /// <summary>
+        /// Last pointer to raise a pointer down event. May be useful for choosing a primary pointer in two handed setups.
+        /// </summary>
+        IMixedRealityPointer LastPointerDown { get; }
+
+        /// <summary>
         /// Indicates if input is currently enabled or not.
         /// </summary>
         bool IsInputEnabled { get; }


### PR DESCRIPTION
Keep track of the last pointer to raise a pointer down event to help on choosing the primary pointer in two handed setups.

- Fixes: #3957 .
