### PR TITLE
Expose ability to get and set scaling limits on bounding box at runtime

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -130,6 +130,30 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("Minimum scaling allowed relative to the initial size")]
         private float scaleMinimum = 0.2f;
 
+        /// <summary>
+        /// Public property for the scale maximum, in the target's local scale.
+        /// Set this value with SetScaleLimits.
+        /// </summary>
+        public float ScaleMaximum
+        {
+            get
+            {
+                return maximumScale != null ? maximumScale.x : scaleMaximum;
+            }
+        }
+
+        /// <summary>
+        /// Public property for the scale minimum, in the target's local scale.
+        /// Set this value with SetScaleLimits.
+        /// </summary>
+        public float ScaleMinimum
+        {
+            get
+            {
+                return minimumScale != null ? minimumScale.x : scaleMinimum;
+            }
+        }
+
         [Header("Box Display")]
         [SerializeField]
         [Tooltip("Flatten bounds in the specified axis or flatten the smallest one if 'auto' is selected")]
@@ -400,6 +424,34 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public void UnhighlightWires()
         {
             ResetHandleVisibility();
+        }
+
+        /// <summary>
+        /// Sets the minimum/maximum scale for the bounding box at runtime.
+        /// </summary>
+        /// <param name="min">Minimum scale</param>
+        /// <param name="max">Maximum scale</param>
+        /// <param name="relativeToInitialState">If true the values will be multiplied by the current target scale. If false they will be in absolute local scale.</param>
+        public void SetScaleLimits(float min, float max, bool relativeToInitialState = true)
+        {
+            scaleMaximum = max;
+            scaleMinimum = min;
+
+            // Update the absolute min/max
+            var target = Target;
+            if (target != null)
+            {
+                if (relativeToInitialState)
+                {
+                    maximumScale = target.transform.localScale * scaleMaximum;
+                    minimumScale = target.transform.localScale * scaleMinimum;
+                }
+                else
+                {
+                    maximumScale = new Vector3(scaleMaximum, scaleMaximum, scaleMaximum);
+                    minimumScale = new Vector3(scaleMinimum, scaleMinimum, scaleMinimum);
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
We're making use of bounding boxes to manipulate dynamic content. Part of this involves dynamically querying the size characteristics of the content and deciding at runtime what the minimum and maximum scale factors should be. Another part of this scenario is detecting when the minimum/maximum are reached to display information to the user.

Exposing these values and the means to update them at runtime (and recalculate the cached parameters based on them) allows completion of this scenario. This also exposes the ability to have more precise control of scaling by setting it in either absolute or relative (default) terms.

partially Fixes:#3950