### PR TITLE
Move package signing into separate template

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -36,5 +36,7 @@ jobs:
     parameters:
       ConfigName: "MRTKSignConfig.xml"
   - template: templates/package.yml
+  - template: templates/tasks/signing.yml
     parameters:
-      Sign: true
+      ConfigName: "MRTKNuGetSignConfig.xml"
+  - template: templates/publishpackages.yml

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -15,4 +15,5 @@ jobs:
   steps:
   - template: templates/common.yml
   - template: templates/package.yml
+  - template: templates/publishpackages.yml
   - template: templates/end.yml

--- a/pipelines/templates/package.yml
+++ b/pipelines/templates/package.yml
@@ -1,8 +1,5 @@
 # [Template] Create NuGet packages.
 
-parameters:
-  Sign: false
-
 steps:
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
   displayName: 'NuGet pack'
@@ -12,21 +9,4 @@ steps:
     packDestination: '$(Build.SourcesDirectory)/artifacts'
     buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'
 
-- ${{ if parameters.Sign }}:
-  - template: tasks/signing.yml
-    parameters:
-      ConfigName: "MRTKNuGetSignConfig.xml"
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Packages'
-  inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
-    ArtifactName: 'mrtk-unity-packages'
-
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
-  displayName: 'NuGet push'
-  inputs:
-    command: push
-    packagesToPush: '$(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.symbols.nupkg'
-    publishVstsFeed: '$(NuGetFeedId)'
-    buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'

--- a/pipelines/templates/publishpackages.yml
+++ b/pipelines/templates/publishpackages.yml
@@ -1,0 +1,16 @@
+# [Template] Publish packages to artifacts and to NuGet feed
+
+steps:
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Packages'
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
+    ArtifactName: 'mrtk-unity-packages'
+
+- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
+  displayName: 'NuGet push'
+  inputs:
+    command: push
+    packagesToPush: '$(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.symbols.nupkg'
+    publishVstsFeed: '$(NuGetFeedId)'
+    buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'


### PR DESCRIPTION
mrtk_CI pipeline is failing due to missing signing task - it appears that it is not enough to disable a task that doesn't exist (in the context of AIPMR project) as perhaps some validation happens before the template is fully evaluated. This change attempts to remove the signing task from the ci.yml template (only left in ci-release.yml).
