### PR TITLE
add additional supportedplatform enum values for future / expansion use

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
   focusProviderType:

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/SupportedPlatforms.cs
@@ -11,14 +11,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [Flags]
     public enum SupportedPlatforms
     {
-        WindowsStandalone = 1 << 0,
-        MacStandalone = 1 << 1,
-        LinuxStandalone = 1 << 2,
-        WindowsUniversal = 1 << 3,
-        WindowsEditor = 1 << 4,
-        Android = 1 << 5,
-        IOS = 1 << 6,
-        Web = 1 << 7,
-        Lumin = 1 << 8
+        WindowsStandalone   = 1 << 0,
+        MacStandalone       = 1 << 1,
+        LinuxStandalone     = 1 << 2,
+        WindowsUniversal    = 1 << 3,
+        WindowsEditor       = 1 << 4,
+        Android             = 1 << 5,
+        MacEditor           = 1 << 6,
+        LinuxEditor         = 1 << 7,
+        IOS                 = 1 << 8,
+        Web                 = 1 << 9,
+        Lumin               = 1 << 10
     }
 }

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/SupportedPlatforms.cs
@@ -16,6 +16,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         LinuxStandalone = 1 << 2,
         WindowsUniversal = 1 << 3,
         WindowsEditor = 1 << 4,
-        Android = 1 << 5
+        Android = 1 << 5,
+        IOS = 1 << 6,
+        Web = 1 << 7,
+        Lumin = 1 << 8
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
@@ -69,11 +69,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             SupportedPlatforms supportedPlatforms = 0;
 
-            if (Application.platform == RuntimePlatform.WindowsEditor)
+            // Editor platforms
+            switch (Application.platform)
             {
-                supportedPlatforms |= SupportedPlatforms.WindowsEditor;
+                case RuntimePlatform.WindowsEditor:
+                    supportedPlatforms |= SupportedPlatforms.WindowsEditor;
+                    break;
+
+                case RuntimePlatform.OSXEditor:
+                    supportedPlatforms |= SupportedPlatforms.MacEditor;
+                    break;
+
+                case RuntimePlatform.LinuxEditor:
+                    supportedPlatforms |= SupportedPlatforms.LinuxEditor;
+                    break;
             }
 
+            // Build target platforms
             switch (editorBuildTarget)
             {
                 case UnityEditor.BuildTarget.StandaloneWindows:

--- a/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
@@ -26,7 +26,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 case RuntimePlatform.WSAPlayerARM:
                 case RuntimePlatform.WSAPlayerX86:
                 case RuntimePlatform.WSAPlayerX64:
-                case RuntimePlatform.XboxOne:
                     supportedPlatforms |= SupportedPlatforms.WindowsUniversal;
                     break;
                 case RuntimePlatform.OSXPlayer:
@@ -39,6 +38,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     break;
                 case RuntimePlatform.Android:
                     supportedPlatforms |= SupportedPlatforms.Android;
+                    break;
+                case RuntimePlatform.IPhonePlayer:
+                    supportedPlatforms |= SupportedPlatforms.IOS;
+                    break;
+                case RuntimePlatform.WebGLPlayer:
+                    supportedPlatforms |= SupportedPlatforms.Web;
+                    break;
+                case RuntimePlatform.Lumin:
+                    supportedPlatforms |= SupportedPlatforms.Lumin;
                     break;
             }
 

--- a/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
@@ -81,7 +81,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     supportedPlatforms |= SupportedPlatforms.WindowsStandalone;
                     break;
                 case UnityEditor.BuildTarget.WSAPlayer:
-                case UnityEditor.BuildTarget.XboxOne:
                     supportedPlatforms |= SupportedPlatforms.WindowsUniversal;
                     break;
                 case UnityEditor.BuildTarget.StandaloneOSX:
@@ -94,6 +93,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     break;
                 case UnityEditor.BuildTarget.Android:
                     supportedPlatforms |= SupportedPlatforms.Android;
+                    break;
+                case UnityEditor.BuildTarget.iOS:
+                    supportedPlatforms |= SupportedPlatforms.IOS;
+                    break;
+                case UnityEditor.BuildTarget.WebGL:
+                    supportedPlatforms |= SupportedPlatforms.Web;
+                    break;
+                case UnityEditor.BuildTarget.Lumin:
+                    supportedPlatforms |= SupportedPlatforms.Lumin;
                     break;
             }
 


### PR DESCRIPTION
## Overview
Add iOS, Web and Lumin to the SupportedPlatform enums. This will allow future platform extensions to be created for these without needing to recompile the core assemblies.

This is related to the work by @Alexees (#4358) that has been moved to being under consideration for the next major MRTK release.

Also added Mac and Linux editor platforms to address #4601.

![image](https://user-images.githubusercontent.com/13281406/58839663-7bbf1180-8617-11e9-9785-fa6d572ad2d0.png)
