### PR TITLE
Updated with a new way of loading resources from project folders

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Devices/ControllerMappingLibrary.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/ControllerMappingLibrary.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #if UNITY_EDITOR
-using System;
-using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 #endif
@@ -280,12 +280,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static Texture2D GetControllerTextureInternal(string relativeTexturePath, Handedness handedness, string suffix)
         {
             string handednessSuffix = string.Empty;
-            if (handedness == Handedness.Left) handednessSuffix = "_left";
-            else if (handedness == Handedness.Right) handednessSuffix = "_right";
+            if (handedness == Handedness.Left)
+            {
+                handednessSuffix = "_left";
+            }
+            else if (handedness == Handedness.Right)
+            {
+                handednessSuffix = "_right";
+            }
 
             string themeSuffix = EditorGUIUtility.isProSkin ? "_white" : "_black";
 
-            string fullTexturePath = $"{MixedRealityEditorSettings.MixedRealityToolkit_RelativeFolderPath}/{relativeTexturePath}{handednessSuffix}{themeSuffix}{suffix}.png";
+            string fullTexturePath = MixedRealityToolkitFiles.MapRelativeFilePath($"{relativeTexturePath}{handednessSuffix}{themeSuffix}{suffix}.png");
             return (Texture2D)AssetDatabase.LoadAssetAtPath(fullTexturePath, typeof(Texture2D));
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using System;
 using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -21,19 +20,19 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         [SerializeField]
         private Texture2D logoDarkTheme = null;
-        
+
         protected virtual void Awake()
         {
-            string assetPath = $"{MixedRealityEditorSettings.MixedRealityToolkit_RelativeFolderPath}/StandardAssets/Textures";
+            string assetPath = "StandardAssets/Textures";
 
             if (logoLightTheme == null)
             {
-                logoLightTheme = (Texture2D)AssetDatabase.LoadAssetAtPath($"{assetPath}/MRTK_Logo_Black.png", typeof(Texture2D));
+                logoLightTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath($"{assetPath}/MRTK_Logo_Black.png"), typeof(Texture2D));
             }
 
             if (logoDarkTheme == null)
             {
-                logoDarkTheme = (Texture2D)AssetDatabase.LoadAssetAtPath($"{assetPath}/MRTK_Logo_White.png", typeof(Texture2D));
+                logoDarkTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath($"{assetPath}/MRTK_Logo_White.png"), typeof(Texture2D));
             }
         }
 
@@ -44,7 +43,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             // If we're being rendered as a sub profile, don't show the logo
             if (RenderAsSubProfile)
+            {
                 return;
+            }
 
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
@@ -53,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUILayout.EndHorizontal();
             GUILayout.Space(12f);
         }
-        
+
         /// <summary>
         /// Renders a button that will take user back to a specified profile object
         /// </summary>
@@ -64,7 +65,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             // If we're being rendered as a sub profile, don't show the button
             if (RenderAsSubProfile)
+            {
                 return false;
+            }
 
             if (GUILayout.Button(message))
             {

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -24,8 +24,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private const string IgnoreKey = "_MixedRealityToolkit_Editor_IgnoreSettingsPrompts";
         private const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
 
-        private static string mixedRealityToolkit_RelativeFolderPath = string.Empty;
-
         [Obsolete("Use the 'MixedRealityToolkitFiles' APIs.")]
         public static string MixedRealityToolkit_AbsoluteFolderPath
         {
@@ -53,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         [Obsolete("Use the 'MixedRealityToolkitFiles' APIs.")]
         public static string MixedRealityToolkit_RelativeFolderPath
         {
-            get { return MakePathRelativeToProject(MixedRealityToolkit_AbsoluteFolderPath); }
+            get { return MixedRealityToolkitFiles.GetAssetDatabasePath(MixedRealityToolkit_AbsoluteFolderPath); }
         }
 
         static MixedRealityEditorSettings()
@@ -170,7 +168,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             string absolutePath;
             if (FindDirectory(directoryPathToSearch, directoryName, out absolutePath))
             {
-                path = MakePathRelativeToProject(absolutePath);
+                path = MixedRealityToolkitFiles.GetAssetDatabasePath(absolutePath);
                 return true;
             }
 
@@ -213,12 +211,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return false;
         }
 
-        internal static string MakePathRelativeToProject(string absolutePath)
-        {
-            return absolutePath.Replace(
-                Application.dataPath + Path.DirectorySeparatorChar,
-                "Assets" + Path.DirectorySeparatorChar);
-        }
+        [Obsolete("Use MixedRealityToolkitFiles.GetAssetDatabasePath instead.")]
+        internal static string MakePathRelativeToProject(string absolutePath) => MixedRealityToolkitFiles.GetAssetDatabasePath(absolutePath);
 
         private static void SetIconTheme()
         {

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
+{
+    /// <summary>
+    /// API for working with MixedRealityToolkit folders contained in the project.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class MixedRealityToolkitFiles
+    {
+        private class AssetPostprocessor : UnityEditor.AssetPostprocessor
+        {
+            public static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+            {
+                searchForFoldersTask.Wait();
+
+                foreach (string asset in importedAssets.Concat(movedAssets))
+                {
+                    string folder = asset.Replace("Assets", Application.dataPath);
+                    if (folder.EndsWith(MixedRealityToolkitDirectory))
+                    {
+                        mrtkFolders.Add(NormalizeSeparators(folder));
+                    }
+                }
+
+                foreach (string asset in deletedAssets.Concat(movedFromAssetPaths))
+                {
+                    string folder = asset.Replace("Assets", Application.dataPath);
+                    if (folder.EndsWith(MixedRealityToolkitDirectory))
+                    {
+                        folder = NormalizeSeparators(folder);
+                        if (mrtkFolders.Contains(folder) && !Directory.Exists(folder))
+                        {
+                            // The contains check in the if statement is faster than Directory.Exists so that's why it's used
+                            // Otherwise, it isn't necessary, as the statement below doesn't throw if item wasn't found
+                            mrtkFolders.Remove(folder);
+                        }
+                    }
+                }
+            }
+        }
+
+        private const string MixedRealityToolkitDirectory = "MixedRealityToolkit";
+
+        private readonly static HashSet<string> mrtkFolders = new HashSet<string>();
+        private readonly static Task searchForFoldersTask;
+
+        /// <summary>
+        /// Returns a collection of MRTK directories found in the project.
+        /// </summary>
+        public static IEnumerable<string> MRTKDirectories { get; } = mrtkFolders;
+
+        /// <summary>
+        /// Are any of the MRTK directories available?
+        /// </summary>
+        public static bool AreFoldersAvailable
+        {
+            get
+            {
+                searchForFoldersTask.Wait();
+                return mrtkFolders.Count > 0;
+            }
+        }
+
+        static MixedRealityToolkitFiles()
+        {
+            string path = Application.dataPath;
+            searchForFoldersTask = Task.Run(() => SearchForFoldersAsync(path));
+        }
+
+        private static void SearchForFoldersAsync(string rootPath)
+        {
+            IEnumerable<string> directories = Directory.GetDirectories(rootPath, MixedRealityToolkitDirectory, SearchOption.AllDirectories)
+                .Select(NormalizeSeparators);
+
+            foreach (string s in directories)
+            {
+                mrtkFolders.Add(s);
+            }
+        }
+
+        private static string NormalizeSeparators(string path) => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+        /// <summary>
+        /// Returns files from all folder instances of the MRTK folder relative path.
+        /// </summary>
+        /// <param name="mrtkRelativeFolder">The MRTK folder relative path to the target folder.</param>
+        /// <returns>The array of files.</returns>
+        public static string[] GetFiles(string mrtkRelativeFolder)
+        {
+            if (!AreFoldersAvailable)
+            {
+                Debug.LogError("Failed to locate MixedRealityToolkit folders in the project.");
+                return null;
+            }
+
+            return mrtkFolders
+                .Select(t => Path.Combine(t, mrtkRelativeFolder))
+                .Where(Directory.Exists)
+                .SelectMany(t => Directory.GetFiles(t))
+                .Select(MixedRealityEditorSettings.MakePathRelativeToProject)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Maps a single relative path file to a concrete path from one of the MRTK folders, if found. Otherwise returns null.
+        /// </summary>
+        /// <param name="mrtkPathToFile">The MRTK folder relative path to the file.</param>
+        /// <returns>The project relative path to the file.</returns>
+        public static string MapRelativeFilePath(string mrtkPathToFile)
+        {
+            if (!AreFoldersAvailable)
+            {
+                Debug.LogError("Failed to locate MixedRealityToolkit folders in the project.");
+                return null;
+            }
+
+            return MixedRealityEditorSettings.MakePathRelativeToProject(mrtkFolders
+                .Select(t => Path.Combine(t, mrtkPathToFile))
+                .FirstOrDefault(t => File.Exists(t)));
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -93,6 +93,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static string NormalizeSeparators(string path) => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
+        private static string FormatSeparatorsForUnity(string path) => path.Replace('\\', '/');
+
+        /// <summary>
+        /// Maps an absolute path to be relative to the Project Root path (the Unity folder that contains Assets)
+        /// </summary>
+        /// <param name="absolutePath">The absolute path to the project/</param>
+        /// <returns>The project relative path.</returns>
+        /// <remarks>This doesn't produce paths that contain step out '..' relative paths.</remarks>
+        public static string GetAssetDatabasePath(string absolutePath) => FormatSeparatorsForUnity(absolutePath).Replace(Application.dataPath, "Assets");
+
         /// <summary>
         /// Returns files from all folder instances of the MRTK folder relative path.
         /// </summary>
@@ -110,7 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 .Select(t => Path.Combine(t, mrtkRelativeFolder))
                 .Where(Directory.Exists)
                 .SelectMany(t => Directory.GetFiles(t))
-                .Select(MixedRealityEditorSettings.MakePathRelativeToProject)
+                .Select(GetAssetDatabasePath)
                 .ToArray();
         }
 
@@ -127,9 +137,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return null;
             }
 
-            return MixedRealityEditorSettings.MakePathRelativeToProject(mrtkFolders
+            string path = mrtkFolders
                 .Select(t => Path.Combine(t, mrtkPathToFile))
-                .FirstOrDefault(t => File.Exists(t)));
+                .FirstOrDefault(t => File.Exists(t));
+
+            return path != null ? GetAssetDatabasePath(path) : null;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -16,6 +16,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     [InitializeOnLoad]
     public static class MixedRealityToolkitFiles
     {
+        /// <summary>
+        /// In order to subscribe for a <see cref="OnPostprocessAllAssets(string[], string[], string[], string[])"/> callback, 
+        /// the class declaring the method must derive from AssetPostprocessor. So this class is nested privately as to prevent instnatiation of it.
+        /// </summary>
         private class AssetPostprocessor : UnityEditor.AssetPostprocessor
         {
             public static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00d4aafcdc7f71249ba8dc40c6762459
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This work is needed when MRTK is split into separate NuGet packages and may contain assets split across those package folders.