### PR TITLE
Workaround for mis-ordered initialization of some input providers.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -275,9 +275,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var pointer = inputSource.Pointers[i];
                 if (pointer.InputSourceParent == inputSource)
                 {
+                    // TODO(https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/4084):
+                    // This !ContainsKey is only necessary due to inconsistent initialization of
+                    // various input providers and this class's ActivateModule() call.
+                    // This is a workaround to unblock consumers while we investigate.
                     int pointerId = (int)pointer.PointerId;
-                    Debug.Assert(!pointerDataToUpdate.ContainsKey(pointerId));
-                    pointerDataToUpdate.Add(pointerId, new PointerData(pointer, eventSystem));
+                    if (!pointerDataToUpdate.ContainsKey(pointerId))
+                    {
+                        pointerDataToUpdate.Add(pointerId, new PointerData(pointer, eventSystem));
+                    }
                 }
             }
         }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -275,10 +275,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var pointer = inputSource.Pointers[i];
                 if (pointer.InputSourceParent == inputSource)
                 {
-                    // TODO(https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/4084):
                     // This !ContainsKey is only necessary due to inconsistent initialization of
                     // various input providers and this class's ActivateModule() call.
-                    // This is a workaround to unblock consumers while we investigate.
                     int pointerId = (int)pointer.PointerId;
                     if (!pointerDataToUpdate.ContainsKey(pointerId))
                     {


### PR DESCRIPTION
We've seen a couple of instances now where the MixedRealityInputModule and various providers (i.e. GazeProvider) are getting initialized in non-deterministic fashion. If the GazeProvider starts first, it will raise its source detected, and then when MixedRealityInputModule::ActivateModule is invoked, it re-invokes OnSourceDetected, which tries to add the same pointer to the pointer dictionary.

This throws an exception (bad). We want to update the OnSourceDetected function to only try to add it to the dictionary if it doesn't exist to work around this and unblock a few consumers.

https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/4084