### PR TITLE
ControllerFinder now registers its interface with the InputSystem

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -59,7 +59,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         protected virtual void OnEnable()
         {
             // Look if the controller has loaded.
+            InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
             RefreshControllerTransform();
+        }
+
+        protected virtual void OnDisable()
+        {
+            InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
         }
 
         #endregion MonoBehaviour Implementation

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     /// <summary>
     /// ControllerFinder is a base class providing simple event handling for getting/releasing MotionController Transforms.
     /// </summary>
-    public abstract class ControllerFinder : MonoBehaviour, IMixedRealitySourceStateHandler
+    public abstract class ControllerFinder : MonoBehaviour
     {
         [SerializeField]
         [Tooltip("The handedness of the controller that should be found.")]
@@ -59,43 +59,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         protected virtual void OnEnable()
         {
             // Look if the controller has loaded.
-            InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
             RefreshControllerTransform();
         }
 
-        protected virtual void OnDisable()
-        {
-            InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
-        }
-
         #endregion MonoBehaviour Implementation
-
-        #region IMixedRealitySourceStateHandler Implementation
-
-        public void OnSourceDetected(SourceStateEventData eventData)
-        {
-            if (eventData.Controller?.ControllerHandedness == handedness)
-            {
-                if (eventData.Controller is IMixedRealityHand)
-                {
-
-                }
-                else
-                {
-                    AddControllerTransform(eventData.Controller);
-                }
-            }
-        }
-
-        public void OnSourceLost(SourceStateEventData eventData)
-        {
-            if (eventData.Controller?.ControllerHandedness == handedness)
-            {
-                RemoveControllerTransform();
-            }
-        }
-
-        #endregion IMixedRealitySourceStateHandler Implementation
 
         /// <summary>
         /// Looks to see if the controller model already exists and registers it if so.

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     /// <summary>
     /// ControllerFinder is a base class providing simple event handling for getting/releasing MotionController Transforms.
     /// </summary>
-    public abstract class ControllerFinder : MonoBehaviour
+    public abstract class ControllerFinder : MonoBehaviour, IMixedRealitySourceStateHandler
     {
         [SerializeField]
         [Tooltip("The handedness of the controller that should be found.")]
@@ -59,10 +59,43 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         protected virtual void OnEnable()
         {
             // Look if the controller has loaded.
+            InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
             RefreshControllerTransform();
         }
 
+        protected virtual void OnDisable()
+        {
+            InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+        }
+
         #endregion MonoBehaviour Implementation
+
+        #region IMixedRealitySourceStateHandler Implementation
+
+        public void OnSourceDetected(SourceStateEventData eventData)
+        {
+            if (eventData.Controller?.ControllerHandedness == handedness)
+            {
+                if (eventData.Controller is IMixedRealityHand)
+                {
+
+                }
+                else
+                {
+                    AddControllerTransform(eventData.Controller);
+                }
+            }
+        }
+
+        public void OnSourceLost(SourceStateEventData eventData)
+        {
+            if (eventData.Controller?.ControllerHandedness == handedness)
+            {
+                RemoveControllerTransform();
+            }
+        }
+
+        #endregion IMixedRealitySourceStateHandler Implementation
 
         /// <summary>
         /// Looks to see if the controller model already exists and registers it if so.


### PR DESCRIPTION
## Changes
- Fixes: #5144

ControllerFinder is capable of searching controllers on it's own but should also be capable of receiving controller detection events in the case a handedness is requested where there is no controller for yet.
Registering the corresponding events completes the amount of necessary calls.

In other words, the interface implementation was already there, it was just not listening at all