### PR TITLE
Enable the input simulation assembly for all platforms.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/MixedRealityToolkit.Services.InputSimulation.asmdef
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/MixedRealityToolkit.Services.InputSimulation.asmdef
@@ -5,9 +5,7 @@
         "Microsoft.MixedReality.Toolkit.SDK"
     ],
     "optionalUnityReferences": [],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
The service itself is still editor-only. Enabling the main assembly for
all platforms removes a warning when the input system tries to
deserialize the input sim profile on a non-editor platform.

Overview
---


Changes
---
- Fixes: # .
