### PR TITLE
Add class for reading new calibration data

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraExtrinsics.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraExtrinsics.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         public byte[] Serialize()
         {
             var str = JsonUtility.ToJson(this);
-            var payload = Encoding.ASCII.GetBytes(str);
+            var payload = Encoding.UTF8.GetBytes(str);
             return payload;
         }
 
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 
             try
             {
-                var str = Encoding.ASCII.GetString(payload);
+                var str = Encoding.UTF8.GetString(payload);
                 extrinsics = JsonUtility.FromJson<CalculatedCameraExtrinsics>(str);
                 return true;
             }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraExtrinsics.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraExtrinsics.cs
@@ -44,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
             }
             catch
             {
+                Debug.LogWarning($"Exception thrown deserializing camera extrinsics: {e.ToString()}");
                 return false;
             }
         }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraExtrinsics.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraExtrinsics.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.MixedReality.Toolkit.Extensions.PhotoCapture;
 using System;
+using System.Text;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
@@ -21,6 +23,29 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         public override string ToString()
         {
             return $"Succeeded: {Succeeded} {base.ToString()}";
+        }
+
+        public byte[] Serialize()
+        {
+            var str = JsonUtility.ToJson(this);
+            var payload = Encoding.ASCII.GetBytes(str);
+            return payload;
+        }
+
+        public static bool TryDeserialize(byte[] payload, out CalculatedCameraExtrinsics extrinsics)
+        {
+            extrinsics = null;
+
+            try
+            {
+                var str = Encoding.ASCII.GetString(payload);
+                extrinsics = JsonUtility.FromJson<CalculatedCameraExtrinsics>(str);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraIntrinsics.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraIntrinsics.cs
@@ -63,6 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
             }
             catch
             {
+                Debug.LogWarning($"Exception thrown deserializing camera intrinsics: {e.ToString()}");
                 return false;
             }
         }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraIntrinsics.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraIntrinsics.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Extensions.PhotoCapture;
 using System;
+using System.Text;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
@@ -41,6 +42,29 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         public override string ToString()
         {
             return $"reprojection error: {ReprojectionError.ToString("G4")} {base.ToString()}";
+        }
+
+        public byte[] Serialize()
+        {
+            var str = JsonUtility.ToJson(this);
+            var payload = Encoding.ASCII.GetBytes(str);
+            return payload;
+        }
+
+        public static bool TryDeserialize(byte[] payload, out CalculatedCameraIntrinsics intrinsics)
+        {
+            intrinsics = null;
+
+            try
+            {
+                var str = Encoding.ASCII.GetString(payload);
+                intrinsics = JsonUtility.FromJson<CalculatedCameraIntrinsics>(str);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraIntrinsics.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalculatedCameraIntrinsics.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         public byte[] Serialize()
         {
             var str = JsonUtility.ToJson(this);
-            var payload = Encoding.ASCII.GetBytes(str);
+            var payload = Encoding.UTF8.GetBytes(str);
             return payload;
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 
             try
             {
-                var str = Encoding.ASCII.GetString(payload);
+                var str = Encoding.UTF8.GetString(payload);
                 intrinsics = JsonUtility.FromJson<CalculatedCameraIntrinsics>(str);
                 return true;
             }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalibrationDataHelper.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/CalibrationDataHelper.cs
@@ -177,8 +177,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
                 path = Path.Combine(GetDocumentsFolderPath(), RootDirectoryName, $"CameraIntrinsics_{i}.json");
                 i++;
             }
-            var str = JsonUtility.ToJson(intrinsics);
-            var payload = Encoding.ASCII.GetBytes(str);
+
+            var payload = intrinsics.Serialize();
             File.WriteAllBytes(path, payload);
             return path;
         }
@@ -187,23 +187,14 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         {
             if (File.Exists(path))
             {
-                try
+                var fileData = File.ReadAllBytes(path);
+                if (CalculatedCameraIntrinsics.TryDeserialize(fileData, out var intrinsics))
                 {
-                    var fileData = File.ReadAllBytes(path);
-                    var str = Encoding.ASCII.GetString(fileData);
-                    var intrinsics = JsonUtility.FromJson<CalculatedCameraIntrinsics>(str);
                     return intrinsics;
                 }
-                catch
-                {
-                    Debug.LogError($"Exception thrown loading camera intrinsics file {path}");
-                }
-            }
-            else
-            {
-                Debug.LogError($"Failed to find camera intrinsics file {path}");
             }
 
+            Debug.LogError($"Failed to load camera intrinsics file {path}");
             return null;
         }
 
@@ -216,8 +207,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
                 path = Path.Combine(GetDocumentsFolderPath(), RootDirectoryName, $"CameraExtrinsics_{i}.json");
                 i++;
             }
-            var str = JsonUtility.ToJson(extrinsics);
-            var payload = Encoding.ASCII.GetBytes(str);
+
+            var payload = extrinsics.Serialize();
             File.WriteAllBytes(path, payload);
             return path;
         }
@@ -226,23 +217,14 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         {
             if (File.Exists(path))
             {
-                try
+                var fileData = File.ReadAllBytes(path);
+                if(CalculatedCameraExtrinsics.TryDeserialize(fileData, out var extrinsics))
                 {
-                    var fileData = File.ReadAllBytes(path);
-                    var str = Encoding.ASCII.GetString(fileData);
-                    var extrinsics = JsonUtility.FromJson<CalculatedCameraExtrinsics>(str);
                     return extrinsics;
                 }
-                catch
-                {
-                    Debug.LogError($"Exception thrown loading camera extrinsics file {path}");
-                }
-            }
-            else
-            {
-                Debug.LogError($"Failed to find camera extrinsics file {path}");
             }
 
+            Debug.LogError($"Failed to load camera extrinsics file {path}");
             return null;
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/HeadsetCalibration.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/HeadsetCalibration.cs
@@ -167,9 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 
         private void SendHeadsetCalibrationDataPayload(HeadsetCalibrationData data)
         {
-            byte[] payload = null;
-            payload = Encoding.ASCII.GetBytes(JsonUtility.ToJson(data));
-
+            byte[] payload = data.Serialize();
             Updated?.Invoke(payload);
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/HeadsetCalibrationData.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Calibration/HeadsetCalibrationData.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         public byte[] Serialize()
         {
             var str = JsonUtility.ToJson(this);
-            var payload = Encoding.ASCII.GetBytes(str);
+            var payload = Encoding.UTF8.GetBytes(str);
             return payload;
         }
 
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 
             try
             {
-                var str = Encoding.ASCII.GetString(payload);
+                var str = Encoding.UTF8.GetString(payload);
                 headsetCalibrationData = JsonUtility.FromJson<HeadsetCalibrationData>(str);
                 return true;
             }
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         public byte[] Serialize()
         {
             var str = JsonUtility.ToJson(this);
-            var payload = Encoding.ASCII.GetBytes(str);
+            var payload = Encoding.UTF8.GetBytes(str);
             return payload;
         }
 
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 
             try
             {
-                var str = Encoding.ASCII.GetString(payload);
+                var str = Encoding.UTF8.GetString(payload);
                 request = JsonUtility.FromJson<HeadsetCalibrationDataRequest>(str);
                 return true;
             }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CalibrationData.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CalibrationData.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
             cameraTransform.transform.localRotation = Quaternion.LookRotation(cameraExtrinsics.ViewFromWorld.GetColumn(2), cameraExtrinsics.ViewFromWorld.GetColumn(1));
 
             // Magic offset from Unity's underlying coordinate frame (WorldManager.GetNativeISpatialCoordinateSystemPtr()) and the head pose used for the camera.
-            // Poses are sent in the coordinate frame space because the camera position uses prediction.
+            // Poses are sent in the coordinate frame space because the Unity camera position uses prediction.
             cameraTransform.localPosition += new Vector3(0f, 0.08f, 0.08f);
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CalibrationData.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CalibrationData.cs
@@ -1,0 +1,100 @@
+﻿using System.IO;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Compositor
+{
+    /// <summary>
+    /// Used for loading/applying camera intrinsics and camera extrinsics obtained through Spectator View's default calibration process.
+    /// </summary>
+    public class CalibrationData : ICalibrationData
+    {
+        private CalculatedCameraIntrinsics cameraIntrinsics;
+        private CalculatedCameraExtrinsics cameraExtrinsics;
+
+        public CalibrationData(string cameraIntrinsicsPath, string cameraExtrinsicsPath)
+        {
+            if (File.Exists(cameraIntrinsicsPath) &&
+                File.Exists(cameraExtrinsicsPath))
+            {
+                cameraIntrinsics = CalibrationDataHelper.LoadCameraIntrinsics(cameraIntrinsicsPath);
+                cameraExtrinsics = CalibrationDataHelper.LoadCameraExtrinsics(cameraExtrinsicsPath);
+
+                if (cameraIntrinsics == null ||
+                    cameraExtrinsics == null)
+                {
+                    Debug.LogError($"Failed to load cameara intrinsics/extrinscs: {cameraIntrinsicsPath}, {cameraExtrinsicsPath}");
+                }
+            }
+            else
+            {
+                Debug.LogError($"Invalid paths provided for camera intrinsics/extrinsics: {cameraIntrinsicsPath}, {cameraExtrinsicsPath}");
+            }
+        }
+
+        public CalibrationData(CalculatedCameraIntrinsics intrinsics, CalculatedCameraExtrinsics extrinsics)
+        {
+            cameraIntrinsics = intrinsics;
+            cameraExtrinsics = extrinsics;
+        }
+
+        /// <inheritdoc />
+        public void SetUnityCameraExtrinstics(Transform cameraTransform)
+        {
+            Matrix4x4 headFromCamera = cameraExtrinsics.ViewFromWorld;
+            cameraTransform.transform.localPosition = cameraExtrinsics.ViewFromWorld.GetColumn(3);
+            cameraTransform.transform.localRotation = Quaternion.LookRotation(cameraExtrinsics.ViewFromWorld.GetColumn(2), cameraExtrinsics.ViewFromWorld.GetColumn(1));
+
+            // Magic offset from Unity's underlying coordinate frame (WorldManager.GetNativeISpatialCoordinateSystemPtr()) and the head pose used for the camera.
+            // Poses are sent in the coordinate frame space because the camera position uses prediction.
+            cameraTransform.localPosition += new Vector3(0f, 0.08f, 0.08f);
+        }
+
+        /// <inheritdoc />
+        public void SetUnityCameraIntrinsics(Camera camera)
+        {
+            // D3D projection matrix (ProjectionMatrixToUnity accounts for it)
+            Matrix4x4 projection = Matrix4x4.zero;
+            projection[0, 0] = 2;
+            projection[1, 1] = -2;
+            projection[2, 0] = -1;
+            projection[2, 1] = 1;
+            projection[2, 2] = (camera.farClipPlane / (camera.farClipPlane - camera.nearClipPlane));
+            projection[2, 3] = 1;
+            projection[3, 2] = ((-camera.farClipPlane * camera.nearClipPlane) / (camera.farClipPlane - camera.nearClipPlane));
+
+            float PX = cameraIntrinsics.PrincipalPoint.x / cameraIntrinsics.ImageWidth;
+            float PY = cameraIntrinsics.PrincipalPoint.y / cameraIntrinsics.ImageHeight;
+            float FX = cameraIntrinsics.FocalLength.x / cameraIntrinsics.ImageWidth;
+            float FY = cameraIntrinsics.FocalLength.y / cameraIntrinsics.ImageHeight;
+
+            // Affine matrix from calibration values
+            Matrix4x4 affine = Matrix4x4.identity;
+            affine[0, 0] = FX;
+            affine[1, 1] = FY;
+            affine[2, 0] = PX;
+            affine[2, 1] = PY;
+
+            // We insert a YZFlip on the front end to compensate for the YZFlip exiting the View matrix layer.
+            var yzflip = Matrix4x4.identity;
+            yzflip[1, 1] = -1;
+            yzflip[2, 2] = -1;
+
+            Matrix4x4 projMat = ProjectionMatrixToUnity((yzflip * affine * projection).transpose);
+            camera.projectionMatrix = ProjectionMatrixToUnity(projMat);
+        }
+
+        private static Matrix4x4 ProjectionMatrixToUnity(Matrix4x4 m)
+        {
+            // to convert from a WinRT/D3D projection matrix to a Unity projection matrix (openGL-style), need to:
+            //      - first convert the matrix generally - transpose since Unity uses column vectors and WinRT/D3D uses row vectors
+            //      - recalculate the near/far plane components using the openGL convention
+            // m23 = B, m22 = -A, 
+            // D3D:     A = f/(f-n),       B = -fn(f-n)     ==> n = -B/A, f = -B/(A-1)  
+            // OpenGL:  A' = -(f+n)/(f-n), B' = -2fn/(f-n)  ==> A' = 1-2A, B' = 2B  ==> A' = 1+2*m22, B' = 2*m23
+
+            m.m22 = 1.0f + 2.0f * m.m22;
+            m.m23 *= 2.0f;
+            return m;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CalibrationData.cs.meta
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CalibrationData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90db0fe00bc7d5840bffd19c49e765fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/ICalibrationData.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/ICalibrationData.cs
@@ -18,8 +18,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         /// holographic camera's position and rotation are correctly offset
         /// from the HoloLens providing poses for the camera rig.
         /// </summary>
-        /// <param name="cameraGO">The transform that contains the holographic camera.</param>
-        void SetUnityCameraExtrinstics(Transform cameraGO);
+        /// <param name="cameraTransform">The transform that contains the holographic camera.</param>
+        void SetUnityCameraExtrinstics(Transform cameraTransform);
 
         /// <summary>
         /// Sets up the intrinsic parameters (such as a projection matrix or field of view) of the holographic

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Sharing/MarkerSpatialCoordinateService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Sharing/MarkerSpatialCoordinateService.cs
@@ -273,13 +273,13 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.S
 
             public static T Deserialize<T>(byte[] data)
             {
-                var json = Encoding.ASCII.GetString(data);
+                var json = Encoding.UTF8.GetString(data);
                 return JsonUtility.FromJson<T>(json);
             }
 
             static byte[] ToBytes(string serialized)
             {
-                var bytes = Encoding.ASCII.GetBytes(serialized);
+                var bytes = Encoding.UTF8.GetBytes(serialized);
                 return bytes;
             }
         }


### PR DESCRIPTION
This review contains the following logic:
1) calculated camera intrinsics/extrinsics serialization is moved within their class
2) An argument name that was a bit unclear has been renamed in ICalibrationData
3) A new class implementing ICalibrationData is added for applying camera intrinsics/extrinsics obtained through the new spectator view calibration process.