### PR TITLE
Add explicit help text around the "Eye Tracking Enabled" property.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -81,6 +81,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("True to prefer eye tracking over head gaze, when available.")]
+        [Help("When enabling eye tracking, please follow the instructions at " 
+               + "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/EyeTracking/EyeTracking_BasicSetup.html#eye-tracking-requirements "
+               + "to set up 'Gaze Input' capabilities through Visual Studio.", "", false)]
         private bool preferEyeTracking = false;
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Attributes/HelpAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/HelpAttribute.cs
@@ -19,17 +19,27 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// The help header foldout text
         /// </summary>
+        /// <remarks>
+        /// If Collapsible is false, then this header text will not be shown.
+        /// </remarks>
         public string Header;
+
+        /// <summary>
+        /// If true, this will be a collapsible help section. Defaults to true.
+        /// </summary>
+        public bool Collapsible;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="helpText">The help text to display</param>
         /// <param name="helpHeader">The help header foldout text</param>
-        public HelpAttribute(string helpText, string helpHeader="Help")
+        /// <param name="collapsible">If true, this help drawer will be collapsible</param>
+        public HelpAttribute(string helpText, string helpHeader="Help", bool collapsible = true)
         {
             Text = helpText;
             Header = helpHeader;
+            Collapsible = collapsible;
         }
     }
 }


### PR DESCRIPTION
It's somewhat of a common thing that folks are hitting that enabling the 'Gaze Input' capability isn't clear (i.e. it's something you have to do as a separate step in VS, and while it's documented in our docs, you don't know it's necessary without reading that or debugging through a number of things). Adding this help text will hopefully get some additional eyes while we wait for Unity to expose this property in its own UI.

I considered doing this automatically in our build process, but not everyone uses the UWP build window, and doing automagic stuff can also be really frustrating (because the user never learns that this is required and one day when the magic stops you have to deal with the pain anyway). We already have significant auto-running code complexity in the editor and I don't think that adding addiitional auto running things makes sense.

https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4194

Note that a larger part of this change is updating the help drawer code to handle word wrapping
