### PR TITLE
Fixes build error when a scene with MRTK instance is open in editor

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Tests.Services;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -643,8 +644,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             MixedRealityToolkit secondInstance = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
 
             GameObject.DestroyImmediate(MixedRealityToolkit.Instance.gameObject);
-
-            MixedRealityToolkit.SetActiveInstance(secondInstance);
 
             Assert.NotNull(MixedRealityToolkit.Instance);
             Assert.AreEqual(secondInstance, MixedRealityToolkit.Instance);

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         private void OnValidate()
         {
-            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            if (EditorApplication.isPlayingOrWillChangePlaymode || BuildPipeline.isBuildingPlayer)
             {   // This check is only necessary in edit mode
                 return;
             }

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// The Profile can be swapped out at any time to meet the needs of your project.
     /// </summary>
     [DisallowMultipleComponent]
+    [ExecuteAlways]
     public class MixedRealityToolkit : MonoBehaviour, IMixedRealityServiceRegistrar
     {
 #region Mixed Reality Toolkit Profile configuration
@@ -644,6 +645,11 @@ namespace Microsoft.MixedReality.Toolkit
 
         private void OnEnable()
         {
+            if (!Application.isPlaying)
+            {   // This is only necessary in edit mode.
+                RegisterInstance(this);
+            }
+
             if (IsActiveInstance)
             {
                 EnableAllServices();
@@ -1526,20 +1532,6 @@ namespace Microsoft.MixedReality.Toolkit
                     }
                 };
             }
-        }
-
-        /// <summary>
-        /// Used to register newly created instances in edit mode.
-        /// Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play mode, which is disruptive to services.
-        /// </summary>
-        private void OnValidate()
-        {
-            if (EditorApplication.isPlayingOrWillChangePlaymode || BuildPipeline.isBuildingPlayer)
-            {   // This check is only necessary in edit mode
-                return;
-            }
-
-            RegisterInstance(this);
         }
 
 #endif // UNITY_EDITOR

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -713,8 +713,21 @@ namespace Microsoft.MixedReality.Toolkit
 
         private static void RegisterInstance(MixedRealityToolkit toolkitInstance, bool setAsActiveInstance = false)
         {
+            if (toolkitInstance == null)
+            {   // Don't register a null instance0
+                Debug.LogWarning("Attempted to register a null MixedRealityToolkit instance.");
+                return;
+            }
+
             if (MixedRealityToolkit.isApplicationQuitting)
             {   // Don't register instances while application is quitting
+                return;
+            }
+
+            if (!toolkitInstance.gameObject.scene.isLoaded)
+            {   // Don't register an instance that's being unloaded
+                // This may happen if an OnDestroy call triggers the active instance
+                // to un-register itself, prompting registration of another instance in the same scene.
                 return;
             }
 


### PR DESCRIPTION
## Overview
Removes OnValidate from MixedRealityToolkit and replaces with ExecuteAlways.

ExecuteAlways was always preferred over OnValidate, but wasn't viable at the time because ExecuteAlways causes the instance to be torn down prior to entering playmode. Now that our teardown issues are resolved we can use it again.

## Changes
- Fixes: #5131

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
