### PR TITLE
Increased indent in Interactable profiles, the Theme label under Targ…

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -75,29 +75,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public virtual void RenderCustomInspector()
         {
-            // TODO: extend the preference array to handle multiple themes open and scroll values!!!
-            // TODO: add  messaging!!!
-            // TODO: handle dimensions
-            // TODO: add profiles
-            // TODO: add themes
-            // TODO: handle/display properties from themes
-
-            // TODO: !!!!! need to make sure we refresh the shader list when the target changes
-
-            // TODO: !!!!! finish incorporating States
-            // TODO: add the default states by default
-            // TODO: let flow into rest of themes and events.
-            // TODO: events should target the state logic they support.
-
-            // FIX: when deleting a theme property, the value resets or the item that's deleted is wrong
-
-            //base.DrawDefaultInspector();
-
             serializedObject.Update();
 
             EditorGUILayout.Space();
             InspectorUIUtility.DrawTitle("Interactable");
-            //EditorGUILayout.LabelField(new GUIContent("Interactable Settings"));
 
             EditorGUILayout.BeginVertical("Box");
 
@@ -177,11 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     actionId.intValue = newActionId;
                 }
             }
-
-            //selected.enumValueIndex = (int)(MixedRealityInputAction)EditorGUILayout.EnumPopup(new GUIContent("Input Action", "Input source for this Interactable, Default: Select"), (MixedRealityInputAction)selected.enumValueIndex);
-
-            // TODO: should IsGlobal only show up on specific press types and indent?
-            // TODO: should we show handedness on certain press types?
+            
             SerializedProperty isGlobal = serializedObject.FindProperty("IsGlobal");
             isGlobal.boolValue = EditorGUILayout.Toggle(new GUIContent("Is Global", "Like a modal, does not require focus"), isGlobal.boolValue);
 
@@ -296,8 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         {
                             themes.InsertArrayElementAtIndex(themes.arraySize);
                             SerializedProperty theme = themes.GetArrayElementAtIndex(themes.arraySize - 1);
-
-                            // TODO: make sure there is only one or make unique
+                            
                             string[] themeLocations = AssetDatabase.FindAssets("DefaultTheme");
                             if (themeLocations.Length > 0)
                             {
@@ -320,9 +296,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         SerializedProperty themeItem = themes.GetArrayElementAtIndex(t);
                         EditorGUI.indentLevel = indentOnSectionStart + 2;
                         EditorGUILayout.PropertyField(themeItem, new GUIContent("Theme", "Theme properties for interaction feedback"));
-
-                        // TODO: we need the theme and target in order to figure out what properties to expose in the list
-                        // TODO: or do we show them all and show alerts when a theme property is not compatible
+                        
                         if (themeItem.objectReferenceValue != null && gameObject.objectReferenceValue)
                         {
                             if (themeItem.objectReferenceValue.name == "DefaultTheme")

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -318,6 +318,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     for (int t = 0; t < themes.arraySize; t++)
                     {
                         SerializedProperty themeItem = themes.GetArrayElementAtIndex(t);
+                        EditorGUI.indentLevel = indentOnSectionStart + 2;
                         EditorGUILayout.PropertyField(themeItem, new GUIContent("Theme", "Theme properties for interaction feedback"));
 
                         // TODO: we need the theme and target in order to figure out what properties to expose in the list
@@ -338,11 +339,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                             SerializedProperty hadDefault = sItem.FindPropertyRelative("HadDefaultTheme");
                             hadDefault.boolValue = true;
-                            EditorGUI.indentLevel = indentOnSectionStart + 2;
+                            EditorGUI.indentLevel = indentOnSectionStart + 3;
 
                             string prefKey = themeItem.objectReferenceValue.name + "Profiles" + i + "_Theme" + t + "_Edit";
                             bool showSettings = EditorPrefs.GetBool(prefKey);
-
+                            
                             InspectorUIUtility.ListSettings settings = listSettings[i];
                             bool show = InspectorUIUtility.DrawSectionStart(themeItem.objectReferenceValue.name + " (Click to edit)", indentOnSectionStart + 3, showSettings, FontStyle.Normal, false);
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
@@ -767,7 +767,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             GUIStyle box = InspectorUIUtility.Box(0);
             if (themeObj != null)
             {
-                box = InspectorUIUtility.Box(30);
+                box = InspectorUIUtility.Box(34);
                 themeObj.Update();
             }
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
@@ -14,11 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// Inspector for themes, and used by Interactable
     /// </summary>
-
-    // TODO: !!!!! need to make sure we refresh the shader list when the target changes
-
-    // FIX : when adding a new setting, the rendered values is a dupe of the previous values in the list, but the dropdown is default.
-
+    
 #if UNITY_EDITOR
     [CustomEditor(typeof(Theme))]
     public class ThemeInspector : UnityEditor.Editor
@@ -355,9 +351,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                             }
                         }
                     }
-
-                    //TODO: make sure shader has currently selected property
-
+                    
                     List<ShaderPropertyType> shaderPropFilter = new List<ShaderPropertyType>();
                     // do we need a propId?
                     if (properties[i].Type == InteractableThemePropertyValueTypes.Color)


### PR DESCRIPTION
Increased indent in Interactable profiles, the Theme label under Target was not consistent when Dimensions were increased, like check boxes.

Issue #3997 

# Overview
https://user-images.githubusercontent.com/22085553/56380628-8ccad500-61c7-11e9-9c84-caef2582874a.png

Shows the first Theme label under target is not indented, but the second one is. They should be consistent and sense they are tied to Target, they should all be indented.

# Changes
Increase intent and added an indent reset at the top of the loop.

