### PR TITLE
Fix using MRTK in Unity editors on non-Windows platforms (part 1)

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -53,10 +53,10 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             await StopRecordingAsync();
         }
 
-#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
         /// <inheritdoc />
         public async Task StartRecordingAsync(GameObject listener = null, float initialSilenceTimeout = 5f, float autoSilenceTimeout = 20f, int recordingTime = 10, string micDeviceName = "")
         {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
             IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
             if (IsListening || isTransitioning || inputSystem == null || !Application.isPlaying)
@@ -105,11 +105,15 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             dictationAudioClip = Microphone.Start(deviceName, false, recordingTime, samplingRate);
             textSoFar = new StringBuilder();
             isTransitioning = false;
+#else
+            await Task.CompletedTask;
+#endif
         }
 
         /// <inheritdoc />
         public async Task<AudioClip> StopRecordingAsync()
         {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
             if (!IsListening || isTransitioning || !Application.isPlaying)
             {
                 Debug.LogWarning("Unable to stop recording");
@@ -144,20 +148,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
             isTransitioning = false;
             return dictationAudioClip;
-        }
 #else
-        /// <inheritdoc />
-        public Task StartRecordingAsync(GameObject listener = null, float initialSilenceTimeout = 5f, float autoSilenceTimeout = 20f, int recordingTime = 10, string micDeviceName = "")
-        {
-            return Task.CompletedTask;
-        }
-
-        /// <inheritdoc />
-        public Task<AudioClip> StopRecordingAsync()
-        {
-            return Task.CompletedTask as Task<AudioClip>;
-        }
+            await Task.CompletedTask;
+            return null;
 #endif
+        }
 
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
         private bool hasFailed;

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -31,8 +31,8 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             IMixedRealityInputSystem inputSystem,
             MixedRealityInputSystemProfile inputSystemProfile,
             Transform playspace,
-            string name = null, 
-            uint priority = DefaultPriority, 
+            string name = null,
+            uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, playspace, name, priority, profile) { }
 
         /// <summary>
@@ -51,14 +51,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         public RecognitionConfidenceLevel RecognitionConfidenceLevel { get; set; }
 
         /// <inheritdoc />
-        public bool IsRecognitionActive
-        {
+        public bool IsRecognitionActive =>
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-            get { return keywordRecognizer != null && keywordRecognizer.IsRunning; }
-#else
-            get { return false; }
+            keywordRecognizer?.IsRunning ??
 #endif
-        }
+            false;
 
         /// <inheritdoc />
         public void StartRecognition()
@@ -100,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         public override void Enable()
         {
             if (!Application.isPlaying || Commands.Length == 0) { return; }
-            
+
             if (InputSystemProfile == null) { return; }
 
             IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -50,14 +50,40 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// </summary>
         public RecognitionConfidenceLevel RecognitionConfidenceLevel { get; set; }
 
-#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-        private KeywordRecognizer keywordRecognizer;
-
         /// <inheritdoc />
         public bool IsRecognitionActive
         {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
             get { return keywordRecognizer != null && keywordRecognizer.IsRunning; }
+#else
+            get { return false; }
+#endif
         }
+
+        /// <inheritdoc />
+        public void StartRecognition()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+            if (keywordRecognizer != null && !keywordRecognizer.IsRunning)
+            {
+                keywordRecognizer.Start();
+            }
+#endif
+        }
+
+        /// <inheritdoc />
+        public void StopRecognition()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+            if (keywordRecognizer != null && keywordRecognizer.IsRunning)
+            {
+                keywordRecognizer.Stop();
+            }
+#endif
+        }
+
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+        private KeywordRecognizer keywordRecognizer;
 
 #if UNITY_EDITOR
         /// <inheritdoc />
@@ -148,24 +174,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             }
         }
 #endif // UNITY_EDITOR
-
-        /// <inheritdoc />
-        public void StartRecognition()
-        {
-            if (keywordRecognizer != null && !keywordRecognizer.IsRunning)
-            {
-                keywordRecognizer.Start();
-            }
-        }
-
-        /// <inheritdoc />
-        public void StopRecognition()
-        {
-            if (keywordRecognizer != null && keywordRecognizer.IsRunning)
-            {
-                keywordRecognizer.Stop();
-            }
-        }
 
         private void KeywordRecognizer_OnPhraseRecognized(PhraseRecognizedEventArgs args)
         {

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -3,10 +3,10 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
 
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
 using System;
-using UnityEngine;
 using UnityEngine.Windows.Speech;
 using UInput = UnityEngine.Input;
 #endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN


### PR DESCRIPTION
Overview
---
Reported on Slack: opening the MRTK caused issues on non-Windows platforms (in this case, Mac).
This PR fixes most of them, but I'll need to get my hands on a Mac to repro the glTF-specific ones.

The fix: I moved the methods required by the interfaces outside of the Windows-platform `#if`s, where possible, or created a second version for non-Windows platforms where not possible.

Report: https://holodevelopers.slack.com/archives/C2H4HT858/p1556141818234600

![image](https://user-images.githubusercontent.com/3580640/56761536-6cb08e00-6752-11e9-8762-38fc7f17cab6.png)
![image](https://user-images.githubusercontent.com/3580640/56761540-70441500-6752-11e9-9f18-749f9011cde4.png)
