### PR TITLE
Update the unitypackage.ps1 to actually build the examples package.

### DIFF
--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -165,7 +165,7 @@ foreach ($entry in $packages.GetEnumerator()) {
 
     Write-Verbose "Generating .unitypackage: $unityPackagePath"
     Write-Verbose "Log location: $logFileName"
-    
+
     # Assumes that unity package building has failed, unless we
     # succeed down below after running the Unity packaging step.
     $exitCode = 1
@@ -206,5 +206,7 @@ foreach ($entry in $packages.GetEnumerator()) {
     }
     catch { Write-Error $_ }
 
-    exit $exitCode
+    if ($exitCode -ne 0) {
+        exit $exitCode
+    }
 }


### PR DESCRIPTION
I was looking at the output from the latest CI runs, and while there was the presence of the Foundation unity package, the examples package was missing:

It turns out, this exit statement was too aggressive, and was leading to us only building the Foundation package. Now we will only early exit in the case of failure.

