### PR TITLE
Update the CI pipeline to run tests first, and then do all of the build tasks.

### DIFF
--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -1,6 +1,10 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
 
 steps:
+# Run tests first so, that engineers can get test failure notifications
+# earlier in the CI process.
+- template: tests.yml
+
 # Build UWP x86
 - template: tasks/unitybuild.yml
   parameters:
@@ -32,4 +36,3 @@ steps:
     Platform: 'Standalone'
 
 - template: assetretargeting.yml
-- template: tests.yml


### PR DESCRIPTION
The build tasks take largest percentage of time (i.e. 80%) but are also the least likely to be the ones that fail repeatedly (generally people are able to make sure that things build before submitting things for PR). However, tests themselves can be trickier because they have slightly different behaviors in batch mode vs in editor. Right now people have to wait ~30 minutes for the builds to complete (successfully each time) before being able to see tests run again. Instead, what should happen is tests should run first (because this will let people iterate more quickly) and then do the long-running build work after.

Note that we're also going to be updating the docs to show how to run the tests in batch mode (so people can iterate on their own machines instead of spinning up CI tasks), but regardless, this is still a more optimal order based on our current dev flow.