### PR TITLE
Update the input simulation docs to mention issues with Unity's built in editor simulation

### DIFF
--- a/Documentation/InputSimulation/InputSimulationService.md
+++ b/Documentation/InputSimulation/InputSimulationService.md
@@ -7,6 +7,9 @@ The Input Simulation Service emulates the behaviour of devices and platforms tha
 
 Users can use a conventional keyboard and mouse combination to control simulated devices at runtime. This allows testing of interactions in the Unity editor without first deploying to a device.
 
+  | __Warning__: This does not work when using Unity's XR Holographic Emulation -> Emulation Mode = "Simulate in Editor". Unity's in-editor simulation will take control away from MRTK's input simulation. In order to use the MRTK input simulation service, you will need to set XR Holographic Emulation to Emulation Mode = "None"|
+  | --- |
+
 ## Enabling the Input Simulation Service
 
 Input simulation is enabled by default in MRTK.


### PR DESCRIPTION
Another point of feedback from partners who hit this (i.e. if you set the holographic emulation setting to "Simulate in Editor", the MRTK's input simulation won't work because Unity will take over the camera and input)

We're following up with Unity to see if we can get an API to know what the current emulation setting is (such that if unity's Simulate in Editor is set, we could show a dialog showing a warning saying that MRTK's simulation will be turned off)