### PR TITLE
Both and Any support in HandJointUtils' FindHand

### DIFF
--- a/Assets/MixedRealityToolkit/Providers/Hands/HandJointUtils.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/HandJointUtils.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var hand = detectedController as T;
                 if (hand != null)
                 {
-                    if (detectedController.ControllerHandedness == handedness)
+                    if ((detectedController.ControllerHandedness & handedness) != 0)
                     {
                         return hand;
                     }


### PR DESCRIPTION
## Overview
Support for `Both` and `Any` bit flags in `HandJointUtils`.

## Changes
- Updates `FindHand` in `HandJointUtils` to properly return a hand if `Both` or `Any` flags are past in.
