### PR TITLE
Fix build warnings

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/EyeCalibrationChecker.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/EyeCalibrationChecker.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         public UnityEvent OnEyeCalibrationDetected;
         public UnityEvent OnNoEyeCalibrationDetected;
 
-        private bool? prevCalibrationStatus = null;        
+        private bool? prevCalibrationStatus = null;
         private IMixedRealityInputSystem inputSystem = null;
 
         /// <summary>
@@ -40,11 +40,17 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         // Update is called once per frame
         void Update()
         {
-            bool? calibrationStatus = InputSystem?.EyeGazeProvider?.IsEyeCalibrationValid;
+            bool? calibrationStatus;
 
-#if UNITY_EDITOR
-            calibrationStatus = editorTestUserIsCalibrated;            
-#endif
+            if (Application.isEditor)
+            {
+                calibrationStatus = editorTestUserIsCalibrated;
+            }
+            else
+            {
+                calibrationStatus = InputSystem?.EyeGazeProvider?.IsEyeCalibrationValid;
+            }
+
             if (calibrationStatus != null)
             {
                 if (prevCalibrationStatus != calibrationStatus)

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/Scripts/MixedRealityCapabilityDemo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/Scripts/MixedRealityCapabilityDemo.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             }
         }
 
-        private async void Start()
+        private void Start()
         {
             IMixedRealityCapabilityCheck capabilityChecker = InputSystem as IMixedRealityCapabilityCheck;
             if (capabilityChecker != null)

--- a/Assets/MixedRealityToolkit/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
@@ -58,7 +58,6 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
             }
         }
 
-#if UNITY_EDITOR
         public bool EditorManageBuildSettings => editorManageBuildSettings;
 
         public bool EditorManageLoadedScenes => editorManageLoadedScenes;
@@ -70,7 +69,6 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         public bool EditorLightingCacheOutOfDate => editorLightingCacheOutOfDate;
 
         public bool EditorLightingCacheUpdateRequested { get; set; }
-#endif
 
         [SerializeField]
         private bool useManagerScene = true;


### PR DESCRIPTION
## Overview
The current state of mrtk_development had a few build warnings.

EyeCalibrationChecker: Changed from `#if UNITY_EDITOR` to `if (Application.isEditor)`, since the code itself is outside the `UnityEditor` namespace and will build for device.

MixedRealityCapabilityDemo: The `Start` method was incorrectly marked as asynchronous.

MixedRealitySceneSystemProfile: Some public properties were marked as `#if UNITY_EDITOR`. I removed these, so the corresponding serialized fields were referenced elsewhere. I wasn't sure the original intent in keeping these `#if`ed out, @railboy?