### PR TITLE
Default GrabPointer grab radius

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab
@@ -43,7 +43,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 1507865967819406}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 2dfa7178ac1c18947adff71ef2792a84, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -71,7 +70,7 @@ MonoBehaviour:
   overrideGlobalPointerExtent: 0
   pointerExtent: 10
   defaultPointerExtent: 10
-  sphereCastRadius: 0.15
+  sphereCastRadius: 0.05
   debugMode: 0
 --- !u!114 &7376459786343609486
 MonoBehaviour:
@@ -82,7 +81,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 1507865967819406}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 6682dc6245ac3fd4ea723a628fbee9ee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -99,7 +97,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 1507865967819406}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 889e684278db8a542aa634e254b665aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -149,7 +146,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 3601038615599929105}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 81c169a39f8e430d869bbc5d938b0e5a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -314,7 +310,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 3601038615599929105}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 1287d4d138a242f794bcfc01354d3ae2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 


### PR DESCRIPTION
## Overview
Addresses good defaults for the `GrabPointer`.

As issue mentions - default radius was set to 15cm. Feedback has been that its much too large. The propose default is 5cm.

## Changes
- Fixes: #4371 


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
