### PR TITLE
Fix the broken NuGet build.

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
@@ -1,49 +1,51 @@
-﻿using System;
-using Microsoft.MixedReality.Toolkit;
+﻿using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
 
-// Simple example script that subscribes to primary pointer changes and applies a cursor highlight to the current one.
-public class PrimaryPointerHandlerExample : MonoBehaviour
+namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 {
-    public GameObject CursorHighlight;
-
-    private void OnEnable()
+    // Simple example script that subscribes to primary pointer changes and applies a cursor highlight to the current one.
+    public class PrimaryPointerHandlerExample : MonoBehaviour
     {
-        MixedRealityToolkit.InputSystem?.FocusProvider?.SubscribeToPrimaryPointerChanged(OnPrimaryPointerChanged, true);
-    }
+        public GameObject CursorHighlight;
 
-    private void OnPrimaryPointerChanged(IMixedRealityPointer oldPointer, IMixedRealityPointer newPointer)
-    {
-        if (CursorHighlight != null)
+        private void OnEnable()
         {
-            if (newPointer != null)
-            {
-                Transform parentTransform = newPointer.BaseCursor?.GameObjectReference?.transform;
-
-                // If there's no cursor try using the controller pointer transform instead
-                if (parentTransform == null)
-                {
-                    var controllerPointer = newPointer as BaseControllerPointer;
-                    parentTransform = controllerPointer?.transform;
-                }
-
-                if (parentTransform != null)
-                {
-                    CursorHighlight.transform.SetParent(parentTransform, false);
-                    CursorHighlight.SetActive(true);
-                    return;
-                }
-            }
-            
-            CursorHighlight.SetActive(false);
-            CursorHighlight.transform.SetParent(null, false);
+            MixedRealityToolkit.InputSystem?.FocusProvider?.SubscribeToPrimaryPointerChanged(OnPrimaryPointerChanged, true);
         }
-    }
 
-    private void OnDisable()
-    {
-        MixedRealityToolkit.InputSystem?.FocusProvider?.UnsubscribeFromPrimaryPointerChanged(OnPrimaryPointerChanged);
-        OnPrimaryPointerChanged(null, null);
+        private void OnPrimaryPointerChanged(IMixedRealityPointer oldPointer, IMixedRealityPointer newPointer)
+        {
+            if (CursorHighlight != null)
+            {
+                if (newPointer != null)
+                {
+                    Transform parentTransform = newPointer.BaseCursor?.GameObjectReference?.transform;
+
+                    // If there's no cursor try using the controller pointer transform instead
+                    if (parentTransform == null)
+                    {
+                        var controllerPointer = newPointer as BaseControllerPointer;
+                        parentTransform = controllerPointer?.transform;
+                    }
+
+                    if (parentTransform != null)
+                    {
+                        CursorHighlight.transform.SetParent(parentTransform, false);
+                        CursorHighlight.SetActive(true);
+                        return;
+                    }
+                }
+
+                CursorHighlight.SetActive(false);
+                CursorHighlight.transform.SetParent(null, false);
+            }
+        }
+
+        private void OnDisable()
+        {
+            MixedRealityToolkit.InputSystem?.FocusProvider?.UnsubscribeFromPrimaryPointerChanged(OnPrimaryPointerChanged);
+            OnPrimaryPointerChanged(null, null);
+        }
     }
 }

--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.MixedReality.Toolkit;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
 


### PR DESCRIPTION
It's been a few days of us not building NuGet packages - here's what happened.

We hit a CI outage earlier in the week caused by an upstream Azure DevOps issue (a bad nuget push package was pushed out). Our build was broken for a couple of days, during which we still had changes going in (mostly we were judging by green-ness of mrtk_pr, which is identical to CI except it doesn't produce and publish NuGet packages).

The problem is, without coverage on the NuGet building, we didn't know that we broke the nuget packages until the upstream nuget push package got fixed.

The asset retargeter assumes that every single class/object in the MRTK is prefixed by the MRTK namespace. This is a fairly reasonable assumption to make, and it throws when it finds something that violates it (so that we can then fix it). The fix is thus to make sure that the class in question is put into an MRTK namespace (the example demos one)

I will follow up here and do work to make sure that the build breaks when this happens, instead of just showing warnings.