### PR TITLE
Fix NullRef when Interactable created at runtime

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -927,7 +927,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public void LoadStates(string statesAssetName)
         {
             string[] stateLocations = AssetDatabase.FindAssets(statesAssetName);
-            Debug.Assert(stateLocations.Length > 0, $"Interactable.LoadStates loading {statesAssetName} but no no {statesAssetName}.asset found");
+            Debug.Assert(stateLocations.Length > 0, $"Interactable.LoadStates loading {statesAssetName} but no {statesAssetName}.asset found");
             string path = AssetDatabase.GUIDToAssetPath(stateLocations[0]);
             States = (States)AssetDatabase.LoadAssetAtPath(path, typeof(States));
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -180,11 +181,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
         #endregion InspectorHelpers
 
-        #region MonoBehaviorImplimentation
+        #region MonoBehaviorImplementation
 
         protected virtual void Awake()
         {
-            //State = new InteractableStates(InteractableStates.Default);
+
+            if (States == null)
+            {
+                Debug.Log("Interactable instantiated at runtime, loading default states");
+                LoadStates("DefaultInteractableStates");
+            }
             InputAction = ResolveInputAction(InputActionId);
             SetupEvents();
             SetupThemes();
@@ -913,6 +919,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
             inputTimer = null;
         }
 
+        /// <summary>
+        /// Sets the states of the interactable to be asset that matches the given asset name
+        /// If more than one asset name is found, uses the first found asset.
+        /// </summary>
+        /// <param name="statesAssetName">The name of the interactable states asset</param>
+        public void LoadStates(string statesAssetName)
+        {
+            string[] stateLocations = AssetDatabase.FindAssets(statesAssetName);
+            Debug.Assert(stateLocations.Length > 0, $"Interactable.LoadStates loading {statesAssetName} but no no {statesAssetName}.asset found");
+            string path = AssetDatabase.GUIDToAssetPath(stateLocations[0]);
+            States = (States)AssetDatabase.LoadAssetAtPath(path, typeof(States));
+        }
+
         #endregion InteractableUtilities
 
         #region VoiceCommands
@@ -989,6 +1008,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion VoiceCommands
 
+        #region IMixedRealityTouchHandler
         void IMixedRealityTouchHandler.OnTouchStarted(HandTrackingInputEventData eventData)
         {
             SetPress(true);
@@ -1002,5 +1022,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData) { }
+        #endregion
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// Unity doesn't include the the required assemblies (i.e. the ones below).
+// Given that the .NET backend is deprecated by Unity at this point it's we have
+// to work around this on our end.
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    class InteractableTests
+    {
+        /// <summary>
+        /// Tests that an interactable component can be added to a GameObject
+        /// at runtime.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestAddInteractableAtRuntime()
+        {
+            TestUtilities.InitializeMixedRealityToolkitScene(true);
+            TestUtilities.InitializePlayspace();
+
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            // This should not throw an excetion
+            var interactable = cube.AddComponent<Interactable>();
+
+            // clean up
+            GameObject.Destroy(cube);
+            yield return null;
+        }
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0706866f136342429340f07946eb014
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Fixes: #4183 by loading the default interactable states if Interactable.States is null on Awake(). This can happen when Interactable is instantiated at runtime.

## Verification
Verified by running repro steps at #4183 and seeing that Interactable is correctly instantiated.
