### PR TITLE
Prepare networking logic to support multiple headers.

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/ISpatialCoordinate.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Sharing/SpatialAlignment/Common/ISpatialCoordinate.cs
@@ -62,22 +62,26 @@ namespace Microsoft.MixedReality.Experimental.SpatialAlignment.Common
         LocatedState State { get; }
 
         /// <summary>
-        /// Converst world space position to coordinate space position.
+        /// Converts world space position to coordinate space position.
+        /// For example, applying this transform to Vector3.zero would return the position of the local application's world space origin in the coordinate space.
         /// </summary>
         Vector3 WorldToCoordinateSpace(Vector3 vector);
 
         /// <summary>
-        /// Converst world space rotation to coordinate space rotation.
+        /// Converts world space rotation to coordinate space rotation.
+        /// For example, applying this transform to Quaternion.identity would return the quaternion of the local application's world space origin in the coordinate space.
         /// </summary>
         Quaternion WorldToCoordinateSpace(Quaternion quaternion);
 
         /// <summary>
-        /// Converst coordinate space position to world space position.
+        /// Converts coordinate space position to world space position.
+        /// For example, applying this transform to Vector3.zero would return the position of the coordinate in the local application's world space.
         /// </summary>
         Vector3 CoordinateToWorldSpace(Vector3 vector);
 
         /// <summary>
-        /// Converst coordinate space position to world space position.
+        /// Converts coordinate space position to world space position.
+        /// For example, applying this transform to Quaternion.identity would return the quaternion of the coordinate in the local application's world space.
         /// </summary>
         Quaternion CoordinateToWorldSpace(Quaternion quaternion);
     }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/MarkerVisualizerSpatialLocalizer.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/MarkerDetection/MarkerVisualizerSpatialLocalizer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
             throw new NotImplementedException();
         }
 
-        internal override void ProcessIncomingMessage(Role role, Guid token, BinaryReader r)
+        internal override void ProcessIncomingMessage(Role role, Guid token, string command, BinaryReader r)
         {
             throw new NotImplementedException();
         }

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialCoordinateSystemManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialCoordinateSystemManager.cs
@@ -53,8 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         [Tooltip("Debug visual scale.")]
         public float debugVisualScale = 1.0f;
 
-        public const string SpatialLocalizationMessageHeader = "LOCALIZE";
-        readonly string[] supportedCommands = { SpatialLocalizationMessageHeader };
+        readonly string[] supportedCommands = { SpatialLocalizer.SpatialLocalizationMessageHeader };
         private Dictionary<SocketEndpoint, SpatialCoordinateSystemMember> members = new Dictionary<SocketEndpoint, SpatialCoordinateSystemMember>();
 
         public void OnConnected(SocketEndpoint endpoint)
@@ -100,20 +99,13 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 
         public void HandleCommand(SocketEndpoint endpoint, string command, BinaryReader reader)
         {
-            switch (command)
+            if (!members.TryGetValue(endpoint, out var member))
             {
-                case SpatialLocalizationMessageHeader:
-                    {
-                        if (!members.TryGetValue(endpoint, out var member))
-                        {
-                            Debug.LogError("Received a message for an endpoint that had no associated spatial coordinate system member");
-                        }
-                        else
-                        {
-                            member.ReceiveMessage(reader);
-                        }
-                    }
-                    break;
+                Debug.LogError("Received a message for an endpoint that had no associated spatial coordinate system member");
+            }
+            else
+            {
+                member.ReceiveMessage(command, reader);
             }
         }
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialLocalizer.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialLocalizer.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
     /// <remarks>In the future this would move to SpatialLocalization in a better form, abstraction-wise.</remarks>
     internal abstract class SpatialLocalizer : MonoBehaviour
     {
+        public const string SpatialLocalizationMessageHeader = "LOCALIZE";
+
         /// <summary>
         /// The spatial coordinate service for sub class to instantiate and this helper base to rely on.
         /// </summary>
@@ -67,8 +69,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         /// </summary>
         /// <param name="role">The role of the requesting entity.</param>
         /// <param name="token">The token representing the session.</param>
+        /// <param name="command">The command associated with the binary reader.</param>
         /// <param name="r">The binary reader for the message.</param>
-        internal abstract void ProcessIncomingMessage(Role role, Guid token, BinaryReader r);
+        internal abstract void ProcessIncomingMessage(Role role, Guid token, string command, BinaryReader r);
 
         /// <summary>
         /// Attempts to localize the given session.

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialLocalizerBase.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/SpatialLocalizerBase.cs
@@ -63,19 +63,22 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         }
 
         /// <inheritdoc/>
-        internal override void ProcessIncomingMessage(Role role, Guid token, BinaryReader r)
+        internal override void ProcessIncomingMessage(Role role, Guid token, string command, BinaryReader r)
         {
             DebugLog("Processing incoming message", token);
-            switch (role)
+            if (command == SpatialLocalizationMessageHeader)
             {
-                case Role.User:
-                    break;
-                case Role.Spectator:
-                    string result = r.ReadString();
-                    DebugLog($"Incoming message string: {result}, setting as coordinate id.", token);
-                    observerCoordinateIdToLookFor.TrySetResult(result);
-                    DebugLog("Set coordinate id.", token);
-                    break;
+                switch (role)
+                {
+                    case Role.User:
+                        break;
+                    case Role.Spectator:
+                        string result = r.ReadString();
+                        DebugLog($"Incoming message string: {result}, setting as coordinate id.", token);
+                        observerCoordinateIdToLookFor.TrySetResult(result);
+                        DebugLog("Set coordinate id.", token);
+                        break;
+                }
             }
         }
 
@@ -91,7 +94,12 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
                     DebugLog("User getting initialized coordinate", token);
                     coordinateToReturn = initializeUserCoordinateTask.Result;
                     DebugLog($"Sending coordinate id: {coordinateToReturn.Id}", token);
-                    writeAndSendMessage(writer => writer.Write(coordinateToReturn.Id));
+                    writeAndSendMessage(writer =>
+                    {
+                        writer.Write(SpatialLocalizationMessageHeader);
+                        writer.Write(coordinateToReturn.Id);
+                    });
+
                     DebugLog("Message sent.", token);
                     break;
 


### PR DESCRIPTION
1) We start handing around the command associated with a binary reader so that different commands can be interpretted.
2) We add richer documentation on how ISpatialCoordinate transforms should be used.