### PR TITLE
Fixed issue where SetSelection was not triggering an update to the ra…

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return;
             }
 
-            ToggleList[index].OnPointerClicked(null);
+            OnSelection(index, true);
         }
 
         /// <summary>


### PR DESCRIPTION
…dial colleciton.

## Overview
There were changed in Interactable that effects how this script changes which radial button is selected. InteractableToggleColleciton.SetSelection(index) used to call into Interactable's pointer click event, but some of the checks do not allow this call to pass, execute a click and call back to the InteractableToggleCollection to set the new selected index.

This fix just brute forces the visual state change without triggering any onClick events in the interactable, which is I think is preferred.

## Changes
- Fixes: #4331  .


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
