### PR TITLE
Input recording gltf

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scripts/TestGltfLoading.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scripts/TestGltfLoading.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf
 
             try
             {
-                gltfObject = await GltfUtility.ImportGltfObjectFromPathAsync(path);
+                gltfObject = await GltfUtility.ImportGltfObjectFromPathAsync(path, true);
             }
             catch (Exception e)
             {

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/IMixedRealityInputPlaybackService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/IMixedRealityInputPlaybackService.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using UnityEngine;
+using System.Threading.Tasks;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -42,11 +41,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         void Pause();
 
         /// <summary>
-        /// Try to load input animation data from the given file.
+        /// Try to load input animation data from a given file.
         /// </summary>
         /// <returns>
         /// True if loading input animation from the file succeeded.
         /// </returns>
-        bool LoadInputAnimation(string filepath);
+        Task<bool> LoadInputAnimation(string filepath);
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimation.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimation.cs
@@ -55,12 +55,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         private AnimationCurve handTrackedCurveLeft;
+        public AnimationCurve HandTrackedCurveLeft => handTrackedCurveLeft;
         [SerializeField]
         private AnimationCurve handTrackedCurveRight;
+        public AnimationCurve HandTrackedCurveRight => handTrackedCurveRight;
         [SerializeField]
         private AnimationCurve handPinchCurveLeft;
+        public AnimationCurve HandPinchCurveLeft => handPinchCurveLeft;
         [SerializeField]
         private AnimationCurve handPinchCurveRight;
+        public AnimationCurve HandPinchCurveRight => handPinchCurveRight;
         [SerializeField]
         private Dictionary<TrackedHandJoint, PoseCurves> handJointCurvesLeft;
         [SerializeField]
@@ -256,6 +260,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static void AddRotationKeyFiltered(AnimationCurve curveX, AnimationCurve curveY, AnimationCurve curveZ, AnimationCurve curveW, float time, Quaternion rotation, float threshold)
         {
             float sqrThreshold = threshold * threshold;
+
+            rotation.Normalize();
 
             int iX = FindKeyframeInterval(curveX, time);
             int iY = FindKeyframeInterval(curveY, time);
@@ -613,7 +619,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return lowIdx;
         }
 
-        private void ComputeDuration()
+        public void ComputeDuration()
         {
             duration = 0.0f;
             foreach (var curve in AnimationCurves)
@@ -632,14 +638,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             var writer = new BinaryWriter(stream);
 
-            InputAnimationSerializationUtils.WriteHeader(writer);
+            InputAnimationBinaryUtils.WriteHeader(writer);
 
             PoseCurvesToStream(writer, cameraCurves, startTime);
 
-            InputAnimationSerializationUtils.WriteBoolCurve(writer, handTrackedCurveLeft, startTime);
-            InputAnimationSerializationUtils.WriteBoolCurve(writer, handTrackedCurveRight, startTime);
-            InputAnimationSerializationUtils.WriteBoolCurve(writer, handPinchCurveLeft, startTime);
-            InputAnimationSerializationUtils.WriteBoolCurve(writer, handPinchCurveRight, startTime);
+            InputAnimationBinaryUtils.WriteBoolCurve(writer, handTrackedCurveLeft, startTime);
+            InputAnimationBinaryUtils.WriteBoolCurve(writer, handTrackedCurveRight, startTime);
+            InputAnimationBinaryUtils.WriteBoolCurve(writer, handPinchCurveLeft, startTime);
+            InputAnimationBinaryUtils.WriteBoolCurve(writer, handPinchCurveRight, startTime);
 
             for (int i = 0; i < jointCount; ++i)
             {
@@ -658,7 +664,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 PoseCurvesToStream(writer, curves, startTime);
             }
 
-            InputAnimationSerializationUtils.WriteMarkerList(writer, markers, startTime);
+            InputAnimationBinaryUtils.WriteMarkerList(writer, markers, startTime);
         }
 
         /// <summary>
@@ -668,7 +674,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             var reader = new BinaryReader(stream);
 
-            InputAnimationSerializationUtils.ReadHeader(reader, out int versionMajor, out int versionMinor);
+            InputAnimationBinaryUtils.ReadHeader(reader, out int versionMajor, out int versionMinor);
             if (versionMajor != 1 || versionMinor != 0)
             {
                 Debug.LogError("Only version 1.0 of input animation file format is supported.");
@@ -677,10 +683,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             PoseCurvesFromStream(reader, cameraCurves);
 
-            InputAnimationSerializationUtils.ReadBoolCurve(reader, handTrackedCurveLeft);
-            InputAnimationSerializationUtils.ReadBoolCurve(reader, handTrackedCurveRight);
-            InputAnimationSerializationUtils.ReadBoolCurve(reader, handPinchCurveLeft);
-            InputAnimationSerializationUtils.ReadBoolCurve(reader, handPinchCurveRight);
+            InputAnimationBinaryUtils.ReadBoolCurve(reader, handTrackedCurveLeft);
+            InputAnimationBinaryUtils.ReadBoolCurve(reader, handTrackedCurveRight);
+            InputAnimationBinaryUtils.ReadBoolCurve(reader, handPinchCurveLeft);
+            InputAnimationBinaryUtils.ReadBoolCurve(reader, handPinchCurveRight);
 
             for (int i = 0; i < jointCount; ++i)
             {
@@ -701,33 +707,33 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 PoseCurvesFromStream(reader, curves);
             }
 
-            InputAnimationSerializationUtils.ReadMarkerList(reader, markers);
+            InputAnimationBinaryUtils.ReadMarkerList(reader, markers);
 
             ComputeDuration();
         }
 
         private static void PoseCurvesToStream(BinaryWriter writer, PoseCurves curves, float startTime)
         {
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.PositionX, startTime);
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.PositionY, startTime);
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.PositionZ, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.PositionX, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.PositionY, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.PositionZ, startTime);
 
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.RotationX, startTime);
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.RotationY, startTime);
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.RotationZ, startTime);
-            InputAnimationSerializationUtils.WriteFloatCurve(writer, curves.RotationW, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.RotationX, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.RotationY, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.RotationZ, startTime);
+            InputAnimationBinaryUtils.WriteFloatCurve(writer, curves.RotationW, startTime);
         }
 
         private static void PoseCurvesFromStream(BinaryReader reader, PoseCurves curves)
         {
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.PositionX);
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.PositionY);
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.PositionZ);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.PositionX);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.PositionY);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.PositionZ);
 
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.RotationX);
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.RotationY);
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.RotationZ);
-            InputAnimationSerializationUtils.ReadFloatCurve(reader, curves.RotationW);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.RotationX);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.RotationY);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.RotationZ);
+            InputAnimationBinaryUtils.ReadFloatCurve(reader, curves.RotationW);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfExporter.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfExporter.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
+using UnityEngine;
+
+using Utils = Microsoft.MixedReality.Toolkit.Input.InputAnimationGltfUtils;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Utility class for exporting input animation data in glTF format.
+    /// </summary>
+    /// <remarks>
+    /// Input animation curves are converted into animation data. The camera as well as each hand joint included in the
+    /// animation is represented as a node in the glTF file.
+    /// </remarks>
+    public static class InputAnimationGltfExporter
+    {
+        /// <summary>
+        /// Serialize the given input animation and save it at the given path.
+        /// </summary>
+        public static async void OnExportInputAnimation(InputAnimation input, string path, MixedRealityInputRecordingProfile profile)
+        {
+            GltfObject exportedObject;
+            using (var builder = new GltfObjectBuilder(profile?.LicenseString, Utils.GeneratorString))
+            {
+                int scene = builder.CreateScene(Utils.SceneName, true);
+
+                int camera;
+                if (CameraCache.Main)
+                {
+                    var cameraData = CameraCache.Main;
+                    camera = builder.CreateCameraPerspective(Utils.CameraName, cameraData.aspect, cameraData.fieldOfView, cameraData.nearClipPlane, cameraData.farClipPlane);
+                }
+                else
+                {
+                    camera = builder.CreateCameraPerspective(Utils.CameraName, 4.0/3.0, 55.0, 0.1, 100.0);
+                }
+
+                CreateAnimation(builder, input, camera);
+
+                exportedObject = builder.Build();
+            }
+
+            await GltfUtility.ExportGltfObjectToPathAsync(exportedObject, path);
+        }
+
+        /// Create an animation from input data and return its index.
+        private static int CreateAnimation(GltfObjectBuilder builder, InputAnimation input, int camera)
+        {
+            using (var animBuilder = new GltfAnimationBuilder(builder, Utils.AnimationName))
+            {
+                int cameraNode = builder.CreateRootNode(Utils.CameraName, Vector3.zero, Quaternion.identity, Vector3.one, 0, camera);
+                CreatePoseAnimation(animBuilder, input.CameraCurves, GltfInterpolationType.LINEAR, cameraNode);
+
+                int leftHandNode = builder.CreateRootNode(Utils.GetHandNodeName(Handedness.Left), Vector3.zero, Quaternion.identity, Vector3.one, 0);
+                int rightHandNode = builder.CreateRootNode(Utils.GetHandNodeName(Handedness.Right), Vector3.zero, Quaternion.identity, Vector3.one, 0);
+
+                int leftTrackingNode = builder.CreateChildNode(Utils.GetTrackingNodeName(Handedness.Left), Vector3.zero, Quaternion.identity, Vector3.one, leftHandNode);
+                int rightTrackingNode = builder.CreateChildNode(Utils.GetTrackingNodeName(Handedness.Right), Vector3.zero, Quaternion.identity, Vector3.one, rightHandNode);
+                CreateBoolAnimation(animBuilder, input.HandTrackedCurveLeft, leftTrackingNode);
+                CreateBoolAnimation(animBuilder, input.HandTrackedCurveRight, rightTrackingNode);
+
+                int leftPinchingNode = builder.CreateChildNode(Utils.GetPinchingNodeName(Handedness.Left), Vector3.zero, Quaternion.identity, Vector3.one, leftHandNode);
+                int rightPinchingNode = builder.CreateChildNode(Utils.GetPinchingNodeName(Handedness.Right), Vector3.zero, Quaternion.identity, Vector3.one, rightHandNode);
+                CreateBoolAnimation(animBuilder, input.HandPinchCurveLeft, leftPinchingNode);
+                CreateBoolAnimation(animBuilder, input.HandPinchCurveRight, rightPinchingNode);
+
+                int leftJointsNode = builder.CreateChildNode(Utils.GetHandJointsNodeName(Handedness.Left), Vector3.zero, Quaternion.identity, Vector3.one, leftHandNode);
+                int rightJointsNode = builder.CreateChildNode(Utils.GetHandJointsNodeName(Handedness.Right), Vector3.zero, Quaternion.identity, Vector3.one, rightHandNode);
+                foreach (var joint in Utils.TrackedHandJointValues)
+                {
+                    string jointName = Utils.TrackedHandJointNames[(int)joint];
+    
+                    InputAnimation.PoseCurves jointCurves;
+                    if (input.TryGetHandJointCurves(Handedness.Left, joint, out jointCurves))
+                    {
+                        int leftJointNode = builder.CreateChildNode(Utils.GetJointNodeName(Handedness.Left, joint), Vector3.zero, Quaternion.identity, Vector3.one, leftJointsNode);
+                        CreatePoseAnimation(animBuilder, jointCurves, GltfInterpolationType.LINEAR, leftJointNode);
+                    }
+                    if (input.TryGetHandJointCurves(Handedness.Right, joint, out jointCurves))
+                    {
+                        int rightJointNode = builder.CreateChildNode(Utils.GetJointNodeName(Handedness.Right, joint), Vector3.zero, Quaternion.identity, Vector3.one, rightJointsNode);
+                        CreatePoseAnimation(animBuilder, jointCurves, GltfInterpolationType.LINEAR, rightJointNode);
+                    }
+                }
+
+                return animBuilder.Index;
+            }
+        }
+
+        private static void CreatePoseAnimation(GltfAnimationBuilder builder, InputAnimation.PoseCurves poseCurves, GltfInterpolationType interpolation, int node)
+        {
+            var positionCurves = new AnimationCurve[] { poseCurves.PositionX, poseCurves.PositionY, poseCurves.PositionZ };
+            var rotationCurves = new AnimationCurve[] { poseCurves.RotationX, poseCurves.RotationY, poseCurves.RotationZ, poseCurves.RotationW };
+            builder.CreateTranslationAnimation(positionCurves, interpolation, node);
+            builder.CreateRotationAnimation(rotationCurves, interpolation, node);
+        }
+
+        // Store a boolean animation as a translation curve.
+        // glTF 2.0 does not support custom animation targets other than translation/rotation/scale/weights.
+        private static void CreateBoolAnimation(GltfAnimationBuilder builder, AnimationCurve curve, int node)
+        {
+            var positionCurves = new AnimationCurve[] { curve, null, null };
+            builder.CreateTranslationAnimation(positionCurves, GltfInterpolationType.STEP, node);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfExporter.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1a1f887b64886b4e8d334722921bd78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfImporter.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfImporter.cs
@@ -1,0 +1,393 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using UnityEngine;
+
+using Utils = Microsoft.MixedReality.Toolkit.Input.InputAnimationGltfUtils;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Utility class for exporting input animation data in glTF format.
+    /// </summary>
+    /// <remarks>
+    /// Input animation curves are converted into animation data. The camera as well as each hand joint included in the
+    /// animation is represented as a node in the glTF file.
+    /// </remarks>
+    public static class InputAnimationGltfImporter
+    {
+        /// <summary>
+        /// Utility class to preprocess a GltfObject and find relevant data to convert into InputAnimation.
+        /// </summary>
+        internal class InputAnimationGltfContent
+        {
+            public GltfObject gltfObject;
+
+            /// The animation used for input
+            public GltfAnimation gltfAnim;
+
+            /// Combined node index and animation channel index
+            public class NodeInfo
+            {
+                public int Node { get; private set; } = -1;
+                public GltfAnimationChannel PositionChannel { get; set; }
+                public GltfAnimationChannel RotationChannel { get; set; }
+
+                public bool Valid => Node >= 0;
+
+                public bool TrySetNode(int node, string name)
+                {
+                    if (Valid)
+                    {
+                        Debug.LogWarning($"More than one {name} node found in glTF file, only the first node will be used.");
+                        return false;
+                    }
+
+                    this.Node = node;
+                    return true;
+                }
+            }
+
+            /// Main camera node index
+            public NodeInfo camera = new NodeInfo();
+
+            public class HandInfo
+            {
+                /// Nodes for tracking and pinching state
+                public NodeInfo tracking = new NodeInfo();
+                public NodeInfo pinching = new NodeInfo();
+                /// Nodes used for hand joints
+                public Dictionary<TrackedHandJoint, NodeInfo> jointMap = new Dictionary<TrackedHandJoint, NodeInfo>();
+            }
+            public Dictionary<Handedness, HandInfo> handMap = new Dictionary<Handedness, HandInfo>()
+            {
+                { Handedness.Left, new HandInfo() },
+                { Handedness.Right, new HandInfo() },
+            };
+
+            public bool TryParseGltfObject(GltfObject gltfObject)
+            {
+                this.gltfObject = gltfObject;
+                if (!TryFindAnimation(gltfObject))
+                {
+                    return false;
+                }
+                if (!TryFindNodes(gltfObject))
+                {
+                    return false;
+                }
+
+                FindAnimationChannels();
+
+                return true;
+            }
+
+            private bool TryFindAnimation(GltfObject gltfObject)
+            {
+                if (gltfObject.animations.Length == 0)
+                {
+                    Debug.LogError("Cannot import input animation, no animations found in glTF file.");
+                    return false;
+                }
+
+                if (gltfObject.animations.Length > 1)
+                {
+                    Debug.LogWarning("More than one animation found in glTF file, only the first animation will be used for input.");
+                }
+
+                gltfAnim = gltfObject.animations[0];
+                return true;
+            }
+
+            private bool TryFindNodes(GltfObject gltfObject)
+            {
+                if (gltfObject.cameras.Length == 0)
+                {
+                    Debug.LogError("Cannot import input animation, no cameras found in glTF file.");
+                    return false;
+                }
+
+                for (int i = 0; i < gltfObject.nodes.Length; ++i)
+                {
+                    var node = gltfObject.nodes[i];
+
+                    if (node.camera >= 0)
+                    {
+                        camera.TrySetNode(i, "camera");
+                    }
+
+                    Handedness handedness;
+                    TrackedHandJoint joint;
+                    if (Utils.TryParseTrackingNodeName(node.name, out handedness))
+                    {
+                        GetOrCreateHandInfo(handedness).tracking.TrySetNode(i, node.name);
+                    }
+                    if (Utils.TryParsePinchingNodeName(node.name, out handedness))
+                    {
+                        GetOrCreateHandInfo(handedness).pinching.TrySetNode(i, node.name);
+                    }
+                    if (Utils.TryParseJointNodeName(node.name, out handedness, out joint))
+                    {
+                        GetOrCreateJointInfo(handedness, joint).TrySetNode(i, node.name);
+                    }
+                }
+
+                return camera.Valid;
+            }
+
+            private HandInfo GetOrCreateHandInfo(Handedness handedness)
+            {
+                if (!handMap.TryGetValue(handedness, out HandInfo handInfo))
+                {
+                    handInfo = new HandInfo();
+                    handMap.Add(handedness, handInfo);
+                }
+                return handInfo;
+            }
+
+            private NodeInfo GetOrCreateJointInfo(Handedness handedness, TrackedHandJoint joint)
+            {
+                HandInfo handInfo = GetOrCreateHandInfo(handedness);
+
+                if (!handInfo.jointMap.TryGetValue(joint, out NodeInfo nodeInfo))
+                {
+                    nodeInfo = new NodeInfo();
+                    handInfo.jointMap.Add(joint, nodeInfo);
+                }
+                return nodeInfo;
+            }
+
+            private void FindAnimationChannels()
+            {
+                // Temp. dictionary for looking up and setting the joint animation channel from the node index
+                var nodeIndexLookup = new Dictionary<int, NodeInfo>();
+
+                nodeIndexLookup[camera.Node] = camera;
+
+                foreach (var handInfo in handMap.Values)
+                {
+                    nodeIndexLookup[handInfo.tracking.Node] = handInfo.tracking;
+                    nodeIndexLookup[handInfo.pinching.Node] = handInfo.pinching;
+                    foreach (var jointInfo in handInfo.jointMap.Values)
+                    {
+                        nodeIndexLookup[jointInfo.Node] = jointInfo;
+                    }
+                }
+
+                foreach (GltfAnimationChannel channel in gltfAnim.channels)
+                {
+                    int node = channel.target.node;
+
+                    if (nodeIndexLookup.TryGetValue(node, out NodeInfo nodeInfo))
+                    {
+                        switch (channel.target.path)
+                        {
+                            case GltfAnimationChannelPath.translation:
+                                nodeInfo.PositionChannel = channel;
+                                break;
+                            case GltfAnimationChannelPath.rotation:
+                                nodeInfo.RotationChannel = channel;
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Serialize the given input animation and save it at the given path.
+        /// </summary>
+        public static async Task<InputAnimation> OnImportInputAnimation(string path)
+        {
+            GltfObject importedObject = await GltfUtility.ImportGltfObjectFromPathAsync(path, false);
+            if (importedObject == null)
+            {
+                return null;
+            }
+
+            var content = new InputAnimationGltfContent();
+            if (!content.TryParseGltfObject(importedObject))
+            {
+                return null;
+            }
+
+            InputAnimation anim = new InputAnimation();
+
+            ImportPoseCurves(content, content.camera, anim.CameraCurves);
+
+            foreach (var handItem in content.handMap)
+            {
+                switch (handItem.Key)
+                {
+                    case Handedness.Left:
+                        ImportBoolCurve(content, handItem.Value.tracking, anim.HandTrackedCurveLeft);
+                        ImportBoolCurve(content, handItem.Value.pinching, anim.HandPinchCurveLeft);
+                        break;
+                    case Handedness.Right:
+                        ImportBoolCurve(content, handItem.Value.tracking, anim.HandTrackedCurveRight);
+                        ImportBoolCurve(content, handItem.Value.pinching, anim.HandPinchCurveRight);
+                        break;
+                }
+
+                foreach (var jointItem in handItem.Value.jointMap)
+                {
+                    var poseCurves = anim.CreateHandJointCurves(handItem.Key, jointItem.Key);
+                    ImportPoseCurves(content, jointItem.Value, poseCurves);
+                }
+            }
+
+            anim.ComputeDuration();
+
+            return anim;
+        }
+
+        private static void ImportPoseCurves(InputAnimationGltfContent content, InputAnimationGltfContent.NodeInfo nodeInfo, InputAnimation.PoseCurves poseCurvesOut)
+        {
+            if (nodeInfo.PositionChannel != null)
+            {
+                TryImportCurves(content, nodeInfo.PositionChannel,
+                    new AnimationCurve[] { poseCurvesOut.PositionX, poseCurvesOut.PositionY, poseCurvesOut.PositionZ });
+            }
+            if (nodeInfo.RotationChannel != null)
+            {
+                TryImportCurves(content, nodeInfo.RotationChannel,
+                    new AnimationCurve[] { poseCurvesOut.RotationX, poseCurvesOut.RotationY, poseCurvesOut.RotationZ, poseCurvesOut.RotationW });
+            }
+        }
+
+        private static void ImportBoolCurve(InputAnimationGltfContent content, InputAnimationGltfContent.NodeInfo nodeInfo, AnimationCurve curveOut)
+        {
+            if (nodeInfo.PositionChannel != null)
+            {
+                TryImportCurves(content, nodeInfo.PositionChannel, new AnimationCurve[] { curveOut, null, null });
+            }
+        }
+
+        private static int GetAccessorByteSize(GltfAccessor accessor)
+        {
+            int stride = GetNumComponents(accessor.type) * GetComponentSize(accessor.componentType);
+            return stride * accessor.count;
+        }
+
+        private static int GetNumComponents(string type)
+        {
+            switch (type)
+            {
+                case "SCALAR": return 1;
+                case "VEC2": return 2;
+                case "VEC3": return 3;
+                case "VEC4": return 4;
+                case "MAT2": return 4;
+                case "MAT3": return 9;
+                case "MAT4": return 16;
+            }
+            return 0;
+        }
+
+        private static int GetComponentSize(GltfComponentType type)
+        {
+            switch (type)
+            {
+                case GltfComponentType.Byte: return 1;
+                case GltfComponentType.UnsignedByte: return 1;
+                case GltfComponentType.Short: return 2;
+                case GltfComponentType.UnsignedShort: return 2;
+                case GltfComponentType.UnsignedInt: return 4;
+                case GltfComponentType.Float : return 4;
+            }
+            return 0;
+        }
+
+        /// Arbitrarily large weight for representing a boolean value in float curves.
+        const float boolOutWeight = 1.0e6f;
+
+        private static bool TryImportCurves(InputAnimationGltfContent content, GltfAnimationChannel gltfChannel, AnimationCurve[] curves)
+        {
+            GltfAnimationSampler sampler = content.gltfAnim.samplers[gltfChannel.sampler];
+            GltfAccessor accTime = content.gltfObject.accessors[sampler.input];
+            GltfAccessor accValue = content.gltfObject.accessors[sampler.output];
+            byte[] bufferData = content.gltfObject.buffers[0].BufferData;
+
+            int numComponents = GetNumComponents(accValue.type);
+            if (curves.Length != numComponents)
+            {
+                Debug.LogWarning($"Expected {curves.Length} components in output accessor for animation sampler {gltfChannel.sampler}, cannot import animation curves.");
+                return false;
+            }
+            if (accTime.componentType != GltfComponentType.Float)
+            {
+                Debug.LogWarning($"{accValue.componentType} component type in input accessor for animation sampler {gltfChannel.sampler} is not supported, cannot import animation curves.");
+                return false;
+            }
+            if (accValue.componentType != GltfComponentType.Float)
+            {
+                Debug.LogWarning($"{accValue.componentType} component type in output accessor for animation sampler {gltfChannel.sampler} is not supported, cannot import animation curves.");
+                return false;
+            }
+            if (sampler.interpolation != GltfInterpolationType.STEP && sampler.interpolation != GltfInterpolationType.LINEAR)
+            {
+                Debug.LogWarning($"{sampler.interpolation} interpolation type in animation sampler {gltfChannel.sampler} is not supported, will use linear interpolation.");
+            }
+
+            var timeStream = new MemoryStream(bufferData, accTime.byteOffset, GetAccessorByteSize(accTime), false);
+            var valueStream = new MemoryStream(bufferData, accValue.byteOffset, GetAccessorByteSize(accValue), false);
+            var timeReader = new BinaryReader(timeStream);
+            var valueReader = new BinaryReader(valueStream);
+
+            Keyframe[][] curveKeys = new Keyframe[numComponents][];
+            for (int c = 0; c < numComponents; ++c)
+            {
+                curveKeys[c] = new Keyframe[accTime.count];
+            }
+            for (int i = 0; i < accTime.count; ++i)
+            {
+                float time = timeReader.ReadSingle();
+
+                for (int c = 0; c < numComponents; ++c)
+                {
+                    ref Keyframe key = ref curveKeys[c][i];
+                    key.time = time;
+                    key.value = valueReader.ReadSingle();
+
+                    switch (sampler.interpolation)
+                    {
+                        case GltfInterpolationType.STEP:
+                            key.weightedMode = WeightedMode.Out;
+                            key.inTangent = 0.0f;
+                            key.outTangent = 0.0f;
+                            key.inWeight = 0.0f;
+                            key.outWeight = boolOutWeight;
+                            break;
+                        case GltfInterpolationType.CUBICSPLINE:
+                        case GltfInterpolationType.CATMULLROMSPLINE:
+                        case GltfInterpolationType.LINEAR:
+                            key.weightedMode = WeightedMode.Both;
+                            key.inTangent = 0.0f;
+                            key.outTangent = 0.0f;
+                            key.inWeight = 0.0f;
+                            key.outWeight = 0.0f;
+                            break;
+                    }
+                }
+            }
+
+            for (int c = 0; c < numComponents; ++c)
+            {
+                if (curves[c] != null)
+                {
+                    curves[c].keys = curveKeys[c];
+                    curves[c].postWrapMode = WrapMode.Clamp;
+                    curves[c].preWrapMode = WrapMode.Clamp;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfImporter.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 979af631a5d9bba44b1a1a0dfd3795d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfUtils.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfUtils.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    public static class InputAnimationGltfUtils
+    {
+        public const string Extension = "glb";
+
+        public const string GeneratorString = "Microsoft.MixedReality.Toolkit.InputAnimation-1.0";
+
+        public const string SceneName = "Scene";
+        public const string CameraName = "Camera";
+        public const string AnimationName = "InputAction";
+
+        public static readonly string[] TrackedHandJointNames = Enum.GetNames(typeof(TrackedHandJoint));
+        public static readonly TrackedHandJoint[] TrackedHandJointValues = (TrackedHandJoint[])Enum.GetValues(typeof(TrackedHandJoint));
+        private static readonly Dictionary<string, TrackedHandJoint> TrackedHandJointMap = TrackedHandJointValues.ToDictionary(j => Enum.GetName(typeof(TrackedHandJoint), j));
+
+        public static readonly Handedness[] HandednessValues = (Handedness[])Enum.GetValues(typeof(Handedness));
+        private static readonly Dictionary<string, Handedness> HandednessMap = HandednessValues.ToDictionary(h => Enum.GetName(typeof(Handedness), h));
+
+        /// <summary>
+        /// Generate a file name for export.
+        /// </summary>
+        public static string GetOutputFilename(string baseName="InputAnimation", bool appendTimestamp=true)
+        {
+            string filename;
+            if (appendTimestamp)
+            {
+                filename = String.Format("{0}-{1}.{2}", baseName, DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"), Extension);
+            }
+            else
+            {
+                filename = baseName;
+            }
+            return filename;
+        }
+
+        public static string GetHandNodeName(Handedness handedness)
+        {
+            return $"Hand.{handedness}";
+        }
+
+        public static string GetTrackingNodeName(Handedness handedness)
+        {
+            return $"Hand.{handedness}.Tracking";
+        }
+
+        public static bool TryParseTrackingNodeName(string name, out Handedness handedness)
+        {
+            string[] parts = name.Split('.');
+            if (parts.Length == 3 && parts[0] == "Hand" && parts[2] == "Tracking")
+            {
+                if (HandednessMap.TryGetValue(parts[1], out handedness))
+                {
+                    return true;
+                }
+            }
+            handedness = Handedness.None;
+            return false;
+        }
+
+        public static string GetPinchingNodeName(Handedness handedness)
+        {
+            return $"Hand.{handedness}.Pinching";
+        }
+
+        public static bool TryParsePinchingNodeName(string name, out Handedness handedness)
+        {
+            string[] parts = name.Split('.');
+            if (parts.Length == 3 && parts[0] == "Hand" && parts[2] == "Pinching")
+            {
+                if (HandednessMap.TryGetValue(parts[1], out handedness))
+                {
+                    return true;
+                }
+            }
+            handedness = Handedness.None;
+            return false;
+        }
+
+        public static string GetHandJointsNodeName(Handedness handedness)
+        {
+            return $"Hand.{handedness}.Joints";
+        }
+
+        public static string GetJointNodeName(Handedness handedness, TrackedHandJoint joint)
+        {
+            return $"Hand.{handedness}.Joint.{joint}";
+        }
+
+        public static bool TryParseJointNodeName(string name, out Handedness handedness, out TrackedHandJoint joint)
+        {
+            string[] parts = name.Split('.');
+            if (parts.Length == 4 && parts[0] == "Hand" && parts[2] == "Joint")
+            {
+                if (HandednessMap.TryGetValue(parts[1], out handedness) && TrackedHandJointMap.TryGetValue(parts[3], out joint))
+                {
+                    return true;
+                }
+            }
+            handedness = Handedness.None;
+            joint = TrackedHandJoint.None;
+            return false;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfUtils.cs.meta
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationGltfUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90f7327a932bd03458c460318bc07645
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationSerializationUtils.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputAnimationSerializationUtils.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Functions for serializing input animation data to and from binary files.
     /// </summary>
-    public static class InputAnimationSerializationUtils
+    public static class InputAnimationBinaryUtils
     {
         private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
 
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             string filename;
             if (appendTimestamp)
             {
-                filename = String.Format("{0}-{1}.{2}", baseName, DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"), InputAnimationSerializationUtils.Extension);
+                filename = String.Format("{0}-{1}.{2}", baseName, DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"), Extension);
             }
             else
             {
@@ -161,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (AnimationCurve curve in curves)
             {
-                InputAnimationSerializationUtils.WriteFloatCurve(writer, curve, startTime);
+                InputAnimationBinaryUtils.WriteFloatCurve(writer, curve, startTime);
             }
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (AnimationCurve curve in curves)
             {
-                InputAnimationSerializationUtils.ReadFloatCurve(reader, curve);
+                InputAnimationBinaryUtils.ReadFloatCurve(reader, curve);
             }
         }
 
@@ -183,7 +183,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (AnimationCurve curve in curves)
             {
-                InputAnimationSerializationUtils.WriteBoolCurve(writer, curve, startTime);
+                InputAnimationBinaryUtils.WriteBoolCurve(writer, curve, startTime);
             }
         }
 
@@ -194,7 +194,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (AnimationCurve curve in curves)
             {
-                InputAnimationSerializationUtils.ReadBoolCurve(reader, curve);
+                InputAnimationBinaryUtils.ReadBoolCurve(reader, curve);
             }
         }
 

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/InputRecordingService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/InputRecordingService.cs
@@ -270,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public string SaveInputAnimation(string directory = null)
         {
-            return SaveInputAnimation(InputAnimationSerializationUtils.GetOutputFilename(), directory);
+            return SaveInputAnimation(InputAnimationGltfUtils.GetOutputFilename(), directory);
         }
 
         /// <inheritdoc />
@@ -280,7 +280,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 string path = Path.Combine(directory ?? Application.persistentDataPath, filename);
 
-                try
+                string extension = Path.GetExtension(path);
+                if (extension.EndsWith(InputAnimationGltfUtils.Extension))
+                {
+                    InputAnimationGltfExporter.OnExportInputAnimation(recordingBuffer, path, InputRecordingProfile);
+                }
+                else if (extension.EndsWith(InputAnimationBinaryUtils.Extension))
                 {
                     using (Stream fileStream = File.Open(path, FileMode.Create))
                     {
@@ -288,12 +293,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         recordingBuffer.ToStream(fileStream, StartTime);
                         Debug.Log($"Recorded input animation exported to {path}");
                     }
-                    return path;
                 }
-                catch (IOException ex)
+                else
                 {
-                    Debug.LogWarning(ex.Message);
+                    Debug.LogError($"Unknown file extension {extension}, cannot save input animation");
+                    return "";
                 }
+
+                return path;
             }
             return "";
         }

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/MixedRealityInputRecordingProfile.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/MixedRealityInputRecordingProfile.cs
@@ -32,5 +32,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("Minimum rotation angle of the camera to record a keyframe")]
         private float cameraRotationThreshold = 0.02f;
         public float CameraRotationThreshold => cameraRotationThreshold;
+
+        [SerializeField]
+        [Tooltip("License for exported input animation data")]
+        private string licenseString = "";
+        public string LicenseString => licenseString;
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/MixedRealityToolkit.Services.InputAnimation.asmdef
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/MixedRealityToolkit.Services.InputAnimation.asmdef
@@ -2,7 +2,8 @@
     "name": "Microsoft.MixedReality.Toolkit.Services.InputAnimation",
     "references": [
         "Microsoft.MixedReality.Toolkit",
-        "Microsoft.MixedReality.Toolkit.Services.InputSimulation"
+        "Microsoft.MixedReality.Toolkit.Services.InputSimulation",
+        "Microsoft.MixedReality.Toolkit.Gltf"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfAccessor.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfAccessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Utilities.Json;
 using System;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
@@ -15,12 +16,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// The index of the bufferView.
         /// If this is undefined, look in the sparse object for the index and value buffer views.
         /// </summary>
+        [JSONInteger(minimum:0)]
         public int bufferView = -1;
 
         /// <summary>
         /// The offset relative to the start of the bufferView in bytes.
         /// This must be a multiple of the size of the component datatype.
         /// </summary>
+        [JSONInteger(minimum:0)]
         public int byteOffset = -1;
 
         /// <summary>
@@ -31,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// 5125 (UNSIGNED_INT) is only allowed when the accessor contains indices
         /// i.e., the accessor is only referenced by `primitive.indices`.
         /// </summary>
+        [JSONEnum(useIntValue:true)]
         public GltfComponentType componentType;
 
         /// <summary>
@@ -71,7 +75,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <minItems>1</minItems>
         /// <maxItems>16</maxItems>
         /// </summary>
-        public float[] max;
+        [JSONArray(minItems:1)]
+        public double[] max;
 
         /// <summary>
         /// Minimum value of each component in this attribute.
@@ -89,7 +94,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <minItems>1</minItems>
         /// <maxItems>16</maxItems>
         /// </summary>
-        public float[] min;
+        [JSONArray(minItems:1)]
+        public double[] min;
 
         /// <summary>
         /// Sparse storage of attributes that deviate from their initialization value.

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfBuffer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfBuffer.cs
@@ -25,6 +25,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// </summary>
         public int byteLength = 0;
 
-        public byte[] BufferData { get; internal set; }
+        public byte[] BufferData { get; set; }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfBufferView.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfBufferView.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Utilities.Json;
 using System;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
@@ -35,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <minimum>0</minimum>
         /// <maximum>255</maximum>
         /// </summary>
+        [JSONInteger(minimum:4)]
         public int byteStride = 0;
 
         /// <summary>
@@ -42,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// All valid values correspond to WebGL enums.
         /// When this is not provided, the bufferView contains animation or skin data.
         /// </summary>
+        [JSONEnum(useIntValue : true, ignoreValues : new object[] {GltfBufferViewTarget.None})]
         public GltfBufferViewTarget target = GltfBufferViewTarget.None;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfCameraOrthographic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfCameraOrthographic.cs
@@ -16,21 +16,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// The floating-point horizontal magnification of the view.
         /// </summary>
-        public double xMag;
+        public double xmag;
 
         /// <summary>
         /// The floating-point vertical magnification of the view.
         /// </summary>
-        public double yMag;
+        public double ymag;
 
         /// <summary>
         /// The floating-point distance to the far clipping plane.
         /// </summary>
-        public double zFar;
+        public double zfar;
 
         /// <summary>
         /// The floating-point distance to the near clipping plane.
         /// </summary>
-        public double zNear;
+        public double znear;
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfCameraPerspective.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfCameraPerspective.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// The floating-point vertical field of view in radians.
         /// <minimum>0.0</minimum>
         /// </summary>
-        public double yFov;
+        public double yfov;
 
         /// <summary>
         /// The floating-point distance to the far clipping plane. When defined,
@@ -32,12 +32,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// If `zfar` is undefined, runtime must use infinite projection matrix.
         /// <minimum>0.0</minimum>
         /// </summary>
-        public double zFar;
+        public double zfar;
 
         /// <summary>
         /// The floating-point distance to the near clipping plane.
         /// <minimum>0.0</minimum>
         /// </summary>
-        public double zNear;
+        public double znear;
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfComponentType.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfComponentType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Utilities.Json;
+
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
 {
     /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfNode.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfNode.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Utilities.Json;
 using System;
 using UnityEngine;
 
@@ -26,21 +27,25 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// If true, extracts transform, rotation, scale values from the Matrix4x4. Otherwise uses the Transform, Rotate, Scale directly as specified by the node.
         /// </summary>
+        [NonSerialized]
         public bool useTRS;
 
         /// <summary>
         /// The index of the camera referenced by this node.
         /// </summary>
+        [JSONInteger(minimum:0)]
         public int camera = -1;
 
         /// <summary>
         /// The indices of this node's children.
         /// </summary>
+        [JSONArray(minItems:1)]
         public int[] children;
 
         /// <summary>
         /// The index of the skin referenced by this node.
         /// </summary>
+        [JSONInteger(minimum:0)]
         public int skin = -1;
 
         /// <summary>
@@ -53,6 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// The index of the mesh in this node.
         /// </summary>
+        [JSONInteger(minimum:0)]
         public int mesh = -1;
 
         /// <summary>
@@ -75,6 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// The weights of the instantiated Morph Target.
         /// Number of elements must match number of Morph Targets of used mesh.
         /// </summary>
+        [JSONArray(minItems:1)]
         public double[] weights;
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfObject.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfObject.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema.Extensions;
+using Microsoft.MixedReality.Toolkit.Utilities.Json;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -16,21 +17,25 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// Names of glTF extensions used somewhere in this asset.
         /// </summary>
+        [JSONArray(minItems:1)]
         public string[] extensionsUsed;
 
         /// <summary>
         /// Names of glTF extensions required to properly load this asset.
         /// </summary>
+        [JSONArray(minItems:1)]
         public string[] extensionsRequired;
 
         /// <summary>
         /// An array of accessors. An accessor is a typed view into a bufferView.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfAccessor[] accessors;
 
         /// <summary>
         /// An array of keyframe animations.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfAnimation[] animations;
 
         /// <summary>
@@ -41,42 +46,50 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// An array of buffers. A buffer points to binary geometry, animation, or skins.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfBuffer[] buffers;
 
         /// <summary>
         /// An array of bufferViews.
         /// A bufferView is a view into a buffer generally representing a subset of the buffer.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfBufferView[] bufferViews;
 
         /// <summary>
         /// An array of cameras. A camera defines a projection matrix.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfCamera[] cameras;
 
         /// <summary>
         /// An array of images. An image defines data used to create a texture.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfImage[] images;
 
         /// <summary>
         /// An array of materials. A material defines the appearance of a primitive.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfMaterial[] materials;
 
         /// <summary>
         /// An array of meshes. A mesh is a set of primitives to be rendered.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfMesh[] meshes;
 
         /// <summary>
         /// An array of nodes.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfNode[] nodes;
 
         /// <summary>
         /// An array of samplers. A sampler contains properties for texture filtering and wrapping modes.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfSampler[] samplers;
 
         /// <summary>
@@ -87,16 +100,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// An array of scenes.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfScene[] scenes;
 
         /// <summary>
         /// An array of skins. A skin is defined by joints and matrices.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfSkin[] skins;
 
         /// <summary>
         /// An array of textures.
         /// </summary>
+        [JSONArray(minItems:1)]
         public GltfTexture[] textures;
 
         #endregion Serialized Fields

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfProperty.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Schema/GltfProperty.cs
@@ -10,11 +10,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         /// <summary>
         /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/extension.schema.json
         /// </summary>
-        public readonly Dictionary<string, string> Extensions = new Dictionary<string, string>();
+        public readonly Dictionary<string, string> extensions = new Dictionary<string, string>();
 
         /// <summary>
         /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/extras.schema.json
         /// </summary>
-        public readonly Dictionary<string, string> Extras = new Dictionary<string, string>();
+        public readonly Dictionary<string, string> extras = new Dictionary<string, string>();
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -282,7 +282,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 var texture = gltfObject.images[gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture.index].Texture;
 
                 Texture2D occlusionTexture = null;
-                if (gltfMaterial.occlusionTexture.index >= 0)
+                if (gltfMaterial.occlusionTexture != null && gltfMaterial.occlusionTexture.index >= 0)
                 {
                     occlusionTexture = gltfObject.images[gltfMaterial.occlusionTexture.index].Texture;
                 }

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfObjectBuilder.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfObjectBuilder.cs
@@ -1,0 +1,449 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf
+{
+    internal static class GltfBuilderUtils
+    {
+        public static int ExtendArray<T>(ref T[] data, T item)
+        {
+            if (data == null)
+            {
+                data = new T[] { item };
+                return 0;
+            }
+
+            var newData = new T[data.Length + 1];
+            for (int i = 0; i < data.Length; ++i)
+            {
+                newData[i] = data[i];
+            }
+            newData[data.Length] = item;
+
+            data = newData;
+            return data.Length - 1;
+        }
+    }
+
+    /// <summary>
+    /// Utility class for constructing a GltfObject.
+    /// </summary>
+    public class GltfObjectBuilder : IDisposable
+    {
+        private GltfObject gltfObject;
+        private int bufferSize = 0;
+        private List<AnimationData> animationData = new List<AnimationData>();
+
+        /// GltfAnimation with associated curves for deferred buffer filling
+        private struct AnimationData
+        {
+            // Array of curves per animation sampler
+            public List<AnimationCurve[]> samplerCurves;
+        }
+
+        public GltfObjectBuilder(string copyright, string generator)
+        {
+            gltfObject = new GltfObject();
+
+            gltfObject.asset = CreateAssetInfo(copyright, generator);
+        }
+
+        public void Dispose()
+        {
+            gltfObject = null;
+            animationData = null;
+        }
+
+        /// <summary>
+        /// Construct a GltfObject from collected data.
+        /// </summary>
+        public GltfObject Build()
+        {
+            // Fill the binary buffer
+            gltfObject.buffers = new GltfBuffer[1];
+            gltfObject.bufferViews = new GltfBufferView[1];
+            FillBuffer(out gltfObject.buffers[0], out gltfObject.bufferViews[0]);
+
+            return gltfObject;
+        }
+
+        private static GltfAssetInfo CreateAssetInfo(string copyright, string generator, string version = "2.0", string minVersion = "2.0")
+        {
+            GltfAssetInfo info = new GltfAssetInfo();
+            info.copyright = copyright;
+            info.generator = generator;
+            info.version = version;
+            info.minVersion = minVersion;
+            return info;
+        }
+
+        public int CreateScene(string name, bool setAsDefaultScene)
+        {
+            GltfScene scene = new GltfScene();
+            scene.name = "Scene";
+
+            int index = GltfBuilderUtils.ExtendArray(ref gltfObject.scenes, scene);
+
+            if (setAsDefaultScene)
+            {
+                gltfObject.scene = index;
+            }
+
+            return index;
+        }
+
+        public int CreateRootNode(string name, Vector3 position, Quaternion rotation, Vector3 scale, int scene, int camera = -1)
+        {
+            int index = CreateNode(name, position, rotation, scale, camera);
+
+            GltfScene gltfScene = gltfObject.scenes[scene];
+            GltfBuilderUtils.ExtendArray(ref gltfScene.nodes, index);
+
+            return index;
+        }
+
+        public int CreateChildNode(string name, Vector3 position, Quaternion rotation, Vector3 scale, int parent, int camera = -1)
+        {
+            int index = CreateNode(name, position, rotation, scale, camera);
+
+            GltfNode gltfParentNode = gltfObject.nodes[parent];
+            GltfBuilderUtils.ExtendArray(ref gltfParentNode.children, index);
+
+            return index;
+        }
+
+        /// Create a node and return its index.
+        private int CreateNode(string name, Vector3 position, Quaternion rotation, Vector3 scale, int camera)
+        {
+            GltfNode node = new GltfNode();
+            node.name = name;
+
+            node.useTRS = true;
+            node.rotation = new float[4] { rotation.x, rotation.y, rotation.z, rotation.w };
+            node.scale = new float[3] { position.x, position.y, position.z };
+            node.translation = new float[3] { scale.x, scale.y, scale.z };
+            node.matrix = null;
+
+            node.camera = camera;
+
+            return GltfBuilderUtils.ExtendArray(ref gltfObject.nodes, node);
+        }
+
+        /// Create a perspective camera and return its index.
+        public int CreateCameraPerspective(string name, double aspectRatio, double yFov, double zNear, double zFar)
+        {
+            GltfCamera camera = new GltfCamera();
+            camera.name = name;
+
+            camera = new GltfCamera();
+
+            camera.perspective = new GltfCameraPerspective();
+            camera.type = GltfCameraType.perspective;
+            camera.perspective.aspectRatio = aspectRatio;
+            camera.perspective.yfov = yFov;
+            camera.perspective.znear = zNear;
+            camera.perspective.zfar = zFar;
+
+            camera.orthographic = null;
+
+            return GltfBuilderUtils.ExtendArray(ref gltfObject.cameras, camera);
+        }
+
+        /// Create a orthographic camera and return its index.
+        public int CreateCameraOrthographic(string name, double xMag, double yMag, double zNear, double zFar)
+        {
+            GltfCamera camera = new GltfCamera();
+            camera.name = name;
+
+            camera = new GltfCamera();
+
+            camera.orthographic = new GltfCameraOrthographic();
+            camera.type = GltfCameraType.orthographic;
+            camera.orthographic.xmag = xMag;
+            camera.orthographic.ymag = yMag;
+            camera.orthographic.znear = zNear;
+            camera.orthographic.zfar = zFar;
+
+            camera.perspective = null;
+
+            return GltfBuilderUtils.ExtendArray(ref gltfObject.cameras, camera);
+        }
+
+        internal int AddAnimationData(GltfAnimation animation, List<AnimationCurve[]> samplerCurves)
+        {
+            var animData = new AnimationData();
+            animData.samplerCurves = samplerCurves;
+            animationData.Add(animData);
+
+            return GltfBuilderUtils.ExtendArray(ref gltfObject.animations, animation);
+        }
+
+        private void FillBuffer(out GltfBuffer buffer, out GltfBufferView bufferView)
+        {
+            byte[] bufferData = new byte[bufferSize];
+
+            Debug.Assert(gltfObject.animations.Length == animationData.Count);
+            for (int i = 0; i < gltfObject.animations.Length; ++i)
+            {
+                var animation = gltfObject.animations[i];
+                var animData = animationData[i];
+
+                Debug.Assert(animData.samplerCurves.Count == animation.samplers.Length);
+                for (int j = 0; j < animation.samplers.Length; ++j)
+                {
+                    var sampler = animation.samplers[j];
+                    var input = gltfObject.accessors[sampler.input];
+                    var output = gltfObject.accessors[sampler.output];
+
+                    var curves = animData.samplerCurves[j];
+
+                    WriteTimeBuffer(bufferData, input, curves);
+                    WriteValueBuffer(bufferData, output, curves);
+                }
+            }
+
+            buffer = new GltfBuffer();
+            buffer.name = "AnimationData";
+            buffer.uri = null; // Stored internally
+            buffer.byteLength = bufferSize;
+            buffer.BufferData = bufferData;
+
+            bufferView = new GltfBufferView();
+            bufferView.name = "BufferView";
+            bufferView.buffer = 0;
+            bufferView.byteLength = bufferSize;
+            bufferView.byteOffset = 0;
+            bufferView.target = GltfBufferViewTarget.None;
+        }
+
+        private static int GetAccessorByteSize(GltfAccessor accessor)
+        {
+            int stride = GetNumComponents(accessor.type) * GetComponentSize(accessor.componentType);
+            return stride * accessor.count;
+        }
+
+        private static int GetNumComponents(string type)
+        {
+            switch (type)
+            {
+                case "SCALAR": return 1;
+                case "VEC2": return 2;
+                case "VEC3": return 3;
+                case "VEC4": return 4;
+                case "MAT2": return 4;
+                case "MAT3": return 9;
+                case "MAT4": return 16;
+            }
+            return 0;
+        }
+
+        private static int GetComponentSize(GltfComponentType type)
+        {
+            switch (type)
+            {
+                case GltfComponentType.Byte: return 1;
+                case GltfComponentType.UnsignedByte: return 1;
+                case GltfComponentType.Short: return 2;
+                case GltfComponentType.UnsignedShort: return 2;
+                case GltfComponentType.UnsignedInt: return 4;
+                case GltfComponentType.Float : return 4;
+            }
+            return 0;
+        }
+
+        public int CreateAccessor(string accType, GltfComponentType compType, int count)
+        {
+            int stride = GetNumComponents(accType) * GetComponentSize(compType);
+            // Align to full element size
+            int byteOffset = bufferSize == 0 ? 0 : bufferSize + stride - (bufferSize % stride);
+            int byteSize = stride * count;
+            bufferSize = byteOffset + byteSize;
+
+            var acc = new GltfAccessor();
+            acc.bufferView = 0;
+            acc.byteOffset = byteOffset;
+            acc.type = accType;
+            acc.componentType = compType;
+            acc.normalized = false;
+            acc.count = count;
+
+            return GltfBuilderUtils.ExtendArray(ref gltfObject.accessors, acc);
+        }
+
+        private static void WriteTimeBuffer(byte[] bufferData, GltfAccessor accessor, AnimationCurve[] curves)
+        {
+            var firstCurve = curves.First(curve => curve != null);
+
+            int byteSize = GetAccessorByteSize(accessor);
+            var stream = new MemoryStream(bufferData, accessor.byteOffset, byteSize, true);
+            var writer = new BinaryWriter(stream);
+
+            Debug.Assert(firstCurve.keys.Length == accessor.count);
+
+            accessor.min = new double[] { float.MaxValue };
+            accessor.max = new double[] { float.MinValue };
+            for (int i = 0; i < accessor.count; ++i)
+            {
+                float time = firstCurve.keys[i].time;
+
+                // Slightly expensive ...
+                // Debug.Assert(curves.All(curve => curve == null || curve.keys[i].time == time));
+
+                writer.Write(time);
+
+                accessor.min[0] = Math.Min(accessor.min[0], time);
+                accessor.max[0] = Math.Max(accessor.max[0], time);
+            }
+        }
+
+        private static void WriteValueBuffer(byte[] bufferData, GltfAccessor accessor, AnimationCurve[] curves)
+        {
+            int byteSize = GetAccessorByteSize(accessor);
+            var stream = new MemoryStream(bufferData, accessor.byteOffset, byteSize, true);
+            var writer = new BinaryWriter(stream);
+
+            int numComponents = GetNumComponents(accessor.type);
+            Debug.Assert(curves.Length == numComponents);
+            Debug.Assert(curves.All(curve => curve == null || curve.keys.Length == accessor.count));
+
+            accessor.min = new double[numComponents];
+            accessor.max = new double[numComponents];
+            for (int c = 0; c < numComponents; ++c)
+            {
+                accessor.min[c] = float.MaxValue;
+                accessor.max[c] = float.MinValue;
+            }
+            for (int i = 0; i < accessor.count; ++i)
+            {
+                for (int c = 0; c < numComponents; ++c)
+                {
+                    var curve = curves[c];
+                    float value = curve != null ? curve.keys[i].value : 0.0f;
+
+                    writer.Write(value);
+
+                    accessor.min[c] = Math.Min(accessor.min[c], value);
+                    accessor.max[c] = Math.Max(accessor.max[c], value);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Utility class for constructing a GltfAnimation.
+    /// </summary>
+    public class GltfAnimationBuilder : IDisposable
+    {
+        public int Index { get; private set; }
+
+        private GltfObjectBuilder objBuilder;
+        private GltfAnimation animation;
+        private List<AnimationCurve[]> samplerCurves;
+
+        public GltfAnimationBuilder(GltfObjectBuilder objBuilder, string name)
+        {
+            this.objBuilder = objBuilder;
+
+            animation = new GltfAnimation();
+            animation.name = name;
+            samplerCurves = new List<AnimationCurve[]>();
+
+            Index = objBuilder.AddAnimationData(animation, samplerCurves);
+        }
+
+        public void Dispose()
+        {
+            objBuilder = null;
+            animation = null;
+            samplerCurves = null;
+        }
+
+        public void CreateWeightsAnimation(AnimationCurve curve, GltfInterpolationType interpolation, int node)
+        {
+            int accTime = objBuilder.CreateAccessor("SCALAR", GltfComponentType.Float, curve.length);
+            int accValue = objBuilder.CreateAccessor("SCALAR", GltfComponentType.Float, curve.length);
+
+            var sampler = new GltfAnimationSampler();
+            sampler.input = accTime;
+            sampler.output = accValue;
+            sampler.interpolation = interpolation;
+            GltfBuilderUtils.ExtendArray(ref animation.samplers, sampler);
+
+            var channel = new GltfAnimationChannel();
+            channel.sampler = animation.samplers.Length - 1;
+            channel.target = new GltfAnimationChannelTarget();
+            channel.target.node = node;
+            channel.target.path = GltfAnimationChannelPath.weights;
+            GltfBuilderUtils.ExtendArray(ref animation.channels, channel);
+            samplerCurves.Add(new AnimationCurve[] { curve });
+        }
+
+        public void CreateTranslationAnimation(AnimationCurve[] curves, GltfInterpolationType interpolation, int node)
+        {
+            Debug.Assert(curves.Length == 3);
+            if (!CurvesLengthMatch(curves, out AnimationCurve firstCurve))
+            {
+                Debug.LogWarning("Translation curves must have same number of keyframes");
+                return;
+            }
+
+            int accTime = objBuilder.CreateAccessor("SCALAR", GltfComponentType.Float, firstCurve.length);
+            int accValue = objBuilder.CreateAccessor("VEC3", GltfComponentType.Float, firstCurve.length);
+
+            var sampler = new GltfAnimationSampler();
+            sampler.input = accTime;
+            sampler.output = accValue;
+            sampler.interpolation = interpolation;
+            GltfBuilderUtils.ExtendArray(ref animation.samplers, sampler);
+
+            var channel = new GltfAnimationChannel();
+            channel.sampler = animation.samplers.Length - 1;
+            channel.target = new GltfAnimationChannelTarget();
+            channel.target.node = node;
+            channel.target.path = GltfAnimationChannelPath.translation;
+            GltfBuilderUtils.ExtendArray(ref animation.channels, channel);
+            samplerCurves.Add(curves);
+        }
+
+        public void CreateRotationAnimation(AnimationCurve[] curves, GltfInterpolationType interpolation, int node)
+        {
+            Debug.Assert(curves.Length == 4);
+            if (!CurvesLengthMatch(curves, out AnimationCurve firstCurve))
+            {
+                Debug.LogWarning("Rotation curves must have same number of keyframes");
+                return;
+            }
+
+            int accTime = objBuilder.CreateAccessor("SCALAR", GltfComponentType.Float, firstCurve.length);
+            int accValue = objBuilder.CreateAccessor("VEC4", GltfComponentType.Float, firstCurve.length);
+
+            var sampler = new GltfAnimationSampler();
+            sampler.input = accTime;
+            sampler.output = accValue;
+            sampler.interpolation = interpolation;
+            GltfBuilderUtils.ExtendArray(ref animation.samplers, sampler);
+
+            var channel = new GltfAnimationChannel();
+            channel.sampler = animation.samplers.Length - 1;
+            channel.target = new GltfAnimationChannelTarget();
+            channel.target.node = node;
+            channel.target.path = GltfAnimationChannelPath.rotation;
+            GltfBuilderUtils.ExtendArray(ref animation.channels, channel);
+            samplerCurves.Add(curves);
+        }
+
+        private static bool CurvesLengthMatch(AnimationCurve[] curves, out AnimationCurve firstCurveOut)
+        {
+            var firstCurve = curves.FirstOrDefault(c => c != null);
+            firstCurveOut = firstCurve;
+            return firstCurve != null && curves.All(c => c == null || c.length == firstCurve.length);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfObjectBuilder.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfObjectBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2a59a880e6db6d4ba528e87f44d6d6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization.Editor
     {
         public static async void OnImportGltfAsset(AssetImportContext context)
         {
-            var importedObject = await GltfUtility.ImportGltfObjectFromPathAsync(context.assetPath);
+            var importedObject = await GltfUtility.ImportGltfObjectFromPathAsync(context.assetPath, true);
 
             if (importedObject == null ||
                 importedObject.GameObjectReference == null)

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8581d18d4cd75c74a86ebadb8a986039
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonAttributes.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonAttributes.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+// Attributes for serializing structs with the JsonBuilder utility.
+// Plain structs do not carry enough information to produce valid JSON depending on the schema.
+// These optional attributes can be used to guide the JsonBuilder tool.
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Json
+{
+    /// <summary>
+    /// Base class for all JSON attributes.
+    /// </summary>
+    public abstract class JsonAttribute : System.Attribute
+    {
+    }
+
+    /// <summary>
+    /// Details of converting enums to JSON values.
+    /// </summary>
+    [System.Serializable]
+    [AttributeUsage(AttributeTargets.All)]
+    public class JSONEnumAttribute : JsonAttribute
+    {
+        private bool useIntValue;
+        /// <summary>
+        /// Serialize as the integer value of the enum rather than a string.
+        /// </summary>
+        public bool UseIntValue => useIntValue;
+
+        private object[] ignoreValues;
+        /// <summary>
+        /// Don't serialize the enum when it has one of the values in this list.
+        /// </summary>
+        public object[] IgnoreValues => ignoreValues;
+
+        public JSONEnumAttribute(bool useIntValue, object[] ignoreValues = null)
+        {
+            this.useIntValue = useIntValue;
+            this.ignoreValues = ignoreValues;
+        }
+    }
+
+    /// <summary>
+    /// Attribute for JSON integer schema details.
+    /// </summary>
+    [System.Serializable]
+    [AttributeUsage(AttributeTargets.Field)]
+    public class JSONIntegerAttribute : JsonAttribute
+    {
+        private int minimum;
+        /// <summary>
+        /// Values below the minimum will not be serialized.
+        /// </summary>
+        public int Minimum => minimum;
+
+        public JSONIntegerAttribute(int minimum)
+        {
+            this.minimum = minimum;
+        }
+    }
+
+    /// <summary>
+    /// Attribute for JSON array schema details.
+    /// </summary>
+    [System.Serializable]
+    [AttributeUsage(AttributeTargets.Field)]
+    public class JSONArrayAttribute : JsonAttribute
+    {
+        private int minItems;
+        /// <summary>
+        /// Arrays with fewer items than this will not be serialized.
+        /// </summary>
+        public int MinItems => minItems;
+
+        public JSONArrayAttribute(int minItems)
+        {
+            this.minItems = minItems;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonAttributes.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonAttributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1851ee9a97130c14a8c961d1eb4406c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonBuilder.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonBuilder.cs
@@ -1,0 +1,273 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Json
+{
+    /// <summary>
+    /// JSON utility class for structured serialization.
+    /// </summary>
+    /// <remarks>
+    /// This class takes optional [JSON attributes](xref:Microsoft.MixedReality.Toolkit.Utilities.Json.JsonAttribute)
+    /// into account to produce valid JSON according to some schema.
+    /// The [Unity JsonUtility class](https://docs.unity3d.com/Manual/JSONSerialization.html) is not flexible enough to
+    /// follow all aspects of a schema, e.g. minimum values or how to serialize an enum.
+    /// </remarks>
+    public class JsonBuilder
+    {
+        /// <summary>
+        /// Serialize the given object to a JSON string.
+        /// </summary>
+        /// <returns>The serialized JSON string.</returns>
+        public string Build(object obj)
+        {
+            return AppendObject(obj);
+        }
+
+        /// Append contents of the object to the JSON string.
+        private string AppendObject(object obj)
+        {
+            Type type = obj.GetType();
+            var fields = type.GetFields();
+            var builder = new StringBuilder();
+
+            int count = 0;
+            builder.Append("{");
+            if (IsDictionary(type))
+            {
+                IDictionary dict = obj as IDictionary;
+                foreach (DictionaryEntry item in dict)
+                {
+
+                    var result = AppendItem(item.Value, null);
+                    if (result.Length > 0)
+                    {
+                        if (count > 0)
+                        {
+                            builder.Append(",");
+                        }
+
+                        builder.Append("\"" + SanitizeString(item.Key.ToString()) + "\":" + result);
+
+                        ++count;
+                    }
+
+                }
+            }
+            else
+            {
+                foreach (var field in fields)
+                {
+                    if (field.IsStatic || field.IsNotSerialized || !field.FieldType.IsSerializable)
+                    {
+                        continue;
+                    }
+
+                    var result = AppendItem(field.GetValue(obj), field);
+                    if (result.Length > 0)
+                    {
+                        if (count > 0)
+                        {
+                            builder.Append(",");
+                        }
+
+                        builder.Append("\"" + SanitizeString(field.Name) + "\":" + result);
+
+                        ++count;
+                    }
+                }
+            }
+            builder.Append("}");
+
+            if (count == 0)
+            {
+                return "";
+            }
+            return builder.ToString();
+        }
+
+        /// Append the contents of an array to the JSON string.
+        private string AppendArray(Array array, MemberInfo member)
+        {
+            Type type = array.GetType();
+            var builder = new StringBuilder();
+
+            int count = 0;
+            builder.Append("[");
+            foreach (var item in array)
+            {
+                string result = AppendItem(item, null);
+                if (result.Length > 0)
+                {
+                    if (count > 0)
+                    {
+                        builder.Append(",");
+                    }
+
+                    builder.Append(result);
+
+                    ++count;
+                }
+            }
+            builder.Append("]");
+
+            var attr = member?.GetCustomAttribute<JSONArrayAttribute>();
+            if (attr != null)
+            {
+                if (count < attr.MinItems)
+                {
+                    return "";
+                }
+            }
+            return builder.ToString();
+        }
+
+        /// Append the value of a field or array item.
+        private string AppendItem(object obj, MemberInfo member)
+        {
+            if (obj == null)
+            {
+                return "";
+            }
+
+            Type type = obj.GetType();
+            if (IsString(type))
+            {
+                return "\"" + obj.ToString() + "\"";
+            }
+            else if (type.IsEnum)
+            {
+                var attr = member?.GetCustomAttribute<JSONEnumAttribute>();
+                if (attr != null)
+                {
+                    if (attr.IgnoreValues != null)
+                    {
+                        foreach (var ignoreValue in attr.IgnoreValues)
+                        {
+                            if ((int)obj == (int)ignoreValue)
+                            {
+                                return "";
+                            }
+                        }
+                    }
+                    if (attr.UseIntValue)
+                    {
+                        return ((int)obj).ToString();
+                    }
+                }
+
+                return "\"" + obj.ToString() + "\"";
+            }
+            else if (IsInteger(type))
+            {
+                var attr = member?.GetCustomAttribute<JSONIntegerAttribute>();
+                if (attr != null)
+                {
+                    if ((int)obj < attr.Minimum)
+                    {
+                        return "";
+                    }
+                }
+
+                return obj.ToString();
+            }
+            else if (IsFloat(type))
+            {
+                return obj.ToString();
+            }
+            else if (IsBoolean(type))
+            {
+                return obj.ToString().ToLower();
+            }
+            else if (type.IsArray)
+            {
+                return AppendArray(obj as Array, member);
+            }
+            else
+            {
+                return AppendObject(obj);
+            }
+        }
+
+        /// Escape characters in a string so it can be used as a JSON literal.
+        private static string SanitizeString(string s)
+        {
+            return s.Replace("\"", "\\\"");
+        }
+
+        /// <summary>
+        /// Returns true if a type is an integer type.
+        /// </summary>
+        public static bool IsInteger(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a type is an floating point type.
+        /// </summary>
+        public static bool IsFloat(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Decimal:
+                case TypeCode.Double:
+                case TypeCode.Single:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a type is an string type.
+        /// </summary>
+        public static bool IsString(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.String:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a type is an boolean type.
+        /// </summary>
+        public static bool IsBoolean(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Boolean:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsDictionary(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonBuilder.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e8aaa946b733db46b350c0997d94671
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonParser.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonParser.cs
@@ -1,0 +1,483 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Json
+{
+    /// <summary>
+    /// JSON utility class for structured deserialization.
+    /// </summary>
+    /// <remarks>
+    /// This class takes optional [JSON attributes](xref:Microsoft.MixedReality.Toolkit.Utilities.Json.JsonAttribute)
+    /// into account to produce valid JSON according to some schema.
+    /// The [Unity JsonUtility class](https://docs.unity3d.com/Manual/JSONSerialization.html) is not flexible enough to
+    /// follow all aspects of a schema, e.g. minimum values or how to serialize an enum.
+    /// </remarks>
+    public class JsonParser
+    {
+        /// <summary>
+        /// Deserialize the given object from a JSON string.
+        /// </summary>
+        public bool Parse(string json, Type type, out object obj)
+        {
+            return TryParseObject(ref json, type, out obj);
+        }
+
+        const int maxLogLength = 120;
+
+        private void LogWarning(string warning)
+        {
+            Debug.LogWarning(warning);
+        }
+
+        private void LogError(string error)
+        {
+            Debug.LogError("Invalid JSON string:" + error);
+        }
+
+        private void LogMissingObject(string json)
+        {
+            LogMissingObject(json, null);
+        }
+
+        private void LogMissingObject(string json, Type expected)
+        {
+            if (expected != null)
+            {
+                LogError($"Expected object of type {expected.Name} at {json.Substring(0, maxLogLength)}");
+            }
+            else
+            {
+                LogError($"Expected object at {json.Substring(0, maxLogLength)}");
+            }
+        }
+
+        private void LogMissingLiteral(string json, string expected)
+        {
+            LogError($"Expected \"{expected}\" at {json.Substring(0, maxLogLength)}");
+        }
+
+        private bool TryParseObject(ref string json, Type type, out object obj)
+        {
+            obj = null;
+
+            if (!TryParseLiteral(ref json, "{"))
+            {
+                return false;
+            }
+
+            if (TryParseLiteral(ref json, "}"))
+            {
+                // Empty list
+                return true;
+            }
+
+            IDictionary dict = null;
+            Type keyType = null;
+            Type valueType = null;
+            if (type != null)
+            {
+                obj = Activator.CreateInstance(type);
+
+                if (IsDictionary(type))
+                {
+                    dict = obj as IDictionary;
+                    Type[] argTypes = type.GetGenericArguments();
+                    keyType = argTypes[0];
+                    valueType = argTypes[1];
+                }
+            }
+
+            while (true)
+            {
+                if (dict != null)
+                {
+                    if (!TryParseItem(ref json, keyType, null, out object key))
+                    {
+                        LogMissingObject(json, keyType);
+                        return false;
+                    }
+                    if (!TryParseLiteral(ref json, ":"))
+                    {
+                        LogMissingLiteral(json, ":");
+                        return false;
+                    }
+                    if (!TryParseItem(ref json, valueType, null, out object value))
+                    {
+                        LogMissingObject(json, valueType);
+                        return false;
+                    }
+
+                    dict.Add(key, value);
+                }
+                else
+                {
+                    if (!TryParseString(ref json, out string fieldName))
+                    {
+                        LogMissingObject(json, typeof(string));
+                        return false;
+                    }
+
+                    if (!TryParseLiteral(ref json, ":"))
+                    {
+                        LogMissingLiteral(json, ":");
+                        return false;
+                    }
+
+                    FieldInfo fieldInfo = null;
+                    if (type != null)
+                    {
+                        fieldInfo = type.GetField(fieldName);
+                    }
+
+                    if (!TryParseItem(ref json, fieldInfo?.FieldType, fieldInfo, out object value))
+                    {
+                        LogMissingObject(json, fieldInfo?.FieldType);
+                        return false;
+                    }
+
+                    if (type != null)
+                    {
+                        if (fieldInfo != null)
+                        {
+                            fieldInfo.SetValue(obj, value);
+                        }
+                        else
+                        {
+                            LogWarning($"Could not find field \"{fieldName}\" in {type.Name}");
+                        }
+                    }
+                }
+
+                if (!TryParseLiteral(ref json, ","))
+                {
+                    break;
+                }
+            }
+
+            if (!TryParseLiteral(ref json, "}"))
+            {
+                LogMissingLiteral(json, "}");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// Append the contents of an array to the JSON string.
+        private bool TryParseArray(ref string json, Type type, MemberInfo member, out object obj)
+        {
+            obj = null;
+
+            if (!TryParseLiteral(ref json, "["))
+            {
+                return false;
+            }
+            if (TryParseLiteral(ref json, "]"))
+            {
+                // Empty list
+                return true;
+            }
+
+            Array array = null;
+            Type elementType = null;
+            if (type != null && type.IsArray)
+            {
+                elementType = type.GetElementType();
+                if (elementType != null)
+                {
+                    array = Array.CreateInstance(elementType, 0);
+                    obj = array;
+                }
+            }
+
+            List<object> tmp = new List<object>();
+            while (true)
+            {
+                if (!TryParseItem(ref json, elementType, null, out object element))
+                {
+                    LogMissingObject(json, elementType);
+                    return false;
+                }
+
+                tmp.Add(element);
+
+                if (!TryParseLiteral(ref json, ","))
+                {
+                    break;
+                }
+            }
+
+            if (!TryParseLiteral(ref json, "]"))
+            {
+                LogMissingLiteral(json, "]");
+                return false;
+            }
+
+            if (elementType != null)
+            {
+                array = Array.CreateInstance(elementType, tmp.Count);
+                obj = array;
+
+                for (int i = 0; i < tmp.Count; ++i)
+                {
+                    array.SetValue(tmp[i], i);
+                }
+            }
+
+            return true;
+        }
+
+        /// Parse the value of a field or array item.
+        private bool TryParseItem(ref string json, Type type, MemberInfo member, out object item)
+        {
+            string orig = json;
+
+            if (TryParseObject(ref json, type, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseArray(ref json, type, member, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseEnumByValue(ref json, type, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseEnumByName(ref json, type, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseString(ref json, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseInt(ref json, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseFloat(ref json, out item))
+            {
+                return true;
+            }
+
+            json = orig;
+            if (TryParseBool(ref json, out item))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static readonly char[] SpecialChars = new char[] { '{', '}', '[', ']', ',', ':' };
+
+        private static bool TryParseLiteral(ref string json, string literal)
+        {
+            string t = json.TrimStart();
+            if (t.StartsWith(literal))
+            {
+                json = t.Substring(literal.Length);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool TryParseString(ref string json, out object result)
+        {
+            bool ok = TryParseString(ref json, out string s);
+            result = s;
+            return ok;
+        }
+
+        private static bool TryParseString(ref string json, out string result)
+        {
+            int end = json.IndexOfAny(SpecialChars);
+
+            var match = Regex.Match(json.Substring(0, end), @"\s*""(([^""\\]|\\.)*)""\s*");
+            if (match.Success)
+            {
+                result = match.Groups[1].Value;
+                json = json.Substring(end);
+                return true;
+            }
+
+            result = "";
+            return false;
+        }
+
+        private static bool TryParseInt(ref string json, out object result)
+        {
+            bool ok = TryParseInt(ref json, out int i);
+            result = i;
+            return ok;
+        }
+
+        private static bool TryParseInt(ref string json, out int result)
+        {
+            int end = json.IndexOfAny(SpecialChars);
+            if (int.TryParse(json.Substring(0, end), out result))
+            {
+                json = json.Substring(end);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool TryParseFloat(ref string json, out object result)
+        {
+            bool ok = TryParseFloat(ref json, out float f);
+            result = f;
+            return ok;
+        }
+
+        private static bool TryParseFloat(ref string json, out float result)
+        {
+            int end = json.IndexOfAny(SpecialChars);
+            if (float.TryParse(json.Substring(0, end), out result))
+            {
+                json = json.Substring(end);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool TryParseBool(ref string json, out object result)
+        {
+            bool ok = TryParseBool(ref json, out bool b);
+            result = b;
+            return ok;
+        }
+
+        private static bool TryParseBool(ref string json, out bool result)
+        {
+            int end = json.IndexOfAny(SpecialChars);
+            if (bool.TryParse(json.Substring(0, end), out result))
+            {
+                json = json.Substring(end);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool TryParseEnumByValue(ref string json, Type type, out object result)
+        {
+            if (type != null && type.IsEnum)
+            {
+                if (TryParseInt(ref json, out int value))
+                {
+                    result = Enum.ToObject(type, value);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private static bool TryParseEnumByName(ref string json, Type type, out object result)
+        {
+            if (type != null && type.IsEnum)
+            {
+                if (TryParseString(ref json, out string name))
+                {
+                    result = Enum.Parse(type, name);
+                    if (result != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if a type is an integer type.
+        /// </summary>
+        public static bool IsInteger(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a type is an floating point type.
+        /// </summary>
+        public static bool IsFloat(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Decimal:
+                case TypeCode.Double:
+                case TypeCode.Single:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a type is an string type.
+        /// </summary>
+        public static bool IsString(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.String:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a type is an boolean type.
+        /// </summary>
+        public static bool IsBoolean(Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Boolean:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsDictionary(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonParser.cs.meta
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Json/JsonParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c34d4c549fdb4494a94a57bab3838f46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/InputSimulation/InputAnimationGltfStructure.md
+++ b/Documentation/InputSimulation/InputAnimationGltfStructure.md
@@ -1,0 +1,58 @@
+# Input Animation glTF Structure
+
+When exporting input animation as a glTF file, the various animated input properties are converted into position and rotation animation channels for nodes in the scene graph. Abstract properties such as hand tracking state are also encoded in node animations.
+
+## Camera Node
+
+The [main camera from the CameraCache](xref:Microsoft.MixedReality.Toolkit.Utilities.CameraCache.Main) is exported as head movement. When importing from a glTF file the first camera node in the file is expected to encode the head movement. The name of the node is not used to identify the main camera.
+
+## Hand State
+
+Tracking and Pinching state of the left and right hand are encoded in node position animations. The X component is used to animate the boolean values, where 1.0 means the hand is tracking/pinching and 0.0 means it is not.
+
+The following node names are used for hand state information:
+
+* "Hand.Left.Tracking"
+* "Hand.Right.Tracking"
+* "Hand.Left.Pinching"
+* "Hand.Right.Pinching"
+
+The position of the nodes in the scene hierarchy does not matter. The exporter will group hand nodes under a common parent node for convenience, but any node with a matching name will be recognized by the importer.
+
+## Joint Nodes
+
+Joint positions and orientations are encoded using node transforms. The nodes for joints are identified using the following naming scheme:
+
+"Hand._HANDEDNESS_.Joint._JOINT_"
+
+where _HANDEDNESS_ can either "Left" or "Right", and _JOINT_ can be one of the following:
+
+* "Wrist"
+* "Palm"
+* "ThumbMetacarpalJoint"
+* "ThumbProximalJoint"
+* "ThumbDistalJoint"
+* "ThumbTip"
+* "IndexMetacarpal"
+* "IndexKnuckle"
+* "IndexMiddleJoint"
+* "IndexDistalJoint"
+* "IndexTip"
+* "MiddleMetacarpal"
+* "MiddleKnuckle"
+* "MiddleMiddleJoint"
+* "MiddleDistalJoint"
+* "MiddleTip"
+* "RingMetacarpal"
+* "RingKnuckle"
+* "RingMiddleJoint"
+* "RingDistalJoint"
+* "RingTip"
+* "PinkyMetacarpal"
+* "PinkyKnuckle"
+* "PinkyMiddleJoint"
+* "PinkyDistalJoint"
+* "PinkyTip"
+* "None"
+
+The position of the nodes in the scene hierarchy does not matter. The exporter will group hand nodes under a common parent node for convenience, but any node with a matching name will be recognized by the importer.

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -54,6 +54,8 @@
   - name: Input Animation Recording
     href: InputSimulation/InputAnimationRecording.md
     items:
+    - name: Input Animation glTF File Structure
+      href: InputSimulation/InputAnimationGltfStructure.md
     - name: Input Animation File Format Specification
       href: InputSimulation/InputAnimationFileFormat.md
   - name: UX Building Blocks


### PR DESCRIPTION
## Overview

Add export and import of input animation data to and from glTF files.
This supplements (and should ultimately replace) the custom binary format, and provides a standardized way to exchange recorded input data with other tools.

A new set of utility classes has been added to serialize `InputAnimation` curves into a binary buffer suitable for glTF accessors. The existing GltfObject in MRTK is constructed with simple nodes that represent the camera and hand controllers. A matching importer finds matching nodes in any glTF file to try and interpret the animation data as MRTK input again.

The Unity JsonUtility class is not flexible enough to handle details of the glTF schema, such as minimum array length, or whether enums should be exported by name or by int value. For this reason an alternative JSON builder and parser pair has been added. These can handle JsonAttributes, which specify schema details as part of the C# reflection, so that the GltfObject can still be exported as "structured JSON".
