### PR TITLE
Adds Documentation link to profile inspectors

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -89,7 +89,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             MixedRealityServiceProfileAttribute profileAttribute = profileObject.GetType().GetCustomAttribute<MixedRealityServiceProfileAttribute>();
             if (profileAttribute == null)
             {   // Can't proceed without the profile attribute.
-                Debug.Log("No profile attribute");
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -99,10 +99,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 if (docLink != null)
                 {
-                    GUIContent buttonContent = new GUIContent();
-                    buttonContent.image = EditorGUIUtility.IconContent("_Help").image;
-                    buttonContent.text = " Documentation";
-                    buttonContent.tooltip = docLink.URL;
+                    var buttonContent = new GUIContent()
+                    {
+                        image = MixedRealityEditorUtility.HelpIcon,
+                        text = " Documentation",
+                        tooltip = docLink.URL,
+                    };
+
                     if (MixedRealityEditorUtility.RenderIndentedButton(buttonContent, EditorStyles.miniButton, GUILayout.MaxWidth(MixedRealityInspectorUtility.DocLinkWidth)))
                     {
                         Application.OpenURL(docLink.URL);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using System.Collections.Generic;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -66,6 +68,50 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             MixedRealityEditorUtility.RenderMixedRealityToolkitLogo();
+        }
+
+        /// <summary>
+        /// Draws a documentation link for the service.
+        /// </summary>
+        protected void RenderDocLink(Object profileObject)
+        {
+            if (profileObject == null)
+            {   // Can't proceed if profile is null.
+                return;
+            }
+
+            if (!MixedRealityToolkit.IsInitialized || !MixedRealityToolkit.Instance.HasActiveProfile)
+            {   // Can't proceed without an active profile
+                return;
+            }
+
+            // Find the service associated with this profile
+            MixedRealityServiceProfileAttribute profileAttribute = profileObject.GetType().GetCustomAttribute<MixedRealityServiceProfileAttribute>();
+            if (profileAttribute == null)
+            {   // Can't proceed without the profile attribute.
+                Debug.Log("No profile attribute");
+                return;
+            }
+
+            IMixedRealityService service;
+            if (MixedRealityToolkit.Instance.ActiveSystems.TryGetValue(profileAttribute.ServiceType, out service))
+            {
+                DocLinkAttribute docLink = service.GetType().GetCustomAttribute<DocLinkAttribute>();
+
+                if (docLink != null)
+                {
+                    GUIContent buttonContent = new GUIContent();
+                    buttonContent.image = EditorGUIUtility.IconContent("_Help").image;
+                    buttonContent.text = " Documentation";
+                    buttonContent.tooltip = docLink.URL;
+                    if (MixedRealityEditorUtility.RenderIndentedButton(buttonContent, EditorStyles.miniButton, GUILayout.MaxWidth(MixedRealityInspectorUtility.DocLinkWidth)))
+                    {
+                        Application.OpenURL(docLink.URL);
+                    }
+                }
+
+                return;
+            }
         }
 
         protected bool DrawBacktrackProfileButton(BackProfileType returnProfileTarget = BackProfileType.Configuration)
@@ -192,6 +238,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             EditorGUILayout.BeginHorizontal();
                 EditorGUILayout.LabelField(new GUIContent(title, description), EditorStyles.boldLabel, GUILayout.ExpandWidth(true));
+                RenderDocLink(selectionObject);
             EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
@@ -36,7 +36,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         Color defaultHeaderColor = (Color)new Color32(194, 194, 194, 255);
 
         const int headerXOffset = 48;
-        const int docLinkWidth = 175;
 
         [SerializeField]
         private Texture2D logoLightTheme = null;
@@ -98,10 +97,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 
             InitializeServiceInspectorLookup();
 
-            bool drawDocLink = DrawDocLink(facade.ServiceType);
             bool drawDataProviders = DrawDataProviders(facade.ServiceType);
             bool drawProfile = DrawProfile(facade.ServiceType);
             bool drawInspector = DrawInspector(facade);
+
+            // Only draw the doc link if we didn't draw a profile
+            // Profiles include doc links by default now
+            if (!drawProfile)
+            {
+                DrawDocLink(facade.ServiceType);
+            }
 
             bool drewSomething = drawProfile | drawInspector | drawDataProviders;
 
@@ -131,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
                 GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
 
-                if (GUILayout.Button(buttonContent, GUILayout.MaxWidth(docLinkWidth)))
+                if (GUILayout.Button(buttonContent, EditorStyles.miniButton, GUILayout.MaxWidth(MixedRealityInspectorUtility.DocLinkWidth)))
                 {
                     Application.OpenURL(docLink.URL);
                 }

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -141,6 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public static readonly Color HandleColorRotation = new Color(0.0f, 1f, 0.2f);
         public static readonly Color HandleColorTangent = new Color(0.1f, 0.8f, 0.5f, 0.7f);
         public static readonly Color LineVelocityColor = new Color(0.9f, 1f, 0f, 0.8f);
+        public static readonly float DocLinkWidth = 175f;
 
         #endregion Colors
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityEditorUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityEditorUtility.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         public static readonly Texture2D LogoDarkTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath("StandardAssets/Textures/MRTK_Logo_White.png"), typeof(Texture2D));
 
-        private static readonly Texture HelpIcon = EditorGUIUtility.IconContent("_Help").image;
+        public static readonly Texture HelpIcon = EditorGUIUtility.IconContent("_Help").image;
 
         /// <summary>
         /// Render the Mixed Reality Toolkit Logo.


### PR DESCRIPTION
## Overview

Profile inspectors now check whether an active service has a DocLink attribute. If one is found, a documentation link is drawn on the profile.

![DocLink](https://user-images.githubusercontent.com/9789716/58725586-59699180-8394-11e9-89fd-bbe787ef1dd2.PNG)

Fixes #4670