### PR TITLE
Update WMR Unity package to support HL2 remoting

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.purchasing": "2.0.3",
     "com.unity.textmeshpro": "1.3.0",
     "com.unity.xr.openvr.standalone": "1.0.2",
-    "com.unity.xr.windowsmr.metro": "1.0.8",
+    "com.unity.xr.windowsmr.metro": "1.0.12",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.4.1f1
+m_EditorVersion: 2018.4.2f1


### PR DESCRIPTION
## Overview
Updates the WMR Unity package to 1.0.12 to include HL2 remoting.
Also updates the editor version to 2018.4.2 to support the HL2 remoting window update.

![image](https://user-images.githubusercontent.com/3580640/60288781-cad02d80-98c9-11e9-9294-c9f1789cea9f.png)

NOTE: Currently, hand joints, hand mesh, and eye tracking are not supported by MRTK over remoting.