### PR TITLE
Correctly handle pointers with no controller attached (i.e. gaze pointer) in manipulation handler

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -227,21 +227,31 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Vector3 GetPointersVelocity()
         {
             Vector3 sum = Vector3.zero;
+            int numControllers = 0;
             foreach (var p in pointerIdToPointerMap.Values)
             {
-                sum += p.Controller.Velocity;
+                if (p.Controller != null)
+                {
+                    numControllers++;
+                    sum += p.Controller.Velocity;
+                }
             }
-            return sum / Math.Max(1, pointerIdToPointerMap.Count);
+            return sum / Math.Max(1, numControllers);
         }
 
         private Vector3 GetPointersAngularVelocity()
         {
             Vector3 sum = Vector3.zero;
+            int numControllers = 0;
             foreach (var p in pointerIdToPointerMap.Values)
             {
-                sum += p.Controller.AngularVelocity;
+                if (p.Controller != null)
+                {
+                    numControllers++;
+                    sum += p.Controller.AngularVelocity;
+                }
             }
-            return sum / Math.Max(1, pointerIdToPointerMap.Count);
+            return sum / Math.Max(1, numControllers);
         }
 
         private bool IsNearManipulation()

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -230,6 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             int numControllers = 0;
             foreach (var p in pointerIdToPointerMap.Values)
             {
+                // Check pointer has a valid controller (e.g. gaze pointer doesn't)
                 if (p.Controller != null)
                 {
                     numControllers++;
@@ -245,6 +246,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             int numControllers = 0;
             foreach (var p in pointerIdToPointerMap.Values)
             {
+                // Check pointer has a valid controller (e.g. gaze pointer doesn't)
                 if (p.Controller != null)
                 {
                     numControllers++;


### PR DESCRIPTION
Fixes: #4117  .
