### PR TITLE
Initial addition of far plane property

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityCameraProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityCameraProfile.asset
@@ -14,10 +14,12 @@ MonoBehaviour:
   isCustomProfile: 0
   isCameraPersistent: 0
   nearClipPlaneOpaqueDisplay: 0.1
+  farClipPlaneOpaqueDisplay: 1000
   cameraClearFlagsOpaqueDisplay: 1
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
   opaqueQualityLevel: 5
-  nearClipPlaneTransparentDisplay: 0.1
+  nearClipPlaneTransparentDisplay: 0.85
+  farClipPlaneTransparentDisplay: 50
   cameraClearFlagsTransparentDisplay: 2
   backgroundColorTransparentDisplay: {r: 0, g: 0, b: 0, a: 0}
   holoLensQualityLevel: 0

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2CameraProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2CameraProfile.asset
@@ -14,10 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isCustomProfile: 0
   nearClipPlaneOpaqueDisplay: 0.1
+  farClipPlaneOpaqueDisplay: 1000
   cameraClearFlagsOpaqueDisplay: 2
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
   opaqueQualityLevel: 0
   nearClipPlaneTransparentDisplay: 0.1
+  farClipPlaneTransparentDisplay: 50
   cameraClearFlagsTransparentDisplay: 2
   backgroundColorTransparentDisplay: {r: 0, g: 0, b: 0, a: 0}
   holoLensQualityLevel: 0

--- a/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -107,6 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         {
             CameraCache.Main.clearFlags = CameraProfile.CameraClearFlagsOpaqueDisplay;
             CameraCache.Main.nearClipPlane = CameraProfile.NearClipPlaneOpaqueDisplay;
+            CameraCache.Main.farClipPlane = CameraProfile.FarClipPlaneOpaqueDisplay;
             CameraCache.Main.backgroundColor = CameraProfile.BackgroundColorOpaqueDisplay;
             QualitySettings.SetQualityLevel(CameraProfile.OpaqueQualityLevel, false);
         }
@@ -119,6 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             CameraCache.Main.clearFlags = CameraProfile.CameraClearFlagsTransparentDisplay;
             CameraCache.Main.backgroundColor = CameraProfile.BackgroundColorTransparentDisplay;
             CameraCache.Main.nearClipPlane = CameraProfile.NearClipPlaneTransparentDisplay;
+            CameraCache.Main.farClipPlane = CameraProfile.FarClipPlaneTransparentDisplay;
             QualitySettings.SetQualityLevel(CameraProfile.HoloLensQualityLevel, false);
         }
 

--- a/Assets/MixedRealityToolkit/Definitions/MixedRealityCameraProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/MixedRealityCameraProfile.cs
@@ -17,11 +17,13 @@ namespace Microsoft.MixedReality.Toolkit
     public class MixedRealityCameraProfile : BaseMixedRealityProfile
     {
         public float NearClipPlaneOpaqueDisplay => nearClipPlaneOpaqueDisplay;
+        public float FarClipPlaneOpaqueDisplay => farClipPlaneOpaqueDisplay;
         public CameraClearFlags CameraClearFlagsOpaqueDisplay => cameraClearFlagsOpaqueDisplay;
         public Color BackgroundColorOpaqueDisplay => backgroundColorOpaqueDisplay;
         public int OpaqueQualityLevel => opaqueQualityLevel;
 
         public float NearClipPlaneTransparentDisplay => nearClipPlaneTransparentDisplay;
+        public float FarClipPlaneTransparentDisplay => farClipPlaneTransparentDisplay;
         public CameraClearFlags CameraClearFlagsTransparentDisplay => cameraClearFlagsTransparentDisplay;
         public Color BackgroundColorTransparentDisplay => backgroundColorTransparentDisplay;
         public int HoloLensQualityLevel => holoLensQualityLevel;
@@ -29,6 +31,10 @@ namespace Microsoft.MixedReality.Toolkit
         [SerializeField]
         [Tooltip("The near clipping plane distance for an opaque display.")]
         private float nearClipPlaneOpaqueDisplay = 0.1f;
+
+        [SerializeField]
+        [Tooltip("The far clipping plane distance for an opaque display.")]
+        private float farClipPlaneOpaqueDisplay = 1000f;
 
         [SerializeField]
         [Tooltip("Values for Camera.clearFlags, determining what to clear when rendering a Camera for an opaque display.")]
@@ -45,6 +51,10 @@ namespace Microsoft.MixedReality.Toolkit
         [SerializeField]
         [Tooltip("The near clipping plane distance for a transparent display.")]
         private float nearClipPlaneTransparentDisplay = 0.85f;
+
+        [SerializeField]
+        [Tooltip("The far clipping plane distance for a transparent display.")]
+        private float farClipPlaneTransparentDisplay = 50f;
 
         [SerializeField]
         [Tooltip("Values for Camera.clearFlags, determining what to clear when rendering a Camera for an opaque display.")]

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -11,16 +11,19 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     public class MixedRealityCameraProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
     {
         private SerializedProperty opaqueNearClip;
+        private SerializedProperty opaqueFarClip;
         private SerializedProperty opaqueClearFlags;
         private SerializedProperty opaqueBackgroundColor;
         private SerializedProperty opaqueQualityLevel;
 
         private SerializedProperty transparentNearClip;
+        private SerializedProperty transparentFarClip;
         private SerializedProperty transparentClearFlags;
         private SerializedProperty transparentBackgroundColor;
         private SerializedProperty holoLensQualityLevel;
 
         private readonly GUIContent nearClipTitle = new GUIContent("Near Clip");
+        private readonly GUIContent farClipTitle = new GUIContent("Far Clip");
         private readonly GUIContent clearFlagsTitle = new GUIContent("Clear Flags");
 
         private const string ProfileTitle = "Camera Settings";
@@ -31,11 +34,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             base.OnEnable();
 
             opaqueNearClip = serializedObject.FindProperty("nearClipPlaneOpaqueDisplay");
+            opaqueFarClip = serializedObject.FindProperty("farClipPlaneOpaqueDisplay");
             opaqueClearFlags = serializedObject.FindProperty("cameraClearFlagsOpaqueDisplay");
             opaqueBackgroundColor = serializedObject.FindProperty("backgroundColorOpaqueDisplay");
             opaqueQualityLevel = serializedObject.FindProperty("opaqueQualityLevel");
 
             transparentNearClip = serializedObject.FindProperty("nearClipPlaneTransparentDisplay");
+            transparentFarClip = serializedObject.FindProperty("farClipPlaneTransparentDisplay");
             transparentClearFlags = serializedObject.FindProperty("cameraClearFlagsTransparentDisplay");
             transparentBackgroundColor = serializedObject.FindProperty("backgroundColorTransparentDisplay");
             holoLensQualityLevel = serializedObject.FindProperty("holoLensQualityLevel");
@@ -53,6 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.LabelField("Opaque Display Settings", EditorStyles.boldLabel);
                 {
                     EditorGUILayout.PropertyField(opaqueNearClip, nearClipTitle);
+                    EditorGUILayout.PropertyField(opaqueFarClip, farClipTitle);
                     EditorGUILayout.PropertyField(opaqueClearFlags, clearFlagsTitle);
 
                     if ((CameraClearFlags)opaqueClearFlags.intValue == CameraClearFlags.Color)
@@ -67,6 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.LabelField("Transparent Display Settings", EditorStyles.boldLabel);
                 {
                     EditorGUILayout.PropertyField(transparentNearClip, nearClipTitle);
+                    EditorGUILayout.PropertyField(transparentFarClip, farClipTitle);
                     EditorGUILayout.PropertyField(transparentClearFlags, clearFlagsTitle);
 
                     if ((CameraClearFlags)transparentClearFlags.intValue == CameraClearFlags.Color)


### PR DESCRIPTION
## Overview
This changes adds the far clip plane property for both the opaque and transparent system in the camera profile. This is important for MRTK developers to set different far clip plane values for opaque vs transparent. Default in Unity is 1000m which for Hololens is well outside the typical rendering/user volume. However, this large value (1000m) for the far clip plane reduces depth fidelity, especially for 16-bit. 

This change also updates the default camera profiles to set Transparent far to 50m and Opaque far to 1000m. 

## Changes
- Fixes: #4783 
Far clip plane not settable in MRTK profiles 

## Verification

Tested profiles actually setting correct values on Camera in Unity editor

Tested camera profiles without serialized far field in text file. MRTK takes default set in the script. 

Tested far clip plane (transparent) actually set on HL device with objects not rendered
