### PR TITLE
Logging of EyeGaze data to csv file is culture-specific

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputPlayback.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputPlayback.cs
@@ -291,7 +291,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
                 // Now let's populate the visualizer
                 for (int i = 0; i < loggedLines.Count; i++)
                 {
-                    string[] split = loggedLines[i].Split(new char[] { ',' });
+                    string[] split = loggedLines[i].Split(System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator.ToCharArray());
                     if (iType == InputSourceType.Eyes)
                         UpdateEyeGazeSignal(split, visualizer);
 
@@ -362,7 +362,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             // Now let's populate the visualizer
             for (int i = 0; i < loggedLines.Count; i++)
             {
-                Ray? currentPointingRay = GetEyeRay(loggedLines[i].Split(new char[] { ',' }));
+                Ray? currentPointingRay = GetEyeRay(loggedLines[i].Split(System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator.ToCharArray()));
                 if (currentPointingRay.HasValue)
                 {
                     if (UnityEngine.Physics.Raycast(currentPointingRay.Value, out hit, maxTargetingDistInMeters))
@@ -520,7 +520,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             // Now let's populate the visualizer step by step
             if (replayIndex < loggedLines.Count)
             {
-                string[] split = loggedLines[replayIndex].Split(new char[] { ',' });
+                string[] split = loggedLines[replayIndex].Split(System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator.ToCharArray());
                 UpdateEyeGazeSignal(split, _EyeGazeVisualizer);
                 UpdateHeadGazeSignal(split, _HeadGazeVisualizer);
                 UpdateTimestampForNextReplay(split);

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorder.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorder.cs
@@ -98,10 +98,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             string strFormat = "";
             for (int i = 0; i < data.Length - 1; i++)
             {
-                strFormat += ("{" + i + "}, ");
+                strFormat += ("{" + i + "}" + System.Globalization.CultureInfo.CurrentCulture.TextInfo.ListSeparator + " ");
             }
             strFormat += ("{" + (data.Length - 1) + "}");
-            
             return strFormat;
         }
         

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c21da7c68c73fe4d900537a83e219c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 51daf08636d709042b1232a6a47d40c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0465bc0773a0ef24d82da5633ee233b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5eda31a4c18a3d4697691aa7119a9a3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: beebda340ad7c7540909557457d273ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NUnit.Framework;
+using System.Globalization;
+
+namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
+{
+    class UserInputRecorderTests
+    {
+        [Test]
+        public void TestGetStringFormat()
+        {
+            // This test array is passed into UserInputRecorder.GetStringFormat and
+            // its content doesn't matter, only its length. The length is arbitrarily
+            // chosen to be relatively short.
+            object[] testArray = new object[5];
+
+            // en-US uses comma separated delimiters.
+            CultureInfo.CurrentCulture = new CultureInfo("en-US", false);
+
+            // In en-US, the generated format should be comma-delimited.
+            Assert.AreEqual(
+                "{0}, {1}, {2}, {3}, {4}",
+                UserInputRecorder.GetStringFormat(testArray));
+
+            // de-DE uses semicolon separated delimiters.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE", false);
+
+            // In de-DE, the generated format should be semicolon-delimited.
+            Assert.AreEqual(
+                "{0}; {1}; {2}; {3}; {4}",
+                UserInputRecorder.GetStringFormat(testArray));
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderTest.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 782dd2a8ce3871947b253278eaf3a294
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef
@@ -8,7 +8,8 @@
         "Microsoft.MixedReality.Toolkit.SDK",
         "Microsoft.MixedReality.Toolkit.Services.InputSystem",
         "Microsoft.MixedReality.Toolkit.Services.InputSimulation",
-        "Microsoft.MixedReality.Toolkit.Tests"
+        "Microsoft.MixedReality.Toolkit.Tests",
+        "Microsoft.MixedReality.Toolkit.Examples"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5184

On certain locales, the CSV delimiter isn't the comma, but the semicolon instead.

Previously, we assumed that the delimiter would always be the comma, but this would cause problems in cases like de-DE where numbers are written with commas (instead of decimals) to represent the decimal digits.

So for example, en_US:

123.123, ABCABC, XYZXYZ

Without this change, it would look like this on de_DE
123,123, ABCABC, XYZXYZ

This is obviously totally wrong - now we have four cells, it doesn't make sense!

The solution is to use the real delimiter for the current locale:
123,123; ABCABC; XYZXYZ
