### PR TITLE
Add IMixedRealityDataProviderAccess and update how data providers are retrieved

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBase.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBase.cs
@@ -123,8 +123,21 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         protected Vector2 originalScale;
         protected Vector2 originalOffset;
 
-        protected IMixedRealityEyeSaccadeProvider EyeSaccadeProvider => eyeSaccadeProvider ?? (eyeSaccadeProvider = MixedRealityToolkit.Instance.GetService<IMixedRealityEyeSaccadeProvider>());
         private IMixedRealityEyeSaccadeProvider eyeSaccadeProvider = null;
+
+        protected IMixedRealityEyeSaccadeProvider EyeSaccadeProvider
+        {
+            get
+            {
+                if (eyeSaccadeProvider == null)
+                {
+                    IMixedRealityEyeGazeDataProvider eyeGazeProvider = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityEyeGazeDataProvider>();
+                    eyeSaccadeProvider = eyeGazeProvider?.SaccadeProvider;
+                }
+                return eyeSaccadeProvider;
+            }
+        }
+
         #endregion
 
         private IMixedRealityInputSystem inputSystem = null;

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -40,6 +40,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         public bool SmoothEyeTracking { get; set; } = false;
 
+        public IMixedRealityEyeSaccadeProvider SaccadeProvider => this;
+
         private readonly float smoothFactorNormalized = 0.96f;
         private readonly float saccadeThreshInDegree = 2.5f; // In degrees (not radians)
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DictationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DictationHandler.cs
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.Start();
 
-            dictationSystem = MixedRealityToolkit.Instance.GetService<IMixedRealityDictationSystem>();
+            dictationSystem = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityDictationSystem>();
             Debug.Assert(dictationSystem != null, "No dictation system found. In order to use dictation, add a dictation system like 'Windows Dictation Input Provider' to the Data Providers in the Input System profile");
 
             if (startRecordingOnStart)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -54,8 +54,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override bool IsInteractionEnabled => isInteractionEnabled;
 
         private IMixedRealityController controller;
+
         private MixedRealityMouseInputProfile mouseInputProfile = null;
-        private MixedRealityMouseInputProfile MouseInputProfile => mouseInputProfile ?? (mouseInputProfile = MixedRealityToolkit.Instance.GetService<MouseDeviceManager>()?.MouseInputProfile);
+
+        private MixedRealityMouseInputProfile MouseInputProfile
+        {
+            get
+            {
+                if (mouseInputProfile == null)
+                {
+                    // Get the profile from the input system's registered mouse device manager.
+                    IMixedRealityMouseDeviceManager mouseManager = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityMouseDeviceManager>();
+                    mouseInputProfile = mouseManager?.MouseInputProfile;
+                }
+                return mouseInputProfile;
+            }
+        }
 
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// <summary>
         /// The active instance of the input system.
         /// </summary>
-        private IMixedRealityInputSystem InputSystem
+        protected IMixedRealityInputSystem InputSystem
         {
             get
             {

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         private GameObject transformWithOffset;
 
-        private IMixedRealityHandJointService HandJointService => handJointService ?? (handJointService = MixedRealityToolkit.Instance.GetService<IMixedRealityHandJointService>());
+        private IMixedRealityHandJointService HandJointService => handJointService ?? (handJointService = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityHandJointService>());
         private IMixedRealityHandJointService handJointService = null;
 
         #region MonoBehaviour Implementation

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         "Profiles/DefaultMixedRealityInputSimulationProfile.asset",
         "MixedRealityToolkit.SDK")]
     [DocLink("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/InputSimulation/InputSimulationService.html")]
-    public class InputSimulationService : BaseInputDeviceManager, IInputSimulationService
+    public class InputSimulationService : BaseInputDeviceManager, IInputSimulationService, IMixedRealityEyeGazeDataProvider
     {
         private ManualCameraControl cameraControl = null;
         private SimulatedHandDataProvider handDataProvider = null;
@@ -49,8 +49,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public InputSimulationService(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            string name, 
-            uint priority, 
+            string name,
+            uint priority,
             BaseMixedRealityProfile profile) : base(registrar, inputSystem, name, priority, profile) { }
 
         /// <inheritdoc />
@@ -97,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (profile.SimulateEyePosition)
             {
-                InputSystem?.EyeGazeProvider?.UpdateEyeGaze(null, new Ray(CameraCache.Main.transform.position, CameraCache.Main.transform.forward), System.DateTime.UtcNow);
+                InputSystem?.EyeGazeProvider?.UpdateEyeGaze(this, new Ray(CameraCache.Main.transform.position, CameraCache.Main.transform.forward), DateTime.UtcNow);
             }
 
             switch (profile.HandSimulationMode)
@@ -162,6 +162,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return inputSimulationProfile;
             }
         }
+
+        /// <inheritdoc/>
+        IMixedRealityEyeSaccadeProvider IMixedRealityEyeGazeDataProvider.SaccadeProvider => null;
+
+        /// <inheritdoc/>
+        bool IMixedRealityEyeGazeDataProvider.SmoothEyeTracking { get; set; }
 
         private void EnableCameraControl()
         {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// The Mixed Reality Toolkit's specific implementation of the <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityInputSystem"/>
     /// </summary>
     [DocLink("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Overview.html")]
-    public class MixedRealityInputSystem : BaseCoreSystem, IMixedRealityInputSystem
+    public class MixedRealityInputSystem : BaseCoreSystem, IMixedRealityInputSystem, IMixedRealityDataProviderAccess
     {
         public MixedRealityInputSystem(
             IMixedRealityServiceRegistrar registrar,
@@ -271,6 +271,66 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         #endregion IMixedRealityService Implementation
+
+        #region GetDataProvider(s) Implementation
+        /// <inheritdoc />
+        public IReadOnlyList<IMixedRealityDataProvider> GetDataProviders()
+        {
+            return new List<IMixedRealityInputDeviceManager>(deviceManagers) as IReadOnlyList<IMixedRealityInputDeviceManager>;
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<T> GetDataProviders<T>() where T : IMixedRealityDataProvider
+        {
+            if (!typeof(IMixedRealityInputDeviceManager).IsAssignableFrom(typeof(T))) { return null; }
+
+            List<T> selected = new List<T>();
+
+            for (int i = 0; i < deviceManagers.Count; i++)
+            {
+                if (deviceManagers[i] is T)
+                {
+                    selected.Add((T)deviceManagers[i]);
+                }
+            }
+
+            return selected;
+        }
+
+        /// <inheritdoc />
+        public IMixedRealityDataProvider GetDataProvider(string name)
+        {
+            for (int i = 0; i < deviceManagers.Count; i++)
+            {
+                if (deviceManagers[i].Name == name)
+                {
+                    return deviceManagers[i];
+                }
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        public T GetDataProvider<T>(string name = null) where T : IMixedRealityDataProvider
+        {
+            if (!typeof(IMixedRealityInputDeviceManager).IsAssignableFrom(typeof(T))) { return default(T); }
+
+            for (int i = 0; i < deviceManagers.Count; i++)
+            {
+                if (deviceManagers[i] is T)
+                {
+                    if ((name == null) || (deviceManagers[i].Name == name))
+                    {
+                        return (T)deviceManagers[i];
+                    }
+                }
+            }
+
+            return default(T);
+        }
+
+        #endregion GetDataProvider(s) Implementation
 
         #region IMixedRealityEventSystem Implementation
 

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -193,11 +193,24 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc />
         public IReadOnlyList<IMixedRealitySpatialAwarenessObserver> GetObservers()
         {
+            return GetDataProviders() as IReadOnlyList<IMixedRealitySpatialAwarenessObserver>;
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<IMixedRealityDataProvider> GetDataProviders()
+        {
             return new List<IMixedRealitySpatialAwarenessObserver>(observers) as IReadOnlyList<IMixedRealitySpatialAwarenessObserver>;
         }
-        
+
         /// <inheritdoc />
         public IReadOnlyList<T> GetObservers<T>() where T : IMixedRealitySpatialAwarenessObserver
+        {
+            return GetDataProviders<T>();
+        }
+
+
+        /// <inheritdoc />
+        public IReadOnlyList<T> GetDataProviders<T>() where T : IMixedRealityDataProvider
         {
             List<T> selected = new List<T>();
 
@@ -215,6 +228,12 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc />
         public IMixedRealitySpatialAwarenessObserver GetObserver(string name)
         {
+            return GetDataProvider(name) as IMixedRealitySpatialAwarenessObserver;
+        }
+
+        /// <inheritdoc />
+        public IMixedRealityDataProvider GetDataProvider(string name)
+        {
             for (int i = 0; i < observers.Count; i++)
             {
                 if (observers[i].Name == name)
@@ -227,13 +246,22 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         }
 
         /// <inheritdoc />
-        public T GetObserver<T>(string name) where T : IMixedRealitySpatialAwarenessObserver
+        public T GetObserver<T>(string name = null) where T : IMixedRealitySpatialAwarenessObserver
+        {
+            return GetDataProvider<T>(name);
+        }
+
+        /// <inheritdoc />
+        public T GetDataProvider<T>(string name = null) where T : IMixedRealityDataProvider
         {
             for (int i = 0; i < observers.Count; i++)
             {
-                if ((observers[i] is T) && (observers[i].Name == name))
+                if (observers[i] is T)
                 {
-                    return (T)observers[i];
+                    if ((name == null) || (observers[i].Name == name))
+                    {
+                        return (T)observers[i];
+                    }
                 }
             }
 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_03_InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_03_InputSystemTests.cs
@@ -44,7 +44,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             TestUtilities.InitializeMixedRealityToolkitScene(true);
 
             // Retrieve Input System
-            var inputSystem = MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>();
+            IMixedRealityInputSystem inputSystem = null;
+            MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
 
             // Tests
             Assert.IsNotNull(inputSystem);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // raise hand up -- gaze cursor should no longer be visible
             // disable user input
-            InputSimulationService inputSimulationService = MixedRealityToolkit.Instance.GetService<InputSimulationService>();
+            InputSimulationService inputSimulationService = (inputSystem as IMixedRealityDataProviderAccess).GetDataProvider<InputSimulationService>();
             Assert.IsNotNull(inputSimulationService, "InputSimulationService is null!");
 
             inputSimulationService.UserInputEnabled = false;

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -93,14 +93,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             internal set { gesturesProfile = value; }
         }
 
-
-        private IMixedRealitySpeechSystem speechSystem;
-
-        /// <summary>
-        /// Current Registered Speech System.
-        /// </summary>
-        public IMixedRealitySpeechSystem SpeechSystem => speechSystem ?? (speechSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySpeechSystem>());
-
         /// <summary>
         /// The list of cultures where speech recognition is supported
         /// </summary>
@@ -130,11 +122,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        /// <summary>
-        /// Is the speech Commands Enabled?
-        /// </summary>
-        public bool IsSpeechCommandsEnabled => speechCommandsProfile != null && SpeechSystem != null && MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled;
-
         [SerializeField]
         [Tooltip("Speech Command profile for wiring up Voice Input to Actions.")]
         private MixedRealitySpeechCommandsProfile speechCommandsProfile;
@@ -147,18 +134,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return speechCommandsProfile; }
             internal set { speechCommandsProfile = value; }
         }
-
-        private IMixedRealityDictationSystem dictationSystem;
-
-        /// <summary>
-        /// Current Registered Dictation System.
-        /// </summary>
-        public IMixedRealityDictationSystem DictationSystem => dictationSystem ?? (dictationSystem = MixedRealityToolkit.Instance.GetService<IMixedRealityDictationSystem>());
-
-        /// <summary>
-        /// Is Dictation Enabled?
-        /// </summary>
-        public bool IsDictationEnabled => MixedRealityToolkit.Instance.ActiveProfile.IsInputSystemEnabled && DictationSystem != null;
 
         [SerializeField]
         [Tooltip("Enable and configure the devices for your application.")]

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityEyeGazeDataProvider.cs
@@ -6,8 +6,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Provides eye tracking information.
     /// </summary>
-    public interface IMixedRealityEyeGazeDataProvider : IMixedRealityDataProvider
+    public interface IMixedRealityEyeGazeDataProvider : IMixedRealityInputDeviceManager
     {
+        IMixedRealityEyeSaccadeProvider SaccadeProvider { get; }
+
         bool SmoothEyeTracking { get; set; }
     }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Input;
+
+/// <summary>
+/// Interface defining a mouse input device manager.
+/// </summary>
+public interface IMixedRealityMouseDeviceManager : IMixedRealityInputDeviceManager
+{
+    /// <summary>
+    /// Typed representation of the ConfigurationProfile property.
+    /// </summary>
+    MixedRealityMouseInputProfile MouseInputProfile { get; }
+}

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b014c73ce8cb9004eac769b5b3271ac3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityDataProviderAccess.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityDataProviderAccess.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.MixedReality.Toolkit
+{
+    /// <summary>
+    /// Allows systems to provide access to their managed data providers.
+    /// </summary>
+    public interface IMixedRealityDataProviderAccess
+    {
+        /// <summary>
+        /// Gets the collection of registered data providers.
+        /// </summary>
+        /// <returns>
+        /// Read only copy of the list of registered data providers.
+        /// </returns>
+        IReadOnlyList<IMixedRealityDataProvider> GetDataProviders();
+
+        /// <summary>
+        /// Get the collection of registered observers of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The desired data provider type</typeparam>
+        /// <returns>
+        /// Read-only copy of the list of registered data providers that implement the specified type.
+        /// </returns>
+        IReadOnlyList<T> GetDataProviders<T>() where T : IMixedRealityDataProvider;
+
+        /// <summary>
+        /// Get the data provider that is registered under the specified name.
+        /// </summary>
+        /// <param name="name">The friendly name of the data provider.</param>
+        /// <returns>
+        /// The requested data provider, or null if one cannot be found.
+        /// </returns>
+        /// <remarks>
+        /// If more than one data provider is registered under the specified name, the first will be returned.
+        /// </remarks>
+        IMixedRealityDataProvider GetDataProvider(string name);
+
+        /// <summary>
+        /// Get the data provider that is registered under the specified name (optional) and matching the specified type.
+        /// </summary>
+        /// <typeparam name="T">The desired data provider type.</typeparam>
+        /// <param name="name">The friendly name of the data provider.</param>
+        /// <returns>
+        /// The requested data provider, or null if one cannot be found.
+        /// </returns>
+        /// <remarks>
+        /// If more than one data provider is registered under the specified name, the first will be returned.
+        /// </remarks>
+        T GetDataProvider<T>(string name = null) where T : IMixedRealityDataProvider;
+    }
+}

--- a/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityDataProviderAccess.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityDataProviderAccess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5068df6c8c17b814ca8af2e2b852c5c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -44,6 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <returns>
         /// Read only copy of the list of registered observers.
         /// </returns>
+        [Obsolete("GetObservers will be removed in a future release. Check to see if the instance implements IMixedRealityDataProviderAccess and call GetDataProviders.")]
         IReadOnlyList<IMixedRealitySpatialAwarenessObserver> GetObservers();
 
         /// <summary>
@@ -53,6 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <returns>
         /// Readonly copy of the list of registered observers that implement the specified type.
         /// </returns>
+        [Obsolete("GetObservers<T> will be removed in a future release. Check to see if the instance implements IMixedRealityDataProviderAccess and call GetDataProviders<T>.")]
         IReadOnlyList<T> GetObservers<T>() where T : IMixedRealitySpatialAwarenessObserver;
 
         /// <summary>
@@ -65,6 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <remarks>
         /// If more than one observer is registered under the specified name, the first will be returned.
         /// </remarks>
+        [Obsolete("GetObserver will be removed in a future release. Check to see if the instance implements IMixedRealityDataProviderAccess and call GetDataProvider.")]
         IMixedRealitySpatialAwarenessObserver GetObserver(string name);
 
         /// <summary>
@@ -78,7 +82,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <remarks>
         /// If more than one observer is registered under the specified name, the first will be returned.
         /// </remarks>
-        T GetObserver<T>(string name) where T : IMixedRealitySpatialAwarenessObserver;
+        [Obsolete("GetObserver<T> will be removed in a future release. Check to see if the instance implements IMixedRealityDataProviderAccess and call GetDataProvider<T>.")]
+        T GetObserver<T>(string name = null) where T : IMixedRealitySpatialAwarenessObserver;
 
         /// <summary>
         /// Starts / restarts all spatial observers of the specified type.

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -50,7 +50,19 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         private MixedRealityPose controllerPose = MixedRealityPose.ZeroIdentity;
 
         private MixedRealityMouseInputProfile mouseInputProfile = null;
-        private MixedRealityMouseInputProfile MouseInputProfile => mouseInputProfile ?? (mouseInputProfile = MixedRealityToolkit.Instance.GetService<MouseDeviceManager>()?.MouseInputProfile);
+        private MixedRealityMouseInputProfile MouseInputProfile
+        {
+            get
+            {
+                if (mouseInputProfile == null)
+                {
+                    // Get the profile from the input system's registered mouse device manager.
+                    IMixedRealityMouseDeviceManager mouseManager = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityMouseDeviceManager>();
+                    mouseInputProfile = mouseManager?.MouseInputProfile;
+                }
+                return mouseInputProfile;
+            }
+        }
 
         /// <summary>
         /// Update controller.

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         typeof(IMixedRealityInputSystem),
         (SupportedPlatforms)(-1), // All platforms supported by Unity
         "Unity Mouse Device Manager")]  
-    public class MouseDeviceManager : BaseInputDeviceManager
+    public class MouseDeviceManager : BaseInputDeviceManager, IMixedRealityMouseDeviceManager
     {
         /// <summary>
         /// Constructor.
@@ -37,18 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// <summary>
         /// Return the service profile and ensure that the type is correct
         /// </summary>
-        public MixedRealityMouseInputProfile MouseInputProfile
-        {
-            get
-            {
-                var profile = ConfigurationProfile as MixedRealityMouseInputProfile;
-                if (!profile)
-                {
-                    Debug.LogError("Profile for Mouse Input Service must be a MixedRealityMouseInputProfile");
-                }
-                return profile;
-            }
-        }
+        public MixedRealityMouseInputProfile MouseInputProfile => ConfigurationProfile as MixedRealityMouseInputProfile;
 
         /// <inheritdoc />
         public override void Enable()


### PR DESCRIPTION
## Overview
This is an RC 2 targetted version of #4466. The previous PR got updated to newer dev branch code prematurely, hence it being recreated.

Below is the original PR description:

This change introduces IMixedRealityDataProviderAccess, which allows system implementations a standard contract through which they can allow components access to data provider instances.

As an example, the solver handler now accesses the hand joint service using the following pattern

handJointService = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityHandJointService>()

This change also adds IMixedRealityMouseDeviceManager to allow for easy recognition of mouse data providers.

To ensure consistency across services with data providers, the spatial awareness system's GetObserver* methods have been marked as obsolete, with a message to check for implementation of IMixedRealityDataProviderAccess and to call GetDataProvider*.

Note: The existing GetObserver* implementations now call the GetDataProvider* equivalents.

This change is part of the #3545 series and gets non-editor code (with a handful of small exceptions) entirely on to the new, flexible pattern.
