### PR TITLE
Update the build pipeline to first build standalone, in order to avoid infinitely hanging play mode tests.

### DIFF
--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -1,8 +1,17 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
 
 steps:
-# Run tests first so, that engineers can get test failure notifications
-# earlier in the CI process.
+# Build Standalone x86.
+# This must happen before tests run, because if the build fails and tests attempt
+# to get run, Unity will hang showing a dialog (even when in batch mode).
+# This is the fastest build, since it doesn't produce an AppX.
+- template: tasks/unitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'Standalone'
+
+# Tests should run earlier in the process, so that engineers can get test failure
+# notifications earlier in the CI process.
 - template: tests.yml
 
 # Build UWP x86
@@ -28,11 +37,5 @@ steps:
     Platform: 'UWP'
     PublishArtifacts: true
     ScriptingBackend: '.NET'
-
-# Build Standalone x86
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
 
 - template: assetretargeting.yml


### PR DESCRIPTION
It turns out that if there's a build error, running play mode tests will hang indefinitely in batch mode (this is because it shows a dialog saying "hey, make sure your stuff builds"). Previously this wasn't an issue because the test step happened after everything else, but now that we moved the test step up to be the first thing, this is now problematic.

Building standalone is the fastest of all of the flavors (because it doesn't have to build an AppX), so we're moving this to the top.