### PR TITLE
Fix MixedRealityToolkitFiles utility to handle the nuget resource path format

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.Core
+{
+    // Tests for the MixedRealityToolkitFiles utility class
+    public class TestFixture_02_MixedRealityToolkitFilesTests
+    {
+        [Test]
+        public void Test_01_FindMatchingModule()
+        {
+            TestInvalidPath("");
+
+            // Test invalid base name
+            TestInvalidPath("aaa");
+            TestInvalidPath(".SDK");
+            TestInvalidPath("aaa.SDK");
+
+            // Test missing chars
+            TestInvalidPath("MixedRealityToolki.SDK");
+            TestInvalidPath("MixedRealityToolkit.SD");
+            TestInvalidPath("ixedRealityToolkit.SDK");
+            TestInvalidPath("MixedRealityToolkit.DK");
+
+            // Test missing dots
+            TestInvalidPath("SDK");
+            TestInvalidPath("MixedRealityToolkitSDK");
+
+            // Test valid paths
+            TestValidPath("MixedRealityToolkit", MixedRealityToolkitModuleType.Core);
+            TestValidPath("MixedRealityToolkit.SDK", MixedRealityToolkitModuleType.SDK);
+
+            var modules = Enum.GetValues(typeof(MixedRealityToolkitModuleType));
+            var moduleNames = Enum.GetNames(typeof(MixedRealityToolkitModuleType));
+            for (int i = 0; i < modules.Length; ++i)
+            {
+                var module = (MixedRealityToolkitModuleType)modules.GetValue(i);
+                if (module != MixedRealityToolkitModuleType.Core)
+                {
+                    TestValidPath($"MixedRealityToolkit.{moduleNames[i]}", module);
+                }
+            }
+        }
+
+        [Test]
+        public void Test_02_FindMatchingModuleNuget()
+        {
+            // Test invalid base name
+            TestInvalidPath("aaa.1.23-45/MRTK");
+            TestInvalidPath(".1.23-45.SDK/MRTK");
+            TestInvalidPath("aaa.1.23-45.SDK/MRTK");
+
+            // Test missing chars
+            TestInvalidPath("Microsoft.MixedReality.Toolki.SDK.1.23-45/MRTK");
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.SD.1.23-45/MRTK");
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.SDK.1.23-45/MRT");
+
+            TestInvalidPath("icrosoft.MixedReality.Toolkit.SDK.1.23-45/MRTK");
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.DK.1.23-45/MRTK");
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.SDK.1.23-45/RTK");
+
+            // Test missing dots
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.SDK1.23-45/MRTK");
+            TestInvalidPath("Microsoft.MixedReality.ToolkitSDK.1.23-45/MRTK");
+            TestInvalidPath("Microsoft.MixedReality.ToolkitSDK1.23-45/MRTK");
+
+            // Test missing version
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.SDK/MRTK");
+            // Test missing MRTK suffix
+            TestInvalidPath("Microsoft.MixedReality.Toolkit.SDK.1.23-45");
+
+            // Test valid paths
+            TestValidPath("Microsoft.MixedReality.Toolkit.1.23-45/MRTK", MixedRealityToolkitModuleType.Core);
+            TestValidPath("Microsoft.MixedReality.Toolkit.SDK.1.23-45/MRTK", MixedRealityToolkitModuleType.SDK);
+
+            var modules = Enum.GetValues(typeof(MixedRealityToolkitModuleType));
+            var moduleNames = Enum.GetNames(typeof(MixedRealityToolkitModuleType));
+            for (int i = 0; i < modules.Length; ++i)
+            {
+                var module = (MixedRealityToolkitModuleType)modules.GetValue(i);
+                if (module != MixedRealityToolkitModuleType.Core)
+                {
+                    TestValidPath($"Microsoft.MixedReality.Toolkit.{moduleNames[i]}.1.23-45/MRTK", (MixedRealityToolkitModuleType)modules.GetValue(i));
+                }
+            }
+        }
+
+        public void TestInvalidPath(string path)
+        {
+            Assert.False(MixedRealityToolkitFiles.FindMatchingModule(path, out MixedRealityToolkitModuleType module));
+        }
+
+        public void TestValidPath(string path, MixedRealityToolkitModuleType expectedModule)
+        {
+            Assert.True(MixedRealityToolkitFiles.FindMatchingModule(path, out MixedRealityToolkitModuleType module));
+            Assert.AreEqual(module, expectedModule);
+        }
+
+        [TearDown]
+        public void CleanupTests()
+        {
+            TestUtilities.TearDownScenes();
+        }
+
+        private void WaitUntilFoldersAvailable()
+        {
+            while (!MixedRealityToolkitFiles.AreFoldersAvailable)
+            {
+                Task.Delay(25);
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
@@ -41,6 +41,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestValidPath("MixedRealityToolkit", MixedRealityToolkitModuleType.Core);
             TestValidPath("MixedRealityToolkit.SDK", MixedRealityToolkitModuleType.SDK);
 
+            // Test that all modules can be found and internal module map is complete.
+            // Check that MixedRealityToolkitFiles.moduleNameMap has all entries if this fails!
             var modules = Enum.GetValues(typeof(MixedRealityToolkitModuleType));
             var moduleNames = Enum.GetNames(typeof(MixedRealityToolkitModuleType));
             for (int i = 0; i < modules.Length; ++i)
@@ -84,6 +86,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestValidPath("Microsoft.MixedReality.Toolkit.1.23-45/MRTK", MixedRealityToolkitModuleType.Core);
             TestValidPath("Microsoft.MixedReality.Toolkit.SDK.1.23-45/MRTK", MixedRealityToolkitModuleType.SDK);
 
+            // Test that all modules can be found and internal module map is complete.
+            // Check that MixedRealityToolkitFiles.moduleNameMap has all entries if this fails!
             var modules = Enum.GetValues(typeof(MixedRealityToolkitModuleType));
             var moduleNames = Enum.GetNames(typeof(MixedRealityToolkitModuleType));
             for (int i = 0; i < modules.Length; ++i)

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
@@ -120,13 +120,5 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         {
             TestUtilities.TearDownScenes();
         }
-
-        private void WaitUntilFoldersAvailable()
-        {
-            while (!MixedRealityToolkitFiles.AreFoldersAvailable)
-            {
-                Task.Delay(25);
-            }
-        }
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Core
@@ -14,6 +15,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
     // Tests for the MixedRealityToolkitFiles utility class
     public class TestFixture_02_MixedRealityToolkitFilesTests
     {
+        string[] basePaths = new string[] { "", "C:\\", "C:\\xyz\\", "C:/xyz/" };
+
         [Test]
         public void Test_01_FindMatchingModule()
         {
@@ -95,13 +98,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
 
         public void TestInvalidPath(string path)
         {
-            Assert.False(MixedRealityToolkitFiles.FindMatchingModule(path, out MixedRealityToolkitModuleType module));
+            foreach (string basePath in basePaths)
+            {
+                string fullPath = Path.Combine(basePath, path);
+                Assert.False(MixedRealityToolkitFiles.FindMatchingModule(fullPath, out MixedRealityToolkitModuleType module));
+            }
         }
 
         public void TestValidPath(string path, MixedRealityToolkitModuleType expectedModule)
         {
-            Assert.True(MixedRealityToolkitFiles.FindMatchingModule(path, out MixedRealityToolkitModuleType module));
-            Assert.AreEqual(module, expectedModule);
+            foreach (string basePath in basePaths)
+            {
+                string fullPath = Path.Combine(basePath, path);
+                Assert.True(MixedRealityToolkitFiles.FindMatchingModule(fullPath, out MixedRealityToolkitModuleType module));
+                Assert.AreEqual(module, expectedModule);
+            }
         }
 
         [TearDown]

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_02_MixedRealityToolkitFilesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69370227085816345b76a6cef22dfcd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -96,13 +96,26 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             foreach (string folder in Directory.EnumerateDirectories(rootPath))
             {
                 TryRegisterModuleFolder(folder);
+
+                // NuGet packages may contain MRTK subfolders, have to include the subfolder level to catch these.
+                // This alternate path is used if above isn't found. This is to work around long paths issue with NuGetForUnity
+                // https://github.com/GlitchEnzo/NuGetForUnity/issues/246
+                foreach (string subfolder in Directory.EnumerateDirectories(folder))
+                {
+                    TryRegisterModuleFolder(subfolder);
+                }
             }
         }
 
         private static bool TryRegisterModuleFolder(string folder)
         {
+            return TryRegisterModuleFolder(folder, out MixedRealityToolkitModuleType module);
+        }
+
+        private static bool TryRegisterModuleFolder(string folder, out MixedRealityToolkitModuleType module)
+        {
             string normalizedFolder = NormalizeSeparators(folder);
-            if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
+            if (FindMatchingModule(normalizedFolder, out module))
             {
                 if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
                 {

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -44,32 +44,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 foreach (string asset in importedAssets.Concat(movedAssets))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    string normalizedFolder = NormalizeSeparators(folder);
-                    if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
-                    {
-                        if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
-                        {
-                            modFolders = new HashSet<string>();
-                            mrtkFolders.Add(module, modFolders);
-                        }
-                        modFolders.Add(normalizedFolder);
-                    }
+                    RegisterModuleFolder(folder);
                 }
 
                 foreach (string asset in deletedAssets.Concat(movedFromAssetPaths))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    folder = NormalizeSeparators(folder);
-                    foreach (var modFolders in mrtkFolders)
-                    {
-                        if (modFolders.Value.Remove(folder))
-                        {
-                            if (modFolders.Value.Count == 0)
-                            {
-                                mrtkFolders.Remove(modFolders.Key);
-                            }
-                        }
-                    }
+                    UnregisterModuleFolder(folder);
                 }
             }
         }
@@ -114,15 +95,35 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             foreach (string folder in Directory.EnumerateDirectories(rootPath))
             {
-                string normalizedFolder = NormalizeSeparators(folder);
-                if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
+                RegisterModuleFolder(folder);
+            }
+        }
+
+        private static void RegisterModuleFolder(string folder)
+        {
+            string normalizedFolder = NormalizeSeparators(folder);
+            if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
+            {
+                if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
                 {
-                    if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
+                    modFolders = new HashSet<string>();
+                    mrtkFolders.Add(module, modFolders);
+                }
+                modFolders.Add(normalizedFolder);
+            }
+        }
+
+        private static void UnregisterModuleFolder(string folder)
+        {
+            string normalizedFolder = NormalizeSeparators(folder);
+            foreach (var modFolders in mrtkFolders)
+            {
+                if (modFolders.Value.Remove(normalizedFolder))
+                {
+                    if (modFolders.Value.Count == 0)
                     {
-                        modFolders = new HashSet<string>();
-                        mrtkFolders.Add(module, modFolders);
+                        mrtkFolders.Remove(modFolders.Key);
                     }
-                    modFolders.Add(normalizedFolder);
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -44,13 +44,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 foreach (string asset in importedAssets.Concat(movedAssets))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    RegisterModuleFolder(folder);
+                    TryRegisterModuleFolder(folder);
                 }
 
                 foreach (string asset in deletedAssets.Concat(movedFromAssetPaths))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    UnregisterModuleFolder(folder);
+                    TryUnregisterModuleFolder(folder);
                 }
             }
         }
@@ -95,11 +95,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             foreach (string folder in Directory.EnumerateDirectories(rootPath))
             {
-                RegisterModuleFolder(folder);
+                TryRegisterModuleFolder(folder);
             }
         }
 
-        private static void RegisterModuleFolder(string folder)
+        private static bool TryRegisterModuleFolder(string folder)
         {
             string normalizedFolder = NormalizeSeparators(folder);
             if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
@@ -110,12 +110,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     mrtkFolders.Add(module, modFolders);
                 }
                 modFolders.Add(normalizedFolder);
+                return true;
             }
+
+            return false;
         }
 
-        private static void UnregisterModuleFolder(string folder)
+        private static bool TryUnregisterModuleFolder(string folder)
         {
             string normalizedFolder = NormalizeSeparators(folder);
+            bool found = false;
             foreach (var modFolders in mrtkFolders)
             {
                 if (modFolders.Value.Remove(normalizedFolder))
@@ -124,8 +128,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     {
                         mrtkFolders.Remove(modFolders.Key);
                     }
+                    found = true;
                 }
             }
+
+            return found;
         }
 
         private static string NormalizeSeparators(string path) => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public enum MixedRealityToolkitModuleType
     {
         Core,
+        Generated,
         Providers,
         Services,
         SDK,
@@ -43,67 +44,34 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 foreach (string asset in importedAssets.Concat(movedAssets))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    foreach (MixedRealityToolkitModuleType module in Enum.GetValues(typeof(MixedRealityToolkitModuleType)))
+                    string normalizedFolder = NormalizeSeparators(folder);
+                    if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
                     {
-                        if (folder.EndsWith(MixedRealityToolkitDirectory(module)))
+                        if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
                         {
-                            if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
-                            {
-                                modFolders = new HashSet<string>();
-                                mrtkFolders.Add(module, modFolders);
-                            }
-                            modFolders.Add(NormalizeSeparators(folder));
+                            modFolders = new HashSet<string>();
+                            mrtkFolders.Add(module, modFolders);
                         }
+                        modFolders.Add(normalizedFolder);
                     }
                 }
 
                 foreach (string asset in deletedAssets.Concat(movedFromAssetPaths))
                 {
                     string folder = asset.Replace("Assets", Application.dataPath);
-                    foreach (MixedRealityToolkitModuleType module in Enum.GetValues(typeof(MixedRealityToolkitModuleType)))
+                    folder = NormalizeSeparators(folder);
+                    foreach (var modFolders in mrtkFolders)
                     {
-                        if (mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
+                        if (modFolders.Value.Remove(folder))
                         {
-                            if (folder.EndsWith(MixedRealityToolkitDirectory(module)))
+                            if (modFolders.Value.Count == 0)
                             {
-                                folder = NormalizeSeparators(folder);
-                                if (modFolders.Contains(folder) && !Directory.Exists(folder))
-                                {
-                                    // The contains check in the if statement is faster than Directory.Exists so that's why it's used
-                                    // Otherwise, it isn't necessary, as the statement below doesn't throw if item wasn't found
-                                    modFolders.Remove(folder);
-                                    if (modFolders.Count == 0)
-                                    {
-                                        mrtkFolders.Remove(module);
-                                    }
-                                }
+                                mrtkFolders.Remove(modFolders.Key);
                             }
                         }
                     }
                 }
             }
-        }
-
-        private static string MixedRealityToolkitDirectory(MixedRealityToolkitModuleType module, string basePath="MixedRealityToolkit")
-        {
-            switch (module)
-            {
-                case MixedRealityToolkitModuleType.Core: return basePath;
-                case MixedRealityToolkitModuleType.Providers: return basePath + ".Providers";
-                case MixedRealityToolkitModuleType.Services: return basePath + ".Services";
-                case MixedRealityToolkitModuleType.SDK: return basePath + ".SDK";
-                case MixedRealityToolkitModuleType.Examples: return basePath + ".Examples";
-                case MixedRealityToolkitModuleType.Tests: return basePath + ".Tests";
-            }
-            Debug.Assert(false);
-            return null;
-        }
-
-        // This alternate path is used if above isn't found. This is to work around long paths issue with NuGetForUnity
-        // https://github.com/GlitchEnzo/NuGetForUnity/issues/246
-        private static string AlternateMixedRealityToolkitDirectory(MixedRealityToolkitModuleType module)
-        {
-            return MixedRealityToolkitDirectory(module, "MRTK");
         }
 
         private readonly static Dictionary<MixedRealityToolkitModuleType, HashSet<string>> mrtkFolders =
@@ -144,25 +112,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static void SearchForFoldersAsync(string rootPath)
         {
-            foreach (MixedRealityToolkitModuleType module in Enum.GetValues(typeof(MixedRealityToolkitModuleType)))
+            foreach (string folder in Directory.EnumerateDirectories(rootPath))
             {
-                IEnumerable<string> directories = Directory.GetDirectories(rootPath, MixedRealityToolkitDirectory(module), SearchOption.AllDirectories);
-
-                if (directories.Count() == 0)
-                {
-                    directories = Directory.GetDirectories(rootPath, AlternateMixedRealityToolkitDirectory(module), SearchOption.AllDirectories);
-                }
-
-                directories = directories.Select(NormalizeSeparators);
-
-                foreach (string s in directories)
+                string normalizedFolder = NormalizeSeparators(folder);
+                if (FindMatchingModule(normalizedFolder, out MixedRealityToolkitModuleType module))
                 {
                     if (!mrtkFolders.TryGetValue(module, out HashSet<string> modFolders))
                     {
                         modFolders = new HashSet<string>();
                         mrtkFolders.Add(module, modFolders);
                     }
-                    modFolders.Add(s);
+                    modFolders.Add(normalizedFolder);
                 }
             }
         }
@@ -245,6 +205,71 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return path != null ? GetAssetDatabasePath(path) : null;
             }
             return null;
+        }
+
+        private static readonly Dictionary<string, MixedRealityToolkitModuleType> moduleNameMap = new Dictionary<string, MixedRealityToolkitModuleType>()
+        {
+            { "", MixedRealityToolkitModuleType.Core },
+            { "Generated", MixedRealityToolkitModuleType.Generated },
+            { "Providers", MixedRealityToolkitModuleType.Providers },
+            { "Services", MixedRealityToolkitModuleType.Services },
+            { "SDK", MixedRealityToolkitModuleType.SDK },
+            { "Examples", MixedRealityToolkitModuleType.Examples },
+            { "Tests", MixedRealityToolkitModuleType.Tests }
+        };
+
+        private static bool FindMatchingModule(string folder, out MixedRealityToolkitModuleType result)
+        {
+            // Matches an optional module suffix, e.g. ".Services"
+            const string modulePattern = @"(\.(?<module>\w+))?";
+            // Matches a version string, e.g. "2.0.0-20190611.2"
+            const string versionPattern = @"(?<version>[.\-0-9]+)";
+            // Matches the naming pattern in the MRTK repository
+            // e.g. "MixedRealityToolkit.Services"
+            const string mrtkPattern = @"MixedRealityToolkit" + modulePattern;
+            // Matches "Microsoft.MixedReality.Toolkit", followed by optional module name, followed by version number
+            // e.g.: "Microsoft.MixedReality.Toolkit.Services.2.0.0-20190611.2"
+            // This alternate path is used if above isn't found. This is to work around long paths issue with NuGetForUnity
+            // https://github.com/GlitchEnzo/NuGetForUnity/issues/246
+            const string nugetParentPattern = @"Microsoft\.MixedReality\.Toolkit" + modulePattern + @"\." + versionPattern;
+
+            var dirInfo = new DirectoryInfo(folder);
+
+            if (TryMatchFolderPattern(dirInfo.Name, mrtkPattern, out result))
+            {
+                return true;
+            }
+            else if (TryMatchFolderPattern(dirInfo.Parent.Name, nugetParentPattern, out result))
+            {
+                return true;
+            }
+            else
+            {
+                result = MixedRealityToolkitModuleType.Core;
+                return false;
+            }
+        }
+
+        private static bool TryMatchFolderPattern(string name, string pattern, out MixedRealityToolkitModuleType result)
+        {
+            var folderMatches = System.Text.RegularExpressions.Regex.Matches(name, pattern);
+            if (folderMatches.Count == 1)
+            {
+                var moduleName = folderMatches[0].Groups["module"].Value;
+                if (moduleNameMap.TryGetValue(moduleName, out result))
+                {
+                    Debug.Log($"Found module path for {result}: {name}");
+                    return true;
+                }
+                else
+                {
+                    Debug.LogWarning($"Found MRTK folder with unknown module extension \"{moduleName}\"");
+                    return false;
+                }
+            }
+
+            result = MixedRealityToolkitModuleType.Core;
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Overview

The files utility was using a simple "endsWith" string comparison to find resource folders for MRTK. This does not work for the path format used by nuget packages, e.g.:

"MixedRealityToolkit.Services" (Unity package)
vs.
"Microsoft.MixedReality.Toolkit.Services.2.0.0-20190611.2/MRTK" (nuget package)

The fix changes the MixedRealityToolkitFiles utility class to search for both patterns and find the matching module name.

## Changes
- Fixes: #4827 

## Verification
* Create a new Unity project
* Install latest NuGet for Unity from here: [https://github.com/GlitchEnzo/NuGetForUnity/releases](https://github.com/GlitchEnzo/NuGetForUnity/releases)
* Add the source URL https://pkgs.dev.azure.com/aipmr/_packaging/MixedRealityToolkit/nuget/v2/ through _Edit > Preferences > NuGet_ for Unity. Uncheck "Read-Only Packaging Files"
* Open the _NuGet > Manage NuGet Packages_ menu
* Check _Show Prerelease_
* Search for Microsoft.MixedReality.Toolkit and install
* Setup the scene with _Mixed Reality Toolkit > Add to Scene and Configure_
* Enter playmode and hold space: Hand joint visualizers are in the same spot (bug)

* Open `Assets/packages.config` and change MRTK package versions to **2.0.0-20190613.4** (a nuget package with the fix applied)
* Delete all "Microsoft.MixedReality.Toolkit***" folders under _Assets/Packages_
* Unity will automatically download the new package versions
* Enter playmode again and hold space: Hand visualizers should be working
