### PR TITLE
camera service manager: fix missing service type reference

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Camera/Prefabs/CameraSystem.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Camera/Prefabs/CameraSystem.prefab
@@ -45,5 +45,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CameraSystemType:
     reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
-      MixedRealityToolkit.Services.CameraSystem
+      Microsoft.MixedReality.Toolkit.Services.CameraSystem
   profile: {fileID: 11400000, guid: 8089ccfdd4494cd38f676f9fc1f46a04, type: 2}


### PR DESCRIPTION
The camera service manager prefab lost the reference to the concrete service type. this change repairs the issue.