### PR TITLE
fix definition of camera system interface

### DIFF
--- a/Assets/MixedRealityToolkit/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
     /// The camera system is expected to manage settings on the main camera.
     /// It should update the camera's clear settings, render mask, etc based on platform.
     /// </summary>
-    public interface IMixedRealityCameraSystem : IMixedRealityEventSystem, IMixedRealityEventSource, IMixedRealityDataProvider
+    public interface IMixedRealityCameraSystem : IMixedRealityEventSystem, IMixedRealityEventSource, IMixedRealityService
     {
         /// <summary>
         /// Typed representation of the ConfigurationProfile property.


### PR DESCRIPTION
The camera system interface defines it as a data provider (incorrect) while the concrete class derives from BaseCoreSystem (correct).

This inconsistency was preventing the camera system to be correctly registered with the service registry and blocks the future ability to run it as a stand alone service.

This change resolves the consistency issue.