### PR TITLE
BoundingBox Fix rig when parent of has non uniform scale

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/BoundingBox/Scripts/BoundingBoxTest.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/BoundingBox/Scripts/BoundingBoxTest.cs
@@ -118,13 +118,13 @@ public class BoundingBoxTest : InputSystemGlobalListener, IMixedRealitySpeechHan
 
             SetStatus("Scale X and update rig");
             cube.transform.localScale = new Vector3(2, 1, 1);
-            bbox.UpdateRig();
+            bbox.CreateRig();
             yield return WaitForSpeechCommand();
 
             SetStatus("Rotate 20 degrees and update rig");
             cube.transform.localRotation = Quaternion.Euler(0, 20, 0);
             bbox.ShowRotationHandleForY = true;
-            bbox.UpdateRig();
+            bbox.CreateRig();
             yield return WaitForSpeechCommand();
 
             SetStatus("Wireframe radius 0.1");

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/BoundingBox/Scripts/BoundingBoxTest.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/BoundingBox/Scripts/BoundingBoxTest.cs
@@ -116,6 +116,17 @@ public class BoundingBoxTest : InputSystemGlobalListener, IMixedRealitySpeechHan
             bbox.BoxMaterial = null;
             yield return WaitForSpeechCommand();
 
+            SetStatus("Scale X and update rig");
+            cube.transform.localScale = new Vector3(2, 1, 1);
+            bbox.UpdateRig();
+            yield return WaitForSpeechCommand();
+
+            SetStatus("Rotate 20 degrees and update rig");
+            cube.transform.localRotation = Quaternion.Euler(0, 20, 0);
+            bbox.ShowRotationHandleForY = true;
+            bbox.UpdateRig();
+            yield return WaitForSpeechCommand();
+
             SetStatus("Wireframe radius 0.1");
             bbox.WireframeEdgeRadius = 0.1f;
             yield return WaitForSpeechCommand();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -705,6 +705,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        /// <summary>
+        /// Destroys and re-creates the rig around the bounding box
+        /// </summary>
+        public void UpdateRig()
+        {
+            CreateRig();
+        }
+
         #endregion
 
         #region MonoBehaviour Methods
@@ -744,6 +752,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion MonoBehaviour Methods
 
         #region Private Methods
+
         private void CreateRig()
         {
             DestroyRig();
@@ -760,7 +769,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             rigRoot.gameObject.SetActive(active);
             UpdateRigVisibilityInInspector();
         }
-
         private void DestroyRig()
         {
             if (boundsOverride == null)
@@ -1563,7 +1571,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void UpdateBounds()
         {
-
             if (cachedTargetCollider != null)
             {
                 // Store current rotation then zero out the rotation so that the bounds
@@ -1602,6 +1609,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (rigRoot != null && Target != null)
             {
+                // We move the rigRoot to the scene root to ensure that non-uniform scaling performed
+                // anywhere above the rigRoot does not impact the position of rig corners / edges
+                rigRoot.parent = null;
+
                 rigRoot.rotation = Quaternion.identity;
                 rigRoot.position = Vector3.zero;
 
@@ -1648,6 +1659,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 //move rig into position and rotation
                 rigRoot.position = cachedTargetCollider.bounds.center;
                 rigRoot.rotation = Target.transform.rotation;
+
+                rigRoot.parent = transform;
             }
         }
         private HandleType GetHandleType(Transform handle)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -708,11 +708,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Destroys and re-creates the rig around the bounding box
         /// </summary>
-        public void UpdateRig()
+        public void CreateRig()
         {
-            CreateRig();
+            DestroyRig();
+            SetMaterials();
+            InitializeDataStructures();
+            SetBoundingBoxCollider();
+            UpdateBounds();
+            AddCorners();
+            AddLinks();
+            AddBoxDisplay();
+            UpdateRigHandles();
+            Flatten();
+            ResetHandleVisibility();
+            rigRoot.gameObject.SetActive(active);
+            UpdateRigVisibilityInInspector();
         }
-
         #endregion
 
         #region MonoBehaviour Methods
@@ -753,22 +764,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region Private Methods
 
-        private void CreateRig()
-        {
-            DestroyRig();
-            SetMaterials();
-            InitializeDataStructures();
-            SetBoundingBoxCollider();
-            UpdateBounds();
-            AddCorners();
-            AddLinks();
-            AddBoxDisplay();
-            UpdateRigHandles();
-            Flatten();
-            ResetHandleVisibility();
-            rigRoot.gameObject.SetActive(active);
-            UpdateRigVisibilityInInspector();
-        }
         private void DestroyRig()
         {
             if (boundsOverride == null)

--- a/Assets/MixedRealityToolkit/Extensions/BoundsExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/BoundsExtensions.cs
@@ -91,11 +91,11 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Gets all the corner points of the bounds in world space
+        /// Gets all the corner points of the bounds in world space by transforming input bounds using the given transform
         /// </summary>
-        /// <param name="transform"></param>
-        /// <param name="positions"></param>
-        /// <param name="bounds"></param>
+        /// <param name="transform">Local to world transform</param>
+        /// <param name="positions">Output corner positions</param>
+        /// <param name="bounds">Input bounds, in local space</param>
         /// <remarks>
         /// Use BoxColliderExtensions.{Left|Right}{Bottom|Top}{Front|Back} consts to index into the output
         /// corners array.
@@ -131,7 +131,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Gets all the corner points of the bounds in local space
+        /// Gets all the corner points of the bounds 
         /// </summary>
         /// <param name="transform"></param>
         /// <param name="positions"></param>


### PR DESCRIPTION
## Changes
- Fixes: #4151
- Add test to BoundingBox test scene to repro the issue and verify the fix
- Expose method BoundingBox.UpdateRig() developers can use to force the bounding box rig to update.

## Verification

> As a reviewer, it is possible to check out this change locally by using the following
> commands
>
> git fetch origin pull/4592/head:name_of_local_branch
>
> git checkout name_of_local_branch
