### PR TITLE
Fix broken .NET build

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Physics/RayStep.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Physics/RayStep.cs
@@ -161,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
 
             float traveledDistance = 0;
             float stepLength = 0;
-            RayStep currentStep = default;
+            RayStep currentStep = new RayStep();
 
 
             foreach (var step in steps)


### PR DESCRIPTION
The default keyword isn't available in the .NET language version that the .NET backend supports.