### PR TITLE
Fixing 3D Mouse Cursor BoundingBox manipulation stuttering

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -103,16 +103,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Debug.DrawRay(ray.origin, ray.direction * PointerExtent, Color.green);
             }
-
-            // ray to worldspace conversion
-            gameObject.transform.position = transform.position + transform.forward * DefaultPointerExtent;
         }
 
         public override Vector3 Position
         {       
             get
             {
-                return gameObject.transform.position;
+                return CameraCache.Main.transform.position + transform.forward * DefaultPointerExtent;
             }
         }
 


### PR DESCRIPTION
## Changes
- Fixes: #5027 

I can not completely say why this fixes the issue, but I think it has something to do with the mouse pointer Transform being positioned and rotated more than once during different steps and then used for calculations that are off at that time.