### PR TITLE
Fix name for cloned profiles.

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -212,7 +212,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void CloneMainProfile()
         {
-            var newChildProfile = CloneProfile(parentProfile, childProfile, childProfileTypeName, childProperty, targetFolder);
+            var newChildProfile = CloneProfile(parentProfile, childProfile, childProfileTypeName, childProperty, targetFolder, childProfileAssetName);
             SerializedObject newChildSerializedObject = new SerializedObject(newChildProfile);
             // First paste all values outright
             PasteProfileValues(parentProfile, childProfile, newChildSerializedObject);


### PR DESCRIPTION
CloneProfile function has an optional argument for the profile name, which
was used for child profile actions, but not for the main profile.

Overview
---


Changes
---
- Fixes: # .
