### PR TITLE
Add definitions of AzurePipelines builds

### DIFF
--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -1,0 +1,197 @@
+pool:
+  name: On-Prem Unity
+
+steps:
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_x86.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -x86 -buildOutput $outDir -buildTarget WSAPlayer -buildAppx" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build UWP x86'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish x86'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\AppPackages\MixedRealityToolkit\MixedRealityToolkit_2.0.0.0_Win32_Master_Test'
+    ArtifactName: 'mrtk-build-x86'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_arm.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -arm -targetUwpSdk 10.0.18432.0 -buildOutput $outDir -buildTarget WSAPlayer -buildAppx" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build UWP ARM'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish ARM'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\AppPackages\MixedRealityToolkit\MixedRealityToolkit_2.0.0.0_ARM_Master_Test'
+    ArtifactName: 'mrtk-build-arm'
+
+- powershell: |
+   $AutoMrtkVersion = Get-Date -format "dd.MM.yyyy"
+   .\build.ps1 -Version $AutoMrtkVersion -NoNuget
+  displayName: 'Build Unity and NuGet packages'
+
+- powershell: |
+   Get-ChildItem "." -Filter Build-UnityPackage*.log | 
+   Foreach-Object {
+       echo "=======================" "Contents of log file $_.FullName:" "======================="
+       Get-Content $_.FullName
+   }
+  displayName: 'Echo packaging logs'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_standalone_x86.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -x86 -buildOutput $outDir -buildTarget StandaloneWindows" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build Standalone x86'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -batchmode -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.AssetScriptReferenceRetargeter.RetargetAssets -logFile $($logFile.FullName) -nographics -quit" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Run Asset Retargetting'
+
+- script: 'Type %Build_ArtifactStagingDirectory%\build\build\retargeting_log.log'
+  displayName: 'Print Unity Log'
+
+- script: 'dir /s/b NuGet'
+  displayName: 'Print Retargeted Directory'
+
+- powershell: |
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   Write-Host "======================= EditMode Tests ======================="
+   
+   $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform editmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: 'test*.xml'
+    failTaskOnFailedTests: true
+
+- task: NuGetCommand@2
+  displayName: 'NuGet pack'
+  inputs:
+    command: pack
+    packagesToPack: 'NuGet/**/*.nuspec'
+    packDestination: '$(Build.SourcesDirectory)/artifacts'
+    buildProperties: 'version=2.0.0-$(Build.BuildNumber)'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Packages'
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
+    ArtifactName: 'mrtk-unity-packages'
+
+- task: NuGetCommand@2
+  displayName: 'NuGet push'
+  inputs:
+    command: push
+    packagesToPush: '$(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.symbols.nupkg'
+    publishVstsFeed: '$(NuGetFeedId)'
+    buildProperties: 'version=2.0.0-$(Build.BuildNumber)'
+
+- powershell: |
+   $unityProcess = Get-Process -Name Unity -ErrorAction SilentlyContinue
+   if ($unityProcess)
+   {
+       Write-Host "Closing Unity Process"
+       Stop-Process $unityProcess
+   }
+   
+  displayName: 'Close Unity'
+  condition: always()
+

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,0 +1,175 @@
+pool:
+  name: On-Prem Unity
+
+steps:
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_x86.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -x86 -buildOutput $outDir -buildTarget WSAPlayer -buildAppx" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build UWP x86'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish x86'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\AppPackages\MixedRealityToolkit\MixedRealityToolkit_2.0.0.0_Win32_Master_Test'
+    ArtifactName: 'mrtk-build-x86'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_arm.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -arm -targetUwpSdk 10.0.18432.0 -buildOutput $outDir -buildTarget WSAPlayer -buildAppx" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build UWP ARM'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish ARM'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\AppPackages\MixedRealityToolkit\MixedRealityToolkit_2.0.0.0_ARM_Master_Test'
+    ArtifactName: 'mrtk-build-arm'
+
+- powershell: |
+   $AutoMrtkVersion = Get-Date -format "dd.MM.yyyy"
+   .\build.ps1 -Version $AutoMrtkVersion -NoNuget
+  displayName: 'Build Unity and NuGet packages'
+
+- powershell: |
+   Get-ChildItem "." -Filter Build-UnityPackage*.log | 
+   Foreach-Object {
+       echo "=======================" "Contents of log file $_.FullName:" "======================="
+       Get-Content $_.FullName
+   }
+  displayName: 'Echo packaging logs'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_standalone_x86.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -x86 -buildOutput $outDir -buildTarget StandaloneWindows" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build Standalone x86'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -batchmode -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.AssetScriptReferenceRetargeter.RetargetAssets -logFile $($logFile.FullName) -nographics -quit" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Run Asset Retargetting'
+
+- script: 'Type %Build_ArtifactStagingDirectory%\build\build\retargeting_log.log'
+  displayName: 'Print Unity Log'
+
+- script: 'dir /s/b NuGet'
+  displayName: 'Print Retargeted Directory'
+
+- powershell: |
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   Write-Host "======================= EditMode Tests ======================="
+   
+   $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform editmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+   
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: 'test*.xml'
+    failTaskOnFailedTests: true
+
+- powershell: |
+   $unityProcess = Get-Process -Name Unity -ErrorAction SilentlyContinue
+   if ($unityProcess)
+   {
+       Write-Host "Closing Unity Process"
+       Stop-Process $unityProcess
+   }
+   
+  displayName: 'Close Unity'
+  condition: always()
+


### PR DESCRIPTION
We should switch to YAML build definitions to leverage the benefits of having "configuration-as-code" (as previously discussed in an internal email thread and offline). 

This change adds YAML configuration files that correspond to the existing MRTK_CI and MRTK_PR jobs.
Switching from visual designer to YAML will require setting up new builds (it should be straightforward although we will lose build history and we need to pay close attention to setting up triggers, etc.) and I can take care of it afterwards.
The CI config references a new variable "NuGetFeedId" (which is a GUID of the feed that we use to publish the packages internally).

I verified the set up by creating personal test builds on my fork of the repo:
https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=1292
https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=1290
