### PR TITLE
Updated outdated description and axis constraint for 'Select' input action in default speech commands profile

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealitySpeechCommandsProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealitySpeechCommandsProfile.asset
@@ -28,5 +28,5 @@ MonoBehaviour:
     keyCode: 49
     action:
       id: 1
-      description: Toggle Diagnostics
-      axisConstraint: 0
+      description: Select
+      axisConstraint: 2


### PR DESCRIPTION
This was causing 'Select' speech comands being ignored when filtering using the 'Select' input action.

Fixes: #4419  .