### PR TITLE
Fix "MRTK not found" errors even when MRTK is present in scene

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity
@@ -4619,7 +4619,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  activeProfile: {fileID: 11400000, guid: a3649293edc1ff34586eea1405cf0467, type: 2}
+  activeProfile: {fileID: 11400000, guid: 31a611a779d3499e8e35f1a2018ca841, type: 2}
 --- !u!4 &509045572
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -158,7 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region InspectorHelpers
         public static bool TryGetInputActions(out string[] descriptionsArray)
         {
-            if (!MixedRealityToolkit.IsInitialized || !MixedRealityToolkit.Instance.HasActiveProfile)
+            if (!MixedRealityToolkit.ConfirmInitialized() || !MixedRealityToolkit.Instance.HasActiveProfile)
             {
                 descriptionsArray = null;
                 return false;

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -550,18 +550,15 @@ namespace Microsoft.MixedReality.Toolkit
                 //
                 // To avoid returning null in this case, make sure to search the scene for MRTK.
                 // We do this only when in editor to avoid any performance cost at runtime.
-                if (activeInstance == null)
+                if (activeInstance != null)
                 {
-                    var mrtks = FindObjectsOfType<MixedRealityToolkit>();
-                    for (int i = 0; i < mrtks.Length; i++)
-                    {
-                        RegisterInstance(mrtks[i]);
-                    }
+                    return activeInstance;
+                }
 
-                    if (activeInstance == null)
-                    {
-                        Debug.LogError("Didn't find / couldn't create an active instance of mixed reality toolkit. You can add one to your scene via 'Mixed Reality Toolkit->Add to Scene and Configure'");
-                    }
+                var mrtks = FindObjectsOfType<MixedRealityToolkit>();
+                for (int i = 0; i < mrtks.Length; i++)
+                {
+                    RegisterInstance(mrtks[i]);
                 }
                 return activeInstance;
             }

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -544,17 +544,17 @@ namespace Microsoft.MixedReality.Toolkit
         {
             get
             {
+                if (activeInstance != null)
+                {
+                    return activeInstance;
+                }
+
                 // It's possible for MRTK to exist in the scene but for activeInstance to be 
                 // null when a custom editor component accesses Instance before the MRTK 
                 // object has clicked on in object hierarchy (see https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4618)
                 //
                 // To avoid returning null in this case, make sure to search the scene for MRTK.
                 // We do this only when in editor to avoid any performance cost at runtime.
-                if (activeInstance != null)
-                {
-                    return activeInstance;
-                }
-
                 var mrtks = FindObjectsOfType<MixedRealityToolkit>();
                 for (int i = 0; i < mrtks.Length; i++)
                 {

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -539,7 +539,29 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// Returns the Singleton instance of the classes type.
         /// </summary>
-        public static MixedRealityToolkit Instance => activeInstance;
+        public static MixedRealityToolkit Instance
+        {
+            get
+            {
+                if (activeInstance != null)
+                {
+                    return activeInstance;
+                }
+
+                var mrtks = FindObjectsOfType<MixedRealityToolkit>();
+                for (int i = 0; i < mrtks.Length; i++)
+                {
+                    RegisterInstance(mrtks[i]);
+                }
+
+                if (activeInstance == null)
+                {
+                    Debug.LogError("Didn't find / couldn't create an active instance of mixed reality toolkit. You can add one to your scene via 'Mixed Reality Toolkit->Add to Scene and Configure'");
+                }
+
+                return activeInstance;
+            }
+        }
 
         private void InitializeInstance()
         {
@@ -680,10 +702,10 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            if (MixedRealityToolkit.activeInstance == null)
+            if (activeInstance == null)
             {   // If we don't have an instance, set it here
                 // Set the instance to active
-                MixedRealityToolkit.activeInstance = toolkitInstance;
+                activeInstance = toolkitInstance;
                 toolkitInstances.Add(toolkitInstance);
                 toolkitInstance.name = ActiveInstanceGameObjectName;
                 toolkitInstance.InitializeInstance();


### PR DESCRIPTION
## Overview
Interactable inspector accesses the MRTK.Instance.ActiveProfile to find available input actions. Currently, MRTK.Instance will return null until the MRTK gameobject has actually been selected by the user.

Therefore, you will get an error when trying to edit an inspector until you click MRTK gameObject.

![image](https://user-images.githubusercontent.com/168492/58583055-ff3bc580-8207-11e9-8fba-abd21492af0e.png)

Fix this by changing the .Instance accessor to actually search for an instance if one is not found.

Fixes: #4610 

## Verification
- Verified that I don't get errors when inspecting interactable
- PlayMode Tests
- EditMode Tests