### PR TITLE
Make types needed for Guides to add custom component broadcasters outside the SpectatorView assembly

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/ComponentBroadcasterDefinition.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/ComponentBroadcasterDefinition.cs
@@ -6,17 +6,47 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
+    /// <summary>
+    /// Component which defines when and how to attach a ComponentBroadcaster to a GameObject.
+    /// ComponentBroadcasters can be created unconditionally or due to certain requirements being
+    /// present on the provided GameObject.
+    /// </summary>
     public abstract class ComponentBroadcasterDefinition
     {
+        /// <summary>
+        /// Method which checks for the existence of requirements on the provided GameObject and either
+        /// creates or destroys ComponentBroadcasters as necessary.
+        /// </summary>
+        /// <param name="gameObject">The GameObject to check the state of.</param>
+        /// <param name="changesDetected">True if ComponentBroadcasters were added or removed, otherwise false.</param>
         public abstract void EnsureComponentBroadcastersCreated(GameObject gameObject, out bool changesDetected);
+
+        /// <summary>
+        /// Gets whether or not this ComponentBroadcasterDefinition may need to perform modifications
+        /// to the GameObject before other ComponentBroadcasterDefinitions are allowed to create
+        /// ComponentBroadcasters.
+        /// </summary>
         public abstract bool IsTransformBroadcasterController { get; }
     }
 
+    /// <summary>
+    /// Attaches a ComponentBroadcaster of type TComponentBroadcaster to a GameObject if and only if
+    /// a required set of Component types are present on the GameObject.
+    /// </summary>
+    /// <typeparam name="TComponentBroadcaster">The type of ComponentBroadcaster to attach when
+    /// requirements are met.</typeparam>
     public class ComponentBroadcasterDefinition<TComponentBroadcaster> : ComponentBroadcasterDefinition where TComponentBroadcaster : Component
     {
         private readonly Type[] requiredComponents;
         private readonly bool isTransformBroadcasterController;
 
+        /// <summary>
+        /// Creates a new definition with a set of required Component types.
+        /// </summary>
+        /// <param name="requiredComponents">The set of Component types
+        /// which must be present on the GameObject in order for the ComponentBroadcaster
+        /// to be created. An empty list means that the ComponentBroadcaster will
+        /// never be created.</param>
         public ComponentBroadcasterDefinition(params Type[] requiredComponents)
             : this(false, requiredComponents)
         {
@@ -27,12 +57,22 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
             get { return isTransformBroadcasterController; }
         }
 
+        /// <summary>
+        /// Creates a new definition, specifying whether the component definition is a transform controller
+        /// and which set of Component types are required.
+        /// </summary>
+        /// <param name="isTransformBroadcasterController">Whether or not this component is a transform controller.</param>
+        /// <param name="requiredComponents">The set of Component types
+        /// which must be present on the GameObject in order for the ComponentBroadcaster
+        /// to be created. An empty list means that the ComponentBroadcaster will
+        /// never be created.</param>
         public ComponentBroadcasterDefinition(bool isTransformBroadcasterController, params Type[] requiredComponents)
         {
             this.isTransformBroadcasterController = isTransformBroadcasterController;
             this.requiredComponents = requiredComponents;
         }
 
+        /// <inheritdoc />
         public override void EnsureComponentBroadcastersCreated(GameObject gameObject, out bool changesDetected)
         {
             changesDetected = false;

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/ComponentBroadcasterDefinition.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/ComponentBroadcasterDefinition.cs
@@ -6,13 +6,13 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
-    internal abstract class ComponentBroadcasterDefinition
+    public abstract class ComponentBroadcasterDefinition
     {
         public abstract void EnsureComponentBroadcastersCreated(GameObject gameObject, out bool changesDetected);
         public abstract bool IsTransformBroadcasterController { get; }
     }
 
-    internal class ComponentBroadcasterDefinition<TComponentBroadcaster> : ComponentBroadcasterDefinition where TComponentBroadcaster : Component
+    public class ComponentBroadcasterDefinition<TComponentBroadcaster> : ComponentBroadcasterDefinition where TComponentBroadcaster : Component
     {
         private readonly Type[] requiredComponents;
         private readonly bool isTransformBroadcasterController;

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/ComponentBroadcasterService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/ComponentBroadcasterService.cs
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         /// <param name="changeType">type of changed that occurred for the specified component</param>
         public void WriteHeader(BinaryWriter message, IComponentBroadcaster component, ComponentBroadcasterChangeType changeType = ComponentBroadcasterChangeType.Updated)
         {
-            StateSynchronizationSceneManager.Instance.WriteHeader(message);
+            StateSynchronizationSceneManager.Instance.WriteSynchronizeCommandHeader(message);
             message.Write(GetID().Value);
             message.Write(component.TransformBroadcaster.Id);
             message.Write((byte)changeType);
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
         /// <param name="changeType">type of changed that occurred for the specified component</param>
         public void WriteHeader(BinaryWriter message, TransformObserver TransformObserver, ComponentBroadcasterChangeType changeType = ComponentBroadcasterChangeType.Updated)
         {
-            StateSynchronizationSceneManager.Instance.WriteHeader(message);
+            StateSynchronizationSceneManager.Instance.WriteSynchronizeCommandHeader(message);
             message.Write(GetID().Value);
             message.Write(TransformObserver.Id);
             message.Write((byte)changeType);

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/GameObjectHierarchyBroadcaster.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/GameObjectHierarchyBroadcaster.cs
@@ -6,6 +6,11 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
+    /// <summary>
+    /// Indicates to the StateSynchronizationBroadcaster that the GameObject
+    /// this is attached to and all of its descendants should be broadcast
+    /// to connected StateSynchronizationObservers.
+    /// </summary>
     public class GameObjectHierarchyBroadcaster : MonoBehaviour
     {
         private TransformBroadcaster TransformBroadcaster;

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/GameObjectHierarchyBroadcaster.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/GameObjectHierarchyBroadcaster.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
-    internal class GameObjectHierarchyBroadcaster : MonoBehaviour
+    public class GameObjectHierarchyBroadcaster : MonoBehaviour
     {
         private TransformBroadcaster TransformBroadcaster;
 

--- a/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/StateSynchronizationSceneManager.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SpectatorView/Scripts/StateSynchronization/StateSynchronizationSceneManager.cs
@@ -15,7 +15,7 @@ using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
 {
-    internal class StateSynchronizationSceneManager : Singleton<StateSynchronizationSceneManager>
+    public class StateSynchronizationSceneManager : Singleton<StateSynchronizationSceneManager>
     {
         private const int FrameVotesUntilChangingFrameSkipCount = 10;
         private const int MaximumQueuedByteCount = 2048;
@@ -161,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Experimental.SpectatorView
             }
         }
 
-        public void SendGlobalShaderProperties(IList<GlobalMaterialPropertyAsset> changedProperties, IEnumerable<SocketEndpoint> endpoints)
+        internal void SendGlobalShaderProperties(IList<GlobalMaterialPropertyAsset> changedProperties, IEnumerable<SocketEndpoint> endpoints)
         {
             using (MemoryStream memoryStream = new MemoryStream())
             using (BinaryWriter message = new BinaryWriter(memoryStream))


### PR DESCRIPTION
These types need to be public for Guides (or any 3rd party) to provide custom component broadcasters.  ComponentBroadcasterDefinition and StateSynchronizationSceneManager are necessary to register the custom broadcaster service.  GameObjectHierarchyBroadcaster is necessary to attach this MonoBehaviour to the hierarchies that Guides wants to sync.