### PR TITLE
Fix spatial coordinate scene and remove some exceptions

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/SpatialCoordinateServiceBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/SpatialCoordinateServiceBase.cs
@@ -161,7 +161,7 @@ namespace Microsoft.MixedReality.Experimental.SpatialAlignment.Common
             {
                 UnityEngine.Debug.LogWarning($"Exception thrown when trying to discover coordinate: {e.ToString()}");
                 isTracking = false;
-                return false;
+                throw e;
             }
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/SpatialCoordinateServiceBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/SpatialCoordinateServiceBase.cs
@@ -84,7 +84,8 @@ namespace Microsoft.MixedReality.Experimental.SpatialAlignment.Common
             {
                 if (!isTracking)
                 {
-                    throw new InvalidOperationException("We aren't tracking, and shouldn't expect additional coordinates to be discovered.");
+                    UnityEngine.Debug.LogWarning("New coordinate discovered, but spatial coordinate service was not tracking");
+                    return;
                 }
             }
 
@@ -94,7 +95,7 @@ namespace Microsoft.MixedReality.Experimental.SpatialAlignment.Common
             }
             else
             {
-                throw new InvalidOperationException($"Coordinate with id '{id}' already discovered.");
+                UnityEngine.Debug.LogWarning($"Unexpected behavior, coordinate {id} was rediscovered.");
             }
         }
 
@@ -156,9 +157,11 @@ namespace Microsoft.MixedReality.Experimental.SpatialAlignment.Common
 
                 return true;
             }
-            finally
+            catch (Exception e)
             {
+                UnityEngine.Debug.LogWarning($"Exception thrown when trying to discover coordinate: {e.ToString()}");
                 isTracking = false;
+                return false;
             }
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scenes/StateSynchronization.unity
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scenes/StateSynchronization.unity
@@ -757,7 +757,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Role: 1
-  localizationMechanism: {fileID: 1399172233}
+  spatialLocalizationMechanizm: {fileID: 1399172233}
   broadcasterIpAddress: 10.89.160.74
   stateSynchronizationSceneManager: {fileID: 685059976}
   stateSynchronizationBroadcaster: {fileID: 2075391329}
@@ -776,6 +776,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _markerSize: 0.03
+  _markerPositionBehavior: 1
 --- !u!114 &1399172233
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -788,7 +789,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 118d29b9f26383b429c376bfa8e5bc7b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugLogging: 0
+  debugLogging: 1
   arucoMarkerDetector: {fileID: 1399172232}
 --- !u!1 &1869681819
 GameObject:

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/MarkerDetectorCoordinateService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/MarkerDetectorCoordinateService.cs
@@ -160,7 +160,10 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.MarkerDetection
                         await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).IgnoreCancellation();
                     }
 
-                    DebugLog("We have been told to stop");
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        DebugLog("We have been told to stop");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
1) The state synchronization demo scene was missing some serialized fields.
2) After completing detection, you can could get into a state where the marker spatial coordinate service states its no longer tracking. This throws an exception if a spatial coordinate is reported at the same time.