### PR TITLE
Fix a broken link/non-formatted section

### DIFF
--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -30,6 +30,7 @@ The surface magnetism scripts rely on a *LayerMask* for raycasting. As a recomme
 When *UpdateLinkedTransform* is true, the solver will calculate position & orientation, but will not apply it. This lets other components use the transform values.
 
 <img src="../Documentation/Images/Solver/MRTK_Solver_Orbital.png" width="450">
+
 *Example of using Orbital solver in the [Slate](README_Slate.md) prefab.*
 
 ## Expectations for extending or adding to the solver system ##


### PR DESCRIPTION
Looking at this page, it seems like the link wasn't actually being formatted because it was too close to the sun (the image preceding it).

Adding another line in there makes it actually render the link and be all good.