### PR TITLE
update spatial observers and demo to use registry

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/SpatialAwareness/Scripts/DemoSpatialMeshHandler.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/SpatialAwareness/Scripts/DemoSpatialMeshHandler.cs
@@ -14,6 +14,19 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
     /// </summary>
     public class DemoSpatialMeshHandler : MonoBehaviour, IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>
     {
+        private IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem = null;
+
+        private IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem
+        {
+            get
+            {
+                if (spatialAwarenessSystem == null)
+                {
+                    MixedRealityServiceRegistry.TryGetService<IMixedRealitySpatialAwarenessSystem>(out spatialAwarenessSystem);
+                }
+                return spatialAwarenessSystem;
+            }
+        }
         /// <summary>
         /// Collection that tracks the IDs and count of updates for each active spatial awareness mesh.
         /// </summary>
@@ -21,13 +34,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 
         private async void OnEnable()
         {
-            await new WaitUntil(() => MixedRealityToolkit.SpatialAwarenessSystem != null);
-            MixedRealityToolkit.SpatialAwarenessSystem.Register(gameObject);
+            await new WaitUntil(() => SpatialAwarenessSystem != null);
+            SpatialAwarenessSystem.Register(gameObject);
         }
 
         private void OnDisable()
         {
-            MixedRealityToolkit.SpatialAwarenessSystem?.Unregister(gameObject);
+            SpatialAwarenessSystem?.Unregister(gameObject);
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -130,13 +130,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         private GameObject ObservedObjectParent => observedObjectParent != null ? observedObjectParent : (observedObjectParent = SpatialAwarenessSystem?.CreateSpatialAwarenessObjectParent("WindowsMixedRealitySpatialMeshObserver"));
 
-        private IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem = null;
-
-        /// <summary>
-        /// The currently active instance of <see cref="Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness.IMixedRealitySpatialAwarenessSystem"/>.
-        /// </summary>
-        private IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem => spatialAwarenessSystem ?? (spatialAwarenessSystem = MixedRealityToolkit.SpatialAwarenessSystem);
-
 #if UNITY_WSA
         /// <inheritdoc />
         protected override void Dispose(bool disposing)

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
@@ -24,17 +24,17 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             uint priority = DefaultPriority, 
             BaseMixedRealityProfile profile = null) : base(registrar, spatialAwarenessSystem, name, priority, profile)
         {
-            if (MixedRealityToolkit.SpatialAwarenessSystem != null)
-            {
-                SourceId = MixedRealityToolkit.SpatialAwarenessSystem.GenerateNewSourceId();
-            }
-            else
-            {
-                Debug.LogError($"A spatial observer is registered in your service providers profile, but the spatial awareness system is turned off. Please either turn on spatial awareness or remove {name}.");
-            }
+            SpatialAwarenessSystem = spatialAwarenessSystem;
 
+            SourceId = (SpatialAwarenessSystem != null) ? SpatialAwarenessSystem.GenerateNewSourceId() : 0;
             SourceName = name;
+
         }
+
+        /// <summary>
+        /// The spatial awareness system that is associated with this observer.
+        /// </summary>
+        protected IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem { get; private set; }
 
         #region IMixedRealityEventSource Implementation
 


### PR DESCRIPTION
## Overview
- Update the base spatial observer to honor the spatial awareness system instance passed in the constructor.
- Remove the duplicate SpatialAwarenessSystem property from the WindowsMixedRealitySpatialMeshObserver.
- Update the spatial awareness demo to retrieve the service instance from the registry,

## Changes
This change builds upon #4099 and is related to #3545.