### PR TITLE
fixed moveable button visuals position update while button is moving

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -201,11 +201,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion
 
-        private void Awake()
-        {
-            initialOffsetMovingVisuals = PushSpaceSourceTransform.localPosition;
-        }
-
         private void OnEnable()
         {
             currentPushDistance = startPushDistance;    
@@ -217,6 +212,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 Debug.LogWarning("PressableButton will not work if game object layer is set to 'Ignore Raycast'.");
             }
+
+            initialOffsetMovingVisuals = PushSpaceSourceTransform.localPosition;
         }
 
         void OnDisable()

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -175,7 +175,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
         
-        private Vector3 initialPosition;
+        /// <summary>
+        /// Initial offset from moving visuals to button
+        /// </summary>
+        private Vector3 initialOffsetMovingVisuals = Vector3.zero;
+
         /// <summary>
         /// The position from where the button starts to move. 
         /// </summary>
@@ -183,9 +187,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                if (Application.isPlaying) // we're using a cached position in play mode as the moving visuals will be moved during button interaction
+                if (Application.isPlaying && movingButtonVisuals) // we're using a cached position in play mode as the moving visuals will be moved during button interaction
                 {
-                    return initialPosition;
+                    return PushSpaceSourceTransform.parent.position + initialOffsetMovingVisuals;
                 }
                 else
                 {
@@ -197,10 +201,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion
 
+        private void Awake()
+        {
+            initialOffsetMovingVisuals = PushSpaceSourceTransform.localPosition;
+        }
+
         private void OnEnable()
         {
-            currentPushDistance = startPushDistance;
-            initialPosition = PushSpaceSourceTransform.position;
+            currentPushDistance = startPushDistance;    
         }
 
         private void Start()
@@ -215,6 +223,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             // clear touch points in case we get disabled and can't receive the touch end event anymore
             touchPoints.Clear();
+
+            // make sure button doesn't stay in a pressed state in case we disable the button while pressing it
+            currentPushDistance = startPushDistance;
+            UpdateMovingVisualsPosition();
         }
 
         private void Update()
@@ -258,8 +270,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 return;
             }
-
-            initialPosition = PushSpaceSourceTransform.position;
 
             if (enforceFrontPush)
             {


### PR DESCRIPTION
## Overview
- we're storing an offset to the parent now instead of the world space position, so we can apply that offset to an up-to-date world space position of the button
- also added proper reset of the moveable button part on disabling of the button

## Changes
- Fixes: #4600  .

