### PR TITLE
Homogenize Script Asset Icons

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Diagnostics/Scripts/DiagnosticsDemoControls.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Diagnostics/Scripts/DiagnosticsDemoControls.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_BasicSetup/Scripts/ColorTap.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_BasicSetup/Scripts/ColorTap.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_BasicSetup/Scripts/FollowEyeGaze_GazeProvider.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_BasicSetup/Scripts/FollowEyeGaze_GazeProvider.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/BaseClasses/PanZoomBase.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/BaseClasses/PanZoomBase.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/BaseClasses/PanZoomBase_RectTransf.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/BaseClasses/PanZoomBase_RectTransf.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/BaseClasses/PanZoomBase_Texture.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/BaseClasses/PanZoomBase_Texture.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/PanZoom_RectTransf.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/PanZoom_RectTransf.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/PanZoom_Texture.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/PanZoom_Texture.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/Scroll_RectTransf.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/Scroll_RectTransf.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/Scroll_Texture.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/Scroll_Texture.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/Target_MoveToCamera.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_ScrollPanZoom/Scripts/Target_MoveToCamera.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/GrabReleaseDetector.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/GrabReleaseDetector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/MoveObjByEyeGaze.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/MoveObjByEyeGaze.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/SnapTo.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/SnapTo.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/TransportToRespawnLocation.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/TransportToRespawnLocation.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/TriggerZone_PlaceObjsWithin.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetPositioning/Scripts/TriggerZone_PlaceObjsWithin.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/HitBehavior_DestroyOnSelect.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/HitBehavior_DestroyOnSelect.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/OnLookAt_Rotate.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/OnLookAt_Rotate.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/TargetGroupCreator_Radial.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/TargetGroupCreator_Radial.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/TargetGroupIterator.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/TargetGroupIterator.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/ToggleGameObject.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_TargetSelections/Scripts/ToggleGameObject.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/AsyncHelpers.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/AsyncHelpers.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/BasicInputLogger.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/BasicInputLogger.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/CustomInputLogger.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/CustomInputLogger.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/DrawOnTexture.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/DrawOnTexture.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/InputPointerVisualizer.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/InputPointerVisualizer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/LogStructure.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/LogStructure.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/LogStructure_EyeGaze.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/LogStructure_EyeGaze.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/OnSelect_VisualizerInputController.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/OnSelect_VisualizerInputController.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/ParticleHeatmap.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/ParticleHeatmap.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/ParticleHeatmap_ParticleData.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/ParticleHeatmap_ParticleData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Playback.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Playback.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Recorder.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Recorder.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Recorder_Feedback.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Recorder_Feedback.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Recorder_UIController.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Demo_Visualizer/Scripts/UserInput_Recorder_UIController.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/AudioFeedbackPlayer.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/AudioFeedbackPlayer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/FollowEyeGaze.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/FollowEyeGaze.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Input/Speech_VisualFeedback.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Input/Speech_VisualFeedback.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/BlendOut.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/BlendOut.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/ChangeSize.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/ChangeSize.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/FaceUser.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/FaceUser.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/KeepFacingCamera.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/KeepFacingCamera.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/LoadAdditiveScene.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/LoadAdditiveScene.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/MoveWithCamera.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/MoveWithCamera.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoad_StartScene.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoad_StartScene.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAt_RotateByEyeGaze.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAt_RotateByEyeGaze.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAt_ShowHoverFeedback.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLookAt_ShowHoverFeedback.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Targeting/DwellSelection.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Targeting/DwellSelection.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Targeting/TargetEventArgs.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Targeting/TargetEventArgs.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/ChangeRenderMode.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/ChangeRenderMode.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/DoNotRender.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/DoNotRender.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/KeepThisAlive.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/KeepThisAlive.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/StatusText.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/StatusText.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/TriggerOnStartup.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/TriggerOnStartup.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/Utils.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/Utils.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ColorChanger.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ColorChanger.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/DebugTextOutput.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/DebugTextOutput.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/DemoTouchButton.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/DemoTouchButton.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GrabTouchExample.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GrabTouchExample.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/HandInteractionTouch.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/HandInteractionTouch.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/HandInteractionTouchRotate.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/HandInteractionTouchRotate.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/OpenKeyboard.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/OpenKeyboard.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/RotateWithPan.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/RotateWithPan.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleBoundingBox.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleBoundingBox.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleHandVisualisation.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleHandVisualisation.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scripts/CustomInteractablesReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scripts/CustomInteractablesReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scripts/ShowSliderValue.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scripts/ShowSliderValue.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Inspectors/InspectorFieldsExampleInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Inspectors/InspectorFieldsExampleInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Scripts/InspectorFieldsExample.cs.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Scripts/InspectorFieldsExample.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityGGVHand.cs.meta
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityGGVHand.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Events/ManipulationEvent.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Events/ManipulationEvent.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Events/ManipulationEventData.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Events/ManipulationEventData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Events/TouchEvent.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Events/TouchEvent.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Events/TouchEventData.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Events/TouchEventData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DictationHandler.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DictationHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/IInteractableHandler.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/IInteractableHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: fc1096a9ad3b5e14b8102fa683bd90b5
-timeCreated: 1517598774
-licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiver.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiver.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiverList.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableReceiverList.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: 4a8e848e5e303864ebdfcd9c46eb22a4
-timeCreated: 1520556697
-licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBaseMonoBehavior.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBaseMonoBehavior.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: 1410eac1ae94b4d4492a09cc368e152c
-timeCreated: 1517593873
-licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSize.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSize.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSizeOffset.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSizeOffset.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBorder.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBorder.cs.meta
@@ -1,12 +1,11 @@
 fileFormatVersion: 2
 guid: e284c41c72ed62145b1ae10cfedd1196
-timeCreated: 1509375612
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonCollider.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonCollider.cs.meta
@@ -1,12 +1,11 @@
 fileFormatVersion: 2
 guid: 4a08075b4fade3f43b9828530084df35
-timeCreated: 1509373324
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonLayout.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonLayout.cs.meta
@@ -1,12 +1,11 @@
 fileFormatVersion: 2
 guid: a2d6129faba6ebd44a660a9eee3a4e01
-timeCreated: 1509372348
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonSize.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonSize.cs.meta
@@ -1,12 +1,11 @@
 fileFormatVersion: 2
 guid: 18715f9b6e2e86c42902a892a35010dc
-timeCreated: 1509372333
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonSizeOffset.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonSizeOffset.cs.meta
@@ -1,12 +1,11 @@
 fileFormatVersion: 2
 guid: b7450a7c8dc3a5f4bb0bab1dc83c3354
-timeCreated: 1509373352
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Profile/InteractableProfileItem.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Simulation/InteractablePointerSimulator.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Simulation/InteractablePointerSimulator.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStateModel.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStateModel.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStates.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStates.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: 33bc56363b94dc34b9fff3f146b5b52b
-timeCreated: 1520547556
-licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: c33e3b76d6c5c0e48bb3b6ee686c7fd6
-timeCreated: 1522264080
-licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableActivateTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableActivateTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAnimatorTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAnimatorTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAudioTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAudioTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorChildrenTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorChildrenTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableMaterialTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableMaterialTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableOffsetTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableOffsetTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableRotationTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableRotationTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableScaleTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableScaleTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableTextureTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableTextureTheme.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeBase.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeBase.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertySettings.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertySettings.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertyValue.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertyValue.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertyValueTypes.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemePropertyValueTypes.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeShaderUtils.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeShaderUtils.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ScaleOffsetColorTheme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ScaleOffsetColorTheme.cs.meta
@@ -7,7 +7,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/Theme.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/Theme.cs.meta
@@ -7,7 +7,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ThemeEaseSettings.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ThemeEaseSettings.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableType.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableType.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypeFinder.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypesContainer.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/InteractableTypesContainer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/TypeRestriction.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/TypeResolution/TypeRestriction.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBar.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBar.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: 80c870726057bb743b9c4f8faa604b98
-timeCreated: 1519284585
-licenseType: Free
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBarButton.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBarButton.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: fb66df91526e2034e94cac3868625598
-timeCreated: 1519284586
-licenseType: Free
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/TileGridObjectCollection.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/TileGridObjectCollection.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/WindowsMixedRealityControllerVisualizer.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/WindowsMixedRealityControllerVisualizer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PhysicalPressEventRouter.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PhysicalPressEventRouter.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/DragEnabler.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/DragEnabler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPan.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPan.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/SlateEnabler.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/SlateEnabler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/PinchSlider.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/PinchSlider.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/SliderEvent.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/SliderEvent.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/SliderEventData.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/SliderEventData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/SliderSounds.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/SliderSounds.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 3b748943b2ee497cb401b923729b41c5, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Easing.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Easing.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/HeadPositionOffset.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/HeadPositionOffset.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ButtonBackgroundSizeGizmo.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ButtonBackgroundSizeGizmo.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs.meta
@@ -7,7 +7,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/StatesInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/StatesInspector.cs.meta
@@ -7,7 +7,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs.meta
@@ -7,7 +7,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Pointers/SpherePointerInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Pointers/SpherePointerInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Sliders/PinchSliderInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Sliders/PinchSliderInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/AttachToControllerInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/AttachToControllerInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 6eccdbd0228d47ab9ac6ca58258f9112, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/IInputSimulationService.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/IInputSimulationService.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 6eccdbd0228d47ab9ac6ca58258f9112, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/InputSimulationEnum.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/InputSimulationEnum.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/ManualCameraControl.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/ManualCameraControl.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedArticulatedHand.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedArticulatedHand.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHand.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHand.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandPose.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandPose.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandUtils.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandUtils.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Utilities/HandGestureRecorder.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Utilities/HandGestureRecorder.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityInputModuleInspector.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Inspectors/MixedRealityInputModuleInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionGrabbable.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionGrabbable.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestFixture_01_SimplePlayModeTest.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestFixture_01_SimplePlayModeTest.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Attributes/HelpAttribute.cs.meta
+++ b/Assets/MixedRealityToolkit/Attributes/HelpAttribute.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Attributes/ReadOnlyAttribute.cs.meta
+++ b/Assets/MixedRealityToolkit/Attributes/ReadOnlyAttribute.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Attributes/ScenePickAttribute.cs.meta
+++ b/Assets/MixedRealityToolkit/Attributes/ScenePickAttribute.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Attributes/TagPropertyAttribute.cs.meta
+++ b/Assets/MixedRealityToolkit/Attributes/TagPropertyAttribute.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Devices/InputSourceType.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/InputSourceType.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/TouchableEventType.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/TouchableEventType.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ControllerElement.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ControllerElement.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/RadialViewReferenceDirection.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/RadialViewReferenceDirection.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/TrackedHandJoint.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/TrackedHandJoint.cs.meta
@@ -1,13 +1,11 @@
 fileFormatVersion: 2
 guid: 05dbaa414de760145a4a85c115550377
-timeCreated: 1525987859
-licenseType: Pro
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/VolumeType.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/VolumeType.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/EventDatum/Input/HandPanEventData.cs.meta
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/HandPanEventData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/EventDatum/Input/HandTrackingInputEventData.cs.meta
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/HandTrackingInputEventData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Extensions/CanvasExtensions.cs.meta
+++ b/Assets/MixedRealityToolkit/Extensions/CanvasExtensions.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Extensions/Texture2DExtensions.cs.meta
+++ b/Assets/MixedRealityToolkit/Extensions/Texture2DExtensions.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/ChannelPackerWindow.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/ChannelPackerWindow.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 6eccdbd0228d47ab9ac6ca58258f9112, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/HelpDrawer.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/HelpDrawer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/ScenePickPropertyDrawer.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/ScenePickPropertyDrawer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TagPropertyDrawer.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TagPropertyDrawer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/ProximityLightInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/ProximityLightInspector.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorFieldsUtility.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorFieldsUtility.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHand.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHand.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHandJointService.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHandJointService.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHandVisualizer.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHandVisualizer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandJointHandler.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandJointHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandPanHandler.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandPanHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandTrackHandler.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityHandTrackHandler.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeGazeDataProvider.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeGazeDataProvider.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeSaccadeProvider.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeSaccadeProvider.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/HandJointService.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/Hands/HandJointService.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/HandJointUtils.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/Hands/HandJointUtils.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/HandRay.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/Hands/HandRay.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/CameraEventRouter.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/CameraEventRouter.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GameObjectCreator.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GameObjectCreator.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GameObjectPool.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GameObjectPool.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GenericPrefabInstanceCreator.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GenericPrefabInstanceCreator.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/IGameObjectCreatorListener.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/IGameObjectCreatorListener.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorField.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorField.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorFieldData.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorFieldData.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorGenericFields.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorGenericFields.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorPropertySettings.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/InspectorFields/InspectorPropertySettings.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BezierInertia.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BezierInertia.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  icon: {fileID: 2800000, guid: 93d49a6ae68a4f6ca0fea653caaa74fc, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityToolkitSceneChecker.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/ProximityLight.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/ProximityLight.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Overview
---
Updates ~200 meta files to use consistent script icons. Mostly demo assets and stuff we pulled in for RC1.

Before:
![Icons1](https://user-images.githubusercontent.com/9789716/56605391-eca2f080-65b8-11e9-924b-186d0017c4bc.PNG)

After:
![Icons2](https://user-images.githubusercontent.com/9789716/56605397-ee6cb400-65b8-11e9-8973-6d3154e34737.PNG)
