### PR TITLE
Removing build.ps1 step from our pipelines

### DIFF
--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -25,19 +25,6 @@ steps:
     PublishArtifacts: true
     ScriptingBackend: '.NET'
 
-- powershell: |
-   $AutoMrtkVersion = Get-Date -format "dd.MM.yyyy"
-   .\build.ps1 -Version $AutoMrtkVersion -NoNuget -Verbose
-  displayName: 'Build Unity packages'
-
-- powershell: |
-   Get-ChildItem "." -Filter Build-UnityPackage*.log | 
-   Foreach-Object {
-       echo "=======================" "Contents of log file $_.FullName:" "======================="
-       Get-Content $_.FullName
-   }
-  displayName: 'Echo packaging logs'
-
 # Build Standalone x86
 - template: tasks/unitybuild.yml
   parameters:

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -27,7 +27,7 @@ steps:
 
 - powershell: |
    $AutoMrtkVersion = Get-Date -format "dd.MM.yyyy"
-   .\build.ps1 -Version $AutoMrtkVersion -NoNuget
+   .\build.ps1 -Version $AutoMrtkVersion -NoNuget -Verbose
   displayName: 'Build Unity packages'
 
 - powershell: |


### PR DESCRIPTION
This step is only creating .unitypackages now. This is no longer necessary for all of our builds. We may need this again for our internal packaging/signing pipeline, but until then we are removing this step.

This will fix an error we are currently seeing on CI.