### PR TITLE
Move MRTK addition to scene to utility class

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
@@ -120,14 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [MenuItem("Mixed Reality Toolkit/Add to Scene and Configure...")]
         public static void CreateMixedRealityToolkitGameObject()
         {
-            if (MixedRealityToolkit.IsInitialized)
-            {
-                EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
-                return;
-            }
-
-            Selection.activeObject = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
-            Debug.Assert(MixedRealityToolkit.IsInitialized);
+            MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();
             EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Boundary;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
@@ -114,7 +115,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.HelpBox("No Mixed Reality Toolkit found in scene.", MessageType.Warning);
                 if (GUILayout.Button("Click here to add Mixed Reality Toolkit instance to scene"))
                 {
-                    new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+                    MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();
+                    EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                     if (showCreateButton && GUILayout.Button("Click here to add Mixed Reality Toolkit instance to scene"))
                     {
-                        new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+                        AddMixedRealityToolkitToScene();
                     }
                     EditorGUILayout.Space();
                 }
@@ -52,6 +52,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// If MRTK is not initialized in scene, adds & initializes instance to current scene
+        /// </summary>
+        public static void AddMixedRealityToolkitToScene()
+        {
+            if (!MixedRealityToolkit.IsInitialized)
+            {
+                Selection.activeObject = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Fixes debug assert with multiple MRTK instances and simplifies code to one utility function for adding MRTK to the current scene

## Changes
- Fixes: #4426
Assert failing in MixedRealityToolkitInspector.CreateMixedRealityToolkitGameObject() 

## Verification
Add to scene & configure
built project
Duplicate MRTK with multiple instances
