### PR TITLE
Pointer Mediators accessible from code and extensible

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -7,14 +7,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     public class DefaultPointerMediator : IMixedRealityPointerMediator
     {
-        private readonly HashSet<IMixedRealityPointer> allPointers = new HashSet<IMixedRealityPointer>();
-        private readonly HashSet<IMixedRealityPointer> farInteractPointers = new HashSet<IMixedRealityPointer>();
-        private readonly HashSet<IMixedRealityNearPointer> nearInteractPointers = new HashSet<IMixedRealityNearPointer>();
-        private readonly HashSet<IMixedRealityTeleportPointer> teleportPointers = new HashSet<IMixedRealityTeleportPointer>();
-        private readonly HashSet<IMixedRealityPointer> unassignedPointers = new HashSet<IMixedRealityPointer>();
-        private readonly Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>> pointerByInputSourceParent = new Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>>();
+        protected readonly HashSet<IMixedRealityPointer> allPointers = new HashSet<IMixedRealityPointer>();
+        protected readonly HashSet<IMixedRealityPointer> farInteractPointers = new HashSet<IMixedRealityPointer>();
+        protected readonly HashSet<IMixedRealityNearPointer> nearInteractPointers = new HashSet<IMixedRealityNearPointer>();
+        protected readonly HashSet<IMixedRealityTeleportPointer> teleportPointers = new HashSet<IMixedRealityTeleportPointer>();
+        protected readonly HashSet<IMixedRealityPointer> unassignedPointers = new HashSet<IMixedRealityPointer>();
+        protected readonly Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>> pointerByInputSourceParent = new Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>>();
 
-        public void RegisterPointers(IMixedRealityPointer[] pointers)
+        public virtual void RegisterPointers(IMixedRealityPointer[] pointers)
         {
             for (int i = 0; i < pointers.Length; i++)
             {
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        public void UnregisterPointers(IMixedRealityPointer[] pointers)
+        public virtual void UnregisterPointers(IMixedRealityPointer[] pointers)
         {
             for (int i = 0; i < pointers.Length; i++)
             {
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        public void UpdatePointers()
+        public virtual void UpdatePointers()
         {
             // If there's any teleportation going on, disable all pointers except the teleporter
             foreach (IMixedRealityTeleportPointer pointer in teleportPointers)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -32,11 +32,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private PointerHitResult hitResult3d = new PointerHitResult();
         private PointerHitResult hitResultUi = new PointerHitResult();
 
-        public ref readonly Dictionary<uint, IMixedRealityPointerMediator> PointerMediators
+        public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators
         {
             get
             {
-                return ref pointerMediators;
+                return pointerMediators;
             }
         }
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -32,6 +32,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private PointerHitResult hitResult3d = new PointerHitResult();
         private PointerHitResult hitResultUi = new PointerHitResult();
 
+        public ref readonly Dictionary<uint, IMixedRealityPointerMediator> PointerMediators
+        {
+            get
+            {
+                return ref pointerMediators;
+            }
+        }
+
         /// <summary>
         /// Number of IMixedRealityNearPointers that are active (IsInteractionEnabled == true).
         /// </summary>
@@ -42,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// are active (IsInteractionEnabled == true), excluding the gaze cursor
         /// </summary>
         public int NumFarPointersActive { get; private set; }
-        
+
         private IMixedRealityInputSystem inputSystem = null;
 
         /// <summary>
@@ -848,7 +856,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             return (hit1.hitObject != null) ? hit1 : hit2;
         }
-        
+
         /// <summary>
         /// Disable inactive pointers to unclutter the way for active ones.
         /// </summary>


### PR DESCRIPTION
## Overview
Fixes: #4696 by making pointer mediators accessible from code. Also allows `DefaultPointerMediator` to be extended by making methods virtual and fields protected.

This enables users to crate solutions like turn off the far hand beams at runtime as described in [this stackoverflow post](https://stackoverflow.com/questions/56248329/how-to-turn-off-motion-controller-pointer-mediator)

