### PR TITLE
Fixed far interaction movement in ManipulationHandler

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -219,15 +219,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return (pointer is IMixedRealityNearPointer);
             }
 
-            public Vector3 GetPositionAtGrabPoint()
+            /// Returns the grab point on the manipulated object in world space
+            public Vector3 GrabPoint
             {
-                if (IsNearPointer())
+                get
                 {
-                    return pointer.Position;
-                }
-                else
-                {
-                    return (pointer.Rotation * initialGrabPointInPointer) + pointer.Position;
+                    if (IsNearPointer())
+                    {
+                        return pointer.Position;
+                    }
+                    else
+                    {
+                        return (pointer.Rotation * initialGrabPointInPointer) + pointer.Position;
+                    }
                 }
             }
         }
@@ -285,7 +289,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             int count = 0;
             foreach (var p in pointerIdToPointerMap.Values)
             {
-                sum += p.GetPositionAtGrabPoint();
+                sum += p.GrabPoint;
                 count++;
             }
             return sum / Math.Max(1, count);
@@ -619,7 +623,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else
             {
-                targetPosition = moveLogic.Update(pointerData.GetPositionAtGrabPoint(), IsNearManipulation());
+                targetPosition = moveLogic.Update(pointerData.GrabPoint, IsNearManipulation());
             }
 
             float lerpAmount = GetLerpAmount();
@@ -653,7 +657,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Assert.IsTrue(pointerIdToPointerMap.Count == 1);
             PointerData pointerData = GetFirstPointer();
             IMixedRealityPointer pointer = pointerData.pointer;
-            moveLogic.Setup(pointerData.GetPositionAtGrabPoint(), hostTransform.position);
+            moveLogic.Setup(pointerData.GrabPoint, hostTransform.position);
 
             // Calculate relative transform from object to hand.
             Quaternion worldToPalmRotation = Quaternion.Inverse(pointer.Rotation);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -199,7 +199,35 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private TwoHandMoveLogic moveLogic;
         private TwoHandScaleLogic scaleLogic;
         private TwoHandRotateLogic rotateLogic;
-        private Dictionary<uint, IMixedRealityPointer> pointerIdToPointerMap = new Dictionary<uint, IMixedRealityPointer>();
+        private struct PointerData
+        {
+            public IMixedRealityPointer pointer;
+            private Vector3 initialGrabPointInPointer;
+
+            public PointerData(IMixedRealityPointer pointer, Vector3 initialGrabPointInPointer) : this()
+            {
+                this.pointer = pointer;
+                this.initialGrabPointInPointer = initialGrabPointInPointer;
+            }
+
+            public bool IsNearPointer()
+            {
+                return (pointer is IMixedRealityNearPointer);
+            }
+
+            public Vector3 GetPositionAtGrabPoint()
+            {
+                if (IsNearPointer())
+                {
+                    return pointer.Position;
+                }
+                else
+                {
+                    return (pointer.Rotation * initialGrabPointInPointer) + pointer.Position;
+                }
+            }
+        }
+        private Dictionary<uint, PointerData> pointerIdToPointerMap = new Dictionary<uint, PointerData>();
         private Quaternion objectToHandRotation;
         private Vector3 objectToHandTranslation;
         private bool isNearManipulation;
@@ -253,7 +281,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             int count = 0;
             foreach (var p in pointerIdToPointerMap.Values)
             {
-                sum += p.Position;
+                sum += p.GetPositionAtGrabPoint();
                 count++;
             }
             return sum / Math.Max(1, count);
@@ -266,10 +294,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             foreach (var p in pointerIdToPointerMap.Values)
             {
                 // Check pointer has a valid controller (e.g. gaze pointer doesn't)
-                if (p.Controller != null)
+                if (p.pointer.Controller != null)
                 {
                     numControllers++;
-                    sum += p.Controller.Velocity;
+                    sum += p.pointer.Controller.Velocity;
                 }
             }
             return sum / Math.Max(1, numControllers);
@@ -282,10 +310,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             foreach (var p in pointerIdToPointerMap.Values)
             {
                 // Check pointer has a valid controller (e.g. gaze pointer doesn't)
-                if (p.Controller != null)
+                if (p.pointer.Controller != null)
                 {
                     numControllers++;
-                    sum += p.Controller.AngularVelocity;
+                    sum += p.pointer.Controller.AngularVelocity;
                 }
             }
             return sum / Math.Max(1, numControllers);
@@ -295,7 +323,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             foreach (var item in pointerIdToPointerMap)
             {
-                if (item.Value is IMixedRealityNearPointer)
+                if (item.Value.IsNearPointer())
                 {
                     return true;
                 }
@@ -455,7 +483,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                             rigidBody.isKinematic = true;
                         }
                     }
-                    pointerIdToPointerMap.Add(id, eventData.Pointer);
+
+                    // cache start ptr grab point
+                    Vector3 initialGrabPoint = Quaternion.Inverse(eventData.Pointer.Rotation) * (eventData.Pointer.Result.Details.Point - eventData.Pointer.Position);
+                    pointerIdToPointerMap.Add(id, new PointerData(eventData.Pointer, initialGrabPoint));
 
                     UpdateStateMachine();
                 }
@@ -530,7 +561,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void HandleOneHandMoveUpdated()
         {
             Debug.Assert(pointerIdToPointerMap.Count == 1);
-            IMixedRealityPointer pointer = GetFirstPointer();
+            PointerData pointerData = GetFirstPointer();
+            IMixedRealityPointer pointer = pointerData.pointer;
 
             Quaternion targetRotation = Quaternion.identity;
             RotateInOneHandType rotateInOneHandType = isNearManipulation ? oneHandRotationModeNear : oneHandRotationModeFar;
@@ -583,7 +615,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else
             {
-                targetPosition = moveLogic.Update(GetPointersCentroid(), IsNearManipulation());
+                targetPosition = moveLogic.Update(pointerData.GetPositionAtGrabPoint(), IsNearManipulation());
             }
 
             float lerpAmount = GetLerpAmount();
@@ -615,9 +647,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void HandleOneHandMoveStarted()
         {
             Assert.IsTrue(pointerIdToPointerMap.Count == 1);
-            IMixedRealityPointer pointer = GetFirstPointer();
-
-            moveLogic.Setup(GetPointersCentroid(), hostTransform.position);
+            PointerData pointerData = GetFirstPointer();
+            IMixedRealityPointer pointer = pointerData.pointer;
+            moveLogic.Setup(pointerData.GetPositionAtGrabPoint(), hostTransform.position);
 
             // Calculate relative transform from object to hand.
             Quaternion worldToPalmRotation = Quaternion.Inverse(pointer.Rotation);
@@ -696,7 +728,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             var handPositionMap = new Dictionary<uint, Vector3>();
             foreach (var item in pointerIdToPointerMap)
             {
-                handPositionMap.Add(item.Key, item.Value.Position);
+                handPositionMap.Add(item.Key, item.Value.pointer.Position);
             }
             return handPositionMap;
         }
@@ -758,7 +790,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
-        private IMixedRealityPointer GetFirstPointer()
+        private PointerData GetFirstPointer()
         {
             // We may be able to do this without allocating memory.
             // Moving to a method for later investigation.

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -199,6 +199,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private TwoHandMoveLogic moveLogic;
         private TwoHandScaleLogic scaleLogic;
         private TwoHandRotateLogic rotateLogic;
+        /// <summary>
+        /// Holds the pointer and the initial intersection point of the pointer ray 
+        /// with the object on pointer down in pointer space
+        /// </summary>
         private struct PointerData
         {
             public IMixedRealityPointer pointer;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -17,6 +17,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
+using System;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
@@ -166,7 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
 
-            Object.Destroy(testObject);
+            GameObject.Destroy(testObject);
         }
 
 
@@ -203,7 +204,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestHand hand = new TestHand(Handedness.Right);
 
             // do this test for every one hand rotation mode
-            for (ManipulationHandler.RotateInOneHandType type = ManipulationHandler.RotateInOneHandType.MaintainRotationToUser; type <= ManipulationHandler.RotateInOneHandType.RotateAboutGrabPoint; ++type)
+            foreach (ManipulationHandler.RotateInOneHandType type in Enum.GetValues(typeof(ManipulationHandler.RotateInOneHandType)))
             {
                 manipHandler.OneHandRotationModeNear = type;
 
@@ -284,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestHand hand = new TestHand(Handedness.Right);     
 
             // do this test for every one hand rotation mode
-            for (ManipulationHandler.RotateInOneHandType type = ManipulationHandler.RotateInOneHandType.MaintainRotationToUser; type <= ManipulationHandler.RotateInOneHandType.RotateAboutGrabPoint; ++type)
+            foreach (ManipulationHandler.RotateInOneHandType type in Enum.GetValues(typeof(ManipulationHandler.RotateInOneHandType)))
             {
                 // TODO: grab point is moving in this test and has to be covered by a different test
                 if (type == ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -253,7 +253,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// This tests the one hand far movement while camera (character) is moving around.
         /// The test will check the offset between object pivot and grab point and make sure we're not drifting
-        /// out of the object on pointer rotation - this test should be the same in all rotation setups
+        /// out of the object on pointer rotation - this test will only work for far interaction rotation modes that 
+        /// aren't influenced by moving the object in space - rotation modes that rotate the cube while moving will cause 
+        /// the pointer grab point to rotate as well and therefor return a different result
         /// </summary>
         /// <returns></returns>
         [UnityTest]
@@ -285,7 +287,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // do this test for every one hand rotation mode
             for (ManipulationHandler.RotateInOneHandType type = ManipulationHandler.RotateInOneHandType.MaintainRotationToUser; type <= ManipulationHandler.RotateInOneHandType.RotateAboutGrabPoint; ++type)
             {
-                manipHandler.OneHandRotationModeNear = type;
+                // skip far interaction modes that would influence the orientation of the cube in move mode
+                // these modes will be covered in tests specific to this type of rotation behavior
+                if (type == ManipulationHandler.RotateInOneHandType.FaceUser || 
+                    type == ManipulationHandler.RotateInOneHandType.FaceAwayFromUser || 
+                    type == ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation)
+                {
+                    continue;
+                }
+
+                manipHandler.OneHandRotationModeFar = type;
 
                 TestUtilities.PlayspaceToOriginLookingForward();
 


### PR DESCRIPTION
## Overview
Manipulationhandler movement for both one and two hand far interaction would only take pointer position into account instead of the point where the pointer ray hits the object for grabbing.

## Changes
- Fixes: #4399 


## Verification
- added test for far interaction movement: moves cube 360 degree around player and makes sure the pointer ray stays on the same position on the cube
- tested in editor hand simulation, far and near interaction
- tested with WMR controllers far and near interaction
- tested on Hololens 2 far and near interaction