### PR TITLE
Added to doc: Input event handlers need to be registered to receive events. 

### DIFF
--- a/Documentation/Input/InputEvents.md
+++ b/Documentation/Input/InputEvents.md
@@ -1,5 +1,6 @@
 # Input Events
 
+## Input event handlers need to be registered to receive events.
 At the script level you consume input events by implementing one of the event handler interfaces:
 
 Handler | Events | Description

--- a/Documentation/Input/InputEvents.md
+++ b/Documentation/Input/InputEvents.md
@@ -1,11 +1,11 @@
 # Input Events
 
-**Input event handlers need to be registered to receive events.**
-By default a script will receive events only while in focus by a pointer. To receive events while out of focus, in addition to implementing the desired handler interfaces, you have to do one of the following:
-- Register the script's game object as a global listener via [`MixedRealityToolkit.InputSystem.Register`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityEventSystem).
-- Derive the script from [`InputSystemGlobalListener`](xref:Microsoft.MixedReality.Toolkit.Input.InputSystemGlobalListener).
+At the script level you consume input events by implementing one of the event handler interfaces shown in the table below.
 
-At the script level you consume input events by implementing one of the event handler interfaces:
+> [!IMPORTANT]
+> By default a script will receive events only while in focus by a pointer. To receive events while out of focus, in addition to implementing the desired handler interfaces, you have to do one of the following:
+> - Register the script's game object as a global listener via [`MixedRealityToolkit.InputSystem.Register`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityEventSystem).
+> - Derive the script from [`InputSystemGlobalListener`](xref:Microsoft.MixedReality.Toolkit.Input.InputSystemGlobalListener).
 
 Handler | Events | Description
 --- | --- | ---

--- a/Documentation/Input/InputEvents.md
+++ b/Documentation/Input/InputEvents.md
@@ -1,6 +1,10 @@
 # Input Events
 
-## Input event handlers need to be registered to receive events.
+**Input event handlers need to be registered to receive events.**
+By default a script will receive events only while in focus by a pointer. To receive events while out of focus, in addition to implementing the desired handler interfaces, you have to do one of the following:
+- Register the script's game object as a global listener via [`MixedRealityToolkit.InputSystem.Register`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityEventSystem).
+- Derive the script from [`InputSystemGlobalListener`](xref:Microsoft.MixedReality.Toolkit.Input.InputSystemGlobalListener).
+
 At the script level you consume input events by implementing one of the event handler interfaces:
 
 Handler | Events | Description
@@ -16,6 +20,3 @@ Handler | Events | Description
 [`IMixedRealityHandJointHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandJointHandler) | Hand Joints Updated | Raised by articulated hand controllers when hand joints are updated.
 [`IMixedRealityHandMeshHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandMeshHandler) | Hand Mesh Updated |  Raised by articulated hand controllers when a hand mesh is updated.
 
-By default a script will receive events only while in focus by a pointer. To receive events while out of focus, in addition to implementing the desired handler interfaces, you have to do one of the following:
-- Register the script's game object as a global listener via [`MixedRealityToolkit.InputSystem.Register`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityEventSystem).
-- Derive the script from [`InputSystemGlobalListener`](xref:Microsoft.MixedReality.Toolkit.Input.InputSystemGlobalListener).


### PR DESCRIPTION
Feedback from Berlin 

This is a common issue with new devs, so may be a good idea to say it more prominently