### PR TITLE
Enable .NET scripting backend support in CI, part 2/2

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -4,15 +4,15 @@ variables:
   UnityVersion: Unity2018.3.7f1
   MRTKVersion: 2.0.0
 
-pool:
-  name: Analog On-Prem
-  demands:
-  - Unity2018.3.7f1  # variable expansion not allowed here
-  - COG-UnityCache-WUS2-01
-  timeoutInMinutes: 90
-
-steps:
-- template: templates/common.yml
-- template: templates/package.yml
-- template: templates/releasesigning.yml
-- template: templates/end.yml
+jobs:
+- job: CIReleaseValidation
+  pool:
+    name: Analog On-Prem
+    demands:
+    - Unity2018.3.7f1  # variable expansion not allowed here
+    - COG-UnityCache-WUS2-01
+  steps:
+  - template: templates/common.yml
+  - template: templates/package.yml
+  - template: templates/releasesigning.yml
+  - template: templates/end.yml

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -8,6 +8,7 @@ pool:
   name: Analog On-Prem
   demands:
   - Unity2018.3.7f1  # variable expansion not allowed here
+  timeoutInMinutes: 90
 
 steps:
 - template: templates/common.yml

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -4,14 +4,15 @@ variables:
   UnityVersion: Unity2018.3.7f1
   MRTKVersion: 2.0.0
 
-pool:
-  name: On-Prem Unity
-  demands:
-  - Unity2018.3.7f1
-  - COG-UnityCache-WUS2-01
+jobs:
+- job: CIDeveloperValidation
   timeoutInMinutes: 90
-
-steps:
-- template: templates/common.yml
-- template: templates/package.yml
-- template: templates/end.yml
+  pool:
+    name: On-Prem Unity
+    demands:
+    - Unity2018.3.7f1
+    - COG-UnityCache-WUS2-01
+  steps:
+  - template: templates/common.yml
+  - template: templates/package.yml
+  - template: templates/end.yml

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -8,6 +8,7 @@ pool:
   name: On-Prem Unity
   demands:
   - Unity2018.3.7f1
+  timeoutInMinutes: 90
 
 steps:
 - template: templates/common.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -5,7 +5,7 @@ variables:
   MRTKVersion: 2.0.0
 
 jobs:
-- job: PR Validation
+- job: PRValidation
   timeoutInMinutes: 90
   pool:
     name: On-Prem Unity

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -8,6 +8,7 @@ pool:
   name: On-Prem Unity
   demands:
   - Unity2018.3.7f1
+  timeoutInMinutes: 90
 
 steps:
 - template: templates/common.yml

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -17,6 +17,14 @@ steps:
     PublishArtifacts: true
     PackagingDir: 'ARM'
 
+# Build UWP x86 .NET backend
+- template: tasks/unitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PublishArtifacts: true
+    ScriptingBackend: '.NET'
+
 - powershell: |
    $AutoMrtkVersion = Get-Date -format "dd.MM.yyyy"
    .\build.ps1 -Version $AutoMrtkVersion -NoNuget

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -44,12 +44,5 @@ steps:
     Arch: 'x86'
     Platform: 'Standalone'
 
-# Build Standalone x86
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    ScriptingBackend: '.NET'
-
 - template: assetretargeting.yml
 - template: tests.yml

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -60,12 +60,12 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'
     inputs:
+      ArtifactName: 'mrtk-build-${{ parameters.Arch }}'
       # The final location of the generated package depends on the type of scripting backend it's built against.
       # For the default scripting backend (IL2CPP) the naming of the appx follows the form below:
-      - ${{ if eq(parameters.ScriptingBackend, 'default' }}:
-        PathtoPublish: '$outDir\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
+      ${{ if eq(parameters.ScriptingBackend, 'default') }}:
+        PathtoPublish: '$(outDir)\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
       # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
       # names are reversed, and the Architecture is part of the AppX name)
-      - ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
-        PathtoPublish: '$outDir\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'
-      ArtifactName: 'mrtk-build-${{ parameters.Arch }}'
+      ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
+        PathtoPublish: '$(outDir)\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -64,8 +64,8 @@ steps:
       # The final location of the generated package depends on the type of scripting backend it's built against.
       # For the default scripting backend (IL2CPP) the naming of the appx follows the form below:
       ${{ if eq(parameters.ScriptingBackend, 'default') }}:
-        PathtoPublish: '$(outDir)\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
       # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
       # names are reversed, and the Architecture is part of the AppX name)
       ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
-        PathtoPublish: '$(outDir)\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -57,7 +57,7 @@ steps:
   displayName: "Build ${{ parameters.Platform }} ${{ parameters.Arch }} ${{ parameters.ScriptingBackend }}"
 
 - task: PublishBuildArtifacts@1
-  enabled: $(parameters.PublishArtifacts)
+  enabled: ${{ parameters.PublishArtifacts }}
   displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'
   inputs:
     ArtifactName: 'mrtk-build-${{ parameters.Arch }}'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -13,8 +13,10 @@ steps:
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
    $editor = Get-ChildItem ${Env:$(UnityVersion)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
-   $outDir = "$(Build.ArtifactStagingDirectory)\build"
-   $logFile = New-Item -Path "$outDir\build\build_${{ parameters.Platform }}_${{ parameters.Arch }}.log" -ItemType File -Force
+   # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
+   # each build will have a fresh destination folder.
+   $outDir = "$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}"
+   $logFile = New-Item -Path "$outDir\build\build.log" -ItemType File -Force
    
    $sceneList = "Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples.unity"
    
@@ -58,5 +60,12 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
+      # The final location of the generated package depends on the type of scripting backend it's built against.
+      # For the default scripting backend (IL2CPP) the naming of the appx follows the form below:
+      - ${{ if eq(parameters.ScriptingBackend, 'default' }}:
+        PathtoPublish: '$outDir\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
+      # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
+      # names are reversed, and the Architecture is part of the AppX name)
+      - ${{ if eq(parameters.ScriptingBackend, '.NET' }}:
+        PathtoPublish: '$outDir\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'
       ArtifactName: 'mrtk-build-${{ parameters.Arch }}'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -57,7 +57,7 @@ steps:
   displayName: "Build ${{ parameters.Platform }} ${{ parameters.Arch }} ${{ parameters.ScriptingBackend }}"
 
 - task: PublishBuildArtifacts@1
-  enabled: parameters.PublishArtifacts
+  enabled: $(parameters.PublishArtifacts)
   displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'
   inputs:
     ArtifactName: 'mrtk-build-${{ parameters.Arch }}'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -66,6 +66,6 @@ steps:
         PathtoPublish: '$outDir\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
       # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
       # names are reversed, and the Architecture is part of the AppX name)
-      - ${{ if eq(parameters.ScriptingBackend, '.NET' }}:
+      - ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
         PathtoPublish: '$outDir\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'
       ArtifactName: 'mrtk-build-${{ parameters.Arch }}'

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -56,16 +56,16 @@ steps:
    Stop-Process $proc
   displayName: "Build ${{ parameters.Platform }} ${{ parameters.Arch }} ${{ parameters.ScriptingBackend }}"
 
-- ${{ if parameters.PublishArtifacts }}:
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'
-    inputs:
-      ArtifactName: 'mrtk-build-${{ parameters.Arch }}'
-      # The final location of the generated package depends on the type of scripting backend it's built against.
-      # For the default scripting backend (IL2CPP) the naming of the appx follows the form below:
-      ${{ if eq(parameters.ScriptingBackend, 'default') }}:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
-      # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
-      # names are reversed, and the Architecture is part of the AppX name)
-      ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'
+- task: PublishBuildArtifacts@1
+  enabled: parameters.PublishArtifacts
+  displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'
+  inputs:
+    ArtifactName: 'mrtk-build-${{ parameters.Arch }}'
+    # The final location of the generated package depends on the type of scripting backend it's built against.
+    # For the default scripting backend (IL2CPP) the naming of the appx follows the form below:
+    ${{ if eq(parameters.ScriptingBackend, 'default') }}:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\AppPackages\MixedRealityToolkit\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.PackagingDir }}_Master_Test'
+    # For .NET scripting backends, the naming is slightly different (mainly the AppPackages and MixedRealityToolkit folder
+    # names are reversed, and the Architecture is part of the AppX name)
+    ${{ if eq(parameters.ScriptingBackend, '.NET') }}:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\MixedRealityToolkit\AppPackages\MixedRealityToolkit_$(MRTKVersion).0_${{ parameters.Arch }}_Master_Test'


### PR DESCRIPTION
#3656

The folder destination of the appx package and its naming are also different when building C# projects, so instead of being in the build/AppPackages/MixedRealityToolkit folder, it's actually in the build/MixedRealityToolkit/AppPackages. And instead of the name MixedRealityToolkit_2.0.0.0_Win32_Master_Test, it's MixedRealityToolkit_2.0.0.0_x86_Master_Test. This will need to be a followup YAML pipeline switch on scripting backend.

Note that this change makes it run in CI and PR, which will increase times. Depending on duration we might look to split this step out into its own check (so that we can parallelize across machines). Note that simply replacing one of the other ones I'm not certain will work, because we depend on those existing pipelines to generate assemblies which get bundled into the final NuGet package.