### PR TITLE
Remove update repaint method in build window

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -318,11 +318,6 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             }
         }
 
-        private void Update()
-        {
-            Repaint();
-        }
-
         private static void OpenPlayerSettingsGUI()
         {
             if (GUILayout.Button("Open Player Settings"))


### PR DESCRIPTION
## Overview
With build window visible and project running, developers notice massive performance drop. Even without play mode, this window is repainting itself more than necessary due to update() method.

This change just removes the excessive repaint

## Changes
- Fixes: #5003 


## Verification
Opened window with game mode and noticed perf drop in half. Now fixed
Close & open window fine
Select buttons to switch tabs 
Build worked
