### PR TITLE
Add api change section to UpdateRC2toGA doc

### DIFF
--- a/Documentation/UpdatingToGA.md
+++ b/Documentation/UpdatingToGA.md
@@ -2,7 +2,35 @@
 
 Between the RC2 and GA releases of the Microsoft Mixed Reality Toolkit, changes were made that may impact existing projects. This document describes those changes and how to update projects to the GA release.
 
+- [API changes](#api-changes)
 - [Assembly name changes](#assembly-name-changes)
+
+## API changes
+
+Since the release of RC2, there have been a number of API changes including some that may break existing projects. The following sections describe the changes that have occurred between the RC2 and GA releases.
+
+- [Breaking changes](#breaking-changes)
+
+### Breaking changes
+
+#### Spatial Awareness
+
+The IMixedRealitySpatialAwarenessSystem and IMixedRealitySpatialAwarenessObserver interfaces have taken multiple breaking changes as described below.
+
+**Changes**
+
+The following method(s) have been renamed to better describe their usage.
+
+- IMixedRealitySpatialAwarenessSystem.CreateSpatialObjectParent has been renaned to IMixedRealitySpatialAwarenessSystem.CreateSpatialAwarenessObservationParent to clarify its usage.
+
+**Additions**
+
+Based on customer feedback, support for easy removal of previously observed spataial awareness data has been added.
+
+- IMixedRealitySpatialAwarenessSystem.ClearObservations()
+- IMixedRealitySpatialAwarenessSystem.ClearObservations\<T\>(string name)
+- IMixedRealitySpatialAwarenessObserver.ClearObservations()
+
 
 ## Assembly name changes
 
@@ -16,8 +44,13 @@ In some instances, multiple assemblies have been merged to create better unity o
 
 The following tables describe how the RC2 .asmdef file names map to the GA release. All assembly names match the .asmdef file name. 
 
+- [MixedRealityToolkit](#mixedrealitytoolkit)
+- [MixeddRealityToolkit.Providers](#mixedrealitytoolkit.providers)
+- [MixeddRealityToolkit.Services](#mixedrealitytoolkit.services)
+- [MixeddRealityToolkit.SDK](#mixedrealitytoolkit.sdk)
+- [MixeddRealityToolkit.Examples](#mixedrealitytoolkit.Examples)
 
-### MixedRealityTookit
+### MixedRealityToolkit
 
 | RC2 | GA |
 | --- | --- |

--- a/Documentation/UpdatingToGA.md
+++ b/Documentation/UpdatingToGA.md
@@ -9,11 +9,9 @@ Between the RC2 and GA releases of the Microsoft Mixed Reality Toolkit, changes 
 
 Since the release of RC2, there have been a number of API changes including some that may break existing projects. The following sections describe the changes that have occurred between the RC2 and GA releases.
 
-- [Breaking changes](#breaking-changes)
+- [Spatial Awareness](#spatial-awareness)
 
-### Breaking changes
-
-#### Spatial Awareness
+### Spatial Awareness
 
 The IMixedRealitySpatialAwarenessSystem and IMixedRealitySpatialAwarenessObserver interfaces have taken multiple breaking changes as described below.
 
@@ -43,12 +41,6 @@ Microsoft.MixedReality.Toolkit[.<name>]
 In some instances, multiple assemblies have been merged to create better unity of their contents. If your project uses custom .asmdef files, they may require updating.
 
 The following tables describe how the RC2 .asmdef file names map to the GA release. All assembly names match the .asmdef file name. 
-
-- [MixedRealityToolkit](#mixedrealitytoolkit)
-- [MixeddRealityToolkit.Providers](#mixedrealitytoolkit.providers)
-- [MixeddRealityToolkit.Services](#mixedrealitytoolkit.services)
-- [MixeddRealityToolkit.SDK](#mixedrealitytoolkit.sdk)
-- [MixeddRealityToolkit.Examples](#mixedrealitytoolkit.Examples)
 
 ### MixedRealityToolkit
 


### PR DESCRIPTION
Adds an api changes section and describes the new changes for clearing spatial observations.

Also fixes some spelling / typing errors in the assembly name section