### PR TITLE
Another iteration on having the proper NuGet package generation

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -582,8 +582,8 @@ PlayerSettings:
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   apiCompatibilityLevelPerPlatform:
-    Metro: 6
-    Standalone: 6
+    Metro: 3
+    Standalone: 3
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Microsoft.MixedReality.Toolkit

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -107,6 +107,31 @@ steps:
    $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    $outDir = "$(Build.ArtifactStagingDirectory)\build"
+   $logFile = New-Item -Path "$outDir\build\build_x86.log" -ItemType File -Force
+   
+   $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.UnityPlayerBuildTools.StartCommandLineBuild -sceneList $sceneList -logFile $($logFile.FullName) -batchMode -x86 -buildOutput $outDir -buildTarget WSAPlayer -scriptingBackend 2" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+  displayName: 'Build UWP x86 (.NET) For NuGet'
+
+- powershell: |
+   # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   $outDir = "$(Build.ArtifactStagingDirectory)\build"
    $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force
    
    $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -batchmode -executeMethod Microsoft.MixedReality.Toolkit.Build.Editor.AssetScriptReferenceRetargeter.RetargetAssets -logFile $($logFile.FullName) -nographics -quit" -PassThru


### PR DESCRIPTION
The issue is that NuGet is being pacakged with UWP DLLs incorrectly targetting System.Numerics instead of System.Numerics.Vectors.

I previously chased a red herring, and the fault actually lies with us not building a .NET flavor of UWP for packaging purposes.