### PR TITLE
Add check to assure that closestProximityTouchable is at least distFront away

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         Vector3 normal;
                         float dist = prox.DistanceToTouchable(Position, out normal);
-                        if (dist < closestDistance)
+                        if (dist < prox.DistFront && dist < closestDistance)
                         {   
                             closestDistance = dist;
                             newClosestTouchable = prox;


### PR DESCRIPTION
## Overview
distFront is now per BaseNearInteractionTouchable. As such, we need to check distFront for each BaseNearInteractionTouchable.

## Changes
- Fixes: #4699.

