### PR TITLE
Update States.cs to use CreateInstance instead of new

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/States.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public static States GetDefaultInteractableStates()
         {
-            States result = new States();
+            States result = CreateInstance<States>();
 
             InteractableStates allInteractableStates = new InteractableStates();
 


### PR DESCRIPTION
## Overview
States.cs was using `new` to create an instance of a `ScriptableObject` instead of `CreateInstance`.
I'm not fully sure how I got into this state, since the `GetDefaultInteractableStates` method appears to only be called if you don't have a state specified in the Inspector, but the Inspector seems to try to make sure the default asset is always loaded in. Deleting the default asset is a good way to repro this issue.

Note: this is currently targeting mrtk_development. Feel free to retarget to stabilization if we want to take this there (my branch is based on stabilization, so it won't be bringing over anything extra from dev), but I don't see this as blocking RC2.

## Changes
- Fixes: #4705 

## Verification
1. Ensure that this call still creates `States` and uses it correctly