### PR TITLE
Reintroduce the Interpolator utilities back to the MRTK

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ede0eddda7293d47872aa6132d10131
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b61ace6971fea64d8fd704e90f5d99c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Physics
+{
+    class InterpolationUtilitiesTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            // The rest of the tests do floating point comparison, so equality comparison must have some
+            // fudge factor.
+            GlobalSettings.DefaultFloatingPointTolerance = .001;
+        }
+
+        [Test]
+        public void TestExpCoefficient()
+        {
+            // Passing a half life value of 0 always returns a value of 1 (this is an 'invalid' calling convention).
+            Assert.That(InterpolationUtilities.ExpCoefficient(0.0f /*hLife*/, 10.0f /*dTime*/), Is.EqualTo(1.0f));
+            Assert.That(InterpolationUtilities.ExpCoefficient(0.0f /*hLife*/, 0.0f /*dTime*/), Is.EqualTo(1.0f));
+
+            // Passing a valid half life and delta time should result in increasingly higher numbers according to
+            // the formula (1-.5^(half life / delta time))
+            Assert.That(InterpolationUtilities.ExpCoefficient(2.0f /*hLife*/, 2.0f /*dTime*/), Is.EqualTo(0.5f));
+            Assert.That(InterpolationUtilities.ExpCoefficient(2.0f /*hLife*/, 4.0f /*dTime*/), Is.EqualTo(0.75f));
+            Assert.That(InterpolationUtilities.ExpCoefficient(2.0f /*hLife*/, 6.0f /*dTime*/), Is.EqualTo(0.875f));
+        }
+
+        [Test]
+        public void TestFloatExpDecay()
+        {
+            // Validates the float overload of InterpolationUtilities::ExpDecay, which lerps between the from value
+            // toward the to value in an exponential fashion.
+            Assert.That(InterpolationUtilities.ExpDecay(50.0f /*from*/, 150.0f /*to*/, 0.0f /*hLife*/, 5.0f /*dTime*/), Is.EqualTo(150f));
+            Assert.That(InterpolationUtilities.ExpDecay(50.0f /*from*/, 150.0f /*to*/, 1.0f /*hLife*/, 1.0f /*dTime*/), Is.EqualTo(100.0f));
+            Assert.That(InterpolationUtilities.ExpDecay(50.0f /*from*/, 150.0f /*to*/, 2.0f /*hLife*/, 2.0f /*dTime*/), Is.EqualTo(100.0f));
+            Assert.That(InterpolationUtilities.ExpDecay(50.0f /*from*/, 150.0f /*to*/, 2.0f /*hLife*/, 4.0f /*dTime*/), Is.EqualTo(125.0f));
+            Assert.That(InterpolationUtilities.ExpDecay(50.0f /*from*/, 150.0f /*to*/, 2.0f /*hLife*/, 6.0f /*dTime*/), Is.EqualTo(137.5f));
+            Assert.That(InterpolationUtilities.ExpDecay(50.0f /*from*/, 150.0f /*to*/, 2.0f /*hLife*/, 20.0f /*dTime*/), Is.EqualTo(149.90234f));
+        }
+
+        [Test]
+        public void TestVector2ExpDecay()
+        {
+            Vector2 from = new Vector2(50.0f, 150.0f);
+            Vector2 to = new Vector2(150.0f, 250.0f);
+
+            // Validates the Vector2 overload of InterpolationUtilities::ExpDecay, which lerps between the from value
+            // toward the to value in an exponential fashion.
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 0.0f /*hLife*/, 5.0f /*dTime*/), Is.EqualTo(new Vector2(150.0f, 250.0f)));
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 1.0f /*hLife*/, 1.0f /*dTime*/), Is.EqualTo(new Vector2(100.0f, 200.0f)));
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 2.0f /*dTime*/), Is.EqualTo(new Vector2(100.0f, 200.0f)));
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 4.0f /*dTime*/), Is.EqualTo(new Vector2(125.0f, 225.0f)));
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 6.0f /*dTime*/), Is.EqualTo(new Vector2(137.5f, 237.5f)));
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 20.0f /*dTime*/), Is.EqualTo(new Vector2(149.90234f, 249.90234f)));
+        }
+
+        [Test]
+        public void TestVector3ExpDecay()
+        {
+            Vector3 from = new Vector3(50.0f, 150.0f, 250.0f);
+            Vector3 to = new Vector3(150.0f, 250.0f, 350.0f);
+
+            // Validates the Vector3 overload of InterpolationUtilities::ExpDecay, which lerps between the from value
+            // toward the to value in an exponential fashion.
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 0.0f /*hLife*/, 5.0f /*dTime*/),
+                Is.EqualTo(new Vector3(150.0f, 250.0f, 350.0f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 1.0f /*hLife*/, 1.0f /*dTime*/),
+                Is.EqualTo(new Vector3(100.0f, 200.0f, 300.0f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 2.0f /*dTime*/),
+                Is.EqualTo(new Vector3(100.0f, 200.0f, 300.0f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 4.0f /*dTime*/),
+                Is.EqualTo(new Vector3(125.0f, 225.0f, 325.0f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 6.0f /*dTime*/),
+                Is.EqualTo(new Vector3(137.5f, 237.5f, 337.5f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 20.0f /*dTime*/), 
+                Is.EqualTo(new Vector3(149.90234f, 249.90234f, 349.90234f)));
+        }
+
+        [Test]
+        public void TestColorExpDecay()
+        {
+            Color from = new Color(0.0f, 0.0f, 1.0f);
+            Color to = new Color(1.0f, 0.0f, 0.0f);
+
+            // Validates the Color overload of InterpolationUtilities::ExpDecay, which lerps between the from value
+            // toward the to value in an exponential fashion.
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 0.0f /*hLife*/, 5.0f /*dTime*/),
+                Is.EqualTo(new Color(1.0f, 0.0f, 0.0f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 1.0f /*hLife*/, 1.0f /*dTime*/),
+                Is.EqualTo(new Color(0.5f, 0.0f, 0.5f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 2.0f /*dTime*/),
+                Is.EqualTo(new Color(0.5f, 0.0f, 0.5f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 4.0f /*dTime*/),
+                Is.EqualTo(new Color(0.75f, 0.0f, 0.25f)));
+
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 6.0f /*dTime*/),
+                Is.EqualTo(new Color(0.875f, 0.0f, 0.125f)));
+        }
+
+        [Test]
+        public void TestQuaternionExpDecay()
+        {
+            // Validates the Quaternion overload of InterpolationUtilities::ExpDecay, which lerps between the from value
+            // toward the to value in an exponential fashion.
+            // Note that Quarternions are a bit funky in that they are using spherical lerps, which means the lerp occurs
+            // on the surface of a sphere (instead of a linear lerp between points)
+            Quaternion from = Quaternion.Euler(new Vector3(0, 0, 0));
+            Quaternion to = Quaternion.Euler(new Vector3(0, 45, 0));
+
+            Assert.IsTrue(InterpolationUtilities.ExpDecay(from, to, 0.0f /*hLife*/, 5.0f /*dTime*/) == to);
+
+            // This test ultimately converts the lerped values into rotation effects on the forward vector, to show
+            // that this is properly lerping in a more human-readable fashion (i.e. reading unit vector directions, instead
+            // of quarternions)
+            Vector3 result = InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 2.0f /*dTime*/) * Vector3.forward;
+            Assert.IsTrue(
+                AreEqual(
+                    InterpolationUtilities.ExpDecay(from, to, 1.0f /*hLife*/, 1.0f /*dTime*/) * Vector3.forward,
+                    new Vector3(0.3826835f, 0.0f, 0.9238795f)));
+
+            Assert.IsTrue(
+                AreEqual(
+                    InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 2.0f /*dTime*/) * Vector3.forward,
+                    new Vector3(0.3826835f, 0.0f, 0.9238795f)));
+
+            Assert.IsTrue(
+                AreEqual(
+                    InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 4.0f /*dTime*/) * Vector3.forward,
+                    new Vector3(0.5555702f, 0.0f, 0.8314696f)));
+
+            Assert.IsTrue(
+                AreEqual(
+                    InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 6.0f /*dTime*/) * Vector3.forward,
+                    new Vector3(0.6343933f, 0.0f, 0.7730104f)));
+        }
+
+        /// <summary>
+        /// A helper to compares two vectors with slightly looser tolerance than the default Vector3 comparison.
+        /// </summary>
+        /// <remarks>
+        /// Primarily useful when looking the results of quaternion-effected rotations, which tends to lead
+        /// to a lot of decimal place digits.
+        /// </remarks>
+        private static bool AreEqual(Vector3 left, Vector3 right)
+        {
+            return Vector3.Distance(left, right) <= GlobalSettings.DefaultFloatingPointTolerance;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d6a4cb0eeef9184d8d187ad47dd4815
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Physics
+{
+    class InterpolatorTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            // The rest of the tests do floating point comparison, so equality comparison must have some
+            // fudge factor.
+            GlobalSettings.DefaultFloatingPointTolerance = .001;
+        }
+
+        [Test]
+        public void TestNonLinearInterpolateToNoSpeed()
+        {
+            Vector3 from = new Vector3(10, 10, 10);
+            Vector3 to = new Vector3(100, 100, 100);
+            
+            // Regardless of the time delta, a zero speed will always snap to the final location.
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 0.0f /*deltaTime*/, 0.0f /*speed*/), Is.EqualTo(to));
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 100.0f /*deltaTime*/, 0.0f /*speed*/), Is.EqualTo(to));
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 1e6f /*deltaTime*/, 0.0f /*speed*/), Is.EqualTo(to));
+        }
+
+        [Test]
+        public void TestNonLinearInterpolateTo()
+        {
+            Vector3 from = new Vector3(0, 0, 0);
+            Vector3 to = new Vector3(100, 100, 100);
+
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 1.0f /*deltaTime*/, 0.5f /*speed*/),
+                Is.EqualTo(new Vector3(50, 50 , 50)));
+
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 2.0f /*deltaTime*/, 0.5f /*speed*/),
+                Is.EqualTo(new Vector3(100, 100, 100)));
+
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 3.0f /*deltaTime*/, 0.5f /*speed*/), 
+                Is.EqualTo(new Vector3(100, 100, 100)));
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0579f0bbcde3db4e92b0028c4ba8c1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Physics/InterpolationUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/InterpolationUtilities.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Physics
+{
+    /// <summary>
+    /// Static class containing interpolation-related utility functions.
+    /// </summary>
+    public static class InterpolationUtilities
+    {
+        #region Exponential Decay
+
+        public static float ExpDecay(float from, float to, float hLife, float dTime)
+        {
+            return Mathf.Lerp(from, to, ExpCoefficient(hLife, dTime));
+        }
+
+        public static Vector2 ExpDecay(Vector2 from, Vector2 to, float hLife, float dTime)
+        {
+            return Vector2.Lerp(from, to, ExpCoefficient(hLife, dTime));
+        }
+
+        public static Vector3 ExpDecay(Vector3 from, Vector3 to, float hLife, float dTime)
+        {
+            return Vector3.Lerp(from, to, ExpCoefficient(hLife, dTime));
+        }
+
+        public static Quaternion ExpDecay(Quaternion from, Quaternion to, float hLife, float dTime)
+        {
+            return Quaternion.Slerp(from, to, ExpCoefficient(hLife, dTime));
+        }
+
+        public static Color ExpDecay(Color from, Color to, float hLife, float dTime)
+        {
+            return Color.Lerp(from, to, ExpCoefficient(hLife, dTime));
+        }
+
+
+        /// <summary>
+        /// Computes an exponential coefficient following the given formula: 1 - .5^(dTime/hLife)
+        /// </summary>
+        public static float ExpCoefficient(float hLife, float dTime)
+        {
+            if (hLife == 0)
+            {
+                return 1;
+            }
+
+            return 1.0f - Mathf.Pow(0.5f, dTime / hLife);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Physics/InterpolationUtilities.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/InterpolationUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2	
+guid: d2528cd8f0eb4d0e83245bbb4f8a34e1	
+MonoImporter:	
+  externalObjects: {}	
+  serializedVersion: 2	
+  defaultReferences: []	
+  executionOrder: 0	
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}	
+  userData: 	
+  assetBundleName: 	
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs
@@ -1,0 +1,454 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Physics
+{
+    /// <summary>
+    /// A MonoBehaviour that interpolates a transform's position, rotation or scale.
+    /// </summary>
+    public class Interpolator : MonoBehaviour
+    {
+        /// <summary>
+        /// A very small number that is used in determining if the Interpolator needs to run at all.
+        /// </summary>
+        private const float Tolerance = 0.0000001f;
+
+        /// <summary>
+        /// The event fired when an Interpolation is started.
+        /// </summary>
+        public event Action InterpolationStarted;
+
+        /// <summary>
+        /// The event fired when an Interpolation is completed.
+        /// </summary>
+        public event Action InterpolationDone;
+
+        [SerializeField]
+        [Tooltip("When interpolating, use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        private bool useUnscaledTime = true;
+
+        [SerializeField]
+        [Tooltip("The movement speed in meters per second.")]
+        private float positionPerSecond = 30.0f;
+
+        [SerializeField]
+        [Tooltip("The rotation speed, in degrees per second.")]
+        private float rotationDegreesPerSecond = 720.0f;
+
+        [SerializeField]
+        [Tooltip("Adjusts rotation speed based on angular distance.")]
+        private float rotationSpeedScaler = 0.0f;
+
+        [SerializeField]
+        [Tooltip("The amount to scale per second.")]
+        private float scalePerSecond = 5.0f;
+
+        /// <summary>
+        /// Lerp the estimated targets towards the object each update, slowing and smoothing movement.
+        /// </summary>
+        public bool SmoothLerpToTarget { get; set; } = false;
+        public float SmoothPositionLerpRatio { get; set; } = 0.5f;
+        public float SmoothRotationLerpRatio { get; set; } = 0.5f;
+        public float SmoothScaleLerpRatio { get; set; } = 0.5f;
+
+        /// <summary>
+        /// If animating position, specifies the target position as specified
+        /// by SetTargetPosition. Otherwise returns the current position of
+        /// the transform.
+        /// </summary>
+        public Vector3 TargetPosition => AnimatingPosition ? targetPosition : transform.position;
+        private Vector3 targetPosition;
+
+        /// <summary>
+        /// If animating rotation, specifies the target rotation as specified
+        /// by SetTargetRotation. Otherwise returns the current rotation of
+        /// the transform.
+        /// </summary>
+        public Quaternion TargetRotation => AnimatingRotation ? targetRotation : transform.rotation;
+        private Quaternion targetRotation;
+
+        /// <summary>
+        /// If animating local rotation, specifies the target local rotation as
+        /// specified by SetTargetLocalRotation. Otherwise returns the current
+        /// local rotation of the transform.
+        /// </summary>
+        public Quaternion TargetLocalRotation => AnimatingLocalRotation ? targetLocalRotation : transform.localRotation;
+        private Quaternion targetLocalRotation;
+
+        /// <summary>
+        /// If animating local scale, specifies the target local scale as
+        /// specified by SetTargetLocalScale. Otherwise returns the current
+        /// local scale of the transform.
+        /// </summary>
+        public Vector3 TargetLocalScale => AnimatingLocalScale ? targetLocalScale : transform.localScale;
+        private Vector3 targetLocalScale;
+
+        /// <summary>
+        /// True if the transform's position is animating; false otherwise.
+        /// </summary>
+        public bool AnimatingPosition { get; private set; }
+
+        /// <summary>
+        /// True if the transform's rotation is animating; false otherwise.
+        /// </summary>
+        public bool AnimatingRotation { get; private set; }
+
+        /// <summary>
+        /// True if the transform's local rotation is animating; false otherwise.
+        /// </summary>
+        public bool AnimatingLocalRotation { get; private set; }
+
+        /// <summary>
+        /// True if the transform's scale is animating; false otherwise.
+        /// </summary>
+        public bool AnimatingLocalScale { get; private set; }
+
+        /// <summary>
+        /// The velocity of a transform whose position is being interpolated.
+        /// </summary>
+        public Vector3 PositionVelocity { get; private set; }
+
+        private Vector3 oldPosition = Vector3.zero;
+
+        /// <summary>
+        /// True if position, rotation or scale are animating; false otherwise.
+        /// </summary>
+        public bool Running => AnimatingPosition || AnimatingRotation || AnimatingLocalRotation || AnimatingLocalScale;
+
+        #region MonoBehaviour Implementation
+
+        private void Awake()
+        {
+            targetPosition = transform.position;
+            targetRotation = transform.rotation;
+            targetLocalRotation = transform.localRotation;
+            targetLocalScale = transform.localScale;
+
+            enabled = false;
+        }
+
+        private void Update()
+        {
+            float deltaTime = useUnscaledTime
+                ? Time.unscaledDeltaTime
+                : Time.deltaTime;
+
+            bool interpOccuredThisFrame = false;
+
+            if (AnimatingPosition)
+            {
+                Vector3 lerpTargetPosition = targetPosition;
+                if (SmoothLerpToTarget)
+                {
+                    lerpTargetPosition = Vector3.Lerp(transform.position, lerpTargetPosition, SmoothPositionLerpRatio);
+                }
+
+                Vector3 newPosition = NonLinearInterpolateTo(transform.position, lerpTargetPosition, deltaTime, positionPerSecond);
+                if ((targetPosition - newPosition).sqrMagnitude <= Tolerance)
+                {
+                    // Snap to final position
+                    newPosition = targetPosition;
+                    AnimatingPosition = false;
+                }
+                else
+                {
+                    interpOccuredThisFrame = true;
+                }
+
+                transform.position = newPosition;
+
+                //calculate interpolatedVelocity and store position for next frame
+                PositionVelocity = oldPosition - newPosition;
+                oldPosition = newPosition;
+            }
+
+            // Determine how far we need to rotate
+            if (AnimatingRotation)
+            {
+                Quaternion lerpTargetRotation = targetRotation;
+                if (SmoothLerpToTarget)
+                {
+                    lerpTargetRotation = Quaternion.Lerp(transform.rotation, lerpTargetRotation, SmoothRotationLerpRatio);
+                }
+
+                float angleDiff = Quaternion.Angle(transform.rotation, lerpTargetRotation);
+                float speedScale = 1.0f + (Mathf.Pow(angleDiff, rotationSpeedScaler) / 180.0f);
+                float ratio = Mathf.Clamp01((speedScale * rotationDegreesPerSecond * deltaTime) / angleDiff);
+
+                if (angleDiff < Mathf.Epsilon)
+                {
+                    AnimatingRotation = false;
+                    transform.rotation = targetRotation;
+                }
+                else
+                {
+                    // Only lerp rotation here, as ratio is NaN if angleDiff is 0.0f
+                    transform.rotation = Quaternion.Slerp(transform.rotation, lerpTargetRotation, ratio);
+                    interpOccuredThisFrame = true;
+                }
+            }
+
+            // Determine how far we need to rotate
+            if (AnimatingLocalRotation)
+            {
+                Quaternion lerpTargetLocalRotation = targetLocalRotation;
+                if (SmoothLerpToTarget)
+                {
+                    lerpTargetLocalRotation = Quaternion.Lerp(transform.localRotation, lerpTargetLocalRotation, SmoothRotationLerpRatio);
+                }
+
+                float angleDiff = Quaternion.Angle(transform.localRotation, lerpTargetLocalRotation);
+                float speedScale = 1.0f + (Mathf.Pow(angleDiff, rotationSpeedScaler) / 180.0f);
+                float ratio = Mathf.Clamp01((speedScale * rotationDegreesPerSecond * deltaTime) / angleDiff);
+
+                if (angleDiff < Mathf.Epsilon)
+                {
+                    AnimatingLocalRotation = false;
+                    transform.localRotation = targetLocalRotation;
+                }
+                else
+                {
+                    // Only lerp rotation here, as ratio is NaN if angleDiff is 0.0f
+                    transform.localRotation = Quaternion.Slerp(transform.localRotation, lerpTargetLocalRotation, ratio);
+                    interpOccuredThisFrame = true;
+                }
+            }
+
+            if (AnimatingLocalScale)
+            {
+                Vector3 lerpTargetLocalScale = targetLocalScale;
+                if (SmoothLerpToTarget)
+                {
+                    lerpTargetLocalScale = Vector3.Lerp(transform.localScale, lerpTargetLocalScale, SmoothScaleLerpRatio);
+                }
+
+                Vector3 newScale = NonLinearInterpolateTo(transform.localScale, lerpTargetLocalScale, deltaTime, scalePerSecond);
+                if ((targetLocalScale - newScale).sqrMagnitude <= Tolerance)
+                {
+                    // Snap to final scale
+                    newScale = targetLocalScale;
+                    AnimatingLocalScale = false;
+                }
+                else
+                {
+                    interpOccuredThisFrame = true;
+                }
+
+                transform.localScale = newScale;
+            }
+
+            // If all interpolations have completed, stop updating
+            if (!interpOccuredThisFrame)
+            {
+                InterpolationDone?.Invoke();
+                enabled = false;
+            }
+        }
+
+        /// <summary>
+        /// Stops the transform in place and terminates any animations.<para/>
+        /// </summary>
+        /// <remarks>Reset() is usually reserved as a MonoBehaviour API call in editor, but is used in this case as a convenience method.</remarks>
+        public void Reset()
+        {
+            targetPosition = transform.position;
+            targetRotation = transform.rotation;
+            targetLocalRotation = transform.localRotation;
+            targetLocalScale = transform.localScale;
+
+            AnimatingPosition = false;
+            AnimatingRotation = false;
+            AnimatingLocalRotation = false;
+            AnimatingLocalScale = false;
+
+            enabled = false;
+        }
+
+        #endregion MonoBehaviour Implementation
+
+        /// <summary>
+        /// Sets the target position for the transform and if position wasn't
+        /// already animating, fires the InterpolationStarted event.
+        /// </summary>
+        /// <param name="target">The new target position to for the transform.</param>
+        public void SetTargetPosition(Vector3 target)
+        {
+            bool wasRunning = Running;
+
+            targetPosition = target;
+
+            float magsq = (targetPosition - transform.position).sqrMagnitude;
+            if (magsq > Tolerance)
+            {
+                AnimatingPosition = true;
+                enabled = true;
+
+                if (InterpolationStarted != null && !wasRunning)
+                {
+                    InterpolationStarted();
+                }
+            }
+            else
+            {
+                // Set immediately to prevent accumulation of error.
+                transform.position = target;
+                AnimatingPosition = false;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target rotation for the transform and if rotation wasn't
+        /// already animating, fires the InterpolationStarted event.
+        /// </summary>
+        /// <param name="target">The new target rotation for the transform.</param>
+        public void SetTargetRotation(Quaternion target)
+        {
+            bool wasRunning = Running;
+
+            targetRotation = target;
+
+            if (Quaternion.Dot(transform.rotation, target) < 1.0f)
+            {
+                AnimatingRotation = true;
+                enabled = true;
+
+                if (InterpolationStarted != null && !wasRunning)
+                {
+                    InterpolationStarted();
+                }
+            }
+            else
+            {
+                // Set immediately to prevent accumulation of error.
+                transform.rotation = target;
+                AnimatingRotation = false;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target local rotation for the transform and if rotation
+        /// wasn't already animating, fires the InterpolationStarted event.
+        /// </summary>
+        /// <param name="target">The new target local rotation for the transform.</param>
+        public void SetTargetLocalRotation(Quaternion target)
+        {
+            bool wasRunning = Running;
+
+            targetLocalRotation = target;
+
+            if (Quaternion.Dot(transform.localRotation, target) < 1.0f)
+            {
+                AnimatingLocalRotation = true;
+                enabled = true;
+
+                if (InterpolationStarted != null && !wasRunning)
+                {
+                    InterpolationStarted();
+                }
+            }
+            else
+            {
+                // Set immediately to prevent accumulation of error.
+                transform.localRotation = target;
+                AnimatingLocalRotation = false;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target local scale for the transform and if scale
+        /// wasn't already animating, fires the InterpolationStarted event.
+        /// </summary>
+        /// <param name="target">The new target local rotation for the transform.</param>
+        public void SetTargetLocalScale(Vector3 target)
+        {
+            bool wasRunning = Running;
+
+            targetLocalScale = target;
+
+            float magsq = (targetLocalScale - transform.localScale).sqrMagnitude;
+            if (magsq > Mathf.Epsilon)
+            {
+                AnimatingLocalScale = true;
+                enabled = true;
+
+                if (InterpolationStarted != null && !wasRunning)
+                {
+                    InterpolationStarted();
+                }
+            }
+            else
+            {
+                // set immediately to prevent accumulation of error
+                transform.localScale = target;
+                AnimatingLocalScale = false;
+            }
+        }
+
+        /// <summary>
+        /// Interpolates smoothly to a target position.
+        /// </summary>
+        /// <param name="start">The starting position.</param>
+        /// <param name="target">The destination position.</param>
+        /// <param name="deltaTime">Caller-provided Time.deltaTime.</param>
+        /// <param name="speed">The speed to apply to the interpolation.</param>
+        /// <returns>New interpolated position closer to target</returns>
+        public static Vector3 NonLinearInterpolateTo(Vector3 start, Vector3 target, float deltaTime, float speed)
+        {
+            // If no interpolation speed, jump to target value.
+            if (speed <= 0.0f)
+            {
+                return target;
+            }
+
+            Vector3 distance = (target - start);
+
+            // When close enough, jump to the target
+            if (distance.sqrMagnitude <= Mathf.Epsilon)
+            {
+                return target;
+            }
+
+            // Apply the delta, then clamp so we don't overshoot the target
+            Vector3 deltaMove = distance * Mathf.Clamp(deltaTime * speed, 0.0f, 1.0f);
+
+            return start + deltaMove;
+        }
+
+        /// <summary>
+        /// Snaps to the final target and stops interpolating
+        /// </summary>
+        public void SnapToTarget()
+        {
+            if (enabled)
+            {
+                transform.position = TargetPosition;
+                transform.rotation = TargetRotation;
+                transform.localRotation = TargetLocalRotation;
+                transform.localScale = TargetLocalScale;
+
+                AnimatingPosition = false;
+                AnimatingLocalScale = false;
+                AnimatingRotation = false;
+                AnimatingLocalRotation = false;
+                enabled = false;
+
+                InterpolationDone?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Stops the interpolation regardless if it has reached the target
+        /// </summary>
+        public void StopInterpolating()
+        {
+            if (enabled)
+            {
+                Reset();
+                InterpolationDone?.Invoke();
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2	
+guid: 49e053307151459ca2db5bdd9176a3b0	
+MonoImporter:	
+  externalObjects: {}	
+  serializedVersion: 2	
+  defaultReferences: []	
+  executionOrder: 0	
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}	
+  userData: 	
+  assetBundleName: 	
+  assetBundleVariant: 


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4191

The previous linked change got rid of some code that wasn't referenced anywhere in the MRTK and had no documentation - along with the private->public payload that came back in March, there was a significant portion of dead code that was introduced and this got cleaned up with it. Based on some feedback from customers, they were in fact using these utilities, so we're adding them back with tests to show how things should expect to work.

I'd love to have more coverage on Interpolator.cs, but this would require some minor refactoring (non breaking changes) in order to actually unit test those things (in particular, we'd need to abstract away the usage of time in order to properly test the script)