### PR TITLE
Remove need for repeated calls to DisplayOption in WindowsMixedRealitySpatialMeshObserver

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -191,11 +191,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
 
             set
             {
-                if (value != displayOption)
-                {
-                    displayOption = value;
-                    ApplyUpdatedMeshDisplayOption(displayOption);
-                }
+                displayOption = value;
+                ApplyUpdatedMeshDisplayOption(displayOption);
             }
         }
 


### PR DESCRIPTION
The current implementation of the DisplayOption setter in WindowsMixedRealitySpatialMeshObserver checks to see if the value being set is _not_ the same as the current value. Only then will it perform any operations (including updating the material on existing meshes).

Because of this, code that changes a material (ec: VisibleMaterial) must set DisplayOption twice.

```
observer.VisibleMaterial = newMaterial;
observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.None;
observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.Visible;
```

This change removes the previous value check and _always_ performs processing when DisplayOption is set. This allows for a more natural calling pattern without the need for knowing the quirks of this observer.

```
observer.VisibleMaterial = newMaterial;
observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.Visible;
```