### PR TITLE
Fix a couple of inspector related bugs and exceptions

### DIFF
--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
@@ -44,7 +44,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             AssetDatabase.CreateAsset(scriptableObject, assetPathAndName);
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
-            EditorUtility.FocusProjectWindow();
             Selection.activeObject = scriptableObject;
             EditorGUIUtility.PingObject(scriptableObject);
             return scriptableObject;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -253,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         var newSubProfile = CloneProfile(newChildProfile, subProfileToClone, action.ProfileType.Name, actionProperty, targetFolder, action.CloneName);
                         SerializedObject newSubProfileSerializedObject = new SerializedObject(newSubProfile);
                         // Paste values from existing profile
-                        PasteProfileValues(newChildProfile, newSubProfile, newSubProfileSerializedObject);
+                        PasteProfileValues(newChildProfile, subProfileToClone, newSubProfileSerializedObject);
                         newSubProfileSerializedObject.ApplyModifiedProperties();
                         break;
 


### PR DESCRIPTION
Fixes two things, which kinda are fixed together because one of them blocks the other. The main thing this addresses is the cloning of profile's failure to clone subprofiles correctly (i.e. if you do:

Click 'Copy & Customize' in Mixed Reality Toolkit component
Click 'Clone' by Input System Profile
Select 'Clone Existing' in Pointer Profile and click 'Clone'
Navigate to newly created pointer profile and observe how the Pointer Options array is empty)

1) Removed line in ScriptableObjectExtensions was causing exceptions in the case where you cloned a profile. This actually was causing the sub-profile cloning code to hit an exception and then never actually copy things over. This also manifests itself when you just hit "copy and customize" for the root profile. AFAICT I can see that this has existed for ~5 months now since the report here: #3225.
2) For MixedRealityProfileCloneWindow, it was just passing the wrong variable (i.e. it was passing the empty thing instead of the non-empty thing).