### PR TITLE
Allow setting the Billboard TargetTransform from code

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Billboard.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/Billboard.cs
@@ -27,7 +27,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// The target we will orient to. If no target is specified, the main camera will be used.
         /// </summary>
-        public Transform TargetTransform => targetTransform;
+        public Transform TargetTransform
+        {
+            get { return targetTransform; }
+            set { targetTransform = value; }
+        }
 
         [Tooltip("Specifies the target we will orient to. If no target is specified, the main camera will be used.")]
         [SerializeField]


### PR DESCRIPTION
## Overview
The current implementation does not allow for spawning a billboard in, because the target cannot be set. Most of the solver allow for doing that. This fixes it.