### PR TITLE
update preferences ui to use full name of MRTK

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region Ignore startup settings prompt
 
-        private static readonly GUIContent IgnoreContent = new GUIContent("Ignore settings prompt on startup", "Prevents settings dialog popup from showing on startup.\n\nThis setting applies to all projects using MRTK.");
+        private static readonly GUIContent IgnoreContent = new GUIContent("Ignore settings prompt on startup", "Prevents settings dialog popup from showing on startup.\n\nThis setting applies to all projects using the Mixed Reality Toolkit.");
         private const string IGNORE_KEY = "MixedRealityToolkit_Editor_IgnoreSettingsPrompts";
         private static bool ignorePrefLoaded;
         private static bool ignoreSettingsPrompt;
@@ -67,9 +67,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SettingsProvider]
         private static SettingsProvider Preferences()
         {
-            var provider = new SettingsProvider("Project/MRTK", SettingsScope.Project)
+            var provider = new SettingsProvider("Project/Mixed Reality Toolkit", SettingsScope.Project)
             {
-                label = "MRTK",
+                label = "Microsoft Mixed Reality Toolkit",
 
                 guiHandler = GUIHandler,
 
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 if (!LockProfiles)
                 {
-                    EditorGUILayout.HelpBox("This is only to be used to update the default SDK profiles. If any edits are made, and not checked into the MRTK's Github, the changes may be lost next time you update your local copy.", MessageType.Warning);
+                    EditorGUILayout.HelpBox("This is only to be used to update the default SDK profiles. If any edits are made, and not checked into the Mixed Reality Toolkit - Unity repository, the changes may be lost next time you update your local copy.", MessageType.Warning);
                 }
 
                 EditorGUI.BeginChangeCheck();


### PR DESCRIPTION
This change replaces "MRTK" with "Mixed Reality Toolkit", "Microsoft Mixed Reality Toolkit" or "Mixed Reality Toolkit - Unity" as appropriate.

![image](https://user-images.githubusercontent.com/13281406/56291114-7ba39a80-60d9-11e9-80d4-db79416b8a07.png)

- Fixes: #3979  .
