### PR TITLE
Update the Pull Request template to include a "Verification" section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,12 +7,12 @@
 
 ## Verification
 > This optional section is a place where you can detail the specific type of verification 
-> you want from reviewers. For example, if you specifically want reviewers to checkout 
-> the PR locally and validate the functionality of specific scenarios, provide instructions
+> you want from reviewers. For example, if you want reviewers to checkout the PR locally
+> and validate the functionality of specific scenarios, provide instructions
 > on the specific scenarios and what you want verified.
 >
 > If there are specific areas of concern or question feel free to highlight them here so
-> that reviewers can watch out specifically for those issues.
+> that reviewers can watch out for those issues.
 >
 > As a reviewer, it is possible to check out this change locally by using the following
 > commands (substituting {PR_ID} with the ID of this pull request):

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,15 @@
-Overview
----
+## Overview
 
 
-Changes
----
+## Changes
 - Fixes: # .
+
+
+## Verification
+> This optional section is a place where you can detail the specific type of verification 
+you want from reviewers. For example, if you specifically want reviewers to checkout 
+the PR locally and validate the functionality of specific scenarios, provide instructions
+on the specific scenarios and what you want verified.
+>
+> If there are specific areas of concern or question feel free to highlight them here so
+that reviewers can watch out specifically for those issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,9 @@
 >
 > If there are specific areas of concern or question feel free to highlight them here so
 > that reviewers can watch out specifically for those issues.
+>
+> As a reviewer, it is possible to check out this change locally by using the following
+> commands (substituting {PR_ID} with the ID of this pull request):
+>
+> git fetch origin pull/{PR_ID}/head:name_of_local_branch
+> git checkout name_of_local_branch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,5 @@
 > commands (substituting {PR_ID} with the ID of this pull request):
 >
 > git fetch origin pull/{PR_ID}/head:name_of_local_branch
+>
 > git checkout name_of_local_branch


### PR DESCRIPTION
One idea point of feedback around pull requests is that it's often not clear the level of verification expected from reviewers - should reviewers be patching all changes to be validating them, only specific ones. For new features, it's also sometimes unclear how a reviewer can functionally test things (i.e. exactly what should be tested, how to engage the scenarios, etc). One idea is to provide an optional section on the PR template where people can call out specifics they want reviewed (i.e. please patch my change and test ABC out, or please pay attention to this specific thing)