### PR TITLE
Sets CameraSystemType on non-default config profiles

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoConfigurationProfile.asset
@@ -9,13 +9,17 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
   m_Name: EyeTrackingDemoConfigurationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   targetExperienceScale: 4
-  enableCameraProfile: 1
+  enableCameraSystem: 1
   cameraProfile: {fileID: 11400000, guid: de38e71178510674fae830377a72888a, type: 2}
+  cameraSystemType:
+    reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
+      MixedRealityToolkit.Services.CameraSystem
   enableInputSystem: 1
   inputSystemProfile: {fileID: 11400000, guid: cc939e5f734608145a0be1e66727eac2, type: 2}
   inputSystemType:
@@ -38,3 +42,4 @@ MonoBehaviour:
     reference: Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem,
       Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
   registeredServiceProvidersProfile: {fileID: 0}
+  useServiceInspectors: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/CustomProfiles/HandInteractionAllExampleMixedRealityToolkitConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/CustomProfiles/HandInteractionAllExampleMixedRealityToolkitConfigurationProfile.asset
@@ -9,13 +9,17 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
   m_Name: HandInteractionAllExampleMixedRealityToolkitConfigurationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   targetExperienceScale: 3
-  enableCameraProfile: 1
+  enableCameraSystem: 1
   cameraProfile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}
+  cameraSystemType:
+    reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
+      MixedRealityToolkit.Services.CameraSystem
   enableInputSystem: 1
   inputSystemProfile: {fileID: 11400000, guid: ad2080e8e71c35f4e8bcde94fa68f098, type: 2}
   inputSystemType:
@@ -34,6 +38,7 @@ MonoBehaviour:
   spatialAwarenessSystemType:
     reference: Microsoft.MixedReality.Toolkit.SpatialAwareness.MixedRealitySpatialAwarenessSystem,
       Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem
+  spatialAwarenessSystemProfile: {fileID: 0}
   diagnosticsSystemProfile: {fileID: 11400000, guid: 478436bd1083882479a52d067e98e537,
     type: 2}
   enableDiagnosticsSystem: 1
@@ -42,3 +47,4 @@ MonoBehaviour:
       Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
   registeredServiceProvidersProfile: {fileID: 11400000, guid: e0bbb696e100b0d4386ce57da2e4636d,
     type: 2}
+  useServiceInspectors: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Dictation/Dictation.MixedRealityToolkitConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Dictation/Dictation.MixedRealityToolkitConfigurationProfile.asset
@@ -9,13 +9,17 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
   m_Name: Dictation.MixedRealityToolkitConfigurationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   targetExperienceScale: 3
-  enableCameraProfile: 1
+  enableCameraSystem: 1
   cameraProfile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}
+  cameraSystemType:
+    reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
+      MixedRealityToolkit.Services.CameraSystem
   enableInputSystem: 1
   inputSystemProfile: {fileID: 11400000, guid: f01a8ddcc32be3d45aa46e1136131a66, type: 2}
   inputSystemType:
@@ -44,3 +48,4 @@ MonoBehaviour:
       Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
   registeredServiceProvidersProfile: {fileID: 11400000, guid: efbaf6ea540c69f4fb75415a5d145a53,
     type: 2}
+  useServiceInspectors: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityToolkitConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityToolkitConfigurationProfile.asset
@@ -9,13 +9,17 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
   m_Name: Speech.MixedRealityToolkitConfigurationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   targetExperienceScale: 3
-  enableCameraProfile: 1
+  enableCameraSystem: 1
   cameraProfile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}
+  cameraSystemType:
+    reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
+      MixedRealityToolkit.Services.CameraSystem
   enableInputSystem: 1
   inputSystemProfile: {fileID: 11400000, guid: 2a6b327d88d172543b7526be8cb2018e, type: 2}
   inputSystemType:
@@ -43,3 +47,4 @@ MonoBehaviour:
       Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
   registeredServiceProvidersProfile: {fileID: 11400000, guid: efbaf6ea540c69f4fb75415a5d145a53,
     type: 2}
+  useServiceInspectors: 0


### PR DESCRIPTION
## Overview

The following profiles didn't have their CameraSystemType set:
- EyeTrackingDemoConfigurationProfile
- HandInteractionAllExampleMixedRealityToolkitConfigurationProfile
- Dictation.MixedRealityToolkitConfigurationProfile.asset
- Speech.MixedRealityToolkitConfigurationProfile.asset