### PR TITLE
Disable MRTK scene checker window while build is active

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
@@ -29,23 +29,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private static void SceneOpened(Scene scene, OpenSceneMode mode)
         {
-            // If building, don't perform this check
-            if (BuildPipeline.isBuildingPlayer)
-            {
-                return;
-            }
-
             CheckMixedRealityToolkitScene();
         }
 
         private static void NewSceneCreated(Scene scene, NewSceneSetup setup, NewSceneMode mode)
         {
-            // If building, don't perform this check
-            if (BuildPipeline.isBuildingPlayer)
-            {
-                return;
-            }
-
             switch (setup)
             {
                 // Ignore the check when the scene is explicitly empty.
@@ -61,6 +49,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private static void CheckMixedRealityToolkitScene()
         {
+            // If building, don't perform this check
+            if (BuildPipeline.isBuildingPlayer)
+            {
+                return;
+            }
+
             // Create The MR Manager if none exists.
             if (!MixedRealityToolkit.IsInitialized)
             {

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs
@@ -29,11 +29,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private static void SceneOpened(Scene scene, OpenSceneMode mode)
         {
+            // If building, don't perform this check
+            if (BuildPipeline.isBuildingPlayer)
+            {
+                return;
+            }
+
             CheckMixedRealityToolkitScene();
         }
 
         private static void NewSceneCreated(Scene scene, NewSceneSetup setup, NewSceneMode mode)
         {
+            // If building, don't perform this check
+            if (BuildPipeline.isBuildingPlayer)
+            {
+                return;
+            }
+
             switch (setup)
             {
                 // Ignore the check when the scene is explicitly empty.


### PR DESCRIPTION
Overview
---
This stops the scene checker window from opening during / immediately after a build as described in #4043

Requests for validation
---
Verify that this fixes the repro case described in #4043