### PR TITLE
Fix VisualProfilerControl.ToggleProfiler implementation

### DIFF
--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/VisualProfilerControl.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/VisualProfilerControl.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         {
             if (DiagnosticsSystem != null)
             {
-                DiagnosticsSystem.ShowDiagnostics = !DiagnosticsSystem.ShowDiagnostics;
+                DiagnosticsSystem.ShowProfiler = !DiagnosticsSystem.ShowProfiler;
             }
         }
 


### PR DESCRIPTION
The VisualProfilerControl script's ToggleProfiler method was toggling all diagnostics, rather than just the profiler. While today there is only a single diagnostic that is controlled by ToggleDiagnostics, in the future, it is anticipated that additional displays (ex: debug panel, individual control of the profiler's settings, etc) will be added.