### PR TITLE
Create a copy of CI definition using internal agent pool

### DIFF
--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -1,0 +1,19 @@
+# CI build producing developer packages.
+
+variables:
+  UnityVersion: Unity2018.3.7f1
+  MRTKVersion: 2.0.0
+
+jobs:
+- job: CIDeveloperValidation
+  timeoutInMinutes: 90
+  pool:
+    name: Analog On-Prem
+    demands:
+    - Unity2018.3.7f1
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+  steps:
+  - template: templates/ci-common.yml
+    parameters:
+      packagingEnabled: true


### PR DESCRIPTION
## Overview
We need a duplicate of the pipeline definition for now because it is not possible to re-assign the Agent Pool using the UI. This is temporary until we can shut down the feed in AIPMR.
