### PR TITLE
Turning off "Enable Hand Joint Visualization" turns off hand input in Editor

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -643,21 +643,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
         private bool TryGetHandPositionFromController(IMixedRealityController controller, TrackedHandJoint joint, out Vector3 position)
         {
-            if (controller != null && controller.Visualizer is IMixedRealityHandVisualizer)
+            if (controller != null &&
+                HandJointUtils.TryGetJointPose(joint, controller.ControllerHandedness, out MixedRealityPose pose))
             {
-                if ((controller.Visualizer as IMixedRealityHandVisualizer).TryGetJointTransform(joint, out Transform palm) == true)
-                {
-                    position = palm.position;
-                    return true;
-                }
-            }
-            else if (controller != null)
-            {
-                if (true == HandJointUtils.TryGetJointPose(joint, controller.ControllerHandedness, out MixedRealityPose pose))
-                {
-                    position = pose.Position;
-                    return true;
-                }
+                position = pose.Position;
+                return true;
             }
 
             position = Vector3.zero;

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityHandVisualizer.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
+using System;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -15,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Get a game object following the hand joint.
         /// </summary>
+        [Obsolete("Use HandJointUtils.TryGetJointPose instead of this")]
         bool TryGetJointTransform(TrackedHandJoint joint, out Transform jointTransform);
     }
 }


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4268

It turns out that the hand pan interaction script was directly calling into the hand visualization code in order to get joint locations, instead of just calling the hand APIs themselves (which have the exact same data). As I understand, historically the only way of getting this information was through the visualization class. It's been a while that this hasn't been the case, so now it's good to just go straight to the joint data.