### PR TITLE
Fix interpolation meta file serialization

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Physics/InterpolationUtilities.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/InterpolationUtilities.cs.meta
@@ -1,11 +1,11 @@
-fileFormatVersion: 2	
-guid: d2528cd8f0eb4d0e83245bbb4f8a34e1	
-MonoImporter:	
-  externalObjects: {}	
-  serializedVersion: 2	
-  defaultReferences: []	
-  executionOrder: 0	
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}	
-  userData: 	
-  assetBundleName: 	
+fileFormatVersion: 2
+guid: d2528cd8f0eb4d0e83245bbb4f8a34e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Interpolator.cs.meta
@@ -1,11 +1,11 @@
-fileFormatVersion: 2	
-guid: 49e053307151459ca2db5bdd9176a3b0	
-MonoImporter:	
-  externalObjects: {}	
-  serializedVersion: 2	
-  defaultReferences: []	
-  executionOrder: 0	
-  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}	
-  userData: 	
-  assetBundleName: 	
+fileFormatVersion: 2
+guid: 49e053307151459ca2db5bdd9176a3b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
## Overview
The two interpolation meta files added in #4677 had some trailing tabs for some reason.
This was causing Unity 2019.3 to regenerate these metas from scratch, including changing their GUIDs.
This PR puts the meta serialization in-line with other metas.