### PR TITLE
Add get services by registrar to the registry

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityServiceRegistry.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityServiceRegistry.cs
@@ -247,5 +247,35 @@ namespace Microsoft.MixedReality.Toolkit
                 out _,                  // The registrar out param is not used, it can be discarded.
                 name);
         }
+
+        /// <summary>
+        /// Returns the collection of all services registered by the specified registrar.
+        /// </summary>
+        /// <param name="registrar">The registrar responsible for the serivces being returned.</param>
+        /// <returns>
+        /// A read only list of the registered services.
+        /// </returns>
+        /// <remarks>
+        /// If the registrar parameter is null, all registered services will be returned.
+        /// </remarks>
+        public static IReadOnlyList<IMixedRealityService> GetServices(IMixedRealityServiceRegistrar registrar = null)
+        {
+            List<IMixedRealityService> services = new List<IMixedRealityService>();
+
+            var registrySnapshot = new Dictionary<Type, List<KeyValuePair<IMixedRealityService, IMixedRealityServiceRegistrar>>>(registry);
+            foreach (Type key in registrySnapshot.Keys)
+            {
+                foreach (var kvp in registrySnapshot[key])
+                {
+                    if ((registrar == null) ||
+                        (object.ReferenceEquals(registrar, kvp.Value)))
+                    {
+                        services.Add(kvp.Key);
+                    }
+                }
+            }
+
+            return services;
+        }
     }
 }


### PR DESCRIPTION
This change adds the ability to query the service registry to retrieve all services registered by a specific registrar. This change reduces the amount of code custom registrars are required to write to find their services.