### PR TITLE
Fix grab pointer is disabled when poke pointer near touchable.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -146,6 +146,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                 continue;
                             }
 
+                            if (otherPointer is IMixedRealityNearPointer)
+                            {
+                                // Only disable far interaction pointers
+                                // It is okay for example to have two near pointers active on a single controller
+                                // like a poke pointer and a grab pointer
+                                continue;
+                            }
+
                             otherPointer.IsActive = false;
                             unassignedPointers.Remove(otherPointer);
                         }

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
@@ -19,7 +19,11 @@ MonoBehaviour:
     m_Bits: 4294967291
   debugDrawPointingRays: 1
   debugDrawPointingRayColors:
-  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 1, g: 0.58280706, b: 0, a: 1}
+  - {r: 0.86426115, g: 1, b: 0, a: 1}
+  - {r: 0, g: 1, b: 0.2163105, a: 1}
+  - {r: 0, g: 0.3028021, b: 1, a: 1}
+  - {r: 0.44855833, g: 0, b: 1, a: 1}
   gazeCursorPrefab: {fileID: 1000012072213228, guid: 5b3e2856904e43c680f84f326861032a,
     type: 3}
   gazeProviderType:

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -703,7 +703,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     MixedRealityRaycaster.DebugEnabled = pointerProfile.DebugDrawPointingRays;
 
                     Color rayColor;
-                    
                     if ((pointerProfile.DebugDrawPointingRayColors != null) && (pointerProfile.DebugDrawPointingRayColors.Length > 0))
                     {
                         rayColor = pointerProfile.DebugDrawPointingRayColors[pointerCount++ % pointerProfile.DebugDrawPointingRayColors.Length];

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -703,7 +703,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     MixedRealityRaycaster.DebugEnabled = pointerProfile.DebugDrawPointingRays;
 
                     Color rayColor;
-
+                    
                     if ((pointerProfile.DebugDrawPointingRayColors != null) && (pointerProfile.DebugDrawPointingRayColors.Length > 0))
                     {
                         rayColor = pointerProfile.DebugDrawPointingRayColors[pointerCount++ % pointerProfile.DebugDrawPointingRayColors.Length];
@@ -711,6 +711,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     else
                     {
                         rayColor = Color.green;
+                    }
+
+                    if (!pointer.Pointer.IsActive)
+                    {
+                        // Only draw pointers that are currently active, but make sure to 
+                        // increment color even if pointer is disabled so that the color for e.g. the 
+                        // sphere pointer or the poke pointer remains consistent.
+                        continue;
                     }
 
                     Debug.DrawRay(pointer.StartPoint, (pointer.Details.Point - pointer.StartPoint), rayColor);


### PR DESCRIPTION
## Overview
- Fixes: #4170

The root cause of this bug is that the grab pointer was getting disabled whenever the poke pointer was near a surface, this was a bug in the input mediator.

In addition, I made a few other changes:
- Only render debug pointer rays if the rays are active (makes them easier to view)
- Update default pointer profile to include several colors of pointer rays so we can tell apart poke pointer from grab pointer. The new colors are as follows:

![image](https://user-images.githubusercontent.com/168492/57115926-b4ad5300-6d06-11e9-9324-c57a80cc7f1c.png)
