### PR TITLE
Update documentation (ToC and ET images / links)

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -7,14 +7,14 @@ Alternatively, you can check out our already configured [MRTK Eye Tracking Examp
 ### Setting up the scene
 Set up the _MixedRealityToolkit_ by simply clicking _'Mixed Reality Toolkit -> Configure…'_ in the menu bar.
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_setup_configure.png)
+![MRTK](../Images/EyeTracking/mrtk_setup_configure.png)
 
 
 ### Setting up the MRTK profiles required for Eye Tracking
 After setting up your MRTK scene, you will be asked to choose a profile for MRTK. 
 You can simply select _DefaultMixedRealityToolkitConfigurationProfile_ and then select the _'Copy & Customize'_ option.
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_setup_configprofile.png)
+![MRTK](../Images/EyeTracking/mrtk_setup_configprofile.png)
 
 
 ### Create an "Eye Gaze Data Provider"
@@ -29,14 +29,14 @@ You can simply select _DefaultMixedRealityToolkitConfigurationProfile_ and then 
     
     - For **Platform(s)** select _'Windows Universal'_.
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_setup_eyes_dataprovider.png)
+![MRTK](../Images/EyeTracking/mrtk_setup_eyes_dataprovider.png)
 
 
 ### Enabling Eye Tracking in the GazeProvider
 In HoloLens v1, head gaze was used as primary pointing technique. 
 While head gaze is still available via the _GazeProvider_ in MRTK which is attached to your [Camera](https://docs.unity3d.com/ScriptReference/Camera.html), you can check to use eye gaze instead by ticking the _'Prefer Eye Tracking'_ checkbox as shown in the screenshot below.
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_setup_eyes_gazeprovider.png)
+![MRTK](../Images/EyeTracking/mrtk_setup_eyes_gazeprovider.png)
 
 
 ### Simulating Eye Tracking in the Unity Editor
@@ -49,8 +49,8 @@ For this, it is better to ensure frequent tests of your eye-based interactions o
     - Navigate to your main _'MRTK Configuration Profile'_ -> _'Input System Profile'_ -> _'Data Providers'_ -> _'Input Simulation Service'_.
     - Check the _'Simulate Eye Position'_ checkbox.
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_setup_eyes_simulate.png)
-    
+![MRTK](../Images/EyeTracking/mrtk_setup_eyes_simulate.png)
+
 2. **Disable default head gaze cursor**: 
 In general, it is recommended to avoid showing an eye gaze cursor or if absolutely required to make it _very_ subtle.
 Check out our [eye gaze cursor tutorial](EyeTracking_Cursor.md) for more information on how to best handle it.
@@ -58,7 +58,7 @@ We do recommend to hide the default head gaze cursor that is attached to the MRT
     - Navigate to your main _'MRTK Configuration Profile'_ -> _'Input System Profile'_ -> _'PointerSettings.PointerProfile'_
     - At the bottom of the _'PointerProfile'_, you should assign an invisible cursor prefab to the _'GazeCursor'_. If you downloaded the MRTK Examples folder, you can simply reference the included -'EyeGazeCursor'_ prefab.
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_setup_eyes_gazesettings.png)
+![MRTK](../Images/EyeTracking/mrtk_setup_eyes_gazesettings.png)
 
 ### Accessing eye gaze data
 Now that your scene is set up to use Eye Tracking, let's take a look at how to access it in your scripts: 
@@ -74,7 +74,7 @@ Follow these steps:
 2. Open your compiled Visual Studio project and then open the _'Package.appxmanifest'_ in your solution.
 3. Make sure to tick the _'Gaze Input'_ checkbox under _Capabilities_.
 
-![Enabling Gaze Input in Visual Studio](../../Documentation/Images/EyeTracking/mrtk_et_gazeinput.jpg)
+![Enabling Gaze Input in Visual Studio](../Images/EyeTracking/mrtk_et_gazeinput.jpg)
 
 If everything is set up correctly, a prompt should pop up asking the user for permission to use Eye Tracking when you start your Unity app on a HoloLens 2 device for the first time.
 

--- a/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
+++ b/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
@@ -10,28 +10,30 @@ Finally, an example is provided for recording and visualizing the user's visual 
 ## Overview of MRTK Eye Tracking Samples
 
 ### Setting up the MRTK Eye Tracking Samples
-The [Eye Tracking example package](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/) comes with a number of different Unity scenes that are described in more detail below:
-- [EyeTrackingDemo-00-RootScene.unity](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/): 
-This is the main (_root_) scene that has all the core MRTK components included. 
-It comes with a graphical scene menu that allows you to easily switch between the different Eye Tracking scenes which will be [loaded additively](href:https://docs.unity3d.com/ScriptReference/SceneManagement.LoadSceneMode.Additive.html). 
+
+The [Eye Tracking example package](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking) comes with a number of different Unity scenes that are described in more detail below:
+
+- EyeTrackingDemo-00-RootScene.unity:
+This is the main (_root_) scene that has all the core MRTK components included.
+It comes with a graphical scene menu that allows you to easily switch between the different Eye Tracking scenes which will be [loaded additively](href:https://docs.unity3d.com/ScriptReference/SceneManagement.LoadSceneMode.Additive.html).
 To try out the Eye Tracking demos in your Unity Player, all you have to do is to load this scene and hit play.
 Make sure that the _'OnLoad_StartScene'_ script is enabled for this so that the root scene knows which additive scene to load first.
 
-![Example for the OnLoad_StartScene script](/Documentation/Images/EyeTracking/mrtk_et_rootscene_onload.png)
+![Example for the OnLoad_StartScene script](../Images/EyeTracking/mrtk_et_rootscene_onload.png)
 
 - Individual Eye Tracking sample scenes - See [Demo Scenarios](#demo-scenarios) for a description of each:
-  - [EyeTrackingDemo-01-BasicSetup.unity](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/)
-  - [EyeTrackingDemo-02-TargetSelection.unity](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/)
-  - [EyeTrackingDemo-03-Navigation.unity](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/)
-  - [EyeTrackingDemo-04-TargetPositioning.unity](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/)
-  - [EyeTrackingDemo-05-Visualizer.unity](/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/)
+  - EyeTrackingDemo-01-BasicSetup.unity
+  - EyeTrackingDemo-02-TargetSelection.unity
+  - EyeTrackingDemo-03-Navigation.unity
+  - EyeTrackingDemo-04-TargetPositioning.unity
+  - EyeTrackingDemo-05-Visualizer.unity
 
 How to quickly change a scene and test it in the Unity editor:
 - Load the _root_ scene
 - Disable the _'OnLoadStartScene'_ script
 - _Drag and drop_ one of the Eye Tracking test scenes that are described below (or any other scene) into your _Hierarchy_ view.
 
-![Example for the OnLoad_StartScene script](/Documentation/Images/EyeTracking/mrtk_et_rootscene_onload2.png)
+![Example for the OnLoad_StartScene script](../Images/EyeTracking/mrtk_et_rootscene_onload2.png)
   
 ### Demo Scenarios
 [**Eye-Supported Target Selection**](EyeTracking_TargetSelection.md)

--- a/Documentation/EyeTracking/EyeTracking_Positioning.md
+++ b/Documentation/EyeTracking/EyeTracking_Positioning.md
@@ -1,4 +1,4 @@
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_et_positioning.png )
+![MRTK](../Images/EyeTracking/mrtk_et_positioning.png)
 
 # Eye-Supported Target Positioning in MRTK
 
@@ -7,8 +7,7 @@ _We're currently restructuring and improving the MRTK documentation.
 This content will be updated soon! 
 If you have any questions regarding this section please post in our MRTK slack channel._
 
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_et_positioning_slider.png)
-
+![MRTK](../Images/EyeTracking/mrtk_et_positioning_slider.png)
 
 ---
 [Back to "Eye Tracking in the MixedRealityToolkit"](EyeTracking_Main.md)

--- a/Documentation/EyeTracking/EyeTracking_TargetSelection.md
+++ b/Documentation/EyeTracking/EyeTracking_TargetSelection.md
@@ -1,4 +1,4 @@
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_et_targetselect.png)
+![MRTK](../Images/EyeTracking/mrtk_et_targetselect.png)
 
 # Eye-Supported Target Selection
 This page discusses different options for accessing eye gaze data and eye gaze specific events to select targets in MRTK. 

--- a/Documentation/EyeTracking/EyeTracking_Visualization.md
+++ b/Documentation/EyeTracking/EyeTracking_Visualization.md
@@ -1,4 +1,4 @@
-![MRTK](../../Documentation/Images/EyeTracking/mrtk_et_heatmaps.png)
+![MRTK](../Images/EyeTracking/mrtk_et_heatmaps.png)
 
 # Visualizing Eye Tracking Data in MRTK
 

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -99,8 +99,6 @@
       href: Utilities/ExtensionServiceCreationWizard.md
   - name: Experimental Features
     items:
-    - name: Spatial Understanding
-      href: TODO.md
     - name: QR Tracking
       href: TODO.md
     - name: Spatial Audio
@@ -109,18 +107,6 @@
     items:
     - name: Shared Experiences
       href: TODO.md
-- name: How-to 
-  items:
-  - name: How to setup global voice commands 
-    href: TODO.md
-  - name: How to setup a scene for Mixed Reality
-    href: TODO.md
-  - name: How to trigger an action using MRTK button
-    href: TODO.md
-  - name: How to use Input Action (voice, controller...)
-    href: TODO.md
-  - name: How to trigger an action using MRTK button
-    href: TODO.md
 - name: Contributing
   href: Contributing/CONTRIBUTING.md
   items:

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -17,8 +17,6 @@
       items:
       - name: Mixed Reality Toolkit Componentization
         href: Packaging/MRTK_Modularization.md
-    - name: Service Provider
-      href: MixedRealityConfigurationGuide.md
     - name: Input
       href: Input/Overview.md
       items:

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -46,10 +46,10 @@
       items:
       - name: Interactable
         href: README_Interactable.md
-      - name: Object Manipulation 
-        href: README_ManipulationHandler.md      
+      - name: Object Manipulation
+        href: README_ManipulationHandler.md
       - name: Fingertip Visualization
-        href: README_FingertipVisualization.md      
+        href: README_FingertipVisualization.md
       - name: App Bar
         href: README_AppBar.md
       - name: Bounding Box
@@ -57,24 +57,24 @@
       - name: Button
         href: README_Button.md
       - name: Object Collection
-        href: README_ObjectCollection.md      
+        href: README_ObjectCollection.md
       - name: Pointers
         href: README_Pointers.md
       - name: Slate
-        href: README_Slate.md       
+        href: README_Slate.md
       - name: System Keyboard
-        href: README_SystemKeyboard.md     
+        href: README_SystemKeyboard.md
       - name: Tooltips
-        href: README_Tooltip.md  
+        href: README_Tooltip.md
       - name: Solvers
-        href: README_Solver.md 
-      - name: Hand Interaction Example 
-        href: README_HandInteractionExamples.md           
+        href: README_Solver.md
+      - name: Hand Interaction Example
+        href: README_HandInteractionExamples.md
       - name: Eye Tracking Interaction Example
-        href: EyeTracking/EyeTracking_ExamplesOverview.md   
+        href: EyeTracking/EyeTracking_ExamplesOverview.md
     - name: Spatial Awareness
       href: SpatialAwareness/SpatialAwarenessGettingStarted.md
-      items:	
+      items:
       - name: Configuring the Spatial Awareness Mesh Observer
         href: SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.md
     - name: Boundary System


### PR DESCRIPTION
## Overview
This PR removes TODO links that were added in #4074, per https://github.com/Microsoft/MixedRealityToolkit-Unity/pull/4074#discussion_r279567577.

This also removes the link under Service Provider, as it led to a more generic guide. This link will be re-added when the Service Provider guide is published.

This also corrects some paths in the ET documentation that were leading to broken links on the GitHub.io page.

## Changes
- Fixes: #4163, fixes #4186 