### PR TITLE
Depth Buffer Sharing Material Warning

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent cullMode = new GUIContent("Cull Mode", "Triangle Culling Mode");
             public static GUIContent renderQueueOverride = new GUIContent("Render Queue Override", "Manually Override the Render Queue");
             public static GUIContent albedo = new GUIContent("Albedo", "Albedo (RGB) and Transparency (Alpha)");
-            public static GUIContent albedoAssignedAtRuntime = new GUIContent("Albedo Assigned at Runtime", "As an optimization albedo operations are disabled when no albedo texture is specified. If a albedo texture will be specified at runtime enable this option.");
+            public static GUIContent albedoAssignedAtRuntime = new GUIContent("Assigned at Runtime", "As an optimization albedo operations are disabled when no albedo texture is specified. If a albedo texture will be specified at runtime enable this option.");
             public static GUIContent alphaCutoff = new GUIContent("Alpha Cutoff", "Threshold for Alpha Cutoff");
             public static GUIContent metallic = new GUIContent("Metallic", "Metallic Value");
             public static GUIContent smoothness = new GUIContent("Smoothness", "Smoothness Value");
@@ -501,6 +501,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUILayout.Label(Styles.primaryMapsTitle, EditorStyles.boldLabel);
 
             materialEditor.TexturePropertySingleLine(Styles.albedo, albedoMap, albedoColor);
+
+            if (albedoMap.textureValue == null)
+            {
+                materialEditor.ShaderProperty(albedoAssignedAtRuntime, Styles.albedoAssignedAtRuntime, 2);
+            }
+
             materialEditor.ShaderProperty(enableChannelMap, Styles.enableChannelMap);
 
             if (PropertyEnabled(enableChannelMap))
@@ -785,11 +791,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (!GUI.enabled && !material.enableInstancing)
             {
                 material.enableInstancing = true;
-            }
-
-            if (albedoMap.textureValue == null)
-            {
-                materialEditor.ShaderProperty(albedoAssignedAtRuntime, Styles.albedoAssignedAtRuntime);
             }
 
             materialEditor.EnableInstancingField();

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
 using System.IO;
 using UnityEditor;
@@ -83,8 +82,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Existing Color");
             public static GUIContent depthTest = new GUIContent("Depth Test", "How Should Depth Testing Be Performed.");
             public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Material Are Written to the Depth Buffer");
-            public static GUIContent depthWriteWarning = new GUIContent("<color=yellow>Warning:</color> Depth buffer sharing is enabled for this project, but this material does not write depth. Enabling depth will improve reprojection, but may cause rendering artifacts in translucent materials.");
-            public static GUIContent depthWriteFixNowButton = new GUIContent("Fix Now", "Enables Depth Write For This Material");
             public static GUIContent depthOffsetFactor = new GUIContent("Depth Offset Factor", "Scales the Maximum Z Slope, with Respect to X or Y of the Polygon");
             public static GUIContent depthOffsetUnits = new GUIContent("Depth Offset Units", "Scales the Minimum Resolvable Depth Buffer Value");
             public static GUIContent colorWriteMask = new GUIContent("Color Write Mask", "Color Channel Writing Mask");
@@ -496,21 +493,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUI.indentLevel -= 2;
             }
 
-            if (!PropertyEnabled(depthWrite) && IsDepthBufferSharingEnabled())
+            if (!PropertyEnabled(depthWrite))
             {
-                var defaultValue = EditorStyles.helpBox.richText;
-                EditorStyles.helpBox.richText = true;
-
-                if (materialEditor.HelpBoxWithButton(Styles.depthWriteWarning, Styles.depthWriteFixNowButton))
+                if (MixedRealityToolkitShaderGUIUtilities.DisplayDepthWriteWarning(materialEditor))
                 {
-                    if (EditorUtility.DisplayDialog("Depth Write", "Change this material to write to the depth buffer?", "Yes", "No"))
-                    {
-                        renderingMode.floatValue = (float)RenderingMode.Custom;
-                        depthWrite.floatValue = (float)DepthWrite.On;
-                    }
+                    renderingMode.floatValue = (float)RenderingMode.Custom;
+                    depthWrite.floatValue = (float)DepthWrite.On;
                 }
-
-                EditorStyles.helpBox.richText = defaultValue;
             }
 
             materialEditor.ShaderProperty(cullMode, Styles.cullMode);
@@ -1084,30 +1073,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 material.SetColor(propertyName, propertyValue.Value);
             }
-        }
-
-        protected static bool IsDepthBufferSharingEnabled()
-        {
-            if (PlayerSettings.VROculus.sharedDepthBuffer)
-            {
-                return true;
-            }
-
-#if UNITY_2019_1_OR_NEWER
-            if (PlayerSettings.VRWindowsMixedReality.depthBufferSharingEnabled)
-            {
-                return true;
-            }
-#else
-            var playerSettings = MixedRealityOptimizeUtils.GetSettingsObject("PlayerSettings");
-            var property = playerSettings?.FindProperty("vrSettings.hololens.depthBufferSharingEnabled");
-            if (property != null && property.boolValue)
-            {
-                return true;
-            }
-#endif
-
-            return false;
         }
 
         [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
 using System.IO;
 using UnityEditor;
@@ -81,7 +82,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Existing Color");
             public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Existing Color");
             public static GUIContent depthTest = new GUIContent("Depth Test", "How Should Depth Testing Be Performed.");
-            public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Object Are Written to the Depth Buffer");
+            public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Material Are Written to the Depth Buffer");
+            public static GUIContent depthWriteWarning = new GUIContent("<color=yellow>Warning:</color> Depth buffer sharing is enabled for this project, but this material does not write depth. Enabling depth will improve reprojection, but may cause rendering artifacts in translucent materials.");
+            public static GUIContent depthWriteFixNowButton = new GUIContent("Fix Now", "Enables Depth Write For This Material");
             public static GUIContent depthOffsetFactor = new GUIContent("Depth Offset Factor", "Scales the Maximum Z Slope, with Respect to X or Y of the Polygon");
             public static GUIContent depthOffsetUnits = new GUIContent("Depth Offset Units", "Scales the Minimum Resolvable Depth Buffer Value");
             public static GUIContent colorWriteMask = new GUIContent("Color Write Mask", "Color Channel Writing Mask");
@@ -491,6 +494,23 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 materialEditor.ShaderProperty(depthOffsetUnits, Styles.depthOffsetUnits);
                 materialEditor.ShaderProperty(colorWriteMask, Styles.colorWriteMask);
                 EditorGUI.indentLevel -= 2;
+            }
+
+            if (!PropertyEnabled(depthWrite) && IsDepthBufferSharingEnabled())
+            {
+                var defaultValue = EditorStyles.helpBox.richText;
+                EditorStyles.helpBox.richText = true;
+
+                if (materialEditor.HelpBoxWithButton(Styles.depthWriteWarning, Styles.depthWriteFixNowButton))
+                {
+                    if (EditorUtility.DisplayDialog("Depth Write", "Change this material to write to the depth buffer?", "Yes", "No"))
+                    {
+                        renderingMode.floatValue = (float)RenderingMode.Custom;
+                        depthWrite.floatValue = (float)DepthWrite.On;
+                    }
+                }
+
+                EditorStyles.helpBox.richText = defaultValue;
             }
 
             materialEditor.ShaderProperty(cullMode, Styles.cullMode);
@@ -1064,6 +1084,30 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 material.SetColor(propertyName, propertyValue.Value);
             }
+        }
+
+        protected static bool IsDepthBufferSharingEnabled()
+        {
+            if (PlayerSettings.VROculus.sharedDepthBuffer)
+            {
+                return true;
+            }
+
+#if UNITY_2019_1_OR_NEWER
+            if (PlayerSettings.VRWindowsMixedReality.depthBufferSharingEnabled)
+            {
+                return true;
+            }
+#else
+            var playerSettings = MixedRealityOptimizeUtils.GetSettingsObject("PlayerSettings");
+            var property = playerSettings?.FindProperty("vrSettings.hololens.depthBufferSharingEnabled");
+            if (property != null && property.boolValue)
+            {
+                return true;
+            }
+#endif
+
+            return false;
         }
 
         [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -517,7 +517,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 albedoAlphaMode.floatValue = EditorGUILayout.Popup(albedoAlphaMode.displayName, (int)albedoAlphaMode.floatValue, Styles.albedoAlphaModeNames);
 
-                if ((RenderingMode)renderingMode.floatValue == RenderingMode.TransparentCutout)
+                if ((RenderingMode)renderingMode.floatValue == RenderingMode.TransparentCutout || 
+                    (RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
                 {
                     materialEditor.ShaderProperty(alphaCutoff, Styles.alphaCutoff.text);
                 }

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityTextMeshProShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityTextMeshProShaderGUI.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using TMPro.EditorUtilities;
+using UnityEditor;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// A custom TMP_SDFShaderGUI inspector for the "Mixed Reality Toolkit/TextMeshPro" shader.
+    /// Adds the ability to change the depth write mode, and a warning about depth write
+    /// when depth buffer sharing is enabled.
+    /// </summary>
+    public class MixedRealityTextMeshProShaderGUI : TMP_SDFShaderGUI
+    {
+        protected override void DoGUI()
+        {
+            BeginPanel("Mode", true);
+            DoModePanel();
+            EndPanel();
+
+            base.DoGUI();
+        }
+
+        protected void DoModePanel()
+        {
+            EditorGUI.indentLevel += 1;
+
+            var depthWrite = FindProperty("_ZWrite", m_Properties, false);
+
+            if (depthWrite != null)
+            {
+                m_Editor.ShaderProperty(depthWrite, depthWrite.displayName);
+
+                if (depthWrite.floatValue.Equals(0.0f))
+                {
+                    if (MixedRealityToolkitShaderGUIUtilities.DisplayDepthWriteWarning(m_Editor))
+                    {
+                        depthWrite.floatValue = 1.0f;
+                    }
+                }
+            }
+
+            EditorGUI.indentLevel -= 1;
+            EditorGUILayout.Space();
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityTextMeshProShaderGUI.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityTextMeshProShaderGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b322d4ab96d0da446be114e721d59c1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkit.Core.Inspectors.asmdef
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkit.Core.Inspectors.asmdef
@@ -6,7 +6,9 @@
         "Microsoft.MixedReality.Toolkit.Core.Build",
         "Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities.Editor",
         "Microsoft.MixedReality.Toolkit.Core.Utilities.Editor",
-        "Microsoft.MixedReality.Toolkit.Core.Utilities.Async"
+        "Microsoft.MixedReality.Toolkit.Core.Utilities.Async",
+        "Unity.TextMeshPro.Editor",
+        "Unity.TextMeshPro"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitShaderGUIUtilities.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitShaderGUIUtilities.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// A collection of shared functionality for MRTK shader GUIs.
+    /// </summary>
+    public static class MixedRealityToolkitShaderGUIUtilities
+    {
+        /// <summary>
+        /// GUI content styles which are common among shader GUIs.
+        /// </summary>
+        public static class Styles
+        {
+            public static readonly GUIContent DepthWriteWarning = new GUIContent("<color=yellow>Warning:</color> Depth buffer sharing is enabled for this project, but this material does not write depth. Enabling depth will improve reprojection, but may cause rendering artifacts in translucent materials.");
+            public static readonly GUIContent DepthWriteFixNowButton = new GUIContent("Fix Now", "Enables Depth Write For This Material");
+        }
+
+        /// <summary>
+        /// Checks if the project has depth buffer sharing enabled.
+        /// </summary>
+        /// <returns>True if the project has depth buffer sharing enabled, false otherwise.</returns>
+        public static bool IsDepthBufferSharingEnabled()
+        {
+            if (PlayerSettings.VROculus.sharedDepthBuffer)
+            {
+                return true;
+            }
+
+#if UNITY_2019_1_OR_NEWER
+            if (PlayerSettings.VRWindowsMixedReality.depthBufferSharingEnabled)
+            {
+                return true;
+            }
+#else
+            var playerSettings = MixedRealityOptimizeUtils.GetSettingsObject("PlayerSettings");
+            var property = playerSettings?.FindProperty("vrSettings.hololens.depthBufferSharingEnabled");
+            if (property != null && property.boolValue)
+            {
+                return true;
+            }
+#endif
+
+            return false;
+        }
+
+        /// <summary>
+        /// Displays a depth write warning and fix button if depth buffer sharing is enabled.
+        /// </summary>
+        /// <param name="materialEditor">The material editor to display the warning in.</param>
+        /// <param name="dialogTitle">The title of the dialog window to display when the user selects the fix button.</param>
+        /// <param name="dialogMessage">The message in the dialog window when the user selects the fix button.</param>
+        /// <returns>True if the user opted to fix the warning, false otherwise.</returns>
+        public static bool DisplayDepthWriteWarning(MaterialEditor materialEditor, string dialogTitle = "Depth Write", string dialogMessage = "Change this material to write to the depth buffer?")
+        {
+            bool dialogConfirmed = false;
+
+            if (IsDepthBufferSharingEnabled())
+            {
+                var defaultValue = EditorStyles.helpBox.richText;
+                EditorStyles.helpBox.richText = true;
+
+                if (materialEditor.HelpBoxWithButton(Styles.DepthWriteWarning, Styles.DepthWriteFixNowButton))
+                {
+                    if (EditorUtility.DisplayDialog(dialogTitle, dialogMessage, "Yes", "No"))
+                    {
+                        dialogConfirmed = true;
+                    }
+                }
+
+                EditorStyles.helpBox.richText = defaultValue;
+            }
+
+            return dialogConfirmed;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitShaderGUIUtilities.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitShaderGUIUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97a49d6c607c32b449bb332cd755610d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityTextMeshPro.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityTextMeshPro.shader
@@ -14,95 +14,95 @@
 Shader "Mixed Reality Toolkit/TextMeshPro" {
 
 Properties {
-	_FaceColor			("Face Color", Color) = (1,1,1,1)
-	_FaceDilate			("Face Dilate", Range(-1,1)) = 0
+    _FaceColor            ("Face Color", Color) = (1,1,1,1)
+    _FaceDilate            ("Face Dilate", Range(-1,1)) = 0
 
-	_OutlineColor		("Outline Color", Color) = (0,0,0,1)
-	_OutlineWidth		("Outline Thickness", Range(0,1)) = 0
-	_OutlineSoftness	("Outline Softness", Range(0,1)) = 0
+    _OutlineColor        ("Outline Color", Color) = (0,0,0,1)
+    _OutlineWidth        ("Outline Thickness", Range(0,1)) = 0
+    _OutlineSoftness    ("Outline Softness", Range(0,1)) = 0
 
-	_UnderlayColor		("Border Color", Color) = (0,0,0,.5)
-	_UnderlayOffsetX 	("Border OffsetX", Range(-1,1)) = 0
-	_UnderlayOffsetY 	("Border OffsetY", Range(-1,1)) = 0
-	_UnderlayDilate		("Border Dilate", Range(-1,1)) = 0
-	_UnderlaySoftness 	("Border Softness", Range(0,1)) = 0
+    _UnderlayColor        ("Border Color", Color) = (0,0,0,.5)
+    _UnderlayOffsetX     ("Border OffsetX", Range(-1,1)) = 0
+    _UnderlayOffsetY     ("Border OffsetY", Range(-1,1)) = 0
+    _UnderlayDilate        ("Border Dilate", Range(-1,1)) = 0
+    _UnderlaySoftness     ("Border Softness", Range(0,1)) = 0
 
-	_WeightNormal		("Weight Normal", float) = 0
-	_WeightBold			("Weight Bold", float) = .5
+    _WeightNormal        ("Weight Normal", float) = 0
+    _WeightBold            ("Weight Bold", float) = .5
 
-	_ShaderFlags		("Flags", float) = 0
-	_ScaleRatioA		("Scale RatioA", float) = 1
-	_ScaleRatioB		("Scale RatioB", float) = 1
-	_ScaleRatioC		("Scale RatioC", float) = 1
+    _ShaderFlags        ("Flags", float) = 0
+    _ScaleRatioA        ("Scale RatioA", float) = 1
+    _ScaleRatioB        ("Scale RatioB", float) = 1
+    _ScaleRatioC        ("Scale RatioC", float) = 1
 
-	_MainTex			("Font Atlas", 2D) = "white" {}
-	_TextureWidth		("Texture Width", float) = 512
-	_TextureHeight		("Texture Height", float) = 512
-	_GradientScale		("Gradient Scale", float) = 5
-	_ScaleX				("Scale X", float) = 1
-	_ScaleY				("Scale Y", float) = 1
-	_PerspectiveFilter	("Perspective Correction", Range(0, 1)) = 0.875
-	_Sharpness			("Sharpness", Range(-1,1)) = 0
+    _MainTex            ("Font Atlas", 2D) = "white" {}
+    _TextureWidth        ("Texture Width", float) = 512
+    _TextureHeight        ("Texture Height", float) = 512
+    _GradientScale        ("Gradient Scale", float) = 5
+    _ScaleX                ("Scale X", float) = 1
+    _ScaleY                ("Scale Y", float) = 1
+    _PerspectiveFilter    ("Perspective Correction", Range(0, 1)) = 0.875
+    _Sharpness            ("Sharpness", Range(-1,1)) = 0
 
-	_VertexOffsetX		("Vertex OffsetX", float) = 0
-	_VertexOffsetY		("Vertex OffsetY", float) = 0
+    _VertexOffsetX        ("Vertex OffsetX", float) = 0
+    _VertexOffsetY        ("Vertex OffsetY", float) = 0
 
-	_ClipRect			("Clip Rect", vector) = (-32767, -32767, 32767, 32767)
-	_MaskSoftnessX		("Mask SoftnessX", float) = 0
-	_MaskSoftnessY		("Mask SoftnessY", float) = 0
-	
-	_StencilComp		("Stencil Comparison", Float) = 8
-	_Stencil			("Stencil ID", Float) = 0
-	_StencilOp			("Stencil Operation", Float) = 0
-	_StencilWriteMask	("Stencil Write Mask", Float) = 255
-	_StencilReadMask	("Stencil Read Mask", Float) = 255
-	
-	_ColorMask			("Color Mask", Float) = 15
+    _ClipRect            ("Clip Rect", vector) = (-32767, -32767, 32767, 32767)
+    _MaskSoftnessX        ("Mask SoftnessX", float) = 0
+    _MaskSoftnessY        ("Mask SoftnessY", float) = 0
+    
+    _StencilComp        ("Stencil Comparison", Float) = 8
+    _Stencil            ("Stencil ID", Float) = 0
+    _StencilOp            ("Stencil Operation", Float) = 0
+    _StencilWriteMask    ("Stencil Write Mask", Float) = 255
+    _StencilReadMask    ("Stencil Read Mask", Float) = 255
+    
+    _ColorMask            ("Color Mask", Float) = 15
     _ZWrite             ("Depth Write", Float) = 0
 }
 
 SubShader {
-	Tags 
-	{
-		"Queue"="Transparent"
-		"IgnoreProjector"="True"
-		"RenderType"="Transparent"
-	}
+    Tags 
+    {
+        "Queue"="Transparent"
+        "IgnoreProjector"="True"
+        "RenderType"="Transparent"
+    }
 
 
-	Stencil
-	{
-		Ref [_Stencil]
-		Comp [_StencilComp]
-		Pass [_StencilOp] 
-		ReadMask [_StencilReadMask]
-		WriteMask [_StencilWriteMask]
-	}
+    Stencil
+    {
+        Ref [_Stencil]
+        Comp [_StencilComp]
+        Pass [_StencilOp] 
+        ReadMask [_StencilReadMask]
+        WriteMask [_StencilWriteMask]
+    }
 
-	Cull [_CullMode]
+    Cull [_CullMode]
     ZWrite[_ZWrite]
-	Lighting Off
-	Fog { Mode Off }
-	ZTest [unity_GUIZTestMode]
-	Blend One OneMinusSrcAlpha
-	ColorMask [_ColorMask]
+    Lighting Off
+    Fog { Mode Off }
+    ZTest [unity_GUIZTestMode]
+    Blend One OneMinusSrcAlpha
+    ColorMask [_ColorMask]
 
-	Pass {
-		CGPROGRAM
-		#pragma vertex VertShader
-		#pragma fragment PixShader
-		#pragma shader_feature __ OUTLINE_ON
-		#pragma shader_feature __ UNDERLAY_ON UNDERLAY_INNER
+    Pass {
+        CGPROGRAM
+        #pragma vertex VertShader
+        #pragma fragment PixShader
+        #pragma shader_feature __ OUTLINE_ON
+        #pragma shader_feature __ UNDERLAY_ON UNDERLAY_INNER
 
-		#pragma multi_compile __ UNITY_UI_CLIP_RECT
-		#pragma multi_compile __ UNITY_UI_ALPHACLIP
+        #pragma multi_compile __ UNITY_UI_CLIP_RECT
+        #pragma multi_compile __ UNITY_UI_ALPHACLIP
 
         #pragma multi_compile __ _CLIPPING_PLANE
         #pragma multi_compile __ _CLIPPING_SPHERE
         #pragma multi_compile __ _CLIPPING_BOX
 
-		#include "UnityCG.cginc"
-		#include "UnityUI.cginc"
+        #include "UnityCG.cginc"
+        #include "UnityUI.cginc"
 
 #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
         #define _CLIPPING_PRIMITIVE
@@ -111,92 +111,92 @@ SubShader {
 #endif
 
         // Direct include for portability.
-		//#include "TMPro_Properties.cginc"
+        //#include "TMPro_Properties.cginc"
         // UI Editable properties
-        uniform sampler2D	_FaceTex;					// Alpha : Signed Distance
-        uniform float		_FaceUVSpeedX;
-        uniform float		_FaceUVSpeedY;
-        uniform fixed4		_FaceColor;					// RGBA : Color + Opacity
-        uniform float		_FaceDilate;				// v[ 0, 1]
-        uniform float		_OutlineSoftness;			// v[ 0, 1]
+        uniform sampler2D    _FaceTex;                    // Alpha : Signed Distance
+        uniform float        _FaceUVSpeedX;
+        uniform float        _FaceUVSpeedY;
+        uniform fixed4        _FaceColor;                    // RGBA : Color + Opacity
+        uniform float        _FaceDilate;                // v[ 0, 1]
+        uniform float        _OutlineSoftness;            // v[ 0, 1]
         
-        uniform sampler2D	_OutlineTex;				// RGBA : Color + Opacity
-        uniform float		_OutlineUVSpeedX;
-        uniform float		_OutlineUVSpeedY;
-        uniform fixed4		_OutlineColor;				// RGBA : Color + Opacity
-        uniform float		_OutlineWidth;				// v[ 0, 1]
+        uniform sampler2D    _OutlineTex;                // RGBA : Color + Opacity
+        uniform float        _OutlineUVSpeedX;
+        uniform float        _OutlineUVSpeedY;
+        uniform fixed4        _OutlineColor;                // RGBA : Color + Opacity
+        uniform float        _OutlineWidth;                // v[ 0, 1]
         
-        uniform float		_Bevel;						// v[ 0, 1]
-        uniform float		_BevelOffset;				// v[-1, 1]
-        uniform float		_BevelWidth;				// v[-1, 1]
-        uniform float		_BevelClamp;				// v[ 0, 1]
-        uniform float		_BevelRoundness;			// v[ 0, 1]
+        uniform float        _Bevel;                        // v[ 0, 1]
+        uniform float        _BevelOffset;                // v[-1, 1]
+        uniform float        _BevelWidth;                // v[-1, 1]
+        uniform float        _BevelClamp;                // v[ 0, 1]
+        uniform float        _BevelRoundness;            // v[ 0, 1]
         
-        uniform sampler2D	_BumpMap;					// Normal map
-        uniform float		_BumpOutline;				// v[ 0, 1]
-        uniform float		_BumpFace;					// v[ 0, 1]
+        uniform sampler2D    _BumpMap;                    // Normal map
+        uniform float        _BumpOutline;                // v[ 0, 1]
+        uniform float        _BumpFace;                    // v[ 0, 1]
         
-        uniform samplerCUBE	_Cube;						// Cube / sphere map
-        uniform fixed4 		_ReflectFaceColor;			// RGB intensity
-        uniform fixed4		_ReflectOutlineColor;
-        //uniform float		_EnvTiltX;					// v[-1, 1]
-        //uniform float		_EnvTiltY;					// v[-1, 1]
+        uniform samplerCUBE    _Cube;                        // Cube / sphere map
+        uniform fixed4         _ReflectFaceColor;            // RGB intensity
+        uniform fixed4        _ReflectOutlineColor;
+        //uniform float        _EnvTiltX;                    // v[-1, 1]
+        //uniform float        _EnvTiltY;                    // v[-1, 1]
         uniform float3      _EnvMatrixRotation;
-        uniform float4x4	_EnvMatrix;
+        uniform float4x4    _EnvMatrix;
         
-        uniform fixed4		_SpecularColor;				// RGB intensity
-        uniform float		_LightAngle;				// v[ 0,Tau]
-        uniform float		_SpecularPower;				// v[ 0, 1]
-        uniform float		_Reflectivity;				// v[ 5, 15]
-        uniform float		_Diffuse;					// v[ 0, 1]
-        uniform float		_Ambient;					// v[ 0, 1]
+        uniform fixed4        _SpecularColor;                // RGB intensity
+        uniform float        _LightAngle;                // v[ 0,Tau]
+        uniform float        _SpecularPower;                // v[ 0, 1]
+        uniform float        _Reflectivity;                // v[ 5, 15]
+        uniform float        _Diffuse;                    // v[ 0, 1]
+        uniform float        _Ambient;                    // v[ 0, 1]
         
-        uniform fixed4		_UnderlayColor;				// RGBA : Color + Opacity
-        uniform float		_UnderlayOffsetX;			// v[-1, 1]
-        uniform float		_UnderlayOffsetY;			// v[-1, 1]
-        uniform float		_UnderlayDilate;			// v[-1, 1]
-        uniform float		_UnderlaySoftness;			// v[ 0, 1]
+        uniform fixed4        _UnderlayColor;                // RGBA : Color + Opacity
+        uniform float        _UnderlayOffsetX;            // v[-1, 1]
+        uniform float        _UnderlayOffsetY;            // v[-1, 1]
+        uniform float        _UnderlayDilate;            // v[-1, 1]
+        uniform float        _UnderlaySoftness;            // v[ 0, 1]
         
-        uniform fixed4 		_GlowColor;					// RGBA : Color + Intensity
-        uniform float 		_GlowOffset;				// v[-1, 1]
-        uniform float 		_GlowOuter;					// v[ 0, 1]
-        uniform float 		_GlowInner;					// v[ 0, 1]
-        uniform float 		_GlowPower;					// v[ 1, 1/(1+4*4)]
+        uniform fixed4         _GlowColor;                    // RGBA : Color + Intensity
+        uniform float         _GlowOffset;                // v[-1, 1]
+        uniform float         _GlowOuter;                    // v[ 0, 1]
+        uniform float         _GlowInner;                    // v[ 0, 1]
+        uniform float         _GlowPower;                    // v[ 1, 1/(1+4*4)]
         
         // API Editable properties
-        uniform float 		_ShaderFlags;
-        uniform float		_WeightNormal;
-        uniform float		_WeightBold;
+        uniform float         _ShaderFlags;
+        uniform float        _WeightNormal;
+        uniform float        _WeightBold;
         
-        uniform float		_ScaleRatioA;
-        uniform float		_ScaleRatioB;
-        uniform float		_ScaleRatioC;
+        uniform float        _ScaleRatioA;
+        uniform float        _ScaleRatioB;
+        uniform float        _ScaleRatioC;
         
-        uniform float		_VertexOffsetX;
-        uniform float		_VertexOffsetY;
+        uniform float        _VertexOffsetX;
+        uniform float        _VertexOffsetY;
         
-        //uniform float		_UseClipRect;
-        uniform float		_MaskID;
-        uniform sampler2D	_MaskTex;
-        uniform float4		_MaskCoord;
-        uniform float4		_ClipRect;	// bottom left(x,y) : top right(z,w)
-        //uniform float		_MaskWipeControl;
-        //uniform float		_MaskEdgeSoftness;
-        //uniform fixed4		_MaskEdgeColor;
-        //uniform bool		_MaskInverse;
+        //uniform float        _UseClipRect;
+        uniform float        _MaskID;
+        uniform sampler2D    _MaskTex;
+        uniform float4        _MaskCoord;
+        uniform float4        _ClipRect;    // bottom left(x,y) : top right(z,w)
+        //uniform float        _MaskWipeControl;
+        //uniform float        _MaskEdgeSoftness;
+        //uniform fixed4        _MaskEdgeColor;
+        //uniform bool        _MaskInverse;
         
-        uniform float		_MaskSoftnessX;
-        uniform float		_MaskSoftnessY;
+        uniform float        _MaskSoftnessX;
+        uniform float        _MaskSoftnessY;
         
         // Font Atlas properties
-        uniform sampler2D	_MainTex;
-        uniform float		_TextureWidth;
-        uniform float		_TextureHeight;
-        uniform float 		_GradientScale;
-        uniform float		_ScaleX;
-        uniform float		_ScaleY;
-        uniform float		_PerspectiveFilter;
-        uniform float		_Sharpness;
+        uniform sampler2D    _MainTex;
+        uniform float        _TextureWidth;
+        uniform float        _TextureHeight;
+        uniform float         _GradientScale;
+        uniform float        _ScaleX;
+        uniform float        _ScaleY;
+        uniform float        _PerspectiveFilter;
+        uniform float        _Sharpness;
 
 #if defined(_CLIPPING_PLANE)
         fixed _ClipPlaneSide;
@@ -231,144 +231,144 @@ SubShader {
         }
 #endif
 
-		struct vertex_t {
-			UNITY_VERTEX_INPUT_INSTANCE_ID
-			float4	vertex			: POSITION;
-			float3	normal			: NORMAL;
-			fixed4	color			: COLOR;
-			float2	texcoord0		: TEXCOORD0;
-			float2	texcoord1		: TEXCOORD1;
-		};
+        struct vertex_t {
+            UNITY_VERTEX_INPUT_INSTANCE_ID
+            float4    vertex            : POSITION;
+            float3    normal            : NORMAL;
+            fixed4    color            : COLOR;
+            float2    texcoord0        : TEXCOORD0;
+            float2    texcoord1        : TEXCOORD1;
+        };
 
-		struct pixel_t {
-			UNITY_VERTEX_INPUT_INSTANCE_ID
-			UNITY_VERTEX_OUTPUT_STEREO
-			float4	vertex			: SV_POSITION;
-			fixed4	faceColor		: COLOR;
-			fixed4	outlineColor	: COLOR1;
-			float4	texcoord0		: TEXCOORD0;			// Texture UV, Mask UV
-			half4	param			: TEXCOORD1;			// Scale(x), BiasIn(y), BiasOut(z), Bias(w)
-			half4	mask			: TEXCOORD2;			// Position in clip space(xy), Softness(zw)
-			#if (UNDERLAY_ON | UNDERLAY_INNER)
-			float4	texcoord1		: TEXCOORD3;			// Texture UV, alpha, reserved
-			half2	underlayParam	: TEXCOORD4;			// Scale(x), Bias(y)
-			#endif
+        struct pixel_t {
+            UNITY_VERTEX_INPUT_INSTANCE_ID
+            UNITY_VERTEX_OUTPUT_STEREO
+            float4    vertex            : SV_POSITION;
+            fixed4    faceColor        : COLOR;
+            fixed4    outlineColor    : COLOR1;
+            float4    texcoord0        : TEXCOORD0;            // Texture UV, Mask UV
+            half4    param            : TEXCOORD1;            // Scale(x), BiasIn(y), BiasOut(z), Bias(w)
+            half4    mask            : TEXCOORD2;            // Position in clip space(xy), Softness(zw)
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            float4    texcoord1        : TEXCOORD3;            // Texture UV, alpha, reserved
+            half2    underlayParam    : TEXCOORD4;            // Scale(x), Bias(y)
+            #endif
 #if defined(_CLIPPING_PRIMITIVE)
             float3 worldPosition    : TEXCOORD5;
 #endif
-		};
+        };
 
 
-		pixel_t VertShader(vertex_t input)
-		{
-			pixel_t output;
+        pixel_t VertShader(vertex_t input)
+        {
+            pixel_t output;
 
-			UNITY_INITIALIZE_OUTPUT(pixel_t, output);
-			UNITY_SETUP_INSTANCE_ID(input);
-			UNITY_TRANSFER_INSTANCE_ID(input, output);
-			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
-			
-			float bold = step(input.texcoord1.y, 0);
+            UNITY_INITIALIZE_OUTPUT(pixel_t, output);
+            UNITY_SETUP_INSTANCE_ID(input);
+            UNITY_TRANSFER_INSTANCE_ID(input, output);
+            UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+            
+            float bold = step(input.texcoord1.y, 0);
 
-			float4 vert = input.vertex;
-			vert.x += _VertexOffsetX;
-			vert.y += _VertexOffsetY;
-			float4 vPosition = UnityObjectToClipPos(vert);
+            float4 vert = input.vertex;
+            vert.x += _VertexOffsetX;
+            vert.y += _VertexOffsetY;
+            float4 vPosition = UnityObjectToClipPos(vert);
 
-			float2 pixelSize = vPosition.w;
-			pixelSize /= float2(_ScaleX, _ScaleY) * abs(mul((float2x2)UNITY_MATRIX_P, _ScreenParams.xy));
-			
-			float scale = rsqrt(dot(pixelSize, pixelSize));
-			scale *= abs(input.texcoord1.y) * _GradientScale * (_Sharpness + 1);
-			if(UNITY_MATRIX_P[3][3] == 0) scale = lerp(abs(scale) * (1 - _PerspectiveFilter), scale, abs(dot(UnityObjectToWorldNormal(input.normal.xyz), normalize(WorldSpaceViewDir(vert)))));
+            float2 pixelSize = vPosition.w;
+            pixelSize /= float2(_ScaleX, _ScaleY) * abs(mul((float2x2)UNITY_MATRIX_P, _ScreenParams.xy));
+            
+            float scale = rsqrt(dot(pixelSize, pixelSize));
+            scale *= abs(input.texcoord1.y) * _GradientScale * (_Sharpness + 1);
+            if(UNITY_MATRIX_P[3][3] == 0) scale = lerp(abs(scale) * (1 - _PerspectiveFilter), scale, abs(dot(UnityObjectToWorldNormal(input.normal.xyz), normalize(WorldSpaceViewDir(vert)))));
 
-			float weight = lerp(_WeightNormal, _WeightBold, bold) / 4.0;
-			weight = (weight + _FaceDilate) * _ScaleRatioA * 0.5;
+            float weight = lerp(_WeightNormal, _WeightBold, bold) / 4.0;
+            weight = (weight + _FaceDilate) * _ScaleRatioA * 0.5;
 
-			float layerScale = scale;
+            float layerScale = scale;
 
-			scale /= 1 + (_OutlineSoftness * _ScaleRatioA * scale);
-			float bias = (0.5 - weight) * scale - 0.5;
-			float outline = _OutlineWidth * _ScaleRatioA * 0.5 * scale;
+            scale /= 1 + (_OutlineSoftness * _ScaleRatioA * scale);
+            float bias = (0.5 - weight) * scale - 0.5;
+            float outline = _OutlineWidth * _ScaleRatioA * 0.5 * scale;
 
-			float opacity = input.color.a;
-			#if (UNDERLAY_ON | UNDERLAY_INNER)
-			opacity = 1.0;
-			#endif
+            float opacity = input.color.a;
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            opacity = 1.0;
+            #endif
 
-			fixed4 faceColor = fixed4(input.color.rgb, opacity) * _FaceColor;
-			faceColor.rgb *= faceColor.a;
+            fixed4 faceColor = fixed4(input.color.rgb, opacity) * _FaceColor;
+            faceColor.rgb *= faceColor.a;
 
-			fixed4 outlineColor = _OutlineColor;
-			outlineColor.a *= opacity;
-			outlineColor.rgb *= outlineColor.a;
-			outlineColor = lerp(faceColor, outlineColor, sqrt(min(1.0, (outline * 2))));
+            fixed4 outlineColor = _OutlineColor;
+            outlineColor.a *= opacity;
+            outlineColor.rgb *= outlineColor.a;
+            outlineColor = lerp(faceColor, outlineColor, sqrt(min(1.0, (outline * 2))));
 
-			#if (UNDERLAY_ON | UNDERLAY_INNER)
-			layerScale /= 1 + ((_UnderlaySoftness * _ScaleRatioC) * layerScale);
-			float layerBias = (.5 - weight) * layerScale - .5 - ((_UnderlayDilate * _ScaleRatioC) * .5 * layerScale);
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            layerScale /= 1 + ((_UnderlaySoftness * _ScaleRatioC) * layerScale);
+            float layerBias = (.5 - weight) * layerScale - .5 - ((_UnderlayDilate * _ScaleRatioC) * .5 * layerScale);
 
-			float x = -(_UnderlayOffsetX * _ScaleRatioC) * _GradientScale / _TextureWidth;
-			float y = -(_UnderlayOffsetY * _ScaleRatioC) * _GradientScale / _TextureHeight;
-			float2 layerOffset = float2(x, y);
-			#endif
+            float x = -(_UnderlayOffsetX * _ScaleRatioC) * _GradientScale / _TextureWidth;
+            float y = -(_UnderlayOffsetY * _ScaleRatioC) * _GradientScale / _TextureHeight;
+            float2 layerOffset = float2(x, y);
+            #endif
 
-			// Generate UV for the Masking Texture
-			float4 clampedRect = clamp(_ClipRect, -2e10, 2e10);
-			float2 maskUV = (vert.xy - clampedRect.xy) / (clampedRect.zw - clampedRect.xy);
+            // Generate UV for the Masking Texture
+            float4 clampedRect = clamp(_ClipRect, -2e10, 2e10);
+            float2 maskUV = (vert.xy - clampedRect.xy) / (clampedRect.zw - clampedRect.xy);
 
-			// Populate structure for pixel shader
-			output.vertex = vPosition;
-			output.faceColor = faceColor;
-			output.outlineColor = outlineColor;
-			output.texcoord0 = float4(input.texcoord0.x, input.texcoord0.y, maskUV.x, maskUV.y);
-			output.param = half4(scale, bias - outline, bias + outline, bias);
-			output.mask = half4(vert.xy * 2 - clampedRect.xy - clampedRect.zw, 0.25 / (0.25 * half2(_MaskSoftnessX, _MaskSoftnessY) + pixelSize.xy));
-			#if (UNDERLAY_ON || UNDERLAY_INNER)
-			output.texcoord1 = float4(input.texcoord0 + layerOffset, input.color.a, 0);
-			output.underlayParam = half2(layerScale, layerBias);
-			#endif
+            // Populate structure for pixel shader
+            output.vertex = vPosition;
+            output.faceColor = faceColor;
+            output.outlineColor = outlineColor;
+            output.texcoord0 = float4(input.texcoord0.x, input.texcoord0.y, maskUV.x, maskUV.y);
+            output.param = half4(scale, bias - outline, bias + outline, bias);
+            output.mask = half4(vert.xy * 2 - clampedRect.xy - clampedRect.zw, 0.25 / (0.25 * half2(_MaskSoftnessX, _MaskSoftnessY) + pixelSize.xy));
+            #if (UNDERLAY_ON || UNDERLAY_INNER)
+            output.texcoord1 = float4(input.texcoord0 + layerOffset, input.color.a, 0);
+            output.underlayParam = half2(layerScale, layerBias);
+            #endif
 #if defined(_CLIPPING_PRIMITIVE)
             output.worldPosition = mul(unity_ObjectToWorld, vert).xyz;
 #endif
 
-			return output;
-		}
+            return output;
+        }
 
 
-		// PIXEL SHADER
-		fixed4 PixShader(pixel_t input) : SV_Target
-		{
-			UNITY_SETUP_INSTANCE_ID(input);
-			
-			half d = tex2D(_MainTex, input.texcoord0.xy).a * input.param.x;
-			half4 c = input.faceColor * saturate(d - input.param.w);
+        // PIXEL SHADER
+        fixed4 PixShader(pixel_t input) : SV_Target
+        {
+            UNITY_SETUP_INSTANCE_ID(input);
+            
+            half d = tex2D(_MainTex, input.texcoord0.xy).a * input.param.x;
+            half4 c = input.faceColor * saturate(d - input.param.w);
 
-			#ifdef OUTLINE_ON
-			c = lerp(input.outlineColor, input.faceColor, saturate(d - input.param.z));
-			c *= saturate(d - input.param.y);
-			#endif
+            #ifdef OUTLINE_ON
+            c = lerp(input.outlineColor, input.faceColor, saturate(d - input.param.z));
+            c *= saturate(d - input.param.y);
+            #endif
 
-			#if UNDERLAY_ON
-			d = tex2D(_MainTex, input.texcoord1.xy).a * input.underlayParam.x;
-			c += float4(_UnderlayColor.rgb * _UnderlayColor.a, _UnderlayColor.a) * saturate(d - input.underlayParam.y) * (1 - c.a);
-			#endif
+            #if UNDERLAY_ON
+            d = tex2D(_MainTex, input.texcoord1.xy).a * input.underlayParam.x;
+            c += float4(_UnderlayColor.rgb * _UnderlayColor.a, _UnderlayColor.a) * saturate(d - input.underlayParam.y) * (1 - c.a);
+            #endif
 
-			#if UNDERLAY_INNER
-			half sd = saturate(d - input.param.z);
-			d = tex2D(_MainTex, input.texcoord1.xy).a * input.underlayParam.x;
-			c += float4(_UnderlayColor.rgb * _UnderlayColor.a, _UnderlayColor.a) * (1 - saturate(d - input.underlayParam.y)) * sd * (1 - c.a);
-			#endif
+            #if UNDERLAY_INNER
+            half sd = saturate(d - input.param.z);
+            d = tex2D(_MainTex, input.texcoord1.xy).a * input.underlayParam.x;
+            c += float4(_UnderlayColor.rgb * _UnderlayColor.a, _UnderlayColor.a) * (1 - saturate(d - input.underlayParam.y)) * sd * (1 - c.a);
+            #endif
 
-			// Alternative implementation to UnityGet2DClipping with support for softness.
-			#if UNITY_UI_CLIP_RECT
-			half2 m = saturate((_ClipRect.zw - _ClipRect.xy - abs(input.mask.xy)) * input.mask.zw);
-			c *= m.x * m.y;
-			#endif
+            // Alternative implementation to UnityGet2DClipping with support for softness.
+            #if UNITY_UI_CLIP_RECT
+            half2 m = saturate((_ClipRect.zw - _ClipRect.xy - abs(input.mask.xy)) * input.mask.zw);
+            c *= m.x * m.y;
+            #endif
 
-			#if (UNDERLAY_ON | UNDERLAY_INNER)
-			c *= input.texcoord1.z;
-			#endif
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            c *= input.texcoord1.z;
+            #endif
 
             // Primitive clipping.
 #if defined(_CLIPPING_PRIMITIVE)
@@ -385,14 +385,14 @@ SubShader {
             c *= step(0.0, primitiveDistance);
 #endif
 
-			#if UNITY_UI_ALPHACLIP
-			clip(c.a - 0.001);
-			#endif
+            #if UNITY_UI_ALPHACLIP
+            clip(c.a - 0.001);
+            #endif
 
-			return c;
-		}
-		ENDCG
-	}
+            return c;
+        }
+        ENDCG
+    }
 }
 
 CustomEditor "Microsoft.MixedReality.Toolkit.Editor.MixedRealityTextMeshProShaderGUI"

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityTextMeshPro.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityTextMeshPro.shader
@@ -9,6 +9,7 @@
 // MRTK Additions
 // - Single Pass Instanced Stereo Rendering Support
 // - Support for Clipping Primitives (Plane, Sphere, Box)
+// - ZWrite Property
 
 Shader "Mixed Reality Toolkit/TextMeshPro" {
 
@@ -57,6 +58,7 @@ Properties {
 	_StencilReadMask	("Stencil Read Mask", Float) = 255
 	
 	_ColorMask			("Color Mask", Float) = 15
+    _ZWrite             ("Depth Write", Float) = 0
 }
 
 SubShader {
@@ -78,7 +80,7 @@ SubShader {
 	}
 
 	Cull [_CullMode]
-	ZWrite Off
+    ZWrite[_ZWrite]
 	Lighting Off
 	Fog { Mode Off }
 	ZTest [unity_GUIZTestMode]
@@ -393,5 +395,5 @@ SubShader {
 	}
 }
 
-CustomEditor "TMPro.EditorUtilities.TMP_SDFShaderGUI"
+CustomEditor "Microsoft.MixedReality.Toolkit.Editor.MixedRealityTextMeshProShaderGUI"
 }


### PR DESCRIPTION
## Overview
When enabling depth buffer sharing the stabilization of renderables greatly diminishes when a user looks at a renderable that has a material which does not write to the depth buffer. This has been a common pain point for HoloLens 2 users which don't understand why their holograms look distorted or unstable.

This pull request introduces a warning and "Fix Now" button on materials which are in a project that has depth buffer sharing enabled and do not write depth.

On the MRTK/Standard shader:
![DepthWarning](https://user-images.githubusercontent.com/13305729/58995160-f159e780-87a7-11e9-8b4c-f88c60f7c425.png)

On the MRTK/Text Mesh Pro shader:
![DepthWarningTMP](https://user-images.githubusercontent.com/13305729/58995166-f454d800-87a7-11e9-9c74-3da05e501960.png)

If the "Fix Now" button will spawn a dialog confirming the user wants to change the material to write to the depth buffer.

Other changes include:

-  Moving the "Albedo Assigned At Runtime" option up the inspector for better visibility.
-  Bug fix, allowing the alpha cutoff slider to be adjusted in the  "Custom" render mode.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4733


## Verification
To verify select a material that does not write depth (often transparent or additive materials) and select the "Fix Now" button and check if zWrite is now enabled.
