### PR TITLE
Stop MRTK resets with inspector tab selection & disable MRTK profile inspectors in play mode

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -184,6 +184,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             var profile = target as BaseMixedRealityProfile;
             if (!RenderAsSubProfile)
             {
+                CheckEditorPlayMode();
+
                 if (!profile.IsCustomProfile)
                 {
                     EditorGUILayout.HelpBox("Default MRTK profiles cannot be edited. Create a clone of this profile to modify settings.", MessageType.Warning);
@@ -230,6 +232,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);
+        }
+
+        /// <summary>
+        /// If application is playing, then show warning to the user and disable inspector GUI
+        /// </summary>
+        /// <returns>true if application is playing, false otherwise</returns>
+        protected bool CheckEditorPlayMode()
+        {
+            if (Application.isPlaying)
+            {
+                EditorGUILayout.HelpBox("Mixed Reality Toolkit settings cannot be edited while in play mode.", MessageType.Warning);
+                GUI.enabled = false;
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -174,6 +174,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             RenderMRTKLogo();
 
+            CheckEditorPlayMode();
+
             if (!MixedRealityToolkit.IsInitialized)
             {
                 EditorGUILayout.HelpBox("No Mixed Reality Toolkit found in scene.", MessageType.Warning);
@@ -212,7 +214,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);
             }
 
-            bool isGUIEnabled = !IsProfileLock((BaseMixedRealityProfile)target);
+            bool isGUIEnabled = !IsProfileLock((BaseMixedRealityProfile)target) && GUI.enabled;
             GUI.enabled = isGUIEnabled;
 
             EditorGUI.BeginChangeCheck();
@@ -229,6 +231,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 EditorGUILayout.Space();
             }
 
+            changed |= EditorGUI.EndChangeCheck();
+
             EditorGUILayout.BeginHorizontal();
 
             EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.Width(100));
@@ -244,11 +248,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
             EditorGUILayout.EndVertical();
             EditorGUILayout.EndHorizontal();
-
-            if (!changed)
-            {
-                changed |= EditorGUI.EndChangeCheck();
-            }
 
             serializedObject.ApplyModifiedProperties();
             GUI.enabled = true;


### PR DESCRIPTION
## Overview

MRTK services are not harden to be reliable enough to be destroyed & recreated at runtime atm. There is work to make this better. This change though does two things

1) Ensure changing tabs in the MRTK inspector is not considered as a profile "change" which will call MRTK to reset configuration. 

2) If in play mode, all profile inspector GUI's are disabled from editing

Number 2 was added because
a) Some MRTK profile changes will cause a reset which will spew errors & problems as in #4944 and #3945
b) Some MRTK profiles changes will not be consumed when changed at runtime. For example, modifying the MRTK near clip plane value in the camera profile will not modify the actual camera near clip plane at runtime. 

Drawback: if a developer wants to make a profile change even though they are aware it will not take effect to next build/play, they will have to exit play mode to make any edits. 

When MRTK services are more stable, it might be worth re-considering number 2. But then it would still have to be communicated per profile and possibly even per property, that some settings will not take effect immediately. 

## Changes
- Fixes: #4944 
Related: #3945

## Verification
Enter play mode and cannot edit both MRTK inspector when selecting game object and cannot edit profiles when drilldown on their own inspectors
