### PR TITLE
Make camera system initiate playspace parenting

### DIFF
--- a/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -80,6 +80,14 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
             {
                 ApplySettingsForTransparentDisplay();
             }
+
+            // Ensure the camera is parented to the playspace which starts, unrotated, at the origin.
+            MixedRealityPlayspace.Position = Vector3.zero;
+            MixedRealityPlayspace.Rotation = Quaternion.identity;
+            if (CameraCache.Main.transform.position != Vector3.zero)
+            {
+                Debug.LogWarning($"The main camera is not positioned at the origin ({Vector3.zero}), immersive experiences may not behave as expected.");
+            }
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -145,10 +145,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            // Ensure the camera starts at the origin.
-            CameraCache.Main.transform.position = Vector3.zero;
-            CameraCache.Main.transform.rotation = Quaternion.identity;
-
             BaseInputModule[] inputModules = UnityEngine.Object.FindObjectsOfType<BaseInputModule>();
 
             if (inputModules.Length == 0)


### PR DESCRIPTION
The camera system was previously not initiating the parenting of the camera to the playspace. This was being performed by most other services when they added a child object to the playspace transform.

Since MRTK expects the camera to be parented to support features such as teleportation, the camera system should ensure proper hierarchy at runtime.

Since the XR SDKs underlying our mixed reality support assume control over the camera's local position and not all platforms enforce the initial camera position be the origin (ex: Windows Mixed Reality uses the origin while OpenVR looks to be honoring the value set in the inspector).

This change adds a log warning that informs developers when the camera is not set to the origin at initialization of the camera system.