### PR TITLE
Standardize on the way we wait for InputSystem validity.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -129,10 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.Start();
 
-            if (MixedRealityToolkit.InputSystem == null)
-            {
-                await WaitUntilInputSystemValid;
-            }
+            await EnsureInputSystemValid();
 
             // We've been destroyed during the await.
             if (this == null)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -353,7 +353,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.Start();
 
-            await WaitUntilInputSystemValid;
+            await EnsureInputSystemValid();
 
             if (this == null)
             {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -486,7 +486,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private async void RaiseSourceDetected()
         {
-            await WaitUntilInputSystemValid;
+            await EnsureInputSystemValid();
+
             if (this == null)
             {
                 // We've been destroyed during the await.

--- a/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -13,6 +14,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         private bool lateInitialize = true;
 
+        /// <summary>
+        /// Prefer using EnsureInputSystemValid(), which will only await if the input system isn't
+        /// yet valid.
+        /// </summary>
         protected readonly WaitUntil WaitUntilInputSystemValid = new WaitUntil(() => MixedRealityToolkit.InputSystem != null);
 
         protected virtual void OnEnable()
@@ -27,10 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (lateInitialize)
             {
-                if (MixedRealityToolkit.InputSystem == null)
-                {
-                    await WaitUntilInputSystemValid;
-                }
+                await EnsureInputSystemValid();
 
                 // We've been destroyed during the await.
                 if (this == null)
@@ -46,6 +48,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected virtual void OnDisable()
         {
             MixedRealityToolkit.InputSystem?.Unregister(gameObject);
+        }
+
+        /// <summary>
+        /// A task that will only complete when the input system has in a valid state.
+        /// </summary>
+        /// <remarks>
+        /// It's possible for this object to have been destroyed after the await, which
+        /// implies that callers should check that this != null after awaiting this task.
+        /// </remarks>
+        protected async Task EnsureInputSystemValid()
+        {
+            if (MixedRealityToolkit.InputSystem == null)
+            {
+                await WaitUntilInputSystemValid;
+            }
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -18,6 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Prefer using EnsureInputSystemValid(), which will only await if the input system isn't
         /// yet valid.
         /// </summary>
+        [Obsolete("Prefer using EnsureInputSystemValid()")]
         protected readonly WaitUntil WaitUntilInputSystemValid = new WaitUntil(() => MixedRealityToolkit.InputSystem != null);
 
         protected virtual void OnEnable()
@@ -61,7 +63,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (MixedRealityToolkit.InputSystem == null)
             {
+#pragma warning disable CS0618 // WaitUntilInputSystemValid is obsolete for outside-of-class usage.
                 await WaitUntilInputSystemValid;
+#pragma warning restore CS0618
             }
         }
     }


### PR DESCRIPTION
There are multiple ways we wait for InputSystem validity, some of which
check for the current state of the object and some of which use the await directly.

AFAICT it looks like we should have moved to a common helper (i.e. in this PR: https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/3462/files), so this common-izes this action into the base class