### PR TITLE
Fix up a few of the doccomments for the EnumFlags and Edge types

### DIFF
--- a/Assets/MixedRealityToolkit/Attributes/EnumFlagsAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/EnumFlagsAttribute.cs
@@ -7,8 +7,12 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit
 {
     /// <summary>
-    /// From https://answers.unity.com/questions/486694/default-editor-enum-as-flags-.html
+    /// An attribute that allows a particular field to be rendered as multi-selectable
+    /// set of flags.
     /// </summary>
+    /// <remarks>
+    /// From https://answers.unity.com/questions/486694/default-editor-enum-as-flags-.html
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class EnumFlagsAttribute : PropertyAttribute
     {

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/Edge.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/Edge.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Boundary
 {
     /// <summary>
-    /// The BoundaryEdge structure defines the points of a line segment that are used to
+    /// The Edge structure defines the points of a line segment that are used to
     /// construct a polygonal boundary.
     /// </summary>
     public struct Edge
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         public readonly Vector2 PointB;
 
         /// <summary>
-        /// Initializes the BoundaryEdge structure.
+        /// Initializes the Edge structure.
         /// </summary>
         /// <param name="pointA">The first point of the line segment.</param>
         /// <param name="pointB">The second point of the line segment.</param>
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         }
 
         /// <summary>
-        /// Initializes the BoundaryEdge structure.
+        /// Initializes the Edge structure.
         /// </summary>
         /// <param name="pointA">The first point of the line segment.</param>
         /// <param name="pointB">The second point of the line segment.</param>


### PR DESCRIPTION
I'm going through the process of looking through our codebase to learn more about everything, and as I'm seeing random issues like this I'm fixing them.

In the case of EnumFlagsAttribute.cs we shouldn't have to go to a link to understand the context.

In the case of Edge.cs it was referencing what appeared to be an older naming of the type.