### PR TITLE
Catch Unity exception in speech input provider.

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -96,9 +96,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 {
                     keywordRecognizer = new KeywordRecognizer(newKeywords, (ConfidenceLevel)RecognitionConfidenceLevel);
                 }
-                catch (UnityException e)
+                catch (UnityException ex)
                 {
-                    Debug.LogError($"Could not start WindowsSpeechInputProvider: {e.Message}");
+                    Debug.LogError($"Failed to start keyword recognizer. Are microphone permissions granted? Exception: {ex}");
                     keywordRecognizer = null;
                     return;
                 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -92,7 +92,17 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
             if (keywordRecognizer == null)
             {
-                keywordRecognizer = new KeywordRecognizer(newKeywords, (ConfidenceLevel)RecognitionConfidenceLevel);
+                try
+                {
+                    keywordRecognizer = new KeywordRecognizer(newKeywords, (ConfidenceLevel)RecognitionConfidenceLevel);
+                }
+                catch (UnityException e)
+                {
+                    Debug.LogError($"Could not start WindowsSpeechInputProvider: {e.Message}");
+                    keywordRecognizer = null;
+                    return;
+                }
+
                 keywordRecognizer.OnPhraseRecognized += KeywordRecognizer_OnPhraseRecognized;
             }
 


### PR DESCRIPTION
This is necessary so other providers can still be enabled after the speech input provider fails.

Overview
---


Changes
---
- Fixes: #4026 .
