### PR TITLE
Add a link.xml to Assets to prevent critical MRTK components from getting optimized away in IL2CPP builds

### DIFF
--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -4,7 +4,7 @@
     during IL2CPP builds. More details on when this is needed and why this is needed
     can be found here: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5273
 
-    If your application some specific services (for example, if teleportation system is
+    If your application doesn't use some specific services (for example, if teleportation system is
     disabled in the profile), it is possible to remove their corresponding lines down
     below (in the previous example, we would remove the TeleportSystem below).
 

--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -1,0 +1,26 @@
+<linker>
+  <!--
+    This link.xml file is provided to prevent MRTK code from being optimized away
+    during IL2CPP builds. More details on when this is needed and why this is needed
+    can be found here: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5273
+
+    If your application some specific services (for example, if teleportation system is
+    disabled in the profile), it is possible to remove their corresponding lines down
+    below (in the previous example, we would remove the TeleportSystem below).
+
+    It's recommended to start with this list and narrow down if you want to ensure
+    specific bits of code get optimized away.
+  -->
+  <assembly fullname="Microsoft.MixedReality.Toolkit" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Providers.OpenVR" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.SDK" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.InputSystem" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.BoundarySystem" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.CameraSystem" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.SceneSystem" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem" preserve="all"/>
+  <assembly fullname="Microsoft.MixedReality.Toolkit.Services.TeleportSystem" preserve="all"/>
+</linker>


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4265

See this comment in that issue for some more details on what happened here:
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4265#issuecomment-510246866

Also, in case you were wondering how this was generated, these are the assemblies that are referenced in the default MRTK profiles (i.e. look for things of type "SystemType" and look at their corresponding references). In the long run this has to be more automated, as this was obviously a highly manual process. See this issue (https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5273) for more details on that.