### PR TITLE
Config Profile Homogenization

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/MixedRealityInputSimulationProfileInspector.cs
@@ -63,8 +63,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false)) { return; }
-
             isCameraControlEnabled = serializedObject.FindProperty("isCameraControlEnabled");
 
             extraMouseSensitivityScale = serializedObject.FindProperty("extraMouseSensitivityScale");
@@ -116,19 +114,19 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Input Simulation settings",
+                "Settings for simulating input devices in the editor.");
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                if (GUILayout.Button("Back to Input Profile"))
+                {
+                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                }
             }
-            EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("Input Simulation settings", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Settings for simulating input devices in the editor.", MessageType.Info);
             CheckProfileLock(target);
-
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured()) { return; }
 
             serializedObject.Update();
 

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SettingsProvider]
         private static SettingsProvider Preferences()
         {
-            var provider = new SettingsProvider("Project/Mixed Reality Toolkit")//, SettingsScope.Project)
+            var provider = new SettingsProvider("Project/Mixed Reality Toolkit", SettingsScope.Project)
             {
                 label = "Microsoft Mixed Reality Toolkit",
 

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityPreferences.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [SettingsProvider]
         private static SettingsProvider Preferences()
         {
-            var provider = new SettingsProvider("Project/Mixed Reality Toolkit", SettingsScope.Project)
+            var provider = new SettingsProvider("Project/Mixed Reality Toolkit")//, SettingsScope.Project)
             {
                 label = "Microsoft Mixed Reality Toolkit",
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             PasteProfileValues();
             Selection.activeObject = profile;
 
-            if (!profileToCopy.IsCustomProfile)
+            if (!profileToCopy.IsCustomProfile && MixedRealityToolkit.IsInitialized)
             {
                 // For now we only replace it if it's the master configuration profile.
                 // Sub-profiles are easy to update in the master configuration inspector.

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Render the Mixed Reality Toolkit Logo.
         /// </summary>
-        protected void RenderMixedRealityToolkitLogo()
+        protected void RenderTitleDescriptionAndLogo(string title, string description)
         {
             // If we're being rendered as a sub profile, don't show the logo
             if (RenderAsSubProfile)
@@ -53,6 +53,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
             GUILayout.Space(12f);
+
+            if (!string.IsNullOrEmpty(title))
+            {
+                EditorGUILayout.LabelField(title, EditorStyles.boldLabel);
+            }
+
+            if (!string.IsNullOrEmpty(description))
+            {
+                EditorGUILayout.HelpBox(description, MessageType.Info);
+            }
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityBoundaryVisualizationProfileInspector.cs
@@ -49,11 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.Boundary.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             boundaryHeight = serializedObject.FindProperty("boundaryHeight");
 
             showFloor = serializedObject.FindProperty("showFloor");
@@ -80,21 +75,17 @@ namespace Microsoft.MixedReality.Toolkit.Boundary.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
+            RenderTitleDescriptionAndLogo(
+                "Boundary Visualization Options",
+                "Boundary visualizations can help users stay oriented and comfortable in the experience.");
 
-            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+                {
+                    return;
+                }
             }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Boundary Visualization Options", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Boundary visualizations can help users stay oriented and comfortable in the experience.", MessageType.Info);
-            EditorGUILayout.Space();
 
             CheckProfileLock(target);
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -29,11 +29,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             opaqueNearClip = serializedObject.FindProperty("nearClipPlaneOpaqueDisplay");
             opaqueClearFlags = serializedObject.FindProperty("cameraClearFlagsOpaqueDisplay");
             opaqueBackgroundColor = serializedObject.FindProperty("backgroundColorOpaqueDisplay");
@@ -47,20 +42,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
+            RenderTitleDescriptionAndLogo(
+                "Camera Profile",
+                "The Camera Profile helps configure cross platform camera settings.");
 
-            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+                {
+                    return;
+                }
             }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Camera Profile", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("The Camera Profile helps configure cross platform camera settings.", MessageType.Info);
 
             CheckProfileLock(target);
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -67,8 +67,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            RenderTitleDescriptionAndLogo(
+                "Controller Input Mapping",
+                "Use this profile to define all the controllers and their inputs your users will be able to use in your application.\n\n" +
+                "You'll want to define all your Input Actions first. They can then be wired up to hardware sensors, controllers, gestures, and other input devices.");
+
+            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
                 return;
             }
@@ -86,11 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             {
                 return;
             }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Controller Input Mapping", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Use this profile to define all the controllers and their inputs your users will be able to use in your application.\n\n" +
-                                    "You'll want to define all your Input Actions first. They can then be wired up to hardware sensors, controllers, gestures, and other input devices.", MessageType.Info);
 
             if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
@@ -48,11 +48,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             defaultLabelWidth = EditorGUIUtility.labelWidth;
             defaultFieldWidth = EditorGUIUtility.fieldWidth;
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             thisProfile = target as MixedRealityControllerVisualizationProfile;
 
             renderMotionControllers = serializedObject.FindProperty("renderMotionControllers");
@@ -67,30 +62,28 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            RenderTitleDescriptionAndLogo(
+                "Controller Visualizations",
+                "Define all the custom controller visualizations you'd like to use for each controller type when they're rendered in the scene.\n\n" +
+                "Global settings are the default fallback, and any specific controller definitions take precedence.");
+
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
+                {
+                    EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
+
+                    DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
+
+                    return;
+                }
+
+                if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
+                {
+                    return;
+                }
             }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
-            {
-                EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
-
-                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
-
-                return;
-            }
-
-            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
-            {
-                return;
-            }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Controller Visualizations", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Define all the custom controller visualizations you'd like to use for each controller type when they're rendered in the scene.\n\n" +
-                                    "Global settings are the default fallback, and any specific controller definitions take precedence.", MessageType.Info);
+            
             serializedObject.Update();
 
             CheckProfileLock(target);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -29,11 +29,6 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             showDiagnostics = serializedObject.FindProperty("showDiagnostics");
             showProfiler = serializedObject.FindProperty("showProfiler");
             frameSampleRate = serializedObject.FindProperty("frameSampleRate");
@@ -45,24 +40,21 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
+            RenderTitleDescriptionAndLogo(
+                "Diagnostic Visualization Options",
+                "Diagnostic visualizations can help monitor system resources and performance inside an application.");
 
-            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+                {
+                    return;
+                }
             }
 
             CheckProfileLock(target);
 
             serializedObject.Update();
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Diagnostic Visualization Options", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Diagnostic visualizations can help monitor system resources and performance inside an application.", MessageType.Info);
 
             EditorGUILayout.Space();
             showGeneralSettings = EditorGUILayout.Foldout(showGeneralSettings, "General Settings", true);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityEyeTrackingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityEyeTrackingProfileInspector.cs
@@ -25,18 +25,23 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Eye tracking settings",
+                "Configuration for eye tracking settings");
 
-            if (GUILayout.Button("Back to Registered Service Providers Profile"))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.RegisteredServiceProvidersProfile;
+                if (GUILayout.Button("Back to Registered Service Providers Profile"))
+                {
+                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.RegisteredServiceProvidersProfile;
+                }
             }
-            EditorGUILayout.Space();
+            else
+            {
+                return;
+            }
 
-            EditorGUILayout.LabelField("Eye tracking settings", EditorStyles.boldLabel);
             CheckProfileLock(target);
-
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured()) { return; }
 
             serializedObject.Update();
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -86,9 +86,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Gesture Input",
+                "This gesture map is any and all movements of part the user's body, especially a hand or the head, that raise actions through the input system." +
+                "\n\nNote: Defined controllers can look up the list of gestures and raise the events based on specific criteria.");
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured()) { return; }
+            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile)) { return; }
 
             if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
             {
@@ -103,10 +106,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             {
                 return;
             }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Gesture Input", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("This gesture map is any and all movements of part the user's body, especially a hand or the head, that raise actions through the input system.\n\nNote: Defined controllers can look up the list of gestures and raise the events based on specific criteria.", MessageType.Info);
 
             if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityHandTrackingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityHandTrackingProfileInspector.cs
@@ -23,8 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false)) { return; }
-
             jointPrefab = serializedObject.FindProperty("jointPrefab");
             fingertipPrefab = serializedObject.FindProperty("fingertipPrefab");
             palmPrefab = serializedObject.FindProperty("palmPrefab");
@@ -35,19 +33,19 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Hand tracking settings",
+                "Use this for platform-specific hand tracking settings.");
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                if (GUILayout.Button("Back to Input Profile"))
+                {
+                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                }
             }
-            EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("Hand tracking settings", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Use this for platform-specific hand tracking settings.", MessageType.Info);
             CheckProfileLock(target);
-
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured()) { return; }
 
             serializedObject.Update();
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -88,9 +88,13 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Input Action Rules Profile",
+                "Input Action Rules help define alternative Actions that will be raised based on specific criteria.\n\n" +
+                "You can create new rules by assigning a base Input Action below, then assigning the criteria you'd like to meet. When the criteria is met, the Rule's Action will be raised with the criteria value.\n\n" +
+                "Note: Rules can only be created for the same axis constraints.");
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
                 return;
             }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -24,42 +24,32 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             inputActionList = serializedObject.FindProperty("inputActions");
         }
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Input Actions",
+                "Input Actions are any/all actions your users will be able to make when interacting with your application.\n\n" +
+                "After defining all your actions, you can then wire up these actions to hardware sensors, controllers, and other input devices.");
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
+                {
+                    EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
+
+                    DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
+
+                    return;
+                }
+
+                if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
+                {
+                    return;
+                }
             }
-
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled)
-            {
-                EditorGUILayout.HelpBox("No input system is enabled, or you need to specify the type in the main configuration profile.", MessageType.Error);
-
-                DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile);
-
-                return;
-            }
-
-            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
-            {
-                return;
-            }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Input Actions", EditorStyles.boldLabel);
-
-            EditorGUILayout.HelpBox("Input Actions are any/all actions your users will be able to make when interacting with your application.\n\n" +
-                                    "After defining all your actions, you can then wire up these actions to hardware sensors, controllers, and other input devices.", MessageType.Info);
 
             CheckProfileLock(target);
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -74,8 +74,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            RenderTitleDescriptionAndLogo(
+                "Input System Profile",
+                "The Input System Profile helps developers configure input for cross-platform applications.");
+
+            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
                 return;
             }
@@ -84,10 +87,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             {
                 return;
             }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Input System Profile", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("The Input System Profile helps developers configure input for cross-platform applications.", MessageType.Info);
 
             CheckProfileLock(target);
 
@@ -189,9 +188,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             EditorGUIUtility.labelWidth = previousLabelWidth;
             serializedObject.ApplyModifiedProperties();
 
-            if (changed)
+            if (MixedRealityToolkit.IsInitialized)
             {
-                EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+                if (changed)
+                {
+                    EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
@@ -24,19 +24,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
+            RenderTitleDescriptionAndLogo(
+                "Mouse Input settings",
+                "Settings for mouse input in the editor.");
 
-            if (GUILayout.Button("Back to Input Profile"))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                if (GUILayout.Button("Back to Input Profile"))
+                {
+                    Selection.activeObject = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile;
+                }
             }
-            EditorGUILayout.Space();
+            else
+            {
+                return;
+            }
 
-            EditorGUILayout.LabelField("Mouse Input settings", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Settings for mouse input in the editor.", MessageType.Info);
             CheckProfileLock(target);
-
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured()) { return; }
 
             serializedObject.Update();
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityPointerProfileInspector.cs
@@ -36,11 +36,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             pointingExtent = serializedObject.FindProperty("pointingExtent");
             pointingRaycastLayerMasks = serializedObject.FindProperty("pointingRaycastLayerMasks");
             pointerOptions = serializedObject.FindProperty("pointerOptions");
@@ -63,21 +58,17 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
+            RenderTitleDescriptionAndLogo(
+                "Pointer Profile",
+                "Pointers attach themselves onto controllers as they are initialized.");
 
-            if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Input Profile", MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile))
+                {
+                    return;
+                }
             }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Pointer Profile", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Pointers attach themselves onto controllers as they are initialized.", MessageType.Info);
-            EditorGUILayout.Space();
 
             CheckProfileLock(target);
             serializedObject.Update();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -21,31 +21,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             configurations = serializedObject.FindProperty("configurations");
             configFoldouts = new bool[configurations.arraySize];
         }
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            RenderTitleDescriptionAndLogo(
+                "Registered Service Providers Profile",
+                "This profile defines any additional Services like systems, features, and managers to register with the Mixed Reality Toolkit.");
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+                {
+                    return;
+                }
             }
-
-            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
-            {
-                return;
-            }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Registered Service Providers Profile", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("This profile defines any additional Services like systems, features, and managers to register with the Mixed Reality Toolkit.", MessageType.Info);
 
             CheckProfileLock(target);
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessMeshObserverProfileInspector.cs
@@ -46,11 +46,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             // General settings
             startupBehavior = serializedObject.FindProperty("startupBehavior");
             observationExtents = serializedObject.FindProperty("observationExtents");
@@ -70,21 +65,18 @@ namespace Microsoft.MixedReality.Toolkit.Editor.SpatialAwareness
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            RenderTitleDescriptionAndLogo(
+                "Spatial Awareness Mesh Observer Profile",
+                "Configuration settings for how the real-world environment will be perceived and displayed.");
+
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+                {
+                    return;
+                }
             }
 
-            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
-            {
-                return;
-            }
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Spatial Awareness Mesh Observer Profile", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Configuration settings for how the real-world environment will be perceived and displayed.", MessageType.Info);
-            EditorGUILayout.Space();
             serializedObject.Update();
 
             if (MixedRealityPreferences.LockProfiles && !((BaseMixedRealityProfile)target).IsCustomProfile)

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessSystemProfileInspector.cs
@@ -28,11 +28,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness.Editor
         {
             base.OnEnable();
 
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(false))
-            {
-                return;
-            }
-
             observerConfigurations = serializedObject.FindProperty("observerConfigurations");
 
             observerFoldouts = new bool[observerConfigurations.arraySize];
@@ -40,15 +35,16 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
-            {
-                return;
-            }
+            RenderTitleDescriptionAndLogo(
+                "Spatial Awareness System Profile",
+                "The Spatial Awareness System profile allows developers to configure cross-platform environmental awareness.");
 
-            if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+            if (MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
-                return;
+                if (DrawBacktrackProfileButton("Back to Configuration Profile", MixedRealityToolkit.Instance.ActiveProfile))
+                {
+                    return;
+                }
             }
 
             EditorGUILayout.Space();
@@ -166,9 +162,12 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness.Editor
                     }
                 }
 
-                if (changed)
+                if (MixedRealityToolkit.IsInitialized)
                 {
-                    EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+                    if (changed)
+                    {
+                        EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(MixedRealityToolkit.Instance.ActiveProfile);
+                    }
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -50,8 +50,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void OnInspectorGUI()
         {
-            RenderMixedRealityToolkitLogo();
-            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured())
+            RenderTitleDescriptionAndLogo(
+                "Speech Commands",
+                "Speech Commands are any/all spoken keywords your users will be able say to raise an Input Action in your application.");
+
+            if (!MixedRealityInspectorUtility.CheckMixedRealityConfigured(true, !RenderAsSubProfile))
             {
                 return;
             }
@@ -71,10 +74,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             CheckProfileLock(target);
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Speech Commands", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Speech Commands are any/all spoken keywords your users will be able say to raise an Input Action in your application.", MessageType.Info);
 
             if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -106,12 +106,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             var configurationProfile = (MixedRealityToolkitConfigurationProfile)target;
 
             serializedObject.Update();
-            RenderMixedRealityToolkitLogo();
+
+            RenderTitleDescriptionAndLogo("Configuration Profile", string.Empty);
 
             if (!MixedRealityToolkit.IsInitialized)
             {
-                EditorGUILayout.HelpBox("Unable to find Mixed Reality Toolkit!", MessageType.Error);
-                return;
+                EditorGUILayout.HelpBox("No Mixed Reality Toolkit found in scene.", MessageType.Warning);
+                if (GUILayout.Button("Click here to add Mixed Reality Toolkit instance to scene"))
+                {
+                    new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+                }
             }
 
             if (!configurationProfile.IsCustomProfile)
@@ -125,13 +129,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     CreateCopyProfileValues();
                 }
 
-                if (GUILayout.Button("Create new profiles"))
+                if (MixedRealityToolkit.IsInitialized)
                 {
-                    ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
-                    var newProfile = profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles") as MixedRealityToolkitConfigurationProfile;
-                    UnityEditor.Undo.RecordObject(MixedRealityToolkit.Instance, "Create new profiles");
-                    MixedRealityToolkit.Instance.ActiveProfile = newProfile;
-                    Selection.activeObject = newProfile;
+                    if (GUILayout.Button("Create new profiles"))
+                    {
+                        ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
+                        var newProfile = profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles") as MixedRealityToolkitConfigurationProfile;
+                        UnityEditor.Undo.RecordObject(MixedRealityToolkit.Instance, "Create new profiles");
+                        MixedRealityToolkit.Instance.ActiveProfile = newProfile;
+                        Selection.activeObject = newProfile;
+                    }
                 }
 
                 EditorGUILayout.EndHorizontal();
@@ -306,7 +313,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUIUtility.labelWidth = previousLabelWidth;
             serializedObject.ApplyModifiedProperties();
 
-            if (changed)
+            if (changed && MixedRealityToolkit.IsInitialized)
             {
                 EditorApplication.delayCall += () => MixedRealityToolkit.Instance.ResetConfiguration(configurationProfile);
             }

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -22,19 +22,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// Check and make sure we have a Mixed Reality Toolkit and an active profile.
         /// </summary>
         /// <returns>True if the Mixed Reality Toolkit is properly initialized.</returns>
-        public static bool CheckMixedRealityConfigured(bool showHelpBox = true)
+        public static bool CheckMixedRealityConfigured(bool renderEditorElements = true, bool showCreateButton = false)
         {
             if (!MixedRealityToolkit.IsInitialized)
             {
-                // Search the scene for one, in case we've just hot reloaded the assembly.
-                var managerSearch = Object.FindObjectsOfType<MixedRealityToolkit>();
-
-                if (managerSearch.Length == 0)
+                if (renderEditorElements)
                 {
-                    if (showHelpBox)
+                    EditorGUILayout.HelpBox("No Mixed Reality Toolkit found in scene.", MessageType.Error);
+
+                    if (showCreateButton && GUILayout.Button("Click here to add Mixed Reality Toolkit instance to scene"))
                     {
-                        EditorGUILayout.HelpBox("No Mixed Reality Toolkit found in scene.", MessageType.Error);
+                        new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
                     }
+                    EditorGUILayout.Space();
                 }
 
                 // Don't proceeed
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             if (!MixedRealityToolkit.Instance.HasActiveProfile)
             {
-                if (showHelpBox)
+                if (renderEditorElements)
                 {
                     EditorGUILayout.HelpBox("No Active Profile set on the Mixed Reality Toolkit.", MessageType.Error);
                 }


### PR DESCRIPTION
## Overview
 Makes the look of headers in profiles more consistent and adds some functions to encourage more consistency in the future.

![ProfileConsistency](https://user-images.githubusercontent.com/9789716/57541305-87166a00-7303-11e9-9e68-17f4cb19f413.PNG)

## Changes
- Adds a `RenderTitleDescriptionAndLogo` function to MixedRealityInspectorUtility. This handles the business of drawing a title and helpbox with consistent spacing etc.
- When an instance of the MRTK isn't found, profile inspectors now provide a button that will add one to your scene.
- Most profiles will now render their contents even if a MixedRealityToolkit instance isn't found. The only exceptions are profiles that require calls to MixedRealityToolkit.Instance to function. In a future PR it would be nice if these could be made to at least render partial contents. Will open an issue for this later.

- Fixes: #3876