### PR TITLE
Fix Unity UI touchable "greedy" activation.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 NearInteractionTouchableUnityUI touchable = NearInteractionTouchableUnityUI.Instances[i];
                 float distance = touchable.DistanceToTouchable(Position, out Vector3 normal);
-                if (distance < closestDistance)
+                if (distance <= touchableDistance && distance < closestDistance)
                 {
                     closest = touchable;
                     closestDistance = distance;


### PR DESCRIPTION
Physics-based touchables now have a broadphase that limits the number of
touchables that need to be examined for finding the closest one.

Unity UI touchables don't have such a broadphase test, so distances needs
to be checked against the touch distance as well, otherwise any UnityUI
touchable will activate if no other touchable is closer.

- Fixes: #5217
