### PR TITLE
Fix potential infinite loop caused by InscribedRectangle

### DIFF
--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -906,7 +906,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             var boundaryGeometry = new List<Vector3>(0);
             var boundaryEdges = new List<Edge>(0);
 
-            if (UnityBoundary.TryGetGeometry(boundaryGeometry, UnityBoundary.Type.TrackedArea))
+            if (UnityBoundary.TryGetGeometry(boundaryGeometry, UnityBoundary.Type.TrackedArea) && boundaryGeometry.Count > 0)
             {
                 // FloorHeight starts out as null. Use a suitably high value for the floor to ensure
                 // that we do not accidentally set it too low.

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/InscribedRectangle.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/InscribedRectangle.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         {
             if (geometryEdges == null || geometryEdges.Length == 0)
             {
-                Debug.LogError("InscribedRectangle requires an array of Edges. You passed in a null or empty array");
+                Debug.LogError("InscribedRectangle requires an array of Edges. You passed in a null or empty array.");
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/InscribedRectangle.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/InscribedRectangle.cs
@@ -85,6 +85,12 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// </remarks>
         public InscribedRectangle(Edge[] geometryEdges, int randomSeed)
         {
+            if (geometryEdges == null || geometryEdges.Length == 0)
+            {
+                Debug.LogError("InscribedRectangle requires an array of Edges. You passed in a null or empty array");
+                return;
+            }
+
             // Clear previous rectangle
             Center = EdgeUtilities.InvalidPoint;
             Width = 0;


### PR DESCRIPTION
## Overview
In some cases, `UnityBoundary.TryGetGeometry` returns true but returns an empty list of boundary points.
In this case, we shouldn't try to create an inscribed rectangle.

## Changes
- Fixes: #4541