### PR TITLE
Add a compositor preview window that can be maximized to take up most of a monitor

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/CompositorWindow.cs
@@ -103,6 +103,16 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
                     string[] compositionOptions = new string[] { "Final composited texture", "All intermediate textures" };
                     GUIContent renderingModeLabel = new GUIContent("Display texture", "Choose between displaying the composited video texture or seeing intermediate textures displayed in 4 sections (top right: input video, bottom right: alpha mask, bottom left: opaque hologram, top left: final alpha-blended hologram)");
                     textureRenderMode = EditorGUILayout.Popup(renderingModeLabel, textureRenderMode, compositionOptions);
+                    FullScreenCompositorWindow fullscreenWindow = FullScreenCompositorWindow.TryGetWindow();
+                    if (fullscreenWindow != null)
+                    {
+                        fullscreenWindow.TextureRenderMode = textureRenderMode;
+                    }
+
+                    if (GUILayout.Button("Fullscreen", GUILayout.Width(120)))
+                    {
+                        FullScreenCompositorWindow.ShowFullscreen();
+                    }
                 }
                 EditorGUILayout.EndHorizontal();
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/EditorWindowBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/EditorWindowBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
     {
         private static Dictionary<Type, EditorWindow> windows = new Dictionary<Type, EditorWindow>();
 
-        private static TWindow GetWindow()
+        public static TWindow TryGetWindow()
         {
             EditorWindow window;
             if (windows.TryGetValue(typeof(TWindow), out window))
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.E
         /// </summary>
         private void CheckEditorWindowStatus()
         {
-            TWindow window = GetWindow();
+            TWindow window = TryGetWindow();
             if (window != null)
             {
                 window.Repaint();

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/FullScreenCompositorWindow.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/FullScreenCompositorWindow.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.Editor
+{
+    [Description("Compositor Preview")]
+    public class FullScreenCompositorWindow : CompositorWindowBase<FullScreenCompositorWindow>
+    {
+        public int TextureRenderMode { get; set; }
+
+        public static void ShowFullscreen()
+        {
+            ShowWindow();
+
+#if UNITY_EDITOR_WIN
+            // Unity does not provide an API to maximize a floating utility window, so
+            // go directly to Win32 to do the work.
+            IntPtr hwnd = WindowsInterop.GetForegroundWindow();
+            WindowsInterop.ShowWindow(hwnd, WindowsInterop.SW_SHOWMAXIMIZED);
+#endif
+        }
+
+        private void OnGUI()
+        {
+            CompositeTextureGUI(TextureRenderMode);
+        }
+
+#if UNITY_EDITOR_WIN
+        private class WindowsInterop
+        {
+            [DllImport("user32")]
+            public static extern int ShowWindow(IntPtr hwnd, int swFlags);
+
+            [DllImport("user32")]
+            public static extern IntPtr GetForegroundWindow();
+
+            public const int SW_SHOWMAXIMIZED = 3;
+        }
+#endif
+    }
+}

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/FullScreenCompositorWindow.cs.meta
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/Editor/FullScreenCompositorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 704669afd15885c49aba9f5e2e2b6684
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change adds a "Fullscreen" button to the Compositor window that shows a second window with just the composition preview (and none of the other UI).  This is useful for live demonstrations, where you want to show a large preview of the composition on a second monitor without hooking up the capture card output to that monitor. The button lives in the Composite second of the UI, next to the display texture choice, and honors the choice of display texture you choose.

![image](https://user-images.githubusercontent.com/10050922/58125283-173a9600-7bc5-11e9-8cb5-6c4753835d74.png)
