### PR TITLE
Bold the fact that the 'Gaze Input' capability is only settable in Visual Studio.

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -8,7 +8,7 @@ For Eye Tracking to work correctly, the following requirements must be met:
 
 1. An _'Eye Gaze Data Provider'_ must be added to the input system. This provides eye tracking data from the platform.
 2. Eye Tracking must be set as the preferred source in the _'Gaze Provider'_. This setting can be toggled at runtime.
-3. The _'Gaze Input'_ capability must be enabled in the application manifest. Currently this is only available in Visual Studio.
+3. The _'Gaze Input'_ capability must be enabled in the application manifest. **Currently this is only available in Visual Studio.**
 4. The HoloLens **must** be calibrated for the current user under system settings.
 
 **IMPORTANT:** If any of the above requirements are not met, the application will automatically fall back to head-based gaze tracking.


### PR DESCRIPTION
This issue comes up repeatedly, but unfortunately isn't something that we have too much control over - there needs to be Unity support added to check this from within Unity, and until that happens, we should try to do all we can to call out in our docs that this is a VS specific step.

https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4193
