### PR TITLE
Rearranging order of Instance and Platform check in MixedRealityToolkit

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -180,15 +180,15 @@ namespace Microsoft.MixedReality.Toolkit
                 return false;
             }
 
-            if (concreteType == null)
-            {
-                Debug.LogError("Unable to register a service with a null concrete type.");
-                return false;
-            }
-
             if (!typeof(IMixedRealityService).IsAssignableFrom(concreteType))
             {
                 Debug.LogError($"Unable to register the {concreteType.Name} service. It does not implement {typeof(IMixedRealityService)}.");
+                return false;
+            }
+
+            if (concreteType == null)
+            {
+                Debug.LogError("Unable to register a service with a null concrete type.");
                 return false;
             }
 


### PR DESCRIPTION
## Overview
the MRTK first checks the existence of concrete type instances and then whether they support the current platform. This is the wrong order because they're allowed to be non existent when they do not support the current platform. Rearranging the checks fixes this.

## Changes
- Fixes: #3567 .