### PR TITLE
From Dot comparison to binary float comparison

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Utilities/MixedRealityPose.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/MixedRealityPose.cs
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public bool Equals(MixedRealityPose other)
         {
             return Position == other.Position &&
-                   Rotation == other.Rotation;
+                   Rotation.Equals(other.Rotation);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
## Overview
According to https://answers.unity.com/questions/288338/how-do-i-compare-quaternions.html

== compares two Quaternions via Dot product, suffering from floating point precision, while
Equals compares binary wise (floats)

## Changes
- Fixes: #4304