### PR TITLE
Fix the reference to the 'Configuring the Spatial Awareness Mesh Observer' page.

### DIFF
--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -85,6 +85,9 @@
         href: README_Solver.md     
     - name: Spatial Awareness
       href: SpatialAwareness/SpatialAwarenessGettingStarted.md
+      items:	
+      - name: Configuring the Spatial Awareness Mesh Observer
+        href: SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.md
     - name: In-Editor Input Simulation
       href: InputSimulation/InputSimulationService.md
     - name: Diagnostics System

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -85,8 +85,6 @@
         href: README_Solver.md     
     - name: Spatial Awareness
       href: SpatialAwareness/SpatialAwarenessGettingStarted.md
-      items:
-      - name: Configuring the Spatial Awareness Mesh Observer
     - name: In-Editor Input Simulation
       href: InputSimulation/InputSimulationService.md
     - name: Diagnostics System


### PR DESCRIPTION
This particular entry in the TOC wasn't hooked up even though the underlying page was already created.