### PR TITLE
Updated DefaultMixedRealityCameraProfile from 0.85m to 0.1m

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityCameraProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityCameraProfile.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   cameraClearFlagsOpaqueDisplay: 1
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
   opaqueQualityLevel: 5
-  nearClipPlaneTransparentDisplay: 0.85
+  nearClipPlaneTransparentDisplay: 0.1
   farClipPlaneTransparentDisplay: 50
   cameraClearFlagsTransparentDisplay: 2
   backgroundColorTransparentDisplay: {r: 0, g: 0, b: 0, a: 0}


### PR DESCRIPTION
## Describe the bug
DefaultMixedRealityCameraProfile's near clipping distance is 0.85m
This clipping plane creates some confusion for the HoloLens (1st gen) developers since objects are abruptly disappearing from 0.85m distance. There are many apps that require content observation closer than 0.85m (e.g. viewing architectural model). 
Instead of forcing hard/abrupt clipping by the camera, we recommend using MRTK Standard Shader's Near Fade property to gradually fade out the objects in the near distance range. (~0.45m) 

## Changes
- Fixes: #4905 

