### PR TITLE
Update solver logic to update more consistently and respect scale

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ConstantViewSize.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ConstantViewSize.cs
@@ -135,8 +135,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 // Save some state information for external use
                 CurrentDistancePercent = Mathf.InverseLerp(minDistance, maxDistance, distance);
                 CurrentScalePercent = Mathf.InverseLerp(minScale, maxScale, scale);
-
-                UpdateWorkingScaleToGoal();
             }
 
             float scaleDifference = (CurrentScalePercent - lastScalePct) / SolverHandler.DeltaTime;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/InBetween.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/InBetween.cs
@@ -84,7 +84,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 Vector3 centerline = targetTransform.position - secondTransform.position;
                 GoalPosition = secondTransform.position + (centerline * partwayOffset);
-                UpdateWorkingPositionToGoal();
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Momentum.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Momentum.cs
@@ -90,9 +90,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         /// <inheritdoc />
-        public override void SnapTo(Vector3 position, Quaternion rotation)
+        public override void SnapTo(Vector3 position, Quaternion rotation, Vector3 scale)
         {
-            base.SnapTo(position, rotation);
+            base.SnapTo(position, rotation, scale);
             velocity = Vector3.zero;
         }
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 {
@@ -59,6 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
+        [FormerlySerializedAs(oldName: "UseAngleSteppingForWorldOffset")]
         [Tooltip("Lock the rotation to a specified number of steps around the tracked object.")]
         private bool useAngleStepping = false;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
-        [Tooltip("XYZ offset for this object in relation to the TrackedObject/TargetTransform. Mixing local and world offsets is not recommended.")]
+        [Tooltip("XYZ offset for this object oriented to the TrackedObject/TargetTransform's forward. Mixing local and world offsets is not recommended. Local offsets are applied before world offsets.")]
         private Vector3 localOffset = new Vector3(0, -1, 1);
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
-        [Tooltip("XYZ offset for this object in worldspace, best used with the YawOnly orientationType. Mixing local and world offsets is not recommended.")]
+        [Tooltip("XYZ offset for this object in worldspace, best used with the YawOnly orientationType. Mixing local and world offsets is not recommended. Local offsets are applied before world offsets.")]
         private Vector3 worldOffset = Vector3.zero;
 
         /// <summary>
@@ -60,15 +60,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         [SerializeField]
         [Tooltip("Lock the rotation to a specified number of steps around the tracked object.")]
-        private bool useAngleSteppingForWorldOffset = false;
+        private bool useAngleStepping = false;
 
         /// <summary>
         /// Lock the rotation to a specified number of steps around the tracked object.
         /// </summary>
-        public bool UseAngleSteppingForWorldOffset
+        public bool UseAngleStepping
         {
-            get { return useAngleSteppingForWorldOffset; }
-            set { useAngleSteppingForWorldOffset = value; }
+            get { return useAngleStepping; }
+            set { useAngleStepping = value; }
         }
 
         [Range(2, 24)]
@@ -101,15 +101,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             GoalPosition = desiredPos;
             GoalRotation = desiredRot;
-
-            UpdateWorkingPositionToGoal();
-            UpdateWorkingRotationToGoal();
         }
 
 
         private Quaternion SnapToTetherAngleSteps(Quaternion rotationToSnap)
         {
-            if (!UseAngleSteppingForWorldOffset || SolverHandler.TransformTarget == null)
+            if (!UseAngleStepping || SolverHandler.TransformTarget == null)
             {
                 return rotationToSnap;
             }
@@ -152,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     break;
             }
 
-            if (UseAngleSteppingForWorldOffset)
+            if (UseAngleStepping)
             {
                 desiredRot = SnapToTetherAngleSteps(desiredRot);
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
-        [Tooltip("XYZ offset for this object oriented to the TrackedObject/TargetTransform's forward. Mixing local and world offsets is not recommended. Local offsets are applied before world offsets.")]
+        [Tooltip("XYZ offset for this object oriented with the TrackedObject/TargetTransform's forward. Mixing local and world offsets is not recommended. Local offsets are applied before world offsets.")]
         private Vector3 localOffset = new Vector3(0, -1, 1);
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
-        [FormerlySerializedAs(oldName: "UseAngleSteppingForWorldOffset")]
+        [FormerlySerializedAs(oldName: "useAngleSteppingForWorldOffset")]
         [Tooltip("Lock the rotation to a specified number of steps around the tracked object.")]
         private bool useAngleStepping = false;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Overlap.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Overlap.cs
@@ -12,9 +12,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             GoalPosition = SolverHandler.TransformTarget.position;
             GoalRotation = SolverHandler.TransformTarget.rotation;
-
-            UpdateWorkingPositionToGoal();
-            UpdateWorkingRotationToGoal();
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
@@ -198,9 +198,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             GoalPosition = goalPosition;
             GoalRotation = goalRotation;
-
-            UpdateWorkingPositionToGoal();
-            UpdateWorkingRotationToGoal();
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -18,15 +18,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         private bool updateLinkedTransform = false;
 
         [SerializeField]
-        [Tooltip("If 0, the position will update immediately.  Otherwise, the higher this attribute the slower the position updates")]
+        [Tooltip("If 0, the position will update immediately.  Otherwise, the greater this attribute the slower the position updates")]
         private float moveLerpTime = 0.1f;
 
         [SerializeField]
-        [Tooltip("If 0, the rotation will update immediately.  Otherwise, the higher this attribute the slower the rotation updates")]
+        [Tooltip("If 0, the rotation will update immediately.  Otherwise, the greater this attribute the slower the rotation updates")]
         private float rotateLerpTime = 0.1f;
 
         [SerializeField]
-        [Tooltip("If 0, the scale will update immediately.  Otherwise, the higher this attribute the slower the scale updates")]
+        [Tooltip("If 0, the scale will update immediately.  Otherwise, the greater this attribute the slower the scale updates")]
         private float scaleLerpTime = 0;
 		
         [SerializeField]

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -35,6 +35,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         private bool maintainScale = true;
         [SerializeField]
         [Tooltip("If true, updates are smoothed to the target. Otherwise, they are snapped to the target")]
+        private bool smoothing = true;
+        public bool Smoothing 
+        { 
+            get => smoothing; 
+            set => smoothing = value; 
+        }
         public bool smoothing = true;
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
@@ -235,6 +236,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             WorkingPosition = position;
             WorkingRotation = rotation;
             WorkingScale = scale;
+        }
+
+        [Obsolete("Use SnapTo(Vector3, Quaternion, Vector3) instead.")]
+        public virtual void SnapTo(Vector3 position, Quaternion rotation)
+        {
+            GoalPosition = position;
+            GoalRotation = rotation;
+        }
+
+        [Obsolete("Use SnapGoalTo(Vector3, Quaternion, Vector3) instead.")]
+        public virtual void SnapGoalTo(Vector3 position, Quaternion rotation)
+        {
+            GoalPosition = position;
+            GoalRotation = rotation;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -321,8 +321,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         public void UpdateWorkingToGoal()
         {
             UpdateWorkingPositionToGoal();
-			UpdateWorkingRotationToGoal();
-			UpdateWorkingScaleToGoal();
+            UpdateWorkingRotationToGoal();
+            UpdateWorkingScaleToGoal();
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     /// </summary>
     [RequireComponent(typeof(SolverHandler))]
     public abstract class Solver : MonoBehaviour
-    {        
+    {
         [SerializeField]
         [Tooltip("If true, the position and orientation will be calculated, but not applied, for other components to use")]
         private bool updateLinkedTransform = false;
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         [SerializeField]
         [Tooltip("If 0, the scale will update immediately.  Otherwise, the greater this attribute the slower the scale updates")]
         private float scaleLerpTime = 0;
-		
+
         [SerializeField]
         [Tooltip("If true, the Solver will respect the object's original scale values")]
         private bool maintainScale = true;
@@ -217,7 +217,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
 
             SolverUpdate();
-
             UpdateWorkingToGoal();
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -33,15 +33,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         [SerializeField]
         [Tooltip("If true, the Solver will respect the object's original scale values")]
         private bool maintainScale = true;
+
         [SerializeField]
         [Tooltip("If true, updates are smoothed to the target. Otherwise, they are snapped to the target")]
         private bool smoothing = true;
+
         public bool Smoothing 
         { 
             get => smoothing; 
             set => smoothing = value; 
         }
-        public bool smoothing = true;
 
         [SerializeField]
         [Tooltip("If > 0, this solver will deactivate after this much time, even if the state is still active")]

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -38,10 +38,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         [Tooltip("If true, updates are smoothed to the target. Otherwise, they are snapped to the target")]
         private bool smoothing = true;
 
-        public bool Smoothing 
-        { 
-            get => smoothing; 
-            set => smoothing = value; 
+        public bool Smoothing
+        {
+            get => smoothing;
+            set => smoothing = value;
         }
 
         [SerializeField]
@@ -62,14 +62,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         protected Vector3 GoalPosition
         {
-            get
-            {
-                return SolverHandler.GoalPosition;
-            }
-            set
-            {
-                SolverHandler.GoalPosition = value;
-            }
+            get { return SolverHandler.GoalPosition; }
+            set { SolverHandler.GoalPosition = value; }
         }
 
         /// <summary>
@@ -77,14 +71,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         protected Quaternion GoalRotation
         {
-            get
-            {
-                return SolverHandler.GoalRotation;
-            }
-            set
-            {
-                SolverHandler.GoalRotation = value;
-            }
+            get { return SolverHandler.GoalRotation; }
+            set { SolverHandler.GoalRotation = value; }
         }
 
         /// <summary>
@@ -92,14 +80,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         protected Vector3 GoalScale
         {
-            get
-            {
-                return SolverHandler.GoalScale;
-            }
-            set
-            {
-                SolverHandler.GoalScale = value;
-            }
+            get { return SolverHandler.GoalScale; }
+            set { SolverHandler.GoalScale = value; }
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -227,20 +227,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             WorkingScale = scale;
         }
 
-        [Obsolete("Use SnapTo(Vector3, Quaternion, Vector3) instead.")]
-        public virtual void SnapTo(Vector3 position, Quaternion rotation)
-        {
-            GoalPosition = position;
-            GoalRotation = rotation;
-        }
-
-        [Obsolete("Use SnapGoalTo(Vector3, Quaternion, Vector3) instead.")]
-        public virtual void SnapGoalTo(Vector3 position, Quaternion rotation)
-        {
-            GoalPosition = position;
-            GoalRotation = rotation;
-        }
-
         /// <summary>
         /// SnapGoalTo only sets the goal orientation.  Not really useful.
         /// </summary>
@@ -251,6 +237,35 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             GoalPosition = position;
             GoalRotation = rotation;
             GoalScale = scale;
+        }
+
+        /// <summary>
+        /// Snaps the solver to the desired pose.
+        /// </summary>
+        /// <remarks>
+        /// SnapTo may be used to bypass smoothing to a certain position if the object is teleported or spawned.
+        /// </remarks>
+        /// <param name="position"></param>
+        /// <param name="rotation"></param>
+        [Obsolete("Use SnapTo(Vector3, Quaternion, Vector3) instead.")]
+        public virtual void SnapTo(Vector3 position, Quaternion rotation)
+        {
+            SnapGoalTo(position, rotation);
+
+            WorkingPosition = position;
+            WorkingRotation = rotation;
+        }
+
+        /// <summary>
+        /// SnapGoalTo only sets the goal orientation.  Not really useful.
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="rotation"></param>
+        [Obsolete("Use SnapGoalTo(Vector3, Quaternion, Vector3) instead.")]
+        public virtual void SnapGoalTo(Vector3 position, Quaternion rotation)
+        {
+            GoalPosition = position;
+            GoalRotation = rotation;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -176,6 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             if (UpdateSolvers)
             {
+                //Before calling solvers, update goal to be the transform so that working and transform will match
                 GoalPosition = transform.position;
                 GoalRotation = transform.rotation;
                 GoalScale = transform.localScale;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -176,16 +176,49 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             if (UpdateSolvers)
             {
+                GoalPosition = transform.position;
+                GoalRotation = transform.rotation;
+                GoalScale = transform.localScale;
+
                 for (int i = 0; i < solvers.Count; ++i)
                 {
                     Solver solver = solvers[i];
 
-                    if (solver.enabled)
+                    if (solver != null && solver.enabled)
                     {
                         solver.SolverUpdateEntry();
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Lerps Vector3 source to goal.
+        /// </summary>
+        /// <remarks>
+        /// Handles lerpTime of 0.
+        /// </remarks>
+        /// <param name="source"></param>
+        /// <param name="goal"></param>
+        /// <param name="deltaTime"></param>
+        /// <param name="lerpTime"></param>
+        /// <returns></returns>
+        public static Vector3 SmoothTo(Vector3 source, Vector3 goal, float deltaTime, float lerpTime)
+        {
+            return Vector3.Lerp(source, goal, lerpTime.Equals(0.0f) ? 1f : deltaTime / lerpTime);
+        }
+
+        /// <summary>
+        /// Slerps Quaternion source to goal, handles lerpTime of 0
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="goal"></param>
+        /// <param name="deltaTime"></param>
+        /// <param name="lerpTime"></param>
+        /// <returns></returns>
+        public static Quaternion SmoothTo(Quaternion source, Quaternion goal, float deltaTime, float lerpTime)
+        {
+            return Quaternion.Slerp(source, goal, lerpTime.Equals(0.0f) ? 1f : deltaTime / lerpTime);
         }
 
         protected void OnDestroy()

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -192,35 +192,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
         }
 
-        /// <summary>
-        /// Lerps Vector3 source to goal.
-        /// </summary>
-        /// <remarks>
-        /// Handles lerpTime of 0.
-        /// </remarks>
-        /// <param name="source"></param>
-        /// <param name="goal"></param>
-        /// <param name="deltaTime"></param>
-        /// <param name="lerpTime"></param>
-        /// <returns></returns>
-        public static Vector3 SmoothTo(Vector3 source, Vector3 goal, float deltaTime, float lerpTime)
-        {
-            return Vector3.Lerp(source, goal, lerpTime.Equals(0.0f) ? 1f : deltaTime / lerpTime);
-        }
-
-        /// <summary>
-        /// Slerps Quaternion source to goal, handles lerpTime of 0
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="goal"></param>
-        /// <param name="deltaTime"></param>
-        /// <param name="lerpTime"></param>
-        /// <returns></returns>
-        public static Quaternion SmoothTo(Quaternion source, Quaternion goal, float deltaTime, float lerpTime)
-        {
-            return Quaternion.Slerp(source, goal, lerpTime.Equals(0.0f) ? 1f : deltaTime / lerpTime);
-        }
-
         protected void OnDestroy()
         {
             DetachFromCurrentTrackedObject();

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -265,10 +265,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     SphereRaycastStepUpdate(rayStep);
                     break;
             }
-
-            // Do frame to frame updates of transform, smoothly toward the goal, if desired
-            UpdateWorkingPositionToGoal();
-            UpdateWorkingRotationToGoal();
         }
 
         private void SimpleRaycastStepUpdate(RayStep rayStep)


### PR DESCRIPTION
## Overview
Changing the solverUpdate methodology to always apply the update from working to goal, regardless of solver. This allows for those creating new solvers to ignore the update process in favor of simply updating the goal position/rotation/scale. Also, by guaranteeing that these are called, maintainScale becomes a functional variable again
Also some minor documentation updates.