### PR TITLE
updated InteractableInspector to fix mismatch repaint issue

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 drawerStarted = true;
                 if (showStates != prefsShowStates)
                 {
-                   EditorPrefs.SetBool(statesPrefKey, showStates);
+                    EditorPrefs.SetBool(statesPrefKey, showStates);
                 }
             }
             else
@@ -119,6 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         }
                     }
 
+                    EditorGUI.indentLevel = indentOnSectionStart + 1;
                     showStates = InspectorUIUtility.DrawSectionStart(states.objectReferenceValue.name + " (Click to edit)", indentOnSectionStart + 2, prefsShowStates, FontStyle.Normal, false);
                     drawerStarted = true;
                 }

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -89,16 +89,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
             bool showStates = false;
             SerializedProperty states = serializedObject.FindProperty("States");
             bool drawerStarted = false;
+            string statesPrefKey = "Settings_States";
+            bool prefsShowStates = EditorPrefs.GetBool(statesPrefKey);
+
             if (states.objectReferenceValue != null)
             {
-                string statesPrefKey = "Settings_States";
-                bool prefsShowStates = EditorPrefs.GetBool(statesPrefKey);
                 EditorGUI.indentLevel = indentOnSectionStart + 1;
                 showStates = InspectorUIUtility.DrawSectionStart(states.objectReferenceValue.name + " (Click to edit)", indentOnSectionStart + 2, prefsShowStates, FontStyle.Normal, false);
                 drawerStarted = true;
                 if (showStates != prefsShowStates)
                 {
-                    EditorPrefs.SetBool(statesPrefKey, showStates);
+                   EditorPrefs.SetBool(statesPrefKey, showStates);
                 }
             }
             else
@@ -117,6 +118,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
                             break;
                         }
                     }
+
+                    showStates = InspectorUIUtility.DrawSectionStart(states.objectReferenceValue.name + " (Click to edit)", indentOnSectionStart + 2, prefsShowStates, FontStyle.Normal, false);
+                    drawerStarted = true;
                 }
                 else
                 {
@@ -135,7 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 InspectorUIUtility.DrawSectionEnd(indentOnSectionStart);
             }
-
+            
             if (states.objectReferenceValue == null)
             {
                 InspectorUIUtility.DrawError("Please assign a States object!");

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -140,7 +140,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 InspectorUIUtility.DrawSectionEnd(indentOnSectionStart);
             }
-            
             if (states.objectReferenceValue == null)
             {
                 InspectorUIUtility.DrawError("Please assign a States object!");


### PR DESCRIPTION
## Overview
Fix for Issue #4011 

When initializing the Interactable the inspector does a check to see if the States property is not null. If it's null, then we try to fill it with the DefaultInteractableStates asset.

The issue came up when the States property was filled in the layout phase, but never rendered. During the repaint phase, now that the property is not null, we attempt to render the field in the inspector.

## Changes
We are now rendering the field in both phases, in the layout phase after the property is filled.

## Verification
I was able to consistently repro this by adding the Interactable component to a GameObject using the Add Component button in the inspector.

1 Create a new Scene
2 Add MRTK by selecting MRTK/Add to Scene and Configure... in the menu
3 Drag a pressable button into the scene
4 press play
5 observe no errors

or 

1 Create a game object in the scene
2 Select it and press Add Component in the inspector
3 Select Interactable as the component to add
4 observe no errors.