### PR TITLE
Add PlayMode tests to the PR and CI pipelines.

### DIFF
--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -153,7 +153,31 @@ steps:
    Remove-Job $ljob
    Stop-Process $proc
 
-  displayName: 'Run tests'
+  displayName: 'Run EditMode tests'
+
+- powershell: |
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   Write-Host "======================= PlayMode Tests ======================="
+   
+   $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform playmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+
+  displayName: 'Run PlayMode tests'
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -153,7 +153,32 @@ steps:
    Remove-Job $ljob
    Stop-Process $proc
    
-  displayName: 'Run tests'
+  displayName: 'Run EditMode tests'
+
+- powershell: |
+   $editor = Get-ChildItem ${Env:Unity2018.3.7f1} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   Write-Host "======================= PlayMode Tests ======================="
+   
+   $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform playmodemode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+   
+  displayName: 'Run PlayMode tests'
+
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -162,7 +162,7 @@ steps:
    
    $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
    
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform playmodemode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform playmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
    $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
    
    while (-not $proc.HasExited -and $ljob.HasMoreData)


### PR DESCRIPTION
As we add more playmode tests we want to make sure that other folks aren't breaking them inadvertently. Easiest way of doing this is to enable these tests as part of PR validation (and CI as well)