### PR TITLE
Interactable Optimization

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeShaderUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeShaderUtils.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <summary>
         /// Grab the shared material to avoid creating new material instances and breaking batching.
-        /// Because MaterialPropertyBlocks are used for setting material properties the shadered material is
+        /// Because MaterialPropertyBlocks are used for setting material properties the shared material is
         /// used to set the initial state of the MaterialPropertyBlock(s) before mutating state.
         /// </summary>
         /// <param name="renderer"></param>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeShaderUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeShaderUtils.cs
@@ -97,7 +97,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Grab a valid Material from an object, if in the editor, use the shared material
+        /// Grab the shared material to avoid creating new material instances and breaking batching.
+        /// Because MaterialPropertyBlocks are used for setting material properties the shadered material is
+        /// used to set the initial state of the MaterialPropertyBlock(s) before mutating state.
         /// </summary>
         /// <param name="renderer"></param>
         /// <returns></returns>
@@ -107,18 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (renderer != null)
             {
-#if UNITY_EDITOR
-                if (!Application.isPlaying)
-                {
-                    material = renderer.sharedMaterial;
-                }
-                else
-                {
-                    material = renderer.material;
-                }
-#else
-                material = renderer.material;
-#endif
+                material = renderer.sharedMaterial;
             }
             return material;
         }


### PR DESCRIPTION
Overview
---
Changing the Interactable system to use the shared material to avoid creating new material instances and breaking batching. Because MaterialPropertyBlocks are used for setting material properties the shared material is used to set the initial state of the MaterialPropertyBlock(s) before mutating state.

