### PR TITLE
Slate prefab box collider performance issue

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/Slate.prefab
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/Slate.prefab
@@ -1090,6 +1090,7 @@ MonoBehaviour:
   scaleHandleSize: 0.04
   rotationHandlePrefab: {fileID: 100000, guid: 57c53da2552a8114ab6d68e0cd31b1eb, type: 3}
   rotationHandleDiameter: 0.035
+  rotationHandlePrefabColliderType: 1
   showScaleHandles: 1
   showRotationHandleForX: 1
   showRotationHandleForY: 1

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -97,6 +97,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
             ActivateByProximityAndPointer,
             ActivateManually
         }
+
+        /// <summary>
+        /// This enum defines the type of collider in use when a rotation handle prefab is provided.
+        /// </summary>
+        public enum RotationHandlePrefabCollider
+        {
+            Sphere,
+            Box
+        }
+
         #endregion Enums
 
         #region Serialized Fields
@@ -399,6 +409,25 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (rotationHandleDiameter != value)
                 {
                     rotationHandleDiameter = value;
+                    CreateRig();
+                }
+            }
+        }
+
+        [SerializeField]
+        [Tooltip("Only used if rotationHandlePrefab is specified. Determines the type of collider that will surround the rotation handle prefab.")]
+        private RotationHandlePrefabCollider rotationHandlePrefabColliderType = RotationHandlePrefabCollider.Sphere;
+        public RotationHandlePrefabCollider RotationHandlePrefabColliderType
+        {
+            get
+            {
+                return rotationHandlePrefabColliderType;
+            }
+            set
+            {
+                if (rotationHandlePrefabColliderType != value)
+                {
+                    rotationHandlePrefabColliderType = value;
                     CreateRig();
                 }
             }
@@ -1040,8 +1069,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     ball.name = "midpoint_" + i.ToString();
                     ball.transform.localPosition = edgeCenters[i];
 
-                    SphereCollider collider = ball.AddComponent<SphereCollider>();
-                    collider.radius = 0.5f * rotationHandleDiameter;
+                    if (rotationHandlePrefabColliderType == RotationHandlePrefabCollider.Sphere)
+                    {
+                        SphereCollider collider = ball.AddComponent<SphereCollider>();
+                        collider.radius = 0.5f * rotationHandleDiameter;
+                    }
+                    else
+                    {
+                        Debug.Assert(rotationHandlePrefabColliderType == RotationHandlePrefabCollider.Box);
+                        BoxCollider collider = ball.AddComponent<BoxCollider>();
+                        collider.size = rotationHandleDiameter * Vector3.one;
+                    }
 
                     // In order for the ball to be grabbed using near interaction we need
                     // to add NearInteractionGrabbable;


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4167

Slates use the bounding box's rotate colliders in order to handle rotation - note that even though the slate provides its own box-like prefab, the bounding box still creates a sphere collider (which has wayyyyy more vertices than the simple box), even though a basic box would suffice. This change addresses the issue by adding an option to either use a box or sphere collider when a custom prefab is provided for bounding box rotate handles.

This is done in this way to avoid being a breaking behavior change - other folks can choose to use a more performant collider, and the slate is the only thing updated to use this behavior for now.

For the prefab, all I did was update the dropdown select button to choose "box"

This is my undoing the revert that did for the merge - this time around I opted to just update the prefab manually (which still works fine).