### PR TITLE
removed roll from "maintain rotation to user" one hand manipulation mode

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -540,7 +540,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else if (rotateInOneHandType == RotateInOneHandType.MaintainRotationToUser)
             {
-                targetRotation = CameraCache.Main.transform.rotation * startObjectRotationCameraSpace;
+                Vector3 euler = CameraCache.Main.transform.rotation.eulerAngles;
+                // don't use roll (feels awkward) - just maintain yaw / pitch angle
+                targetRotation = Quaternion.Euler(euler.x, euler.y, 0) * startObjectRotationCameraSpace;
             }
             else if (rotateInOneHandType == RotateInOneHandType.GravityAlignedMaintainRotationToUser)
             {

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -188,5 +188,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var dist = (actual - expected).magnitude;
             Debug.Assert(dist < vector3DistanceEpsilon, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
         }
+
+        public static void AssertNotAboutEqual(Vector3 val1, Vector3 val2, string message)
+        {
+            var dist = (val1 - val2).magnitude;
+            Debug.Assert(dist >= vector3DistanceEpsilon, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
+        }
     }
 }

--- a/Documentation/README_ManipulationHandler.md
+++ b/Documentation/README_ManipulationHandler.md
@@ -50,7 +50,7 @@ Specifies how the object will behave when it is being grabbed with one hand / co
 Specifies how the object will rotate when it is being grabbed with one hand.
 
 * *Maintain original rotation*: Does not rotate object as it is being moved
-* *Maintain rotation to user*: Maintains the object's original rotation to the user
+* *Maintain rotation to user*: Maintains the object's original rotation for X/Y axis to the user
 * *Gravity aligned maintain rotation to user*: Maintains object's original rotation to user, but makes the object vertical. Useful for bounding boxes.
 * *Face user*: Ensures object always faces the user. Useful for slates/panels.
 * *Face away from user*: Ensures object always faces away from user. Useful for slates/panels that are configured backwards.


### PR DESCRIPTION
manipulation handler one hand manipulation set to maintain rotation to user will now not take roll into account anymore.


## Changes
- Fixes: #4295 


## Verification
tested with WMR headset