### PR TITLE
Fix the broken NuGet packages.

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -22,11 +22,7 @@
     <!-- Reuse MixedReality.Toolkit.targets, as the MSBuild logic is the same for all MRTK nuget packages. -->
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Examples.targets" />
 
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.Demos.StandardShader.Inspectors.dll*" target="Plugins\" />
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\MixedRealityToolkit.Examples.Demos.Utilities.InspectorFields.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\MixedRealityToolkit.Examples.Demos.Utilities.InspectorFields.Inspectors.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\MixedRealityToolkit.Examples.Demos.UX.Interactables.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Demos.*" target="Plugins\" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Providers/MixedReality.Toolkit.Providers.nuspec
+++ b/Assets/MixedRealityToolkit.Providers/MixedReality.Toolkit.Providers.nuspec
@@ -22,8 +22,6 @@
     <!-- Reuse MixedReality.Toolkit.targets, as the MSBuild logic is the same for all MRTK nuget packages. -->
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Providers.targets" />
 
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.OpenVR.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.*" target="Plugins\" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Services/MixedReality.Toolkit.Services.nuspec
+++ b/Assets/MixedRealityToolkit.Services/MixedReality.Toolkit.Services.nuspec
@@ -22,13 +22,6 @@
     <!-- Reuse MixedReality.Toolkit.targets, as the MSBuild logic is the same for all MRTK nuget packages. -->
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Services.targets" />
 
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.BoundarySystem.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.InputSimulation.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.InputSystem.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.InputSystem.Inspectors.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.TeleportSystem.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.*" target="Plugins\" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit/MixedReality.Toolkit.nuspec
+++ b/Assets/MixedRealityToolkit/MixedReality.Toolkit.nuspec
@@ -18,14 +18,14 @@
 
     <file src="MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.targets" />
 
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Core.Build.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Core.Definitions.Utilities.Editor.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Core.Extensions.EditorClassExtensions.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Core.Inspectors.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Core.Utilities.Async.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Core.Utilities.Editor.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Editor.BuildAndDeploy.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Editor.ClassExtensions.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Editor.Inspectors.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Editor.ServiceInspectors.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Async.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Editor.Utilities.dll*" target="Plugins\" />
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Utilities.Gltf.dll*" target="Plugins\" />
-    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Utilities.Gltf.Importers.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Gltf.dll*" target="Plugins\" />
+    <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Gltf.Importers.dll*" target="Plugins\" />
   </files>
 </package>


### PR DESCRIPTION
Our NuGet packages have been broken due to this PR:

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4858

Which updated assembly names, but didn't also update the corresponding nuspec files to ensure that they would continue to get copied over.

Thankfully, there was also this pretty sweet migration guide which makes it super clear where things moved: https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/UpdatingToGA.html