### PR TITLE
Don't fire pointer events if IsInteractionEnabled == false

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -458,6 +458,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnInputUp(InputEventData eventData)
         {
+            if(!IsInteractionEnabled) { return; }
+
             base.OnInputUp(eventData);
 
             if (eventData.SourceId == InputSourceParent.SourceId)
@@ -480,6 +482,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnInputDown(InputEventData eventData)
         {
+            if (!IsInteractionEnabled) { return; }
+
             base.OnInputDown(eventData);
 
             if (eventData.SourceId == InputSourceParent.SourceId)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Vector3 position;
                 if (TryGetNearGraspPoint(out position))
                 {
-                    return UnityEngine.Physics.CheckSphere(position, SphereCastRadius + 0.05f, ~UnityEngine.Physics.IgnoreRaycastLayer);
+                    return UnityEngine.Physics.CheckSphere(position, SphereCastRadius, ~UnityEngine.Physics.IgnoreRaycastLayer);
                 }
 
                 return false;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -30,6 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly Dictionary<uint, IMixedRealityPointerMediator> pointerMediators = new Dictionary<uint, IMixedRealityPointerMediator>();
         private PointerHitResult hitResult3d = new PointerHitResult();
         private PointerHitResult hitResultUi = new PointerHitResult();
+        private Collider[] colliderQueryBuffer;
+        private int sceneQueryBufferSize = 64;
 
         public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators
         {
@@ -484,6 +486,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 FindOrCreateUiRaycastCamera();
             }
 
+            colliderQueryBuffer = new Collider[sceneQueryBufferSize];
+
             var primaryPointerSelectorType = InputSystem?.InputSystemProfile.PointerProfile.PrimaryPointerSelector.Type;
             if (primaryPointerSelectorType != null)
             {
@@ -866,7 +870,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // Perform raycast to determine focused object
                     var raycastProvider = InputSystem.RaycastProvider;
                     hitResult3d.Clear();
-                    QueryScene(pointer.Pointer, raycastProvider, prioritizedLayerMasks, hitResult3d);
+                    QueryScene(pointer.Pointer, raycastProvider, prioritizedLayerMasks, hitResult3d, colliderQueryBuffer);
                     PointerHitResult hit = hitResult3d;
 
                     // If we have a unity event system, perform graphics raycasts as well to support Unity UI interactions
@@ -978,7 +982,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         /// <param name="pointerData"></param>
         /// <param name="prioritizedLayerMasks"></param>
-        private static void QueryScene(IMixedRealityPointer pointer, IMixedRealityRaycastProvider raycastProvider, LayerMask[] prioritizedLayerMasks, PointerHitResult hit)
+        private static void QueryScene(IMixedRealityPointer pointer, IMixedRealityRaycastProvider raycastProvider, LayerMask[] prioritizedLayerMasks, PointerHitResult hit, Collider[] colliderBuffer = null)
         {
             float rayStartDistance = 0;
             MixedRealityRaycastHit hitInfo;
@@ -1019,17 +1023,30 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         }
                         break;
                     case SceneQueryType.SphereOverlap:
-                        Collider[] colliders = UnityEngine.Physics.OverlapSphere(pointer.Rays[i].Origin, pointer.SphereCastRadius, ~UnityEngine.Physics.IgnoreRaycastLayer);
 
-                        if (colliders.Length > 0)
+                        int numColliders;
+
+                        if (colliderBuffer != null)
+                        {
+                            numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(pointer.Rays[i].Origin, pointer.SphereCastRadius, colliderBuffer, ~UnityEngine.Physics.IgnoreRaycastLayer);
+                        }
+                        else
+                        {
+                            colliderBuffer = UnityEngine.Physics.OverlapSphere(pointer.Rays[i].Origin, pointer.SphereCastRadius, ~UnityEngine.Physics.IgnoreRaycastLayer);
+                            numColliders = colliderBuffer.Length;
+                        }                        
+
+                        if (colliderBuffer.Length > 0)
                         {
                             Vector3 testPoint = pointer.Rays[i].Origin;
                             GameObject closest = null;
                             float closestDistance = Mathf.Infinity;
                             Vector3 objectHitPoint = testPoint;
 
-                            foreach (Collider collider in colliders)
+                            for (int c = 0; c < numColliders; c++)
                             {
+                                Collider collider = colliderBuffer[c];
+
                                 // Policy: in order for an collider to be near interactable it must have
                                 // a NearInteractionGrabbable component on it.
                                 // FIXME: This is assuming only the grab pointer is using SceneQueryType.SphereOverlap,


### PR DESCRIPTION
## Overview
The bug listed in #4857 was caused by a missed check `BaseControllerPointer`:
- Pointer Up/down events were fired without checking `IsInteractionEnabled`
- This caused Pointer Up event to be fired by the GrabPointer, even when it was disabled. The repro in #4857 had a modal dialog that would show when a button B was clicked. The modal would then disappear whenever it saw a click form any pointer. The bug was that after user pressed select on controller, Bwould receive click from line pointer, which would show modal M. Then the grab pointer (from that same select gesture) would fire a second click, which would hide the modal M.

## Changes
- Fixes: #4857 
- Also remove extra 0.05 m buffer when doing test for is sphere collider near grabbable. This was causing confusing UX feedback where the line pointer would disappear (therefore communicating that object is close enough to grab), but object was not actually grabbable.

## Note
This has been successfully tested both on device and in editor, doesn't break existing components such as `ManipulationHandler`.

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
