### PR TITLE
Fix: Slate scroll with hand not working with GGV on Hololens 1 and Motion Controllers in VR #4702

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -646,15 +646,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (data.currentPointer != null)
             {
                 Vector3 pt = data.currentPointer.Position;
-                //if (data.currentController.IsRotationAvailable)
-                //{
-                //   // Vector3 dir = controller.InputSource.Pointers[0].Rays[0].Direction * (controller.InputSource.Pointers[0].SphereCastRadius);
-                //    data.initialProjectedOffset = SnapFingerToQuad(pt);
-                //}
-                //else//pointer is GGVPOinter and has no SphereCastRadius
-                //{
-                    data.initialProjectedOffset = SnapFingerToQuad(pt);
-                //}
+                data.initialProjectedOffset = SnapFingerToQuad(pt);
             }
 
             data.touchingQuadCoord = GetUVFromPoint(data.touchingPoint);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -839,8 +839,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #endregion IMixedRealitySourceStateHandler Methods
 
         #region Unused Methods
-        public void OnPositionInputChanged(InputEventData<Vector2> eventData) { }
-        public void OnInputPressed(InputEventData<float> eventData) { }
         public void OnSourceDetected(SourceStateEventData eventData) { }   
         public void OnPointerDragged(MixedRealityPointerEventData eventData) { }
         public void OnPointerClicked(MixedRealityPointerEventData eventData) { }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -206,6 +206,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         #region Private Methods
         private bool TryGetMRControllerRayPoint(HandPanData data, out Vector3 rayPoint)
         {
+           
             if (data.currentPointer != null && data.currentController != null && data.currentController.IsPositionAvailable)
             {
                 rayPoint = data.touchingInitialPt + (SnapFingerToQuad(data.currentPointer.Position) - data.initialProjectedOffset);
@@ -226,17 +227,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 if (data.IsActive == true)
                 {
-                    if (TryGetMRControllerRayPoint(data, out tryHandPoint))
-                    {
-                        tryGetSucceeded = true;
-                    }
-                    else if (data.IsSourceNear == true)
+                    if (data.IsSourceNear == true)
                     {
                         tryGetSucceeded = TryGetHandPositionFromController(data.currentController, TrackedHandJoint.IndexTip, out tryHandPoint);
                     }
                     else
                     {
                         tryGetSucceeded = TryGetHandPositionFromController(data.currentController, TrackedHandJoint.Palm, out tryHandPoint);
+                    }
+                    if (!tryGetSucceeded)
+                    {
+                        tryGetSucceeded = TryGetMRControllerRayPoint(data, out tryHandPoint);
                     }
 
                     if (tryGetSucceeded == true)


### PR DESCRIPTION
## Overview


## Changes
- Fixes: #4702


## Verification
hand held MR Controllers and GGV now scrolls slate control

