### PR TITLE
Reintroduce .unitypackage building into our build system

### DIFF
--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -5,6 +5,7 @@ parameters:
 steps:
 - template: common.yml
 - ${{ if eq(parameters.packagingEnabled, true) }}:
+  - template: tasks/unitypackages.yml
   - template: package.yml
   - template: publishpackages.yml
 - template: end.yml

--- a/pipelines/templates/publishpackages.yml
+++ b/pipelines/templates/publishpackages.yml
@@ -14,8 +14,3 @@ steps:
     packagesToPush: '$(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.symbols.nupkg'
     publishVstsFeed: '$(NuGetFeedId)'
     buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish .unitypackages'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\unitypackages\output'
-    ArtifactName: 'mrtk-unitypackages'

--- a/pipelines/templates/publishpackages.yml
+++ b/pipelines/templates/publishpackages.yml
@@ -14,3 +14,8 @@ steps:
     packagesToPush: '$(Build.SourcesDirectory)/artifacts/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/**/*.symbols.nupkg'
     publishVstsFeed: '$(NuGetFeedId)'
     buildProperties: 'version=$(MRTKVersion)-$(Build.BuildNumber)'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish .unitypackages'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\unitypackages\output'
+    ArtifactName: 'mrtk-unitypackages'

--- a/pipelines/templates/tasks/unitypackages.yml
+++ b/pipelines/templates/tasks/unitypackages.yml
@@ -1,6 +1,6 @@
 # [Template] Builds and publishes .unitypackages
 parameters:
-  version: '$(MRTKVersion).$(Build.BuildNumber)'
+  version: '$(MRTKVersion)-$(Build.BuildNumber)'
 
 steps:
 - task: PowerShell@2

--- a/pipelines/templates/tasks/unitypackages.yml
+++ b/pipelines/templates/tasks/unitypackages.yml
@@ -1,0 +1,22 @@
+# [Template] Builds and publishes .unitypackages
+parameters:
+  version: '$(MRTKVersion).$(Build.BuildNumber)'
+
+steps:
+- task: PowerShell@2
+  displayName: 'Build .unitypackages'
+  inputs:
+    targetType: filePath
+    filePath: ./scripts/packaging/unitypackage.ps1
+    arguments: >
+      -UnityDirectory ${Env:Unity2018.3.7f1}
+      -OutputDirectory $(Build.ArtifactStagingDirectory)\build\unitypackages\output
+      -RepoDirectory $(Get-Location)
+      -LogDirectory $(Build.ArtifactStagingDirectory)\build\unitypackages\logs
+      -PackageVersion ${{ parameters.version }}
+      -Verbose
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish .unitypackages'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\build\unitypackages\output'
+    ArtifactName: 'mrtk-unitypackages'

--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -58,7 +58,7 @@ param(
     [string]$RepoDirectory = ".",
     [string]$LogDirectory,
     [string]$UnityDirectory,
-    [ValidatePattern("^\d+\.\d+\.\d+\.*\d*$")]
+    [ValidatePattern("^\d+\.\d+\.\d+-?[a-zA-Z0-9\.]*$")]
     [string]$PackageVersion,
     [switch]$Clean,
     [switch]$Verbose


### PR DESCRIPTION
Build.ps1 has been out of commission for a while now, and building .unitypackages has been a manual step for us prior to release.

This change removes build.ps1 and moves some of its functionality into a script that is just designed to do .unitypackages, and in a way that is also compatible with the way the rest of our pipelines work now.

This also updates our CI pipeline (not PR pipeline) to generate .unitypackage artifacts in the build (the Foundation and Examples package)