### PR TITLE
Centralize coordinate creation callback logic

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/ISpatialCoordinate.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/ISpatialCoordinate.cs
@@ -62,22 +62,26 @@ namespace Microsoft.MixedReality.Experimental.SpatialAlignment.Common
         LocatedState State { get; }
 
         /// <summary>
-        /// Converst world space position to coordinate space position.
+        /// Converts world space position to coordinate space position.
+        /// For example, applying this transform to Vector3.zero would return the position of the local application's world space origin in the coordinate space.
         /// </summary>
         Vector3 WorldToCoordinateSpace(Vector3 vector);
 
         /// <summary>
-        /// Converst world space rotation to coordinate space rotation.
+        /// Converts world space rotation to coordinate space rotation.
+        /// For example, applying this transform to Quaternion.identity would return the quaternion of the local application's world space origin in the coordinate space.
         /// </summary>
         Quaternion WorldToCoordinateSpace(Quaternion quaternion);
 
         /// <summary>
-        /// Converst coordinate space position to world space position.
+        /// Converts coordinate space position to world space position.
+        /// For example, applying this transform to Vector3.zero would return the position of the coordinate in the local application's world space.
         /// </summary>
         Vector3 CoordinateToWorldSpace(Vector3 vector);
 
         /// <summary>
-        /// Converst coordinate space position to world space position.
+        /// Converts coordinate space position to world space position.
+        /// For example, applying this transform to Quaternion.identity would return the quaternion of the coordinate in the local application's world space.
         /// </summary>
         Quaternion CoordinateToWorldSpace(Quaternion quaternion);
     }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/MarkerVisualizerSpatialLocalizer.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/MarkerVisualizerSpatialLocalizer.cs
@@ -19,22 +19,22 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         /// <inheritdoc/>
         protected override ISpatialCoordinateService SpatialCoordinateService => spatialCoordinateService;
 
-        internal override Task<Guid> InitializeAsync(Role role, CancellationToken cancellationToken)
+        internal override Task<Guid> InitializeAsync(LocalizerRole role, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        internal override Task<ISpatialCoordinate> LocalizeAsync(Role role, Guid token, Action<Action<BinaryWriter>> writeAndSendMessage, CancellationToken cancellationToken)
+        internal override Task<ISpatialCoordinate> LocalizeAsync(LocalizerRole role, Guid token, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        internal override void ProcessIncomingMessage(Role role, Guid token, BinaryReader r)
+        internal override bool TrySetCoordinateId(LocalizerRole role, Guid token, string coordinateId)
         {
             throw new NotImplementedException();
         }
 
-        internal override void Uninitialize(Role role, Guid token)
+        internal override void Uninitialize(LocalizerRole role, Guid token)
         {
             throw new NotImplementedException();
         }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialLocalizer.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialLocalizer.cs
@@ -10,6 +10,12 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
+    internal enum LocalizerRole
+    {
+        Creator,
+        Consumer
+    }
+
     /// <summary>
     /// Helper class to enable spatial localization between two entities on SpectatorView.
     /// </summary>
@@ -53,31 +59,29 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         /// <param name="role">The role of the requesting entity.</param>
         /// <param name="cancellationToken">The cancellation token to cancel this async operation.</param>
         /// <returns>The token representing this session, should be used for subsequent calls.</returns>
-        internal abstract Task<Guid> InitializeAsync(Role role, CancellationToken cancellationToken);
+        internal abstract Task<Guid> InitializeAsync(LocalizerRole role, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deinitializes the session.
         /// </summary>
         /// <param name="role">The role of the requesting entity.</param>
         /// <param name="token">The token representing the session.</param>
-        internal abstract void Uninitialize(Role role, Guid token);
+        internal abstract void Uninitialize(LocalizerRole role, Guid token);
 
         /// <summary>
-        /// Handles incoming message for the session.
+        /// Attempts to set a coordinate id. For some localizers a coordinate id must be specified.
         /// </summary>
         /// <param name="role">The role of the requesting entity.</param>
-        /// <param name="token">The token representing the session.</param>
-        /// <param name="r">The binary reader for the message.</param>
-        internal abstract void ProcessIncomingMessage(Role role, Guid token, BinaryReader r);
+        /// <param name="coordinateId">The coordinate id to use for localization.</param>
+        internal abstract bool TrySetCoordinateId(LocalizerRole role, Guid token, string coordinateId);
 
         /// <summary>
         /// Attempts to localize the given session.
         /// </summary>
         /// <param name="role">The role of the requesting entity.</param>
         /// <param name="token">The token representing the session.</param>
-        /// <param name="writeAndSendMessage">A function that allows the spatialLocalizer to write and send content to other devices.</param>
         /// <param name="cancellationToken">The cancellation token to cancel this async operation.</param>
         /// <returns>The spatial coordinate when this operation is complete.</returns>
-        internal abstract Task<ISpatialCoordinate> LocalizeAsync(Role role, Guid token, Action<Action<BinaryWriter>> writeAndSendMessage, CancellationToken cancellationToken);
+        internal abstract Task<ISpatialCoordinate> LocalizeAsync(LocalizerRole role, Guid token, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
There are some limitations/difficulties in using the current coordinate creation callback logic in the SpatialCoordinateSystemMember and SpatialLocalizer classes:

1) SpatialLocalizers were previously configured with an assumption that users will always create host spatial coordinates while spectators will always consume host spatial coordinates. This will not always be the case. For DSLR/editor based experiences, the editor/spectator may specify the id the of a coordinate, requiring the user to act as a consumer of said coordinate compared to the creator. Its also likely that mobile devices/spectators will declare coordinates when they show marker visuals while the user acts as the consumer of said declared coordinate in detecting the marker visual.

2) It feels less intuitive to persist state information through anonymous functions compared to class callbacks. There is interest in having the SpatialCoordinateSystemManager have a global picture of all user device locations/coordinates for debugging purposes. This seems easier to facilitate through callbacks to the SpatialCoordinateSystemManager on coordinate localization/network events compared to in the anonymous functions that were handed around previously.

3) The previous anonymous functions declared in SpatialLocalizerBase for network communication didn't easily allow for having the SpatialCoordinateSystemManager kick off coordinate creation/consumption. The current dslr spectator view experience will likely have buttons in the editor that tell both the user and spectator devices what coordinates to consume, which requires having the SpatialCoordinateSystemManager assign coordinate ids for consumer SpatialLocalizers. This wasn't previously possible and was directly linked to reading a network message.

Changes in this review based on above:

1) We now have SpatialLocalizers based on a LocalizerRole enum. For now, Role.Spectator/Role.User map 1:1 with LocalizerRole.Consumer/LocalizerRole.Creator. But this will change soon with the dslr work.

2) SpatialCoordinateSystemMembers are handed callback frunctions from the SpatialCoordinateSystemManager to inform the spatial coordinate system manager of coordinate localization.

3) Networking logic that had previously been facilitated through the SpatialCoordinateSystemMember is now rerouted to the SpatialCoordinateSystemManager. This will allow us to change how we do coordinate reporting. It is likely that we will want different spatial coordinate system participants to declare local coordinate transforms in network payloads to share with all other participants for debugging.

TODO:
1) WIth this change the SpatialCoordinateSystemManager will be informed of all ISpatialCoordinates and different device locations. Its likely that we should move the application of transforms to unity cameras to this class. In doing so, we will be able to have the shared scene origin conform to one of the spatial coordinate systems pariticipant's origins. This will make for more intuitive scene setup with marker detection.

2) We need to define a richer network message to send between devices. I believe that at the bare minimum each participant in the coordinate system needs to report their camera location in their local scene as well as all known coordinates with locations in their local scene