### PR TITLE
fix doc comments in new ClearObservations methods

### DIFF
--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -122,15 +122,15 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         void SuspendObserver<T>(string name) where T : IMixedRealitySpatialAwarenessObserver;
 
         /// <summary>
-        /// todo
+        /// Clears all registered observer's observations.
         /// </summary>
         void ClearObservations();
 
         /// <summary>
-        /// todo
+        /// Clears the observations of the specified observer.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="name"></param>
+        /// <typeparam name="T">The observer type.</typeparam>
+        /// <param name="name">The name of the observer.</param>
         void ClearObservations<T>(string name = null) where T : IMixedRealitySpatialAwarenessObserver;
 
         // TODO: make these (and future plane) events more generic

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessSystem.cs
@@ -122,7 +122,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         void SuspendObserver<T>(string name) where T : IMixedRealitySpatialAwarenessObserver;
 
         /// <summary>
-        /// Clears all registered observer's observations.
+        /// Clears all registered observers' observations.
         /// </summary>
         void ClearObservations();
 

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessObserver.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessObserver.cs
@@ -76,8 +76,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         void Suspend();
 
         /// <summary>
-        /// todo - should this suspend, clear, resume? should it require the observers to be suspended?
+        /// Clears the observer's collection of observations.
         /// </summary>
-        /* todo: bool? */void ClearObservations();
+        /// <remarks>
+        /// If the observer is currently running, calling ClearObservations will suspend it.
+        /// </remarks>
+        void ClearObservations();
     }
 }


### PR DESCRIPTION
#5035 had some todo comments where the documentation comments should have been. this change adds the proper text.