### PR TITLE
Fix documentation link for service extension wizard

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/ExtensionTemplates/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ExtensionTemplates/ExtensionServiceWizard.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly Color enabledColor = Color.white;
         private static readonly Color disabledColor = Color.gray;
         private static readonly Color readOnlyColor = Color.Lerp(enabledColor, Color.clear, 0.5f);
-        private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html";
+        private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Utilities/ExtensionServiceCreationWizard.html";
         private static readonly Vector2 minWindowSize = new Vector2(500, 0);
         private const int docLinkWidth = 200;
 


### PR DESCRIPTION
## Overview
Change link to documentation page dedicated to service extension wizard

## Changes
- Fixes: #4740 

## Verification
Clicked the button, new url
