### PR TITLE
Add error logs on destroying event system with dangling listeners

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -182,6 +182,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <inheritdoc />
+        public virtual void Destroy()
+        {
+            // Cursor needs to unregister its input handlers explicitly, while input system is still active.
+            // If this would be done from OnDestroy, it will happen in the end of Update loop,
+            // when the input system itself is already destroyed.
+            UnregisterManagers();
+        }
+
+        /// <inheritdoc />
         public bool IsVisible => PrimaryCursorVisual != null ? PrimaryCursorVisual.gameObject.activeInHierarchy : gameObject.activeInHierarchy;
 
         /// <inheritdoc />
@@ -333,11 +342,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             TargetedObject = null;
             visibleSourcesCount = 0;
             OnCursorStateChange(CursorStateEnum.Contextual);
-        }
-
-        private void OnDestroy()
-        {
-            UnregisterManagers();
         }
 
         #endregion MonoBehaviour Implementation

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -59,6 +59,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected bool IsHoldPressed = false;
 
+        private bool isCursorInstantiatedFromPrefab = false;
+
         /// <summary>
         /// Set a new cursor for this <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer"/>
         /// </summary>
@@ -68,21 +70,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (cursorInstance != null)
             {
-                if (Application.isEditor)
-                {
-                    DestroyImmediate(cursorInstance);
-                }
-                else
-                {
-                    Destroy(cursorInstance);
-                }
-
+                DestroyCursorInstance();
                 cursorInstance = newCursor;
             }
 
             if (cursorInstance == null && cursorPrefab != null)
             {
                 cursorInstance = Instantiate(cursorPrefab, transform);
+                isCursorInstantiatedFromPrefab = true;
             }
 
             if (cursorInstance != null)
@@ -117,6 +112,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 else
                 {
                     Debug.LogError($"No IMixedRealityCursor component found on {cursorInstance.name}");
+                }
+            }
+        }
+
+        private void DestroyCursorInstance()
+        {
+            if (cursorInstance != null)
+            {
+                if (Application.isPlaying)
+                {
+                    Destroy(cursorInstance);
+                }
+                else
+                {
+                    DestroyImmediate(cursorInstance);
                 }
             }
         }
@@ -178,6 +188,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (c != null)
             {
                 c.VisibleSourcesCount--;
+            }
+
+            // Need to destroy instantiated cursor prefab if it was added by the controller itself in 'OnEnable'
+            if (isCursorInstantiatedFromPrefab)
+            {
+                // Manually reset base cursor before destroying it
+                BaseCursor.Destroy();
+                DestroyCursorInstance();
+                isCursorInstantiatedFromPrefab = false;
             }
         }
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -306,10 +306,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var inputModule = CameraCache.Main.gameObject.GetComponent<MixedRealityInputModule>();
                 if (inputModule)
                 {
-                    inputModule.DeactivateModule();
-
                     if (Application.isPlaying)
                     {
+                        inputModule.DeactivateModule();
                         UnityEngine.Object.Destroy(inputModule);
                     }
                     else

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -269,9 +269,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Unity's way to remove component is to destroy it.
             if (GazeProvider != null)
             {
-                GazeProvider.GazePointer.BaseCursor.Destroy();
                 if (Application.isPlaying)
                 {
+                    GazeProvider.GazePointer.BaseCursor.Destroy();
                     UnityEngine.Object.Destroy(GazeProvider as Component);
                 }
                 else
@@ -304,15 +304,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (isInputModuleAdded)
             {
                 var inputModule = CameraCache.Main.gameObject.GetComponent<MixedRealityInputModule>();
-                inputModule.DeactivateModule();
+                if (inputModule)
+                {
+                    inputModule.DeactivateModule();
 
-                if (Application.isPlaying)
-                {
-                    UnityEngine.Object.Destroy(inputModule);
-                }
-                else
-                {
-                    UnityEngine.Object.DestroyImmediate(inputModule);
+                    if (Application.isPlaying)
+                    {
+                        UnityEngine.Object.Destroy(inputModule);
+                    }
+                    else
+                    {
+                        UnityEngine.Object.DestroyImmediate(inputModule);
+                    }
                 }
             }
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -269,6 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Unity's way to remove component is to destroy it.
             if (GazeProvider != null)
             {
+                GazeProvider.GazePointer.BaseCursor.Destroy();
                 if (Application.isPlaying)
                 {
                     UnityEngine.Object.Destroy(GazeProvider as Component);

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -76,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public bool IsInputEnabled => disabledRefCount <= 0;
 
         private int disabledRefCount;
+        private bool isInputModuleAdded = false;
 
         private SourceStateEventData sourceStateEventData;
         private SourcePoseEventData<TrackingState> sourceTrackingEventData;
@@ -151,6 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 // There is no input module attached to the camera, add one.
                 CameraCache.Main.gameObject.AddComponent<MixedRealityInputModule>();
+                isInputModuleAdded = true;
             }
             else if ((inputModules.Length == 1) && (inputModules[0] is MixedRealityInputModule))
             { /* Nothing to do, a MixedRealityInputModule was applied in the editor. */ }
@@ -294,6 +296,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
             deviceManagers.Clear();
 
             InputDisabled?.Invoke();
+        }
+
+        public override void Destroy()
+        {
+            if (isInputModuleAdded)
+            {
+                var inputModule = CameraCache.Main.gameObject.GetComponent<MixedRealityInputModule>();
+                inputModule.DeactivateModule();
+
+                if (Application.isPlaying)
+                {
+                    UnityEngine.Object.Destroy(inputModule);
+                }
+                else
+                {
+                    UnityEngine.Object.DestroyImmediate(inputModule);
+                }
+            }
+
+            base.Destroy();
         }
 
         #endregion IMixedRealityService Implementation

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
@@ -12,6 +12,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
 {
     public class TestFixture_01_MixedRealityToolkitTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+        }
+
         #region Service Locator Tests
 
         [Test]

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/DefaultPrimaryPointerSelectorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/DefaultPrimaryPointerSelectorTests.cs
@@ -8,6 +8,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 {
     public class DefaultPrimaryPointerSelectorTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+        }
+
         [Test]
         public void Test()
         {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/GazePointerStateMachineTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/GazePointerStateMachineTests.cs
@@ -11,6 +11,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 {
     class GazePointerStateMachineTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+        }
+
         [Test]
         public void TestHeadGazeHandAndSpeechBehaviour()
         {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_03_InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestFixture_03_InputSystemTests.cs
@@ -10,6 +10,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 {
     public class TestFixture_03_InputSystemTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+        }
+
         [Test]
         public void Test01_CreateMixedRealityInputSystem()
         {

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/DemoSceneTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/DemoSceneTests.cs
@@ -50,6 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.SanityTests
             Scene scene = SceneManager.GetSceneByName(HandInteractionExamplesSceneName);
             if (scene.isLoaded)
             {
+                Scene playModeTestScene = SceneManager.CreateScene("Empty");
+                SceneManager.SetActiveScene(playModeTestScene);
                 SceneManager.UnloadSceneAsync(scene.buildIndex);
             }
         }

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -173,7 +173,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public static void ShutdownMixedRealityToolkit()
         {
             MixedRealityToolkit.SetInstanceInactive(MixedRealityToolkit.Instance);
-            MixedRealityPlayspace.Destroy();
+            if (Application.isPlaying)
+            {
+                MixedRealityPlayspace.Destroy();
+            }
 
             BaseEventSystem.enableDanglingHandlerDiagnostics = false;
         }

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -153,7 +153,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 MixedRealityToolkit.ConfirmInitialized();
             }
 
-            BaseEventSystem.enableDanglingHandlerDiagnostics = true;
+            // Todo: this condition shouldn't be here.
+            // It's here due to some edit mode tests initializing Mrtk instance in Edit mode, causing some of 
+            // event handler registration to live over tests and cause next tests to fail.
+            // Exact reason requires investigation.
+            if (Application.isPlaying)
+            {
+                BaseEventSystem.enableDanglingHandlerDiagnostics = true;
+            }
 
             // Tests
             Assert.IsTrue(MixedRealityToolkit.IsInitialized);

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -153,6 +153,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 MixedRealityToolkit.ConfirmInitialized();
             }
 
+            BaseEventSystem.enableDanglingHandlerDiagnostics = true;
+
             // Tests
             Assert.IsTrue(MixedRealityToolkit.IsInitialized);
             Assert.IsNotNull(MixedRealityToolkit.Instance);
@@ -172,6 +174,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             MixedRealityToolkit.SetInstanceInactive(MixedRealityToolkit.Instance);
             MixedRealityPlayspace.Destroy();
+
+            BaseEventSystem.enableDanglingHandlerDiagnostics = false;
         }
 
         private static T GetDefaultMixedRealityProfile<T>() where T : BaseMixedRealityProfile

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityCursor.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityCursor.cs
@@ -47,6 +47,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         void SetVisibility(bool visible);
 
         /// <summary>
+        /// Utility method to destroy cursor dependencies (e.g. event subscriptions) in the system
+        /// explicitly in the middle update loop. This is a "replacement" of Unity OnDestroy.
+        /// Relying on Unity OnDestroy may cause event handler subscription to 
+        /// become invalid at the point of destroying.
+        /// </summary>
+        void Destroy();
+
+        /// <summary>
         /// Is the cursor currently visible?
         /// </summary>
         bool IsVisible { get; }

--- a/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
@@ -269,12 +269,9 @@ namespace Microsoft.MixedReality.Toolkit
                 for (int index = 0; index < typeEntry.Value.Count; index++)
                 {
                     var handlerEntry = typeEntry.Value[index];
-                    if (handlerEntry.handler != null)
-                    {
-                        Debug.LogError("Event system is being destroyed while still having a registered listener. " +
-                           "Make sure that all global event listeners have been unregistered before destroying the event system. " +
-                            $"Dangling listener: handler {handlerEntry.handler}");
-                    }
+                    Debug.LogError("Event system is being destroyed while still having a registered listener. " +
+                        "Make sure that all global event listeners have been unregistered before destroying the event system. " +
+                        $"Dangling listener: handler {handlerEntry.handler}");
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
@@ -244,6 +244,28 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        public override void Destroy()
+        {
+            foreach (var listener in EventListeners)
+            {
+                Debug.LogError("Event system is destroyed, while still having a registered listener. " +
+                    "Make sure that all global event listeners have been unregistered before destroying the event system. " +
+                    $"Dangling listener: object {listener.name}");
+            }
+
+            foreach (var typeEntry in EventHandlersByType)
+            {
+                for (int index = 0; index < typeEntry.Value.Count; index++)
+                {
+                    var handlerEntry = typeEntry.Value[index];
+
+                    Debug.LogError("Event system is being destroyed while still having a registered listener. " +
+                        "Make sure that all global event listeners have been unregistered before destroying the event system. " +
+                        $"Dangling listener: handler {handlerEntry.handler}");
+                }
+            }
+        }
+
     #endregion IMixedRealityEventSystem Implementation
 
     #region Registration helpers


### PR DESCRIPTION
## Overview

This change has originally been triggered by #5116 to first of all ease test debugging, when test runtime environment is not clean after running another test.
So, the change should only have been messages in `BaseEventSystem`. However, adding these messages highlighted few fundamental issues:
* Mrtk had incorrect order of deinitialization for core systems. They should be disabled and destroyed in a reverse order to how they are initialized. This PR fixes that.
* Unregistering event handlers in unity `OnDestroy` is semantically incorrect: Mrtk tear down happens in the middle of `Update` loop, which Deinitializes and Destroys all global services. When components are then destroyed _in the end_ of the `Update` loop, they can't rely on valid state of services (e.g. Input System). Ideally we would like global listeners to go away in `OnDisable`. However, this would require to move their initialization to `OnEnable`, which is much trickier to do. Solved this by modifying `IMixedRealityCursor` interface. I don't like it, but it solves an issue.