### PR TITLE
Replace explicit hand animation step numbers with a central definition.

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -24,9 +24,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     // Tests to verify that cursor state is updated correctly
     public class BaseCursorTests
     {
-        // Keeping this low by default so the test runs fast. Increase it to be able to see hand movements in the editor.
-        private const int numFramesPerMove = 1;
-
         GameObject cube;
 
         // Initializes MRTK, instantiates the test content prefab 
@@ -102,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move hand closer to the collider so the cursor is on it
             Vector3 onObjectPos = new Vector3(0.05f, 0, 1.5f);
-            yield return hand.MoveTo(onObjectPos, numFramesPerMove);
+            yield return hand.MoveTo(onObjectPos);
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.InteractHover);
 
             // Trigger pinch
@@ -118,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.InteractHover);
 
             // Move back so the cursor is no longer on the object
-            yield return hand.MoveTo(offObjectPos, numFramesPerMove);
+            yield return hand.MoveTo(offObjectPos);
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.Interact);
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -128,11 +128,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var frontRightCornerPos = bbox.ScaleCorners[3].transform.position;
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.Open, initialHandPosition);
-            yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, frontRightCornerPos, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(frontRightCornerPos, frontRightCornerPos + delta, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(initialHandPosition, frontRightCornerPos, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(frontRightCornerPos, frontRightCornerPos + delta, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
 
             var endBounds = bbox.GetComponent<BoxCollider>().bounds;
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -86,13 +86,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move the hand forward to intersect the interactable
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 32;
             Vector3 p1 = new Vector3(0.0f, 0f, 0f);
             Vector3 p2 = new Vector3(0.05f, 0f, 0.51f);
             Vector3 p3 = new Vector3(0.0f, 0f, 0.0f);
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(p1, p2, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
 
             float pressStartTime = Time.time;
             bool wasTranslated = false;
@@ -103,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Move the hand back
-            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(p2, p3, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
             yield return new WaitForSeconds(buttonReleaseAnimationDelay);
 
@@ -228,13 +227,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move the hand forward to intersect the interactable
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 32;
             Vector3 p1 = new Vector3(0.0f, 0f, 0f);
             Vector3 p2 = new Vector3(0.05f, 0f, 0.51f);
             Vector3 p3 = new Vector3(0.0f, 0f, 0.0f);
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(p1, p2, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
 
             float pressStartTime = Time.time;
             bool wasTranslated = false;
@@ -245,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             // Move the hand back
-            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(p2, p3, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
             yield return new WaitForSeconds(buttonReleaseAnimationDelay);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -129,15 +129,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // grab the cube - move it to the right 
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 30;
             
             Vector3 handOffset = new Vector3(0, 0, 0.1f);
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
             Vector3 rightPosition = new Vector3(1f, 0f, 1f);
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, initialObjectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(initialObjectPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(initialHandPosition, initialObjectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(initialObjectPosition, rightPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
 
             yield return null;
 
@@ -148,7 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // forcefully end manipulation and drag with hand back to original position - object shouldn't move with hand
             manipHandler.ForceEndManipulation();
-            yield return PlayModeTestUtilities.MoveHandFromTo(rightPosition, initialObjectPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(rightPosition, initialObjectPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
 
             posDiff = testObject.transform.position - initialObjectPosition;
             Assert.IsTrue(posDiff.magnitude > maxError, "Manipulationhandler modified objects even though manipulation was forcefully ended.");
@@ -156,10 +155,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(posDiff.magnitude <= maxError, "Manipulated object didn't remain in place after forcefully ending manipulation");
 
             // move hand back to object
-            yield return PlayModeTestUtilities.MoveHandFromTo(initialObjectPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(initialObjectPosition, rightPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
 
             // grab object again and move to original position
-            yield return PlayModeTestUtilities.MoveHandFromTo(rightPosition, initialObjectPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(rightPosition, initialObjectPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSimulationService);
 
             // test if object was moved by manipulationhandler
             posDiff = testObject.transform.position - initialObjectPosition;
@@ -316,7 +315,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             const int numCircleSteps = 10;
-            const int numHandSteps = 3;
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
             Vector3 initialGrabPosition = new Vector3(-0.1f, -0.1f, 1f); // grab the left bottom corner of the cube 
@@ -330,7 +328,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 TestUtilities.PlayspaceToOriginLookingForward();
 
                 yield return hand.Show(initialHandPosition);
-                yield return hand.MoveTo(initialGrabPosition, numHandSteps);
+                yield return hand.MoveTo(initialGrabPosition);
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
                 // save relative pos grab point to object
@@ -356,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                     // move hand with the camera
                     Vector3 newHandPosition = Quaternion.AngleAxis(degreeStep * i, Vector3.up) * initialGrabPosition;
-                    yield return hand.MoveTo(newHandPosition, numHandSteps);
+                    yield return hand.MoveToFast(newHandPosition);
 
                     // make sure that the offset between grab point and object pivot hasn't changed while rotating
                     Vector3 offsetRotated = MixedRealityPlayspace.InverseTransformPoint(newHandPosition) - MixedRealityPlayspace.InverseTransformPoint(testObject.transform.position);
@@ -397,7 +395,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             const int numCircleSteps = 10;
-            const int numHandSteps = 3;
 
             Vector3 initialHandPosition = new Vector3(0.04f, -0.18f, 0.3f); // grab point on the lower center part of the cube
             
@@ -458,7 +455,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                     // move hand with the camera
                     Vector3 newHandPosition = Quaternion.AngleAxis(degreeStep * i, Vector3.up) * initialHandPosition;
-                    yield return hand.MoveTo(newHandPosition, numHandSteps);
+                    yield return hand.MoveToFast(newHandPosition);
                     yield return new WaitForFixedUpdate();
                     yield return null;
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -76,7 +76,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        private const int numSteps = 30;
         // Scale larger than bounds vector to test bounds checks
         private float objectScale = 0.4f;
         private Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
@@ -161,29 +160,29 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             using (var catcher = CreateEventCatcher(touchable))
             {
                 // Touch started and completed when entering and exiting
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.AreEqual(1, catcher.EventsStarted);
                 Assert.AreEqual(0, catcher.EventsCompleted);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition, rightPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.AreEqual(1, catcher.EventsStarted);
                 Assert.AreEqual(1, catcher.EventsCompleted);
 
                 // Touch started and completed when entering and exiting behind the plane
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(1, catcher.EventsCompleted);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, backPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition, backPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
 
                 // No touch when moving at behind the plane
-                yield return PlayModeTestUtilities.MoveHandFromTo(backPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(backPosition, rightPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
 
                 // No touch when moving outside the bounds
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition + outOfBoundsOffset, objectPosition + outOfBoundsOffset, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition + outOfBoundsOffset, rightPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition + outOfBoundsOffset, objectPosition + outOfBoundsOffset, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition + outOfBoundsOffset, rightPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
             }
@@ -210,21 +209,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             using (var catcher = CreateEventCatcher(touchable))
             {
                 // Touch started and completed when entering and exiting the collider
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.AreEqual(1, catcher.EventsStarted);
                 Assert.AreEqual(0, catcher.EventsCompleted);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition, rightPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.AreEqual(1, catcher.EventsStarted);
                 Assert.AreEqual(1, catcher.EventsCompleted);
 
                 // No touch when moving outside the collider
-                yield return PlayModeTestUtilities.MoveHandFromTo(backPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(backPosition, rightPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.AreEqual(1, catcher.EventsStarted);
                 Assert.AreEqual(1, catcher.EventsCompleted);
 
                 // Touch when moving off-center
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition + outOfBoundsOffset, objectPosition + outOfBoundsOffset, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition + outOfBoundsOffset, rightPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition + outOfBoundsOffset, objectPosition + outOfBoundsOffset, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition + outOfBoundsOffset, rightPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
             }
@@ -272,13 +271,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSim);
 
-            yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+            yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
             // No. 0 is touched initially
             TestEvents(catchers, new int [] { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, new int [] { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
-            yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+            yield return PlayModeTestUtilities.MoveHand(objectPosition, rightPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
             // Only No. 3 gets touched when moving through the row, because No. 0 is still active while inside the poke threshold
             TestEvents(catchers, new int [] { 1, 0, 0, 1, 0, 0, 0, 0, 0, 0 }, new int [] { 1, 0, 0, 1, 0, 0, 0, 0, 0, 0 });
-            yield return PlayModeTestUtilities.MoveHandFromTo(rightPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+            yield return PlayModeTestUtilities.MoveHand(rightPosition, objectPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
             // No. 3 touched a second time
             TestEvents(catchers, new int [] { 1, 0, 0, 2, 0, 0, 0, 0, 0, 0 }, new int [] { 1, 0, 0, 2, 0, 0, 0, 0, 0, 0 });
 
@@ -322,8 +321,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSim);
-            yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, 1, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+            yield return PlayModeTestUtilities.SetHandState(objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
 
+            int numSteps = 10;
             for (int i = 0; i < numSteps; ++i)
             {
                 float scale = radiusStart + (radiusEnd - radiusStart) * (float)(i + 1) / (float)numSteps;
@@ -368,9 +368,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             using (var catcher = new UnityButtonEventCatcher(button))
             {
                 // Touch started and completed when entering and exiting
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.AreEqual(0, catcher.Click);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, initialHandPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition, initialHandPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.AreEqual(1, catcher.Click);
             }
 
@@ -402,18 +402,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             using (var catcher = new UnityToggleEventCatcher(toggle))
             {
                 // Turn on the toggle after exiting
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.IsFalse(catcher.IsOn);
                 Assert.AreEqual(0, catcher.Changed);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, initialHandPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition, initialHandPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.IsTrue(catcher.IsOn);
                 Assert.AreEqual(1, catcher.Changed);
 
                 // Turn off the toggle after exiting
-                yield return PlayModeTestUtilities.MoveHandFromTo(initialHandPosition, objectPosition, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(initialHandPosition, objectPosition, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                 Assert.IsTrue(catcher.IsOn);
                 Assert.AreEqual(1, catcher.Changed);
-                yield return PlayModeTestUtilities.MoveHandFromTo(objectPosition, initialHandPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
+                yield return PlayModeTestUtilities.MoveHand(objectPosition, initialHandPosition, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);
                 Assert.IsFalse(catcher.IsOn);
                 Assert.AreEqual(2, catcher.Changed);
             }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
@@ -35,6 +35,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // Unity's default scene name for a recently created scene
         const string playModeTestSceneName = "MixedRealityToolkit.PlayModeTestScene";
 
+        public const int HandMoveStepsFast = 3;
+        public const int HandMoveStepsSlow = 30;
+
+        // Keep number of steps low so tests run fast in batch mode.
+        private const int handMoveStepsDefaultBatchMode = 5;
+        // Increased number of steps to be able to see hand movements in the editor test runner.
+        private const int handMoveStepsDefaultEditor = 20;
+        public static int HandMoveStepsDefault => Application.isBatchMode ? handMoveStepsDefaultBatchMode : handMoveStepsDefaultEditor;
+
         private static Stack<MixedRealityInputSimulationProfile> inputSimulationProfiles = new Stack<MixedRealityInputSimulationProfile>();
 
         /// <summary>
@@ -238,10 +247,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         internal static IEnumerator SetHandState(Vector3 handPos, ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)
         {
-            yield return MoveHandFromTo(handPos, handPos, 2, ArticulatedHandPose.GestureId.Pinch, handedness, inputSimulationService);
+            yield return MoveHandSteps(handPos, handPos, 1, ArticulatedHandPose.GestureId.Pinch, handedness, inputSimulationService);
         }
 
-        internal static IEnumerator MoveHandFromTo(
+        /// <summary>
+        /// Move a hand controller over a given number of steps.
+        /// </summary>
+        internal static IEnumerator MoveHandSteps(
             Vector3 startPos, Vector3 endPos, int numSteps,
             ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)
         {
@@ -250,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             for (int i = 1; i <= numSteps; i++)
             {
-                float t = i / (float) numSteps;
+                float t = i / (float)numSteps;
                 Vector3 handPos = Vector3.Lerp(startPos, endPos, t);
                 var handDataGenerator = GenerateHandPose(
                         gestureId,
@@ -260,6 +272,36 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 handData.Update(true, isPinching, handDataGenerator);
                 yield return null;
             }
+        }
+
+        /// <summary>
+        /// Move a hand controller using the default number of steps.
+        /// </summary>
+        internal static IEnumerator MoveHand(
+            Vector3 startPos, Vector3 endPos,
+            ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)
+        {
+            yield return MoveHandSteps(startPos, endPos, HandMoveStepsDefault, gestureId, handedness, inputSimulationService);
+        }
+
+        /// <summary>
+        /// Move a hand controller with minimal number of steps.
+        /// </summary>
+        internal static IEnumerator MoveHandFast(
+            Vector3 startPos, Vector3 endPos,
+            ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)
+        {
+            yield return MoveHandSteps(startPos, endPos, HandMoveStepsFast, gestureId, handedness, inputSimulationService);
+        }
+
+        /// <summary>
+        /// Move a hand controller with large number of steps.
+        /// </summary>
+        internal static IEnumerator MoveHandSlow(
+            Vector3 startPos, Vector3 endPos,
+            ArticulatedHandPose.GestureId gestureId, Handedness handedness, InputSimulationService inputSimulationService)
+        {
+            yield return MoveHandSteps(startPos, endPos, HandMoveStepsSlow, gestureId, handedness, inputSimulationService);
         }
 
         internal static IEnumerator HideHand(Handedness handedness, InputSimulationService inputSimulationService)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerEventsTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerEventsTests.cs
@@ -123,9 +123,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private PointerHandler handler;
 
-        // Keeping this low by default so the test runs fast. Increase it to be able to see hand movements in the editor.
-        private const int numFramesPerMove = 1;
-
         // Initializes MRTK, instantiates the test content prefab and adds a pointer handler to the test collider
         [SetUp]
         public void SetUp()
@@ -184,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move hand closer to the collider so it gives it focus
             Vector3 rightFocusPos = new Vector3(0.05f, 0, 1.5f);
-            yield return rightHand.MoveTo(rightFocusPos, numFramesPerMove);
+            yield return rightHand.MoveTo(rightFocusPos);
 
             expected.numBeforeFocusChange++;
             expected.numFocusChanged++;
@@ -201,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Maintain pinch for a number of frames
             previousNumPointerDragged = handler.state.numPointerDragged;
-            yield return rightHand.MoveTo(rightFocusPos, numFramesPerMove);
+            yield return rightHand.MoveTo(rightFocusPos);
 
             Assert.Greater(handler.state.numPointerDragged, previousNumPointerDragged);
             handler.state.AssertEqual(expected);
@@ -214,7 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             handler.state.AssertEqual(expected);
 
             // Move back to no focus
-            yield return rightHand.MoveTo(rightNoFocusPos, numFramesPerMove);
+            yield return rightHand.MoveTo(rightNoFocusPos);
 
             expected.numBeforeFocusChange++;
             expected.numFocusChanged++;
@@ -235,7 +232,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move left hand to give focus
             Vector3 leftFocusPos = new Vector3(-0.05f, 0, 1.5f);
-            yield return leftHand.MoveTo(leftFocusPos, numFramesPerMove);
+            yield return leftHand.MoveTo(leftFocusPos);
 
             expected.numBeforeFocusChange++;
             expected.numFocusChanged++;
@@ -243,7 +240,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             handler.state.AssertEqual(expected);
 
             // Move right hand to give focus
-            yield return rightHand.MoveTo(rightFocusPos, numFramesPerMove);
+            yield return rightHand.MoveTo(rightFocusPos);
 
             // Focus enter should not be raised as the object is already in focus.
             expected.numBeforeFocusChange++;
@@ -286,7 +283,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             handler.state.AssertEqual(expected);
 
             // Move left out of focus
-            yield return leftHand.MoveTo(leftNoFocusPos, numFramesPerMove);
+            yield return leftHand.MoveTo(leftNoFocusPos);
 
             // Focus exit should not be raised as the object is still in focus.
             expected.numBeforeFocusChange++;
@@ -294,7 +291,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             handler.state.AssertEqual(expected);
 
             // Move right out of focus
-            yield return rightHand.MoveTo(rightNoFocusPos, numFramesPerMove);
+            yield return rightHand.MoveTo(rightNoFocusPos);
 
             expected.numBeforeFocusChange++;
             expected.numFocusChanged++;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -94,14 +94,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move the hand forward to press button, then off to the right
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 30;
             Vector3 p1 = new Vector3(0, 0, 0.5f);
             Vector3 p2 = new Vector3(0, 0, 1.08f);
             Vector3 p3 = new Vector3(0.1f, 0, 1.08f);
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(p1, p2, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHand(p2, p3, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
 
             Assert.IsTrue(buttonPressed, "Button did not get pressed when hand moved to press it.");
@@ -135,12 +134,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // move the hand quickly from very far distance into the button and check if it was pressed
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 2;
             Vector3 p1 = new Vector3(0, 0, -20.0f);
             Vector3 p2 = new Vector3(0, 0, 0.02f);
 
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHandFast(p1, p2, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
 
             Assert.IsTrue(buttonPressed, "Button did not get pressed when hand moved to press it.");
@@ -395,15 +393,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestHand hand = new TestHand(Handedness.Right);
 
             // test scenarios in normal and low framerate
-            int[] stepVariations = { 30, 2 };
+            int[] stepVariations = { PlayModeTestUtilities.HandMoveStepsSlow, PlayModeTestUtilities.HandMoveStepsFast };
             for (int i = 0; i < stepVariations.Length; ++i)
             {
                 int numSteps = stepVariations[i];
 
                 // test release
                 yield return hand.Show(startHand);
-                yield return hand.MoveTo(inButtonOnPress, numSteps);
-                yield return hand.MoveTo(inButtonOnRelease, numSteps);
+                yield return hand.MoveToSteps(inButtonOnPress, numSteps);
+                yield return hand.MoveToSteps(inButtonOnRelease, numSteps);
                 yield return hand.Hide();
                 
                 Assert.IsTrue(buttonPressed, "Button did not get pressed when hand moved to press it.");
@@ -416,8 +414,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                 // test release on moving outside of button 
                 yield return hand.Show(startHand);
-                yield return hand.MoveTo(inButtonOnPress, numSteps);
-                yield return hand.MoveTo(rightOfButtonPress, numSteps);
+                yield return hand.MoveToSteps(inButtonOnPress, numSteps);
+                yield return hand.MoveToSteps(rightOfButtonPress, numSteps);
                 yield return hand.Hide();
                 
                 Assert.IsTrue(buttonPressed, "Button did not get pressed when hand moved to press it.");
@@ -430,8 +428,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                 // test no release on moving outside of button when releaseOnTouchEnd is disabled
                 yield return hand.Show(startHand);
-                yield return hand.MoveTo(inButtonOnPress, numSteps);
-                yield return hand.MoveTo(rightOfButtonPress, numSteps);
+                yield return hand.MoveToSteps(inButtonOnPress, numSteps);
+                yield return hand.MoveToSteps(rightOfButtonPress, numSteps);
                 yield return hand.Hide();
 
                 Assert.IsTrue(buttonPressed, "Button did not get pressed when hand moved to press it.");

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             TestHand h = new TestHand(Handedness.Right); ;
             yield return h.MoveTo(panObject.transform.position);
-            yield return h.Move(new Vector3(0, -0.05f, 0), 10);
+            yield return h.Move(new Vector3(0, -0.05f, 0));
 
             Assert.AreEqual(0.1, totalPanDelta.y, 0.05, "pan delta is not correct");
 
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return h.Show(CameraCache.Main.ScreenToWorldPoint(screenPoint));
 
             yield return h.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return h.Move(new Vector3(0, -0.05f, 0), 10);
+            yield return h.Move(new Vector3(0, -0.05f, 0));
             yield return h.SetGesture(ArticulatedHandPose.GestureId.Open);
 
             Assert.AreEqual(0.1, totalPanDelta.y, 0.05, "pan delta is not correct");
@@ -98,11 +98,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestHand h = new TestHand(Handedness.Right);
             yield return h.Show(Vector3.zero);
 
-            yield return h.MoveTo(panZoom.transform.position, 10);
+            yield return h.MoveTo(panZoom.transform.position);
 
             TestHand h2 = new TestHand(Handedness.Left);
             yield return h2.Show(Vector3.zero);
-            yield return h2.MoveTo(panZoom.transform.position + Vector3.right * -0.01f, 10);
+            yield return h2.MoveTo(panZoom.transform.position + Vector3.right * -0.01f);
 
             yield return h.Move(new Vector3(0.01f, 0f, 0f));
             yield return h2.Move(new Vector3(-0.01f, 0f, 0f));

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpherePointerTests.cs
@@ -23,9 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     // Tests to verify sphere pointer distances
     public class SpherePointerTests
     {
-        // Keeping this low by default so the test runs fast. Increase it to be able to see hand movements in the editor.
-        private const int numFramesPerMove = 3;
-
         private float colliderSurfaceZ;
 
         // Initializes MRTK, instantiates the test content prefab and adds a pointer handler to the test collider
@@ -72,34 +69,34 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(pointer.IsInteractionEnabled);
 
             // Move hand closer to the collider to enable IsNearObject
-            yield return rightHand.MoveTo(nearObjectPos - margin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos - margin);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
-            yield return rightHand.MoveTo(nearObjectPos + margin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos + margin);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
             // Move hand closer to the collider to enable IsInteractionEnabled
-            yield return rightHand.MoveTo(interactionEnabledPos - margin, numFramesPerMove);
+            yield return rightHand.MoveTo(interactionEnabledPos - margin);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
-            yield return rightHand.MoveTo(interactionEnabledPos + margin, numFramesPerMove);
+            yield return rightHand.MoveTo(interactionEnabledPos + margin);
             Assert.True(pointer.IsNearObject);
             Assert.True(pointer.IsInteractionEnabled);
             // Move hand back out to disable IsInteractionEnabled
-            yield return rightHand.MoveTo(interactionEnabledPos - margin, numFramesPerMove);
+            yield return rightHand.MoveTo(interactionEnabledPos - margin);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
             // Move hand back out to disable IsNearObject
-            yield return rightHand.MoveTo(nearObjectPos + margin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos + margin);
             Assert.True(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
-            yield return rightHand.MoveTo(nearObjectPos - margin, numFramesPerMove);
+            yield return rightHand.MoveTo(nearObjectPos - margin);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
-            yield return rightHand.MoveTo(idlePos, numFramesPerMove);
+            yield return rightHand.MoveTo(idlePos);
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
@@ -50,30 +50,60 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return new WaitForFixedUpdate();
         }
 
-        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 30)
+        public IEnumerator MoveToSteps(Vector3 newPosition, int numSteps)
         {
             Vector3 oldPosition = position;
             position = newPosition;
-            yield return PlayModeTestUtilities.MoveHandFromTo(oldPosition, newPosition, numSteps, gestureId, handedness, simulationService);
+            yield return PlayModeTestUtilities.MoveHandSteps(oldPosition, newPosition, numSteps, gestureId, handedness, simulationService);
             yield return new WaitForFixedUpdate();
         }
 
-        public IEnumerator Move(Vector3 delta, int numSteps = 30)
+        public IEnumerator MoveTo(Vector3 newPosition)
         {
-            yield return MoveTo(position + delta, numSteps);
+            yield return MoveToSteps(newPosition, PlayModeTestUtilities.HandMoveStepsDefault);
+        }
+
+        public IEnumerator MoveToFast(Vector3 newPosition)
+        {
+            yield return MoveToSteps(newPosition, PlayModeTestUtilities.HandMoveStepsFast);
+        }
+
+        public IEnumerator MoveToSlow(Vector3 newPosition)
+        {
+            yield return MoveToSteps(newPosition, PlayModeTestUtilities.HandMoveStepsSlow);
+        }
+
+        public IEnumerator MoveSteps(Vector3 delta, int numSteps)
+        {
+            yield return MoveToSteps(position + delta, numSteps);
+        }
+
+        public IEnumerator Move(Vector3 delta)
+        {
+            yield return MoveSteps(position, PlayModeTestUtilities.HandMoveStepsDefault);
+        }
+
+        public IEnumerator MoveFast(Vector3 delta)
+        {
+            yield return MoveSteps(position, PlayModeTestUtilities.HandMoveStepsFast);
+        }
+
+        public IEnumerator MoveSlow(Vector3 delta)
+        {
+            yield return MoveSteps(position, PlayModeTestUtilities.HandMoveStepsSlow);
         }
 
         public IEnumerator SetGesture(ArticulatedHandPose.GestureId newGestureId)
         {
             gestureId = newGestureId;
-            yield return PlayModeTestUtilities.MoveHandFromTo(position, position, 1, gestureId, handedness, simulationService);
+            yield return PlayModeTestUtilities.SetHandState(position, gestureId, handedness, simulationService);
             yield return new WaitForFixedUpdate();
         }
 
-        public IEnumerator GrabAndThrowAt(Vector3 positionToRelease, int numSteps = 30)
+        public IEnumerator GrabAndThrowAt(Vector3 positionToRelease)
         {
             yield return SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return MoveTo(positionToRelease, numSteps);
+            yield return MoveTo(positionToRelease);
             yield return SetGesture(ArticulatedHandPose.GestureId.Open);
         }
 


### PR DESCRIPTION
## Overview

Hand movement in tests is currently done with explicit frame step numbers in every test. Each test has its own definition for the number of tests, some running with lower numbers to decrease overall test run time.

This change adds a few central hand move step numbers in the PlayModeTestUtilities for fast/slow/default movement. The default is lower when run in batch mode to speed up test runs.

## Verification
Make sure tests pass both locally and on CI (use the -batchmode argument to run CI-like tests locally).