### PR TITLE
Remove warnings in Unity 2019

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -20,7 +20,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 
         static MixedRealityToolkitFacadeHandler()
         {
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui += UpdateServiceFacades;
+#else
             SceneView.onSceneGUIDelegate += UpdateServiceFacades;
+#endif
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
@@ -25,7 +25,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         static ServiceFacadeEditor()
         {
             // Register this on startup so we can update whether a facade inspector is updated or not
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui += DrawSceneGUI;
+#else
             SceneView.onSceneGUIDelegate += DrawSceneGUI;
+#endif
         }
 
         private static List<string> dataProviderList = new List<string>();

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -112,11 +112,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 }
             }
 
+#if !UNITY_2019_3_OR_NEWER
             if (PlayerSettings.scriptingRuntimeVersion != ScriptingRuntimeVersion.Latest)
             {
                 PlayerSettings.scriptingRuntimeVersion = ScriptingRuntimeVersion.Latest;
                 restart = true;
             }
+#endif
 
             if (refresh || restart)
             {

--- a/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/PlatformUtility.cs
@@ -98,9 +98,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 case UnityEditor.BuildTarget.StandaloneOSX:
                     supportedPlatforms |= SupportedPlatforms.MacStandalone;
                     break;
+#if !UNITY_2019_2_OR_NEWER
                 case UnityEditor.BuildTarget.StandaloneLinux:
-                case UnityEditor.BuildTarget.StandaloneLinux64:
                 case UnityEditor.BuildTarget.StandaloneLinuxUniversal:
+#endif
+                case UnityEditor.BuildTarget.StandaloneLinux64:
                     supportedPlatforms |= SupportedPlatforms.LinuxStandalone;
                     break;
                 case UnityEditor.BuildTarget.Android:


### PR DESCRIPTION
## Overview
MixedRealityToolkitFacadeHandler and ServiceFacadeInspector:
![image](https://user-images.githubusercontent.com/3580640/59643072-38d36280-911c-11e9-9279-0daed85e3372.png)

Platform Utility:
![image](https://user-images.githubusercontent.com/3580640/59643081-412b9d80-911c-11e9-9e65-4fb7d09b0c6a.png)
![image](https://user-images.githubusercontent.com/3580640/59643085-44268e00-911c-11e9-9b27-cd1095c1322d.png)

MixedRealityEditorSettings:
![image](https://user-images.githubusercontent.com/3580640/59643189-86e86600-911c-11e9-9236-6396905faec5.png)

Note: This doesn't remove all issues with 2019.3, as that version adds a requirement for the `Unity.ugui` package to be added to all our asmdefs (#4545). Unfortunately, that fix is backwards compatible with previous versions of Unity 2019 but causes errors in Unity 2018.

## Fixes
Fixes: #4831