### PR TITLE
Add a Calibration Test window for recording and testing Spectator View calibration files

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -33,6 +33,11 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         public bool IsCalibrationDataLoaded { get; private set; }
 
         /// <summary>
+        /// Gets the calibration data loaded by the camera.
+        /// </summary>
+        public ICalibrationData CalibrationData => calibrationData;
+
+        /// <summary>
         /// Gets or sets the texture depth used for the RenderTextures used during compositing.
         /// </summary>
         [Header("Hologram Settings")]

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CompositionManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/CompositionManager.cs
@@ -27,17 +27,6 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         public TextureManager TextureManager => textureManager;
 
         /// <summary>
-        /// Gets whether or not a holographic camera rig has sent calibration data
-        /// that has been loaded to set up the virtual camera pose for rendering.
-        /// </summary>
-        public bool IsCalibrationDataLoaded { get; private set; }
-
-        /// <summary>
-        /// Gets the calibration data loaded by the camera.
-        /// </summary>
-        public ICalibrationData CalibrationData => calibrationData;
-
-        /// <summary>
         /// Gets or sets the texture depth used for the RenderTextures used during compositing.
         /// </summary>
         [Header("Hologram Settings")]
@@ -101,6 +90,17 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         public bool IsVideoFrameProviderInitialized => isVideoFrameProviderInitialized;
 
 #if UNITY_EDITOR
+        /// <summary>
+        /// Gets the calibration data loaded by the camera.
+        /// </summary>
+        public ICalibrationData CalibrationData => calibrationData;
+
+        /// <summary>
+        /// Gets whether or not a holographic camera rig has sent calibration data
+        /// that has been loaded to set up the virtual camera pose for rendering.
+        /// </summary>
+        public bool IsCalibrationDataLoaded { get; private set; }
+
         private bool overrideCameraPose;
         private Vector3 overrideCameraPosition;
         private Quaternion overrideCameraRotation;
@@ -202,10 +202,11 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
        
         private void Start()
         {
-            IsCalibrationDataLoaded = false;
             spectatorCamera = GetComponent<Camera>();
 
-#if !UNITY_EDITOR
+#if UNITY_EDITOR
+            IsCalibrationDataLoaded = false;
+#else
             Camera[] cameras = gameObject.GetComponentsInChildren<Camera>();
             for (int i = 0; i < cameras.Length; i++)
             {
@@ -492,7 +493,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         /// </summary>
         public void ResetOnNewCameraConnection()
         {
+#if UNITY_EDITOR
             IsCalibrationDataLoaded = false;
+#endif
             timeSynchronizer.Reset();
             poseCache.Reset();
         }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/HolographicCameraNetworkManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/HolographicCameraNetworkManager.cs
@@ -15,9 +15,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
     [RequireComponent(typeof(TCPConnectionManager))]
     public class HolographicCameraNetworkManager : MonoBehaviour
     {
+        public const float arUcoMarkerSizeInMeters = 0.1f;
         private TCPConnectionManager connectionManager;
         private const float trackingStalledReceiveDelay = 1.0f;
-        private const float arUcoMarkerSizeInMeters = 0.1f;
         private float lastReceivedPoseTime = -1;
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/HolographicCameraNetworkManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Compositor/HolographicCameraNetworkManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
     public class HolographicCameraNetworkManager : MonoBehaviour
     {
         public const float arUcoMarkerSizeInMeters = 0.1f;
+        public const string CreateSharedSpatialCoordinateCommand = "CreateSharedSpatialCoordinate";
         private TCPConnectionManager connectionManager;
         private const float trackingStalledReceiveDelay = 1.0f;
         private float lastReceivedPoseTime = -1;
@@ -31,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         private string holoLensName;
         private string holoLensIPAddress;
         private bool hasTracking;
-        private bool isAnchorLocated;
+        private bool isSharedSpatialCoordinateLocated;
 
         /// <summary>
         /// Gets the name of the HoloLens running on the holographic camera rig.
@@ -57,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
         /// Gets the last-reported status of whether or not the WorldAnchor used for spatial position sharing is located
         /// on the holographic camera rig.
         /// </summary>
-        public bool IsAnchorLocated => isAnchorLocated;
+        public bool IsSharedSpatialCoordinateLocated => isSharedSpatialCoordinateLocated;
 
         private void Awake()
         {
@@ -167,25 +168,25 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.C
                     case "Status":
                         {
                             hasTracking = reader.ReadBoolean();
-                            isAnchorLocated = reader.ReadBoolean();
+                            isSharedSpatialCoordinateLocated = reader.ReadBoolean();
                         }
                         break;
                 }
             }
         }
 
-        public void SendLocateSharedAnchorCommand()
+        public void SendLocateSharedSpatialCoordinateCommand()
         {
             if (currentConnection == null)
             {
-                Debug.LogError("Can't locate shared anchor while disconnected");
+                Debug.LogError("Can't locate shared spatial coordinate while disconnected");
                 return;
             }
 
             using (MemoryStream memoryStream = new MemoryStream())
             using (BinaryWriter message = new BinaryWriter(memoryStream))
             {
-                message.Write("CreateSharedAnchor");
+                message.Write(CreateSharedSpatialCoordinateCommand);
                 message.Write(arUcoMarkerSizeInMeters);
 
                 currentConnection.Send(memoryStream.ToArray());

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
@@ -482,7 +482,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
             compositionManager.EnableHolographicCamera(networkManager.transform, calibrationDataForPlayback);
 
             testCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            testCube.transform.localScale = Vector3.one * 0.1f;
+            testCube.transform.localScale = Vector3.one * HolographicCameraNetworkManager.arUcoMarkerSizeInMeters;
             testCube.transform.localPosition = new Vector3(0.0f, 0.0f, 0.05f);
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
@@ -80,6 +80,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
         {
             base.OnEnable();
 
+            IsRecording = false;
+            IsPlaying = false;
+
             holographicCameraIPAddress = PlayerPrefs.GetString(holographicCameraIPAddressKey, "localhost");
             indexFilePath = PlayerPrefs.GetString(calibrationPlaybackIndexFilePathPreferenceKey, string.Empty);
             calibrationFilePath = PlayerPrefs.GetString(calibrationPlaybackCalibrationFilePathPreferenceKey, string.Empty);
@@ -93,6 +96,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
         private void OnDisable()
         {
+            IsRecording = false;
+            IsPlaying = false;
+
             PlayerPrefs.SetString(holographicCameraIPAddressKey, holographicCameraIPAddress);
             PlayerPrefs.SetString(calibrationPlaybackIndexFilePathPreferenceKey, indexFilePath);
             PlayerPrefs.SetString(calibrationPlaybackCalibrationFilePathPreferenceKey, calibrationFilePath);
@@ -104,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
             base.Update();
 
             CompositionManager compositionManager = GetCompositionManager();
-            if (compositionManager == null && compositionManager.TextureManager == null)
+            if (compositionManager == null || compositionManager.TextureManager == null)
             {
                 IsPlaying = false;
             }
@@ -314,7 +320,10 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                     }
                     else
                     {
-                        compositionManager.TextureManager.TextureRenderCompleted -= Instance_TextureRenderCompleted;
+                        if (compositionManager != null && compositionManager.TextureManager != null)
+                        {
+                            compositionManager.TextureManager.TextureRenderCompleted -= Instance_TextureRenderCompleted;
+                        }
 
                         if (recordingForRecording.Poses.Count > 0)
                         {
@@ -482,7 +491,10 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                 compositionManager.TextureManager.SetOverrideColorTexture(null);
                 compositionManager.ClearOverridePose();
 
-                compositionManager.EnableHolographicCamera(networkManager.transform, previousCalibrationData);
+                if (previousCalibrationData != null)
+                {
+                    compositionManager.EnableHolographicCamera(networkManager.transform, previousCalibrationData);
+                }
                 Destroy(testCube);
             }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Compositor;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor
+{
+    [Serializable]
+    public class CalibrationRecording
+    {
+        public int FrameWidth;
+        public int FrameHeight;
+        public List<CalibrationRecordingPose> Poses;
+    }
+
+    [Serializable]
+    public class CalibrationRecordingPose
+    {
+        public int FrameFileNumber;
+        public float FrameTime;
+        public Vector3 CameraPosition;
+        public Vector3 CameraRotationEuler;
+    }
+
+    [Description("Calibration Test")]
+    public class CalibrationTestWindow : CompositorWindowBase<CalibrationTestWindow>
+    {
+        private Vector2 scrollPosition;
+
+        private static string holographicCameraIPAddressKey = $"{nameof(CalibrationTestWindow)}.{nameof(holographicCameraIPAddress)}";
+        private const int startStopRecordingButtonWidth = 200;
+        private const int startStopRecordingButtonHeight = 100;
+        private const int startStopRecordingButtonRightMargin = 30;
+        private const string indexFileName = "index.json";
+
+        private bool isRecording;
+
+        private string currentRecordingSubdirectoryName;
+        private float recordingStartTime;
+        private float nextRecordingFrameTime;
+
+        private CalibrationRecording recording = new CalibrationRecording()
+        {
+            Poses = new List<CalibrationRecordingPose>()
+        };
+
+        [MenuItem("Spectator View/Calibration Test", false, 1)]
+        public static void ShowCalibrationRecordingWindow()
+        {
+            ShowWindow();
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            holographicCameraIPAddress = PlayerPrefs.GetString(holographicCameraIPAddressKey, "localhost");
+            recording.FrameWidth = renderFrameWidth;
+            recording.FrameHeight = renderFrameHeight;
+        }
+
+        private void OnDisable()
+        {
+            PlayerPrefs.SetString(holographicCameraIPAddressKey, holographicCameraIPAddress);
+            PlayerPrefs.Save();
+        }
+
+        private void OnGUI()
+        {
+            scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
+            {
+                EditorGUILayout.BeginHorizontal();
+                {
+                    EditorGUILayout.BeginVertical();
+                    {
+                        RenderTitle("Recording", Color.green);
+
+                        EditorGUILayout.BeginVertical("Box");
+                        {
+                            HolographicCameraNetworkConnectionGUI();
+                            RecordControllerGUI();
+                        }
+                        EditorGUILayout.EndVertical();
+                    }
+                    EditorGUILayout.EndVertical();
+                }
+                EditorGUILayout.EndHorizontal();
+
+                CompositeTextureGUI(textureRenderModeComposite);
+            }
+            EditorGUILayout.EndScrollView();
+        }
+
+        private void RecordControllerGUI()
+        {
+            if (!CanRecord)
+            {
+                IsRecording = false;
+            }
+
+            EditorGUILayout.BeginVertical("Box");
+            {
+                if (IsRecording)
+                {
+                    GUILayout.BeginHorizontal();
+                    {
+                        if (GUILayout.Button("Stop Recording", GUILayout.Width(startStopRecordingButtonWidth), GUILayout.Height(startStopRecordingButtonHeight)))
+                        {
+                            IsRecording = false;
+                        }
+
+                        GUILayout.Space(startStopRecordingButtonRightMargin);
+                        GUILayout.Label($"Recorded {recording.Poses.Count} frames");
+                    }
+                    GUILayout.EndHorizontal();
+                }
+                else
+                {
+                    GUILayout.BeginHorizontal();
+                    {
+                        GUI.enabled = CanRecord;
+
+                        if (GUILayout.Button("Start Recording", GUILayout.Width(startStopRecordingButtonWidth), GUILayout.Height(startStopRecordingButtonHeight)))
+                        {
+                            IsRecording = true;
+                        }
+
+                        GUI.enabled = true;
+
+                        if (!string.IsNullOrEmpty(currentRecordingSubdirectoryName))
+                        {
+                            GUILayout.Space(startStopRecordingButtonRightMargin);
+                            GUILayout.BeginVertical();
+                            {
+                                GUILayout.Label($"Recording complete: {currentRecordingSubdirectoryName}");
+                            }
+                            GUILayout.EndVertical();
+                        }
+
+                    }
+                    GUILayout.EndHorizontal();
+                }
+            }
+            EditorGUILayout.EndVertical();
+        }
+
+        private bool CanRecord
+        {
+            get
+            {
+                HolographicCameraNetworkManager cameraNetworkManager = GetHolographicCameraNetworkManager();
+                return cameraNetworkManager != null && cameraNetworkManager.IsConnected;
+            }
+        }
+
+        private bool IsRecording
+        {
+            get { return isRecording; }
+            set
+            {
+                if (isRecording != value)
+                {
+                    isRecording = value;
+
+                    CompositionManager compositionManager = GetCompositionManager();
+
+                    if (isRecording)
+                    {
+                        recording.Poses.Clear();
+                        currentRecordingSubdirectoryName = DateTime.Now.ToString("s").Replace(':', '.');
+                        recordingStartTime = Time.time;
+                        nextRecordingFrameTime = recordingStartTime;
+
+                        compositionManager.TextureManager.TextureRenderCompleted += Instance_TextureRenderCompleted;
+                    }
+                    else
+                    {
+                        compositionManager.TextureManager.TextureRenderCompleted -= Instance_TextureRenderCompleted;
+
+                        if (recording.Poses.Count > 0)
+                        {
+                            string rootFolder, targetFolder;
+                            GetRecordingDirectories(out rootFolder, out targetFolder);
+                            string indexPath = Path.Combine(targetFolder, indexFileName);
+
+                            File.WriteAllText(indexPath, JsonUtility.ToJson(recording));
+                        }
+                    }
+                }
+            }
+        }
+
+        private void Instance_TextureRenderCompleted()
+        {
+            if (Time.time > nextRecordingFrameTime)
+            {
+                CompositionManager compositionManager = GetCompositionManager();
+
+                string rootFolder, targetFolder;
+                GetRecordingDirectories(out rootFolder, out targetFolder);
+                if (!Directory.Exists(rootFolder))
+                {
+                    Directory.CreateDirectory(rootFolder);
+                }
+                if (!Directory.Exists(targetFolder))
+                {
+                    Directory.CreateDirectory(targetFolder);
+                }
+
+                string fileName = Path.Combine(targetFolder, $"{recording.Poses.Count}.raw");
+
+                UnityCompositorInterface.TakeRawPicture(fileName);
+
+                recording.Poses.Add(new CalibrationRecordingPose
+                {
+                    FrameFileNumber = recording.Poses.Count,
+                    FrameTime = Time.time,
+                    CameraPosition = compositionManager.transform.parent.localPosition,
+                    CameraRotationEuler = compositionManager.transform.parent.localRotation.eulerAngles,
+                });
+
+                nextRecordingFrameTime += 1.0f / 10.0f;
+            }
+        }
+
+        private void GetRecordingDirectories(out string rootFolder, out string targetFolder)
+        {
+            rootFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "CalibrationVideos");
+            targetFolder = Path.Combine(rootFolder, currentRecordingSubdirectoryName);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
@@ -380,11 +380,15 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
             try
             {
-                recordingForPlayback = JsonUtility.FromJson<CalibrationRecording>(File.ReadAllText(indexFilePath));
-                isIndexFileParsed = true;
+                if (File.Exists(indexFilePath))
+                {
+                    recordingForPlayback = JsonUtility.FromJson<CalibrationRecording>(File.ReadAllText(indexFilePath));
+                    isIndexFileParsed = true;
+                }
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.LogWarning($"Unexpected exception parsing file {indexFilePath}: {ex.ToString()}");
             }
         }
 
@@ -406,7 +410,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
             isCalibrationDataParsed = false;
             try
             {
-                if (!string.IsNullOrEmpty(calibrationFilePath))
+                if (File.Exists(calibrationFilePath))
                 {
                     byte[] calibrationDataPayload = File.ReadAllBytes(calibrationFilePath);
 
@@ -419,8 +423,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.LogWarning($"Unexpected exception parsing file {indexFilePath}: {ex.ToString()}");
             }
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs
@@ -34,7 +34,10 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
     {
         private Vector2 scrollPosition;
 
-        private static string holographicCameraIPAddressKey = $"{nameof(CalibrationTestWindow)}.{nameof(holographicCameraIPAddress)}";
+        private static readonly string holographicCameraIPAddressKey = $"{nameof(CalibrationTestWindow)}.{nameof(holographicCameraIPAddress)}";
+        private static readonly string calibrationPlaybackIndexFilePathPreferenceKey = $"{nameof(CalibrationTestWindow)}.{nameof(indexFilePath)}";
+        private static readonly string calibrationPlaybackCalibrationFilePathPreferenceKey = $"{nameof(CalibrationTestWindow)}.{nameof(calibrationFilePath)}";
+
         private const int startStopRecordingButtonWidth = 200;
         private const int startStopRecordingButtonHeight = 100;
         private const string indexFileName = "index.json";
@@ -78,6 +81,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
             base.OnEnable();
 
             holographicCameraIPAddress = PlayerPrefs.GetString(holographicCameraIPAddressKey, "localhost");
+            indexFilePath = PlayerPrefs.GetString(calibrationPlaybackIndexFilePathPreferenceKey, string.Empty);
+            calibrationFilePath = PlayerPrefs.GetString(calibrationPlaybackCalibrationFilePathPreferenceKey, string.Empty);
+
             recordingForRecording.FrameWidth = renderFrameWidth;
             recordingForRecording.FrameHeight = renderFrameHeight;
 
@@ -88,6 +94,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
         private void OnDisable()
         {
             PlayerPrefs.SetString(holographicCameraIPAddressKey, holographicCameraIPAddress);
+            PlayerPrefs.SetString(calibrationPlaybackIndexFilePathPreferenceKey, indexFilePath);
+            PlayerPrefs.SetString(calibrationPlaybackCalibrationFilePathPreferenceKey, calibrationFilePath);
             PlayerPrefs.Save();
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs.meta
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CalibrationTestWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f8b117576190504d94626a1805694fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindow.cs
@@ -15,25 +15,12 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor
 {
     [Description("Compositor")]
-    public class CompositorWindow : EditorWindowBase<CompositorWindow>
+    public class CompositorWindow : CompositorWindowBase<CompositorWindow>
     {
         private const float maxFrameOffset = 0.2f;
         private const float statisticsUpdateCooldownTimeSeconds = 0.1f;
-        private const float quadPadding = 4;
-        private const int textureRenderModeComposite = 0;
-        private const int textureRenderModeSplit = 1;
-        private const int horizontalFrameRectangleMargin = 50;
         private const int lowQueuedOutputFrameWarningMark = 6;
-        private const string trackingLostStatusMessage = "Tracking lost";
-        private const string trackingStalledStatusMessage = "No tracking update in over a second";
-        private const string locatingWorldAnchorStatusMessage = "Locating world anchor...";
-        private const string locatedWorldAnchorStatusMessage = "Located";
-        private const string calibrationLoadedMessage = "Loaded";
-        private const string calibrationNotLoadedMessage = "No camera calibration received";
         private Vector2 scrollPosition;
-        private int renderFrameWidth;
-        private int renderFrameHeight;
-        private float aspect;
         private int textureRenderMode;
         private string framerateStatisticsMessage;
         private Color framerateStatisticsColor = Color.green;
@@ -44,14 +31,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
         private float hologramAlpha;
 
-        private float uiFrameWidth = 100;
-        private float uiFrameHeight = 100;
         private float statisticsUpdateTimeSeconds = 0.0f;
 
-        private CompositionManager cachedCompositionManager;
-        private HolographicCameraNetworkManager cachedHolographicCameraNetworkManager;
-
-        private string holographicCameraIPAddress;
+        private static string holographicCameraIPAddressKey = $"{nameof(CompositorWindow)}.{nameof(holographicCameraIPAddress)}";
 
         [MenuItem("Spectator View/Compositor", false, 0)]
         public static void ShowCompositorWindow()
@@ -59,11 +41,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
             ShowWindow();
         }
 
-        private void OnEnable()
+        protected override void OnEnable()
         {
-            renderFrameWidth = CompositionManager.GetVideoFrameWidth();
-            renderFrameHeight = CompositionManager.GetVideoFrameHeight();
-            aspect = ((float)renderFrameWidth) / renderFrameHeight;
+            base.OnEnable();
 
             CompositionManager compositionManager = GetCompositionManager();
             if (compositionManager != null)
@@ -71,12 +51,12 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                 hologramAlpha = compositionManager.DefaultAlpha;
             }
 
-            holographicCameraIPAddress = PlayerPrefs.GetString(nameof(holographicCameraIPAddress), "localhost");
+            holographicCameraIPAddress = PlayerPrefs.GetString(holographicCameraIPAddressKey, "localhost");
         }
 
         private void OnDisable()
         {
-            PlayerPrefs.SetString(nameof(holographicCameraIPAddress), holographicCameraIPAddress);
+            PlayerPrefs.SetString(holographicCameraIPAddressKey, holographicCameraIPAddress);
             PlayerPrefs.Save();
         }
 
@@ -95,142 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
         private void NetworkConnectionGUI()
         {
-            CompositionManager compositionManager = GetCompositionManager();
-            HolographicCameraNetworkManager cameraNetworkManager = GetHolographicCameraNetworkManager();
-
-            EditorGUILayout.BeginVertical("Box");
-            {
-                Color titleColor;
-                if (cameraNetworkManager != null &&
-                    cameraNetworkManager.IsConnected &&
-                    cameraNetworkManager.HasTracking &&
-                    cameraNetworkManager.IsAnchorLocated &&
-                    !cameraNetworkManager.IsTrackingStalled &&
-                    compositionManager != null &&
-                    compositionManager.IsCalibrationDataLoaded)
-                {
-                    titleColor = Color.green;
-                }
-                else
-                {
-                    titleColor = Color.yellow;
-                }
-                RenderTitle("Holographic Camera", titleColor);
-
-                if (cameraNetworkManager != null && cameraNetworkManager.IsConnected)
-                {
-                    if (cameraNetworkManager.ConnectedIPAddress == cameraNetworkManager.HoloLensIPAddress)
-                    {
-                        GUILayout.Label($"Connected to {cameraNetworkManager.HoloLensName} ({cameraNetworkManager.HoloLensIPAddress})");
-                    }
-                    else
-                    {
-                        GUILayout.Label($"Connected to {cameraNetworkManager.HoloLensName} ({cameraNetworkManager.ConnectedIPAddress} -> {cameraNetworkManager.HoloLensIPAddress})");
-                    }
-
-                    string anchorStatusMessage;
-                    if (!cameraNetworkManager.HasTracking)
-                    {
-                        anchorStatusMessage = trackingLostStatusMessage;
-                    }
-                    else if (cameraNetworkManager.IsTrackingStalled)
-                    {
-                        anchorStatusMessage = trackingStalledStatusMessage;
-                    }
-                    else if (!cameraNetworkManager.IsAnchorLocated)
-                    {
-                        anchorStatusMessage = locatingWorldAnchorStatusMessage;
-                    }
-                    else
-                    {
-                        anchorStatusMessage = locatedWorldAnchorStatusMessage;
-                    }
-
-                    GUILayout.Label($"Anchor status: {anchorStatusMessage}");
-
-                    string calibrationStatusMessage;
-                    if (compositionManager != null && compositionManager.IsCalibrationDataLoaded)
-                    {
-                        calibrationStatusMessage = calibrationLoadedMessage;
-                    }
-                    else
-                    {
-                        calibrationStatusMessage = calibrationNotLoadedMessage;
-                    }
-
-                    GUILayout.Label($"Calibration status: {calibrationStatusMessage}");
-
-                    if (GUILayout.Button(new GUIContent("Disconnect", "Disconnects the network connection to the holographic camera.")))
-                    {
-                        cameraNetworkManager.Disconnect();
-                    }
-
-                    if (GUILayout.Button(new GUIContent("Locate Shared Anchor", "Locates an ArUco marker to set the world origin for the camera")))
-                    {
-                        cameraNetworkManager.SendLocateSharedAnchorCommand();
-                    }
-                }
-                else
-                {
-                    GUILayout.Label("Not connected.");
-
-                    GUILayout.BeginHorizontal();
-                    {
-                        holographicCameraIPAddress = EditorGUILayout.TextField(holographicCameraIPAddress);
-                        ConnectButtonGUI(holographicCameraIPAddress, cameraNetworkManager);
-                    }
-                    GUILayout.EndHorizontal();
-                }
-            }
-            EditorGUILayout.EndVertical();
-        }
-
-        protected void ConnectButtonGUI(string targetIpString, HolographicCameraNetworkManager remoteDevice)
-        {
-            string tooltip = string.Empty;
-            IPAddress targetIp;
-            bool validAddress = ParseAddress(targetIpString, out targetIp);
-
-            if (remoteDevice == null)
-            {
-                tooltip = $"{nameof(HolographicCameraNetworkManager)} is missing from the scene.";
-            }
-            else if (!Application.isPlaying)
-            {
-                tooltip = "The scene must be in play mode to connect.";
-            }
-            else if (!validAddress)
-            {
-                tooltip = "The IP address for the remote device is not valid.";
-            }
-
-            GUI.enabled = validAddress && Application.isPlaying && remoteDevice != null;
-            string label = remoteDevice != null && remoteDevice.IsConnecting ? "Disconnect" : "Connect";
-            if (GUILayout.Button(new GUIContent(label, tooltip), GUILayout.Width(90)) && remoteDevice != null)
-            {
-                if (remoteDevice.IsConnecting)
-                {
-                    remoteDevice.Disconnect();
-                }
-                else
-                {
-                    remoteDevice.ConnectTo(targetIpString);
-                }
-            }
-            GUI.enabled = true;
-        }
-
-        private bool ParseAddress(string targetIpString, out IPAddress targetIp)
-        {
-            if (targetIpString == "localhost")
-            {
-                targetIp = IPAddress.Loopback;
-                return true;
-            }
-            else
-            {
-                return IPAddress.TryParse(targetIpString, out targetIp);
-            }
+            HolographicCameraNetworkConnectionGUI();
         }
 
         private void CompositeGUI()
@@ -262,51 +107,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                 EditorGUILayout.EndHorizontal();
 
                 // Rendering
-                CompositeTextureGUI();
+                CompositeTextureGUI(textureRenderMode);
             }
             EditorGUILayout.EndVertical();
-        }
-
-        private void CompositeTextureGUI()
-        {
-            UpdateFrameDimensions();
-
-            Rect framesRect = GUILayoutUtility.GetRect(uiFrameWidth, uiFrameHeight);
-
-            if (Event.current != null && Event.current.type == EventType.Repaint)
-            {
-                CompositionManager compositionManager = GetCompositionManager();
-                if (compositionManager != null && compositionManager.TextureManager != null)
-                {
-                    if (textureRenderMode == textureRenderModeSplit)
-                    {
-                        Rect[] quadrantRects = CalculateVideoQuadrants(framesRect);
-                        if (compositionManager.TextureManager.compositeTexture != null)
-                        {
-                            Graphics.DrawTexture(quadrantRects[0], compositionManager.TextureManager.compositeTexture);
-                        }
-
-                        if (compositionManager.TextureManager.colorRGBTexture != null)
-                        {
-                            Graphics.DrawTexture(quadrantRects[1], compositionManager.TextureManager.colorRGBTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
-                        }
-
-                        if (compositionManager.TextureManager.renderTexture != null)
-                        {
-                            Graphics.DrawTexture(quadrantRects[2], compositionManager.TextureManager.renderTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
-                        }
-
-                        if (compositionManager.TextureManager.alphaTexture != null)
-                        {
-                            Graphics.DrawTexture(quadrantRects[3], compositionManager.TextureManager.alphaTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
-                        }
-                    }
-                    else
-                    {
-                        Graphics.DrawTexture(framesRect, compositionManager.TextureManager.compositeTexture);
-                    }
-                }
-            }
         }
 
         private void RecordingGUI()
@@ -465,55 +268,6 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
         private string GetFramerateStatistics(CompositionManager compositionManager, out float average)
         {
             return GetStatsString("Compositor framerate", compositionManager.FramerateStatistics, out average);
-        }
-
-        private void UpdateFrameDimensions()
-        {
-            uiFrameWidth = position.width;
-            uiFrameHeight = position.height;
-
-            if (uiFrameWidth <= uiFrameHeight * aspect)
-            {
-                uiFrameHeight = uiFrameWidth / aspect;
-            }
-            else
-            {
-                uiFrameWidth = uiFrameHeight * aspect;
-            }
-
-            uiFrameWidth -= horizontalFrameRectangleMargin;
-        }
-
-        private Rect[] CalculateVideoQuadrants(Rect videoRect)
-        {
-            float quadWidth = videoRect.width / 2 - quadPadding / 2;
-            float quadHeight = videoRect.height / 2 - quadPadding / 2;
-            Rect[] rects = new Rect[4];
-            rects[0] = new Rect(videoRect.x, videoRect.y, quadWidth, quadHeight);
-            rects[1] = new Rect(videoRect.x + quadWidth + quadPadding, videoRect.y, quadWidth, quadHeight);
-            rects[2] = new Rect(videoRect.x, videoRect.y + quadHeight + quadPadding, quadWidth, quadHeight);
-            rects[3] = new Rect(videoRect.x + quadWidth + quadPadding, videoRect.y + quadHeight + quadPadding, quadWidth, quadHeight);
-            return rects;
-        }
-
-        private CompositionManager GetCompositionManager()
-        {
-            if (cachedCompositionManager == null)
-            {
-                cachedCompositionManager = FindObjectOfType<CompositionManager>();
-            }
-
-            return cachedCompositionManager;
-        }
-
-        private HolographicCameraNetworkManager GetHolographicCameraNetworkManager()
-        {
-            if (cachedHolographicCameraNetworkManager == null)
-            {
-                cachedHolographicCameraNetworkManager = FindObjectOfType<HolographicCameraNetworkManager>();
-            }
-
-            return cachedHolographicCameraNetworkManager;
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs
@@ -25,8 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
         private const string trackingLostStatusMessage = "Tracking lost";
         private const string trackingStalledStatusMessage = "No tracking update in over a second";
-        private const string locatingWorldAnchorStatusMessage = "Locating world anchor...";
-        private const string locatedWorldAnchorStatusMessage = "Located";
+        private const string locatingSharedSpatialCoordinate = "Locating shared spatial coordinate...";
+        private const string locatedSharedSpatialCoordinateMessage = "Located";
         private const string calibrationLoadedMessage = "Loaded";
         private const string calibrationNotLoadedMessage = "No camera calibration received";
         private const int horizontalFrameRectangleMargin = 50;
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                 if (cameraNetworkManager != null &&
                     cameraNetworkManager.IsConnected &&
                     cameraNetworkManager.HasTracking &&
-                    cameraNetworkManager.IsAnchorLocated &&
+                    cameraNetworkManager.IsSharedSpatialCoordinateLocated &&
                     !cameraNetworkManager.IsTrackingStalled &&
                     compositionManager != null &&
                     compositionManager.IsCalibrationDataLoaded)
@@ -76,25 +76,25 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                         GUILayout.Label($"Connected to {cameraNetworkManager.HoloLensName} ({cameraNetworkManager.ConnectedIPAddress} -> {cameraNetworkManager.HoloLensIPAddress})");
                     }
 
-                    string anchorStatusMessage;
+                    string sharedSpatialCoordinateStatusMessage;
                     if (!cameraNetworkManager.HasTracking)
                     {
-                        anchorStatusMessage = trackingLostStatusMessage;
+                        sharedSpatialCoordinateStatusMessage = trackingLostStatusMessage;
                     }
                     else if (cameraNetworkManager.IsTrackingStalled)
                     {
-                        anchorStatusMessage = trackingStalledStatusMessage;
+                        sharedSpatialCoordinateStatusMessage = trackingStalledStatusMessage;
                     }
-                    else if (!cameraNetworkManager.IsAnchorLocated)
+                    else if (!cameraNetworkManager.IsSharedSpatialCoordinateLocated)
                     {
-                        anchorStatusMessage = locatingWorldAnchorStatusMessage;
+                        sharedSpatialCoordinateStatusMessage = locatingSharedSpatialCoordinate;
                     }
                     else
                     {
-                        anchorStatusMessage = locatedWorldAnchorStatusMessage;
+                        sharedSpatialCoordinateStatusMessage = locatedSharedSpatialCoordinateMessage;
                     }
 
-                    GUILayout.Label($"Anchor status: {anchorStatusMessage}");
+                    GUILayout.Label($"Shared spatial coordinate status: {sharedSpatialCoordinateStatusMessage}");
 
                     string calibrationStatusMessage;
                     if (compositionManager != null && compositionManager.IsCalibrationDataLoaded)
@@ -115,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
                     if (GUILayout.Button(new GUIContent("Locate Shared Spatial Coordinate", "Detects the shared location used to position objects in the same physical location on multiple devices")))
                     {
-                        cameraNetworkManager.SendLocateSharedAnchorCommand();
+                        cameraNetworkManager.SendLocateSharedSpatialCoordinateCommand();
                     }
                 }
                 else

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs
@@ -1,0 +1,275 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Compositor;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor
+{
+    public class CompositorWindowBase<TWindow> : EditorWindowBase<TWindow> where TWindow : EditorWindowBase<TWindow>
+    {
+        protected string holographicCameraIPAddress;
+
+        private CompositionManager cachedCompositionManager;
+        private HolographicCameraNetworkManager cachedHolographicCameraNetworkManager;
+
+        protected int renderFrameWidth;
+        protected int renderFrameHeight;
+        private float uiFrameWidth = 100;
+        private float uiFrameHeight = 100;
+        private float aspect;
+
+        private const string trackingLostStatusMessage = "Tracking lost";
+        private const string trackingStalledStatusMessage = "No tracking update in over a second";
+        private const string locatingWorldAnchorStatusMessage = "Locating world anchor...";
+        private const string locatedWorldAnchorStatusMessage = "Located";
+        private const string calibrationLoadedMessage = "Loaded";
+        private const string calibrationNotLoadedMessage = "No camera calibration received";
+        private const int horizontalFrameRectangleMargin = 50;
+        protected const int textureRenderModeComposite = 0;
+        protected const int textureRenderModeSplit = 1;
+        private const float quadPadding = 4;
+
+        protected virtual void OnEnable()
+        {
+            renderFrameWidth = CompositionManager.GetVideoFrameWidth();
+            renderFrameHeight = CompositionManager.GetVideoFrameHeight();
+            aspect = ((float)renderFrameWidth) / renderFrameHeight;
+        }
+
+        protected void HolographicCameraNetworkConnectionGUI()
+        {
+            CompositionManager compositionManager = GetCompositionManager();
+            HolographicCameraNetworkManager cameraNetworkManager = GetHolographicCameraNetworkManager();
+
+            EditorGUILayout.BeginVertical("Box");
+            {
+                Color titleColor;
+                if (cameraNetworkManager != null &&
+                    cameraNetworkManager.IsConnected &&
+                    cameraNetworkManager.HasTracking &&
+                    cameraNetworkManager.IsAnchorLocated &&
+                    !cameraNetworkManager.IsTrackingStalled &&
+                    compositionManager != null &&
+                    compositionManager.IsCalibrationDataLoaded)
+                {
+                    titleColor = Color.green;
+                }
+                else
+                {
+                    titleColor = Color.yellow;
+                }
+                RenderTitle("Holographic Camera", titleColor);
+
+                if (cameraNetworkManager != null && cameraNetworkManager.IsConnected)
+                {
+                    if (cameraNetworkManager.ConnectedIPAddress == cameraNetworkManager.HoloLensIPAddress)
+                    {
+                        GUILayout.Label($"Connected to {cameraNetworkManager.HoloLensName} ({cameraNetworkManager.HoloLensIPAddress})");
+                    }
+                    else
+                    {
+                        GUILayout.Label($"Connected to {cameraNetworkManager.HoloLensName} ({cameraNetworkManager.ConnectedIPAddress} -> {cameraNetworkManager.HoloLensIPAddress})");
+                    }
+
+                    string anchorStatusMessage;
+                    if (!cameraNetworkManager.HasTracking)
+                    {
+                        anchorStatusMessage = trackingLostStatusMessage;
+                    }
+                    else if (cameraNetworkManager.IsTrackingStalled)
+                    {
+                        anchorStatusMessage = trackingStalledStatusMessage;
+                    }
+                    else if (!cameraNetworkManager.IsAnchorLocated)
+                    {
+                        anchorStatusMessage = locatingWorldAnchorStatusMessage;
+                    }
+                    else
+                    {
+                        anchorStatusMessage = locatedWorldAnchorStatusMessage;
+                    }
+
+                    GUILayout.Label($"Anchor status: {anchorStatusMessage}");
+
+                    string calibrationStatusMessage;
+                    if (compositionManager != null && compositionManager.IsCalibrationDataLoaded)
+                    {
+                        calibrationStatusMessage = calibrationLoadedMessage;
+                    }
+                    else
+                    {
+                        calibrationStatusMessage = calibrationNotLoadedMessage;
+                    }
+
+                    GUILayout.Label($"Calibration status: {calibrationStatusMessage}");
+
+                    if (GUILayout.Button(new GUIContent("Disconnect", "Disconnects the network connection to the holographic camera.")))
+                    {
+                        cameraNetworkManager.Disconnect();
+                    }
+
+                    if (GUILayout.Button(new GUIContent("Locate Shared Spatial Coordinate", "Detects the shared location used to position objects in the same physical location on multiple devices")))
+                    {
+                        cameraNetworkManager.SendLocateSharedAnchorCommand();
+                    }
+                }
+                else
+                {
+                    GUILayout.Label("Not connected.");
+
+                    GUILayout.BeginHorizontal();
+                    {
+                        holographicCameraIPAddress = EditorGUILayout.TextField(holographicCameraIPAddress);
+                        ConnectButtonGUI(holographicCameraIPAddress, cameraNetworkManager);
+                    }
+                    GUILayout.EndHorizontal();
+                }
+            }
+            EditorGUILayout.EndVertical();
+        }
+
+        protected void CompositeTextureGUI(int textureRenderMode)
+        {
+            UpdateFrameDimensions();
+
+            Rect framesRect = GUILayoutUtility.GetRect(uiFrameWidth, uiFrameHeight);
+
+            if (Event.current != null && Event.current.type == EventType.Repaint)
+            {
+                CompositionManager compositionManager = GetCompositionManager();
+                if (compositionManager != null && compositionManager.TextureManager != null)
+                {
+                    if (textureRenderMode == textureRenderModeSplit)
+                    {
+                        Rect[] quadrantRects = CalculateVideoQuadrants(framesRect);
+                        if (compositionManager.TextureManager.compositeTexture != null)
+                        {
+                            Graphics.DrawTexture(quadrantRects[0], compositionManager.TextureManager.compositeTexture);
+                        }
+
+                        if (compositionManager.TextureManager.colorRGBTexture != null)
+                        {
+                            Graphics.DrawTexture(quadrantRects[1], compositionManager.TextureManager.colorRGBTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
+                        }
+
+                        if (compositionManager.TextureManager.renderTexture != null)
+                        {
+                            Graphics.DrawTexture(quadrantRects[2], compositionManager.TextureManager.renderTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
+                        }
+
+                        if (compositionManager.TextureManager.alphaTexture != null)
+                        {
+                            Graphics.DrawTexture(quadrantRects[3], compositionManager.TextureManager.alphaTexture, compositionManager.TextureManager.IgnoreAlphaMaterial);
+                        }
+                    }
+                    else
+                    {
+                        Graphics.DrawTexture(framesRect, compositionManager.TextureManager.compositeTexture);
+                    }
+                }
+            }
+        }
+
+        protected void ConnectButtonGUI(string targetIpString, HolographicCameraNetworkManager remoteDevice)
+        {
+            string tooltip = string.Empty;
+            IPAddress targetIp;
+            bool validAddress = ParseAddress(targetIpString, out targetIp);
+
+            if (remoteDevice == null)
+            {
+                tooltip = $"{nameof(HolographicCameraNetworkManager)} is missing from the scene.";
+            }
+            else if (!Application.isPlaying)
+            {
+                tooltip = "The scene must be in play mode to connect.";
+            }
+            else if (!validAddress)
+            {
+                tooltip = "The IP address for the remote device is not valid.";
+            }
+
+            GUI.enabled = validAddress && Application.isPlaying && remoteDevice != null;
+            string label = remoteDevice != null && remoteDevice.IsConnecting ? "Disconnect" : "Connect";
+            if (GUILayout.Button(new GUIContent(label, tooltip), GUILayout.Width(90)) && remoteDevice != null)
+            {
+                if (remoteDevice.IsConnecting)
+                {
+                    remoteDevice.Disconnect();
+                }
+                else
+                {
+                    remoteDevice.ConnectTo(targetIpString);
+                }
+            }
+            GUI.enabled = true;
+        }
+
+        private bool ParseAddress(string targetIpString, out IPAddress targetIp)
+        {
+            if (targetIpString == "localhost")
+            {
+                targetIp = IPAddress.Loopback;
+                return true;
+            }
+            else
+            {
+                return IPAddress.TryParse(targetIpString, out targetIp);
+            }
+        }
+
+        private void UpdateFrameDimensions()
+        {
+            uiFrameWidth = position.width;
+            uiFrameHeight = position.height;
+
+            if (uiFrameWidth <= uiFrameHeight * aspect)
+            {
+                uiFrameHeight = uiFrameWidth / aspect;
+            }
+            else
+            {
+                uiFrameWidth = uiFrameHeight * aspect;
+            }
+
+            uiFrameWidth -= horizontalFrameRectangleMargin;
+        }
+
+        private Rect[] CalculateVideoQuadrants(Rect videoRect)
+        {
+            float quadWidth = videoRect.width / 2 - quadPadding / 2;
+            float quadHeight = videoRect.height / 2 - quadPadding / 2;
+            Rect[] rects = new Rect[4];
+            rects[0] = new Rect(videoRect.x, videoRect.y, quadWidth, quadHeight);
+            rects[1] = new Rect(videoRect.x + quadWidth + quadPadding, videoRect.y, quadWidth, quadHeight);
+            rects[2] = new Rect(videoRect.x, videoRect.y + quadHeight + quadPadding, quadWidth, quadHeight);
+            rects[3] = new Rect(videoRect.x + quadWidth + quadPadding, videoRect.y + quadHeight + quadPadding, quadWidth, quadHeight);
+            return rects;
+        }
+
+        protected CompositionManager GetCompositionManager()
+        {
+            if (cachedCompositionManager == null)
+            {
+                cachedCompositionManager = FindObjectOfType<CompositionManager>();
+            }
+
+            return cachedCompositionManager;
+        }
+
+        protected HolographicCameraNetworkManager GetHolographicCameraNetworkManager()
+        {
+            if (cachedHolographicCameraNetworkManager == null)
+            {
+                cachedHolographicCameraNetworkManager = FindObjectOfType<HolographicCameraNetworkManager>();
+            }
+
+            return cachedHolographicCameraNetworkManager;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs
@@ -19,9 +19,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
 
         protected int renderFrameWidth;
         protected int renderFrameHeight;
+        protected float aspect;
         private float uiFrameWidth = 100;
         private float uiFrameHeight = 100;
-        private float aspect;
 
         private const string trackingLostStatusMessage = "Tracking lost";
         private const string trackingStalledStatusMessage = "No tracking update in over a second";

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs.meta
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindowBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 262977c55f5a63344be87a92e712e63e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor.asmdef
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor",
     "references": [
         "Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView",
-        "Microsoft.MixedReality.Toolkit.Extensions.Experimental.Socketer"
+        "Microsoft.MixedReality.Toolkit.Extensions.Experimental.Socketer",
+        "Microsoft.MixedReality.Toolkit.Extensions.PhotoCapture"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/HolographicCamera/HolographicCameraOriginAnchor.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/HolographicCamera/HolographicCameraOriginAnchor.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Extensions.Experimental.MarkerDetection;
 using Microsoft.MixedReality.Toolkit.Extensions.Experimental.Socketer;
+using Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Compositor;
 using Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.WorldAnchors;
 using System.Collections;
 using System.Collections.Generic;
@@ -79,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.H
 
                 switch (command)
                 {
-                    case "CreateSharedAnchor":
+                    case HolographicCameraNetworkManager.CreateSharedSpatialCoordinateCommand:
                         {
                             float markerDistance = reader.ReadSingle();
 


### PR DESCRIPTION
This PR adds a new window called Calibration Test for testing out a calibration file.  There are two steps to testing:

1. Recording a test video.  This process connects to the holographic camera rig and captures video frames with the pose that the HMD was at for that frame. The video should include the ArUco marker used to establish an origin for the camera tracking.  The camera rig does not need to be calibrated yet during this process, as only the video input and HMD pose are recorded
2. Playing back a test video.  This process loads a calibration file and the recording from step 1 and renders a cube placed on top of the ArUco marker.  This can be used to judge the quality of the calibration file. If the quality is great, the cube should appear to sit on top of the ArUco marker.

![CalibrationTestWindow](https://user-images.githubusercontent.com/10050922/57957879-b9e7d180-78b2-11e9-9d90-a7311bd87db2.png)
