### PR TITLE
[Shell Parity] Proximity Light Shell Parity

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Materials/HolographicButtonContentCageProximity.mat
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Materials/HolographicButtonContentCageProximity.mat
@@ -85,7 +85,7 @@ Material:
     - _BorderLightReplacesAlbedo: 0
     - _BorderLightUsesHoverColor: 1
     - _BorderMinValue: 1
-    - _BorderWidth: 0.1
+    - _BorderWidth: 0.06
     - _BorderWidthHorizontal: 0.1
     - _BorderWidthVertical: 0.1
     - _BumpScale: 1

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/FingerCursor.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/FingerCursor.prefab
@@ -82,7 +82,7 @@ MonoBehaviour:
   rotationLerpTime: 0.1
   lookRotationBlend: 0.5
   PrimaryCursorVisual: {fileID: 7521151737680088869}
-  IsPointerDown: 0
+  SourceDownIds: 
   defaultCursorDistance: 2
   checkForGrabbables: 0
   skinSurfaceOffset: 0.01
@@ -137,9 +137,9 @@ MonoBehaviour:
     farRadius: 0.2
     nearDistance: 0.02
     minNearSizePercentage: 0.35
-    centerColor: {r: 0.078431375, g: 0.4745098, b: 0.98039216, a: 0}
-    middleColor: {r: 0.011764706, g: 0.43529412, b: 1, a: 0.32941177}
-    outerColor: {r: 1.372549, g: 0, b: 3.745098, a: 1}
+    centerColor: {r: 0.21176471, g: 0.5568628, b: 0.98039216, a: 0}
+    middleColor: {r: 0.18431373, g: 0.5176471, b: 1, a: 0.2}
+    outerColor: {r: 0.9647059, g: 0.3647059, b: 2.2470589, a: 1}
 --- !u!1001 &7442314219997024738
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -578,11 +578,11 @@ Shader "Mixed Reality Toolkit/Standard"
                 float normalizedProximityLightDistance = saturate(proximityLightDistance * proximityLightParams.y);
                 float3 projectedProximityLight = proximityLight.xyz - (worldNormal * abs(proximityLightDistance));
                 float projectedProximityLightDistance = length(projectedProximityLight - worldPosition);
-                float attenuation = (1.0 - pow(normalizedProximityLightDistance, 2.0)) * proximityLight.w;
+                float attenuation = (1.0 - normalizedProximityLightDistance) * proximityLight.w;
                 colorValue = saturate(projectedProximityLightDistance * proximityLightParams.z);
                 float pulse = step(proximityLightPulseParams.x, projectedProximityLightDistance) * proximityLightPulseParams.y;
 
-                return smoothstep(1.0, 0.0, projectedProximityLightDistance / (proximityLightParams.x * max(normalizedProximityLightDistance, proximityLightParams.w))) * pulse * attenuation;
+                return smoothstep(1.0, 0.0, projectedProximityLightDistance / (proximityLightParams.x * max(pow(normalizedProximityLightDistance, 0.25), proximityLightParams.w))) * pulse * attenuation;
             }
 
             inline fixed3 MixProximityLightColor(fixed4 centerColor, fixed4 middleColor, fixed4 outerColor, fixed t)

--- a/Assets/MixedRealityToolkit/Utilities/ProximityLight.cs
+++ b/Assets/MixedRealityToolkit/Utilities/ProximityLight.cs
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             [Tooltip("The color of the ProximityLight gradient at the center (RGB) and (A) is gradient extent.")]
             [ColorUsageAttribute(true, true)]
             [SerializeField]
-            private Color centerColor = new Color(20.0f / 255.0f, 121.0f / 255.0f, 250.0f / 255.0f, 0.0f / 255.0f);
+            private Color centerColor = new Color(54.0f / 255.0f, 142.0f / 255.0f, 250.0f / 255.0f, 0.0f / 255.0f);
 
             /// <summary>
             /// The color of the ProximityLight gradient at the center (RGB) and (A) is gradient extent.
@@ -110,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             [Tooltip("The color of the ProximityLight gradient at the middle (RGB) and (A) is gradient extent.")]
             [SerializeField]
             [ColorUsageAttribute(true, true)]
-            private Color middleColor = new Color(3.0f / 255.0f, 111.0f / 255.0f, 255.0f / 255.0f, 84.0f / 255.0f);
+            private Color middleColor = new Color(47.0f / 255.0f, 132.0f / 255.0f, 255.0f / 255.0f, 51.0f / 255.0f);
 
             /// <summary>
             /// The color of the ProximityLight gradient at the center (RGB) and (A) is gradient extent.
@@ -124,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             [Tooltip("The color of the ProximityLight gradient at the outer (RGB) and (A) is gradient extent.")]
             [SerializeField]
             [ColorUsageAttribute(true, true)]
-            private Color outerColor = new Color((70.0f * 5.0f) / 255.0f, (0.0f * 5.0f) / 255.0f, (191.0f * 5.0f) / 255.0f, 255.0f / 255.0f);
+            private Color outerColor = new Color((82.0f * 3.0f) / 255.0f, (31.0f * 3.0f) / 255.0f, (191.0f * 3.0f) / 255.0f, 255.0f / 255.0f);
         }
 
         public LightSettings Settings
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     float pulseScaler = 1.0f + light.pulseTime;
                     proximityLightData[dataIndex + 1] = new Vector4(light.Settings.NearRadius * pulseScaler,
                                                                     1.0f / Mathf.Clamp(light.Settings.FarRadius * pulseScaler, 0.001f, 1.0f),
-                                                                    1.0f / Mathf.Clamp(light.Settings.NearDistance* pulseScaler, 0.001f, 1.0f),
+                                                                    1.0f / Mathf.Clamp(light.Settings.NearDistance * pulseScaler, 0.001f, 1.0f),
                                                                     Mathf.Clamp01(light.Settings.MinNearSizePercentage));
                     proximityLightData[dataIndex + 2] = new Vector4(light.Settings.NearDistance * light.pulseTime,
                                                                     Mathf.Clamp01(1.0f - light.pulseFade),


### PR DESCRIPTION
Tweaking proximity light behavior and parameters to closer match the shell.

Below this change is the proximity light in the Shell (left) and the MRTK (right).
![CaptureBefore](https://user-images.githubusercontent.com/13305729/61008188-bd805d80-a323-11e9-895d-dab7c138c93f.PNG)

After this change is the proximity light in the Shell (left) and the MRTK (right).

![Capture](https://user-images.githubusercontent.com/13305729/61008226-d8eb6880-a323-11e9-9c9d-e1927dcd8539.PNG)

Note, the colors were tuned as close as possible but the shell using a texture whereas the MRTK uses a 3 way color blend to allow for easy customization. The button border width was also adjusted to match the shell.  

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5218

## Verification
Try pressing buttons in the Hand Interaction Examples scene.

>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
