### PR TITLE
Report active inputs (non-zero/true) as changed

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_02_InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_02_InteractionDefinitionTests.cs
@@ -138,7 +138,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 
             interaction.BoolData = testValue;
 
-            // Make sure if we set the same value it's false
+            // Make sure if we set again the true value it's true
+            Assert.IsTrue(interaction.Changed);
+
+            // Make sure setting the false value twice reports no change
+            interaction.BoolData = false;
+            Assert.IsTrue(interaction.Changed);
+            interaction.BoolData = false;
             Assert.IsFalse(interaction.Changed);
         }
 
@@ -197,7 +203,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 
             interaction.FloatData = testValue;
 
-            // Make sure if we set the same value it's false
+            // Make sure if we set the same non-zero value it's true
+            Assert.IsTrue(interaction.Changed);
+
+            // Make sure setting a zero value twice reports no change
+            interaction.FloatData = 0f;
+            Assert.IsTrue(interaction.Changed);
+            interaction.FloatData = 0f;
             Assert.IsFalse(interaction.Changed);
         }
 
@@ -209,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
         public void Test07_TestVector2()
         {
             bool[] invertAxisValues = { true, false };
-            Vector2[] vectorValues = { new Vector2(1, 1), new Vector2(1, -1) };
+            Vector2[] vectorValues = { Vector2.zero, new Vector2(1, 1), new Vector2(1, -1) };
 
             foreach (var invertXAxis in invertAxisValues)
             {
@@ -238,15 +250,29 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             i.Vector2Data = vectorValue;
             Vector2 invertedValue = vectorValue * new Vector2(invertXAxis ? -1f : 1f, invertYAxis ? -1f : 1f);
             Assert.AreEqual(invertedValue, i.Vector2Data, msg);
-            Assert.IsTrue(i.Changed, msg);
+            if (vectorValue != Vector2.zero)
+            {
+                Assert.IsTrue(i.Changed, msg);
+            }
+            else
+            {
+                Assert.IsFalse(i.Changed, msg);
+            }
 
             // Test Changed gets reset after querying
             Assert.IsFalse(i.Changed, msg);
 
-            // Test no change
+            // Test setting the same value again
             i.Vector2Data = vectorValue;
             Assert.AreEqual(invertedValue, i.Vector2Data, msg);
-            Assert.IsFalse(i.Changed, msg);
+            if (vectorValue != Vector2.zero)
+            {
+                Assert.IsTrue(i.Changed, msg);
+            }
+            else
+            {
+                Assert.IsFalse(i.Changed, msg);
+            }
         }
 
         #endregion Vector2

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_02_InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_02_InteractionDefinitionTests.cs
@@ -122,23 +122,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
         public void Test04_TestBoolNoChange()
         {
             var interaction = new MixedRealityInteractionMapping(1, string.Empty, AxisType.Digital, DeviceInputType.None, MixedRealityInputAction.None);
-            var testValue = true;
 
             var initialValue = interaction.BoolData;
 
             Assert.IsFalse(initialValue);
             Assert.IsFalse(interaction.Changed);
 
-            interaction.BoolData = testValue;
+            interaction.BoolData = true;
 
             Assert.IsTrue(interaction.Changed);
 
             // Make sure the second time we query it's false
             Assert.IsFalse(interaction.Changed);
 
-            interaction.BoolData = testValue;
+            interaction.BoolData = true;
 
-            // Make sure if we set again the true value it's true
+            // Make sure setting the value to true a second time is reported as change, as it is indicative of an active input.
             Assert.IsTrue(interaction.Changed);
 
             // Make sure setting the false value twice reports no change
@@ -256,6 +255,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             }
             else
             {
+                // Setting to zero again should not report change
                 Assert.IsFalse(i.Changed, msg);
             }
 

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityInteractionMapping.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityInteractionMapping.cs
@@ -349,7 +349,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     Debug.LogError($"SetBoolValue is only valid for AxisType.Digital, AxisType.SingleAxis, or AxisType.DualAxis InteractionMappings\nPlease check the {inputType} mapping for the current controller");
                 }
 
-                Changed = boolData != value;
+                Changed = value || value != boolData;
                 boolData = value;
             }
         }
@@ -372,16 +372,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     Debug.LogError($"SetFloatValue is only valid for AxisType.SingleAxis InteractionMappings\nPlease check the {inputType} mapping for the current controller");
                 }
 
-                if (invertXAxis)
-                {
-                    Changed = !floatData.Equals(value * -1f);
-                    floatData = value * -1f;
-                }
-                else
-                {
-                    Changed = !floatData.Equals(value);
-                    floatData = value;
-                }
+                float newValue = (invertXAxis ? -1f : 1f) * value;
+                Changed = newValue != 0f || newValue != floatData;
+                floatData = newValue;
             }
         }
 
@@ -404,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 Vector2 newValue = value * new Vector2(invertXAxis ? -1f : 1f, invertYAxis ? -1f : 1f);
-                Changed = vector2Data != newValue;
+                Changed = newValue != Vector2.zero || newValue != vector2Data;
                 vector2Data = newValue;
             }
         }


### PR DESCRIPTION
This aims to fix #3253 . It is a breaking change because it changes the current behavior but I don't think in practice would cause much trouble.

For clarity, I think we should also update naming throughout to talk in terms input Updated or Active instead of input Changed. This will be quite disruptive as it will affect all implementations IMixedRealityInputHandler so we probably want to defer that to v3.