### PR TITLE
add playmode test that toggles the profiler using speech kbd shortcuts

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpeechTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpeechTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System.Linq;
+using Microsoft.MixedReality.Toolkit.Diagnostics;
+using System.Runtime.InteropServices;
+using System;
+using Microsoft.MixedReality.Toolkit.UI;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class SpeechTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestToggleProfilerCommand()
+        {
+            // Confirm that the Diagnostics system is enabled and the VisualProfiler is in the scene.
+            IMixedRealityDiagnosticsSystem diagnosticsSystem = null;
+            MixedRealityServiceRegistry.TryGetService<IMixedRealityDiagnosticsSystem>(out diagnosticsSystem);
+            Assert.IsNotNull(diagnosticsSystem, "The diagnostics system is not enabled in the scene.");
+            yield return null;
+
+            // Verfiy that the VisualProfiler is enabled.
+            Assert.IsTrue(diagnosticsSystem.ShowProfiler, "The VisualProfiler is not active.");
+            yield return null;
+
+            // Toggle the profiler visualization off.
+            KeyboardEvent(VirtualKey_9, ScanCode_9, 0, IntPtr.Zero); // key down
+            yield return null;
+            KeyboardEvent(VirtualKey_9, ScanCode_9, KeyboardFlag_KeyUp, IntPtr.Zero); // key up
+            for (int i = 0; i < 10; i++) { yield return null; }
+
+            // Verify that the VisualProfiler is disabled.
+            Assert.IsFalse(diagnosticsSystem.ShowProfiler, "The VisualProfiler is active (should be inactive).");
+            yield return null;
+
+            // Toggle the profiler visualization on.
+            KeyboardEvent(VirtualKey_9, ScanCode_9, 0, IntPtr.Zero); // key down
+            yield return null;
+            KeyboardEvent(VirtualKey_9, ScanCode_9, KeyboardFlag_KeyUp, IntPtr.Zero); // key up
+            for (int i = 0; i < 10; i++) { yield return null; }
+
+            // Verfiy that the VisualProfiler is enabled.
+            Assert.IsTrue(diagnosticsSystem.ShowProfiler, "The VisualProfiler is inactive (should be active).");
+            yield return null;
+        }
+
+        /// <summary>
+        /// Virutal Key Code and Scan Code values used in this test.
+        /// </summary>
+        private const Byte VirtualKey_9 = 0x39;
+        private const Byte ScanCode_9 = 0x0A;
+
+        /// <summary>
+        /// Flags, for the keybd_event function, used in this test.
+        /// </summary>
+        private const UInt32 KeyboardFlag_KeyUp = 0x0002;
+
+        /// <summary>
+        /// P/Invoke signature for the Windows keybd_event function.
+        /// </summary>
+        /// <param name="keyCode">Virtual Key Code for the desired keyboard event.</param>
+        /// <param name="scanCode">Scan Code for the desired keybaord event.</param>
+        /// <param name="flags">Flags used to interpret the keyboard event.</param>
+        /// <param name="extraInfo">Additional information associated with the keyboard event.</param>
+        [DllImport("user32.dll", EntryPoint = "keybd_event")]
+        private static extern void KeyboardEvent(
+            Byte keyCode,
+            Byte scanCode,
+            UInt32 flags,
+            IntPtr extraInfo);
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpeechTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpeechTests.cs
@@ -39,8 +39,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestToggleProfilerCommand()
         {
-            int frameDelay = 10;
-
             // Confirm that the diagnostics system is enabled.
             IMixedRealityDiagnosticsSystem diagnosticsSystem = null;
             MixedRealityServiceRegistry.TryGetService<IMixedRealityDiagnosticsSystem>(out diagnosticsSystem);
@@ -56,6 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Verfiy that the VisualProfiler is enabled.
             Assert.IsTrue(diagnosticsSystem.ShowProfiler, "The VisualProfiler is not active.");
             yield return null;
+
+            int frameDelay = 10;
 
             // Toggle the profiler visualization off.
             var gazeInputSource = inputSystem.DetectedInputSources.Where(x => x.SourceName.Equals("Gaze")).First();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpeechTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpeechTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2adbbca4e23c314999cc839c93e5027
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change adds a test to toggle the diagnostics system's profiler off using the speech provider. In MRTK v2, the profiler toggle command is associated with the "9" key on the keyboard. This key stroke is used to simulate a user speaking "Toggle Profiler"

Resolves #5216