### PR TITLE
Added ability for MRTK to appear as a virtual Package Manager Package

### DIFF
--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "com.microsoft.mixedrealitytoolkit",
+  "name": "com.microsoft.mixedreality.toolkit.all",
   "version": "2.0.0",
   "displayName": "Mixed Reality Toolkit",
   "description": "MRTK virtual package.",
@@ -19,7 +19,6 @@
   ],
   "author": {
     "name": "Microsoft",
-    "email": "opencode@microsoft.com",
     "url": "https://github.com/microsoft/MixedRealityToolkit-Unity"
   } 
 }

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -2,7 +2,7 @@
   "name": "com.microsoft.mixedrealitytoolkit",
   "version": "2.0.0",
   "displayName": "Mixed Reality Toolkit",
-  "description": "MRTK virtal package.",
+  "description": "MRTK virtual package.",
   "unity": "2018.4",
   "unityRelease": "0f1",
   "dependencies": {

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "com.microsoft.mixedrealitytoolkit",
+  "version": "2.0.0",
+  "displayName": "Mixed Reality Toolkit",
+  "description": "MRTK virtal package.",
+  "unity": "2018.4",
+  "unityRelease": "0f1",
+  "dependencies": {
+ },
+ "keywords": [
+    "holotoolkit",
+	"holotoolkit-unity",
+	"mixed-reality",
+	"hololens",
+	"mixedrealitytoolkit",
+	"mrtk",
+	"mixedrealitytookit-unity",
+	"openvr"
+  ],
+  "author": {
+    "name": "Microsoft",
+    "email": "opencode@microsoft.com",
+    "url": "https://github.com/microsoft/MixedRealityToolkit-Unity"
+  } 
+}

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -14,7 +14,7 @@
 	"hololens",
 	"mixedrealitytoolkit",
 	"mrtk",
-	"mixedrealitytookit-unity",
+	"mixedrealitytoolkit-unity",
 	"openvr"
   ],
   "author": {

--- a/Assets/package.json.meta
+++ b/Assets/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 30c70a5f6f83acc4e912f668dd2c2b24
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/DownloadingTheMRTK.md
+++ b/Documentation/DownloadingTheMRTK.md
@@ -2,22 +2,43 @@
 
 ![](../Documentation/Images/MRTK_Logo_Rev.png)
 
-The MRTK is available via the following methods. For feedback on these methods, or to request an additional distribution method, please [file an issue on Github](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose)
+Below you'll find several methods for importing the MRTK into your project. For feedback on these methods, or to request an additional distribution method, please [file an issue on GitHub](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose)
 
-## Unity asset downloadable from the MRTK GitHub site
+## Unity Asset Packages - Easy to get started
 
-You can download the packaged [Unity assets from here](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases) for importing into your project.
+The easiest way to get started is to download MRTK as a set of Unity Asset Packages. These can be downloaded from the [Releases](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases) page of the MRTK project. 
 
-There are two Unity packages available for each release:
+There are two asset packages for each release:
 
-### Foundation
-This package contains the MRTK itself and all of the code and materials needed to build Mixed Reality experiences.
+- **Foundation -** Contains the core MRTK as well as all of the code and materials needed to build Mixed Reality experiences.
+- **Examples -** An optional package which contains example scenes and samples. This package depends on the **Foundation** package to function.  
 
-### Examples
-This is an optional package which contains example scenes and samples. This package is dependent on the Foundation package.
+With this approach, to update the version of MRTK your project is using:
 
-## GitHub submodule (advanced users)
+1. Delete existing MRTK folders from your project. These folders begin with '*MixedRealityToolkit*'. This step should not be skipped as Unity doesn't overwrite existing files when importing a package.
+2. Download the latest asset packages from the [Releases](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases) page on GitHub.
+3. Import the updated packages in Unity from **Assets -> Import Package -> Custom Package**
 
-For those who would like to contribute to the MRTK or prefer to have the latest code in their project, there is another way to get access to the latest and greatest of the Mixed Reality Toolkit, be it the Release code or the in-progress development of the project.
+**IMPORTANT:** When using this approach be aware that a *copy* of MRTK will be added to your project. If you commit your project to source control, by default you'll also be committing your own *copy* of MRTK as well. This may be desirable in many projects, but just be aware that your copy will not remain "in sync" with ongoing development on GitHub. 
 
-[Stephen Hodgson has provided a full guide](https://www.rageagainstthepixel.com/expert-import-mrtk/) for how to use Git Submodules to download and synchronize the toolkit in to your project.
+## Unity Virtual Package - Easy to share and update
+
+If you want to share one copy of the MRTK across multiple projects, or if you frequently want to update to the latest code on GitHub, a Unity Virtual Package can help. Here's how:
+
+1. Using your Git tool of choice, pull MRTK down to a local folder on your machine.
+2. In Unity, open Package Manager using **Window -> Package Manager**.
+3. Under the packages list, click on the '+' sign and select '*Add package from disk...*'
+4. Browse to the local folder where you just pulled MRTK, then go into the *Assets* folder.
+5. Double-click on **package.json**.
+
+Unity will now treat the MRTK folder as if it were a Package Manager package.
+
+With this approach, to update the version of MRTK your project is using simply pull latest changes. Unity should automatically detect any updates.
+
+**IMPORTANT:** When using this approach please be aware that all Unity projects which reference this folder are effectively sharing the same copy of MRTK. It can be highly beneficial that updating one folder automatically updates all projects. However, you may also find it desirable to keep some projects on certain versions of the MRTK longer. This can be accomplished by pulling down different versions of MRTK into different folders.
+
+Finally, be aware that Package Manager will write the *absolute* path of the virtual package into **manifest.json** for your project. This is fine for a single developer or a single machine, but paths often change across machines. It's possible to edit **manifest.json** and use relative paths rather than absolute ones.
+
+## GitHub Submodule - Fine-grained control
+
+If you want very fine-grained control over how MRTK is incorporated into individual projects, it's possible to setup MRTK as a Git Submodule. For step-by-step instructions please see [this guide](https://www.rageagainstthepixel.com/expert-import-mrtk/) by Stephen Hodgson.


### PR DESCRIPTION
## Overview
Added the ability for MRTK, when pulled from GitHub to a local folder, to appear as a virtual package in Package Manager. Please see updates made to [DownloadingTheMRTK.md](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/def4d6e77ae83dcde237805fed684f0a1df06303/Documentation/DownloadingTheMRTK.md) for how this can be used and why it's valuable.

## Changes
- Added **Assets\package.json** which is the virtual package descriptor.
- Updated **DownloadingTheMRTK.md** with information about the 3 approaches and why developers may wish to use each.

## Verification
Other that documentation, the only real change is adding a **package.json** file to the **Assets** folder. I have tested that this file doesn't break opening the MRTK in Unity, and I have tested that this file does in fact allow the MRTK to appear as a virtual package in other projects. Please just verify this to be the case on your machine as well.