### PR TITLE
Reserialize metas

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Boundary/Scenes/BoundaryVisualization.unity.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Boundary/Scenes/BoundaryVisualization.unity.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 35b95b3c4099413d88322156538b340f
-timeCreated: 1509573767
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Prefabs/EyeTrackingDemos SceneDescriptionPanel.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Prefabs/EyeTrackingDemos SceneDescriptionPanel.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 427730042d0a7ac41b1d81947f081754
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Prefabs/MixedRealityBasicSceneSetup.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Prefabs/MixedRealityBasicSceneSetup.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: d9db4fe4b37b2024ea85c888f8d74e12
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/Piano.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/Piano.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: ffbe4bef620a0a542bb77fe2f765c905
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/TestCanvas.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/TestCanvas.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 655521c3560b40f40b75cd30857eae84
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/ChaseSource.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/ChaseSource.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: de99acdc648a6d945ba138103ed87328
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/ChaseSourceWithOffset.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/ChaseSourceWithOffset.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 118ca9eb859ed4a42beb80e64c3380ab
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/ChaseSourceWithOffsetThenFaceHead.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/ChaseSourceWithOffsetThenFaceHead.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 72dfc8e6a20d95041b3f652885a7ea9f
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/InBetweenSources.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/InBetweenSources.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 57dd3f4049bf6bb4cbcd5fd64c88ecca
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/Orbital.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/Orbital.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: eab8031fa00c51d458f94c301aec122b
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/OrbitalWithStepping.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/OrbitalWithStepping.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: c1a5decf3f13c2847b2e92b462ec9886
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/Snake.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/Snake.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 3788010008fc88047aa60e19868f58f9
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/SolverSwappingVolume.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/SolverSwappingVolume.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 20761d7153c2c724a8739c1ebac24bea
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/SurfaceMagnetism.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/SurfaceMagnetism.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: aa50dc498bdec8646b565cb0fcb35316
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/SurfaceMagnetismAndRadialView.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Prefabs/SurfaceMagnetismAndRadialView.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 75c7d301572f36d4aaf8d864a8f869f2
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Prefabs/Placard.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Prefabs/Placard.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: 28f445004b874b329a03cd0e3cc63e5d
-timeCreated: 1510072233
-licenseType: Pro
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/MaterialGallery.unity.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/MaterialGallery.unity.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: c6b1477d31864dff836e9738518eae60
-timeCreated: 1509573767
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterialComparison.unity.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterialComparison.unity.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 9062cba753294447939429c74463c088
-timeCreated: 1509573767
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterials.unity.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/StandardMaterials.unity.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 1a710d2648be4878bd88f8fa546526ab
-timeCreated: 1509573767
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/CoffeeCup.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/CoffeeCup.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: d12fcfca48d5bea4885b7957a82235f8
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_Bucky.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_Bucky.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 50eb8d97f29f335409ec2df393ed6cc5
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 29a6f5316e0868e47adff5eee8945193
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/balloon.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/balloon.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 0ceaaf28e492a284fbf57901d04075ad
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: de90a43947eced441b4c426e11f35f28
-timeCreated: 1520445447
-licenseType: Free
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Scenes/InspectorFieldsExamples.unity.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Scenes/InspectorFieldsExamples.unity.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: d4083f42bece21c49b26e5acc1f2cbf6
-timeCreated: 1509573767
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/Prefabs/FingerChaser.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/Prefabs/FingerChaser.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 9e3b415b3451d3841a17e33255808fdd
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Cheese.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Cheese.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: e9e54ebd208487c409e32502a50a1f20
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/CoffeeCup.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/CoffeeCup.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: b52d9c3a778f1bd4aa6f7c8f911604fe
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Chevron.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Chevron.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 088efeed31a081c419979a80a12c5b0f
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Icosa.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Icosa.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 196ac8955822b944eb7d920135ebc301
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Octa.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Octa.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 79a9b8cde49cb98449897deffb812f39
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Torus.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Prototyping/Torus.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 735f28ace3c5a1542b3f2efacbda5d32
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Reticle.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Reticle.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: eb3627b069d8e8044a4ce84651787f6a
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/SceneDescriptionPanel.prefab.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/SceneDescriptionPanel.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: a900c08743a94c328074df8bbe3eb63c
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/AnimationButton.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/AnimationButton.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: d5e0e8cc740eb134789fd1f6bb5bb80a
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Button.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Button.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 02c524b22137b5449904f5395141cc73
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ButtonHoloLens1.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ButtonHoloLens1.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: 80cec532ae7b6c1429d0f5494e7dbd8c
-timeCreated: 1519322244
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ButtonHoloLens1Toggle.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ButtonHoloLens1Toggle.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 4b1ffbebacd36694ebea9fb6d437c68f
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/CheckBox.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/CheckBox.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 6f89876ff9050224f949c0490969219d
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Radial.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Radial.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 0f83fa6afa56ead46bbd762156f1137e
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 8b83134143223104c9bc3865a565cab3
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/SimpleButton.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/SimpleButton.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: f75829242875c1c4ca4ea5a5e7a6a742
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Toggle.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Toggle.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: a0dc4a34875700c4aba845405dc43a89
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ToggleButton.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ToggleButton.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 51cc6641d88b49d46bd38572540efe6c
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 5eac1712038236e4b8ffdb3893804fe1
-timeCreated: 1522264535
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/FocusPressTouchGrabStates.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/FocusPressTouchGrabStates.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: e51893c8eb7938e4ba43985af43c0f72
-timeCreated: 1522264535
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/HoloLensInteractableStates.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/HoloLensInteractableStates.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 2adb1a81e63716d4a904392a7ee65b16
-timeCreated: 1522264535
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/AnimatorTheme.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/AnimatorTheme.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: c786ef085bfd755409c87a7eadcbb450
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackground.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackground.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 61962e4d95d843842bb2dee96b41da6c
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackgroundSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBackgroundSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 435bbaee4d9763b4891ab39b7462ec31
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBorders.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBorders.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: b1ef68ffe69fad14a8d8401f7bd17db5
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBordersSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonBordersSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 6309da53723ca964fa65893eb0df5b4e
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabel.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabel.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 210ecfb82b9f09c4d835184cd0034155
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelColor.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelColor.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: afb9a653b3359b345aeb3ab2e0479189
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ButtonLabelSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 689bdf5999aa8014694da2cb1c1c1a27
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/DefaultTheme.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/DefaultTheme.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 34927bf1a1259e141a45f1dedff98d7f
-timeCreated: 1517598332
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlate.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlate.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: d37afabc007bf774d9431b9a7cbe6fba
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlateToggleSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonBackPlateToggleSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 29b20ecfcc16eef4dad8989c360f2988
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonFrontPlate.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonFrontPlate.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: cbde7890146c3024d928b7afc2e16065
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonFrontPlateThick.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonFrontPlateThick.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: bb190ed70543b6d488ccc57101c49231
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/PressableButtonFrontPlate.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/PressableButtonFrontPlate.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 8f8cfb3041153fa45bccb6d664a563ec
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackground.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackground.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 5753d89c205814542ba3fef191dc4682
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackgroundSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleBackgroundSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 25fd4afc60b411a4899da8c48e287906
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButton.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButton.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 6c08928bdf950d54390c1346d23d422b
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButtonSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleButtonSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: cb5abaa7279811d409e5bac06ad02a1f
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDot.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDot.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 02c718b28bedf814ea16dd51767befc6
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDotSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleDotSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 69ccbccdd82ebc34283000ef061eab28
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIcon.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIcon.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: c5fe122d2d821434894bbf06f71057d3
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIconSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleIconSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: dae413b1fffbbf841ae1176deb55d3c0
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabel.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabel.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 0eea8a8be0e42494083a2dc52fab717f
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabelSelected.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/ToggleLabelSelected.asset.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 077f50c510dd803449e2247b7fbe3122
-timeCreated: 1531192099
-licenseType: Pro
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/AppBar/AppBar.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/AppBar/AppBar.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: 83c02591e2867124181bcd3bcb65e288
-timeCreated: 1519284601
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 5b3e2856904e43c680f84f326861032a
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/EyeGazeCursor.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/EyeGazeCursor.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 521049f9431e342478200d59fce43f92
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/MouseCursor.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/MouseCursor.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 667821d88830305449757690d22f71e0
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/TeleportCursor.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/TeleportCursor.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: ae2b3fffb00f464287cda86f49109b47
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Hands/HandJoint.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Hands/HandJoint.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: a0842b2d2ca469847b09a969426bb48e
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Hands/HandJointGizmo.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Hands/HandJointGizmo.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 3e8988bbb870e1a4a81fd2c177b29865
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Hands/HandJointSmall.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Hands/HandJointSmall.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 6a3f88d2571cd234a86d95ee5856b9ec
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: d5b94136462644c9873bb3347169ae7e
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GGVPointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GGVPointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 039b325c9e8fd0545a0475fd4aa35b10
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 526b854247016cf47bc5c58e01d82407
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/MousePointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/MousePointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 31d81f88cf3f71d4b8392ded50df3f05
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: c4fd3c6fc7ff484eb434775066e7f327
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/PokePointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/PokePointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 38b548c6a2c270545a383296ad2bc4d5
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/TouchPointer.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/TouchPointer.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 51e60b8742bc47640923ac9e75ea74e9
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: ee519d5fb10a6db4f84d116e66f872b6
-timeCreated: 1518462253
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: 618bf808bd514c94dbe92e33f7196490
-timeCreated: 1518462252
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: 8769cb43fa542914f8aaceee4736c815
-timeCreated: 1518560609
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips/Constrained Parabola Tooltip.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips/Constrained Parabola Tooltip.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 4e88d209b9ebe8b42a4d4748bd9b7141
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips/Simple Line ToolTip.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips/Simple Line ToolTip.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: afaef0108a478c44a9eac26658bc29bf
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips/Spline ToolTip.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips/Spline ToolTip.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 44ac04f8e1e21474991e4b59809859f4
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/GizmoLeft.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/GizmoLeft.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 626257b1a6cd47c2a32a18cf75b2fb23
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/GizmoRight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/GizmoRight.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 9ef0df44319c4fb4a05649e5b8ceb6d1
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/HandLeft.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/HandLeft.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 378f91dbbff9e2343b27a467467750bf
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/HandRight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Controllers/DebugControllers/HandRight.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 132c9402d5843aa4f94380840186fd41
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawik.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawik.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: adce165054b90864492ee4f57710e214
-timeCreated: 1480372998
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikBold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikBold.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 92c82c17afbf2754393680f3ab0a1849
-timeCreated: 1480372998
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikLight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikLight.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 4b130d74b0f8d5549b85e26ef52813fc
-timeCreated: 1480372998
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemibold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemibold.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: c3180659337f41c4c9f172bb44b0f867
-timeCreated: 1480372998
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemilight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemilight.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: c07f18faebebb2d409b2f26d63cad856
-timeCreated: 1480372998
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawik.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawik.prefab.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: 7ea8eb39469b42d4faf18a5d262f6d66
-timeCreated: 1480372996
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikBold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikBold.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 1e4e5794f301cf54481a9551940961cb
-timeCreated: 1480372996
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikLight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikLight.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 6ff8b82e3bd96854bb810f387edfe000
-timeCreated: 1480372996
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemibold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemibold.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 4dc7c4982b8b66f45a374ad4fbf5b0da
-timeCreated: 1480372996
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemilight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemilight.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: fa5b294186aedf84bb82749c797e1821
-timeCreated: 1480372996
-licenseType: Free
-NativeFormatImporter:
+PrefabImporter:
+  externalObjects: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
## Overview
This change reserializes our metas via 2018.4. Updating our serialization will help reduce errant, seemingly unrelated changes in both PRs into this project and other projects that consume the MRTK via source / unitypackage.

For the most part, these changes are just the removal of stale `timeCreated` and `licenseType` info, which are no longer included in meta files.

![image](https://user-images.githubusercontent.com/3580640/61418502-94297980-a8af-11e9-9609-ff562ea33ced.png)

## Changes
- Part of #4914