### PR TITLE
Added TextMeshPro support to the InteractableColorTheme

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -264,6 +264,35 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return false;
         }
+
+        public static bool HasTextComponentOnObject(GameObject host)
+        {
+            TextMeshPro tmp = host.GetComponent<TextMeshPro>();
+            if(tmp != null)
+            {
+                return true;
+            }
+
+            TextMeshProUGUI tmpUGUI = host.GetComponent<TextMeshProUGUI>();
+            if (tmpUGUI != null)
+            {
+                return true;
+            }
+
+            TextMesh mesh = host.GetComponent<TextMesh>();
+            if (mesh != null)
+            {
+                return true;
+            }
+
+            Text text = host.GetComponent<Text>();
+            if (text != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
         
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -13,8 +13,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
     {
         // caching methods to set and get colors from text object
         // this will avoid 4 if statements for every set or get
-        private delegate bool SetColorOnText(Color colour);
-        private delegate Color GetColorFromText(out bool success);
+        private delegate bool SetColorOnText(Color color);
+        private delegate bool GetColorFromText(out Color color);
         private SetColorOnText SetColorValue = null;
         private GetColorFromText GetColorValue = null;
 
@@ -44,37 +44,32 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             // check if a text object exists and get the color,
             // if not then fall back to renderer based color getting.
-            bool success = false;
             if (GetColorValue != null)
             {
-                color.Color = GetColorValue(out success);
+                GetColorValue(out color.Color);
                 return color;
             }
             else
             {
-                color.Color = GetTextMeshProColor(out success);
-                if (success)
+                if (GetTextMeshProColor(out color.Color))
                 {
                     GetColorValue = GetTextMeshProColor;
                     return color;
                 }
 
-                color.Color = GetTextMeshProUGUIColor(out success);
-                if (success)
+                if (GetTextMeshProUGUIColor(out color.Color))
                 {
                     GetColorValue = GetTextMeshProUGUIColor;
                     return color;
                 }
 
-                color.Color = GetTextMeshColor(out success);
-                if (success)
+                if (GetTextMeshColor(out color.Color))
                 {
                     GetColorValue = GetTextMeshColor;
                     return color;
                 }
 
-                color.Color = GetTextColor(out success);
-                if (success)
+                if (GetTextColor(out color.Color))
                 {
                     GetColorValue = GetTextColor;
                     return color;
@@ -130,17 +125,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="success"></param>
         /// <returns></returns>
-        protected Color GetTextColor(out bool success)
+        protected bool GetTextColor(out Color color)
         {
             Color colour = Color.white;
             Text text = Host.GetComponent<Text>();
             if (text != null)
             {
-                success = true;
-                return text.color;
+                color = text.color;
+                return true;
             }
-            success = false;
-            return colour;
+            color = colour;
+            return false;
         }
 
         /// <summary>
@@ -148,17 +143,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="success"></param>
         /// <returns></returns>
-        protected Color GetTextMeshColor(out bool success)
+        protected bool GetTextMeshColor(out Color color)
         {
             Color colour = Color.white;
             TextMesh mesh = Host.GetComponent<TextMesh>();
             if (mesh != null)
             {
-                success = true;
-                return mesh.color;
+                color = mesh.color;
+                return true;
             }
-            success = false;
-            return colour;
+            color = colour;
+            return false;
         }
 
         /// <summary>
@@ -166,17 +161,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="success"></param>
         /// <returns></returns>
-        protected Color GetTextMeshProColor(out bool success)
+        protected bool GetTextMeshProColor(out Color color)
         {
             Color colour = Color.white;
             TextMeshPro tmp = Host.GetComponent<TextMeshPro>();
             if (tmp)
             {
-                success = true;
-                return tmp.color;
+                color = tmp.color;
+                return true;
             }
-            success = false;
-            return colour;
+            color = colour;
+            return false;
         }
 
         /// <summary>
@@ -184,17 +179,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="success"></param>
         /// <returns></returns>
-        protected Color GetTextMeshProUGUIColor(out bool success)
+        protected bool GetTextMeshProUGUIColor(out Color color)
         {
             Color colour = Color.white;
             TextMeshProUGUI tmp = Host.GetComponent<TextMeshProUGUI>();
             if (tmp)
             {
-                success = true;
-                return tmp.color;
+                
+                color = tmp.color;
+                return true;
             }
-            success = false;
-            return colour;
+            
+            color = colour;
+            return false;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public InteractableColorTheme()
         {
-            Types = new Type[] { typeof(Renderer), typeof(TextMesh), typeof(Text) };
+            Types = new Type[] { typeof(Renderer), typeof(TextMesh), typeof(Text), typeof(TextMeshPro), typeof(TextMeshProUGUI) };
             Name = "Color Theme";
             ThemeProperties = new List<InteractableThemeProperty>();
             ThemeProperties.Add(

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -10,8 +11,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 {
     public class InteractableColorTheme : InteractableShaderTheme
     {
-        private TextMesh mesh;
-        private Text text;
+        // caching methods to set and get colors from text object
+        // this will avoid 4 if statements for every set or get
+        private delegate bool SetColorOnText(Color colour);
+        private delegate Color GetColorFromText(out bool success);
+        private SetColorOnText SetColorValue = null;
+        private GetColorFromText GetColorValue = null;
 
         public InteractableColorTheme()
         {
@@ -31,24 +36,49 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
-            mesh = Host.GetComponent<TextMesh>();
-            text = Host.GetComponent<Text>();
         }
 
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue color = new InteractableThemePropertyValue();
 
-            if (mesh != null)
+            // check if a text object exists and get the color,
+            // if not then fall back to renderer based color getting.
+            bool success = false;
+            if (GetColorValue != null)
             {
-                color.Color = mesh.color;
+                color.Color = GetTextColor(out success);
                 return color;
             }
-
-            if (text != null)
+            else
             {
-                color.Color = text.color;
-                return color;
+                color.Color = GetTextMeshProColor(out success);
+                if (success)
+                {
+                    GetColorValue = GetTextMeshProColor;
+                    return color;
+                }
+
+                color.Color = GetTextMeshProUGUIColor(out success);
+                if (success)
+                {
+                    GetColorValue = GetTextMeshProUGUIColor;
+                    return color;
+                }
+
+                color.Color = GetTextMeshColor(out success);
+                if (success)
+                {
+                    GetColorValue = GetTextMeshColor;
+                    return color;
+                }
+
+                color.Color = GetTextColor(out success);
+                if (success)
+                {
+                    GetColorValue = GetTextColor;
+                    return color;
+                }
             }
 
             return base.GetProperty(property);
@@ -58,20 +88,182 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Color color = Color.Lerp(property.StartValue.Color, property.Values[index].Color, percentage);
 
-            if (mesh != null)
+            // check if a text object exists and set the color,
+            // if not then fall back to renderer based color setting.
+            if (SetColorValue != null)
             {
-                mesh.color = color;
-                return;
+                SetTextColor(color);
+            }
+            else
+            {
+                if (SetTextMeshProColor(color))
+                {
+                    SetColorValue = SetTextMeshProColor;
+                    return;
+                }
+
+                if (SetTextMeshProUGUIColor(color))
+                {
+                    SetColorValue = SetTextMeshProUGUIColor;
+                    return;
+                }
+
+                if (SetTextMeshColor(color))
+                {
+                    SetColorValue = SetTextMeshColor;
+                    return;
+                }
+
+                if (SetTextColor(color))
+                {
+                    SetColorValue = SetTextColor;
+                    return;
+                }
             }
 
-            if (text != null)
-            {
-                text.color = color;
-                return;
-            }
-
-           base.SetValue(property, index, percentage);
+            base.SetValue(property, index, percentage);
 
         }
+
+        /// <summary>
+        /// Get color on UI Text
+        /// </summary>
+        /// <param name="success"></param>
+        /// <returns></returns>
+        protected Color GetTextColor(out bool success)
+        {
+            Color colour = Color.white;
+            Text text = Host.GetComponent<Text>();
+            if (text != null)
+            {
+                success = true;
+                return text.color;
+            }
+            success = false;
+            return colour;
+        }
+
+        /// <summary>
+        /// Get color from TextMesh
+        /// </summary>
+        /// <param name="success"></param>
+        /// <returns></returns>
+        protected Color GetTextMeshColor(out bool success)
+        {
+            Color colour = Color.white;
+            TextMesh mesh = Host.GetComponent<TextMesh>();
+            if (mesh != null)
+            {
+                success = true;
+                return mesh.color;
+            }
+            success = false;
+            return colour;
+        }
+
+        /// <summary>
+        /// Get color from TextMeshPro
+        /// </summary>
+        /// <param name="success"></param>
+        /// <returns></returns>
+        protected Color GetTextMeshProColor(out bool success)
+        {
+            Color colour = Color.white;
+            TextMeshPro tmp = Host.GetComponent<TextMeshPro>();
+            if (tmp)
+            {
+                success = true;
+                return tmp.color;
+            }
+            success = false;
+            return colour;
+        }
+
+        /// <summary>
+        /// Get color from TextMeshProUGUI
+        /// </summary>
+        /// <param name="success"></param>
+        /// <returns></returns>
+        protected Color GetTextMeshProUGUIColor(out bool success)
+        {
+            Color colour = Color.white;
+            TextMeshProUGUI tmp = Host.GetComponent<TextMeshProUGUI>();
+            if (tmp)
+            {
+                success = true;
+                return tmp.color;
+            }
+            success = false;
+            return colour;
+        }
+
+        /// <summary>
+        /// Set color on UI Text
+        /// </summary>
+        /// <param name="colour"></param>
+        /// <returns></returns>
+        protected bool SetTextColor(Color colour)
+        {
+            Text text = Host.GetComponent<Text>();
+            if (text != null)
+            {
+                text.color = colour;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Set color on TextMesh
+        /// </summary>
+        /// <param name="colour"></param>
+        /// <returns></returns>
+        protected bool SetTextMeshColor(Color colour)
+        {
+            TextMesh mesh = Host.GetComponent<TextMesh>();
+            if (mesh != null)
+            {
+                mesh.color = colour;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Set color on TextMeshPro
+        /// </summary>
+        /// <param name="colour"></param>
+        /// <returns></returns>
+        protected bool SetTextMeshProColor(Color colour)
+        {
+            TextMeshPro tmp = Host.GetComponent<TextMeshPro>();
+            if (tmp)
+            {
+                tmp.color = colour;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Set color on TextMeshProUGUI
+        /// </summary>
+        /// <param name="colour"></param>
+        /// <returns></returns>
+        protected bool SetTextMeshProUGUIColor(Color colour)
+        {
+            TextMeshProUGUI tmp = Host.GetComponent<TextMeshProUGUI>();
+            if (tmp)
+            {
+                tmp.color = colour;
+                return true;
+            }
+
+            return false;
+        }
+        
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             bool success = false;
             if (GetColorValue != null)
             {
-                color.Color = GetTextColor(out success);
+                color.Color = GetColorValue(out success);
                 return color;
             }
             else
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // if not then fall back to renderer based color setting.
             if (SetColorValue != null)
             {
-                SetTextColor(color);
+                SetColorValue(color);
             }
             else
             {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ScaleOffsetColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/ScaleOffsetColorTheme.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI
@@ -23,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public ScaleOffsetColorTheme()
         {
-            Types = new Type[] { typeof(Transform), typeof(TextMesh), typeof(TextMesh), typeof(Renderer) };
+            Types = new Type[] { typeof(Transform), typeof(TextMesh), typeof(TextMesh), typeof(TextMeshPro), typeof(TextMeshProUGUI), typeof(Renderer) };
             Name = "Default: Scale, Offset, Color";
             ThemeProperties = new List<InteractableThemeProperty>();
             ThemeProperties.Add(

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
@@ -855,9 +855,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                             if (renderHost != null)
                             {
                                 Renderer renderer = renderHost.GetComponent<Renderer>();
-                                TextMesh mesh = renderHost.GetComponent<TextMesh>();
-                                Text text = renderHost.GetComponent<Text>();
-                                hasTextComp = text != null || mesh != null;
+                                hasTextComp = InteractableColorTheme.HasTextComponentOnObject(renderHost);
                                 if (renderer != null && !hasTextComp)
                                 {
                                     ShaderPropertyType[] filter = new ShaderPropertyType[0];

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
@@ -909,7 +909,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         }
                         else
                         {
-                            EditorGUILayout.LabelField(new GUIContent("Text Property: " + (InteractableThemePropertyValueTypes)propId.intValue));
+                            EditorGUILayout.LabelField(new GUIContent("Text Property: Color"));
                         }
 
                         // Handle issue where the material color id renders on objects it shouldn't!!!!!!!!!!!!!!


### PR DESCRIPTION
## Overview
The InteractableColorTheme will color meshRenderers, as well as Text objects. Previously it only set the color fields of UI Text and TextMesh objects.

## Changes
- Fixes: #4551 .


## Verification
- Different Text objects will be effected by color changes from the InteractableColorTheme and ScaleOffsetColorTheme.
- Renderers are the fall back option.
- Theme does not show shader property drop down when the target is a text base object.
- Only does the check for each text object once, then will use a delegate to apply colors is a text object exists.
