### PR TITLE
Update the assert text to be more helpful, and update the doccomments of the focus handler interfaces.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -939,7 +939,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnFocusEnter(FocusEventData eventData)
         {
-            Debug.Assert(focusingPointers.Count > 0, "OnFocusEnter called but focusingPointers == 0");
+            Debug.Assert(focusingPointers.Count > 0,
+                "OnFocusEnter called but focusingPointers == 0. Most likely caused by the presence of a child object " +
+                "that is handling IMixedRealityFocusChangedHandler");
             if (CanInteract())
             {
                 SetFocus(true);

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusChangedHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusChangedHandler.cs
@@ -8,6 +8,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Interface to implement to react to focus changed events.
     /// </summary>
+    /// <remarks>
+    /// The events on this interface are related to those of <see cref="IMixedRealityFocusHandler"/>, whose event have
+    /// a known ordering with this interface:
+    ///
+    /// IMixedRealityFocusChangedHandler::OnBeforeFocusChange
+    /// IMixedRealityFocusHandler::OnFocusEnter
+    /// IMixedRealityFocusHandler::OnFocusExit
+    /// IMixedRealityFocusChangedHandler::OnFocusChanged
+    ///
+    /// Because these two interfaces are different, consumers must be wary about having nested
+    /// heirarchies where some game objects will implement both interfaces, and more deeply nested
+    /// object within the same parent-child chain that implement a single one of these - such
+    /// a presence can lead to scenarios where one interface is invoked on the child object, and then
+    /// the other interface is invoked on the parent object (thus, the parent would "miss" getting
+    /// the event that the child had already processed).
+    /// </remarks>
     public interface IMixedRealityFocusChangedHandler : IEventSystemHandler
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusHandler.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/Handlers/IMixedRealityFocusHandler.cs
@@ -8,6 +8,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Interface to implement to react to focus enter/exit.
     /// </summary>
+    /// <remarks>
+    /// The events on this interface are related to those of <see cref="IMixedRealityFocusChangedHandler"/>, whose event have
+    /// a known ordering with this interface:
+    ///
+    /// IMixedRealityFocusChangedHandler::OnBeforeFocusChange
+    /// IMixedRealityFocusHandler::OnFocusEnter
+    /// IMixedRealityFocusHandler::OnFocusExit
+    /// IMixedRealityFocusChangedHandler::OnFocusChanged
+    ///
+    /// Because these two interfaces are different, consumers must be wary about having nested
+    /// heirarchies where some game objects will implement both interfaces, and more deeply nested
+    /// object within the same parent-child chain that implement a single one of these - such
+    /// a presence can lead to scenarios where one interface is invoked on the child object, and then
+    /// the other interface is invoked on the parent object (thus, the parent would "miss" getting
+    /// the event that the child had already processed).
+    /// </remarks>
     public interface IMixedRealityFocusHandler : IEventSystemHandler
     {
         /// <summary>


### PR DESCRIPTION
I was spending time updating the Periodic Table app from RC2 -> GA, and while mostly things were working, I noticed that this assert was firing (it was added after RC2.1) pretty much every time you had a near pointer around the molecule object. It turns out, there's an issue in the heirarchy of the app itself that leads to this issue, but I was initially super confused about this, since this assert seems bad, but there's really not that much guidance on how to fix it and what's wrong.

To that end, I've updated the assert to suggest where to look (i.e. the common case) and also updated the doccomments associated with the corresponding interfaces to provide more information about both state transition mechanics, and also the general warning to be careful about having different nesting mechanics and pitfalls