### PR TITLE
Add calibration status message to the Compositor window

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -27,10 +27,10 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         public TextureManager TextureManager => textureManager;
 
         /// <summary>
-        /// Gets whether or not the holographic camera rig is connected and sending poses
-        /// for the camera to the compositor.
+        /// Gets whether or not a holographic camera rig has sent calibration data
+        /// that has been loaded to set up the virtual camera pose for rendering.
         /// </summary>
-        public bool IsHolographicCameraConnected { get; set; }
+        public bool IsCalibrationDataLoaded { get; private set; }
 
         /// <summary>
         /// Gets or sets the texture depth used for the RenderTextures used during compositing.
@@ -197,7 +197,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
        
         private void Start()
         {
-            IsHolographicCameraConnected = false;
+            IsCalibrationDataLoaded = false;
             spectatorCamera = GetComponent<Camera>();
 
 #if !UNITY_EDITOR
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
             UnityCompositorInterface.SetCompositeFrameIndex(CurrentCompositeFrame);
 
             #region Spectator View Transform
-            if (IsHolographicCameraConnected && transform.parent != null)
+            if (IsCalibrationDataLoaded && transform.parent != null)
             {
                 //Update time syncronizer
                 {
@@ -478,15 +478,16 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
             calibrationData.SetUnityCameraExtrinstics(transform);
             calibrationData.SetUnityCameraIntrinsics(GetComponent<Camera>());
 
-            IsHolographicCameraConnected = true;
+            IsCalibrationDataLoaded = true;
 #endif
         }
 
         /// <summary>
         /// Clears cached information about synchronized poses and time offsets.
         /// </summary>
-        public void ResetPoseSynchronization()
+        public void ResetOnNewCameraConnection()
         {
+            IsCalibrationDataLoaded = false;
             timeSynchronizer.Reset();
             poseCache.Reset();
         }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/HolographicCameraNetworkManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/HolographicCameraNetworkManager.cs
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         {
             currentConnection = endpoint;
             lastReceivedPoseTime = Time.time;
-            compositionManager.ResetPoseSynchronization();
+            compositionManager.ResetOnNewCameraConnection();
         }
 
         private void ConnectionManager_OnDisconnected(SocketEndpoint endpoint)

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindow.cs
@@ -28,6 +28,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
         private const string trackingStalledStatusMessage = "No tracking update in over a second";
         private const string locatingWorldAnchorStatusMessage = "Locating world anchor...";
         private const string locatedWorldAnchorStatusMessage = "Located";
+        private const string calibrationLoadedMessage = "Loaded";
+        private const string calibrationNotLoadedMessage = "No camera calibration received";
         private Vector2 scrollPosition;
         private int renderFrameWidth;
         private int renderFrameHeight;
@@ -93,6 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
         private void NetworkConnectionGUI()
         {
+            CompositionManager compositionManager = GetCompositionManager();
             HolographicCameraNetworkManager cameraNetworkManager = GetHolographicCameraNetworkManager();
 
             EditorGUILayout.BeginVertical("Box");
@@ -102,7 +105,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                     cameraNetworkManager.IsConnected &&
                     cameraNetworkManager.HasTracking &&
                     cameraNetworkManager.IsAnchorLocated &&
-                    !cameraNetworkManager.IsTrackingStalled)
+                    !cameraNetworkManager.IsTrackingStalled &&
+                    compositionManager != null &&
+                    compositionManager.IsCalibrationDataLoaded)
                 {
                     titleColor = Color.green;
                 }
@@ -142,6 +147,18 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                     }
 
                     GUILayout.Label($"Anchor status: {anchorStatusMessage}");
+
+                    string calibrationStatusMessage;
+                    if (compositionManager != null && compositionManager.IsCalibrationDataLoaded)
+                    {
+                        calibrationStatusMessage = calibrationLoadedMessage;
+                    }
+                    else
+                    {
+                        calibrationStatusMessage = calibrationNotLoadedMessage;
+                    }
+
+                    GUILayout.Label($"Calibration status: {calibrationStatusMessage}");
 
                     if (GUILayout.Button(new GUIContent("Disconnect", "Disconnects the network connection to the holographic camera.")))
                     {


### PR DESCRIPTION
This change adds one more line of status information to the Compositor window so that you can easily tell whether or not calibration data was received and loaded from the connected camera rig.