### PR TITLE
Make pointers dispatch events for all button types

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
@@ -444,12 +444,12 @@ MonoBehaviour:
     id: 0
     description: None
     axisConstraint: 0
-  pointerAction:
+  selectAction:
     id: 1
     description: Select
     axisConstraint: 2
   requiresHoldAction: 0
-  requiresActionBeforeEnabling: 0
+  requiresSelectBeforeEnabling: 0
   overrideGlobalPointerExtent: 0
   pointerExtent: 10
   defaultPointerExtent: 5.5

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -157,7 +157,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (closestProximityTouchable.EventsToReceive == TouchableEventType.Pointer)
                     {
-                        InputSystem?.RaisePointerDown(this, pointerAction, Handedness);
+                        InputSystem?.RaisePointerDown(this, selectAction, Handedness);
                     }
                     else if (closestProximityTouchable.EventsToReceive == TouchableEventType.Touch)
                     {
@@ -179,8 +179,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (closestProximityTouchable.EventsToReceive == TouchableEventType.Pointer)
                 {
-                    InputSystem.RaisePointerClicked(this, pointerAction, 0, Handedness);
-                    InputSystem?.RaisePointerUp(this, pointerAction, Handedness);
+                    InputSystem.RaisePointerClicked(this, selectAction, 0, Handedness);
+                    InputSystem?.RaisePointerUp(this, selectAction, Handedness);
                 }
                 else if (closestProximityTouchable.EventsToReceive == TouchableEventType.Touch)
                 {


### PR DESCRIPTION
## Overview
Fixes: #4492 

Any pointer that extends BaseControllerPointer will by default only dispatch pointer events for input actions that match "pointerAction". This behavior is actually not consistent between other pointer types.
For example, SpherePointer overrides OnInputDown and dispatches pointer events for all actions. GazePointer also dispatches pointer events for all actions.

Consolidate pointer behavior by dispatching pointer events even when the input action doesn't match pointerAction. 

Changes:
- Rename "pointerAction" to "selectAction".
- Track all action down events that have been sent by pointer to make sure to send pointer up events correctly when source disappears or is lost.


## Verification
- I verified that this fixed #4492
- Tested that nothing unusual was happening in HandInteractionExample, using editor.
- Tested in VR in the editor
- Tested on HoloLens

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
