### PR TITLE
Removes ExecuteAlways from MixedRealityToolkit

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
@@ -16,7 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         public void Test_01_InitializeMixedRealityToolkit()
         {
             TestUtilities.CleanupScene();
-            new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            MixedRealityToolkit mixedRealityToolkit = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            MixedRealityToolkit.SetActiveInstance(mixedRealityToolkit);
             MixedRealityToolkit.ConfirmInitialized();
 
             // Tests
@@ -28,7 +29,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         public void Test_02_TestNoMixedRealityConfigurationFound()
         {
             TestUtilities.CleanupScene();
-            new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            MixedRealityToolkit mixedRealityToolkit = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            MixedRealityToolkit.SetActiveInstance(mixedRealityToolkit);
             MixedRealityToolkit.ConfirmInitialized();
 
             MixedRealityToolkit.Instance.ActiveProfile = null;

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -59,7 +59,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Setup
             CleanupScene();
 
-            new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            MixedRealityToolkit mixedRealityToolkit = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            MixedRealityToolkit.SetActiveInstance(mixedRealityToolkit);
 
             if (!MixedRealityToolkit.IsInitialized)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -24,6 +24,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             MixedRealityToolkit instance = (MixedRealityToolkit)target;
 
+            if (MixedRealityToolkit.Instance == null)
+            {   // See if an active instance exists at all. If it doesn't register this instance pre-emptively.
+                MixedRealityToolkit.SetActiveInstance(instance);
+            }
+
             if (!instance.IsActiveInstance)
             {
                 EditorGUILayout.HelpBox("This instance of the toolkt is inactive. There can only be one active instance loaded at any time.", MessageType.Warning);

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -26,7 +26,6 @@ namespace Microsoft.MixedReality.Toolkit
     /// The Profile can be swapped out at any time to meet the needs of your project.
     /// </summary>
     [DisallowMultipleComponent]
-    [ExecuteAlways]
     public class MixedRealityToolkit : MonoBehaviour, IMixedRealityServiceRegistrar
     {
 #region Mixed Reality Toolkit Profile configuration
@@ -687,10 +686,7 @@ namespace Microsoft.MixedReality.Toolkit
                 MixedRealityToolkit.activeInstance = toolkitInstance;
                 toolkitInstances.Add(toolkitInstance);
                 toolkitInstance.name = ActiveInstanceGameObjectName;
-                if (!toolkitInstance.HasProfileAndIsInitialized)
-                {   // Initialize the instance, if we haven't already
-                    toolkitInstance.InitializeInstance();
-                }
+                toolkitInstance.InitializeInstance();
                 return;
             }
 


### PR DESCRIPTION
## Overview

Removes the [ExecuteAlways] attribute from MixedRealityToolkit instance to prevent it from being destroyed on entering play mode in editor. This was causing some services like camera and input simulation to not function.

Fixes #4392
Follow-up fix for #4381