### PR TITLE
Interactable scene & inspector updates

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scenes/InteractablesExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scenes/InteractablesExamples.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -240,6 +240,7 @@ MonoBehaviour:
   layout: 0
   radius: 2
   radialRange: 180
+  distance: 1
   rows: 3
   cellWidth: 0.07
   cellHeight: 0.07
@@ -2342,6 +2343,7 @@ MonoBehaviour:
   layout: 0
   radius: 2
   radialRange: 180
+  distance: 1
   rows: 3
   cellWidth: 0.07
   cellHeight: 0.07
@@ -2660,7 +2662,6 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_textAlignment: 514
-  m_isAlignmentEnumConverted: 1
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -2687,6 +2688,7 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
@@ -2701,12 +2703,9 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 0
-  m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1409442362}
   m_subTextObjects:
@@ -3141,6 +3140,7 @@ MonoBehaviour:
   InputActionId: 0
   IsGlobal: 0
   Dimensions: 1
+  StartDimensionIndex: 0
   CanSelect: 1
   CanDeselect: 1
   VoiceCommand: Select
@@ -3231,6 +3231,7 @@ MonoBehaviour:
           Culture=neutral, PublicKeyToken=null
       Options: []
     HideUnityEvents: 0
+  dimensionIndex: 0
 --- !u!114 &1590642588
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3244,13 +3245,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   eventsToReceive: 0
-  touchableCollider: {fileID: 1590642586}
-  distBack: 0.25
+  pokeThreshold: 0.25
   debounceThreshold: 0.01
+  touchableCollider: {fileID: 1590642586}
   localForward: {x: 0, y: 0, z: -1}
   localUp: {x: 0, y: 1, z: 0}
   localCenter: {x: 0, y: 0, z: -0.06}
-  touchableSurface: 0
   bounds: {x: 0.12, y: 0.12}
 --- !u!114 &1590642589
 MonoBehaviour:
@@ -3360,7 +3360,6 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_textAlignment: 514
-  m_isAlignmentEnumConverted: 1
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -3387,6 +3386,7 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
@@ -3401,12 +3401,9 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 0
-  m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1601961664}
   m_subTextObjects:
@@ -4013,11 +4010,6 @@ PrefabInstance:
       propertyPath: Events.Array.data[1].Settings.Array.data[3].EventValue.m_TypeName
       value: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
         Culture=neutral, PublicKeyToken=null
-      objectReference: {fileID: 0}
-    - target: {fileID: 114856665817931228, guid: 4b1ffbebacd36694ebea9fb6d437c68f,
-        type: 3}
-      propertyPath: InputActionId
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4b1ffbebacd36694ebea9fb6d437c68f, type: 3}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
@@ -3,8 +3,9 @@
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -13,110 +14,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Name: 
   Settings:
-  - Name: ScaleOffsetColorTheme
-    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.UI.ScaleOffsetColorTheme,
+  - Name: InteractableRotationTheme
+    AssemblyQualifiedName: Microsoft.MixedReality.Toolkit.UI.InteractableRotationTheme,
       Microsoft.MixedReality.Toolkit.SDK
     Properties:
-    - Name: Scale
-      Type: 6
-      Values:
-      - Name: Default
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 1, y: 1, z: 1}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      - Name: Focus
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 1.1, y: 1.1, z: 1.1}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      - Name: Pressed
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0.9, y: 0.9, z: 0.9}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      - Name: Disabled
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 1, y: 1, z: 1}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      StartValue:
-        Name: 
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      PropId: 0
-      ShaderOptions: []
-      ShaderOptionNames: []
-      Default:
-        Name: 
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      ShaderName: 
-    - Name: Offset
+    - Name: Rotation
       Type: 6
       Values:
       - Name: Default
@@ -143,7 +45,7 @@ MonoBehaviour:
         Material: {fileID: 0}
         GameObject: {fileID: 0}
         Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
+        Vector3: {x: 0, y: 90, z: 0}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
         Color: {r: 0, g: 0, b: 0, a: 0}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
@@ -158,7 +60,7 @@ MonoBehaviour:
         Material: {fileID: 0}
         GameObject: {fileID: 0}
         Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
+        Vector3: {x: 0, y: 270, z: 0}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
         Color: {r: 0, g: 0, b: 0, a: 0}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
@@ -176,105 +78,6 @@ MonoBehaviour:
         Vector3: {x: 0, y: 0, z: 0}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
         Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      StartValue:
-        Name: 
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      PropId: 0
-      ShaderOptions: []
-      ShaderOptionNames: []
-      Default:
-        Name: 
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0, b: 0, a: 0}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      ShaderName: 
-    - Name: Color
-      Type: 2
-      Values:
-      - Name: Default
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0, g: 0.7529412, b: 1, a: 1}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      - Name: Focus
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 1, g: 0.62734854, b: 0, a: 1}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      - Name: Pressed
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 0.06915272, g: 0.6981132, b: 0.45621789, a: 1}
-        Quaternion: {x: 0, y: 0, z: 0, w: 0}
-        AudioClip: {fileID: 0}
-        Animation: {fileID: 0}
-      - Name: Disabled
-        String: 
-        Bool: 0
-        Int: 0
-        Float: 0
-        Texture: {fileID: 0}
-        Material: {fileID: 0}
-        GameObject: {fileID: 0}
-        Vector2: {x: 0, y: 0}
-        Vector3: {x: 0, y: 0, z: 0}
-        Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 1, g: 1, b: 1, a: 1}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
@@ -329,7 +132,7 @@ MonoBehaviour:
         Vector2: {x: 0, y: 0}
         Vector3: {x: 0, y: 0, z: 0}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 1, g: 1, b: 1, a: 1}
+        Color: {r: 0, g: 0.7529412, b: 1, a: 1}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
@@ -344,7 +147,7 @@ MonoBehaviour:
         Vector2: {x: 0, y: 0}
         Vector3: {x: 0, y: 0, z: 0}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 1, g: 1, b: 1, a: 1}
+        Color: {r: 1, g: 0.62734854, b: 0, a: 1}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
@@ -359,7 +162,7 @@ MonoBehaviour:
         Vector2: {x: 0, y: 0}
         Vector3: {x: 0, y: 0, z: 0}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
-        Color: {r: 1, g: 1, b: 1, a: 1}
+        Color: {r: 0.06915272, g: 0.6981132, b: 0.45621789, a: 1}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
@@ -540,7 +343,7 @@ MonoBehaviour:
         Material: {fileID: 0}
         GameObject: {fileID: 0}
         Vector2: {x: 0, y: 0}
-        Vector3: {x: 1, y: 1, z: 1}
+        Vector3: {x: 1.1, y: 1.1, z: 1.1}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
         Color: {r: 0, g: 0, b: 0, a: 0}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
@@ -555,7 +358,7 @@ MonoBehaviour:
         Material: {fileID: 0}
         GameObject: {fileID: 0}
         Vector2: {x: 0, y: 0}
-        Vector3: {x: 1, y: 1, z: 1}
+        Vector3: {x: 0.9, y: 0.9, z: 0.9}
         Vector4: {x: 0, y: 0, z: 0, w: 0}
         Color: {r: 0, g: 0, b: 0, a: 0}
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
@@ -612,6 +415,503 @@ MonoBehaviour:
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
       ShaderName: 
+    - Name: Rotation
+      Type: 6
+      Values:
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      StartValue:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      PropId: 0
+      ShaderOptions: []
+      ShaderOptionNames: []
+      Default:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      ShaderName: 
+    - Name: Animator Trigger
+      Type: 16
+      Values:
+      - Name: 
+        String: Default
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: Focus
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: Pressed
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: Disabled
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      StartValue:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      PropId: 0
+      ShaderOptions: []
+      ShaderOptionNames: []
+      Default:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      ShaderName: 
+    - Name: String
+      Type: 14
+      Values:
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      StartValue:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      PropId: 0
+      ShaderOptions: []
+      ShaderOptionNames: []
+      Default:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      ShaderName: 
+    - Name: Audio
+      Type: 11
+      Values:
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      StartValue:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      PropId: 0
+      ShaderOptions: []
+      ShaderOptionNames: []
+      Default:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      ShaderName: 
+    - Name: Activate
+      Type: 15
+      Values:
+      - Name: 
+        String: 
+        Bool: 1
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 1
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 1
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      - Name: 
+        String: 
+        Bool: 1
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      StartValue:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      PropId: 0
+      ShaderOptions: []
+      ShaderOptionNames: []
+      Default:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
+      ShaderName: 
+    CustomSettings: []
+    CustomHistory: []
     Easing:
       Enabled: 1
       Curve:
@@ -640,10 +940,30 @@ MonoBehaviour:
         m_RotationOrder: 4
       LerpTime: 0.2
     NoEasing: 0
-    IsValid: 0
+    IsValid: 1
     ThemeTarget:
       Properties: []
       Target: {fileID: 0}
-      States: []
+      States:
+      - Name: Default
+        Index: 0
+        Bit: 1
+        Value: 0
+        ActiveIndex: 0
+      - Name: Focus
+        Index: 1
+        Bit: 2
+        Value: 0
+        ActiveIndex: 1
+      - Name: Pressed
+        Index: 2
+        Bit: 4
+        Value: 0
+        ActiveIndex: 2
+      - Name: Disabled
+        Index: 7
+        Bit: 8
+        Value: 0
+        ActiveIndex: 3
   CustomSettings: []
   States: {fileID: 11400000, guid: 5eac1712038236e4b8ffdb3893804fe1, type: 2}

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -319,7 +319,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             #endregion
 
-            InspectorUIUtility.DrawDivider();
+            EditorGUILayout.Space();
 
             if (!ProfilesSetup && !showProfiles)
             {
@@ -362,7 +362,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     EditorGUILayout.BeginHorizontal();
 
-                        //InspectorUIUtility.DrawLabel(targetName, 12, InspectorUIUtility.ColorTint100);
                         EditorGUILayout.PropertyField(gameObject, new GUIContent("Target", "Target gameObject for this theme properties to manipulate"));
                         bool triggered = InspectorUIUtility.SmallButton(new GUIContent(InspectorUIUtility.Minus, "Remove Profile"), i, RemoveProfile);
 
@@ -580,7 +579,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             #endregion
 
-            InspectorUIUtility.DrawDivider();
+            EditorGUILayout.Space();
 
             #region Events settings
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -142,7 +142,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (showStates)
             {
                 GUI.enabled = !isPlayMode;
-                EditorGUILayout.PropertyField(states, new GUIContent("States", "The States this Interactable is based on"));
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    EditorGUILayout.PropertyField(states, new GUIContent("States", "The States this Interactable is based on"));
+                }
                 GUI.enabled = true;
             }
 
@@ -444,43 +447,40 @@ namespace Microsoft.MixedReality.Toolkit.UI
                                 showSettings = true;
                             }
 
-                            using (new EditorGUI.IndentLevelScope())
+                            InspectorUIUtility.ListSettings settings = listSettings[i];
+                            bool show = InspectorUIUtility.DrawSectionStart(themeItem.objectReferenceValue.name + " (Click to edit)", showSettings, FontStyle.Normal);
+
+                            if (show != showSettings)
                             {
-                                InspectorUIUtility.ListSettings settings = listSettings[i];
-                                bool show = InspectorUIUtility.DrawSectionStart(themeItem.objectReferenceValue.name + " (Click to edit)", showSettings, FontStyle.Normal);
-
-                                if (show != showSettings)
-                                {
-                                    EditorPrefs.SetBool(prefKey, show);
-                                    settings.Show = show;
-                                }
-
-                                if (show)
-                                {
-                                    SerializedObject themeObj = new SerializedObject(themeItem.objectReferenceValue);
-                                    SerializedProperty themeObjSettings = themeObj.FindProperty("Settings");
-                                    themeObj.Update();
-
-                                    GUILayout.Space(5);
-
-                                    if (themeObjSettings.arraySize < 1)
-                                    {
-                                        AddThemeProperty(new int[] { i, t, 0 });
-                                    }
-
-                                    int[] location = new int[] { i, t, 0 };
-                                    State[] iStates = GetStates();
-
-                                    ThemeInspector.RenderThemeSettings(themeObjSettings, themeObj, themeOptions, gameObject, location, iStates, ThemePropertiesBoxMargin);
-                                    InspectorUIUtility.FlexButton(new GUIContent("+", "Add Theme Property"), location, AddThemeProperty);
-                                    ThemeInspector.RenderThemeStates(themeObjSettings, iStates, ThemePropertiesBoxMargin);
-
-                                    themeObj.ApplyModifiedProperties();
-                                }
-                                listSettings[i] = settings;
-
-                                InspectorUIUtility.DrawSectionEnd();
+                                EditorPrefs.SetBool(prefKey, show);
+                                settings.Show = show;
                             }
+
+                            if (show)
+                            {
+                                SerializedObject themeObj = new SerializedObject(themeItem.objectReferenceValue);
+                                SerializedProperty themeObjSettings = themeObj.FindProperty("Settings");
+                                themeObj.Update();
+
+                                GUILayout.Space(5);
+
+                                if (themeObjSettings.arraySize < 1)
+                                {
+                                    AddThemeProperty(new int[] { i, t, 0 });
+                                }
+
+                                int[] location = new int[] { i, t, 0 };
+                                State[] iStates = GetStates();
+
+                                ThemeInspector.RenderThemeSettings(themeObjSettings, themeObj, themeOptions, gameObject, location, iStates, ThemePropertiesBoxMargin);
+                                InspectorUIUtility.FlexButton(new GUIContent("+", "Add Theme Property"), location, AddThemeProperty);
+                                ThemeInspector.RenderThemeStates(themeObjSettings, iStates, ThemePropertiesBoxMargin);
+
+                                themeObj.ApplyModifiedProperties();
+                            }
+                            listSettings[i] = settings;
+
+                            InspectorUIUtility.DrawSectionEnd();
 
                             validProfileCnt++;
                         }

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // If states value is not provided, try to use Default states type
             if (states.objectReferenceValue == null)
             {
-                GetDefaultInteractableStates(states);
+                states.objectReferenceValue = ThemeInspector.GetDefaultInteractableStates();
             }
 
             GUI.enabled = !isPlayMode;
@@ -569,25 +569,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             #endregion
 
             serializedObject.ApplyModifiedProperties();
-        }
-
-        private static void GetDefaultInteractableStates(SerializedProperty states)
-        {
-            AssetDatabase.Refresh();
-            string[] stateLocations = AssetDatabase.FindAssets("DefaultInteractableStates");
-            if (stateLocations.Length > 0)
-            {
-                for (int i = 0; i < stateLocations.Length; i++)
-                {
-                    string path = AssetDatabase.GUIDToAssetPath(stateLocations[i]);
-                    States defaultStates = (States)AssetDatabase.LoadAssetAtPath(path, typeof(States));
-                    if (defaultStates != null)
-                    {
-                        states.objectReferenceValue = defaultStates;
-                        break;
-                    }
-                }
-            }
         }
 
         private static string BuildThemeTitle(SelectionModes selectionMode, int themeIndex)

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -98,61 +98,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
 
             // States
-            bool showStates = false;
             SerializedProperty states = serializedObject.FindProperty("States");
-            bool drawerStarted = false;
-            string statesPrefKey = "Settings_States";
-            bool prefsShowStates = EditorPrefs.GetBool(statesPrefKey);
 
-            if (states.objectReferenceValue != null)
+            // If states value is not provided, try to use Default states type
+            if (states.objectReferenceValue == null)
             {
-                showStates = InspectorUIUtility.DrawSectionStart(states.objectReferenceValue.name + " (Click to edit)", prefsShowStates, FontStyle.Normal);
-                drawerStarted = true;
-                if (showStates != prefsShowStates)
-                {
-                    EditorPrefs.SetBool(statesPrefKey, showStates);
-                }
-            }
-            else
-            {
-                AssetDatabase.Refresh();
-                string[] stateLocations = AssetDatabase.FindAssets("DefaultInteractableStates");
-                if (stateLocations.Length > 0)
-                {
-                    for (int i = 0; i < stateLocations.Length; i++)
-                    {
-                        string path = AssetDatabase.GUIDToAssetPath(stateLocations[i]);
-                        States defaultStates = (States)AssetDatabase.LoadAssetAtPath(path, typeof(States));
-                        if (defaultStates != null)
-                        {
-                            states.objectReferenceValue = defaultStates;
-                            break;
-                        }
-                    }
-
-                    showStates = InspectorUIUtility.DrawSectionStart(states.objectReferenceValue.name + " (Click to edit)", prefsShowStates, FontStyle.Normal);
-                    drawerStarted = true;
-                }
-                else
-                {
-                    showStates = true;
-                }
+                GetDefaultInteractableStates(states);
             }
 
-            if (showStates)
-            {
-                GUI.enabled = !isPlayMode;
-                using (new EditorGUI.IndentLevelScope())
-                {
-                    EditorGUILayout.PropertyField(states, new GUIContent("States", "The States this Interactable is based on"));
-                }
-                GUI.enabled = true;
-            }
-
-            if (drawerStarted)
-            {
-                InspectorUIUtility.DrawSectionEnd();
-            }
+            GUI.enabled = !isPlayMode;
+                EditorGUILayout.PropertyField(states, new GUIContent("States", "The States this Interactable is based on"));
+            GUI.enabled = true;
 
             if (states.objectReferenceValue == null)
             {
@@ -331,7 +287,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             #region Profiles
 
-            bool isProfilesOpen = InspectorUIUtility.DrawSectionStart("Profiles", showProfiles, FontStyle.Bold, InspectorUIUtility.TitleFontSize);
+            bool isProfilesOpen = InspectorUIUtility.DrawSectionFoldout("Profiles", showProfiles, FontStyle.Bold, InspectorUIUtility.TitleFontSize);
 
             if (showProfiles != isProfilesOpen)
             {
@@ -448,7 +404,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                             }
 
                             InspectorUIUtility.ListSettings settings = listSettings[i];
-                            bool show = InspectorUIUtility.DrawSectionStart(themeItem.objectReferenceValue.name + " (Click to edit)", showSettings, FontStyle.Normal);
+                            bool show = InspectorUIUtility.DrawSectionFoldout(themeItem.objectReferenceValue.name + " (Click to edit)", showSettings, FontStyle.Normal);
 
                             if (show != showSettings)
                             {
@@ -479,8 +435,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                                 themeObj.ApplyModifiedProperties();
                             }
                             listSettings[i] = settings;
-
-                            InspectorUIUtility.DrawSectionEnd();
 
                             validProfileCnt++;
                         }
@@ -575,15 +529,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
            
             ProfilesSetup = validProfileCnt == profileList.arraySize + themeCnt;
 
-            InspectorUIUtility.DrawSectionEnd();
-
             #endregion
 
             EditorGUILayout.Space();
 
             #region Events settings
 
-            bool isEventsOpen = InspectorUIUtility.DrawSectionStart("Events", showEvents, FontStyle.Bold, InspectorUIUtility.TitleFontSize);
+            bool isEventsOpen = InspectorUIUtility.DrawSectionFoldout("Events", showEvents, FontStyle.Bold, InspectorUIUtility.TitleFontSize);
             if (showEvents != isEventsOpen)
             {
                 showEvents = isEventsOpen;
@@ -614,10 +566,28 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            InspectorUIUtility.DrawSectionEnd();
             #endregion
 
             serializedObject.ApplyModifiedProperties();
+        }
+
+        private static void GetDefaultInteractableStates(SerializedProperty states)
+        {
+            AssetDatabase.Refresh();
+            string[] stateLocations = AssetDatabase.FindAssets("DefaultInteractableStates");
+            if (stateLocations.Length > 0)
+            {
+                for (int i = 0; i < stateLocations.Length; i++)
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(stateLocations[i]);
+                    States defaultStates = (States)AssetDatabase.LoadAssetAtPath(path, typeof(States));
+                    if (defaultStates != null)
+                    {
+                        states.objectReferenceValue = defaultStates;
+                        break;
+                    }
+                }
+            }
         }
 
         private static string BuildThemeTitle(SelectionModes selectionMode, int themeIndex)

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs
@@ -127,7 +127,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public static void RenderEventSettings(SerializedProperty eventItem, int index, InteractableTypesContainer options, InspectorUIUtility.MultiListButtonEvent changeEvent, InspectorUIUtility.ListButtonEvent removeEvent)
         {
-            EditorGUILayout.BeginVertical("Box");
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
             SerializedProperty uEvent = eventItem.FindPropertyRelative("Event");
             SerializedProperty eventName = eventItem.FindPropertyRelative("Name");
             SerializedProperty className = eventItem.FindPropertyRelative("ClassName");
@@ -136,12 +137,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             // show event dropdown
             int id = InspectorUIUtility.ReverseLookup(className.stringValue, options.ClassNames);
-            
+
+            EditorGUILayout.BeginHorizontal();
+
             Rect position = EditorGUILayout.GetControlRect();
-            GUIContent selectLable = new GUIContent("Select Event Type", "Select the event type from the list");
-            EditorGUI.BeginProperty(position, selectLable, className);
+            GUIContent selectLabel = new GUIContent("Select Event Type", "Select the event type from the list");
+            EditorGUI.BeginProperty(position, selectLabel, className);
             {
-                int newId = EditorGUI.Popup(position, selectLable.text, id, options.ClassNames);
+                //int newId = EditorGUI.Popup(position, selectLabel.text, id, options.ClassNames);
+                int newId = EditorGUI.Popup(position, id, options.ClassNames);
 
                 if (id != newId || String.IsNullOrEmpty(className.stringValue))
                 {
@@ -154,13 +158,20 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             EditorGUI.EndProperty();
 
+            if (removeEvent != null)
+            {
+                InspectorUIUtility.FlexButton(new GUIContent("Remove Event"), index, removeEvent);
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+
             if (!hideEvents.boolValue)
             {
                 EditorGUILayout.PropertyField(uEvent, new GUIContent(eventName.stringValue));
             }
 
             // show event properties
-            EditorGUI.indentLevel = indentOnSectionStart + 1;
             SerializedProperty eventSettings = eventItem.FindPropertyRelative("Settings");
             for (int j = 0; j < eventSettings.arraySize; j++)
             {
@@ -171,14 +182,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     InspectorFieldsUtility.DisplayPropertyField(eventSettings.GetArrayElementAtIndex(j));
                 }
-            }
-            EditorGUI.indentLevel = indentOnSectionStart;
-
-            EditorGUILayout.Space();
-
-            if(removeEvent != null)
-            {
-                InspectorUIUtility.FlexButton(new GUIContent("Remove Event"), index, removeEvent);
             }
 
             EditorGUILayout.EndVertical();

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
@@ -112,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 string statesPrefKey = target.name + "Settings_States";
                 bool prefsShowStates = EditorPrefs.GetBool(statesPrefKey);
 
-                showStates = InspectorUIUtility.DrawSectionStart(states.objectReferenceValue.name + " (Click to edit)", prefsShowStates, FontStyle.Normal);
+                showStates = InspectorUIUtility.DrawSectionFoldout(states.objectReferenceValue.name + " (Click to edit)", prefsShowStates, FontStyle.Normal);
                 drawerStarted = true;
 
                 if (showStates != prefsShowStates)

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/ThemeInspector.cs
@@ -27,6 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         protected GUIStyle boxStyle;
         protected bool layoutComplete = false;
+        private const float ThemeStateFontScale = 1.2f;
 
         protected virtual void OnEnable()
         {
@@ -1052,7 +1053,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     SerializedProperty noEasing = settingsItem.FindPropertyRelative("NoEasing");
                     if (!noEasing.boolValue)
                     {
-                        InspectorUIUtility.DrawDivider();
                         enabled.boolValue = EditorGUILayout.Toggle(new GUIContent("Easing", "should the theme animate state values"), enabled.boolValue);
 
                         if (enabled.boolValue)
@@ -1227,7 +1227,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 for (int n = 0; n < states.Length; n++)
                 {
-                    InspectorUIUtility.DrawLabel(states[n].Name, 12, InspectorUIUtility.ColorTint50);
+                    InspectorUIUtility.DrawLabel(states[n].Name, (int)(InspectorUIUtility.DefaultFontSize * ThemeStateFontScale), InspectorUIUtility.ColorTint50);
 
                     for (int j = 0; j < settings.arraySize; j++)
                     {

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -412,13 +412,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public static void DrawDivider()
         {
             EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);
-            /*
-            GUIStyle styleHR = new GUIStyle(GUI.skin.box);
-            styleHR.stretchWidth = true;
-            styleHR.fixedHeight = 1;
-            styleHR.border = new RectOffset(1, 1, 1, 0);
-            GUILayout.Box("", styleHR);
-            */
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -436,8 +436,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             bool drawSection = false;
 
-            EditorGUI.indentLevel++;
-            drawSection = EditorGUILayout.Foldout(open, headerName, true, sectionStyle);
+            // To make foldout render properly, indent only this control
+            using (new EditorGUI.IndentLevelScope())
+            {
+                drawSection = EditorGUILayout.Foldout(open, headerName, true, sectionStyle);
+            }
 
             return drawSection;
         }
@@ -447,7 +450,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void DrawSectionEnd()
         {
-            EditorGUI.indentLevel--;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -424,7 +424,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <param name="open"></param>
         /// <param name="size"></param>
         /// <returns></returns>
-        public static bool DrawSectionStart(string headerName, bool open = true, FontStyle style = FontStyle.Bold, int size = 0)
+        public static bool DrawSectionFoldout(string headerName, bool open = true, FontStyle style = FontStyle.Bold, int size = 0)
         {
             GUIStyle sectionStyle = new GUIStyle(EditorStyles.foldout);
             sectionStyle.fontStyle = style;
@@ -443,13 +443,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             return drawSection;
-        }
-
-        /// <summary>
-        /// Draws section end (initiated by next Header attribute)
-        /// </summary>
-        public static void DrawSectionEnd()
-        {
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -411,11 +411,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void DrawDivider()
         {
+            EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);
+            /*
             GUIStyle styleHR = new GUIStyle(GUI.skin.box);
             styleHR.stretchWidth = true;
             styleHR.fixedHeight = 1;
             styleHR.border = new RectOffset(1, 1, 1, 0);
             GUILayout.Box("", styleHR);
+            */
         }
 
         /// <summary>
@@ -428,7 +431,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <param name="open"></param>
         /// <param name="size"></param>
         /// <returns></returns>
-        public static bool DrawSectionStart(string headerName, int indent, bool open = true, FontStyle style = FontStyle.Bold, bool toUpper = true, int size = 0)
+        public static bool DrawSectionStart(string headerName, bool open = true, FontStyle style = FontStyle.Bold, int size = 0)
         {
             GUIStyle sectionStyle = new GUIStyle(EditorStyles.foldout);
             sectionStyle.fontStyle = style;
@@ -437,27 +440,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 sectionStyle.fontSize = size;
                 sectionStyle.fixedHeight = size * 2;
             }
-            Color tColor = GUI.color;
-            GUI.color = MixedRealityInspectorUtility.SectionColor;
-
-            if (toUpper)
-            {
-                headerName = headerName.ToUpper();
-            }
 
             bool drawSection = false;
+
+            EditorGUI.indentLevel++;
             drawSection = EditorGUILayout.Foldout(open, headerName, true, sectionStyle);
-            GUI.color = tColor;
-            EditorGUI.indentLevel = indent;
+
             return drawSection;
         }
 
         /// <summary>
         /// Draws section end (initiated by next Header attribute)
         /// </summary>
-        public static void DrawSectionEnd(int indent)
+        public static void DrawSectionEnd()
         {
-            EditorGUI.indentLevel = indent;
+            EditorGUI.indentLevel--;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

This change does two primary things:
1) Modifies interactable inspector to be visually more in line with other components in Unity (see details below)
2) Fix interactables example scene

**Inspector changes:**
-> Added documentation link and goes to interactable readme
-> Converted existing "box" style to helpbox style which matches Unity and MRTK profiles
-> Removed redundant title of profile target (i.e gameobject being targeted) and just left target property field
-> Reduced amount of indentation, also cleaned up indent usage in code
-> Updated Events title to be a section foldout so we can hide long lists of receivers
-> Changed "Interactable" title to "General" since "Interactable" label is already listed right above for the component and thus reduces redundancy
-> Removed dividers from interactable sections...dividers suggest different component
-> Removed States foldout to simplify code & design

**Scene changes:**
-> Square toggle button had input action set to "menu" which didn't work. It would never toggle. Reverting back to prefab default of "select" made it function again 
-> Bucky ball didn't perform anything in it's rotation theme profile. Added easing & rotation values on focus/press

![image](https://user-images.githubusercontent.com/25975362/61487072-ce4f5580-a959-11e9-89a7-8309f468649c.png)

## Changes
- Fixes: #5320 
Related: #4943 

## Verification
Tested InteractablesExamples scene