### PR TITLE
Revert "Make EyeTrackingTarget's Start() function match the definition of its base class"

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public static Vector3 LookedAtPoint { get; private set; }
 
         #region Focus handling
-        protected override async void Start()
+        protected override void Start()
         {
             base.Start();
             IsLookedAt = false;


### PR DESCRIPTION
Reverts microsoft/MixedRealityToolkit-Unity#4850