### PR TITLE
Adding undo support to ObjectCollection.UpdateCollection

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
@@ -75,8 +75,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             for (int i = 0; i < transform.childCount; i++)
             {
                 Transform child = transform.GetChild(i);
+#if UNITY_EDITOR
                 Undo.RecordObject(child, "ObjectCollection modify transform");
-
+#endif
                 if (!ContainsNode(child) && (child.gameObject.activeSelf || !IgnoreInactiveTransforms))
                 {
                     NodeList.Add(new ObjectCollectionNode { Name = child.name, Transform = child });

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
@@ -74,6 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             for (int i = 0; i < transform.childCount; i++)
             {
                 Transform child = transform.GetChild(i);
+                Undo.RecordObject(child, "ObjectCollection modify transform");
 
                 if (!ContainsNode(child) && (child.gameObject.activeSelf || !IgnoreInactiveTransforms))
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         [Tooltip("Should the objects in the collection be rotated / how should they be rotated")]
         [SerializeField]
-        private OrientationType orientType = OrientationType.FaceOrigin;
+        private OrientationType orientType = OrientationType.None;
 
         /// <summary>
         /// Should the objects in the collection face the origin of the collection


### PR DESCRIPTION
## Overview
Fixing object collection to record changes to transform of children. Also making default orient type None since Face Origin is generally awkward for Plane grid default

## Changes
- Fixes: #4272 Update collection on a Grid object in a prefab does not save changes.
- Fixes: #4231 GridObjectCollection should support undo

## Verification
Tested GridObjectCollection with capsules children, update collection, then cntrl+z
Tested modifying update collection inside prefab, and seeing results updated when exiting prefab

Unity 2018.3.14f1