### PR TITLE
Update runtime components to access system profiles from the system instance

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs
@@ -21,6 +21,19 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         public GameObject RailsAxisY = null;
         public GameObject RailsAxisZ = null;
 
+        private IMixedRealityInputSystem inputSystem = null;
+        private IMixedRealityInputSystem InputSystem
+        {
+            get
+            {
+                if (InputSystem == null)
+                {
+                    MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
+                }
+                return inputSystem;
+            }
+        }
+
         void OnEnable()
         {
             HideRails();
@@ -148,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
 
         private void ShowRails(Vector3 position)
         {
-            var gestureProfile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile;
+            var gestureProfile = InputSystem.InputSystemProfile.GesturesProfile;
             var useRails = gestureProfile.UseRailsNavigation;
 
             if (RailsAxisX)

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
         {
             get
             {
-                if (InputSystem == null)
+                if (inputSystem == null)
                 {
                     MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
                 }

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleHandVisualisation.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleHandVisualisation.cs
@@ -11,9 +11,22 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         public bool isHandMeshVisible = false;
         public bool isHandJointVisible = false;
 
+        private IMixedRealityInputSystem inputSystem = null;
+        protected IMixedRealityInputSystem InputSystem
+        {
+            get
+            {
+                if (InputSystem == null)
+                {
+                    MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
+                }
+                return inputSystem;
+            }
+        }
+
         void updateHandVisibility()
         {
-            MixedRealityHandTrackingProfile handTrackingProfile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile;
+            MixedRealityHandTrackingProfile handTrackingProfile = InputSystem?.InputSystemProfile?.HandTrackingProfile;
             if (handTrackingProfile != null)
             { 
                 handTrackingProfile.EnableHandMeshVisualization = isHandMeshVisible;

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleHandVisualisation.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleHandVisualisation.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         {
             get
             {
-                if (InputSystem == null)
+                if (inputSystem == null)
                 {
                     MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
                 }

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/OpenVRDeviceManager.cs
@@ -23,17 +23,15 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public OpenVRDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null, 
             uint priority = DefaultPriority, 
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
         #region Controller Utilities
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -237,7 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 {
                     HandPose handPose = sourceState.TryGetHandPose();
 
-                    if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile.EnableHandMeshVisualization)
+                    if (InputSystem.InputSystemProfile.HandTrackingProfile.EnableHandMeshVisualization)
                     {
                         // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
                         if (handMeshObserver == null && !hasRequestedHandMeshObserver)

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -27,17 +27,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public WindowsMixedRealityDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
 #if UNITY_WSA
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -28,17 +28,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public WindowsMixedRealityEyeGazeDataProvider(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile) : base(registrar, inputSystem, name, priority, profile) { }
 
         public bool SmoothEyeTracking { get; set; } = false;
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -77,9 +77,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// <inheritdoc />
         public override void Initialize()
         {
-            // Only initialize if the Spatial Awareness system has been enabled in the configuration profile.
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsSpatialAwarenessSystemEnabled) { return; }
-
             CreateObserver();
 
             // Apply the initial observer volume settings.
@@ -367,8 +364,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         private void UpdateObserver()
         {
-            if (!MixedRealityToolkit.Instance.ActiveProfile.IsSpatialAwarenessSystemEnabled ||
-                (SpatialAwarenessSystem == null))
+            if (SpatialAwarenessSystem == null)
             {
                 return;
             }

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -25,17 +25,15 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public WindowsDictationInputProvider(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
         /// <inheritdoc />
         public bool IsListening { get; private set; } = false;

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -25,17 +25,15 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the service.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public WindowsSpeechInputProvider(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null, 
             uint priority = DefaultPriority, 
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
         /// <summary>
         /// The keywords to be recognized and optional keyboard shortcuts.

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -35,7 +35,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Setup the input system
         /// </summary>
         private static IMixedRealityInputSystem inputSystem = null;
-        protected static IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>());
+        protected static IMixedRealityInputSystem InputSystem
+        {
+            get
+            {
+                if (InputSystem == null)
+                {
+                    MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
+                }
+                return InputSystem;
+            }
+        }
 
         // list of pointers
         protected List<IMixedRealityPointer> pointers = new List<IMixedRealityPointer>();
@@ -155,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return false;
             }
 
-            MixedRealityInputAction[] actions = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions;
+            MixedRealityInputAction[] actions = InputSystem.InputSystemProfile.InputActionsProfile.InputActions;
 
             descriptionsArray = new string[actions.Length];
             for (int i = 0; i < actions.Length; i++)
@@ -782,7 +792,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <returns></returns>
         public static MixedRealityInputAction ResolveInputAction(int index)
         {
-            MixedRealityInputAction[] actions = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions;
+            MixedRealityInputAction[] actions = InputSystem.InputSystemProfile.InputActionsProfile.InputActions;
             index = Mathf.Clamp(index, 0, actions.Length - 1);
             return actions[index];
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                if (InputSystem == null)
+                if (inputSystem == null)
                 {
                     MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
                 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
                 }
-                return InputSystem;
+                return inputSystem;
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -358,12 +358,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            if (!MixedRealityToolkit.IsInitialized)
-            {
-                // Wait until the toolkit is initialized before taking action.
-                return;
-            }
-
             FocusDetails focusDetails;
 
             if (!InputSystem.FocusProvider.TryGetFocusDetails(Pointer, out focusDetails))

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -290,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         private int ignoreRaycastLayerValue = 2;
 
         /// <inheritdoc/>
-        public MixedRealityBoundaryVisualizationProfile Profile => ConfigurationProfile as MixedRealityBoundaryVisualizationProfile;
+        public MixedRealityBoundaryVisualizationProfile BoundaryVisualizationProfile => ConfigurationProfile as MixedRealityBoundaryVisualizationProfile;
 
         /// <inheritdoc/>
         public ExperienceScale Scale { get; set; }

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -289,8 +289,20 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// </summary>
         private int ignoreRaycastLayerValue = 2;
 
+        private MixedRealityBoundaryVisualizationProfile boundaryVisualizationProfile = null;
+        
         /// <inheritdoc/>
-        public MixedRealityBoundaryVisualizationProfile BoundaryVisualizationProfile => ConfigurationProfile as MixedRealityBoundaryVisualizationProfile;
+        public MixedRealityBoundaryVisualizationProfile BoundaryVisualizationProfile
+        {
+            get
+            {
+                if (boundaryVisualizationProfile == null)
+                {
+                    boundaryVisualizationProfile = ConfigurationProfile as MixedRealityBoundaryVisualizationProfile;
+                }
+                return boundaryVisualizationProfile;
+            }
+        }
 
         /// <inheritdoc/>
         public ExperienceScale Scale { get; set; }

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -290,6 +290,9 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         private int ignoreRaycastLayerValue = 2;
 
         /// <inheritdoc/>
+        public MixedRealityBoundaryVisualizationProfile Profile => ConfigurationProfile as MixedRealityBoundaryVisualizationProfile;
+
+        /// <inheritdoc/>
         public ExperienceScale Scale { get; set; }
 
         /// <inheritdoc/>

--- a/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -23,7 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             IMixedRealityServiceRegistrar registrar,
             BaseMixedRealityProfile profile = null) : base(registrar, profile)
         {
-            cameraProfile = (MixedRealityCameraProfile)profile;
         }
 
         /// <summary>
@@ -50,7 +49,21 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         /// <inheritdoc />
         public string SourceName { get; } = "Mixed Reality Camera System";
 
-        private MixedRealityCameraProfile cameraProfile;
+        private MixedRealityCameraProfile cameraProfile = null;
+
+        /// <inheritdoc/>
+        public MixedRealityCameraProfile CameraProfile
+        {
+            get
+            {
+                if (cameraProfile == null)
+                {
+                    cameraProfile = ConfigurationProfile as MixedRealityCameraProfile;
+                }
+                return cameraProfile;
+            }
+        }
+
         private DisplayType currentDisplayType;
         private bool cameraOpaqueLastFrame = false;
 
@@ -92,10 +105,10 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         /// </summary>
         private void ApplySettingsForOpaqueDisplay()
         {
-            CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsOpaqueDisplay;
-            CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneOpaqueDisplay;
-            CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorOpaqueDisplay;
-            QualitySettings.SetQualityLevel(cameraProfile.OpaqueQualityLevel, false);
+            CameraCache.Main.clearFlags = CameraProfile.CameraClearFlagsOpaqueDisplay;
+            CameraCache.Main.nearClipPlane = CameraProfile.NearClipPlaneOpaqueDisplay;
+            CameraCache.Main.backgroundColor = CameraProfile.BackgroundColorOpaqueDisplay;
+            QualitySettings.SetQualityLevel(CameraProfile.OpaqueQualityLevel, false);
         }
 
         /// <summary>
@@ -103,10 +116,10 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         /// </summary>
         private void ApplySettingsForTransparentDisplay()
         {
-            CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsTransparentDisplay;
-            CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorTransparentDisplay;
-            CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneTransparentDisplay;
-            QualitySettings.SetQualityLevel(cameraProfile.HoloLensQualityLevel, false);
+            CameraCache.Main.clearFlags = CameraProfile.CameraClearFlagsTransparentDisplay;
+            CameraCache.Main.backgroundColor = CameraProfile.BackgroundColorTransparentDisplay;
+            CameraCache.Main.nearClipPlane = CameraProfile.NearClipPlaneTransparentDisplay;
+            QualitySettings.SetQualityLevel(CameraProfile.HoloLensQualityLevel, false);
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -91,6 +91,9 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         #region IMixedRealityDiagnosticsSystem
 
+        /// <inheritdoc />
+        public MixedRealityDiagnosticsProfile Profile => ConfigurationProfile as MixedRealityDiagnosticsProfile;
+
         private bool showDiagnostics;
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         #region IMixedRealityDiagnosticsSystem
 
         /// <inheritdoc />
-        public MixedRealityDiagnosticsProfile Profile => ConfigurationProfile as MixedRealityDiagnosticsProfile;
+        public MixedRealityDiagnosticsProfile DiagnosticsSystemProfile => ConfigurationProfile as MixedRealityDiagnosticsProfile;
 
         private bool showDiagnostics;
 

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -91,8 +91,20 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         #region IMixedRealityDiagnosticsSystem
 
-        /// <inheritdoc />
-        public MixedRealityDiagnosticsProfile DiagnosticsSystemProfile => ConfigurationProfile as MixedRealityDiagnosticsProfile;
+        private MixedRealityDiagnosticsProfile diagnosticsSystemProfile = null;
+
+        /// <inheritdoc/>
+        public MixedRealityDiagnosticsProfile DiagnosticsSystemProfile
+        {
+            get
+            {
+                if (diagnosticsSystemProfile == null)
+                {
+                    diagnosticsSystemProfile = ConfigurationProfile as MixedRealityDiagnosticsProfile;
+                }
+                return diagnosticsSystemProfile;
+            }
+        }
 
         private bool showDiagnostics;
 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -148,19 +148,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #endregion BaseInputDeviceManager Implementation
 
-        /// <summary>
-        /// Return the service profile and ensure that the type is correct
-        /// </summary>
+        private MixedRealityInputSimulationProfile inputSimulationProfile = null;
+
+        /// <inheritdoc/>
         public MixedRealityInputSimulationProfile InputSimulationProfile
         {
             get
+            {
+                if (inputSimulationProfile == null)
                 {
-                var profile = ConfigurationProfile as MixedRealityInputSimulationProfile;
-                if (!profile)
-                {
-                    Debug.LogError("Profile for Input Simulation Service must be a MixedRealityInputSimulationProfile");
+                    inputSimulationProfile = ConfigurationProfile as MixedRealityInputSimulationProfile;
                 }
-                return profile;
+                return inputSimulationProfile;
             }
         }
 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -49,10 +49,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public InputSimulationService(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name, 
             uint priority, 
-            BaseMixedRealityProfile profile) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile) : base(registrar, inputSystem, name, priority, profile) { }
 
         /// <inheritdoc />
         public override IMixedRealityController[] GetActiveControllers()

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/IInputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/IInputSimulationService.cs
@@ -5,6 +5,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 { 
     public interface IInputSimulationService : IMixedRealityInputDeviceManager
     {
+        /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
         MixedRealityInputSimulationProfile InputSimulationProfile { get; }
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             initializedFromProfile = true;
 
-            var gestureProfile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile;
+            var gestureProfile = InputSystem?.InputSystemProfile?.GesturesProfile;
             if (gestureProfile != null)
             {
                 for (int i = 0; i < gestureProfile.Gestures.Length; i++)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -615,9 +615,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             IMixedRealityPointerMediator mediator = null;
 
-            if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile.PointerMediator.Type != null)
+            if (InputSystem?.InputSystemProfile.PointerProfile.PointerMediator.Type != null)
             {
-                mediator = Activator.CreateInstance(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.PointerProfile.PointerMediator.Type) as IMixedRealityPointerMediator;
+                mediator = Activator.CreateInstance(InputSystem.InputSystemProfile.PointerProfile.PointerMediator.Type) as IMixedRealityPointerMediator;
             }
 
             if (mediator != null)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected virtual void OnEnable()
         {
-            if (MixedRealityToolkit.IsInitialized && InputSystem != null && !lateInitialize)
+            if (InputSystem != null && !lateInitialize)
             {
                 InputSystem.Register(gameObject);
             }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -37,8 +37,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public HashSet<IMixedRealityController> DetectedControllers { get; } = new HashSet<IMixedRealityController>();
 
-        /// <inheritdoc />
-        public MixedRealityInputSystemProfile InputSystemProfile => ConfigurationProfile as MixedRealityInputSystemProfile;
+
+        private MixedRealityInputSystemProfile inputSystemProfile = null;
+
+        /// <inheritdoc/>
+        public MixedRealityInputSystemProfile InputSystemProfile
+        {
+            get
+            {
+                if (inputSystemProfile == null)
+                {
+                    inputSystemProfile = ConfigurationProfile as MixedRealityInputSystemProfile;
+                }
+                return inputSystemProfile;
+            }
+        }
 
         private IMixedRealityFocusProvider focusProvider = null;
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            if (MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile == null)
+            if (InputSystemProfile == null)
             {
                 Debug.LogError("The Input system is missing the required Input System Profile!");
                 return;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -37,6 +37,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public HashSet<IMixedRealityController> DetectedControllers { get; } = new HashSet<IMixedRealityController>();
 
+        /// <inheritdoc />
+        public MixedRealityInputSystemProfile Profile => ConfigurationProfile as MixedRealityInputSystemProfile;
+
         private IMixedRealityFocusProvider focusProvider = null;
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -203,7 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 for (int i = 0; i < profile.DataProviderConfigurations.Length; i++)
                 {
                     MixedRealityInputDataProviderConfiguration configuration = profile.DataProviderConfigurations[i];
-                    object[] args = { Registrar, this, profile, configuration.ComponentName, configuration.Priority, configuration.DeviceManagerProfile };
+                    object[] args = { Registrar, this, configuration.ComponentName, configuration.Priority, configuration.DeviceManagerProfile };
 
                     if (Registrar.RegisterDataProvider<IMixedRealityInputDeviceManager>(
                         configuration.ComponentType.Type,

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public HashSet<IMixedRealityController> DetectedControllers { get; } = new HashSet<IMixedRealityController>();
 
         /// <inheritdoc />
-        public MixedRealityInputSystemProfile Profile => ConfigurationProfile as MixedRealityInputSystemProfile;
+        public MixedRealityInputSystemProfile InputSystemProfile => ConfigurationProfile as MixedRealityInputSystemProfile;
 
         private IMixedRealityFocusProvider focusProvider = null;
 

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -175,6 +175,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             return nextSourceId++;
         }
 
+        /// <inheritdoc/>
+        public MixedRealitySpatialAwarenessSystemProfile SpatialAwarenessSystemProfile => ConfigurationProfile as MixedRealitySpatialAwarenessSystemProfile;
+
         /// <inheritdoc />
         public IReadOnlyList<IMixedRealitySpatialAwarenessObserver> GetObservers()
         {

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -175,8 +175,20 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             return nextSourceId++;
         }
 
+        private MixedRealitySpatialAwarenessSystemProfile spatialAwarenessSystemProfile = null;
+
         /// <inheritdoc/>
-        public MixedRealitySpatialAwarenessSystemProfile SpatialAwarenessSystemProfile => ConfigurationProfile as MixedRealitySpatialAwarenessSystemProfile;
+        public MixedRealitySpatialAwarenessSystemProfile SpatialAwarenessSystemProfile
+        {
+            get
+            {
+                if (spatialAwarenessSystemProfile == null)
+                {
+                    spatialAwarenessSystemProfile = ConfigurationProfile as MixedRealitySpatialAwarenessSystemProfile;
+                }
+                return spatialAwarenessSystemProfile;
+            }
+        }
 
         /// <inheritdoc />
         public IReadOnlyList<IMixedRealitySpatialAwarenessObserver> GetObservers()

--- a/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <summary>
         /// Typed representation of the ConfigurationProfile property.
         /// </summary>
-        MixedRealityBoundaryVisualizationProfile Profile { get; }
+        MixedRealityBoundaryVisualizationProfile BoundaryVisualizationProfile { get; }
         /// <summary>
         /// The scale (ex: World Scale) of the experience.
         /// </summary>

--- a/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
@@ -14,6 +14,10 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
     public interface IMixedRealityBoundarySystem : IMixedRealityEventSystem, IMixedRealityEventSource
     {
         /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
+        MixedRealityBoundaryVisualizationProfile Profile { get; }
+        /// <summary>
         /// The scale (ex: World Scale) of the experience.
         /// </summary>
         ExperienceScale Scale { get; set; }

--- a/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// Typed representation of the ConfigurationProfile property.
         /// </summary>
         MixedRealityBoundaryVisualizationProfile BoundaryVisualizationProfile { get; }
+
         /// <summary>
         /// The scale (ex: World Scale) of the experience.
         /// </summary>

--- a/Assets/MixedRealityToolkit/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
@@ -11,6 +11,11 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
     public interface IMixedRealityCameraSystem : IMixedRealityEventSystem, IMixedRealityEventSource, IMixedRealityDataProvider
     {
         /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
+        MixedRealityCameraProfile CameraProfile { get; }
+
+        /// <summary>
         /// Is the current camera displaying on an Opaque (AR) device or a VR / immersive device
         /// </summary>
         bool IsOpaque { get; }

--- a/Assets/MixedRealityToolkit/Interfaces/Diagnostics/IMixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Diagnostics/IMixedRealityDiagnosticsSystem.cs
@@ -10,6 +10,11 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
     public interface IMixedRealityDiagnosticsSystem : IMixedRealityEventSystem, IMixedRealityEventSource
     {
         /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
+        MixedRealityDiagnosticsProfile Profile { get; }
+
+        /// <summary>
         /// Enable / disable diagnostic display.
         /// </summary>
         /// <remarks>

--- a/Assets/MixedRealityToolkit/Interfaces/Diagnostics/IMixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Diagnostics/IMixedRealityDiagnosticsSystem.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         /// <summary>
         /// Typed representation of the ConfigurationProfile property.
         /// </summary>
-        MixedRealityDiagnosticsProfile Profile { get; }
+        MixedRealityDiagnosticsProfile DiagnosticsSystemProfile { get; }
 
         /// <summary>
         /// Enable / disable diagnostic display.

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -38,6 +38,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         HashSet<IMixedRealityController> DetectedControllers { get; }
 
         /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
+        MixedRealityInputSystemProfile Profile { get; }
+
+        /// <summary>
         /// The current Focus Provider that's been implemented by this Input System.
         /// </summary>
         IMixedRealityFocusProvider FocusProvider { get; }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Typed representation of the ConfigurationProfile property.
         /// </summary>
-        MixedRealityInputSystemProfile Profile { get; }
+        MixedRealityInputSystemProfile InputSystemProfile { get; }
 
         /// <summary>
         /// The current Focus Provider that's been implemented by this Input System.

--- a/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityService.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityService.cs
@@ -21,6 +21,14 @@ namespace Microsoft.MixedReality.Toolkit
         uint Priority { get; }
 
         /// <summary>
+        /// The configuration profile for the service.
+        /// </summary>
+        /// <remarks>
+        /// Many services may wish to provide a typed version (ex: MixedRealityInputSystemProfile) that casts this value for ease of use in calling code.
+        /// </remarks>
+        BaseMixedRealityProfile ConfigurationProfile { get; }
+
+        /// <summary>
         /// The initialize function is used to setup the service once created.
         /// This method is called once all services have been registered in the Mixed Reality Toolkit.
         /// </summary>

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -34,6 +34,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         uint GenerateNewSourceId();
 
         /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
+        MixedRealitySpatialAwarenessSystemProfile SpatialAwarenessSystemProfile { get; }
+
+        /// <summary>
         /// Gets the collection of registered <see cref="IMixedRealitySpatialAwarenessObserver"/> data providers.
         /// </summary>
         /// <returns>

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -283,11 +283,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #region MRTK instance helpers
         protected MixedRealityControllerVisualizationProfile GetControllerVisualizationProfile()
         {
-            if (MixedRealityToolkit.Instance != null &&
-                MixedRealityToolkit.Instance.ActiveProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null)
+            if (InputSystem?.InputSystemProfile != null)
             {
-                return MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.ControllerVisualizationProfile;
+                return InputSystem.InputSystemProfile.ControllerVisualizationProfile;
             }
 
             return null;
@@ -295,11 +293,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected bool IsControllerMappingEnabled()
         {
-            if (MixedRealityToolkit.Instance != null &&
-                MixedRealityToolkit.Instance.ActiveProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null)
+            if (InputSystem?.InputSystemProfile != null)
             {
-                return MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.IsControllerMappingEnabled;
+                return InputSystem.InputSystemProfile.IsControllerMappingEnabled;
             }
 
             return false;
@@ -307,12 +303,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected MixedRealityControllerMapping[] GetControllerMappings()
         {
-            if (MixedRealityToolkit.Instance != null &&
-                MixedRealityToolkit.Instance.ActiveProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.ControllerMappingProfile != null)
+            if (InputSystem?.InputSystemProfile?.ControllerMappingProfile != null)
             {
-                return MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.ControllerMappingProfile.MixedRealityControllerMappingProfiles;
+                return InputSystem.InputSystemProfile.ControllerMappingProfile.MixedRealityControllerMappingProfiles;
             }
 
             return null;

--- a/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
@@ -17,14 +17,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public BaseInputDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name, 
             uint priority, 
             BaseMixedRealityProfile profile): base(registrar, inputSystem, name, priority, profile)
@@ -35,11 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             InputSystem = inputSystem;
 
-            if (inputSystemProfile == null)
-            {
-                Debug.LogError($"{name} requires a valid input system profile.");
-            }
-            InputSystemProfile = inputSystemProfile;
         }
 
         /// <summary>
@@ -50,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The input system configuration profile in use in the application.
         /// </summary>
-        protected MixedRealityInputSystemProfile InputSystemProfile = null;
+        protected MixedRealityInputSystemProfile InputSystemProfile => InputSystem?.InputSystemProfile;
 
         /// <inheritdoc />
         public virtual IMixedRealityController[] GetActiveControllers() => new IMixedRealityController[0];

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            MixedRealityHandTrackingProfile handTrackingProfile = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile;
+            MixedRealityHandTrackingProfile handTrackingProfile = InputSystem?.InputSystemProfile?.HandTrackingProfile;
             if (handTrackingProfile != null && !handTrackingProfile.EnableHandJointVisualization)
             {
                 // clear existing joint gameobjects / meshes
@@ -115,14 +115,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    GameObject prefab = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile.JointPrefab;
+                    GameObject prefab = InputSystem.InputSystemProfile.HandTrackingProfile.JointPrefab;
                     if (handJoint == TrackedHandJoint.Palm)
                     {
-                        prefab = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile.PalmJointPrefab;
+                        prefab = InputSystem.InputSystemProfile.HandTrackingProfile.PalmJointPrefab;
                     }
                     else if (handJoint == TrackedHandJoint.IndexTip)
                     {
-                        prefab = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile.FingerTipPrefab;
+                        prefab = InputSystem.InputSystemProfile.HandTrackingProfile.FingerTipPrefab;
                     }
 
                     GameObject jointObject;
@@ -153,12 +153,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             if (handMeshFilter == null &&
-                MixedRealityToolkit.Instance.HasActiveProfile &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile != null &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile.HandMeshPrefab != null)
+                InputSystem?.InputSystemProfile?.HandTrackingProfile?.HandMeshPrefab != null)
             {
-                handMeshFilter = Instantiate(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
+                handMeshFilter = Instantiate(InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
             }
 
             if (handMeshFilter != null)

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            MixedRealityHandTrackingProfile handTrackingProfile = InputSystem?.InputSystemProfile?.HandTrackingProfile;
+            MixedRealityHandTrackingProfile handTrackingProfile = InputSystem?.InputSystemProfile.HandTrackingProfile;
             if (handTrackingProfile != null && !handTrackingProfile.EnableHandJointVisualization)
             {
                 // clear existing joint gameobjects / meshes

--- a/Assets/MixedRealityToolkit/Providers/Hands/HandJointService.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/HandJointService.cs
@@ -25,10 +25,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public HandJointService(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile) : base(registrar, inputSystem, name, priority, profile) { }
 
         /// <inheritdoc />
         public override void LateUpdate()

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -19,17 +19,15 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public MouseDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
         /// <summary>
         /// Current Mouse Controller.

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityJoystickManager.cs
@@ -24,17 +24,15 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public UnityJoystickManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
         private const float DeviceRefreshInterval = 3.0f;
 

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchController.cs
@@ -62,12 +62,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         public override void SetupDefaultInteractions(Handedness controllerHandedness)
         {
             AssignControllerMappings(DefaultInteractions);
-            if (MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled &&
-                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile != null)
+            if (InputSystem?.InputSystemProfile.GesturesProfile != null)
             {
-                for (int i = 0; i < MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile.Gestures.Length; i++)
+                for (int i = 0; i < InputSystem.InputSystemProfile.GesturesProfile.Gestures.Length; i++)
                 {
-                    var gesture = MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.GesturesProfile.Gestures[i];
+                    var gesture = InputSystem.InputSystemProfile.GesturesProfile.Gestures[i];
 
                     switch (gesture.GestureType)
                     {

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -22,17 +22,15 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// </summary>
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the data provider.</param>
         /// <param name="inputSystem">The <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/> instance that receives data from this provider.</param>
-        /// <param name="inputSystemProfile">The input system configuration profile.</param>
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public UnityTouchDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            MixedRealityInputSystemProfile inputSystemProfile,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, inputSystemProfile, name, priority, profile) { }
+            BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile) { }
 
         private static readonly Dictionary<int, UnityTouchController> ActiveTouches = new Dictionary<int, UnityTouchController>();
 

--- a/Assets/MixedRealityToolkit/Services/BaseCoreSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseCoreSystem.cs
@@ -12,17 +12,12 @@ namespace Microsoft.MixedReality.Toolkit
         {
             Registrar = registrar;
             ConfigurationProfile = profile;
-            Priority = 5; // Core systems have a higher default priority than other services   
+            Priority = 5; // Core systems have a higher default priority than other services
         }
 
         /// <summary>
         /// The service registrar instance that registered this service.
         /// </summary>
         protected IMixedRealityServiceRegistrar Registrar { get; set; } = null;
-
-        /// <summary>
-        /// Configuration Profile
-        /// </summary>
-        protected BaseMixedRealityProfile ConfigurationProfile { get; set; } = null;
     }
 }

--- a/Assets/MixedRealityToolkit/Services/BaseService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseService.cs
@@ -21,6 +21,9 @@ namespace Microsoft.MixedReality.Toolkit
         public virtual uint Priority { get; protected set; } = DefaultPriority;
 
         /// <inheritdoc />
+        public virtual BaseMixedRealityProfile ConfigurationProfile { get; protected set; } = null;
+
+        /// <inheritdoc />
         public virtual void Initialize() { }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Overview
As part of #3545, systems are passed their profile via the constructor. With the PR series that started with #4099, client code can access system instances from the service registry.

This change updates runtime and client code (with a small set of exceptions) to access system profiles directly from the system instance. For example:

```
 MixedRealityInputAction[] actions = InputSystem.InputSystemProfile.InputActionsProfile.InputActions;
```

NOTE:
While this _is_ a breaking change, it is purely additive for code that _consumes_ services. Services themselves will require updating to support IMixedRealityService.ConfigurationProfile and <serviceinterface>.<service>Profile properties.

Changes to handle editor code (and the set of remaining runtime files) are forthcoming.

Fixes: #4335

## Testing performed
- Play mode, solver demo scene (select objects, teleport)
    - OpenVR
    - Windows Mixed Reality Immersive
- Edit mode test automation