### PR TITLE
Fixing a bug where NullReferenceException occurs every frame if grabbed object is destroyed

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointerVisual.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointerVisual.cs
@@ -99,7 +99,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private NearInteractionGrabbable GetGrabbedObject()
         {
-            return pointer.Result?.Details.Object?.GetComponent<NearInteractionGrabbable>();
+            if (pointer.Result?.Details.Object != null)
+            {
+                return pointer.Result.Details.Object.GetComponent<NearInteractionGrabbable>();
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
In a scenario where we had an object with a BoundingBox that triggers its own destruction once its scale gets sufficiently large, the SpherePointerVisual doesn't properly identify that the object it is grabbing has been destroyed and spams this error every frame in Release (and shows as a warning about referencing a destroyed object in the Editor):

NullReferenceException: Object reference not set to an instance of an object.
  at UnityEngine.GameObject.GetComponentFastPath (System.Type type, System.IntPtr oneFurtherThanResultValue) [0x00000] in <00000000000000000000000000000000>:0 
  at UnityEngine.GameObject.GetComponent[T] () [0x00000] in <00000000000000000000000000000000>:0 
  at Microsoft.MixedReality.Toolkit.Input.SpherePointerVisual.Update () [0x00000] in <00000000000000000000000000000000>:0 

This appears to be a quirk of the C# "?." operator where it doesn't properly use Unity's "!= null" overload that checks the internal reference for null. Switching to use "!= null" explicitly fixes the issue.