### PR TITLE
Pipeline changes for NuGet release process

### DIFF
--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -1,9 +1,9 @@
-# CI build for developer builds.
+# CI build producing developer packages.
 
 variables:
   UnityVersion: Unity2018.3.7f1
   MRTKVersion: 2.0.0
-  packagingEnabled: false
+  packagingEnabled: true
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -2,7 +2,8 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.0.0
+  MRTKVersion: 2.0.0  # Major.Minor.Patch
+  MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
 
 jobs:
 - job: CIReleaseValidation
@@ -33,11 +34,50 @@ jobs:
       downloadType: 'single'
       artifactName: 'NuGet'
       downloadPath: '$(Build.SourcesDirectory)'
+    
+  # sign all DLLs
   - template: templates/tasks/signing.yml
     parameters:
       ConfigName: "MRTKSignConfig.xml"
-  - template: templates/package.yml
+
+  # Create pre-release packages
+  - ${{ if eq(variables['MRTKReleaseTag'], '') }}:
+    - template: templates/package.yml
+      parameters:
+        version: '$(MRTKVersion)-$(Build.BuildNumber).prerelease'
+        packDestination: '$(Build.SourcesDirectory)\artifacts\prerelease'
+  - ${{ if ne(variables['MRTKReleaseTag'], '') }}:
+    - template: templates/package.yml
+      parameters:
+        version: '$(MRTKVersion)-$(Build.BuildNumber).prerelease.$(MRTKReleaseTag)'
+        packDestination: '$(Build.SourcesDirectory)\artifacts\prerelease'
+
+  # Create release packages
+  - ${{ if eq(variables['MRTKReleaseTag'], '') }}:
+    - template: templates/package.yml
+      parameters:
+        version: '$(MRTKVersion)'
+        packDestination: '$(Build.SourcesDirectory)\artifacts\release'
+  - ${{ if ne(variables['MRTKReleaseTag'], '') }}:
+    - template: templates/package.yml
+      parameters:
+        version: '$(MRTKVersion)-$(MRTKReleaseTag)'
+        packDestination: '$(Build.SourcesDirectory)\artifacts\release'        
+
   - template: templates/tasks/signing.yml
     parameters:
       ConfigName: "MRTKNuGetSignConfig.xml"
-  - template: templates/publishpackages.yml
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Packages'
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
+      ArtifactName: 'mrtk-unity-packages'
+
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
+    displayName: 'NuGet push'
+    inputs:
+      command: push
+      packagesToPush: '$(Build.SourcesDirectory)/artifacts/prerelease/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/prerelease/**/*.symbols.nupkg'
+      publishVstsFeed: '$(NuGetFeedId)'
+      buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -34,11 +34,16 @@ jobs:
       downloadType: 'single'
       artifactName: 'NuGet'
       downloadPath: '$(Build.SourcesDirectory)'
-    
+
+  - powershell: |
+      $Authorization = "Basic " + [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes('$(scriptsRepoVSTSuser):$(scriptsRepoPAT)'))
+      git clone -c http.extraheader="AUTHORIZATION: $Authorization" -b mrtk $(scriptsRepoURL) $(Build.ArtifactStagingDirectory)\scripts
+    displayName: "Clone release scripts"
+
   # sign all DLLs
   - template: templates/tasks/signing.yml
     parameters:
-      ConfigName: "MRTKSignConfig.xml"
+      ConfigName: "$(Build.ArtifactStagingDirectory)/scripts/signconfig/MRTKSignConfig.xml"
 
   # Create pre-release packages
   - ${{ if eq(variables['MRTKReleaseTag'], '') }}:
@@ -66,7 +71,7 @@ jobs:
 
   - template: templates/tasks/signing.yml
     parameters:
-      ConfigName: "MRTKNuGetSignConfig.xml"
+      ConfigName: "$(Build.ArtifactStagingDirectory)/scripts/signconfig/MRTKNuGetSignConfig.xml"
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Packages'

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -1,0 +1,8 @@
+# CI build for developer builds.
+
+steps:
+- template: common.yml
+- ${{ if eq(variables['packagingEnabled'], true) }}:
+  - template: package.yml
+  - template: publishpackages.yml
+- template: end.yml

--- a/pipelines/templates/package.yml
+++ b/pipelines/templates/package.yml
@@ -1,4 +1,7 @@
 # [Template] Create NuGet packages.
+parameters:
+  version: '$(MRTKVersion)-$(Build.BuildNumber)'
+  packDestination: '$(Build.SourcesDirectory)/artifacts'
 
 steps:
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
@@ -6,7 +9,7 @@ steps:
   inputs:
     command: pack
     packagesToPack: 'NuGet/**/*.nuspec'
-    packDestination: '$(Build.SourcesDirectory)/artifacts'
-    buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'
+    packDestination: ${{ parameters.packDestination }}
+    buildProperties: 'version=${{ parameters.version }}'
 
 

--- a/pipelines/templates/tasks/signing.yml
+++ b/pipelines/templates/tasks/signing.yml
@@ -4,12 +4,9 @@ parameters:
   ConfigName: ""
 
 steps:
-- task: DownloadSecureFile@1
-  inputs:
-    secureFile: "${{ parameters.ConfigName }}"
 - task: PkgESCodeSign@10
   inputs:
-    signConfigXml: $(Agent.TempDirectory)\${{ parameters.ConfigName }}
+    signConfigXml: ${{ parameters.ConfigName }}
     inPathRoot: $(Build.SourcesDirectory)
     outPathRoot: $(Build.SourcesDirectory)  
   env:


### PR DESCRIPTION
## Overview
Implement changes from the NuGet versioning / release planning thread.
- Split mrtk_CI into two templates - CI in AIPMR project will no longer produce NuGet packages. We will set up an internal build that will push CI packages to internal feed in microsoft ADO org. (We can continue publishing packages as before until we communicate the switch internally).
- Release CI in microsoft org (manually triggered) will produce both prerelease and release packages. Pre-release packages will be uploaded to the artifact feed while the release packages will flow through the Release Pipeline after we test the pre-release package and it's ready to be published.
- Signing configuration moved to an internal "build" repo.

## Verification
PR validation is not necessary as only CI build will be affected. It will need to be manually switched to use ci-packaging.yml template (if we want to continue publishing NuGet packages to the same feed as before).
I already tested all builds (CI, CI-packaging, CI-release) manually.