### PR TITLE
Update other inputsystemprofiles and mark simulation service as cross-editor-platform

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoInputSystemProfile.asset
@@ -52,7 +52,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 0e54184c8f9cca44aad8fdda3f62fd82,
       type: 2}
   - componentType:

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/CustomProfiles/HandInteractionRecordArticulatedHandPoseMixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/CustomProfiles/HandInteractionRecordArticulatedHandPoseMixedRealityInputSystemProfile.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
   focusProviderType:

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Dictation/Dictation.MixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Dictation/Dictation.MixedRealityInputSystemProfile.asset
@@ -59,7 +59,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
   - componentType:

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityInputSystemProfile.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: dbb7d9502608042489e0a90bd8c6e73a,
       type: 2}
   focusProviderType:

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/Speech/Speech.MixedRealityInputSystemProfile.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
   focusProviderType:

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Profiles/Interactable_MixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Profiles/Interactable_MixedRealityInputSystemProfile.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
   focusProviderType:

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset
@@ -66,7 +66,7 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
     componentName: Input Simulation Service
     priority: 0
-    runtimePlatform: 16
+    runtimePlatform: 208
     deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
       type: 2}
   - componentType:

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 {
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
-        SupportedPlatforms.WindowsEditor,
+        SupportedPlatforms.WindowsEditor | SupportedPlatforms.MacEditor | SupportedPlatforms.LinuxEditor,
         "Input Simulation Service",
         "Profiles/DefaultMixedRealityInputSimulationProfile.asset",
         "MixedRealityToolkit.SDK")]


### PR DESCRIPTION
## Overview
Following up on #4691, a few input system profiles needed to be updated. Additionally, I marked the service itself as cross-editor-platform via the system attribute.

## Changes
- Additional support for #4601
