### PR TITLE
Add the link.xml in the Foundation NuGet package.

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -41,5 +41,12 @@
 
     <!-- Assemblies that are built from the MixedRealityToolkit.Services folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.*" target="Plugins\" />
+
+    <!-- 
+      link.xml is copied to the root location, so that it can catch IL2CPP
+      bytecode stripping issues for all scripts included in this package.
+    -->
+    <file src="link.xml" target="" />
+    <file src="link.xml.meta" target="" />
   </files>
 </package>


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4265

See the linked issue for more details about what we're doing here - this is being included as a convenience to NuGet consumers so that things just "work out of the box" and they don't have to define their own link.xml in order to avoid IL2CPP bytecode stripping
