### PR TITLE
Revert "Slate prefab box collider performance issue"

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/Slate.prefab
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/Slate.prefab
@@ -461,19 +461,15 @@ MonoBehaviour:
   enableZoom: 1
   lockHorizontal: 1
   lockVertical: 0
-  unlimitedPan: 1
-  maxPanHorizontal: 2
-  maxPanVertical: 2
-  minScale: 0.2
-  maxScale: 1.5
-  momentumHorizontal: 0.9
-  momentumVertical: 0.9
+  wrapTexture: 1
+  velocityActive: 1
+  velocityDampingX: 0.9
+  velocityDampingY: 0.9
   panZoomSmoothing: 80
   panEventReceivers: []
   reticle: {fileID: 0}
   leftPoint: {fileID: 0}
   rightPoint: {fileID: 0}
-  currentScale: 0
 --- !u!1 &7779420038487776842
 GameObject:
   m_ObjectHideFlags: 0
@@ -878,7 +874,6 @@ MonoBehaviour:
   scaleHandleSize: 0.04
   rotationHandlePrefab: {fileID: 100000, guid: 57c53da2552a8114ab6d68e0cd31b1eb, type: 3}
   rotationHandleDiameter: 0.035
-  rotationHandlePrefabColliderType: 1
   showScaleHandles: 1
   showRotationHandleForX: 1
   showRotationHandleForY: 1
@@ -1028,6 +1023,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: localCenter.z
+      value: -0.008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: localCenter.z
+      value: -0.008
+      objectReference: {fileID: 0}
     - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}
       propertyPath: m_Mesh
@@ -1070,16 +1075,6 @@ PrefabInstance:
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: localCenter.z
-      value: -0.008
-      objectReference: {fileID: 0}
-    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: localCenter.z
-      value: -0.008
-      objectReference: {fileID: 0}
     - target: {fileID: 2951882602880698967, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}
       propertyPath: localCenter.z
@@ -1103,6 +1098,18 @@ PrefabInstance:
     - target: {fileID: 316800718, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_Name
       value: Pressable Button (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 316800721, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
+      propertyPath: minPressDepth
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 316800721, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
+      propertyPath: withdrawActivationAmount
+      value: 0.0001
+      objectReference: {fileID: 0}
+    - target: {fileID: 316800721, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
+      propertyPath: buttonSizeRelativeToCollider
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 937783102, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_havePropertiesChanged
@@ -1176,6 +1183,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: localCenter.z
+      value: -0.008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: localCenter.z
+      value: -0.008
+      objectReference: {fileID: 0}
     - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}
       propertyPath: m_Mesh
@@ -1212,28 +1229,6 @@ PrefabInstance:
     - target: {fileID: 247466359, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: localCenter.z
-      value: -0.008
-      objectReference: {fileID: 0}
-    - target: {fileID: 2034987663884019302, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: localCenter.z
-      value: -0.008
-      objectReference: {fileID: 0}
-    - target: {fileID: 316800721, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
-      propertyPath: minPressDepth
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 316800721, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
-      propertyPath: withdrawActivationAmount
-      value: 0.0001
-      objectReference: {fileID: 0}
-    - target: {fileID: 316800721, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
-      propertyPath: buttonSizeRelativeToCollider
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2951882602880698967, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
         type: 3}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -97,16 +97,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             ActivateByProximityAndPointer,
             ActivateManually
         }
-
-        /// <summary>
-        /// This enum defines the type of collider in use when a rotation handle prefab is provided.
-        /// </summary>
-        public enum RotationHandlePrefabCollider
-        {
-            Sphere,
-            Box
-        }
-
         #endregion Enums
 
         #region Serialized Fields
@@ -409,25 +399,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (rotationHandleDiameter != value)
                 {
                     rotationHandleDiameter = value;
-                    CreateRig();
-                }
-            }
-        }
-
-        [SerializeField]
-        [Tooltip("Only used if rotationHandlePrefab is specified. Determines the type of collider that will surround the rotation handle prefab.")]
-        private RotationHandlePrefabCollider rotationHandlePrefabColliderType = RotationHandlePrefabCollider.Sphere;
-        public RotationHandlePrefabCollider RotationHandlePrefabColliderType
-        {
-            get
-            {
-                return rotationHandlePrefabColliderType;
-            }
-            set
-            {
-                if (rotationHandlePrefabColliderType != value)
-                {
-                    rotationHandlePrefabColliderType = value;
                     CreateRig();
                 }
             }
@@ -1069,17 +1040,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     ball.name = "midpoint_" + i.ToString();
                     ball.transform.localPosition = edgeCenters[i];
 
-                    if (rotationHandlePrefabColliderType == RotationHandlePrefabCollider.Sphere)
-                    {
-                        SphereCollider collider = ball.AddComponent<SphereCollider>();
-                        collider.radius = 0.5f * rotationHandleDiameter;
-                    }
-                    else
-                    {
-                        Debug.Assert(rotationHandlePrefabColliderType == RotationHandlePrefabCollider.Box);
-                        BoxCollider collider = ball.AddComponent<BoxCollider>();
-                        collider.size = rotationHandleDiameter * Vector3.one;
-                    }
+                    SphereCollider collider = ball.AddComponent<SphereCollider>();
+                    collider.radius = 0.5f * rotationHandleDiameter;
 
                     // In order for the ball to be grabbed using near interaction we need
                     // to add NearInteractionGrabbable;


### PR DESCRIPTION
We're currently trying to merge some changes that went into the stabilization branch back into the mrtk_development branch.

Unfortunately, there's a conflict that was caused by the meeting of two changes:

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4514
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4461

I'm reverting my change that I made, and will be re-applying it after the stabilization->development branch merge. My change was just caused by re-serialization of the prefab after I changed a single property on the prefab (i.e. changing the handle setting to 'box'). This is easy enough to do in Unity through the UI, and really hard to do manually merging on Github.