### PR TITLE
Removes dependencies on individual service binaries from service inspectors

### DIFF
--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -130,26 +130,6 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <inheritdoc />
         public string SourceName { get; } = "Mixed Reality Scene System";
 
-        /// <summary>
-        /// Returns the manager scene found in profile.
-        /// </summary>
-        public SceneInfo ManagerScene => profile.ManagerScene;
-
-        /// <summary>
-        /// Returns all lighting scenes found in profile.
-        /// </summary>
-        public SceneInfo[] LightingScenes => contentTracker.SortedLightingScenes;
-
-        /// <summary>
-        /// Returns all content scenes found in profile.
-        /// </summary>
-        public SceneInfo[] ContentScenes => contentTracker.SortedContentScenes;
-
-        /// <summary>
-        /// Returns all content tags found in profile scenes.
-        /// </summary>
-        public IEnumerable<string> ContentTags => profile.ContentTags;
-
         #endregion
 
         #region Service Methods

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -334,7 +334,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             List<string> lightingSceneNames = new List<string>();
             // Create a list of lighting scenes to unload
-            foreach (SceneInfo lso in LightingScenes)
+            foreach (SceneInfo lso in profile.LightingScenes)
             {
                 if (lso.Name != newLightingSceneName)
                 {
@@ -786,7 +786,8 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         public Scene GetScene(string sceneName)
         {
             Scene scene = default(Scene);
-            RuntimeSceneUtils.FindScene(sceneName, out scene, out int sceneIndex);
+            int sceneIndex;
+            RuntimeSceneUtils.FindScene(sceneName, out scene, out sceneIndex);
             return scene;
         }
 

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -296,8 +296,6 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <inheritdoc />
         public async void SetLightingScene(string newLightingSceneName, LightingSceneTransitionType transitionType = LightingSceneTransitionType.None, float transitionDuration = 1f)
         {
-            Debug.Log("Set lighting scene: " + newLightingSceneName);
-
             if (ActiveLightingScene == newLightingSceneName)
             {   // Nothing to do here
                 return;

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// The default implementation of the <see cref="Microsoft.MixedReality.Toolkit.SceneSystem.IMixedRealitySceneSystem"/>
     /// This file handles the editor-oriented parts of the service.
     /// </summary>
-    public partial class MixedRealitySceneSystem : BaseCoreSystem, IMixedRealitySceneSystem
+    public partial class MixedRealitySceneSystem : BaseCoreSystem, IMixedRealitySceneSystem, IMixedRealitySceneSystemEditor
     {
 
 #if UNITY_EDITOR
@@ -38,6 +38,26 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 return paths;
             }
         }
+
+        /// <summary>
+        /// Returns the manager scene found in profile.
+        /// </summary>
+        public SceneInfo ManagerScene => profile.ManagerScene;
+
+        /// <summary>
+        /// Returns all lighting scenes found in profile.
+        /// </summary>
+        public SceneInfo[] LightingScenes => contentTracker.SortedLightingScenes;
+
+        /// <summary>
+        /// Returns all content scenes found in profile.
+        /// </summary>
+        public SceneInfo[] ContentScenes => contentTracker.SortedContentScenes;
+
+        /// <summary>
+        /// Returns all content tags found in profile scenes.
+        /// </summary>
+        public IEnumerable<string> ContentTags => profile.ContentTags;
 
         // Cache these so we're not looking them up constantly
         private EditorBuildSettingsScene[] cachedBuildScenes = new EditorBuildSettingsScene[0];
@@ -499,14 +519,13 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                     {
                         // This can happen if the scene isn't valid
                         // Not an issue - we'll take care of it on the next update.
+                        return;
                     }
 
                     if (!foundToolkitInstance)
                     {
                         GameObject mrtkGo = new GameObject("MixedRealityToolkit");
                         MixedRealityToolkit toolkitInstance = mrtkGo.AddComponent<MixedRealityToolkit>();
-                        // Set the config profile to use the same profile as the current instance
-                        toolkitInstance.ActiveProfile = MixedRealityToolkit.Instance.ActiveProfile;
 
                         try
                         {

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -17,15 +17,29 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         private static List<Transform> childrenToDelete = new List<Transform>();
         private static List<IMixedRealityService> servicesToSort = new List<IMixedRealityService>();
         private static MixedRealityToolkit previousActiveInstance;
+        private static long previousFrameCount;
 
         static MixedRealityToolkitFacadeHandler()
         {
 #if UNITY_2019_1_OR_NEWER
-            SceneView.duringSceneGui += UpdateServiceFacades;
+            SceneView.duringSceneGui += OnSceneGUI;
 #else
-            SceneView.onSceneGUIDelegate += UpdateServiceFacades;
+            SceneView.onSceneGUIDelegate += OnSceneGUI;
 #endif
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            EditorApplication.update += OnUpdate;
+        }
+
+        #region callbacks
+
+        private static void OnSceneGUI(SceneView sceneView)
+        {
+            UpdateServiceFacades();
+        }
+
+        private static void OnUpdate()
+        {
+            UpdateServiceFacades();
         }
 
         [UnityEditor.Callbacks.DidReloadScripts]
@@ -48,7 +62,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             previousActiveInstance = null;
         }
 
-        private static void UpdateServiceFacades(SceneView sceneView)
+        #endregion
+
+        private static void UpdateServiceFacades()
         {
             if (!MixedRealityToolkit.IsInitialized)
             {   // Nothing to do here.
@@ -59,6 +75,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             {   // Wait for compilation to complete before creating or destroying facades
                 return;
             }
+
+            if (Application.isPlaying && Time.frameCount == previousFrameCount)
+            {   // Only update once per frame (SceneGUI + Update may result in multiple calls)
+                return;
+            }
+
+            previousFrameCount = Time.frameCount;
 
             if (previousActiveInstance != null && MixedRealityToolkit.Instance != previousActiveInstance)
             {   // We've changed active instances. Destroy all children in the previous instance.

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/FocusProviderInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/FocusProviderInspector.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
-    [MixedRealityServiceInspector(typeof(FocusProvider))]
+    [MixedRealityServiceInspector(typeof(IMixedRealityFocusProvider))]
     public class FocusProviderInspector : BaseMixedRealityServiceInspector
     {
         private static readonly Color enabledColor = GUI.backgroundColor;

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/Microsoft.MixedReality.Toolkit.Editor.ServiceInspectors.asmdef
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/Microsoft.MixedReality.Toolkit.Editor.ServiceInspectors.asmdef
@@ -5,12 +5,7 @@
         "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit.Editor.ClassExtensions",
         "Microsoft.MixedReality.Toolkit.Editor.Inspectors",
-        "Microsoft.MixedReality.Toolkit.Editor.Utilities",
-        "Microsoft.MixedReality.Toolkit.Services.BoundarySystem",
-        "Microsoft.MixedReality.Toolkit.Services.InputSystem",
-        "Microsoft.MixedReality.Toolkit.Services.SceneSystem",
-        "Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem",
-        "Microsoft.MixedReality.Toolkit.Services.TeleportSystem"
+        "Microsoft.MixedReality.Toolkit.Editor.Utilities"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.SceneSystem;
-using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -11,7 +10,7 @@ using UnityEngine.SceneManagement;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
-    [MixedRealityServiceInspector(typeof(MixedRealitySceneSystem))]
+    [MixedRealityServiceInspector(typeof(IMixedRealitySceneSystem))]
     public class SceneSystemInspector : BaseMixedRealityServiceInspector
     {
         private const float maxLoadButtonWidth = 50;
@@ -31,7 +30,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void DrawInspectorGUI(object target)
         {
-            MixedRealitySceneSystem sceneSystem = (MixedRealitySceneSystem)target;
+            IMixedRealitySceneSystem sceneSystem = (IMixedRealitySceneSystem)target;
+            IMixedRealitySceneSystemEditor sceneSystemEditor = (IMixedRealitySceneSystemEditor)target;
+
+            if (sceneSystemEditor == null)
+            {
+                EditorGUILayout.HelpBox("This scene service implementation does not implement IMixedRealitySceneSystemEditor. Inspector will not be rendered.", MessageType.Info);
+                return;
+            }
 
             GUI.color = enabledColor;
 
@@ -40,14 +46,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (profile.UseLightingScene)
             {
                 EditorGUILayout.LabelField("Lighting Scene", EditorStyles.boldLabel);
-                List<SceneInfo> lightingScenes = new List<SceneInfo>(sceneSystem.LightingScenes);
+                List<SceneInfo> lightingScenes = new List<SceneInfo>(sceneSystemEditor.LightingScenes);
                 if (lightingScenes.Count == 0)
                 {
                     EditorGUILayout.LabelField("(No lighting scenes found)", EditorStyles.miniLabel);
                 }
                 else
                 {
-                    RenderLightingScenes(sceneSystem, lightingScenes);
+                    RenderLightingScenes(sceneSystem, sceneSystemEditor, lightingScenes);
                 }
                 EditorGUILayout.Space();
             }
@@ -55,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUI.color = enabledColor;
 
             EditorGUILayout.LabelField("Content Scenes", EditorStyles.boldLabel);
-            List<SceneInfo> contentScenes = new List<SceneInfo>(sceneSystem.ContentScenes);
+            List<SceneInfo> contentScenes = new List<SceneInfo>(sceneSystemEditor.ContentScenes);
             if (contentScenes.Count == 0)
             {
                 EditorGUILayout.LabelField("(No content scenes found)", EditorStyles.miniLabel);
@@ -88,14 +94,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
 
                 EditorGUI.BeginDisabledGroup(sceneSystem.SceneOperationInProgress);
-                RenderContentScenes(sceneSystem, contentScenes);
+                RenderContentScenes(sceneSystem, sceneSystemEditor, contentScenes);
                 EditorGUI.EndDisabledGroup();
             }
 
             EditorGUILayout.Space();
         }
 
-        private void RenderLightingScenes(MixedRealitySceneSystem sceneSystem, List<SceneInfo> lightingScenes)
+        private void RenderLightingScenes(IMixedRealitySceneSystem sceneSystem, IMixedRealitySceneSystemEditor sceneSystemEditor, List<SceneInfo> lightingScenes)
         {
             EditorGUILayout.HelpBox("Select the active lighting scene by clicking its name.", MessageType.Info);
 
@@ -136,12 +142,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.EndVertical();
         }
 
-        private void RenderContentScenes(MixedRealitySceneSystem sceneSystem, List<SceneInfo> contentScenes)
+        private void RenderContentScenes(IMixedRealitySceneSystem sceneSystem, IMixedRealitySceneSystemEditor sceneSystemEditor, List<SceneInfo> contentScenes)
         {
             EditorGUILayout.Space();
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Load / Unload by tag", EditorStyles.miniBoldLabel);
-            List<string> contentTags = new List<string>(sceneSystem.ContentTags);
+            List<string> contentTags = new List<string>(sceneSystemEditor.ContentTags);
 
             if (contentTags.Count == 0)
             {
@@ -164,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         }
                         else
                         {
-                            foreach (SceneInfo contentScene in sceneSystem.ContentScenes)
+                            foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
                             {
                                 if (contentScene.Tag == tag)
                                 {
@@ -181,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         }
                         else
                         {
-                            foreach (SceneInfo contentScene in sceneSystem.ContentScenes)
+                            foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
                             {
                                 if (contentScene.Tag == tag)
                                 {
@@ -209,7 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
                 else
                 {
-                    sceneSystem.EditorLoadPrevContent();
+                    sceneSystemEditor.EditorLoadPrevContent();
                 }
             }
             EditorGUI.EndDisabledGroup();
@@ -223,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
                 else
                 {
-                    sceneSystem.EditorLoadNextContent();
+                    sceneSystemEditor.EditorLoadNextContent();
                 }
             }
             EditorGUI.EndDisabledGroup();
@@ -232,7 +238,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Load / Unload individually", EditorStyles.miniBoldLabel);
-            foreach (SceneInfo contentScene in sceneSystem.ContentScenes)
+            foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
             {
                 if (contentScene.IsEmpty)
                 {
@@ -273,17 +279,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
-        private async void ServiceContentLoadNext(MixedRealitySceneSystem sceneSystem)
+        private async void ServiceContentLoadNext(IMixedRealitySceneSystem sceneSystem)
         {
             await sceneSystem.LoadNextContent(false, LoadSceneMode.Single, activationToken);
         }
 
-        private async void ServiceContentLoadPrev(MixedRealitySceneSystem sceneSystem)
+        private async void ServiceContentLoadPrev(IMixedRealitySceneSystem sceneSystem)
         {
             await sceneSystem.LoadPrevContent(false, LoadSceneMode.Single, activationToken);
         }
 
-        private async void ServiceContentLoadByTag(MixedRealitySceneSystem sceneSystem, string tag)
+        private async void ServiceContentLoadByTag(IMixedRealitySceneSystem sceneSystem, string tag)
         {
             if (requireActivationToken)
             {
@@ -293,12 +299,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             await sceneSystem.LoadContentByTag(tag, loadSceneMode, activationToken);
         }
 
-        private async void ServiceContentUnloadByTag(MixedRealitySceneSystem sceneSystem, string tag)
+        private async void ServiceContentUnloadByTag(IMixedRealitySceneSystem sceneSystem, string tag)
         {
             await sceneSystem.UnloadContentByTag(tag);
         }
 
-        private async void ServiceContentLoad(MixedRealitySceneSystem sceneSystem, string sceneName)
+        private async void ServiceContentLoad(IMixedRealitySceneSystem sceneSystem, string sceneName)
         {
             if (requireActivationToken)
             {
@@ -308,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             await sceneSystem.LoadContent(sceneName, loadSceneMode, activationToken);
         }
 
-        private async void ServiceContentUnload(MixedRealitySceneSystem sceneSystem, string sceneName)
+        private async void ServiceContentUnload(IMixedRealitySceneSystem sceneSystem, string sceneName)
         {
             await sceneSystem.UnloadContent(sceneName);
         }

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         public override void DrawInspectorGUI(object target)
         {
             IMixedRealitySceneSystem sceneSystem = (IMixedRealitySceneSystem)target;
-            IMixedRealitySceneSystemEditor sceneSystemEditor = (IMixedRealitySceneSystemEditor)target;
+            IMixedRealitySceneSystemEditor sceneSystemEditor = target as IMixedRealitySceneSystemEditor;
 
             if (sceneSystemEditor == null)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
@@ -30,7 +30,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void DrawInspectorGUI(object target)
         {
-            IMixedRealitySceneSystem sceneSystem = (IMixedRealitySceneSystem)target;
+            // Get the scene system itself
+            IMixedRealitySceneSystem sceneSystem = target as IMixedRealitySceneSystem;
+            // Get the scene system's editor interface
             IMixedRealitySceneSystemEditor sceneSystemEditor = target as IMixedRealitySceneSystemEditor;
 
             if (sceneSystemEditor == null)

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
@@ -168,9 +168,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             }
             return false;
         }
-               
+
         /// <summary>
-        /// Draws the custom inspector gui for service type.
+        /// Draws the custom inspector gui for all of the service's interfaces that have custom inspectors.
         /// </summary>
         /// <param name="facade"></param>
         /// <returns></returns>
@@ -190,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         }
 
         /// <summary>
-        /// Draws the profile for the service type, if wanted by inspector and found.
+        /// Draws the profile for all of the service's interfaces that have custom inspectors, if wanted by inspector and found.
         /// </summary>
         /// <param name="serviceType"></param>
         /// <returns></returns>
@@ -342,7 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             foreach (Type interfaceType in facade.ServiceType.GetInterfaces())
             {
                 IMixedRealityServiceInspector inspectorInstance;
-                if (GetServiceInspectorInstance(facade.ServiceType, out inspectorInstance))
+                if (GetServiceInspectorInstance(interfaceType, out inspectorInstance))
                 {
                     // If we've implemented a facade inspector, draw gizmos now
                     inspectorInstance.DrawGizmos(facade.Service);
@@ -376,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
                 foreach (Type interfaceType in inspectorTypePair.Key.GetInterfaces())
                 {
                     IMixedRealityServiceInspector inspectorInstance;
-                    if (!GetServiceInspectorInstance(inspectorTypePair.Key, out inspectorInstance))
+                    if (!GetServiceInspectorInstance(interfaceType, out inspectorInstance))
                     {
                         continue;
                     }
@@ -392,15 +392,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         /// <summary>
         /// Gets an instance of the service type. Returns false if no instance is found.
         /// </summary>
-        /// <param name="serviceType"></param>
+        /// <param name="interfaceType"></param>
         /// <param name="inspectorInstance"></param>
         /// <returns></returns>
-        private static bool GetServiceInspectorInstance(Type serviceType, out IMixedRealityServiceInspector inspectorInstance)
+        private static bool GetServiceInspectorInstance(Type interfaceType, out IMixedRealityServiceInspector inspectorInstance)
         {
             inspectorInstance = null;
 
             Type inspectorType;
-            if (inspectorTypeLookup.TryGetValue(serviceType, out inspectorType))
+            if (inspectorTypeLookup.TryGetValue(interfaceType, out inspectorType))
             {
                 if (!inspectorInstanceLookup.TryGetValue(inspectorType, out inspectorInstance))
                 {

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
@@ -176,13 +176,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         /// <returns></returns>
         private bool DrawInspector(ServiceFacade facade)
         {
-            IMixedRealityServiceInspector inspectorInstance;
-            if (GetServiceInspectorInstance(facade.ServiceType, out inspectorInstance))
+            bool drewInspector = false;
+            foreach (Type interfaceType in facade.ServiceType.GetInterfaces())
             {
-                inspectorInstance.DrawInspectorGUI(facade.Service);
-                return true;
+                IMixedRealityServiceInspector inspectorInstance;
+                if (GetServiceInspectorInstance(interfaceType, out inspectorInstance))
+                {
+                    inspectorInstance.DrawInspectorGUI(facade.Service);
+                    drewInspector = true;
+                }
             }
-            return false;
+            return drewInspector;
         }
 
         /// <summary>
@@ -192,13 +196,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         /// <returns></returns>
         private bool DrawProfile(Type serviceType)
         {
-            IMixedRealityServiceInspector inspectorInstance;
-            if (GetServiceInspectorInstance(serviceType, out inspectorInstance))
+            bool drawProfileField = true;
+            foreach (Type interfaceType in serviceType.GetInterfaces())
             {
-                if (!inspectorInstance.DrawProfileField)
-                {   // We've been instructed to skip drawing a profile by the inspector
-                    return false;
+                IMixedRealityServiceInspector inspectorInstance;
+                if (GetServiceInspectorInstance(interfaceType, out inspectorInstance))
+                {
+                    drawProfileField &= inspectorInstance.DrawProfileField;
                 }
+            }
+
+            if (!drawProfileField)
+            {   // We've been instructed to skip drawing a profile by the inspector
+                return false;
             }
 
             bool foundAndDrewProfile = false;
@@ -329,14 +339,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             InitializeServiceInspectorLookup();
 
             // Find and draw the custom inspector
-            IMixedRealityServiceInspector inspectorInstance;
-            if (!GetServiceInspectorInstance(facade.ServiceType, out inspectorInstance))
+            foreach (Type interfaceType in facade.ServiceType.GetInterfaces())
             {
-                return;
+                IMixedRealityServiceInspector inspectorInstance;
+                if (GetServiceInspectorInstance(facade.ServiceType, out inspectorInstance))
+                {
+                    // If we've implemented a facade inspector, draw gizmos now
+                    inspectorInstance.DrawGizmos(facade.Service);
+                }
             }
-
-            // If we've implemented a facade inspector, draw gizmos now
-            inspectorInstance.DrawGizmos(facade.Service);
         }
 
         /// <summary>
@@ -362,15 +373,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
                     continue;
                 }
 
-                IMixedRealityServiceInspector inspectorInstance;
-                if (!GetServiceInspectorInstance(inspectorTypePair.Key, out inspectorInstance))
+                foreach (Type interfaceType in inspectorTypePair.Key.GetInterfaces())
                 {
-                    continue;
-                }
+                    IMixedRealityServiceInspector inspectorInstance;
+                    if (!GetServiceInspectorInstance(inspectorTypePair.Key, out inspectorInstance))
+                    {
+                        continue;
+                    }
 
-                if (Selection.Contains(facade) || inspectorInstance.AlwaysDrawSceneGUI)
-                {
-                    inspectorInstance.DrawSceneGUI(facade.Service, sceneView);
+                    if (Selection.Contains(facade) || inspectorInstance.AlwaysDrawSceneGUI)
+                    {
+                        inspectorInstance.DrawSceneGUI(facade.Service, sceneView);
+                    }
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SpatialAwarenessSystemInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SpatialAwarenessSystemInspector.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
-    [MixedRealityServiceInspector(typeof(MixedRealitySpatialAwarenessSystem))]
+    [MixedRealityServiceInspector(typeof(IMixedRealitySpatialAwarenessSystem))]
     public class SpatialAwarenessSystemInspector : BaseMixedRealityServiceInspector
     {
         private const string ShowObserverBoundaryKey = "MRTK_SpatialAwarenessSystemInspector_ShowObserverBoundaryKey";
@@ -26,11 +26,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         
         public override void DrawInspectorGUI(object target)
         {
-            MixedRealitySpatialAwarenessSystem spatial = (MixedRealitySpatialAwarenessSystem)target;
+            IMixedRealitySpatialAwarenessSystem spatial = (IMixedRealitySpatialAwarenessSystem)target;
+            IMixedRealityDataProviderAccess dataProviderAccess = (IMixedRealityDataProviderAccess)spatial;
 
             EditorGUILayout.LabelField("Observers", EditorStyles.boldLabel);
             int observerIndex = 0;
-            foreach (IMixedRealitySpatialAwarenessObserver observer in spatial.GetObservers())
+            foreach (IMixedRealitySpatialAwarenessObserver observer in dataProviderAccess.GetDataProviders())
             {
                 GUI.color = observer.IsRunning ? enabledColor : disabledColor;
 
@@ -88,10 +89,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 return;
             }
 
-            MixedRealitySpatialAwarenessSystem spatial = (MixedRealitySpatialAwarenessSystem)target;
+            IMixedRealitySpatialAwarenessSystem spatial = (IMixedRealitySpatialAwarenessSystem)target;
+            IMixedRealityDataProviderAccess dataProviderAccess = (IMixedRealityDataProviderAccess)spatial;
 
             int observerIndex = 0;
-            foreach (IMixedRealitySpatialAwarenessObserver observer in spatial.GetObservers())
+            foreach (IMixedRealitySpatialAwarenessObserver observer in dataProviderAccess.GetDataProviders())
             {
                 Gizmos.color = GetObserverColor(observerIndex);
 

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/TeleportSystemInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/TeleportSystemInspector.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
-    [MixedRealityServiceInspector(typeof(MixedRealityTeleportSystem))]
+    [MixedRealityServiceInspector(typeof(IMixedRealityTeleportSystem))]
     public class TeleportSystemInspector : BaseMixedRealityServiceInspector
     {
         private static readonly Color enabledColor = GUI.backgroundColor;
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void DrawInspectorGUI(object target)
         {
-            MixedRealityTeleportSystem teleport = (MixedRealityTeleportSystem)target;
+            IMixedRealityTeleportSystem teleport = (IMixedRealityTeleportSystem)target;
 
             EditorGUILayout.LabelField("Event Listeners", EditorStyles.boldLabel);
 

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
@@ -29,13 +29,13 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         SceneInfo[] LightingScenes { get; }
 
         /// <summary>
-        /// Loads the next content scene in-editor. Use instead of LoadNextContent while not in play mode.
+        /// Loads the next content scene in-editor. Use instead of IMixedRealitySceneSystem.LoadNextContent while not in play mode.
         /// </summary>
         /// <param name="wrap"></param>
         void EditorLoadNextContent(bool wrap = false);
 
         /// <summary>
-        /// Loads the prev content scene in-editor. Use instead of LoadPrevContent while not in play mode.
+        /// Loads the prev content scene in-editor. Use instead of IMixedRealitySceneSystem.LoadPrevContent while not in play mode.
         /// </summary>
         /// <param name="wrap"></param>
         void EditorLoadPrevContent(bool wrap = false);

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.MixedReality.Toolkit.SceneSystem;
 
 namespace Microsoft.MixedReality.Toolkit.SceneSystem
 {
@@ -31,13 +30,13 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <summary>
         /// Loads the next content scene in-editor. Use instead of IMixedRealitySceneSystem.LoadNextContent while not in play mode.
         /// </summary>
-        /// <param name="wrap"></param>
+        /// <param name="wrap">If true, if the current scene is the LAST content scene, the FIRST content scene will be loaded.</param>
         void EditorLoadNextContent(bool wrap = false);
 
         /// <summary>
         /// Loads the prev content scene in-editor. Use instead of IMixedRealitySceneSystem.LoadPrevContent while not in play mode.
         /// </summary>
-        /// <param name="wrap"></param>
+        /// <param name="wrap">If true, if the current scene is the FIRST content scene, the LAST content scene will be loaded.</param>
         void EditorLoadPrevContent(bool wrap = false);
 #endif
     }

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.MixedReality.Toolkit.SceneSystem;
+
+/// <summary>
+/// Optional editor-only interface for use with facade inspectors.
+/// If a scene system service does not implement this interface, the facade will not be rendered.
+/// </summary>
+public interface IMixedRealitySceneSystemEditor
+{
+#if UNITY_EDITOR
+    /// <summary>
+    /// Returns all content scene tags in the scene service profile.
+    /// </summary>
+    IEnumerable<string> ContentTags { get; }
+
+    /// <summary>
+    /// Returns the content scenes in the scene service profile.
+    /// </summary>
+    SceneInfo[] ContentScenes { get; }
+
+    /// <summary>
+    ///  Returns the lighting scenes in the scene service profile.
+    /// </summary>
+    SceneInfo[] LightingScenes { get; }
+    
+    /// <summary>
+    /// Loads the next content scene in-editor. Use instead of LoadNextContent while not in play mode.
+    /// </summary>
+    /// <param name="wrap"></param>
+    void EditorLoadNextContent(bool wrap = false);
+
+    /// <summary>
+    /// Loads the prev content scene in-editor. Use instead of LoadPrevContent while not in play mode.
+    /// </summary>
+    /// <param name="wrap"></param>
+    void EditorLoadPrevContent(bool wrap = false);
+#endif
+}

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs
@@ -4,38 +4,41 @@
 using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.SceneSystem;
 
-/// <summary>
-/// Optional editor-only interface for use with facade inspectors.
-/// If a scene system service does not implement this interface, the facade will not be rendered.
-/// </summary>
-public interface IMixedRealitySceneSystemEditor
+namespace Microsoft.MixedReality.Toolkit.SceneSystem
 {
+    /// <summary>
+    /// Optional editor-only interface for use with facade inspectors.
+    /// If a scene system service does not implement this interface, the facade will not be rendered.
+    /// </summary>
+    public interface IMixedRealitySceneSystemEditor
+    {
 #if UNITY_EDITOR
-    /// <summary>
-    /// Returns all content scene tags in the scene service profile.
-    /// </summary>
-    IEnumerable<string> ContentTags { get; }
+        /// <summary>
+        /// Returns all content scene tags in the scene service profile.
+        /// </summary>
+        IEnumerable<string> ContentTags { get; }
 
-    /// <summary>
-    /// Returns the content scenes in the scene service profile.
-    /// </summary>
-    SceneInfo[] ContentScenes { get; }
+        /// <summary>
+        /// Returns the content scenes in the scene service profile.
+        /// </summary>
+        SceneInfo[] ContentScenes { get; }
 
-    /// <summary>
-    ///  Returns the lighting scenes in the scene service profile.
-    /// </summary>
-    SceneInfo[] LightingScenes { get; }
-    
-    /// <summary>
-    /// Loads the next content scene in-editor. Use instead of LoadNextContent while not in play mode.
-    /// </summary>
-    /// <param name="wrap"></param>
-    void EditorLoadNextContent(bool wrap = false);
+        /// <summary>
+        ///  Returns the lighting scenes in the scene service profile.
+        /// </summary>
+        SceneInfo[] LightingScenes { get; }
 
-    /// <summary>
-    /// Loads the prev content scene in-editor. Use instead of LoadPrevContent while not in play mode.
-    /// </summary>
-    /// <param name="wrap"></param>
-    void EditorLoadPrevContent(bool wrap = false);
+        /// <summary>
+        /// Loads the next content scene in-editor. Use instead of LoadNextContent while not in play mode.
+        /// </summary>
+        /// <param name="wrap"></param>
+        void EditorLoadNextContent(bool wrap = false);
+
+        /// <summary>
+        /// Loads the prev content scene in-editor. Use instead of LoadPrevContent while not in play mode.
+        /// </summary>
+        /// <param name="wrap"></param>
+        void EditorLoadPrevContent(bool wrap = false);
 #endif
+    }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs.meta
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystemEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c883a0df024f2424b8f44cd106479eec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 961230b29c294bb780054c5d02eb6180, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Service inspectors now work with service interfaces instead of concrete implementations.

For most inspectors this change was trivial. For `IMixedRealitySceneService` an optional `IMixedRealitySceneServiceEditor` interface was created for editor-only functionality used by the inspector.

## Changes
- Fixes: #4825

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
