### PR TITLE
Remove unused scripts from the diagnostics demo scene

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Diagnostics/Scenes/DiagnosticsDemo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Diagnostics/Scenes/DiagnosticsDemo.unity
@@ -243,6 +243,7 @@ MonoBehaviour:
   gazeTransform: {fileID: 0}
   minHeadVelocityThreshold: 0.5
   maxHeadVelocityThreshold: 2
+  useEyeTracking: 1
 --- !u!114 &469757469
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,6 +256,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7a21b486d0bb44444b1418aaa38b44de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
 --- !u!81 &469757470
 AudioListener:
   m_ObjectHideFlags: 0
@@ -329,8 +337,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 797421872}
-  - component: {fileID: 797421873}
-  - component: {fileID: 797421874}
   m_Layer: 0
   m_Name: SceneContent
   m_TagString: Untagged
@@ -353,67 +359,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &797421873
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 797421871}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ddff6079fd6eaff4794af645b5ded417, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &797421874
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 797421871}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45b3eff181cc4244a8a14234096e62fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isFocusRequired: 0
-  keywords:
-  - keyword: Toggle Profiler
-    response:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 797421873}
-          m_MethodName: OnToggleProfiler
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - keyword: Toggle Diagnostics
-    response:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 797421873}
-          m_MethodName: OnToggleDiagnostics
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  persistentKeywords: 0
 --- !u!1 &878628103
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
#4708 removed a script from the project and removed the need for the diagnostics demo to contain a SpeechInputHandler.

However, I forgot to remove the references to these scripts from the demo scene. This change fixes the issue.