### PR TITLE
Fix simulated hand ray not correct until hand moves

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalHandlerListener.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalHandlerListener.cs
@@ -12,7 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public abstract class InputSystemGlobalHandlerListener : MonoBehaviour
     {
-        private bool lateInitialize = true;
+        // If true, we will try to register ourselves as a global input listener in Start
+        private bool lateInitialize = false;
         private IMixedRealityInputSystem inputSystem = null;
 
         /// <summary>
@@ -32,9 +33,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected virtual void OnEnable()
         {
-            if (InputSystem != null && !lateInitialize)
+            if (InputSystem != null)
             {
                 RegisterHandlers();
+            }
+            else
+            {
+                // We tried to register for input, but no input system found. Try again at Start
+                lateInitialize = true;
             }
         }
 


### PR DESCRIPTION
## Overview
Update InputSystemGlobalHandlerListener to try register as a global listener in OnEnable. Previously it was trying to register in Start, causing it to miss some events.

## Changes
- Fixes: #5029

## Background
The `lateInitialize` variable was introduced in the following commit:

```
1c17f7847e1d3a3a8e125b876a9c57ad1fb42a6f
Author: Stephen Hodgson <hodgson.designs@gmail.com>
Date:   Sun Sep 9 14:13:25 2018 -0700

Fixed input handler race condition if input system and teleport system not found before gameobjects wake up
```

So it sounds like there were cases when a component was enabled before input system was valid. However, we do want to register some components in OnEnable to ensure they get all input events. Therefore, modify the code s.t. we try to register both in OnEnable and in Start.

## Verification
Verified that simulated hand ray is valid when hand appears. 