### PR TITLE
Make EyeTrackingTarget's Start() function match the definition of its base class

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public static Vector3 LookedAtPoint { get; private set; }
 
         #region Focus handling
-        protected override void Start()
+        protected override async void Start()
         {
             base.Start();
             IsLookedAt = false;


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4849

I had missed this in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4845