### PR TITLE
Can't build UWP APPX from MRTK Build Window in Unity

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -61,6 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 OutputDirectory = buildDirectory,
                 Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path),
                 BuildAppx = !showDialog,
+                BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
 
                 // Configure a post build action that will compile the generated solution
                 PostBuildAction = PostBuildAction


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4485

If you're building the UWP AppX from the build window for the very first time (without having built the Unity project before) this error shows up because the current platform isn't being properly propagated to the second step (i.e. the actual building of the AppX). If it's already been built (which is the case once you've started using your project for a while) you won't hit this codepath.

It's a pretty annoying thing to see as a first time user (i.e. I would expect it to work) so making sure that the right data (platform) is getting piped through is the right thing to do!