### PR TITLE
Support focus requested property change in runtime

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("Is Focus required to receive input events on this GameObject?")]
         private bool isFocusRequired = true;
 
-        private bool initializationDone = false;
+        private bool activeFocusValue = true;
 
         /// <summary>
         /// Is Focus required to receive input events on this GameObject?
@@ -22,12 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public virtual bool IsFocusRequired
         {
             get { return isFocusRequired; }
-            protected set
-            {
-                bool oldValue = isFocusRequired;
-                isFocusRequired = value;
-                UpdateHandlersState(oldValue);
-            }
+            protected set { isFocusRequired = value; }
         }
 
         #region MonoBehaviour Implementation
@@ -47,28 +42,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 base.Start();
             }
 
-            initializationDone = true;
+            activeFocusValue = isFocusRequired;
         }
 
-        protected override void OnDisable()
+        protected void Update()
         {
-            if (!isFocusRequired)
+            if(activeFocusValue != isFocusRequired)
             {
-                base.OnDisable();
-            }
-        }
+                activeFocusValue = isFocusRequired;
 
-        #endregion MonoBehaviour Implementation
-
-        private void UpdateHandlersState(bool oldValue)
-        {
-            if (oldValue == isFocusRequired)
-            {
-                return;
-            }
-
-            if (initializationDone && Application.isPlaying && isActiveAndEnabled)
-            {
                 // If focus wasn't required before and is required now, unregister global handlers.
                 // Otherwise, register them.
                 if (isFocusRequired)
@@ -81,5 +63,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
         }
+
+        protected override void OnDisable()
+        {
+            if (!isFocusRequired)
+            {
+                base.OnDisable();
+            }
+        }
+
+        #endregion MonoBehaviour Implementation
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -14,7 +14,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("Is Focus required to receive input events on this GameObject?")]
         private bool isFocusRequired = true;
 
-        private bool activeFocusValue = true;
+        // Helper variable used to register/unregister handlers during play mode
+        private bool isFocusRequiredRuntime = true;
 
         /// <summary>
         /// Is Focus required to receive input events on this GameObject?
@@ -42,14 +43,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 base.Start();
             }
 
-            activeFocusValue = isFocusRequired;
+            isFocusRequiredRuntime = isFocusRequired;
         }
 
         protected void Update()
         {
-            if(activeFocusValue != isFocusRequired)
+            if(isFocusRequiredRuntime != isFocusRequired)
             {
-                activeFocusValue = isFocusRequired;
+                isFocusRequiredRuntime = isFocusRequired;
 
                 // If focus wasn't required before and is required now, unregister global handlers.
                 // Otherwise, register them.
@@ -66,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected override void OnDisable()
         {
-            if (!isFocusRequired)
+            if (!isFocusRequiredRuntime)
             {
                 base.OnDisable();
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -14,13 +14,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("Is Focus required to receive input events on this GameObject?")]
         private bool isFocusRequired = true;
 
+        private bool initializationDone = false;
+
         /// <summary>
         /// Is Focus required to receive input events on this GameObject?
         /// </summary>
         public virtual bool IsFocusRequired
         {
             get { return isFocusRequired; }
-            protected set { isFocusRequired = value; }
+            protected set
+            {
+                bool oldValue = isFocusRequired;
+                isFocusRequired = value;
+                UpdateHandlersState(oldValue);
+            }
         }
 
         #region MonoBehaviour Implementation
@@ -39,6 +46,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 base.Start();
             }
+
+            initializationDone = true;
         }
 
         protected override void OnDisable()
@@ -50,5 +59,27 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         #endregion MonoBehaviour Implementation
+
+        private void UpdateHandlersState(bool oldValue)
+        {
+            if (oldValue == isFocusRequired)
+            {
+                return;
+            }
+
+            if (initializationDone && Application.isPlaying && isActiveAndEnabled)
+            {
+                // If focus wasn't required before and is required now, unregister global handlers.
+                // Otherwise, register them.
+                if (isFocusRequired)
+                {
+                    UnregisterHandlers();
+                }
+                else
+                {
+                    RegisterHandlers();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Overview

Allow `BaseInputHandler.IsFocusRequested` to be changed during play mode (and propagate a change to handler registration).