### PR TITLE
Make sure sim hands are initialized when starting in persistent mode.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
@@ -291,7 +291,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Vector3 mouseDelta,
             Vector3 rotationDeltaEulerAngles)
         {
-            if (!state.IsTracked && isSimulating)
+            bool enableTracking = isAlwaysVisible || isSimulating;
+            if (!state.IsTracked && enableTracking)
             {
                 // Start at current mouse position
                 Vector3 mousePos = UnityEngine.Input.mousePosition;
@@ -319,7 +320,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // TODO: DateTime.UtcNow can be quite imprecise, better use Stopwatch.GetTimestamp
             // https://stackoverflow.com/questions/2143140/c-sharp-datetime-now-precision
             DateTime currentTime = DateTime.UtcNow;
-            if (isAlwaysVisible || isSimulating)
+            if (enableTracking)
             {
                 state.IsTracked = true;
                 lastSimulatedTimestamp = currentTime.Ticks;


### PR DESCRIPTION
## Overview
Simulated hands would not show when toggling persistent hands as the first action (T/Y keys) before first moving them (shift/space). They are now initialized in both cases where tracking starts, either when simulating hands or when just toggling them on.

## Changes
- Fixes: #4365 .
