### PR TITLE
Fix regression caused by #5167

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <summary>
         /// The keywords to be recognized and optional keyboard shortcuts.
         /// </summary>
-        private SpeechCommands[] Commands => (ConfigurationProfile as MixedRealityInputSystemProfile)?.SpeechCommandsProfile?.SpeechCommands;
+        private SpeechCommands[] Commands => InputSystemProfile?.SpeechCommandsProfile.SpeechCommands;
 
         /// <summary>
         /// The Input Source for Windows Speech Input.

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <summary>
         /// The keywords to be recognized and optional keyboard shortcuts.
         /// </summary>
-        private SpeechCommands[] Commands => InputSystemProfile?.SpeechCommandsProfile.SpeechCommands;
+        private SpeechCommands[] Commands => InputSystemProfile.SpeechCommandsProfile.SpeechCommands;
 
         /// <summary>
         /// The Input Source for Windows Speech Input.


### PR DESCRIPTION
#5167 introduced a regression in accessing the registered speech commands.

This change fixes it by referencing the correct profile in the property.

Fixes #5192

Confirmed issue and verified fix using keyboard shortcuts in editor and stepping through the speech provider startup code in the debugger.