### PR TITLE
Update Wireframe Shader & Inspector for transparency support

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
@@ -71,9 +71,122 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent renderQueueOverride = new GUIContent("Render Queue Override", "Manually Override the Render Queue");
         }
 
+        protected bool initialized;
+
+        protected MaterialProperty renderingMode;
+        protected MaterialProperty customRenderingMode;
+        protected MaterialProperty sourceBlend;
+        protected MaterialProperty destinationBlend;
+        protected MaterialProperty blendOperation;
+        protected MaterialProperty depthTest;
+        protected MaterialProperty depthWrite;
+        protected MaterialProperty depthOffsetFactor;
+        protected MaterialProperty depthOffsetUnits;
+        protected MaterialProperty colorWriteMask;
+        protected MaterialProperty cullMode;
+        protected MaterialProperty renderQueueOverride;
+
         protected const string LegacyShadersPath = "Legacy Shaders/";
         protected const string TransparentShadersPath = "/Transparent/";
         protected const string TransparentCutoutShadersPath = "/Transparent/Cutout/";
+
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        {
+            Material material = (Material)materialEditor.target;
+
+            FindProperties(props);
+            Initialize(material);
+
+            RenderingModeOptions(materialEditor);
+        }
+
+        protected virtual void FindProperties(MaterialProperty[] props)
+        {
+            renderingMode = FindProperty(BaseStyles.renderingModeName, props);
+            customRenderingMode = FindProperty(BaseStyles.customRenderingModeName, props);
+            sourceBlend = FindProperty(BaseStyles.sourceBlendName, props);
+            destinationBlend = FindProperty(BaseStyles.destinationBlendName, props);
+            blendOperation = FindProperty(BaseStyles.blendOperationName, props);
+            depthTest = FindProperty(BaseStyles.depthTestName, props);
+            depthWrite = FindProperty(BaseStyles.depthWriteName, props);
+            depthOffsetFactor = FindProperty(BaseStyles.depthOffsetFactorName, props);
+            depthOffsetUnits = FindProperty(BaseStyles.depthOffsetUnitsName, props);
+            colorWriteMask = FindProperty(BaseStyles.colorWriteMaskName, props);
+
+            cullMode = FindProperty("_CullMode", props);
+            renderQueueOverride = FindProperty("_RenderQueueOverride", props);
+        }
+
+        protected void Initialize(Material material)
+        {
+            if (!initialized)
+            {
+                MaterialChanged(material);
+                initialized = true;
+            }
+        }
+
+        protected virtual void MaterialChanged(Material material)
+        {
+            SetupMaterialWithRenderingMode(material,
+                (RenderingMode)renderingMode.floatValue,
+                (CustomRenderingMode)customRenderingMode.floatValue,
+                (int)renderQueueOverride.floatValue);
+        }
+
+        protected void RenderingModeOptions(MaterialEditor materialEditor)
+        {
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.showMixedValue = renderingMode.hasMixedValue;
+            RenderingMode mode = (RenderingMode)renderingMode.floatValue;
+            EditorGUI.BeginChangeCheck();
+            mode = (RenderingMode)EditorGUILayout.Popup(renderingMode.displayName, (int)mode, BaseStyles.renderingModeNames);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                materialEditor.RegisterPropertyChangeUndo(renderingMode.displayName);
+                renderingMode.floatValue = (float)mode;
+            }
+
+            EditorGUI.showMixedValue = false;
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                Object[] targets = renderingMode.targets;
+
+                foreach (Object target in targets)
+                {
+                    MaterialChanged((Material)target);
+                }
+            }
+
+            if ((RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
+            {
+                EditorGUI.indentLevel += 2;
+                customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, BaseStyles.customRenderingModeNames);
+                materialEditor.ShaderProperty(sourceBlend, BaseStyles.sourceBlend);
+                materialEditor.ShaderProperty(destinationBlend, BaseStyles.destinationBlend);
+                materialEditor.ShaderProperty(blendOperation, BaseStyles.blendOperation);
+                materialEditor.ShaderProperty(depthTest, BaseStyles.depthTest);
+                depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, BaseStyles.depthWriteNames);
+                materialEditor.ShaderProperty(depthOffsetFactor, BaseStyles.depthOffsetFactor);
+                materialEditor.ShaderProperty(depthOffsetUnits, BaseStyles.depthOffsetUnits);
+                materialEditor.ShaderProperty(colorWriteMask, BaseStyles.colorWriteMask);
+                EditorGUI.indentLevel -= 2;
+            }
+
+            if (!PropertyEnabled(depthWrite))
+            {
+                if (MixedRealityToolkitShaderGUIUtilities.DisplayDepthWriteWarning(materialEditor))
+                {
+                    renderingMode.floatValue = (float)RenderingMode.Custom;
+                    depthWrite.floatValue = (float)DepthWrite.On;
+                }
+            }
+
+            materialEditor.ShaderProperty(cullMode, BaseStyles.cullMode);
+        }
 
         protected static void SetupMaterialWithRenderingMode(Material material, RenderingMode mode, CustomRenderingMode customMode, int renderQueueOverride)
         {

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
@@ -366,7 +366,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <param name="material">Material to modify</param>
         /// <param name="keywordName">Keyword of shader feature</param>
         /// <param name="propertyName">Associated property name for shader feature</param>
-        /// <param name="propertyValue">boolean toggle of active/inactive wrapped through float</param>
+        /// <param name="propertyValue">float to be treated as a boolean flag for setting shader feature active or inactive</param>
         protected static void SetShaderFeatureActive(Material material, string keywordName, string propertyName, float? propertyValue)
         {
             if (propertyValue.HasValue)

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+using Object = UnityEngine.Object;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// A custom shader inspector for the "Mixed Reality Toolkit/Wireframe" shader.
+    /// </summary>
+    public abstract class MixedRealityShaderGUI : ShaderGUI
+    {
+        protected enum RenderingMode
+        {
+            Opaque,
+            TransparentCutout,
+            Transparent,
+            PremultipliedTransparent,
+            Additive,
+            Custom
+        }
+
+        protected enum CustomRenderingMode
+        {
+            Opaque,
+            TransparentCutout,
+            Transparent
+        }
+
+        protected enum DepthWrite
+        {
+            Off,
+            On
+        }
+
+        protected static class BaseStyles
+        {
+            public static string renderingOptionsTitle = "Rendering Options";
+            public static string advancedOptionsTitle = "Advanced Options";
+            public static string renderTypeName = "RenderType";
+            public static string renderingModeName = "_Mode";
+            public static string customRenderingModeName = "_CustomMode";
+            public static string sourceBlendName = "_SrcBlend";
+            public static string destinationBlendName = "_DstBlend";
+            public static string blendOperationName = "_BlendOp";
+            public static string depthTestName = "_ZTest";
+            public static string depthWriteName = "_ZWrite";
+            public static string depthOffsetFactorName = "_ZOffsetFactor";
+            public static string depthOffsetUnitsName = "_ZOffsetUnits";
+            public static string colorWriteMaskName = "_ColorWriteMask";
+
+            public static string alphaTestOnName = "_ALPHATEST_ON";
+            public static string alphaBlendOnName = "_ALPHABLEND_ON";
+
+            public static readonly string[] renderingModeNames = Enum.GetNames(typeof(RenderingMode));
+            public static readonly string[] customRenderingModeNames = Enum.GetNames(typeof(CustomRenderingMode));
+            public static readonly string[] depthWriteNames = Enum.GetNames(typeof(DepthWrite));
+            public static GUIContent sourceBlend = new GUIContent("Source Blend", "Blend Mode of Newly Calculated Color");
+            public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Existing Color");
+            public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Existing Color");
+            public static GUIContent depthTest = new GUIContent("Depth Test", "How Should Depth Testing Be Performed.");
+            public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Material Are Written to the Depth Buffer");
+            public static GUIContent depthOffsetFactor = new GUIContent("Depth Offset Factor", "Scales the Maximum Z Slope, with Respect to X or Y of the Polygon");
+            public static GUIContent depthOffsetUnits = new GUIContent("Depth Offset Units", "Scales the Minimum Resolvable Depth Buffer Value");
+            public static GUIContent colorWriteMask = new GUIContent("Color Write Mask", "Color Channel Writing Mask");
+            public static GUIContent cullMode = new GUIContent("Cull Mode", "Triangle Culling Mode");
+            public static GUIContent renderQueueOverride = new GUIContent("Render Queue Override", "Manually Override the Render Queue");
+        }
+
+        protected static void SetupMaterialWithRenderingMode(Material material, RenderingMode mode, CustomRenderingMode customMode, int renderQueueOverride)
+        {
+            switch (mode)
+            {
+                case RenderingMode.Opaque:
+                    {
+                        material.SetOverrideTag(BaseStyles.renderTypeName, BaseStyles.renderingModeNames[(int)RenderingMode.Opaque]);
+                        material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Opaque);
+                        material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
+                        material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.Zero);
+                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
+                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
+                        material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.On);
+                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
+                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
+                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
+                        material.DisableKeyword(BaseStyles.alphaTestOnName);
+                        material.DisableKeyword(BaseStyles.alphaBlendOnName);
+                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Geometry;
+                    }
+                    break;
+
+                case RenderingMode.TransparentCutout:
+                    {
+                        material.SetOverrideTag(BaseStyles.renderTypeName, BaseStyles.renderingModeNames[(int)RenderingMode.TransparentCutout]);
+                        material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.TransparentCutout);
+                        material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
+                        material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.Zero);
+                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
+                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
+                        material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.On);
+                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
+                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
+                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
+                        material.EnableKeyword(BaseStyles.alphaTestOnName);
+                        material.DisableKeyword(BaseStyles.alphaBlendOnName);
+                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.AlphaTest;
+                    }
+                    break;
+
+                case RenderingMode.Transparent:
+                    {
+                        material.SetOverrideTag(BaseStyles.renderTypeName, BaseStyles.renderingModeNames[(int)RenderingMode.Transparent]);
+                        material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
+                        material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.SrcAlpha);
+                        material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.OneMinusSrcAlpha);
+                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
+                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
+                        material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.Off);
+                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
+                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
+                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
+                        material.DisableKeyword(BaseStyles.alphaTestOnName);
+                        material.EnableKeyword(BaseStyles.alphaBlendOnName);
+                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
+                    }
+                    break;
+
+                case RenderingMode.PremultipliedTransparent:
+                    {
+                        material.SetOverrideTag(BaseStyles.renderTypeName, BaseStyles.renderingModeNames[(int)RenderingMode.Transparent]);
+                        material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
+                        material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
+                        material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.OneMinusSrcAlpha);
+                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
+                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
+                        material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.Off);
+                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
+                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
+                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
+                        material.DisableKeyword(BaseStyles.alphaTestOnName);
+                        material.EnableKeyword(BaseStyles.alphaBlendOnName);
+                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
+                    }
+                    break;
+
+                case RenderingMode.Additive:
+                    {
+                        material.SetOverrideTag(BaseStyles.renderTypeName, BaseStyles.renderingModeNames[(int)RenderingMode.Transparent]);
+                        material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
+                        material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
+                        material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.One);
+                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
+                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
+                        material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.Off);
+                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
+                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
+                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
+                        material.DisableKeyword(BaseStyles.alphaTestOnName);
+                        material.EnableKeyword(BaseStyles.alphaBlendOnName);
+                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
+                    }
+                    break;
+
+                case RenderingMode.Custom:
+                    {
+                        material.SetOverrideTag(BaseStyles.renderTypeName, BaseStyles.customRenderingModeNames[(int)customMode]);
+                        // _SrcBlend, _DstBlend, _BlendOp, _ZTest, _ZWrite, _ColorWriteMask are controlled by UI.
+
+                        switch (customMode)
+                        {
+                            case CustomRenderingMode.Opaque:
+                                {
+                                    material.DisableKeyword(BaseStyles.alphaTestOnName);
+                                    material.DisableKeyword(BaseStyles.alphaBlendOnName);
+                                }
+                                break;
+
+                            case CustomRenderingMode.TransparentCutout:
+                                {
+                                    material.EnableKeyword(BaseStyles.alphaTestOnName);
+                                    material.DisableKeyword(BaseStyles.alphaBlendOnName);
+                                }
+                                break;
+
+                            case CustomRenderingMode.Transparent:
+                                {
+                                    material.DisableKeyword(BaseStyles.alphaTestOnName);
+                                    material.EnableKeyword(BaseStyles.alphaBlendOnName);
+                                }
+                                break;
+                        }
+
+                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : material.renderQueue;
+                    }
+                    break;
+            }
+        }
+
+        protected static bool PropertyEnabled(MaterialProperty property)
+        {
+            return !property.floatValue.Equals(0.0f);
+        }
+
+        protected static float? GetFloatProperty(Material material, string propertyName)
+        {
+            if (material.HasProperty(propertyName))
+            {
+                return material.GetFloat(propertyName);
+            }
+
+            return null;
+        }
+
+        protected static Vector4? GetVectorProperty(Material material, string propertyName)
+        {
+            if (material.HasProperty(propertyName))
+            {
+                return material.GetVector(propertyName);
+            }
+
+            return null;
+        }
+
+        protected static Color? GetColorProperty(Material material, string propertyName)
+        {
+            if (material.HasProperty(propertyName))
+            {
+                return material.GetColor(propertyName);
+            }
+
+            return null;
+        }
+
+        protected static void SetFloatProperty(Material material, string keywordName, string propertyName, float? propertyValue)
+        {
+            if (propertyValue.HasValue)
+            {
+                if (keywordName != null)
+                {
+                    if (!propertyValue.Value.Equals(0.0f))
+                    {
+                        material.EnableKeyword(keywordName);
+                    }
+                    else
+                    {
+                        material.DisableKeyword(keywordName);
+                    }
+                }
+
+                material.SetFloat(propertyName, propertyValue.Value);
+            }
+        }
+
+        protected static void SetVectorProperty(Material material, string propertyName, Vector4? propertyValue)
+        {
+            if (propertyValue.HasValue)
+            {
+                material.SetVector(propertyName, propertyValue.Value);
+            }
+        }
+
+        protected static void SetColorProperty(Material material, string propertyName, Color? propertyValue)
+        {
+            if (propertyValue.HasValue)
+            {
+                material.SetColor(propertyName, propertyValue.Value);
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
@@ -53,6 +53,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static string depthOffsetUnitsName = "_ZOffsetUnits";
             public static string colorWriteMaskName = "_ColorWriteMask";
 
+            public static string cullModeName = "_CullMode";
+            public static string renderQueueOverrideName = "_RenderQueueOverride";
+
             public static string alphaTestOnName = "_ALPHATEST_ON";
             public static string alphaBlendOnName = "_ALPHABLEND_ON";
 
@@ -113,8 +116,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             depthOffsetUnits = FindProperty(BaseStyles.depthOffsetUnitsName, props);
             colorWriteMask = FindProperty(BaseStyles.colorWriteMaskName, props);
 
-            cullMode = FindProperty("_CullMode", props);
-            renderQueueOverride = FindProperty("_RenderQueueOverride", props);
+            cullMode = FindProperty(BaseStyles.cullModeName, props);
+            renderQueueOverride = FindProperty(BaseStyles.renderQueueOverrideName, props);
         }
 
         protected void Initialize(Material material)
@@ -147,12 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 materialEditor.RegisterPropertyChangeUndo(renderingMode.displayName);
                 renderingMode.floatValue = (float)mode;
-            }
 
-            EditorGUI.showMixedValue = false;
-
-            if (EditorGUI.EndChangeCheck())
-            {
                 Object[] targets = renderingMode.targets;
 
                 foreach (Object target in targets)
@@ -160,6 +158,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     MaterialChanged((Material)target);
                 }
             }
+
+            EditorGUI.showMixedValue = false;
 
             if ((RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
             {
@@ -190,6 +190,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         protected static void SetupMaterialWithRenderingMode(Material material, RenderingMode mode, CustomRenderingMode customMode, int renderQueueOverride)
         {
+            // If we aren't switching to Custom, then set default values for all RenderingMode types. Otherwise keep whatever user had before
+            if (mode != RenderingMode.Custom)
+            {
+                material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
+                material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
+                material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
+                material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
+                material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
+            }
+
             switch (mode)
             {
                 case RenderingMode.Opaque:
@@ -198,12 +208,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Opaque);
                         material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
                         material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.Zero);
-                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
                         material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.On);
-                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
                         material.DisableKeyword(BaseStyles.alphaTestOnName);
                         material.DisableKeyword(BaseStyles.alphaBlendOnName);
                         material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Geometry;
@@ -216,12 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.TransparentCutout);
                         material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
                         material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.Zero);
-                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
                         material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.On);
-                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
                         material.EnableKeyword(BaseStyles.alphaTestOnName);
                         material.DisableKeyword(BaseStyles.alphaBlendOnName);
                         material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.AlphaTest;
@@ -234,12 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
                         material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.SrcAlpha);
                         material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.OneMinusSrcAlpha);
-                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
                         material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.Off);
-                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
                         material.DisableKeyword(BaseStyles.alphaTestOnName);
                         material.EnableKeyword(BaseStyles.alphaBlendOnName);
                         material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
@@ -252,12 +247,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
                         material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
                         material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.OneMinusSrcAlpha);
-                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
                         material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.Off);
-                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
                         material.DisableKeyword(BaseStyles.alphaTestOnName);
                         material.EnableKeyword(BaseStyles.alphaBlendOnName);
                         material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
@@ -270,12 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         material.SetInt(BaseStyles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
                         material.SetInt(BaseStyles.sourceBlendName, (int)BlendMode.One);
                         material.SetInt(BaseStyles.destinationBlendName, (int)BlendMode.One);
-                        material.SetInt(BaseStyles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(BaseStyles.depthTestName, (int)CompareFunction.LessEqual);
                         material.SetInt(BaseStyles.depthWriteName, (int)DepthWrite.Off);
-                        material.SetFloat(BaseStyles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(BaseStyles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(BaseStyles.colorWriteMaskName, (int)ColorWriteMask.All);
                         material.DisableKeyword(BaseStyles.alphaTestOnName);
                         material.EnableKeyword(BaseStyles.alphaBlendOnName);
                         material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs
@@ -10,7 +10,7 @@ using Object = UnityEngine.Object;
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
     /// <summary>
-    /// A custom shader inspector for the "Mixed Reality Toolkit/Wireframe" shader.
+    /// A custom base shader inspector for Mixed Reality Toolkit shaders.
     /// </summary>
     public abstract class MixedRealityShaderGUI : ShaderGUI
     {
@@ -70,6 +70,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent cullMode = new GUIContent("Cull Mode", "Triangle Culling Mode");
             public static GUIContent renderQueueOverride = new GUIContent("Render Queue Override", "Manually Override the Render Queue");
         }
+
+        protected const string LegacyShadersPath = "Legacy Shaders/";
+        protected const string TransparentShadersPath = "/Transparent/";
+        protected const string TransparentCutoutShadersPath = "/Transparent/Cutout/";
 
         protected static void SetupMaterialWithRenderingMode(Material material, RenderingMode mode, CustomRenderingMode customMode, int renderQueueOverride)
         {
@@ -200,11 +204,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Check whether shader feature is enabled
+        /// </summary>
+        /// <param name="property">float property to check against</param>
+        /// <returns>false if 0.0f, true otherwise</returns>
         protected static bool PropertyEnabled(MaterialProperty property)
         {
             return !property.floatValue.Equals(0.0f);
         }
 
+        /// <summary>
+        /// Get the value of a given float property for a material
+        /// </summary>
+        /// <param name="material">material to check</param>
+        /// <param name="propertyName">name of property against material</param>
+        /// <returns>if has property, then value of that property for current material, null otherwise</returns>
         protected static float? GetFloatProperty(Material material, string propertyName)
         {
             if (material.HasProperty(propertyName))
@@ -215,6 +230,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return null;
         }
 
+        /// <summary>
+        /// Get the value of a given vector property for a material
+        /// </summary>
+        /// <param name="material">material to check</param>
+        /// <param name="propertyName">name of property against material</param>
+        /// <returns>if has property, then value of that property for current material, null otherwise</returns>
         protected static Vector4? GetVectorProperty(Material material, string propertyName)
         {
             if (material.HasProperty(propertyName))
@@ -225,6 +246,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return null;
         }
 
+        /// <summary>
+        /// Get the value of a given color property for a material
+        /// </summary>
+        /// <param name="material">material to check</param>
+        /// <param name="propertyName">name of property against material</param>
+        /// <returns>if has property, then value of that property for current material, null otherwise</returns>
         protected static Color? GetColorProperty(Material material, string propertyName)
         {
             if (material.HasProperty(propertyName))
@@ -235,7 +262,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return null;
         }
 
-        protected static void SetFloatProperty(Material material, string keywordName, string propertyName, float? propertyValue)
+        /// <summary>
+        /// Sets the shader feature controlled by keyword & property name parameters active or inactive
+        /// </summary>
+        /// <param name="material">Material to modify</param>
+        /// <param name="keywordName">Keyword of shader feature</param>
+        /// <param name="propertyName">Associated property name for shader feature</param>
+        /// <param name="propertyValue">boolean toggle of active/inactive wrapped through float</param>
+        protected static void SetShaderFeatureActive(Material material, string keywordName, string propertyName, float? propertyValue)
         {
             if (propertyValue.HasValue)
             {
@@ -255,6 +289,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Sets vector property against associated material
+        /// </summary>
+        /// <param name="material">material to control</param>
+        /// <param name="propertyName">name of property to set</param>
+        /// <param name="propertyValue">value of property to set</param>
         protected static void SetVectorProperty(Material material, string propertyName, Vector4? propertyValue)
         {
             if (propertyValue.HasValue)
@@ -263,6 +303,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Set color property against associated material
+        /// </summary>
+        /// <param name="material">material to control</param>
+        /// <param name="propertyName">name of property to set</param>
+        /// <param name="propertyValue">value of property to set</param>
         protected static void SetColorProperty(Material material, string propertyName, Color? propertyValue)
         {
             if (propertyValue.HasValue)

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityShaderGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c455a0029df0144a8d8bd9b27f781eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -361,26 +361,26 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             base.AssignNewShaderToMaterial(material, oldShader, newShader);
 
             // Apply old shader properties to the new shader.
-            SetFloatProperty(material, null, "_Smoothness", smoothness);
-            SetFloatProperty(material, "_DIRECTIONAL_LIGHT", "_DirectionalLight", diffuse);
-            SetFloatProperty(material, "_SPECULAR_HIGHLIGHTS", "_SpecularHighlights", specularHighlights);
-            SetFloatProperty(material, "_NORMAL_MAP", "_EnableNormalMap", normalMap);
+            SetShaderFeatureActive(material, null, "_Smoothness", smoothness);
+            SetShaderFeatureActive(material, "_DIRECTIONAL_LIGHT", "_DirectionalLight", diffuse);
+            SetShaderFeatureActive(material, "_SPECULAR_HIGHLIGHTS", "_SpecularHighlights", specularHighlights);
+            SetShaderFeatureActive(material, "_NORMAL_MAP", "_EnableNormalMap", normalMap);
 
             if (normalMapTexture)
             {
                 material.SetTexture("_NormalMap", normalMapTexture);
             }
 
-            SetFloatProperty(material, null, "_NormalMapScale", normalMapScale);
-            SetFloatProperty(material, "_EMISSION", "_EnableEmission", emission);
+            SetShaderFeatureActive(material, null, "_NormalMapScale", normalMapScale);
+            SetShaderFeatureActive(material, "_EMISSION", "_EnableEmission", emission);
             SetColorProperty(material, "_EmissiveColor", emissionColor);
-            SetFloatProperty(material, "_REFLECTIONS", "_Reflections", reflections);
-            SetFloatProperty(material, "_RIM_LIGHT", "_RimLight", rimLighting);
+            SetShaderFeatureActive(material, "_REFLECTIONS", "_Reflections", reflections);
+            SetShaderFeatureActive(material, "_RIM_LIGHT", "_RimLight", rimLighting);
             SetVectorProperty(material, "_MainTex_ST", textureScaleOffset);
-            SetFloatProperty(material, null, "_CullMode", cullMode);
+            SetShaderFeatureActive(material, null, "_CullMode", cullMode);
 
             // Setup the rendering mode based on the old shader.
-            if (oldShader == null || !oldShader.name.Contains("Legacy Shaders/"))
+            if (oldShader == null || !oldShader.name.Contains(LegacyShadersPath))
             {
                 SetupMaterialWithRenderingMode(material, (RenderingMode)material.GetFloat(BaseStyles.renderingModeName), CustomRenderingMode.Opaque, -1);
             }
@@ -388,11 +388,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 RenderingMode mode = RenderingMode.Opaque;
 
-                if (oldShader.name.Contains("/Transparent/Cutout/"))
+                if (oldShader.name.Contains(TransparentCutoutShadersPath))
                 {
                     mode = RenderingMode.TransparentCutout;
                 }
-                else if (oldShader.name.Contains("/Transparent/"))
+                else if (oldShader.name.Contains(TransparentShadersPath))
                 {
                     mode = RenderingMode.Transparent;
                 }
@@ -789,7 +789,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             else
             {
                 // When instancing is disable, disable instanced color.
-                SetFloatProperty(material, Styles.instancedColorFeatureName, Styles.instancedColorName, 0.0f);
+                SetShaderFeatureActive(material, Styles.instancedColorFeatureName, Styles.instancedColorName, 0.0f);
             }
 
             materialEditor.ShaderProperty(stencil, Styles.stencil);

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -16,7 +16,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// </summary>
     public class MixedRealityStandardShaderGUI : MixedRealityShaderGUI
     {
-
         protected enum AlbedoAlphaMode
         {
             Transparency,
@@ -119,21 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent stencilOperation = new GUIContent("Stencil Operation", "What to do When the Stencil Test Passes");
         }
 
-        protected bool initialized;
-
-        protected MaterialProperty renderingMode;
-        protected MaterialProperty customRenderingMode;
-        protected MaterialProperty sourceBlend;
-        protected MaterialProperty destinationBlend;
-        protected MaterialProperty blendOperation;
-        protected MaterialProperty depthTest;
-        protected MaterialProperty depthWrite;
-        protected MaterialProperty depthOffsetFactor;
-        protected MaterialProperty depthOffsetUnits;
-        protected MaterialProperty colorWriteMask;
         protected MaterialProperty instancedColor;
-        protected MaterialProperty cullMode;
-        protected MaterialProperty renderQueueOverride;
         protected MaterialProperty albedoMap;
         protected MaterialProperty albedoColor;
         protected MaterialProperty albedoAlphaMode;
@@ -214,21 +199,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         protected MaterialProperty stencilComparison;
         protected MaterialProperty stencilOperation;
 
-        protected void FindProperties(MaterialProperty[] props)
+        protected override void FindProperties(MaterialProperty[] props)
         {
-            renderingMode = FindProperty(BaseStyles.renderingModeName, props);
-            customRenderingMode = FindProperty(BaseStyles.customRenderingModeName, props);
-            sourceBlend = FindProperty(BaseStyles.sourceBlendName, props);
-            destinationBlend = FindProperty(BaseStyles.destinationBlendName, props);
-            blendOperation = FindProperty(BaseStyles.blendOperationName, props);
-            depthTest = FindProperty(BaseStyles.depthTestName, props);
-            depthWrite = FindProperty(BaseStyles.depthWriteName, props);
-            depthOffsetFactor = FindProperty(BaseStyles.depthOffsetFactorName, props);
-            depthOffsetUnits = FindProperty(BaseStyles.depthOffsetUnitsName, props);
-            colorWriteMask = FindProperty(BaseStyles.colorWriteMaskName, props);
+            base.FindProperties(props);
+
             instancedColor = FindProperty(Styles.instancedColorName, props);
-            cullMode = FindProperty("_CullMode", props);
-            renderQueueOverride = FindProperty("_RenderQueueOverride", props);
             albedoMap = FindProperty("_MainTex", props);
             albedoColor = FindProperty("_Color", props);
             albedoAlphaMode = FindProperty("_AlbedoAlphaMode", props);
@@ -314,10 +289,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             Material material = (Material)materialEditor.target;
 
-            FindProperties(props);
-            Initialize(material);
+            base.OnGUI(materialEditor, props);
 
-            RenderingModeOptions(materialEditor);
             MainMapOptions(materialEditor, material);
             RenderingOptions(materialEditor, material);
             FluentOptions(materialEditor, material);
@@ -403,73 +376,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
-        protected void Initialize(Material material)
-        {
-            if (!initialized)
-            {
-                MaterialChanged(material);
-                initialized = true;
-            }
-        }
-
-        protected void MaterialChanged(Material material)
+        protected override void MaterialChanged(Material material)
         {
             SetupMaterialWithAlbedo(material, albedoMap, albedoAlphaMode, albedoAssignedAtRuntime);
-            SetupMaterialWithRenderingMode(material, (RenderingMode)renderingMode.floatValue, (CustomRenderingMode)customRenderingMode.floatValue, (int)renderQueueOverride.floatValue);
-        }
 
-        protected void RenderingModeOptions(MaterialEditor materialEditor)
-        {
-            EditorGUI.BeginChangeCheck();
-
-            EditorGUI.showMixedValue = renderingMode.hasMixedValue;
-            RenderingMode mode = (RenderingMode)renderingMode.floatValue;
-            EditorGUI.BeginChangeCheck();
-            mode = (RenderingMode)EditorGUILayout.Popup(renderingMode.displayName, (int)mode, BaseStyles.renderingModeNames);
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                materialEditor.RegisterPropertyChangeUndo(renderingMode.displayName);
-                renderingMode.floatValue = (float)mode;
-            }
-
-            EditorGUI.showMixedValue = false;
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                Object[] targets = renderingMode.targets;
-
-                foreach (Object target in targets)
-                {
-                    MaterialChanged((Material)target);
-                }
-            }
-
-            if ((RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
-            {
-                EditorGUI.indentLevel += 2;
-                customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, BaseStyles.customRenderingModeNames);
-                materialEditor.ShaderProperty(sourceBlend, BaseStyles.sourceBlend);
-                materialEditor.ShaderProperty(destinationBlend, BaseStyles.destinationBlend);
-                materialEditor.ShaderProperty(blendOperation, BaseStyles.blendOperation);
-                materialEditor.ShaderProperty(depthTest, BaseStyles.depthTest);
-                depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, BaseStyles.depthWriteNames);
-                materialEditor.ShaderProperty(depthOffsetFactor, BaseStyles.depthOffsetFactor);
-                materialEditor.ShaderProperty(depthOffsetUnits, BaseStyles.depthOffsetUnits);
-                materialEditor.ShaderProperty(colorWriteMask, BaseStyles.colorWriteMask);
-                EditorGUI.indentLevel -= 2;
-            }
-
-            if (!PropertyEnabled(depthWrite))
-            {
-                if (MixedRealityToolkitShaderGUIUtilities.DisplayDepthWriteWarning(materialEditor))
-                {
-                    renderingMode.floatValue = (float)RenderingMode.Custom;
-                    depthWrite.floatValue = (float)DepthWrite.On;
-                }
-            }
-
-            materialEditor.ShaderProperty(cullMode, BaseStyles.cullMode);
+            base.MaterialChanged(material);
         }
 
         protected void MainMapOptions(MaterialEditor materialEditor, Material material)

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -14,24 +14,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// <summary>
     /// A custom shader inspector for the "Mixed Reality Toolkit/Standard" shader.
     /// </summary>
-    public class MixedRealityStandardShaderGUI : ShaderGUI
+    public class MixedRealityStandardShaderGUI : MixedRealityShaderGUI
     {
-        protected enum RenderingMode
-        {
-            Opaque,
-            TransparentCutout,
-            Transparent,
-            PremultipliedTransparent,
-            Additive,
-            Custom
-        }
-
-        protected enum CustomRenderingMode
-        {
-            Opaque,
-            TransparentCutout,
-            Transparent
-        }
 
         protected enum AlbedoAlphaMode
         {
@@ -40,54 +24,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             Smoothness
         }
 
-        protected enum DepthWrite
-        {
-            Off,
-            On
-        }
-
         protected static class Styles
         {
             public static string primaryMapsTitle = "Main Maps";
             public static string renderingOptionsTitle = "Rendering Options";
             public static string advancedOptionsTitle = "Advanced Options";
             public static string fluentOptionsTitle = "Fluent Options";
-            public static string renderTypeName = "RenderType";
-            public static string renderingModeName = "_Mode";
-            public static string customRenderingModeName = "_CustomMode";
-            public static string sourceBlendName = "_SrcBlend";
-            public static string destinationBlendName = "_DstBlend";
-            public static string blendOperationName = "_BlendOp";
-            public static string depthTestName = "_ZTest";
-            public static string depthWriteName = "_ZWrite";
-            public static string depthOffsetFactorName = "_ZOffsetFactor";
-            public static string depthOffsetUnitsName = "_ZOffsetUnits";
-            public static string colorWriteMaskName = "_ColorWriteMask";
             public static string instancedColorName = "_InstancedColor";
             public static string instancedColorFeatureName = "_INSTANCED_COLOR";
             public static string stencilComparisonName = "_StencilComparison";
             public static string stencilOperationName = "_StencilOperation";
-            public static string alphaTestOnName = "_ALPHATEST_ON";
-            public static string alphaBlendOnName = "_ALPHABLEND_ON";
             public static string disableAlbedoMapName = "_DISABLE_ALBEDO_MAP";
             public static string albedoMapAlphaMetallicName = "_METALLIC_TEXTURE_ALBEDO_CHANNEL_A";
             public static string albedoMapAlphaSmoothnessName = "_SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A";
             public static string propertiesComponentHelp = "Use the {0} component to control {1} properties.";
-            public static readonly string[] renderingModeNames = Enum.GetNames(typeof(RenderingMode));
-            public static readonly string[] customRenderingModeNames = Enum.GetNames(typeof(CustomRenderingMode));
             public static readonly string[] albedoAlphaModeNames = Enum.GetNames(typeof(AlbedoAlphaMode));
-            public static readonly string[] depthWriteNames = Enum.GetNames(typeof(DepthWrite));
-            public static GUIContent sourceBlend = new GUIContent("Source Blend", "Blend Mode of Newly Calculated Color");
-            public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Existing Color");
-            public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Existing Color");
-            public static GUIContent depthTest = new GUIContent("Depth Test", "How Should Depth Testing Be Performed.");
-            public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Material Are Written to the Depth Buffer");
-            public static GUIContent depthOffsetFactor = new GUIContent("Depth Offset Factor", "Scales the Maximum Z Slope, with Respect to X or Y of the Polygon");
-            public static GUIContent depthOffsetUnits = new GUIContent("Depth Offset Units", "Scales the Minimum Resolvable Depth Buffer Value");
-            public static GUIContent colorWriteMask = new GUIContent("Color Write Mask", "Color Channel Writing Mask");
             public static GUIContent instancedColor = new GUIContent("Instanced Color", "Enable a Unique Color Per Instance");
-            public static GUIContent cullMode = new GUIContent("Cull Mode", "Triangle Culling Mode");
-            public static GUIContent renderQueueOverride = new GUIContent("Render Queue Override", "Manually Override the Render Queue");
             public static GUIContent albedo = new GUIContent("Albedo", "Albedo (RGB) and Transparency (Alpha)");
             public static GUIContent albedoAssignedAtRuntime = new GUIContent("Assigned at Runtime", "As an optimization albedo operations are disabled when no albedo texture is specified. If a albedo texture will be specified at runtime enable this option.");
             public static GUIContent alphaCutoff = new GUIContent("Alpha Cutoff", "Threshold for Alpha Cutoff");
@@ -264,16 +216,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         protected void FindProperties(MaterialProperty[] props)
         {
-            renderingMode = FindProperty(Styles.renderingModeName, props);
-            customRenderingMode = FindProperty(Styles.customRenderingModeName, props);
-            sourceBlend = FindProperty(Styles.sourceBlendName, props);
-            destinationBlend = FindProperty(Styles.destinationBlendName, props);
-            blendOperation = FindProperty(Styles.blendOperationName, props);
-            depthTest = FindProperty(Styles.depthTestName, props);
-            depthWrite = FindProperty(Styles.depthWriteName, props);
-            depthOffsetFactor = FindProperty(Styles.depthOffsetFactorName, props);
-            depthOffsetUnits = FindProperty(Styles.depthOffsetUnitsName, props);
-            colorWriteMask = FindProperty(Styles.colorWriteMaskName, props);
+            renderingMode = FindProperty(BaseStyles.renderingModeName, props);
+            customRenderingMode = FindProperty(BaseStyles.customRenderingModeName, props);
+            sourceBlend = FindProperty(BaseStyles.sourceBlendName, props);
+            destinationBlend = FindProperty(BaseStyles.destinationBlendName, props);
+            blendOperation = FindProperty(BaseStyles.blendOperationName, props);
+            depthTest = FindProperty(BaseStyles.depthTestName, props);
+            depthWrite = FindProperty(BaseStyles.depthWriteName, props);
+            depthOffsetFactor = FindProperty(BaseStyles.depthOffsetFactorName, props);
+            depthOffsetUnits = FindProperty(BaseStyles.depthOffsetUnitsName, props);
+            colorWriteMask = FindProperty(BaseStyles.colorWriteMaskName, props);
             instancedColor = FindProperty(Styles.instancedColorName, props);
             cullMode = FindProperty("_CullMode", props);
             renderQueueOverride = FindProperty("_RenderQueueOverride", props);
@@ -430,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Setup the rendering mode based on the old shader.
             if (oldShader == null || !oldShader.name.Contains("Legacy Shaders/"))
             {
-                SetupMaterialWithRenderingMode(material, (RenderingMode)material.GetFloat(Styles.renderingModeName), CustomRenderingMode.Opaque, -1);
+                SetupMaterialWithRenderingMode(material, (RenderingMode)material.GetFloat(BaseStyles.renderingModeName), CustomRenderingMode.Opaque, -1);
             }
             else
             {
@@ -445,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     mode = RenderingMode.Transparent;
                 }
 
-                material.SetFloat(Styles.renderingModeName, (float)mode);
+                material.SetFloat(BaseStyles.renderingModeName, (float)mode);
 
                 MaterialChanged(material);
             }
@@ -473,7 +425,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUI.showMixedValue = renderingMode.hasMixedValue;
             RenderingMode mode = (RenderingMode)renderingMode.floatValue;
             EditorGUI.BeginChangeCheck();
-            mode = (RenderingMode)EditorGUILayout.Popup(renderingMode.displayName, (int)mode, Styles.renderingModeNames);
+            mode = (RenderingMode)EditorGUILayout.Popup(renderingMode.displayName, (int)mode, BaseStyles.renderingModeNames);
 
             if (EditorGUI.EndChangeCheck())
             {
@@ -496,15 +448,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if ((RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
             {
                 EditorGUI.indentLevel += 2;
-                customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, Styles.customRenderingModeNames);
-                materialEditor.ShaderProperty(sourceBlend, Styles.sourceBlend);
-                materialEditor.ShaderProperty(destinationBlend, Styles.destinationBlend);
-                materialEditor.ShaderProperty(blendOperation, Styles.blendOperation);
-                materialEditor.ShaderProperty(depthTest, Styles.depthTest);
-                depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, Styles.depthWriteNames);
-                materialEditor.ShaderProperty(depthOffsetFactor, Styles.depthOffsetFactor);
-                materialEditor.ShaderProperty(depthOffsetUnits, Styles.depthOffsetUnits);
-                materialEditor.ShaderProperty(colorWriteMask, Styles.colorWriteMask);
+                customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, BaseStyles.customRenderingModeNames);
+                materialEditor.ShaderProperty(sourceBlend, BaseStyles.sourceBlend);
+                materialEditor.ShaderProperty(destinationBlend, BaseStyles.destinationBlend);
+                materialEditor.ShaderProperty(blendOperation, BaseStyles.blendOperation);
+                materialEditor.ShaderProperty(depthTest, BaseStyles.depthTest);
+                depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, BaseStyles.depthWriteNames);
+                materialEditor.ShaderProperty(depthOffsetFactor, BaseStyles.depthOffsetFactor);
+                materialEditor.ShaderProperty(depthOffsetUnits, BaseStyles.depthOffsetUnits);
+                materialEditor.ShaderProperty(colorWriteMask, BaseStyles.colorWriteMask);
                 EditorGUI.indentLevel -= 2;
             }
 
@@ -517,7 +469,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
             }
 
-            materialEditor.ShaderProperty(cullMode, Styles.cullMode);
+            materialEditor.ShaderProperty(cullMode, BaseStyles.cullMode);
         }
 
         protected void MainMapOptions(MaterialEditor materialEditor, Material material)
@@ -807,7 +759,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             EditorGUI.BeginChangeCheck();
 
-            materialEditor.ShaderProperty(renderQueueOverride, Styles.renderQueueOverride);
+            materialEditor.ShaderProperty(renderQueueOverride, BaseStyles.renderQueueOverride);
 
             if (EditorGUI.EndChangeCheck())
             {
@@ -897,206 +849,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         material.EnableKeyword(Styles.albedoMapAlphaSmoothnessName);
                     }
                     break;
-            }
-        }
-
-        protected static void SetupMaterialWithRenderingMode(Material material, RenderingMode mode, CustomRenderingMode customMode, int renderQueueOverride)
-        {
-            switch (mode)
-            {
-                case RenderingMode.Opaque:
-                    {
-                        material.SetOverrideTag(Styles.renderTypeName, Styles.renderingModeNames[(int)RenderingMode.Opaque]);
-                        material.SetInt(Styles.customRenderingModeName, (int)CustomRenderingMode.Opaque);
-                        material.SetInt(Styles.sourceBlendName, (int)BlendMode.One);
-                        material.SetInt(Styles.destinationBlendName, (int)BlendMode.Zero);
-                        material.SetInt(Styles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(Styles.depthTestName, (int)CompareFunction.LessEqual);
-                        material.SetInt(Styles.depthWriteName, (int)DepthWrite.On);
-                        material.SetFloat(Styles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(Styles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(Styles.colorWriteMaskName, (int)ColorWriteMask.All);
-                        material.DisableKeyword(Styles.alphaTestOnName);
-                        material.DisableKeyword(Styles.alphaBlendOnName);
-                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Geometry;
-                    }
-                    break;
-
-                case RenderingMode.TransparentCutout:
-                    {
-                        material.SetOverrideTag(Styles.renderTypeName, Styles.renderingModeNames[(int)RenderingMode.TransparentCutout]);
-                        material.SetInt(Styles.customRenderingModeName, (int)CustomRenderingMode.TransparentCutout);
-                        material.SetInt(Styles.sourceBlendName, (int)BlendMode.One);
-                        material.SetInt(Styles.destinationBlendName, (int)BlendMode.Zero);
-                        material.SetInt(Styles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(Styles.depthTestName, (int)CompareFunction.LessEqual);
-                        material.SetInt(Styles.depthWriteName, (int)DepthWrite.On);
-                        material.SetFloat(Styles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(Styles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(Styles.colorWriteMaskName, (int)ColorWriteMask.All);
-                        material.EnableKeyword(Styles.alphaTestOnName);
-                        material.DisableKeyword(Styles.alphaBlendOnName);
-                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.AlphaTest;
-                    }
-                    break;
-
-                case RenderingMode.Transparent:
-                    {
-                        material.SetOverrideTag(Styles.renderTypeName, Styles.renderingModeNames[(int)RenderingMode.Transparent]);
-                        material.SetInt(Styles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
-                        material.SetInt(Styles.sourceBlendName, (int)BlendMode.SrcAlpha);
-                        material.SetInt(Styles.destinationBlendName, (int)BlendMode.OneMinusSrcAlpha);
-                        material.SetInt(Styles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(Styles.depthTestName, (int)CompareFunction.LessEqual);
-                        material.SetInt(Styles.depthWriteName, (int)DepthWrite.Off);
-                        material.SetFloat(Styles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(Styles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(Styles.colorWriteMaskName, (int)ColorWriteMask.All);
-                        material.DisableKeyword(Styles.alphaTestOnName);
-                        material.EnableKeyword(Styles.alphaBlendOnName);
-                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
-                    }
-                    break;
-
-                case RenderingMode.PremultipliedTransparent:
-                    {
-                        material.SetOverrideTag(Styles.renderTypeName, Styles.renderingModeNames[(int)RenderingMode.Transparent]);
-                        material.SetInt(Styles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
-                        material.SetInt(Styles.sourceBlendName, (int)BlendMode.One);
-                        material.SetInt(Styles.destinationBlendName, (int)BlendMode.OneMinusSrcAlpha);
-                        material.SetInt(Styles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(Styles.depthTestName, (int)CompareFunction.LessEqual);
-                        material.SetInt(Styles.depthWriteName, (int)DepthWrite.Off);
-                        material.SetFloat(Styles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(Styles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(Styles.colorWriteMaskName, (int)ColorWriteMask.All);
-                        material.DisableKeyword(Styles.alphaTestOnName);
-                        material.EnableKeyword(Styles.alphaBlendOnName);
-                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
-                    }
-                    break;
-
-                case RenderingMode.Additive:
-                    {
-                        material.SetOverrideTag(Styles.renderTypeName, Styles.renderingModeNames[(int)RenderingMode.Transparent]);
-                        material.SetInt(Styles.customRenderingModeName, (int)CustomRenderingMode.Transparent);
-                        material.SetInt(Styles.sourceBlendName, (int)BlendMode.One);
-                        material.SetInt(Styles.destinationBlendName, (int)BlendMode.One);
-                        material.SetInt(Styles.blendOperationName, (int)BlendOp.Add);
-                        material.SetInt(Styles.depthTestName, (int)CompareFunction.LessEqual);
-                        material.SetInt(Styles.depthWriteName, (int)DepthWrite.Off);
-                        material.SetFloat(Styles.depthOffsetFactorName, 0.0f);
-                        material.SetFloat(Styles.depthOffsetUnitsName, 0.0f);
-                        material.SetInt(Styles.colorWriteMaskName, (int)ColorWriteMask.All);
-                        material.DisableKeyword(Styles.alphaTestOnName);
-                        material.EnableKeyword(Styles.alphaBlendOnName);
-                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : (int)RenderQueue.Transparent;
-                    }
-                    break;
-
-                case RenderingMode.Custom:
-                    {
-                        material.SetOverrideTag(Styles.renderTypeName, Styles.customRenderingModeNames[(int)customMode]);
-                        // _SrcBlend, _DstBlend, _BlendOp, _ZTest, _ZWrite, _ColorWriteMask are controlled by UI.
-
-                        switch (customMode)
-                        {
-                            case CustomRenderingMode.Opaque:
-                                {
-                                    material.DisableKeyword(Styles.alphaTestOnName);
-                                    material.DisableKeyword(Styles.alphaBlendOnName);
-                                }
-                                break;
-
-                            case CustomRenderingMode.TransparentCutout:
-                                {
-                                    material.EnableKeyword(Styles.alphaTestOnName);
-                                    material.DisableKeyword(Styles.alphaBlendOnName);
-                                }
-                                break;
-
-                            case CustomRenderingMode.Transparent:
-                                {
-                                    material.DisableKeyword(Styles.alphaTestOnName);
-                                    material.EnableKeyword(Styles.alphaBlendOnName);
-                                }
-                                break;
-                        }
-
-                        material.renderQueue = (renderQueueOverride >= 0) ? renderQueueOverride : material.renderQueue;
-                    }
-                    break;
-            }
-        }
-
-        protected static bool PropertyEnabled(MaterialProperty property)
-        {
-            return !property.floatValue.Equals(0.0f);
-        }
-
-        protected static float? GetFloatProperty(Material material, string propertyName)
-        {
-            if (material.HasProperty(propertyName))
-            {
-                return material.GetFloat(propertyName);
-            }
-
-            return null;
-        }
-
-        protected static Vector4? GetVectorProperty(Material material, string propertyName)
-        {
-            if (material.HasProperty(propertyName))
-            {
-                return material.GetVector(propertyName);
-            }
-
-            return null;
-        }
-
-        protected static Color? GetColorProperty(Material material, string propertyName)
-        {
-            if (material.HasProperty(propertyName))
-            {
-                return material.GetColor(propertyName);
-            }
-
-            return null;
-        }
-
-        protected static void SetFloatProperty(Material material, string keywordName, string propertyName, float? propertyValue)
-        {
-            if (propertyValue.HasValue)
-            {
-                if (keywordName != null)
-                {
-                    if (!propertyValue.Value.Equals(0.0f))
-                    {
-                        material.EnableKeyword(keywordName);
-                    }
-                    else
-                    {
-                        material.DisableKeyword(keywordName);
-                    }
-                }
-
-                material.SetFloat(propertyName, propertyValue.Value);
-            }
-        }
-
-        protected static void SetVectorProperty(Material material, string propertyName, Vector4? propertyValue)
-        {
-            if (propertyValue.HasValue)
-            {
-                material.SetVector(propertyName, propertyValue.Value);
-            }
-        }
-
-        protected static void SetColorProperty(Material material, string propertyName, Color? propertyValue)
-        {
-            if (propertyValue.HasValue)
-            {
-                material.SetColor(propertyName, propertyValue.Value);
             }
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
@@ -21,21 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent wireThickness = new GUIContent("Wire Thickness", "Thickness of wires");
         }
 
-        protected bool initialized;
-
-        protected MaterialProperty renderingMode;
-        protected MaterialProperty customRenderingMode;
-        protected MaterialProperty sourceBlend;
-        protected MaterialProperty destinationBlend;
-        protected MaterialProperty blendOperation;
-        protected MaterialProperty depthTest;
-        protected MaterialProperty depthWrite;
-        protected MaterialProperty depthOffsetFactor;
-        protected MaterialProperty depthOffsetUnits;
-        protected MaterialProperty colorWriteMask;
-        protected MaterialProperty cullMode;
-        protected MaterialProperty renderQueueOverride;
-
         protected MaterialProperty baseColor;
         protected MaterialProperty wireColor;
         protected MaterialProperty wireThickness;
@@ -44,10 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             Material material = (Material)materialEditor.target;
 
-            FindProperties(props);
-            Initialize(material);
-
-            RenderingModeOptions(materialEditor);
+            base.OnGUI(materialEditor, props);
 
             GUILayout.Label(Styles.mainPropertiesTitle, EditorStyles.boldLabel);
             materialEditor.ShaderProperty(baseColor, Styles.baseColor);
@@ -57,21 +39,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             AdvancedOptions(materialEditor, material);
         }
 
-        protected void FindProperties(MaterialProperty[] props)
+        protected override void FindProperties(MaterialProperty[] props)
         {
-            renderingMode = FindProperty(BaseStyles.renderingModeName, props);
-            customRenderingMode = FindProperty(BaseStyles.customRenderingModeName, props);
-            sourceBlend = FindProperty(BaseStyles.sourceBlendName, props);
-            destinationBlend = FindProperty(BaseStyles.destinationBlendName, props);
-            blendOperation = FindProperty(BaseStyles.blendOperationName, props);
-            depthTest = FindProperty(BaseStyles.depthTestName, props);
-            depthWrite = FindProperty(BaseStyles.depthWriteName, props);
-            depthOffsetFactor = FindProperty(BaseStyles.depthOffsetFactorName, props);
-            depthOffsetUnits = FindProperty(BaseStyles.depthOffsetUnitsName, props);
-            colorWriteMask = FindProperty(BaseStyles.colorWriteMaskName, props);
-
-            cullMode = FindProperty("_CullMode", props);
-            renderQueueOverride = FindProperty("_RenderQueueOverride", props);
+            base.FindProperties(props);
 
             baseColor = FindProperty("_BaseColor", props);
             wireColor = FindProperty("_WireColor", props);
@@ -108,77 +78,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 MaterialChanged(material);
             }
-        }
-
-        protected void Initialize(Material material)
-        {
-            if (!initialized)
-            {
-                MaterialChanged(material);
-                initialized = true;
-            }
-        }
-
-        protected void MaterialChanged(Material material)
-        {
-            SetupMaterialWithRenderingMode(material, 
-                (RenderingMode)renderingMode.floatValue, 
-                (CustomRenderingMode)customRenderingMode.floatValue, 
-                (int)renderQueueOverride.floatValue);
-        }
-
-        protected void RenderingModeOptions(MaterialEditor materialEditor)
-        {
-            EditorGUI.BeginChangeCheck();
-
-            EditorGUI.showMixedValue = renderingMode.hasMixedValue;
-            RenderingMode mode = (RenderingMode)renderingMode.floatValue;
-            EditorGUI.BeginChangeCheck();
-            mode = (RenderingMode)EditorGUILayout.Popup(renderingMode.displayName, (int)mode, BaseStyles.renderingModeNames);
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                materialEditor.RegisterPropertyChangeUndo(renderingMode.displayName);
-                renderingMode.floatValue = (float)mode;
-            }
-
-            EditorGUI.showMixedValue = false;
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                Object[] targets = renderingMode.targets;
-
-                foreach (Object target in targets)
-                {
-                    MaterialChanged((Material)target);
-                }
-            }
-
-            if ((RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
-            {
-                EditorGUI.indentLevel += 2;
-                customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, BaseStyles.customRenderingModeNames);
-                materialEditor.ShaderProperty(sourceBlend, BaseStyles.sourceBlend);
-                materialEditor.ShaderProperty(destinationBlend, BaseStyles.destinationBlend);
-                materialEditor.ShaderProperty(blendOperation, BaseStyles.blendOperation);
-                materialEditor.ShaderProperty(depthTest, BaseStyles.depthTest);
-                depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, BaseStyles.depthWriteNames);
-                materialEditor.ShaderProperty(depthOffsetFactor, BaseStyles.depthOffsetFactor);
-                materialEditor.ShaderProperty(depthOffsetUnits, BaseStyles.depthOffsetUnits);
-                materialEditor.ShaderProperty(colorWriteMask, BaseStyles.colorWriteMask);
-                EditorGUI.indentLevel -= 2;
-            }
-
-            if (!PropertyEnabled(depthWrite))
-            {
-                if (MixedRealityToolkitShaderGUIUtilities.DisplayDepthWriteWarning(materialEditor))
-                {
-                    renderingMode.floatValue = (float)RenderingMode.Custom;
-                    depthWrite.floatValue = (float)DepthWrite.On;
-                }
-            }
-
-            materialEditor.ShaderProperty(cullMode, BaseStyles.cullMode);
         }
 
         protected void AdvancedOptions(MaterialEditor materialEditor, Material material)

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// A custom shader inspector for the "Mixed Reality Toolkit/Wireframe" shader.
+    /// </summary>
+    public class MixedRealityWireframeShaderGUI : MixedRealityShaderGUI
+    {
+        protected static class Styles
+        {
+            public static string mainPropertiesTitle = "Main Properties";
+            public static string advancedOptionsTitle = "Advanced Options";
+            public static GUIContent baseColor = new GUIContent("Base Color", "Color of faces");
+            public static GUIContent wireColor = new GUIContent("Wire Color", "Color of wires");
+            public static GUIContent wireThickness = new GUIContent("Wire Thickness", "Thickness of wires");
+        }
+
+        protected bool initialized;
+
+        protected MaterialProperty renderingMode;
+        protected MaterialProperty customRenderingMode;
+        protected MaterialProperty sourceBlend;
+        protected MaterialProperty destinationBlend;
+        protected MaterialProperty blendOperation;
+        protected MaterialProperty depthTest;
+        protected MaterialProperty depthWrite;
+        protected MaterialProperty depthOffsetFactor;
+        protected MaterialProperty depthOffsetUnits;
+        protected MaterialProperty colorWriteMask;
+        protected MaterialProperty cullMode;
+        protected MaterialProperty renderQueueOverride;
+
+        protected MaterialProperty baseColor;
+        protected MaterialProperty wireColor;
+        protected MaterialProperty wireThickness;
+
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        {
+            Material material = (Material)materialEditor.target;
+
+            FindProperties(props);
+            Initialize(material);
+
+            RenderingModeOptions(materialEditor);
+
+            GUILayout.Label(Styles.mainPropertiesTitle, EditorStyles.boldLabel);
+            materialEditor.ShaderProperty(baseColor, Styles.baseColor);
+            materialEditor.ShaderProperty(wireColor, Styles.wireColor);
+            materialEditor.ShaderProperty(wireThickness, Styles.wireThickness);
+
+            AdvancedOptions(materialEditor, material);
+
+            //base.OnGUI(materialEditor, props);
+        }
+
+        protected void FindProperties(MaterialProperty[] props)
+        {
+            renderingMode = FindProperty(BaseStyles.renderingModeName, props);
+            customRenderingMode = FindProperty(BaseStyles.customRenderingModeName, props);
+            sourceBlend = FindProperty(BaseStyles.sourceBlendName, props);
+            destinationBlend = FindProperty(BaseStyles.destinationBlendName, props);
+            blendOperation = FindProperty(BaseStyles.blendOperationName, props);
+            depthTest = FindProperty(BaseStyles.depthTestName, props);
+            depthWrite = FindProperty(BaseStyles.depthWriteName, props);
+            depthOffsetFactor = FindProperty(BaseStyles.depthOffsetFactorName, props);
+            depthOffsetUnits = FindProperty(BaseStyles.depthOffsetUnitsName, props);
+            colorWriteMask = FindProperty(BaseStyles.colorWriteMaskName, props);
+
+            cullMode = FindProperty("_CullMode", props);
+            renderQueueOverride = FindProperty("_RenderQueueOverride", props);
+
+            baseColor = FindProperty("_BaseColor", props);
+            wireColor = FindProperty("_WireColor", props);
+            wireThickness = FindProperty("_WireThickness", props);
+        }
+
+        public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
+        {
+            float? cullMode = GetFloatProperty(material, "_Cull");
+
+            base.AssignNewShaderToMaterial(material, oldShader, newShader);
+   
+            SetFloatProperty(material, null, "_CullMode", cullMode);
+
+            // Setup the rendering mode based on the old shader.
+            if (oldShader == null || !oldShader.name.Contains("Legacy Shaders/"))
+            {
+                SetupMaterialWithRenderingMode(material, (RenderingMode)material.GetFloat(BaseStyles.renderingModeName), CustomRenderingMode.Opaque, -1);
+            }
+            else
+            {
+                RenderingMode mode = RenderingMode.Opaque;
+
+                if (oldShader.name.Contains("/Transparent/Cutout/"))
+                {
+                    mode = RenderingMode.TransparentCutout;
+                }
+                else if (oldShader.name.Contains("/Transparent/"))
+                {
+                    mode = RenderingMode.Transparent;
+                }
+
+                material.SetFloat(BaseStyles.renderingModeName, (float)mode);
+
+                MaterialChanged(material);
+            }
+        }
+
+        protected void Initialize(Material material)
+        {
+            if (!initialized)
+            {
+                MaterialChanged(material);
+                initialized = true;
+            }
+        }
+
+        protected void MaterialChanged(Material material)
+        {
+            SetupMaterialWithRenderingMode(material, 
+                (RenderingMode)renderingMode.floatValue, 
+                (CustomRenderingMode)customRenderingMode.floatValue, 
+                (int)renderQueueOverride.floatValue);
+        }
+
+        // TODO: Merge this out? with StandardShaderGUI
+        protected void RenderingModeOptions(MaterialEditor materialEditor)
+        {
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.showMixedValue = renderingMode.hasMixedValue;
+            RenderingMode mode = (RenderingMode)renderingMode.floatValue;
+            EditorGUI.BeginChangeCheck();
+            mode = (RenderingMode)EditorGUILayout.Popup(renderingMode.displayName, (int)mode, BaseStyles.renderingModeNames);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                materialEditor.RegisterPropertyChangeUndo(renderingMode.displayName);
+                renderingMode.floatValue = (float)mode;
+            }
+
+            EditorGUI.showMixedValue = false;
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                Object[] targets = renderingMode.targets;
+
+                foreach (Object target in targets)
+                {
+                    MaterialChanged((Material)target);
+                }
+            }
+
+            if ((RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
+            {
+                EditorGUI.indentLevel += 2;
+                customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, BaseStyles.customRenderingModeNames);
+                materialEditor.ShaderProperty(sourceBlend, BaseStyles.sourceBlend);
+                materialEditor.ShaderProperty(destinationBlend, BaseStyles.destinationBlend);
+                materialEditor.ShaderProperty(blendOperation, BaseStyles.blendOperation);
+                materialEditor.ShaderProperty(depthTest, BaseStyles.depthTest);
+                depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, BaseStyles.depthWriteNames);
+                materialEditor.ShaderProperty(depthOffsetFactor, BaseStyles.depthOffsetFactor);
+                materialEditor.ShaderProperty(depthOffsetUnits, BaseStyles.depthOffsetUnits);
+                materialEditor.ShaderProperty(colorWriteMask, BaseStyles.colorWriteMask);
+                EditorGUI.indentLevel -= 2;
+            }
+
+            if (!PropertyEnabled(depthWrite))
+            {
+                if (MixedRealityToolkitShaderGUIUtilities.DisplayDepthWriteWarning(materialEditor))
+                {
+                    renderingMode.floatValue = (float)RenderingMode.Custom;
+                    depthWrite.floatValue = (float)DepthWrite.On;
+                }
+            }
+
+            materialEditor.ShaderProperty(cullMode, BaseStyles.cullMode);
+        }
+
+        protected void AdvancedOptions(MaterialEditor materialEditor, Material material)
+        {
+            GUILayout.Label(Styles.advancedOptionsTitle, EditorStyles.boldLabel);
+
+            EditorGUILayout.Space();
+
+            EditorGUI.BeginChangeCheck();
+
+            materialEditor.ShaderProperty(renderQueueOverride, BaseStyles.renderQueueOverride);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                MaterialChanged(material);
+            }
+
+            // Show the RenderQueueField but do not allow users to directly manipulate it. That is done via the renderQueueOverride.
+            GUI.enabled = false;
+            materialEditor.RenderQueueField();
+            GUI.enabled = true;
+
+            materialEditor.EnableInstancingField();
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
@@ -55,8 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             materialEditor.ShaderProperty(wireThickness, Styles.wireThickness);
 
             AdvancedOptions(materialEditor, material);
-
-            //base.OnGUI(materialEditor, props);
         }
 
         protected void FindProperties(MaterialProperty[] props)
@@ -86,10 +84,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             base.AssignNewShaderToMaterial(material, oldShader, newShader);
    
-            SetFloatProperty(material, null, "_CullMode", cullMode);
+            SetShaderFeatureActive(material, null, "_CullMode", cullMode);
 
             // Setup the rendering mode based on the old shader.
-            if (oldShader == null || !oldShader.name.Contains("Legacy Shaders/"))
+            if (oldShader == null || !oldShader.name.Contains(LegacyShadersPath))
             {
                 SetupMaterialWithRenderingMode(material, (RenderingMode)material.GetFloat(BaseStyles.renderingModeName), CustomRenderingMode.Opaque, -1);
             }
@@ -97,11 +95,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 RenderingMode mode = RenderingMode.Opaque;
 
-                if (oldShader.name.Contains("/Transparent/Cutout/"))
+                if (oldShader.name.Contains(TransparentCutoutShadersPath))
                 {
                     mode = RenderingMode.TransparentCutout;
                 }
-                else if (oldShader.name.Contains("/Transparent/"))
+                else if (oldShader.name.Contains(TransparentShadersPath))
                 {
                     mode = RenderingMode.Transparent;
                 }
@@ -129,7 +127,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 (int)renderQueueOverride.floatValue);
         }
 
-        // TODO: Merge this out? with StandardShaderGUI
         protected void RenderingModeOptions(MaterialEditor materialEditor)
         {
             EditorGUI.BeginChangeCheck();

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             public static string mainPropertiesTitle = "Main Properties";
             public static string advancedOptionsTitle = "Advanced Options";
+
             public static GUIContent baseColor = new GUIContent("Base Color", "Color of faces");
             public static GUIContent wireColor = new GUIContent("Wire Color", "Color of wires");
             public static GUIContent wireThickness = new GUIContent("Wire Thickness", "Thickness of wires");
@@ -54,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             base.AssignNewShaderToMaterial(material, oldShader, newShader);
    
-            SetShaderFeatureActive(material, null, "_CullMode", cullMode);
+            SetShaderFeatureActive(material, null, BaseStyles.cullModeName, cullMode);
 
             // Setup the rendering mode based on the old shader.
             if (oldShader == null || !oldShader.name.Contains(LegacyShadersPath))

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityWireframeShaderGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: beab471bae7ba484d8c3a51dc9c3cbf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
@@ -8,6 +8,20 @@ Shader "Mixed Reality Toolkit/Wireframe"
 {
     Properties
     {
+        // Advanced options.
+        [Enum(RenderingMode)] _Mode("Rendering Mode", Float) = 0                                     // "Opaque"
+        [Enum(CustomRenderingMode)] _CustomMode("Mode", Float) = 0                                   // "Opaque"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0            // "Zero"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                 // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                // "LessEqual"
+        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1                                         // "On"
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                             // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                               // "Zero"
+        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15 // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                     // "Back"
+        _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
+
         _BaseColor("Base color", Color) = (0.0, 0.0, 0.0, 1.0)
         _WireColor("Wire color", Color) = (1.0, 1.0, 1.0, 1.0)
         _WireThickness("Wire thickness", Range(0, 800)) = 100
@@ -15,6 +29,13 @@ Shader "Mixed Reality Toolkit/Wireframe"
     SubShader
     {
         Tags { "RenderType" = "Opaque" }
+        Blend[_SrcBlend][_DstBlend]
+        BlendOp[_BlendOp]
+        ZTest[_ZTest]
+        ZWrite[_ZWrite]
+        Cull[_CullMode]
+        Offset[_ZOffsetFactor],[_ZOffsetUnits]
+        ColorMask[_ColorWriteMask]
 
         Pass
         {
@@ -27,7 +48,7 @@ Shader "Mixed Reality Toolkit/Wireframe"
 
             // We only target the HoloLens (and the Unity editor), so take advantage of shader model 5.
             #pragma target 5.0
-            #pragma only_renderers d3d11
+            #pragma only_renderers d3d11 //D3D 11 & 12
 
             #include "UnityCG.cginc"
 
@@ -118,5 +139,7 @@ Shader "Mixed Reality Toolkit/Wireframe"
             ENDCG
         }
     }
+
     FallBack "Diffuse"
+    CustomEditor "Microsoft.MixedReality.Toolkit.Editor.MixedRealityWireframeShaderGUI"
 }

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
@@ -46,9 +46,9 @@ Shader "Mixed Reality Toolkit/Wireframe"
             #pragma geometry geom
             #pragma fragment frag
 
-            // We only target the HoloLens (and the Unity editor), so take advantage of shader model 5.
+            #if defined(SHADER_API_D3D11)
             #pragma target 5.0
-            #pragma only_renderers d3d11 //D3D 11 & 12
+            #endif
 
             #include "UnityCG.cginc"
 

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
@@ -132,9 +132,7 @@ Shader "Mixed Reality Toolkit/Wireframe"
 
                 // Fade out the alpha but not the color so we don't get any weird halo effects from
                 // a fade to a different color.
-                float4 color = I * _WireColor + (1 - I) * _BaseColor;
-                color.a = I;
-                return color;
+                return I * _WireColor + (1 - I) * _BaseColor;
             }
             ENDCG
         }

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
@@ -130,8 +130,6 @@ Shader "Mixed Reality Toolkit/Wireframe"
                 // quickly.
                 float I = exp2(-2 * dist * dist);
 
-                // Fade out the alpha but not the color so we don't get any weird halo effects from
-                // a fade to a different color.
                 return I * _WireColor + (1 - I) * _BaseColor;
             }
             ENDCG


### PR DESCRIPTION
## Overview
This change updates the MRTK wireframe shader to support multiple rendering modes identical to the functionality in the MRTK standard shader. This is primarily to support transparency & other similar settings. 

The change creates a new base shaderGUI inspector class to be shared by both wireframe & standard shader. The related functionality is removed from StandardShaderGUI and WireframeShaderGUI is given the necessary code to render it's base properties plus the shared rendering mode-type properties. 

The shader is also updated to take the output alpha from both the base & wire color values instead of just wire intensity which will always be transparent on the faces. This gives developers more flexibility and control

## Changes
- Fixes: #4992 

## Verification
![image](https://user-images.githubusercontent.com/25975362/59857025-5ac92100-9378-11e9-8fc8-c49afed02a35.png)

![image](https://user-images.githubusercontent.com/25975362/59857035-63215c00-9378-11e9-87a0-fd9647925d31.png)

![image](https://user-images.githubusercontent.com/25975362/59857062-6ddbf100-9378-11e9-8557-6603f176846f.png)

