### PR TITLE
Fix the broken Standalone build.

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/SystemKeyboardExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/SystemKeyboardExample.cs
@@ -6,6 +6,14 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 {
+    /// <summary>
+    /// An example script that delegates keyboard API access either to the WMR workaround
+    /// (MixedRealityKeyboard) or Unity's TouchScreenKeyboard API depending on the platform.
+    /// </summary>
+    /// <remarks>
+    /// Note that like Unity's TouchScreenKeyboard API, this script only supports WSA, iOS,
+    /// and Android.
+    /// </remarks>
     public class SystemKeyboardExample : MonoBehaviour
     {
         private MixedRealityKeyboard wmrKeyboard;
@@ -18,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 #if !UNITY_EDITOR && UNITY_WSA
             // Windows mixed reality keyboard initialization goes here
             wmrKeyboard = gameObject.AddComponent<MixedRealityKeyboard>();
-#else
+#elif UNITY_IOS || UNITY_ANDROID
             // non-Windows mixed reality keyboard initialization goes here
 #endif
         }
@@ -27,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         {
 #if !UNITY_EDITOR && UNITY_WSA
             wmrKeyboard.ShowKeyboard();
-#else
+#elif UNITY_IOS || UNITY_ANDROID
             touchscreenKeyboard = TouchScreenKeyboard.Open("", TouchScreenKeyboardType.Default, false, false, false, false);
 #endif
         }
@@ -52,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                     debugMessage.text = "typed " + keyboardText;
                 }
             }
-#else
+#elif UNITY_IOS || UNITY_ANDROID
             // non-Windows mixed reality keyboard initialization goes here
             // for non-Windows mixed reality keyboards just use Unity's default
             // touchscreenkeyboard. 


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5018 broke the standalone build, but we didn't know until roughly today.

Here's what happened.

TouchScreenKeyboard is only documented to be useable on the WSA/iOS/Android build options. It turns out that the "visible" property just doesn't exist on the object when build against Standalone targets. The code will build fine in editor but when you actually try to build the player, it doesn't work.

So to that end, I've wrapped the rest of the code in platform specific wrappers (to target only the places where TouchScreenKeyboard is documented to work)

I only caught this because I was making asset retargeting actually fail the build if it failed:

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5103

I'm going to make a change after this to ensure that player builds will actually fail the build if they fail, instead of just silently succeeding.
