### PR TITLE
Don't create a rendered object for the None hand joint.

### DIFF
--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
@@ -115,14 +115,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    GameObject prefab = InputSystem.InputSystemProfile.HandTrackingProfile.JointPrefab;
-                    if (handJoint == TrackedHandJoint.Palm)
+                    GameObject prefab;
+                    if (handJoint == TrackedHandJoint.None)
+                    {
+                        // No visible mesh for the "None" joint
+                        prefab = null;
+                    }
+                    else if (handJoint == TrackedHandJoint.Palm)
                     {
                         prefab = InputSystem.InputSystemProfile.HandTrackingProfile.PalmJointPrefab;
                     }
                     else if (handJoint == TrackedHandJoint.IndexTip)
                     {
                         prefab = InputSystem.InputSystemProfile.HandTrackingProfile.FingerTipPrefab;
+                    }
+                    else
+                    {
+                        prefab = InputSystem.InputSystemProfile.HandTrackingProfile.JointPrefab;
                     }
 
                     GameObject jointObject;


### PR DESCRIPTION
## Overview

Don't create a mesh object in the hand visualizer for the "None" joint. The position of that joint is quite arbitrary and creates a distracting floating cube.

## Changes
- Fixes: #4534 .
