### PR TITLE
Mark the speech event data as "used" to prevent double invocation of the handler.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/SpeechInputHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/SpeechInputHandler.cs
@@ -93,6 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (enabled && responses.TryGetValue(eventData.Command.Keyword.ToLower(), out keywordResponse))
             {
                 keywordResponse.Invoke();
+                eventData.Use();
             }
         }
 


### PR DESCRIPTION
## Overview

It seems that event data is supposed to be marked as "used" by handlers, so it doesn't bubble up further. The SpeechInputHandler is not doing this and so gets invoked twice for the same speech event, when it is both a global and focused listener.

## Changes
- Fixes: #4368 
