### PR TITLE
Fix spatial mapping to work with teleport and camera control.

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -416,20 +416,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
             /// <summary>
             /// Compute concatenation of lhs * rhs such that lhs * (rhs * v) = Concat(lhs, rhs) * v
             /// </summary>
-            /// <remarks>
-            /// Start defining pose * vector = pose.p + pose.r * vector
-            /// lhs * (rhs * v)
-            /// = lhs * (rhs.p + rhs.r * v)
-            /// = lhs.p + lhs.r * (rhs.p + rhs.r * v) 
-            /// = lhs.p + lhs.r * rhs.p + lhs.r * rhs.r * v
-            /// = Pose(lhs.p + lhs.r * rhs.p, lhs.r * rhs.r) * v
-            /// </remarks>
             /// <param name="lhs">Second transform to apply</param>
             /// <param name="rhs">First transform to apply</param>
             /// <returns></returns>
             private static Pose Concatenate(Pose lhs, Pose rhs)
             {
-                return new Pose(lhs.position + lhs.rotation * rhs.position, lhs.rotation * rhs.rotation);
+                return rhs.GetTransformedBy(lhs);
             }
 
             /// <summary>

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -460,12 +460,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
             {
                 newMesh = SpatialAwarenessMeshObject.Create(null, MeshPhysicsLayer, meshName, surfaceId.handle);
 
-                // The WorldAnchor component places its object exactly where the anchor is in the same space as the camera. 
-                // But the meshes should show up transformed by the MixedRealityPlayspace transform, the same one that modifies the camera.
-                // So rather than put the WorldAnchor on the meshes GameObject, the WorldAnchor is placed out of the way in the scene,
-                // and its transform is concatenated with the Playspace transform to give the mesh's transform.
-                // That adapting the WorldAnchor's transform into playspace is done by the intermal PlayspaceAdapter component.
-                // 
+                // The WorldAnchor component places its object where the anchor is in the same space as the camera. 
+                // But since the camera is repositioned by the MixedRealityPlayspace's transform, the meshes' transforms
+                // should also the WorldAnchor position repositioned by the MixedRealityPlayspace's transform.
+                // So rather than put the WorldAnchor on the mesh's GameObject, the WorldAnchor is placed out of the way in the scene,
+                // and its transform is concatenated with the Playspace transform to compute the transform on the mesh's object.
+                // That adapting the WorldAnchor's transform into playspace is done by the internal PlayspaceAdapter component.
+                // The GameObject the WorldAnchor is placed on is unimportant, but it is convenient for cleanup to make it a child
+                // of the GameObject whose transform will track it.
                 GameObject anchorHolder = new GameObject(meshName + "_anchor");
                 anchorHolder.AddComponent<PlayspaceAdapter>(); // replace with required component?
                 worldAnchor = anchorHolder.AddComponent<WorldAnchor>(); // replace with required component and GetComponent()? 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -683,11 +683,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         }
 #endif // UNITY_WSA
 
-                /// <summary>
-                /// Applies the mesh display option to existing meshes when modified at runtime.
-                /// </summary>
-                /// <param name="option">The <see cref="SpatialAwarenessMeshDisplayOptions"/> to apply to the meshes.</param>
-                private void ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions option)
+        /// <summary>
+        /// Applies the mesh display option to existing meshes when modified at runtime.
+        /// </summary>
+        /// <param name="option">The <see cref="SpatialAwarenessMeshDisplayOptions"/> to apply to the meshes.</param>
+        private void ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions option)
         {
             bool enable = (option != SpatialAwarenessMeshDisplayOptions.None);
 

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+//#define MAFINC_IN_OBJECT
+
 using System;
 using UnityEngine;
 
@@ -17,9 +19,16 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </summary>
         private static Type[] requiredMeshComponents =
         {
+#if !MAFINC_IN_OBJECT
             typeof(MeshFilter),
             typeof(MeshRenderer),
             typeof(MeshCollider)
+#else // MAFINC_IN_OBJECT
+            typeof(MeshFilter),
+            typeof(MeshRenderer),
+            typeof(MeshCollider),
+            typeof(PlayspaceAdapter)
+#endif // MAFINC_IN_OBJECT
         };
 
         /// <summary>
@@ -31,6 +40,75 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// Constructor
         /// </summary>
         private SpatialAwarenessMeshObject() : base() { }
+
+#if MAFINC_IN_OBJECT // mafinc
+        private class PlayspaceAdapter : MonoBehaviour
+        {
+            /// <summary>
+            /// Compute concatenation of lhs * rhs such that lhs * (rhs * v) = Concat(lhs, rhs) * v
+            /// </summary>
+            /// <remarks>
+            /// Start defining pose * vector = pose.p + pose.r * vector
+            /// lhs * (rhs * v)
+            /// = lhs * (rhs.p + rhs.r * v)
+            /// = lhs.p + lhs.r * (rhs.p + rhs.r * v) 
+            /// = lhs.p + lhs.r * rhs.p + lhs.r * rhs.r * v
+            /// = Pose(lhs.p + lhs.r * rhs.p, lhs.r * rhs.r) * v
+            /// </remarks>
+            /// <param name="lhs">Second transform to apply</param>
+            /// <param name="rhs">First transform to apply</param>
+            /// <returns></returns>
+            private static Pose Concatenate(Pose lhs, Pose rhs)
+            {
+                return new Pose(lhs.position + lhs.rotation * rhs.position, lhs.rotation * rhs.rotation);
+            }
+
+            /// <summary>
+            /// Compute the pose that concatenated with the input produces an identity pose (pos=0, rot=none).
+            /// </summary>
+            /// <remarks>
+            /// Concatenate(inv, pose) = Pose.identity === (Vector3.zero, Quatenion.identity)  
+            /// (inv.p + inv.r * pose.p, inv.r * pose.r) = (Vector3.zero, Quatenion.identity)  // see def of Concatena5te above.
+            /// Therefore:
+            /// inv.r * pose.r = Quaternion.identity
+            /// inv.r * pose.r * pose.r.inverse() = Quaternion.identity * pose.r.inverse()
+            /// inv.r = pose.r.inverse()
+            /// And
+            /// inv.p + inv.r * pose.p = Vector3.zero
+            /// inv.p = -(inv.r * pose.p)
+            /// inv.p = -(pose.r.inverse() * pose.p) // using inv.r == pose.r.inverse() from above.
+            /// So then:
+            /// inv = (-(pose.r.inverse() * pose.p), pose.r.inverse())
+            /// </remarks>
+            /// <param name="pose">The pose to return the inverse of.</param>
+            /// <returns>The inverse of pose</returns>
+            private static Pose Invert(Pose pose)
+            {
+                var inverseRotation = Quaternion.Inverse(pose.rotation);
+                return new Pose(-(inverseRotation * pose.position), inverseRotation);
+            }
+
+            private Pose ComputeAdaptedPose()
+            {
+                Pose worldFromPlayspace = new Pose(MixedRealityPlayspace.Position, MixedRealityPlayspace.Rotation);
+                Transform parentTransform = transform.parent.transform;
+                Pose playspaceFromParent = new Pose(parentTransform.position, parentTransform.rotation);
+                Pose parentFromPlayspace = Invert(playspaceFromParent);
+
+                return Concatenate(parentFromPlayspace, Concatenate(worldFromPlayspace, playspaceFromParent));
+                //return Concatenate(parentFromPlayspace, playspaceFromParent);
+                //return new Pose(Vector3.zero, Quaternion.identity);
+            }
+
+            private void Update()
+            {
+                Pose adaptedPose = ComputeAdaptedPose();
+                transform.localPosition = adaptedPose.position;
+                transform.localRotation = adaptedPose.rotation;
+            }
+        }
+
+#endif // marfinc
 
         /// <summary>
         /// Creates a <see cref="SpatialAwarenessMeshObject"/>.
@@ -46,6 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         {
             SpatialAwarenessMeshObject newMesh = new SpatialAwarenessMeshObject();
 
+#if !MAFINC_IN_OBJECT // mafinc
             newMesh.Id = meshId;
             newMesh.GameObject = new GameObject(name, requiredMeshComponents);
             newMesh.GameObject.layer = layer;
@@ -62,6 +141,28 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             newMesh.Collider = newMesh.GameObject.GetComponent<MeshCollider>();
             newMesh.Collider.sharedMesh = null;
             newMesh.Collider.sharedMesh = newMesh.Filter.sharedMesh;
+#else // mafinc
+            newMesh.Id = meshId;
+            newMesh.GameObject = new GameObject(name);
+            newMesh.GameObject.layer = layer;
+
+            var adapter = new GameObject(name + "transformed", requiredMeshComponents);
+            //adapter.AddComponent<PlayspaceAdapter>(); // mafinc - add to required?
+            adapter.transform.SetParent(newMesh.GameObject.transform, false);
+
+            newMesh.Filter = adapter.GetComponent<MeshFilter>();
+            newMesh.Filter.sharedMesh = mesh;
+
+            newMesh.Renderer = adapter.GetComponent<MeshRenderer>();
+
+            // Reset the surface mesh collider to fit the updated mesh. 
+            // Unity tribal knowledge indicates that to change the mesh assigned to a
+            // mesh collider, the mesh must first be set to null.  Presumably there
+            // is a side effect in the setter when setting the shared mesh to null.
+            newMesh.Collider = adapter.GetComponent<MeshCollider>();
+            newMesh.Collider.sharedMesh = null;
+            newMesh.Collider.sharedMesh = newMesh.Filter.sharedMesh;
+#endif // mafinc
 
             return newMesh;
         }

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-//#define MAFINC_IN_OBJECT
-
 using System;
 using UnityEngine;
 
@@ -19,16 +17,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </summary>
         private static Type[] requiredMeshComponents =
         {
-#if !MAFINC_IN_OBJECT
             typeof(MeshFilter),
             typeof(MeshRenderer),
             typeof(MeshCollider)
-#else // MAFINC_IN_OBJECT
-            typeof(MeshFilter),
-            typeof(MeshRenderer),
-            typeof(MeshCollider),
-            typeof(PlayspaceAdapter)
-#endif // MAFINC_IN_OBJECT
         };
 
         /// <summary>
@@ -40,75 +31,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// Constructor
         /// </summary>
         private SpatialAwarenessMeshObject() : base() { }
-
-#if MAFINC_IN_OBJECT // mafinc
-        private class PlayspaceAdapter : MonoBehaviour
-        {
-            /// <summary>
-            /// Compute concatenation of lhs * rhs such that lhs * (rhs * v) = Concat(lhs, rhs) * v
-            /// </summary>
-            /// <remarks>
-            /// Start defining pose * vector = pose.p + pose.r * vector
-            /// lhs * (rhs * v)
-            /// = lhs * (rhs.p + rhs.r * v)
-            /// = lhs.p + lhs.r * (rhs.p + rhs.r * v) 
-            /// = lhs.p + lhs.r * rhs.p + lhs.r * rhs.r * v
-            /// = Pose(lhs.p + lhs.r * rhs.p, lhs.r * rhs.r) * v
-            /// </remarks>
-            /// <param name="lhs">Second transform to apply</param>
-            /// <param name="rhs">First transform to apply</param>
-            /// <returns></returns>
-            private static Pose Concatenate(Pose lhs, Pose rhs)
-            {
-                return new Pose(lhs.position + lhs.rotation * rhs.position, lhs.rotation * rhs.rotation);
-            }
-
-            /// <summary>
-            /// Compute the pose that concatenated with the input produces an identity pose (pos=0, rot=none).
-            /// </summary>
-            /// <remarks>
-            /// Concatenate(inv, pose) = Pose.identity === (Vector3.zero, Quatenion.identity)  
-            /// (inv.p + inv.r * pose.p, inv.r * pose.r) = (Vector3.zero, Quatenion.identity)  // see def of Concatena5te above.
-            /// Therefore:
-            /// inv.r * pose.r = Quaternion.identity
-            /// inv.r * pose.r * pose.r.inverse() = Quaternion.identity * pose.r.inverse()
-            /// inv.r = pose.r.inverse()
-            /// And
-            /// inv.p + inv.r * pose.p = Vector3.zero
-            /// inv.p = -(inv.r * pose.p)
-            /// inv.p = -(pose.r.inverse() * pose.p) // using inv.r == pose.r.inverse() from above.
-            /// So then:
-            /// inv = (-(pose.r.inverse() * pose.p), pose.r.inverse())
-            /// </remarks>
-            /// <param name="pose">The pose to return the inverse of.</param>
-            /// <returns>The inverse of pose</returns>
-            private static Pose Invert(Pose pose)
-            {
-                var inverseRotation = Quaternion.Inverse(pose.rotation);
-                return new Pose(-(inverseRotation * pose.position), inverseRotation);
-            }
-
-            private Pose ComputeAdaptedPose()
-            {
-                Pose worldFromPlayspace = new Pose(MixedRealityPlayspace.Position, MixedRealityPlayspace.Rotation);
-                Transform parentTransform = transform.parent.transform;
-                Pose playspaceFromParent = new Pose(parentTransform.position, parentTransform.rotation);
-                Pose parentFromPlayspace = Invert(playspaceFromParent);
-
-                return Concatenate(parentFromPlayspace, Concatenate(worldFromPlayspace, playspaceFromParent));
-                //return Concatenate(parentFromPlayspace, playspaceFromParent);
-                //return new Pose(Vector3.zero, Quaternion.identity);
-            }
-
-            private void Update()
-            {
-                Pose adaptedPose = ComputeAdaptedPose();
-                transform.localPosition = adaptedPose.position;
-                transform.localRotation = adaptedPose.rotation;
-            }
-        }
-
-#endif // marfinc
 
         /// <summary>
         /// Creates a <see cref="SpatialAwarenessMeshObject"/>.
@@ -124,7 +46,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         {
             SpatialAwarenessMeshObject newMesh = new SpatialAwarenessMeshObject();
 
-#if !MAFINC_IN_OBJECT // mafinc
             newMesh.Id = meshId;
             newMesh.GameObject = new GameObject(name, requiredMeshComponents);
             newMesh.GameObject.layer = layer;
@@ -141,28 +62,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             newMesh.Collider = newMesh.GameObject.GetComponent<MeshCollider>();
             newMesh.Collider.sharedMesh = null;
             newMesh.Collider.sharedMesh = newMesh.Filter.sharedMesh;
-#else // mafinc
-            newMesh.Id = meshId;
-            newMesh.GameObject = new GameObject(name);
-            newMesh.GameObject.layer = layer;
-
-            var adapter = new GameObject(name + "transformed", requiredMeshComponents);
-            //adapter.AddComponent<PlayspaceAdapter>(); // mafinc - add to required?
-            adapter.transform.SetParent(newMesh.GameObject.transform, false);
-
-            newMesh.Filter = adapter.GetComponent<MeshFilter>();
-            newMesh.Filter.sharedMesh = mesh;
-
-            newMesh.Renderer = adapter.GetComponent<MeshRenderer>();
-
-            // Reset the surface mesh collider to fit the updated mesh. 
-            // Unity tribal knowledge indicates that to change the mesh assigned to a
-            // mesh collider, the mesh must first be set to null.  Presumably there
-            // is a side effect in the setter when setting the shared mesh to null.
-            newMesh.Collider = adapter.GetComponent<MeshCollider>();
-            newMesh.Collider.sharedMesh = null;
-            newMesh.Collider.sharedMesh = newMesh.Filter.sharedMesh;
-#endif // mafinc
 
             return newMesh;
         }


### PR DESCRIPTION
## Overview
Modification to allow spatial mapping to work with teleport and camera control via the MixedRealityPlayspace.

Rather than having a WorldAnchor directly control the spatial mesh's transform, read the WorldAnchor's transform and concatenate with the playspace transform to get the mesh's transform.

## Changes
- Fixes: #4276  .


> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
