### PR TITLE
Exception raised in call to InteractionManager.GetCurrentReading()

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -42,10 +42,22 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 #if UNITY_WSA
 
         /// <summary>
-        /// The max expected sources is two - two controllers and/or two hands.
-        /// We'll set it to 20 just to be certain we can't run out of sources.
+        /// The initial size of interactionmanagerStates.
         /// </summary>
+        /// <remarks>
+        /// This value is arbitrary but chosen to be a number larger than the typical expected number (to avoid
+        /// having to do further allocations).
+        /// </remarks>
         public const int MaxInteractionSourceStates = 20;
+
+        /// <summary>
+        /// This number controls how much the interactionmanagerStates array should grow by each time it must
+        /// be resized (larger) in order to accommodate more InteractionSourceState values.
+        /// </summary>
+        /// <remarks>
+        /// This must be a value greater than 1.
+        /// </remarks>
+        private const int InteractionManagerStatesGrowthFactor = 2;
 
         /// <summary>
         /// Dictionary to capture all active controllers detected
@@ -287,7 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             InteractionManager.InteractionSourcePressed += InteractionManager_InteractionSourcePressed;
             InteractionManager.InteractionSourceReleased += InteractionManager_InteractionSourceReleased;
 
-            numInteractionManagerStates = InteractionManager.GetCurrentReading(interactionmanagerStates);
+            UpdateInteractionManagerReading();
 
             // Avoids a Unity Editor bug detecting a controller from the previous run during the first frame
 #if !UNITY_EDITOR
@@ -317,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         {
             base.Update();
 
-            numInteractionManagerStates = InteractionManager.GetCurrentReading(interactionmanagerStates);
+            UpdateInteractionManagerReading();
 
             for (var i = 0; i < numInteractionManagerStates; i++)
             {
@@ -744,6 +756,39 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         }
 
         #endregion Navigation Recognizer Events
+
+        #region Private Methods
+
+        /// <summary>
+        /// Gets the latest interaction manager states and counts from InteractionManager
+        /// </summary>
+        /// <remarks>
+        /// Abstracts away some of the array resize handling and another underlying Unity issue
+        /// when InteractionManager.GetCurrentReading is called when there are no detected sources.
+        /// </remarks>
+        private void UpdateInteractionManagerReading()
+        {
+            int newSourceStateCount = InteractionManager.numSourceStates;
+            // If there isn't enough space in the cache to hold the results, we should grow it so that it can, but also
+            // grow it in a way that is unlikely to require re-allocations each time.
+            if (newSourceStateCount > interactionmanagerStates.Length)
+            {
+                interactionmanagerStates = new InteractionSourceState[newSourceStateCount * InteractionManagerStatesGrowthFactor];
+            }
+
+            // Note that InteractionManager.GetCurrentReading throws when invoked when the number of
+            // source states is zero. In that case, we want to just update the number of read states to be zero.
+            if (newSourceStateCount == 0)
+            {
+                numInteractionManagerStates = 0;
+            }
+            else
+            {
+                numInteractionManagerStates = InteractionManager.GetCurrentReading(interactionmanagerStates);
+            }
+        }
+
+        #endregion Private Methods
 
 #endif // UNITY_WSA
 


### PR DESCRIPTION
There's an underlying Unity bug where calling InteractionManager:GetCurrentReading when there are no sources trips this asssertion. This change addresses a couple of things:

1) Works around this underlying bug by checking to see if numSourceStates == 0 (if so, don't bother calling that API)
2) As a related but not totally related change, making it so that we now support cases where the number of states is > the value of 20. Note that I didn't change the naming of it because the value is public (and thus, it would be a value-less breaking change).  When we detect that our array size is not large enough, we will re-allocate (and in a way that should reduce the number of repeat allocations if the numbers are fluctuating a lot).

https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4287