### PR TITLE
Remove references to dead field showCursorWithEyeGaze.

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
@@ -24,7 +24,6 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  showCursorWithEyeGaze: 0
   pointerOptions:
   - controllerType: 256
     handedness: 7

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
@@ -24,7 +24,6 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  showCursorWithEyeGaze: 0
   pointerOptions:
   - controllerType: 1071
     handedness: 7

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -71,15 +71,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [SerializeField]
-        [Tooltip("Whether or not to show the cursor when using eye gaze.")]
-        private bool showCursorWithEyeGaze = false;
-
-        /// <summary>
-        /// Whether or not to show the cursor when using eye gaze.
-        /// </summary>
-        public bool ShowCursorWithEyeGaze => showCursorWithEyeGaze;
-
-        [SerializeField]
         [Tooltip("The Pointer options for this profile.")]
         private PointerOption[] pointerOptions = new PointerOption[0];
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -127,7 +127,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     EditorGUILayout.Space();
                     EditorGUILayout.PropertyField(gazeCursorPrefab);
                     EditorGUILayout.PropertyField(gazeProviderType);
-                    EditorGUILayout.PropertyField(showCursorWithEyeGaze);
 
                     EditorGUILayout.Space();
                     if (GUILayout.Button("Customize Gaze Provider Settings"))


### PR DESCRIPTION
This was introduced as part of our large payload but was actually never hooked up to anything - it shows up as an option in the inspector but is misleading (i.e. you think it should show a cursor with eye gaze, but it doesn't)