### PR TITLE
Extend the Files utility to support non-core modules and loading.

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ArticulatedHandPose.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ArticulatedHandPose.cs
@@ -199,20 +199,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// </summary>
         public static void LoadGesturePoses()
         {
-            string basePath = "Assets/MixedRealityToolkit.Services/InputSimulation/ArticulatedHandPoses/";
-            LoadGesturePose(GestureId.Flat, basePath + "ArticulatedHandPose_Flat.json");
-            LoadGesturePose(GestureId.Open, basePath + "ArticulatedHandPose_Open.json");
-            LoadGesturePose(GestureId.Pinch, basePath + "ArticulatedHandPose_Pinch.json");
-            LoadGesturePose(GestureId.PinchSteadyWrist, basePath + "ArticulatedHandPose_PinchSteadyWrist.json");
-            LoadGesturePose(GestureId.Poke, basePath + "ArticulatedHandPose_Poke.json");
-            LoadGesturePose(GestureId.Grab, basePath + "ArticulatedHandPose_Grab.json");
-            LoadGesturePose(GestureId.ThumbsUp, basePath + "ArticulatedHandPose_ThumbsUp.json");
-            LoadGesturePose(GestureId.Victory, basePath + "ArticulatedHandPose_Victory.json");
+            string[] gestureNames = Enum.GetNames(typeof(GestureId));
+            string basePath = Path.Combine("InputSimulation", "ArticulatedHandPoses");
+            for (int i = 0; i < gestureNames.Length; ++i)
+            {
+                string relPath = Path.Combine(basePath, String.Format("ArticulatedHandPose_{0}.json", gestureNames[i]));
+                string absPath = MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Services, relPath);
+                LoadGesturePose((GestureId)i, absPath);
+            }
         }
 
         private static ArticulatedHandPose LoadGesturePose(GestureId gesture, string filePath)
         {
-            if (filePath.Length > 0)
+            if (!string.IsNullOrEmpty(filePath))
             {
                 var pose = new ArticulatedHandPose();
                 pose.FromJson(File.ReadAllText(filePath));

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 if (MixedRealityToolkitFiles.AreFoldersAvailable)
                 {
 #if UNITY_EDITOR
-                    if (MixedRealityToolkitFiles.MRTKDirectories.Count() > 1)
+                    if (MixedRealityToolkitFiles.GetDirectories(MixedRealityToolkitModuleType.Core).Count() > 1)
                     {
                         Debug.LogError($"A deprecated API '{nameof(MixedRealityEditorSettings)}.{nameof(MixedRealityToolkit_AbsoluteFolderPath)}' " +
                             "is being used, and there are more than one MRTK directory in the project; most likely due to ingestion as NuGet. " +
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     }
 #endif
 
-                    return MixedRealityToolkitFiles.MRTKDirectories.First();
+                    return MixedRealityToolkitFiles.GetDirectories(MixedRealityToolkitModuleType.Core).First();
                 }
 
                 Debug.LogError("Unable to find the Mixed Reality Toolkit's directory!");

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,6 +11,19 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
+    /// <summary>
+    /// Base folder types for module searched by the MixedRealityToolkitFiles utilty.
+    /// </summary>
+    public enum MixedRealityToolkitModuleType
+    {
+        Core,
+        Providers,
+        Services,
+        SDK,
+        Examples,
+        Tests,
+    }
+
     /// <summary>
     /// API for working with MixedRealityToolkit folders contained in the project.
     /// </summary>
@@ -29,42 +43,82 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 foreach (string asset in importedAssets.Concat(movedAssets))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    if (folder.EndsWith(MixedRealityToolkitDirectory))
+                    foreach (MixedRealityToolkitModuleType module in Enum.GetValues(typeof(MixedRealityToolkitModuleType)))
                     {
-                        mrtkFolders.Add(NormalizeSeparators(folder));
+                        if (folder.EndsWith(MixedRealityToolkitDirectory(module)))
+                        {
+                            if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
+                            {
+                                modFolders = new HashSet<string>();
+                                mrtkFolders.Add(module, modFolders);
+                            }
+                            modFolders.Add(NormalizeSeparators(folder));
+                        }
                     }
                 }
 
                 foreach (string asset in deletedAssets.Concat(movedFromAssetPaths))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    if (folder.EndsWith(MixedRealityToolkitDirectory))
+                    foreach (MixedRealityToolkitModuleType module in Enum.GetValues(typeof(MixedRealityToolkitModuleType)))
                     {
-                        folder = NormalizeSeparators(folder);
-                        if (mrtkFolders.Contains(folder) && !Directory.Exists(folder))
+                        if (mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
                         {
-                            // The contains check in the if statement is faster than Directory.Exists so that's why it's used
-                            // Otherwise, it isn't necessary, as the statement below doesn't throw if item wasn't found
-                            mrtkFolders.Remove(folder);
+                            if (folder.EndsWith(MixedRealityToolkitDirectory(module)))
+                            {
+                                folder = NormalizeSeparators(folder);
+                                if (modFolders.Contains(folder) && !Directory.Exists(folder))
+                                {
+                                    // The contains check in the if statement is faster than Directory.Exists so that's why it's used
+                                    // Otherwise, it isn't necessary, as the statement below doesn't throw if item wasn't found
+                                    modFolders.Remove(folder);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
 
-        private const string MixedRealityToolkitDirectory = "MixedRealityToolkit";
+        private static string MixedRealityToolkitDirectory(MixedRealityToolkitModuleType module, string basePath="MixedRealityToolkit")
+        {
+            switch (module)
+            {
+                case MixedRealityToolkitModuleType.Core: return basePath;
+                case MixedRealityToolkitModuleType.Providers: return basePath + ".Providers";
+                case MixedRealityToolkitModuleType.Services: return basePath + ".Services";
+                case MixedRealityToolkitModuleType.SDK: return basePath + ".SDK";
+                case MixedRealityToolkitModuleType.Examples: return basePath + ".Examples";
+                case MixedRealityToolkitModuleType.Tests: return basePath + ".Tests";
+            }
+            Debug.Assert(false);
+            return null;
+        }
 
         // This alternate path is used if above isn't found. This is to work around long paths issue with NuGetForUnity
         // https://github.com/GlitchEnzo/NuGetForUnity/issues/246
-        private const string AlternateMixedRealityToolkitDirectory = "MRTK";
+        private static string AlternateMixedRealityToolkitDirectory(MixedRealityToolkitModuleType module)
+        {
+            return MixedRealityToolkitDirectory(module, "MRTK");
+        }
 
-        private readonly static HashSet<string> mrtkFolders = new HashSet<string>();
+        private readonly static Dictionary<MixedRealityToolkitModuleType, HashSet<string>> mrtkFolders =
+            new Dictionary<MixedRealityToolkitModuleType, HashSet<string>>();
         private readonly static Task searchForFoldersTask;
 
         /// <summary>
         /// Returns a collection of MRTK directories found in the project.
         /// </summary>
-        public static IEnumerable<string> MRTKDirectories { get; } = mrtkFolders;
+        public static IEnumerable<string> MRTKDirectories => GetDirectories(MixedRealityToolkitModuleType.Core);
+
+        public static IEnumerable<string> GetDirectories(MixedRealityToolkitModuleType module)
+        {
+            if (mrtkFolders.TryGetValue(module, out HashSet<string> folders))
+            {
+                return folders;
+            }
+            return null;
+        }
 
         /// <summary>
         /// Are any of the MRTK directories available?
@@ -86,18 +140,26 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static void SearchForFoldersAsync(string rootPath)
         {
-            IEnumerable<string> directories = Directory.GetDirectories(rootPath, MixedRealityToolkitDirectory, SearchOption.AllDirectories);
-
-            if (directories.Count() == 0)
+            foreach (MixedRealityToolkitModuleType module in Enum.GetValues(typeof(MixedRealityToolkitModuleType)))
             {
-                directories = Directory.GetDirectories(rootPath, AlternateMixedRealityToolkitDirectory, SearchOption.AllDirectories);
-            }
+                IEnumerable<string> directories = Directory.GetDirectories(rootPath, MixedRealityToolkitDirectory(module), SearchOption.AllDirectories);
 
-            directories = directories.Select(NormalizeSeparators);
+                if (directories.Count() == 0)
+                {
+                    directories = Directory.GetDirectories(rootPath, AlternateMixedRealityToolkitDirectory(module), SearchOption.AllDirectories);
+                }
 
-            foreach (string s in directories)
-            {
-                mrtkFolders.Add(s);
+                directories = directories.Select(NormalizeSeparators);
+
+                foreach (string s in directories)
+                {
+                    if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
+                    {
+                        modFolders = new HashSet<string>();
+                        mrtkFolders.Add(module, modFolders);
+                    }
+                    modFolders.Add(s);
+                }
             }
         }
 
@@ -120,18 +182,32 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <returns>The array of files.</returns>
         public static string[] GetFiles(string mrtkRelativeFolder)
         {
+            return GetFiles(MixedRealityToolkitModuleType.Core, mrtkRelativeFolder);
+        }
+
+        /// <summary>
+        /// Returns files from all folder instances of the MRTK folder relative path.
+        /// </summary>
+        /// <param name="mrtkRelativeFolder">The MRTK folder relative path to the target folder.</param>
+        /// <returns>The array of files.</returns>
+        public static string[] GetFiles(MixedRealityToolkitModuleType module, string mrtkRelativeFolder)
+        {
             if (!AreFoldersAvailable)
             {
                 Debug.LogError("Failed to locate MixedRealityToolkit folders in the project.");
                 return null;
             }
 
-            return mrtkFolders
-                .Select(t => Path.Combine(t, mrtkRelativeFolder))
-                .Where(Directory.Exists)
-                .SelectMany(t => Directory.GetFiles(t))
-                .Select(GetAssetDatabasePath)
-                .ToArray();
+            if (mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
+            {
+                return modFolders
+                    .Select(t => Path.Combine(t, mrtkRelativeFolder))
+                    .Where(Directory.Exists)
+                    .SelectMany(t => Directory.GetFiles(t))
+                    .Select(GetAssetDatabasePath)
+                    .ToArray();
+            }
+            return null;
         }
 
         /// <summary>
@@ -141,17 +217,30 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <returns>The project relative path to the file.</returns>
         public static string MapRelativeFilePath(string mrtkPathToFile)
         {
+            return MapRelativeFilePath(MixedRealityToolkitModuleType.Core, mrtkPathToFile);
+        }
+
+        /// <summary>
+        /// Maps a single relative path file to a concrete path from one of the MRTK folders, if found. Otherwise returns null.
+        /// </summary>
+        /// <param name="mrtkPathToFile">The MRTK folder relative path to the file.</param>
+        /// <returns>The project relative path to the file.</returns>
+        public static string MapRelativeFilePath(MixedRealityToolkitModuleType module, string mrtkPathToFile)
+        {
             if (!AreFoldersAvailable)
             {
                 Debug.LogError("Failed to locate MixedRealityToolkit folders in the project.");
                 return null;
             }
 
-            string path = mrtkFolders
-                .Select(t => Path.Combine(t, mrtkPathToFile))
-                .FirstOrDefault(t => File.Exists(t));
-
-            return path != null ? GetAssetDatabasePath(path) : null;
+            if (mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
+            {
+                string path = modFolders
+                    .Select(t => Path.Combine(t, mrtkPathToFile))
+                    .FirstOrDefault(t => File.Exists(t));
+                return path != null ? GetAssetDatabasePath(path) : null;
+            }
+            return null;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
     /// <summary>
-    /// Base folder types for module searched by the MixedRealityToolkitFiles utilty.
+    /// Base folder types for modules searched by the MixedRealityToolkitFiles utilty.
     /// </summary>
     public enum MixedRealityToolkitModuleType
     {
@@ -72,6 +72,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                                     // The contains check in the if statement is faster than Directory.Exists so that's why it's used
                                     // Otherwise, it isn't necessary, as the statement below doesn't throw if item wasn't found
                                     modFolders.Remove(folder);
+                                    if (modFolders.Count == 0)
+                                    {
+                                        mrtkFolders.Remove(module);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Overview

Articulated hand pose data loading from json files depends on finding paths in the InputSimulation folder. This was using a hardcoded relative path that can easily be broken by installing MRTK into a non-conventional directory.

The fix involves using the MixedRealityToolkitFiles utility class that registers the MRTK directory and provides convenient path construction. However, the utility was only registering the core MixedRealityToolkit path, so it has to be extended to track all the major modules in MRTK.

## Changes
- Fixes: #4448 