### PR TITLE
[RC2] Add ability to scroll, drag UnityUI canvas on HoloLens 1

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -191,8 +191,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             // Reset the RaycastCamera for projecting (used in calculating deltas)
             Debug.Assert(pointer.Rays != null && pointer.Rays.Length > 0);
-            RaycastCamera.transform.position = pointer.Rays[0].Origin;
-            RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction);
+
+            if (pointer.Controller != null && pointer.Controller.IsRotationAvailable)
+            {
+                RaycastCamera.transform.position = pointer.Rays[0].Origin;
+                RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction);
+            }
+            else
+            {
+                // The pointer.Controller does not provide rotation, for example on HoloLens 1 hands.
+                // In this case pointer.Rays[0].Origin will be the head position, but we want the 
+                // hand to do drag operations, not the head.
+                // pointer.Position gives the position of the hand, use that to compute drag deltas.
+                RaycastCamera.transform.position = pointer.Position;
+                RaycastCamera.transform.rotation = Quaternion.LookRotation(pointer.Rays[0].Direction);
+            }
+
 
             // Populate eventDataLeft
             pointerData.eventDataLeft.Reset();


### PR DESCRIPTION
## Overview
Add support for drag interactions in Unity UI for HoloLens 1 GGV interactions. This is done by using the pointer position instead of the pointer ray origin in cases when the pointer ray is decoupled from the actual pointer, like with hands (pointer ray is the head, but pointer position is hands).

## Changes
- Fixes: #4750 


## Verification
All tests done in editor, not on device.
- Tested articulated hands
- Tested gesture hands