### PR TITLE
Remove extra configuration profile references

### DIFF
--- a/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
@@ -43,10 +43,5 @@ namespace Microsoft.MixedReality.Toolkit
         /// The service instance to which this provider is providing data.
         /// </summary>
         protected IMixedRealityService Service { get; set; } = null;
-
-        /// <summary>
-        /// Configuration Profile
-        /// </summary>
-        protected BaseMixedRealityProfile ConfigurationProfile { get; set; } = null;
     }
 }

--- a/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
@@ -35,10 +35,5 @@ namespace Microsoft.MixedReality.Toolkit
         /// The service registrar instance that registered this service.
         /// </summary>
         protected IMixedRealityServiceRegistrar Registrar { get; set; } = null;
-
-        /// <summary>
-        /// Configuration Profile
-        /// </summary>
-        protected BaseMixedRealityProfile ConfigurationProfile { get; set; } = null;
     }
 }


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/3580640/58057910-b1de9a80-7b1b-11e9-8e99-0858c13d4df5.png)

A `ConfigurationProfile` is [already defined in `BaseService`](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit/Services/BaseService.cs#L24), leading to the above warning.