### PR TITLE
Move remarks tags outside of summary tags

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -57,8 +57,8 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
         /// <summary>
         /// The device audio sampling rate.
-        /// <remarks>Set by UnityEngine.Microphone.<see cref="Microphone.GetDeviceCaps"/></remarks>
         /// </summary>
+        /// <remarks>Set by UnityEngine.Microphone.<see cref="Microphone.GetDeviceCaps"/></remarks>
         private int samplingRate;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/InteractableHighlight.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/InteractableHighlight.cs
@@ -10,8 +10,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
     /// Adds or removes materials to target renderer for highlighting Focused <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>s.
-    /// <remarks>Useful with focusable <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>s</remarks>
     /// </summary>
+    /// <remarks>Useful with focusable <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>s</remarks>
     public class InteractableHighlight : BaseFocusHandler
     {
         [Flags]

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
@@ -137,8 +137,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         /// <summary>
         /// The up direction to use for orientation.
-        /// <remarks>Cone may roll with head, or not.</remarks>
         /// </summary>
+        /// <remarks>Cone may roll with head, or not.</remarks>
         private Vector3 UpReference
         {
             get

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -13,8 +13,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// The focus provider handles the focused objects per input source.
-    /// <remarks>There are convenience properties for getting only Gaze Pointer if needed.</remarks>
     /// </summary>
+    /// <remarks>There are convenience properties for getting only Gaze Pointer if needed.</remarks>
     public class FocusProvider : BaseDataProvider, IMixedRealityFocusProvider
     {
         public FocusProvider(
@@ -131,8 +131,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// Cached <see href="https://docs.unity3d.com/ScriptReference/Vector3.html">Vector3</see> reference to the new raycast position.
-        /// <remarks>Only used to update UI raycast results.</remarks>
         /// </summary>
+        /// <remarks>Only used to update UI raycast results.</remarks>
         private Vector3 newUiRaycastPosition = Vector3.zero;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -418,8 +418,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Register a <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> to listen to events that will receive all input events, regardless
         /// of which other <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>s might have handled the event beforehand.
-        /// <remarks>Useful for listening to events when the <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> is currently not being raycasted against by the <see cref="FocusProvider"/>.</remarks>
         /// </summary>
+        /// <remarks>Useful for listening to events when the <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> is currently not being raycasted against by the <see cref="FocusProvider"/>.</remarks>
         /// <param name="listener">Listener to add.</param>
         public override void Register(GameObject listener)
         {

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityInteractionMapping.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityInteractionMapping.cs
@@ -9,8 +9,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Maps the capabilities of controllers, linking the Physical inputs of a controller to a Logical construct in a runtime project<para/>
-    /// <remarks>One definition should exist for each physical device input, such as buttons, triggers, joysticks, dpads, and more.</remarks>
     /// </summary>
+    /// <remarks>
+    /// One definition should exist for each physical device input, such as buttons, triggers, joysticks, dpads, and more.
+    /// </remarks>
     [Serializable]
     public class MixedRealityInteractionMapping
     {

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputActionsProfile.cs
@@ -53,8 +53,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// The list of actions users can do in your application.
-        /// <remarks>Input Actions are device agnostic and can be paired with any number of device inputs across all platforms.</remarks>
         /// </summary>
+        /// <remarks>Input Actions are device agnostic and can be paired with any number of device inputs across all platforms.</remarks>
         public MixedRealityInputAction[] InputActions => inputActions;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/EventDatum/Input/HandPanEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/HandPanEventData.cs
@@ -8,8 +8,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Describes an source state event that has a source id.
-    /// <remarks>Source State events do not have an associated <see cref="Microsoft.MixedReality.Toolkit.Input.MixedRealityInputAction"/>.</remarks>
     /// </summary>
+    /// <remarks>Source State events do not have an associated <see cref="Microsoft.MixedReality.Toolkit.Input.MixedRealityInputAction"/>.</remarks>
     public class HandPanEventData : BaseInputEventData
     {
         public Vector2 PanPosition

--- a/Assets/MixedRealityToolkit/EventDatum/Input/SourcePoseEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/SourcePoseEventData.cs
@@ -7,8 +7,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Describes a source change event.
-    /// <remarks>Source State events do not have an associated <see cref="MixedRealityInputAction"/>.</remarks>
     /// </summary>
+    /// <remarks>Source State events do not have an associated <see cref="MixedRealityInputAction"/>.</remarks>
     public class SourcePoseEventData<T> : SourceStateEventData
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit/EventDatum/Input/SourceStateEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/Input/SourceStateEventData.cs
@@ -7,8 +7,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Describes an source state event that has a source id.
-    /// <remarks>Source State events do not have an associated <see cref="MixedRealityInputAction"/>.</remarks>
     /// </summary>
+    /// <remarks>Source State events do not have an associated <see cref="MixedRealityInputAction"/>.</remarks>
     public class SourceStateEventData : BaseInputEventData
     {
         public IMixedRealityController Controller { get; private set; }

--- a/Assets/MixedRealityToolkit/Extensions/ProcessExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/ProcessExtensions.cs
@@ -40,8 +40,8 @@ namespace Microsoft.MixedReality.Toolkit
 
         /// <summary>
         /// Starts a process asynchronously.<para/>
-        /// <remarks>The provided Process Start Info must not use shell execution, and should redirect the standard output and errors.</remarks>
         /// </summary>
+        /// <remarks>The provided Process Start Info must not use shell execution, and should redirect the standard output and errors.</remarks>
         /// <param name="process">This Process.</param>
         /// <param name="startInfo">The Process start info.</param>
         /// <param name="showDebug">Should output debug code to Editor Console?</param>

--- a/Assets/MixedRealityToolkit/Interfaces/EventSystem/IMixedRealityEventSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/EventSystem/IMixedRealityEventSystem.cs
@@ -19,8 +19,8 @@ namespace Microsoft.MixedReality.Toolkit
 
         /// <summary>
         /// The main function for handling and forwarding all events to their intended recipients.
-        /// <para><remarks>See: https://docs.unity3d.com/Manual/MessagingSystem.html </remarks></para>
         /// </summary>
+        /// <remarks>See: https://docs.unity3d.com/Manual/MessagingSystem.html </remarks>
         /// <typeparam name="T">Event Handler Interface Type</typeparam>
         /// <param name="eventData">Event Data</param>
         /// <param name="eventHandler">Event Handler delegate</param>

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusChangedHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusChangedHandler.cs
@@ -12,8 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         /// <summary>
         /// Focus event that is raised before the focus is actually changed.
-        /// <remarks>Useful for logic that needs to take place before focus changes.</remarks>
         /// </summary>
+        /// <remarks>Useful for logic that needs to take place before focus changes.</remarks>
         /// <param name="eventData"></param>
         void OnBeforeFocusChange(FocusEventData eventData);
 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityFocusProvider.cs
@@ -24,14 +24,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// The Camera the <see href="https://docs.unity3d.com/ScriptReference/EventSystems.EventSystem.html">EventSystem</see> uses to raycast against.
-        /// <para><remarks>Every uGUI canvas in your scene should use this camera as its event camera.</remarks></para>
         /// </summary>
+        /// <remarks>Every uGUI canvas in your scene should use this camera as its event camera.</remarks>
         Camera UIRaycastCamera { get; }
 
         /// <summary>
         /// Gets the currently focused object for the pointing source.
-        /// <para><remarks>If the pointing source is not registered, then the Gaze's Focused <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> is returned.</remarks></para>
         /// </summary>
+        /// <remarks>If the pointing source is not registered, then the Gaze's Focused <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> is returned.</remarks>
         /// <param name="pointingSource"></param>
         /// <returns>Currently Focused Object.</returns>
         GameObject GetFocusedObject(IMixedRealityPointer pointingSource);

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -115,8 +115,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// Generates a new unique input source id.<para/>
-        /// <remarks>All Input Sources are required to call this method in their constructor or initialization.</remarks>
         /// </summary>
+        /// <remarks>All Input Sources are required to call this method in their constructor or initialization.</remarks>
         /// <returns>a new unique Id for the input source.</returns>
         uint GenerateNewSourceId();
 
@@ -182,8 +182,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <summary>
         /// Raise the pre-focus changed event.
-        /// <remarks>This event is useful for doing logic before the focus changed event.</remarks>
         /// </summary>
+        /// <remarks>This event is useful for doing logic before the focus changed event.</remarks>
         /// <param name="pointer">The pointer that the focus change event is raised on.</param>
         /// <param name="oldFocusedObject">The old focused object.</param>
         /// <param name="newFocusedObject">The new focused object.</param>

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityPointer.cs
@@ -70,8 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The physics layers to use when performing scene queries.
         /// </summary>
-        /// <remarks>If set, will override the <see cref="IMixedRealityInputSystem"/>'s default scene query layer mask array.
-        /// </remarks>
+        /// <remarks>If set, will override the <see cref="IMixedRealityInputSystem"/>'s default scene query layer mask array.</remarks>
         /// <example>
         /// Allow the pointer to hit SR, but first prioritize any DefaultRaycastLayers (potentially behind SR)
         /// <code language="csharp"><![CDATA[

--- a/Assets/MixedRealityToolkit/Interfaces/Registrars/IMixedRealityServiceRegistrar.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Registrars/IMixedRealityServiceRegistrar.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <typeparam name="T">The interface type of the service to be unregistered (ex: IMixedRealityBoundarySystem).</typeparam>
         /// <param name="name">The name of the service to unregister.</param>
         /// <returns>True if the service was successfully unregistered, false otherwise.</returns>
-        /// <remarks>If the name argument is not especified, the first instance will be unregistered</remarks>
+        /// <remarks>If the name argument is not specified, the first instance will be unregistered</remarks>
         bool UnregisterService<T>(string name = null) where T : IMixedRealityService;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Interfaces/TeleportSystem/IMixedRealityTeleportHotSpot.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/TeleportSystem/IMixedRealityTeleportHotSpot.cs
@@ -30,10 +30,10 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         /// <summary>
         /// Should the destination orientation be overridden?
         /// Useful when you want to orient the user in a specific direction when they teleport to this position.
+        /// </summary>
         /// <remarks>
         /// Override orientation is the transform forward of the GameObject this component is attached to.
         /// </remarks>
-        /// </summary>
         float TargetOrientation { get; }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Providers/BaseGenericInputSource.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseGenericInputSource.cs
@@ -8,9 +8,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Base class for input sources that don't inherit from MonoBehaviour.
+    /// </summary>
     /// <remarks>This base class does not support adding or removing pointers, because many will never
     /// pass pointers in their constructors and will fall back to either the Gaze or Mouse Pointer.</remarks>
-    /// </summary>
     public class BaseGenericInputSource : IMixedRealityInputSource, IDisposable
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorAssemblyReloadManager.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorAssemblyReloadManager.cs
@@ -12,11 +12,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         /// <summary>
         /// Locks the Editor's ability to reload assemblies.<para/>
+        /// </summary>
         /// <remarks>
         /// This is useful for ensuring async tasks complete in the editor without having to worry if any script
         /// changes that happen during the running task will cancel it when the editor re-compiles the assemblies.
         /// </remarks>
-        /// </summary>
         public static bool LockReloadAssemblies
         {
             set

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -132,8 +132,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         /// <summary>
         /// Returns true the first time it is called within this editor session, and false for all subsequent calls.
-        /// <remarks>A new session is also true if the editor build target group is changed.</remarks>
         /// </summary>
+        /// <remarks>A new session is also true if the editor build target group is changed.</remarks>
         private static bool IsNewSession
         {
             get

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs
@@ -250,8 +250,8 @@ namespace Microsoft.MixedReality.Toolkit.Physics
 
         /// <summary>
         /// Stops the transform in place and terminates any animations.<para/>
-        /// <remarks>Reset() is usually reserved as a MonoBehaviour API call in editor, but is used in this case as a convenience method.</remarks>
         /// </summary>
+        /// <remarks>Reset() is usually reserved as a MonoBehaviour API call in editor, but is used in this case as a convenience method.</remarks>
         public void Reset()
         {
             targetPosition = transform.position;

--- a/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
@@ -11,9 +11,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
 {
     /// <summary>
     /// Helper class for determining if a Windows API contract is available.
+    /// </summary>
     /// <remarks> See https://docs.microsoft.com/en-us/uwp/extension-sdks/windows-universal-sdk
     /// for a full list of contracts.</remarks>
-    /// </summary>
     public static class WindowsApiChecker
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]

--- a/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -754,8 +754,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
         /// <summary>
         /// This Utility method finalizes the URL and formats the HTTPS string if needed.
-        /// <remarks>Local Machine will be changed to 127.0.1:10080 for HoloLens connections.</remarks>
         /// </summary>
+        /// <remarks>Local Machine will be changed to 127.0.1:10080 for HoloLens connections.</remarks>
         /// <param name="targetUrl">The target URL i.e. 128.128.128.128</param>
         /// <returns>The finalized URL with http/https prefix.</returns>
         public static string FinalizeUrl(string targetUrl)


### PR DESCRIPTION
Overview
---
Some of our summary tags were misformatted. This moves all tags into their own scope, to improve the layouting of our docs (remarks tags get their own section):

![image](https://user-images.githubusercontent.com/3580640/56838764-2af81400-6834-11e9-806c-7cefb63e506c.png)

