### PR TITLE
Fix/clone settings should dirty scene

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -186,6 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 // Sub-profiles are easy to update in the master configuration inspector.
                 if (MixedRealityToolkit.Instance.ActiveProfile.GetType() == profile.GetType())
                 {
+                    UnityEditor.Undo.RecordObject(MixedRealityToolkit.Instance, "Copy & Customize Profile");
                     MixedRealityToolkit.Instance.ActiveProfile = profile as MixedRealityToolkitConfigurationProfile;
                 }
             }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -117,6 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
                     var newProfile = profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles") as MixedRealityToolkitConfigurationProfile;
+                    UnityEditor.Undo.RecordObject(MixedRealityToolkit.Instance, "Create new profiles");
                     MixedRealityToolkit.Instance.ActiveProfile = newProfile;
                     Selection.activeObject = newProfile;
                 }


### PR DESCRIPTION
Call Undo.RecordObject so that editor will dirty the scene when ActiveProfile setting is changed.
Fixes #4109.
