### PR TITLE
Update Interactable property code to utilize shader int keys instead of strings

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorChildrenTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorChildrenTheme.cs
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             InteractableThemePropertyValue color = new InteractableThemePropertyValue();
 
-            string propId = property.GetShaderPropId();
+            int propId = property.GetShaderPropertyId();
 
             if (propertyBlocks.Count > 0)
             {
@@ -78,7 +78,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Color color = Color.Lerp(property.StartValue.Color, property.Values[index].Color, percentage);
 
-            string propId = property.GetShaderPropId();
+            int propId = property.GetShaderPropertyId();
 
             for (int i = 0; i < propertyBlocks.Count; i++)
             {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             renderer.GetPropertyBlock(propertyBlock);
 
-            string propId = property.GetShaderPropId();
+            int propId = property.GetShaderPropertyId();
             float newValue;
             switch (property.Type)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             startValue.Reset();
             
-            string propId = property.GetShaderPropId();
+            int propId = property.GetShaderPropertyId();
             switch (property.Type)
             {
                 case InteractableThemePropertyValueTypes.Color:
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return startValue;
         }
 
-        public static float GetFloat(GameObject host, string propId)
+        public static float GetFloat(GameObject host, int propId)
         {
             if (host == null)
                 return 0;
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             renderer.SetPropertyBlock(block);
         }
 
-        public static MaterialPropertyBlock SetFloat(MaterialPropertyBlock block, float value, string propId)
+        public static MaterialPropertyBlock SetFloat(MaterialPropertyBlock block, float value, int propId)
         {
             if (block == null)
                 return null;
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return block;
         }
 
-        public static Color GetColor(GameObject host, string propId)
+        public static Color GetColor(GameObject host, int propId)
         {
             if (host == null)
                 return Color.white;
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return block.GetVector(propId);
         }
 
-        public static MaterialPropertyBlock SetColor(MaterialPropertyBlock block, Color color, string propId)
+        public static MaterialPropertyBlock SetColor(MaterialPropertyBlock block, Color color, int propId)
         {
             if (block == null)
                 return null;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public string GetShaderPropertyName()
         {
-            if (ShaderOptions.Count > PropId)
+            if (ShaderOptionNames.Count > PropId)
             {
                 return ShaderOptionNames[PropId];
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -16,20 +17,43 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public InteractableThemePropertyValueTypes Type;
         public List<InteractableThemePropertyValue> Values;
         public InteractableThemePropertyValue StartValue;
-        public int PropId;
+        public int PropId; // i.e OptionIndex
         public List<ShaderProperties> ShaderOptions;
         public List<string> ShaderOptionNames;
         public InteractableThemePropertyValue Default;
         public string ShaderName;
 
-        public string GetShaderPropId()
+        private List<int> ShaderPropertyIDs = null;
+        private const string DefaultProperty = "_Color";
+
+        public int GetShaderPropertyId()
         {
-            if (ShaderOptionNames.Count > PropId)
+            // Lazy load Shader Properties
+            if (ShaderPropertyIDs == null)
+            {
+                ShaderPropertyIDs = new List<int>(ShaderOptionNames.Count);
+                for(int i = 0; i < this.ShaderOptionNames.Count; i++)
+                {
+                    ShaderPropertyIDs.Add(Shader.PropertyToID(this.ShaderOptionNames[i]));
+                }
+            }
+
+            if (ShaderPropertyIDs.Count > PropId)
+            {
+                return ShaderPropertyIDs[PropId];
+            }
+
+            return Shader.PropertyToID(DefaultProperty);
+        }
+
+        public string GetShaderPropertyName()
+        {
+            if (ShaderOptions.Count > PropId)
             {
                 return ShaderOptionNames[PropId];
             }
 
-            return "_Color";
+            return DefaultProperty;
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
@@ -26,6 +26,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private List<int> ShaderPropertyIDs = null;
         private const string DefaultProperty = "_Color";
 
+        /// <summary>
+        /// This method gets the integer key assigned by Unity at runtime for the current shader property. 
+        /// It will also lazy load the array of possible key values on first access using Unity's Shader.PropertyToID()
+        /// It is generally preferred to use the integer key over the string key with Unity to avoid perf cost for the dictionary lookup on every get/set.
+        /// ex: On SetFloat(string key), Unity will perform Shader.PropertyToID() itself every call
+        /// </summary>
+        /// <returns>integer key for current shader property to get/set shader values. Returns default backup property in case of failure</returns>
         public int GetShaderPropertyId()
         {
             // Lazy load Shader Properties
@@ -46,6 +53,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return Shader.PropertyToID(DefaultProperty);
         }
 
+        /// <summary>
+        /// Get the current shader property name. Again it is preferred to utilize the integer key over the string key in Unity
+        /// </summary>
+        /// <returns>string name of current property. Returns default backup property in case of failure</returns>
         public string GetShaderPropertyName()
         {
             if (ShaderOptionNames.Count > PropId)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableThemeProperty.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (ShaderPropertyIDs == null)
             {
                 ShaderPropertyIDs = new List<int>(ShaderOptionNames.Count);
-                for(int i = 0; i < this.ShaderOptionNames.Count; i++)
+                for (int i = 0; i < this.ShaderOptionNames.Count; i++)
                 {
                     ShaderPropertyIDs.Add(Shader.PropertyToID(this.ShaderOptionNames[i]));
                 }


### PR DESCRIPTION
## Overview

InteractableTheme classes are able to update shader properties such as color or glow, etc in response to scene interactions such as focus or click. These theme handler classes updates shaders in Unity via string properties. Whenever a property is updated via a string key such as GetFloat(), Unity will automatically call Shader.PropertyToId() to get it's int key and then perform the get or the set. 

This change caches the integer property keys for all property strings in a given theme class so as to help with performance when calling the get/set functions at runtime

## Changes
- Fixes: #4228 
Optimize Shader property and Material access on Interactable*Theme class

## Verification
Confirmed HandInteraction scene worked with Interactable classes on changes such as focus or clicks, etc. 
