### PR TITLE
Fixes MRTK inspector setting active instance when selected instance is disabled

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             MixedRealityToolkit instance = (MixedRealityToolkit)target;
 
-            if (MixedRealityToolkit.Instance == null)
+            if (MixedRealityToolkit.Instance == null && instance.isActiveAndEnabled)
             {   // See if an active instance exists at all. If it doesn't register this instance preemptively.
                 MixedRealityToolkit.SetActiveInstance(instance);
             }


### PR DESCRIPTION
## Overview
- Fixes: #5277


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
