### PR TITLE
Added a C# event for handling pointer events to the input system

### DIFF
--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityPointerHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityPointerHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     }
 
     /// <summary>
-    /// Type of pointer event. Matches the methods defined in <see cref="IMixedRealityPointerHandler"/>
+    /// Type of pointer event. Matches the methods defined in <see cref="IMixedRealityPointerHandler"/>.
     /// </summary>
     public enum PointerEventType
     {
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     }
 
     /// <summary>
-    /// Delegate type for handling pointer events. Subscribe via <see cref="IMixedRealityInputSystem.PointerEvent"/>
+    /// Delegate type for handling pointer events. Subscribe via <see cref="IMixedRealityInputSystem.PointerEvent"/>.
     /// </summary>
     public delegate void PointerHandler(MixedRealityPointerEventData eventData, PointerEventType eventType);
 }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityPointerHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityPointerHandler.cs
@@ -34,4 +34,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="eventData"></param>
         void OnPointerClicked(MixedRealityPointerEventData eventData);
     }
+
+    /// <summary>
+    /// Type of pointer event. Matches the methods defined in <see cref="IMixedRealityPointerHandler"/>
+    /// </summary>
+    public enum PointerEventType
+    {
+        Down,
+        Up,
+        Dragged,
+        Clicked
+    }
+
+    /// <summary>
+    /// Delegate type for handling pointer events. Subscribe via <see cref="IMixedRealityInputSystem.PointerEvent"/>
+    /// </summary>
+    public delegate void PointerHandler(MixedRealityPointerEventData eventData, PointerEventType eventType);
 }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -220,6 +220,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region Pointers
 
+        /// <summary>
+        /// Event raised to notify of all pointer activity. This can be used as an alternative to implementing 
+        /// <see cref="IMixedRealityPointerHandler"/> and registering as a event system listener.
+        /// </summary>
+        event PointerHandler PointerEvent;
+
         #region Pointer Down
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityInputSystem.cs
@@ -221,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #region Pointers
 
         /// <summary>
-        /// Event raised to notify of all pointer activity. This can be used as an alternative to implementing 
+        /// Event raised to notify of pointer activity. This can be used as an alternative to implementing 
         /// <see cref="IMixedRealityPointerHandler"/> and registering as a event system listener.
         /// </summary>
         event PointerHandler PointerEvent;


### PR DESCRIPTION
This is so we can have global pointer event listeners that are not scripts. This is required for the upcoming PR addressing #3957 .

Fixes #4535 .