### PR TITLE
Fixing Normal Direction on Back Face Triangles

### DIFF
--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -802,7 +802,7 @@ Shader "Mixed Reality Toolkit/Standard"
 #if defined(SHADER_API_D3D11) && !defined(_ALPHA_CLIP) && !defined(_TRANSPARENT)
             [earlydepthstencil]
 #endif
-            fixed4 frag(v2f i) : SV_Target
+            fixed4 frag(v2f i, fixed facing : VFACE) : SV_Target
             {
 #if defined(_INSTANCED_COLOR)
                 UNITY_SETUP_INSTANCE_ID(i);
@@ -1023,10 +1023,10 @@ Shader "Mixed Reality Toolkit/Standard"
                 worldNormal.x = dot(i.tangentX, tangentNormal);
                 worldNormal.y = dot(i.tangentY, tangentNormal);
                 worldNormal.z = dot(i.tangentZ, tangentNormal);
-                worldNormal = normalize(worldNormal);
+                worldNormal = normalize(worldNormal) * facing;
 #endif
 #else
-                worldNormal = normalize(i.worldNormal);
+                worldNormal = normalize(i.worldNormal) * facing;
 #endif
 #endif
 


### PR DESCRIPTION
## Overview
When rendering the back faces of triangles, the normals are flipped the opposite way which can lead to artifacts in lighting calculations and other techniques which utilize normals. This change flips the normals based on which side of the triangle face is being rendered.

![Compare](https://user-images.githubusercontent.com/13305729/59703195-37eb1100-91ae-11e9-807b-7e42baf5e5f4.png)

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4946


## Verification
To verify the fix look at lit surfaces with back face culling disabled in the Material Gallery.

>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
