### PR TITLE
Tests for Sliders

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/PinchSlider.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Sliders/PinchSlider.cs
@@ -20,6 +20,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("The gameObject that contains the slider thumb.")]
         [SerializeField]
         private GameObject thumbRoot = null;
+        public GameObject ThumbRoot
+        {
+            get
+            {
+                return thumbRoot;
+            }
+            set
+            {
+                thumbRoot = value;
+                InitializeSliderThumb();
+            }
+        }
 
         [Range(0, 1)]
         [SerializeField]
@@ -99,11 +111,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region Event Handlers
         [Header("Events")]
-        public SliderEvent OnValueUpdated;
-        public SliderEvent OnInteractionStarted;
-        public SliderEvent OnInteractionEnded;
-        public SliderEvent OnHoverEntered;
-        public SliderEvent OnHoverExited;
+        public SliderEvent OnValueUpdated = new SliderEvent();
+        public SliderEvent OnInteractionStarted = new SliderEvent();
+        public SliderEvent OnInteractionEnded = new SliderEvent();
+        public SliderEvent OnHoverEntered = new SliderEvent();
+        public SliderEvent OnHoverExited = new SliderEvent();
         #endregion
 
         #region Private Members
@@ -128,14 +140,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 throw new Exception($"Slider thumb on gameObject {gameObject.name} is not specified. Did you forget to set it?");
             }
-
-            var startToThumb = thumbRoot.transform.position - SliderStartPosition;
-            var thumbProjectedOnTrack = SliderStartPosition + Vector3.Project(startToThumb, SliderTrackDirection);
-            sliderThumbOffset = thumbRoot.transform.position - thumbProjectedOnTrack;
-
-            UpdateUI();
+            InitializeSliderThumb();
             OnValueUpdated.Invoke(new SliderEventData(sliderValue, sliderValue, null, this));
         }
+
+
 
         private void OnDisable()
         {
@@ -147,6 +156,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion
 
         #region Private Methods
+        private void InitializeSliderThumb()
+        {
+            var startToThumb = thumbRoot.transform.position - SliderStartPosition;
+            var thumbProjectedOnTrack = SliderStartPosition + Vector3.Project(startToThumb, SliderTrackDirection);
+            sliderThumbOffset = thumbRoot.transform.position - thumbProjectedOnTrack;
+
+            UpdateUI();
+        }
+
         private Vector3 GetSliderAxis()
         {
             switch (sliderAxis)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -160,26 +160,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(bounds.center, startCenter, "bbox incorrect center at start");
             TestUtilities.AssertAboutEqual(bounds.size, startSize, "bbox incorrect size at start");
 
-            var iss = PlayModeTestUtilities.GetInputSimulationService();
-            var oldIsp = iss.InputSimulationProfile;
-            var isp = ScriptableObject.CreateInstance<MixedRealityInputSimulationProfile>();
-            isp.HandSimulationMode = HandSimulationMode.Gestures;
-            iss.InputSimulationProfile = isp;
+            PlayModeTestUtilities.PushHandSimulationProfile();
+            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
             CameraCache.Main.transform.LookAt(bbox.ScaleCorners[3].transform);
 
-            var startHandPos = CameraCache.Main.transform.TransformPoint(new Vector3( 0.1f, 0f, isp.DefaultHandDistance));
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, iss, ArticulatedHandPose.GestureId.Open, startHandPos);
-            yield return PlayModeTestUtilities.SetHandState(startHandPos, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, iss);
-            var delta = new Vector3(0.1f, 0.1f, 0f);
-
+            var startHandPos = CameraCache.Main.transform.TransformPoint(new Vector3( 0.1f, 0f, 1.5f));
+            TestHand rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(startHandPos);
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             // After pinching, center should remain the same
             var afterPinchbounds = bbox.GetComponent<BoxCollider>().bounds;
             TestUtilities.AssertAboutEqual(afterPinchbounds.center, startCenter, "bbox incorrect center after pinch");
             TestUtilities.AssertAboutEqual(afterPinchbounds.size, startSize, "bbox incorrect size after pinch");
 
+            var delta = new Vector3(0.1f, 0.1f, 0f);
+            yield return rightHand.Move(delta);
 
-            yield return PlayModeTestUtilities.MoveHandFromTo(startHandPos, startHandPos + delta, 10, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, iss);
             var endBounds = bbox.GetComponent<BoxCollider>().bounds;
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .567f, "endBounds incorrect size");
@@ -189,7 +186,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             // Restore the input simulation profile
-            iss.InputSimulationProfile = oldIsp;
+            PlayModeTestUtilities.PopHandSimulationProfile();
+
             yield return null;
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    class PinchSliderTests
+    {
+        const string defaultPinchSliderPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab";
+
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+            TestUtilities.PlayspaceToOriginLookingForward();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+        }
+
+        /// <summary>
+        /// Tests that a slider component can be added at runtime.
+        /// at runtime.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestAddInteractableAtRuntime()
+        {
+            GameObject pinchSliderObject;
+            PinchSlider slider;
+            Transform sliderThumbRoot;
+
+            // This should not throw exception
+            AssembleSlider(Vector3.forward, Quaternion.identity, out pinchSliderObject, out slider, out sliderThumbRoot);
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // clean up
+            GameObject.Destroy(pinchSliderObject);
+            yield return null;
+        }
+        /// <summary>
+        /// Generates an interactable from primitives and assigns a select action.
+        /// </summary>
+        /// <param name="pinchSliderObject"></param>
+        /// <param name="slider"></param>
+        /// <param name="sliderThumbRoot"></param>
+        /// <param name="selectActionDescription"></param>
+        private void AssembleSlider(Vector3 position, Quaternion rotation, out GameObject pinchSliderObject, out PinchSlider slider, out Transform sliderThumbRoot)
+        {
+            // Assemble an interactable out of a set of primitives
+            // This will be the slider root
+            pinchSliderObject = new GameObject();
+            pinchSliderObject.name = "PinchSliderRoot";
+
+            // Make the slider track
+            var sliderTrack = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject.Destroy(sliderTrack.GetComponent<BoxCollider>());
+            sliderTrack.transform.position = Vector3.zero;
+            sliderTrack.transform.localScale = new Vector3(1f, .01f, .01f);
+            sliderTrack.transform.parent = pinchSliderObject.transform;
+
+            // Make the thumb root
+            var thumbRoot = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            thumbRoot.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
+            thumbRoot.transform.parent = pinchSliderObject.transform;
+            sliderThumbRoot = thumbRoot.transform;
+
+            slider = pinchSliderObject.AddComponent<PinchSlider>();
+            slider.ThumbRoot = thumbRoot;
+
+            pinchSliderObject.transform.position = position;
+            pinchSliderObject.transform.localRotation = rotation;
+        }
+
+        /// <summary>
+        /// Instantiates the default interactable button.
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="rotation"></param>
+        /// <param name="sliderObject"></param>
+        /// <param name="pinchSlider"></param>
+        /// <param name="pinchSliderRoot"></param>
+        private void InstantiateDefaultSliderPrefab(Vector3 position, Vector3 rotation, out GameObject sliderObject, out PinchSlider pinchSlider, out Transform pinchSliderRoot)
+        {
+            // Load interactable prefab
+            Object sliderPrefab = AssetDatabase.LoadAssetAtPath(defaultPinchSliderPrefabPath, typeof(Object));
+            sliderObject = Object.Instantiate(sliderPrefab) as GameObject;
+            pinchSlider = sliderObject.GetComponent<PinchSlider>();
+            Assert.IsNotNull(pinchSlider);
+
+            // Find the target object for the interactable transformation
+            pinchSliderRoot = pinchSlider.ThumbRoot.transform;
+
+            // Move the object into position
+            sliderObject.transform.position = position;
+            sliderObject.transform.eulerAngles = rotation;
+        }
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d87cc07b78998e4c9e5f38d6a2a9a8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
@@ -20,6 +20,7 @@ using Microsoft.MixedReality.Toolkit.Diagnostics;
 using System.Reflection;
 using System.Collections.Generic;
 using UnityEngine.SceneManagement;
+using System;
 
 #if UNITY_EDITOR
 using TMPro;
@@ -136,10 +137,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             // Switch off / Destroy all input components, which listen to global events
-            Object.Destroy(inputSystem.GazeProvider.GazeCursor as Behaviour);
+            UnityEngine.Object.Destroy(inputSystem.GazeProvider.GazeCursor as Behaviour);
             inputSystem.GazeProvider.Enabled = false;
 
-            var diagnosticsVoiceControls = Object.FindObjectsOfType<DiagnosticsSystemVoiceControls>();
+            var diagnosticsVoiceControls = UnityEngine.Object.FindObjectsOfType<DiagnosticsSystemVoiceControls>();
             foreach (var diagnosticsComponent in diagnosticsVoiceControls)
             {
                 diagnosticsComponent.enabled = false;
@@ -171,6 +172,27 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             CollectionAssert.IsEmpty(((BaseEventSystem)inputSystem).EventHandlersByType, "Input event system handler registry is not empty in the beginning of the test.");
 
             yield return null;
+        }
+
+        private static Stack<MixedRealityInputSimulationProfile> inputSimulationProfiles = new Stack<MixedRealityInputSimulationProfile>();
+        public static void PushHandSimulationProfile()
+        {
+            var iss = GetInputSimulationService();
+            inputSimulationProfiles.Push(iss.InputSimulationProfile);
+        }
+
+        public static void PopHandSimulationProfile()
+        {
+            var iss = GetInputSimulationService();
+            iss.InputSimulationProfile = inputSimulationProfiles.Pop();
+        }
+
+        internal static void SetHandSimulationMode(HandSimulationMode mode)
+        {
+            var iss = GetInputSimulationService();
+            var isp = ScriptableObject.CreateInstance<MixedRealityInputSimulationProfile>();
+            isp.HandSimulationMode = mode;
+            iss.InputSimulationProfile = isp;
         }
 
         internal static IEnumerator SetHandState(Vector3 handPos, ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
@@ -35,6 +35,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // Unity's default scene name for a recently created scene
         const string playModeTestSceneName = "MixedRealityToolkit.PlayModeTestScene";
 
+        private static Stack<MixedRealityInputSimulationProfile> inputSimulationProfiles = new Stack<MixedRealityInputSimulationProfile>();
+
         /// <summary>
         /// Creates a play mode test scene, creates an MRTK instance, initializes playspace.
         /// </summary>
@@ -174,7 +176,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        private static Stack<MixedRealityInputSimulationProfile> inputSimulationProfiles = new Stack<MixedRealityInputSimulationProfile>();
         public static void PushHandSimulationProfile()
         {
             var iss = GetInputSimulationService();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
@@ -52,6 +52,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return new WaitForFixedUpdate();
         }
 
+        public IEnumerator Move(Vector3 delta, int numSteps = 30)
+        {
+            yield return MoveTo(position + delta, numSteps);
+        }
+
         public IEnumerator SetGesture(ArticulatedHandPose.GestureId newGestureId)
         {
             gestureId = newGestureId;


### PR DESCRIPTION
## Overview
Adds playmode tests for sliders and a few extra test utilities / cleanups.

## Changes
- Fixes: #4759 
- Fix bugs causing slider to not be configurable from code
- Add Push/Pop InputSimulationProfile and SetInputSimulationMode to test utilities to allow easier switching between articulated and GGV hands for tests
- Add TestHand.Move()

Note: This change also has a couple of changes to test setup and teardown from Railboy's PR #4723. Hopefully that will go in before this one.

## Verification
Verified all playmode tests pass.