### PR TITLE
Relax the thresholds on the ArUco marker detection

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/ArUco/HoloLens/SpectatorViewPluginArUcoMarkerDetector.cs
@@ -360,8 +360,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView.M
             private const int _requiredObservations = 5;
             private const int _requiredInlierCount = 5;
             private const int _maximumMarkerSampleCount = 15;
-            private const float _maximumPositionDistanceStandardDeviation = 0.001f;
-            private const float _maximumRotationAngleStandardDeviation = 0.25f;
+            private const float _maximumPositionDistanceStandardDeviation = 0.01f;
+            private const float _maximumRotationAngleStandardDeviation = 0.75f;
             private const float _markerInlierStandardDeviationThreshold = 1.5f;
 
             public override int MaximumMarkerSampleCount => _maximumMarkerSampleCount;


### PR DESCRIPTION
This change reduces the threshold for accepting/rejecting markers, which allows detection to succeed in more cases without significantly affecting the quality of the successfully-detected markers.