### PR TITLE
Add MRTK inspector preferences 

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -214,11 +214,25 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <param name="currentState">reference bool for current visibility state of foldout</param>
         /// <param name="title">Title in foldout</param>
         /// <param name="renderContent">code to execute to render inside of foldout</param>
-        protected static void RenderFoldout(ref bool currentState, string title, Action renderContent)
+        /// <param name="preferenceKey">optional argument, current show/hide state will be tracked associated with provided preference key</param>
+        protected static void RenderFoldout(ref bool currentState, string title, Action renderContent, string preferenceKey = null)
         {
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
 
-            currentState = EditorGUILayout.Foldout(currentState, title, true, MixedRealityStylesUtility.BoldFoldoutStyle);
+            bool isValidPreferenceKey = !string.IsNullOrEmpty(preferenceKey);
+            bool state = currentState;
+            if (isValidPreferenceKey)
+            {
+                state = EditorPrefs.GetBool(preferenceKey, currentState);
+            }
+
+            currentState = EditorGUILayout.Foldout(state, title, true, MixedRealityStylesUtility.BoldFoldoutStyle);
+
+            if (isValidPreferenceKey && currentState != state)
+            {
+                EditorPrefs.SetBool(preferenceKey, currentState);
+            }
+
             if (currentState)
             {
                 renderContent();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -19,6 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private static readonly GUIContent RuntimePlatformContent = new GUIContent("Platform(s)");
 
         private static bool showDataProviders = false;
+        private const string ShowInputSystem_DataProviders_PreferenceKey = "ShowInputSystem_DataProviders_PreferenceKey";
         private SerializedProperty dataProviderConfigurations;
 
         private SerializedProperty focusProviderType;
@@ -26,24 +27,30 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private SerializedProperty raycastProviderType;
 
         private static bool showPointerProperties = false;
+        private const string ShowInputSystem_Pointers_PreferenceKey = "ShowInputSystem_Pointers_PreferenceKey";
         private SerializedProperty pointerProfile;
 
         private static bool showActionsProperties = false;
+        private const string ShowInputSystem_Actions_PreferenceKey = "ShowInputSystem_Actions_PreferenceKey";
         private SerializedProperty inputActionsProfile;
         private SerializedProperty inputActionRulesProfile;
 
         private static bool showControllerProperties = false;
+        private const string ShowInputSystem_Controller_PreferenceKey = "ShowInputSystem_Controller_PreferenceKey";
         private SerializedProperty enableControllerMapping;
         private SerializedProperty controllerMappingProfile;
         private SerializedProperty controllerVisualizationProfile;
 
         private static bool showGestureProperties = false;
+        private const string ShowInputSystem_Gesture_PreferenceKey = "ShowInputSystem_Gesture_PreferenceKey";
         private SerializedProperty gesturesProfile;
 
         private static bool showSpeechCommandsProperties = false;
+        private const string ShowInputSystem_Speech_PreferenceKey = "ShowInputSystem_Speech_PreferenceKey";
         private SerializedProperty speechCommandsProfile;
 
         private static bool showHandTrackingProperties = false;
+        private const string ShowInputSystem_HandTracking_PreferenceKey = "ShowInputSystem_HandTracking_PreferenceKey";
         private SerializedProperty handTrackingProfile;
 
         private static bool[] providerFoldouts;
@@ -85,6 +92,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(focusProviderType);
                 EditorGUILayout.PropertyField(raycastProviderType);
+                changed |= EditorGUI.EndChangeCheck();
+
                 EditorGUILayout.Space();
 
                 bool isSubProfile = RenderAsSubProfile;
@@ -99,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     {
                         RenderList(dataProviderConfigurations);
                     }
-                });
+                }, ShowInputSystem_DataProviders_PreferenceKey);
 
                 RenderFoldout(ref showPointerProperties, "Pointers", () =>
                 {
@@ -107,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     {
                         changed |= RenderProfile(pointerProfile, typeof(MixedRealityPointerProfile), true, false);
                     }
-                });
+                }, ShowInputSystem_Pointers_PreferenceKey);
 
                 RenderFoldout(ref showActionsProperties, "Input Actions", () =>
                 {
@@ -118,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                         EditorGUILayout.Space();
                         changed |= RenderProfile(inputActionRulesProfile, typeof(MixedRealityInputActionRulesProfile), true, false);
                     }
-                });
+                }, ShowInputSystem_Actions_PreferenceKey);
 
                 RenderFoldout(ref showControllerProperties, "Controllers", () =>
                 {
@@ -129,7 +138,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                         EditorGUILayout.Space();
                         changed |= RenderProfile(controllerVisualizationProfile, null, true, false, typeof(IMixedRealityControllerVisualizer));
                     }
-                });
+                }, ShowInputSystem_Controller_PreferenceKey);
 
                 RenderFoldout(ref showGestureProperties, "Gestures", () =>
                 {
@@ -137,7 +146,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     {
                         changed |= RenderProfile(gesturesProfile, typeof(MixedRealityGesturesProfile), true, false);
                     }
-                });
+                }, ShowInputSystem_Gesture_PreferenceKey);
 
                 RenderFoldout(ref showSpeechCommandsProperties, "Speech", () =>
                 {
@@ -145,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     {
                         changed |= RenderProfile(speechCommandsProfile, typeof(MixedRealitySpeechCommandsProfile), true, false);
                     }
-                });
+                }, ShowInputSystem_Speech_PreferenceKey);
 
                 RenderFoldout(ref showHandTrackingProperties, "Hand Tracking", () =>
                 {
@@ -153,16 +162,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     {
                         changed |= RenderProfile(handTrackingProfile, typeof(MixedRealityHandTrackingProfile), true, false);
                     }
-                });
+                }, ShowInputSystem_HandTracking_PreferenceKey);
 
                 if (!isSubProfile)
                 {
                     EditorGUI.indentLevel--;
-                }
-
-                if (!changed)
-                {
-                    changed |= EditorGUI.EndChangeCheck();
                 }
 
                 serializedObject.ApplyModifiedProperties();
@@ -256,6 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                                     serializedObject.ApplyModifiedProperties();
                                     System.Type type = ((MixedRealityInputSystemProfile)serializedObject.targetObject).DataProviderConfigurations[i].ComponentType.Type;
                                     ApplyDataProviderConfiguration(type, providerName, configurationProfile, runtimePlatform);
+                                    changed = true;
                                     break;
                                 }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
@@ -29,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             "Content scenes are everything else. You can load and unload any number of content scenes in any combination, and their content is unrestricted.";
 
         private static bool showEditorProperties = true;
+        private const string ShowSceneSystem_Editor_PreferenceKey = "ShowSceneSystem_Editor_PreferenceKey";
         private SerializedProperty editorManageBuildSettings;
         private SerializedProperty editorManageLoadedScenes;
         private SerializedProperty editorEnforceSceneOrder;
@@ -36,13 +37,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty permittedLightingSceneComponentTypes;
 
         private static bool showManagerProperties = true;
+        private const string ShowSceneSystem_Manager_PreferenceKey = "ShowSceneSystem_Manager_PreferenceKey";
         private SerializedProperty useManagerScene;
         private SerializedProperty managerScene;
 
         private static bool showContentProperties = true;
+        private const string ShowSceneSystem_Content_PreferenceKey = "ShowSceneSystem_Content_PreferenceKey";
         private SerializedProperty contentScenes;
 
         private static bool showLightingProperties = true;
+        private const string ShowSceneSystem_Lighting_PreferenceKey = "ShowSceneSystem_Lighting_PreferenceKey";
         private SerializedProperty useLightingScene;
         private SerializedProperty defaultLightingSceneIndex;
         private SerializedProperty lightingScenes;
@@ -109,7 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         EditorGUIUtility.labelWidth = 0;
                     }
                 }
-            });
+            }, ShowSceneSystem_Editor_PreferenceKey);
 
             RenderFoldout(ref showManagerProperties, "Manager Scene Settings", () =>
             {
@@ -140,7 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         EditorGUILayout.PropertyField(managerScene, includeChildren: true);
                     }
                 }
-            });
+            }, ShowSceneSystem_Manager_PreferenceKey);
 
             RenderFoldout(ref showLightingProperties, "Lighting Scene Settings", () =>
             {
@@ -197,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         EditorGUILayout.Space();
                     }
                 }
-            });
+            }, ShowSceneSystem_Lighting_PreferenceKey);
 
             RenderFoldout(ref showContentProperties, "Content Scene Settings", () =>
             {
@@ -210,7 +214,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     EditorGUILayout.PropertyField(contentScenes, includeChildren: true);
                     //DrawSceneInfoDragAndDrop(contentScenes);
                 }
-            });
+            }, ShowSceneSystem_Content_PreferenceKey);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -60,6 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private static string[] ProfileTabTitles = { "Camera", "Input", "Boundary", "Teleport", "Spatial Mapping", "Diagnostics", "Scene System", "Extensions", "Editor" };
         private static int SelectedProfileTab = 0;
+        private const string SelectedTabPreferenceKey = "SelectedProfileTab";
 
         protected override void OnEnable()
         {
@@ -106,6 +107,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             // Editor settings
             useServiceInspectors = serializedObject.FindProperty("useServiceInspectors");
+
+            SelectedProfileTab = EditorPrefs.GetInt(SelectedTabPreferenceKey, SelectedProfileTab);
 
             if (this.RenderProfileFuncs == null)
             {
@@ -237,7 +240,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.Width(100));
             GUI.enabled = true; // Force enable so we can view profile defaults
-            SelectedProfileTab = GUILayout.SelectionGrid(SelectedProfileTab, ProfileTabTitles, 1, EditorStyles.boldLabel, GUILayout.MaxWidth(125));
+
+            int prefsSelectedTab = EditorPrefs.GetInt(SelectedTabPreferenceKey);
+            SelectedProfileTab = GUILayout.SelectionGrid(prefsSelectedTab, ProfileTabTitles, 1, EditorStyles.boldLabel, GUILayout.MaxWidth(125));
+            if (SelectedProfileTab != prefsSelectedTab)
+            {
+                EditorPrefs.SetInt(SelectedTabPreferenceKey, SelectedProfileTab);
+            }
+
             GUI.enabled = isGUIEnabled;
             EditorGUILayout.EndVertical();
 


### PR DESCRIPTION
## Overview
This change adds MRTK editor preferences to save the view state of certain foldouts. This way when user enters play mode or inspector refreshes, it doesn't repaint to default state. 

Also fixed missing issue for input system that causes MRTK to reset when showing/hiding input foldouts which become considered as "changes"

## Changes
- Fixes: #4997 

## Verification
Enter/exit playmode
Drill down into input profile
