### PR TITLE
Code cleanup, 2 of N

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -176,9 +176,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         };
 
         private State currentState = State.Start;
-        private TwoHandMoveLogic m_moveLogic;
-        private TwoHandScaleLogic m_scaleLogic;
-        private TwoHandRotateLogic m_rotateLogic;
+        private TwoHandMoveLogic moveLogic;
+        private TwoHandScaleLogic scaleLogic;
+        private TwoHandRotateLogic rotateLogic;
         private Dictionary<uint, IMixedRealityPointer> pointerIdToPointerMap = new Dictionary<uint, IMixedRealityPointer>();
 
         private Quaternion objectToHandRotation;
@@ -198,9 +198,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region MonoBehaviour Functions
         private void Awake()
         {
-            m_moveLogic = new TwoHandMoveLogic(constraintOnMovement);
-            m_rotateLogic = new TwoHandRotateLogic();
-            m_scaleLogic = new TwoHandScaleLogic();
+            moveLogic = new TwoHandMoveLogic(constraintOnMovement);
+            rotateLogic = new TwoHandRotateLogic();
+            scaleLogic = new TwoHandScaleLogic();
         }
         private void Start()
         {
@@ -317,7 +317,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 case State.MovingRotating:
                 case State.RotatingScaling:
                 case State.MovingRotatingScaling:
-                    // TODO: if < 2, make this go to start state ('drop it')
                     if (handsPressedCount == 0)
                     {
                         newState = State.Start;
@@ -483,18 +482,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if ((currentState & State.Moving) > 0)
             {
-                targetPosition = m_moveLogic.Update(GetPointersCentroid(), IsNearManipulation());
+                targetPosition = moveLogic.Update(GetPointersCentroid(), IsNearManipulation());
             }
 
             var handPositionMap = GetHandPositionMap();
 
             if ((currentState & State.Rotating) > 0)
             {
-                targetRotationTwoHands = m_rotateLogic.Update(handPositionMap, targetRotationTwoHands, constraintOnRotation);
+                targetRotationTwoHands = rotateLogic.Update(handPositionMap, targetRotationTwoHands, constraintOnRotation);
             }
             if ((currentState & State.Scaling) > 0)
             {
-                targetScale = m_scaleLogic.UpdateMap(handPositionMap);
+                targetScale = scaleLogic.UpdateMap(handPositionMap);
             }
 
             float lerpAmount = GetLerpAmount();
@@ -566,7 +565,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else
             {
-                targetPosition = m_moveLogic.Update(GetPointersCentroid(), IsNearManipulation());
+                targetPosition = moveLogic.Update(GetPointersCentroid(), IsNearManipulation());
             }
 
             float lerpAmount = GetLerpAmount();
@@ -582,15 +581,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if ((newState & State.Rotating) > 0)
             {
-                m_rotateLogic.Setup(handPositionMap, hostTransform, ConstraintOnRotation);
+                rotateLogic.Setup(handPositionMap, hostTransform, ConstraintOnRotation);
             }
             if ((newState & State.Moving) > 0)
             {
-                m_moveLogic.Setup(GetPointersCentroid(), hostTransform.position);
+                moveLogic.Setup(GetPointersCentroid(), hostTransform.position);
             }
             if ((newState & State.Scaling) > 0)
             {
-                m_scaleLogic.Setup(handPositionMap, hostTransform);
+                scaleLogic.Setup(handPositionMap, hostTransform);
             }
         }
         private void HandleTwoHandManipulationEnded() { }
@@ -600,7 +599,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Assert.IsTrue(pointerIdToPointerMap.Count == 1);
             IMixedRealityPointer pointer = pointerIdToPointerMap.Values.First();
 
-            m_moveLogic.Setup(GetPointersCentroid(), hostTransform.position);
+            moveLogic.Setup(GetPointersCentroid(), hostTransform.position);
 
             // Calculate relative transform from object to hand.
             Quaternion worldToPalmRotation = Quaternion.Inverse(pointer.Rotation);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStateModel.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStateModel.cs
@@ -8,18 +8,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// State data model, state management and comparison instructions
     /// </summary>
-
-    /*
-     * Have an enum with all the button states -
-     * Create a list using the enums as the state type -
-     * Setup the bit and index automatically -
-     * Store the values for all the states -
-     * Have a sub state with only the states we care about - 
-     * On update, set those states and update the current state
-     * The other states can be checked anytime through the Interactive.
-     * 
-     */
-
     [System.Serializable]
     public class State
     {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Object that represents a cursor in 3D space controlled by gaze.
+    /// Object that represents a cursor in 3D space.
     /// </summary>
     public class BaseCursor : InputSystemGlobalListener, IMixedRealityCursor
     {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/CursorModifier.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/CursorModifier.cs
@@ -8,7 +8,10 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Component that can be added to any <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> with a <see href="https://docs.unity3d.com/ScriptReference/Collider.html">Collider</see> to Modifies either the <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityCursor"/> reacts when focused by a <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer"/>.
+    /// Component that can be added to any <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>
+    /// with a <see href="https://docs.unity3d.com/ScriptReference/Collider.html">Collider</see> to
+    /// modify the <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityCursor"/> reacts when
+    /// focused by a <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer"/>.
     /// </summary>
     public class CursorModifier : MonoBehaviour, ICursorModifier
     {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Input;
 using System;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionGrabbable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionGrabbable.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         #region IMixedRealitySpatialAwarenessSystem Implementation
 
         /// <summary>
-        ///  The collection of registered spatial awareness observers.
+        /// The collection of registered spatial awareness observers.
         /// </summary>
         private List<IMixedRealitySpatialAwarenessObserver> observers = new List<IMixedRealitySpatialAwarenessObserver>();
 

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -133,7 +133,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// This method is to be called by implementations of the <see cref="IMixedRealitySpatialAwarenessObserver"/> interface, not by application code.
         /// </remarks>
         void RaiseMeshUpdated(IMixedRealitySpatialAwarenessObserver observer, int meshId, SpatialAwarenessMeshObject meshObject);
-        //        void RaiseObservedObjectUpdated<T>(IMixedRealitySpatialAwarenessObserver observer, int meshId, T observedObject);
 
         /// <summary>
         /// <see cref="IMixedRealitySpatialAwarenessMeshObserver"/>'s should call this method to indicate an existing mesh has been removed.


### PR DESCRIPTION
Was going through the code to learn more, found some other small things for cleanup, so cleaning them up here.

General changes:
m_* -> not m_* (this is a C++ like coding convention which doesn't follow our C# guidelines)
InteractableStateModel.cs -> comments removed because they looked like there were notes-to-self and didn't help a reader understand what was going on (I'm more confused reading it).
BaseCursor -> It powers non-gaze cursors as well.
Everything else - general comment cleanup