### PR TITLE
Fix teleport pointer to support mrtk object or standalone service

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -252,7 +252,6 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             TeleportSurfaceResult = TeleportSurfaceResult.None;
             GravityDistorter.enabled = false;
 
-
             if (IsInteractionEnabled)
             {
                 LineBase.enabled = true;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -90,11 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             }
         }
 
-<<<<<<< HEAD
-=======
-        private bool usingMixedRealityToolkitObject = false;
-
->>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -104,11 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 gravityDistorter = GetComponent<DistorterGravity>();
             }
 
-<<<<<<< HEAD
-            if (MixedRealityToolkit.IsInitialized && TeleportSystem != null && !lateRegisterTeleport)
-=======
             if (!lateRegisterTeleport)
->>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
             {
                 TeleportSystem?.Register(gameObject);
             }
@@ -118,11 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             base.Start();
 
-<<<<<<< HEAD
-            if (lateRegisterTeleport && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled)
-=======
             if (lateRegisterTeleport)
->>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
             {
                 if (TeleportSystem == null)
                 {
@@ -265,6 +252,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             TeleportSurfaceResult = TeleportSurfaceResult.None;
             GravityDistorter.enabled = false;
 
+
             if (IsInteractionEnabled)
             {
                 LineBase.enabled = true;
@@ -333,11 +321,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         public override void OnInputChanged(InputEventData<Vector2> eventData)
         {
             // Don't process input if we've got an active teleport request in progress.
-<<<<<<< HEAD
-            if (isTeleportRequestActive || !MixedRealityToolkit.IsTeleportSystemEnabled)
-=======
             if (isTeleportRequestActive || TeleportSystem == null)
->>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
             {
                 return;
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -90,6 +90,11 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             }
         }
 
+<<<<<<< HEAD
+=======
+        private bool usingMixedRealityToolkitObject = false;
+
+>>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -99,9 +104,13 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 gravityDistorter = GetComponent<DistorterGravity>();
             }
 
+<<<<<<< HEAD
             if (MixedRealityToolkit.IsInitialized && TeleportSystem != null && !lateRegisterTeleport)
+=======
+            if (!lateRegisterTeleport)
+>>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
             {
-                TeleportSystem.Register(gameObject);
+                TeleportSystem?.Register(gameObject);
             }
         }
 
@@ -109,7 +118,11 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             base.Start();
 
+<<<<<<< HEAD
             if (lateRegisterTeleport && MixedRealityToolkit.Instance.ActiveProfile.IsTeleportSystemEnabled)
+=======
+            if (lateRegisterTeleport)
+>>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
             {
                 if (TeleportSystem == null)
                 {
@@ -128,7 +141,6 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                         return;
                     }
                 }
-
                 lateRegisterTeleport = false;
                 TeleportSystem.Register(gameObject);
             }
@@ -321,7 +333,11 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         public override void OnInputChanged(InputEventData<Vector2> eventData)
         {
             // Don't process input if we've got an active teleport request in progress.
+<<<<<<< HEAD
             if (isTeleportRequestActive || !MixedRealityToolkit.IsTeleportSystemEnabled)
+=======
+            if (isTeleportRequestActive || TeleportSystem == null)
+>>>>>>> 6c13a8766... fix pointer 'mediation' when using both svc locator and standalone teleport
             {
                 return;
             }


### PR DESCRIPTION
While working on an experimental standalone teleport service, it was discovered that there were hard coded references to the MixedRealityToolkit object that was blocking the standalone service.

This change updates how the teleport pointer behaves and has been tested in the following configurations:

* MRTK input and teleport enabled
* MRTK input enabled and teleport disabled
* MRTK input enebled, teleport enabled with standalone teleport service prototype

Each of the above configurations behaved as expected (teleport supported, not supported and supported, respectively).

This change is needed to ensure support for a standalone teleportation service is possible without requiring a new version of the mrtk core assembly.