### PR TITLE
Reset touchPoints on Enable on PressableButtons

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -130,6 +130,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        private void OnEnable()
+        {
+            touchPoints.Clear()
+        }
+
         private void Update()
         {
             IsTouching = (touchPoints.Count != 0);


### PR DESCRIPTION

If a pressable button is disabled before the OnTouchCompleted event, the button remains in an unusable state as the touchPoints controller is never resetted

to be sure, the button is always in a usable state, the touchpoint list is always resetted on OnEnable