### PR TITLE
Update the build window's min Windows SDK version.

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 {
     public static class UwpBuildDeployPreferences
     {
-        public static Version MIN_SDK_VERSION = new Version("10.0.17134.0");
+        public static Version MIN_SDK_VERSION = new Version("10.0.18362.0");
         private const string EDITOR_PREF_BUILD_CONFIG = "BuildDeployWindow_BuildConfig";
         private const string EDITOR_PREF_FORCE_REBUILD = "BuildDeployWindow_ForceRebuild";
         private const string EDITOR_PREF_CONNECT_INFOS = "BuildDeployWindow_DeviceConnections";


### PR DESCRIPTION
This reflects the actual requirements set out on:
https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html