### PR TITLE
Update the HL2 profile description's SA section

### DIFF
--- a/Documentation/Profiles/Profiles.md
+++ b/Documentation/Profiles/Profiles.md
@@ -37,7 +37,7 @@ The key differences between the HoloLens2 profile and the Default Profile are:
 - Spatial Awareness System has been disabled (spatial meshes won't render, but this can be turned back
   on by following the [instructions here](../SpatialAwareness/SpatialAwarenessGettingStarted.md). Spatial
   meshes are turned off by default based on client feedback - it is an interesting visualization to see
-  initially but is typically turned off to avoid the visual distraction and the additional perf hit of
+  initially but is typically turned off to avoid the visual distraction and the additional performance hit of
   having it on.
 - The eye tracking provider and settings have been enabled
 - Eye simulation has been enabled by default

--- a/Documentation/Profiles/Profiles.md
+++ b/Documentation/Profiles/Profiles.md
@@ -43,3 +43,7 @@ The key differences between the HoloLens2 profile and the Default Profile are:
 - Eye simulation has been enabled by default
 - Hand mesh visualization is disabled (there is a performance overhead associated with using hand meshes)
 - Camera profile settings are set to match such that the editor quality and player quality are the same.
+  (This is different from the default camera profile where Opaque displays are set to higher quality -
+  this change makes it so that in-editor quality will be lower, which will more closely match what will
+  be rendered on the device)
+  

--- a/Documentation/Profiles/Profiles.md
+++ b/Documentation/Profiles/Profiles.md
@@ -35,7 +35,10 @@ The key differences between the HoloLens2 profile and the Default Profile are:
 - Boundary System has been disabled (there are no boundaries in AR)
 - Teleport System has been disabled (primarily a VR concept)
 - Spatial Awareness System has been disabled (spatial meshes won't render, but this can be turned back
-  on by following the [instructions here](../SpatialAwareness/SpatialAwarenessGettingStarted.md))
+  on by following the [instructions here](../SpatialAwareness/SpatialAwarenessGettingStarted.md). Spatial
+  meshes are turned off by default based on client feedback - it is an interesting visualization to see
+  initially but is typically turned off to avoid the visual distraction and the additional perf hit of
+  having it on)
 - The eye tracking provider and settings have been enabled
 - Eye simulation has been enabled by default
 - Hand mesh visualization is disabled (there is a performance overhead associated with using hand meshes)

--- a/Documentation/Profiles/Profiles.md
+++ b/Documentation/Profiles/Profiles.md
@@ -38,7 +38,7 @@ The key differences between the HoloLens2 profile and the Default Profile are:
   on by following the [instructions here](../SpatialAwareness/SpatialAwarenessGettingStarted.md). Spatial
   meshes are turned off by default based on client feedback - it is an interesting visualization to see
   initially but is typically turned off to avoid the visual distraction and the additional perf hit of
-  having it on)
+  having it on.
 - The eye tracking provider and settings have been enabled
 - Eye simulation has been enabled by default
 - Hand mesh visualization is disabled (there is a performance overhead associated with using hand meshes)


### PR DESCRIPTION
This provides a little history for why the SA system was disabled by default on the HL2 profiles.

#4945