### PR TITLE
add missing interface declaration to spatial awareness

### DIFF
--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// Class providing the default implementation of the <see cref="IMixedRealitySpatialAwarenessSystem"/> interface.
     /// </summary>
     [DocLink("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.html")]
-    public class MixedRealitySpatialAwarenessSystem : BaseCoreSystem, IMixedRealitySpatialAwarenessSystem
+    public class MixedRealitySpatialAwarenessSystem : BaseCoreSystem, IMixedRealitySpatialAwarenessSystem, IMixedRealityDataProviderAccess
     {
         public MixedRealitySpatialAwarenessSystem(
             IMixedRealityServiceRegistrar registrar,


### PR DESCRIPTION
When #4593 was merged, the spatial awareness system was updated to implement the IMixedRealityDataProviderAccess interface. With one notable exception....

It was never tagged as implementing the interface. 

All code paths that were added were validated by being used by the now deprecated GetIObserver and GetObservers methods. The only thing missing was the interface in the class definition.

This change adds IMixedRealityDataProviderAccess to MixedRealitySpatialAwarenssSystem.