### PR TITLE
Bug fix: warning message on FollowMeToggle.cs

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -10,9 +10,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
     {
         [SerializeField]
         [Tooltip("An opional object for visualizing the carry mode state")]
-        private GameObject visualizationObject;
+        private GameObject visualizationObject = null;
 
-        private Orbital orbital;
+        private Orbital orbital = null;
 
         private void Start()
         {


### PR DESCRIPTION
## Overview
Warning message 'FollowMeToggle.visualizationObject' is never assigned to, and will always have its default value null

Explicitly assigned null

## Changes
- Fixes: #4613 

![2019-05-29 10_00_53-Unity 2018 3 8f1 Personal - Untitled - MRTK-Public-Microsoft - Universal Windows](https://user-images.githubusercontent.com/13754172/58576923-3905cf80-81fa-11e9-9fd0-081dabcf07bd.png)

