### PR TITLE
Fix cursor not displaying on HoloLens 1

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -857,6 +857,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             var gazePointer = gazeProviderPointingData?.Pointer as GenericPointer;
             NumFarPointersActive = 0;
             NumNearPointersActive = 0;
+            int numFarPointersWithoutCursorActive = 0;
 
             foreach (var pointerData in pointers)
             {
@@ -867,7 +868,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         NumNearPointersActive++;
                     }
                 }
-                else if (pointerData.Pointer.BaseCursor != null
+                else if (
+                    // pointerData.Pointer.BaseCursor == null means this is a GGV Pointer
+                    pointerData.Pointer.BaseCursor != null
                     && !(pointerData.Pointer == gazePointer)
                     && pointerData.Pointer.IsInteractionEnabled)
                 {
@@ -875,12 +878,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // hand input or the gamepad, we want to show the cursor still.
                     NumFarPointersActive++;
                 }
+                else if (pointerData.Pointer.BaseCursor == null
+                    && pointerData.Pointer.IsInteractionEnabled)
+                {
+                    numFarPointersWithoutCursorActive++;
+                }
             }
             if (gazePointer != null)
             {
                 gazePointerStateMachine.UpdateState(
                     NumNearPointersActive,
                     NumFarPointersActive,
+                    numFarPointersWithoutCursorActive,
                     InputSystem.EyeGazeProvider.IsEyeGazeValid);
 
                 // The gaze cursor's visibility is controlled by IsInteractionEnabled

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazePointerVisibilityStateMachine.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazePointerVisibilityStateMachine.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Updates the state machine based on the number of near pointers, the number of far pointers,
         /// and whether or not eye gaze is valid.
         /// </summary>
-        public void UpdateState(int numNearPointersActive, int numFarPointersActive, bool isEyeGazeValid)
+        public void UpdateState(int numNearPointersActive, int numFarPointersActive, int numFarPointersWithoutCursorActive, bool isEyeGazeValid)
         {
             if (eyeGazeValid != isEyeGazeValid)
             {
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             else
             {
-                UpdateStateHeadGaze(numNearPointersActive, numFarPointersActive);
+                UpdateStateHeadGaze(numNearPointersActive, numFarPointersActive, numFarPointersWithoutCursorActive);
             }
         }
 
@@ -72,9 +72,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 GazePointerState.GazePointerInactive;
         }
 
-        private void UpdateStateHeadGaze(int numNearPointersActive, int numFarPointersActive)
+        private void UpdateStateHeadGaze(int numNearPointersActive, int numFarPointersActive, int numFarPointersWithoutCursorActive)
         {
-            bool canGazeCursorShow = numFarPointersActive == 1 && numNearPointersActive == 0;
+            bool canGazeCursorShow = numFarPointersActive == 0 && numNearPointersActive == 0;
             switch (gazePointerState)
             {
                 case GazePointerState.Initial:
@@ -96,6 +96,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 case GazePointerState.GazePointerInactive:
                     // Go from inactive to active if we say the word "select"
                     if (activateGazeKeywordIsSet)
+                    {
+                        activateGazeKeywordIsSet = false;
+                        gazePointerState = GazePointerState.GazePointerActive;
+                    }
+                    if (canGazeCursorShow && numFarPointersWithoutCursorActive > 0)
                     {
                         activateGazeKeywordIsSet = false;
                         gazePointerState = GazePointerState.GazePointerActive;

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/GazePointerStateMachineTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/GazePointerStateMachineTests.cs
@@ -24,33 +24,98 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             Assert.IsTrue(gsm.IsGazePointerActive, "Head gaze pointer should be visible on start");
 
             // After hand is raised, no pointer should show up;
-            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, false);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsFalse(gsm.IsGazePointerActive, "After hand is raised, head gaze pointer should go away");
 
             // After select called, pointer should show up again but only if no hands are up
             FireSelectKeyword(gsm);
             Assert.IsFalse(gsm.IsGazePointerActive, "After select is called but hands are up, head gaze pointer should not show up");
 
-            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, false);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             FireSelectKeyword(gsm);
-            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, false);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsTrue(gsm.IsGazePointerActive, "When no hands present and select called, head gaze pointer should show up");
 
             // Say select while gaze pointer is active, then raise hand. Gaze pointer should go away
             FireSelectKeyword(gsm);
-            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, false);
-            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, false);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsFalse(gsm.IsGazePointerActive, "After select called with hands present, then hand up, head gaze pointer should go away");
 
             // Simulate a scene with just the head gaze ray to reset the state such that
             // the head gaze pointer is active.
             FireSelectKeyword(gsm);
-            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, false);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsTrue(gsm.IsGazePointerActive, "Head gaze pointer should be visible with just the gaze pointer in the scene");
 
             // Simulate the addition of a far hand ray - the head gaze pointer should be hidden now.
-            gsm.UpdateState(0 /*numNearPointersActive*/, 2 /*numFarPointersActive*/, false);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 2 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsFalse(gsm.IsGazePointerActive, "Head gaze pointer should be hidden in the presence of another far pointer");
+        }
+
+        [Test]
+        /// <summary>
+        /// Tests scenarios when the hands are in HoloLens 1 mode (GGV behavior).
+        /// GGV stands for gaze, gesture, voice.
+        /// </summary>
+        public void TestHeadGazeHoloLens1GGV()
+        {
+            TestUtilities.InitializeMixedRealityToolkitScene(true);
+
+            // Initial state: gaze pointer active
+            var gsm = new GazePointerVisibilityStateMachine();
+            Assert.IsTrue(gsm.IsGazePointerActive, "Head gaze pointer should be visible on start");
+
+            // Note that in these tests numFarPointersWithoutCursorActive is 1 here. The GGV pointer is a pointer that does not have
+            // a base cursor associated with it, there is one of these for each hand.
+
+
+            // When a hand is raised in HoloLens 1 there will be no near pointers. Gaze cursor should stay on
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 2 /*numFarPointersWithoutCursorActive*/, false);
+            Assert.IsTrue(gsm.IsGazePointerActive, "After hand is raised, head gaze pointer should not go away");
+
+            // Saying "select" should have no impact on the state of HoloLens 1 interactions.
+            FireSelectKeyword(gsm);
+            Assert.IsTrue(gsm.IsGazePointerActive, "Saying 'select' should have no impact on HoloLens 1");
+        }
+
+        [Test]
+        /// <summary>
+        /// Tests scenarios when we have articulated hands (HoloLens 2), but the hands
+        /// are using the GGV pointers / we are emulating HoloLens 1 behavior
+        /// </summary>
+        public void TestHeadGazeGGVArticulatedHands()
+        {
+            TestUtilities.InitializeMixedRealityToolkitScene(true);
+
+            // Initial state: gaze pointer active
+            var gsm = new GazePointerVisibilityStateMachine();
+            Assert.IsTrue(gsm.IsGazePointerActive, "Head gaze pointer should be visible on start");
+
+            // Note that in these tests numFarPointersWithoutCursorActive is 1 here. The GGV pointer is a pointer that does not have
+            // a base cursor associated with it, there is one of these for each hand.
+
+            // When a hand is raised there will be a frame when the near pointer is active. Cursor should go away
+            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 2 /*numFarPointersWithoutCursorActive*/, false);
+            Assert.IsFalse(gsm.IsGazePointerActive, "After hand is raised, head gaze pointer should go away");
+
+            // Shortly after the near pointer for the hand will be disabled if there is nothing nearby
+            // The gaze cursor should now appear
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 2 /*numFarPointersWithoutCursorActive*/, false);
+            Assert.IsTrue(gsm.IsGazePointerActive, "If hand is not near anything, the gaze cursor should show up again (gaze cursor disappears when hand is near something)");
+
+            // If a near pointer appears again, the gaze cursor should go away
+            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 2 /*numFarPointersWithoutCursorActive*/, false);
+            Assert.IsFalse(gsm.IsGazePointerActive, "If hand goes near a grabbable, the gaze cursor should disappear");
+
+
+            // Saying "select" should have no impact on the state of interactions.
+            FireSelectKeyword(gsm);
+            Assert.IsFalse(gsm.IsGazePointerActive, "Saying 'select' should have no impact on GGV articulated hands");
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 2 /*numFarPointersWithoutCursorActive*/, false);
+            FireSelectKeyword(gsm);
+            Assert.IsTrue(gsm.IsGazePointerActive, "Saying 'select' should have no impact on GGV articulated hands");
+
         }
 
         [Test]
@@ -64,15 +129,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 
             // With the hand raised, eye gaze pointer should still exist because only far interaction causes the 
             // eye gaze pointer to go away.
-            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, true);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsTrue(gsm.IsGazePointerActive, "With near interaction, eye gaze pointer should continue to exist");
 
             // With far interaction active, eye gaze pointer should be hidden.
-            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, true);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsFalse(gsm.IsGazePointerActive, "With far interaction, eye gaze pointer should go away");
 
             // Reset the state and validate that it goes back to being visible.
-            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, true);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsTrue(gsm.IsGazePointerActive, "Eye gaze pointer should be visible when no near or far pointers");
 
             // Saying "select" should have no impact on the state of eye gaze-based interactions.
@@ -81,7 +146,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 
             // With far and near interaction active, eye gaze pointer should be hidden (because far interaction wins over
             // the eye gaze regardless of near interaction state).
-            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, true);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsFalse(gsm.IsGazePointerActive, "With far and near interaction, gaze pointer should go away");
         }
 
@@ -96,11 +161,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 
             // With the hand raised, eye gaze pointer should still exist because only far interaction causes the
             // eye gaze pointer to go away.
-            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, true);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsTrue(gsm.IsGazePointerActive, "With near interaction, gaze pointer should continue to exist");
 
             // With far interaction active, eye gaze pointer should be hidden.
-            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, true);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 1 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsFalse(gsm.IsGazePointerActive, "With far interaction, gaze pointer should go away");
 
             // Send a "select" command right now, to show that this cached select value doesn't affect the
@@ -113,12 +178,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             // because "select" wasn't spoken after the degredation happened.
             // A user saying "select" 10 minutes before shouldn't have that "select" invocation carry over
             // 10 minutes later.
-            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, false);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsFalse(gsm.IsGazePointerActive, "Gaze pointer should be inactive");
 
             // Saying select at this point should now show the eye gaze pointer.
             FireSelectKeyword(gsm);
-            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, false);
+            gsm.UpdateState(0 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsTrue(gsm.IsGazePointerActive, "Gaze pointer should be active");
         }
 
@@ -132,12 +197,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             Assert.IsTrue(gsm.IsGazePointerActive, "Gaze pointer should be visible on start");
 
             // The eye pointer should go away because a hand was raised and head gaze is active.
-            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, false);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, false);
             Assert.IsFalse(gsm.IsGazePointerActive, "With near interaction and head gaze, gaze pointer should be inactive");
 
             // After transitioning to eye gaze, the gaze pointer should now be active because near interaction
             // doesn't affect the visibility of eye-gaze style pointers.
-            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, true);
+            gsm.UpdateState(1 /*numNearPointersActive*/, 0 /*numFarPointersActive*/, 0 /*numFarPointersWithoutCursorActive*/, true);
             Assert.IsTrue(gsm.IsGazePointerActive, "With near interaction and eye gaze, gaze pointer should be active");
         }
 


### PR DESCRIPTION
## Overview
Fixes: #4510 while maintaining ability to show cursor when articulated hands are used in GGV mode.

Also add unit tests to cover HoloLens 1 and articulated hands in GGV.
