### PR TITLE
Clean up delivery mechanism documentation.

### DIFF
--- a/Documentation/DownloadingTheMRTK.md
+++ b/Documentation/DownloadingTheMRTK.md
@@ -2,36 +2,22 @@
 
 ![](../Documentation/Images/MRTK_Logo_Rev.png)
 
-Recognizing there are multiple ways in which developers want to be able to get access to project through Unity, the Mixed Reality Toolkit has been engineered to be available through the following methods:
+The MRTK is available via the following methods. For feedback on these methods, or to request an additional distribution method, please [file an issue on Github](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose)
 
-## Unity Asset downloadable from the MRTK GitHub site
+## Unity asset downloadable from the MRTK GitHub site
 
-You can download the packaged [Unity Asset from here](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases) for importing in to your project.
+You can download the packaged [Unity assets from here](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases) for importing into your project.
 
-## Unity NuGet delivery (*Coming soon*)
+There are two Unity packages available for each release:
 
-Unity now has an asset plugin for getting access to Unity projects using the dependency delivery solution known as NuGet.
+### Foundation
+This package contains the MRTK itself and all of the code and materials needed to build Mixed Reality experiences.
 
-Simply install the [Unity NuGet package](https://assetstore.unity.com/packages/tools/utilities/nuget-for-unity-104640) and search for the Mixed Reality Toolkit to download the project.
-
-## Unity Package Manager (*Coming soon*)
-
-As soon as it's available, the MRTK team will be working with Unity to publish the Mixed Reality Toolkit as a package through their Unity Package Manager.
-
-## Unity Asset Store (*under discussion*)
-
-It has been raised within the Mixed Reality Toolkit team that the package should be published to the Unity store, this is currently being investigated.  
-
-Feedback is welcome through the [Mixed Reality GitHub site](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues) (raise an issue to offer an opinion) and the [HoloDevelopers Slack channel](https://holodevelopersslack.azurewebsites.net/) for the Mixed Reality Toolkit.
+### Examples
+This is an optional package which contains example scenes and samples. This package is dependent on the Foundation package.
 
 ## GitHub submodule (advanced users)
 
 For those who would like to contribute to the MRTK or prefer to have the latest code in their project, there is another way to get access to the latest and greatest of the Mixed Reality Toolkit, be it the Release code or the in-progress development of the project.
 
 [Stephen Hodgson has provided a full guide](https://www.rageagainstthepixel.com/expert-import-mrtk/) for how to use Git Submodules to download and synchronize the toolkit in to your project.
-Don't worry though, you still have control on how you update your project and can even "Go back" to a previous version of the toolkit at any time by simply checking out a specific commit or tag.
-
-
-
-## Feedback welcome
-If you feel there are other options not listed above that would be beneficial to Unity developers, please let us know on the links above

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -18,7 +18,7 @@ To get started with the Mixed Reality Toolkit you will need:
 1. Go to the  [MRTK release page](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases).
 2. Under Assets, download both `Microsoft.MixedRealityToolkit.Unity.Examples.unitypackage` and `Microsoft.MixedRealityToolkit.Unity.Foundation.unitypackage`
 
-The Mixed Reality Toolkit is available via [multiple delivery mechanisms](DownloadingTheMRTK.md) and in the future will be available via the Unity package manager.
+For additional delivery mechanisms, please see [Downloading the MRTK](DownloadingTheMRTK.md).
 
 ## Import MRTK packages into your Unity project
 1. Create a new Unity project, or open an existing project. When creating a project, make sure to select "3D" as the template type. We used 2018.3.9f1 for this tutorial, though any Unity 2018.3.x release should work.


### PR DESCRIPTION
We currently do not support several of the other mechanisms listed in the DownloadingTheMRTK page, and there's nothing more frustrating when coming upon docs than seeing text that says "coming soon" that isn't helpful.

Our docs should reflect the current state of how to use the product, and when additional support is added for other delivery mechanisms, we should then update the docs to describe those mechanisms.