### PR TITLE
Temporarily remove the "Architecture" tab from the github.io docs

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -3,5 +3,3 @@
   homepage: Documentation/GettingStartedWithTheMRTK.md
 - name: API Documentation
   href: obj/api/
-- name: Architecture
-  href: Documentation/Architecture/


### PR DESCRIPTION
The Architecture side of the MRTK docs has been pretty sparse for a long time, and there's currently an issue where clicking on the 'Architecture' tab will go to a seemingly random page (spatial awareness). After reading through all of these pages, there's SOME interesting content, but probably 95% of it isn't actually useful for the reader (i.e. many things list random names without giving any relationship between them)

While I work on getting new architecture docs up, we're removing this tab to prevent us from leading people down the wrong path. I'm not deleting the existing MD files themselves, just making them WAY harder to access. I will do the actual cleanup as part of my next docs pass.

## Changes
- Fixes: #4789 