### PR TITLE
Add Platform Toolset switch to Build Window

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -41,6 +41,13 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             ARM = 2,
         }
 
+        private enum PlatformToolset
+        {
+            Solution,
+            v141,
+            v142,
+        }
+
         #endregion Internal Types
 
         #region Constants and Readonly Values
@@ -515,6 +522,31 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             if (newBuildArchitectureString != currentArchitectureString)
             {
                 EditorUserBuildSettings.wsaArchitecture = newBuildArchitectureString;
+            }
+
+            // Platform Toolset (and save setting, if it's changed)
+            string currentPlatformToolsetString = UwpBuildDeployPreferences.PlatformToolset;
+
+            PlatformToolset platformToolset = PlatformToolset.Solution;
+            if (string.IsNullOrEmpty(currentPlatformToolsetString))
+            {
+                platformToolset = PlatformToolset.Solution;
+            }
+            else if(currentPlatformToolsetString.ToLower().Equals(PlatformToolset.v141.ToString().ToLower()))
+            {
+                platformToolset = PlatformToolset.v141;
+            }
+            else if (currentPlatformToolsetString.ToLower().Equals(PlatformToolset.v142.ToString().ToLower()))
+            {
+                platformToolset = PlatformToolset.v142;
+            }
+
+            platformToolset = (PlatformToolset)EditorGUILayout.EnumPopup("Platform Toolset", platformToolset, GUILayout.Width(HALF_WIDTH));
+
+            string platformToolsetString = platformToolset == PlatformToolset.Solution ? string.Empty : platformToolset.ToString();
+            if (platformToolsetString != currentPlatformToolsetString)
+            {
+                UwpBuildDeployPreferences.PlatformToolset = platformToolsetString;
             }
 
             // The 'Gaze Input' capability support was added for HL2 in the Windows SDK 18362, but 

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             // Now that NuGet packages have been restored, we can run the actual build process.
             exitCode = await Run(msBuildPath, 
-                $"\"{solutionProjectPath}\" /t:{(buildInfo.RebuildAppx ? "Rebuild" : "Build")} /p:Configuration={buildInfo.Configuration} /p:Platform={buildInfo.BuildPlatform} {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "buildAppx.log")}",
+                $"\"{solutionProjectPath}\" /t:{(buildInfo.RebuildAppx ? "Rebuild" : "Build")} /p:Configuration={buildInfo.Configuration} /p:Platform={buildInfo.BuildPlatform} {(string.IsNullOrEmpty(buildInfo.PlatformToolset) ? string.Empty : $"/p:PlatformToolset={buildInfo.PlatformToolset}")} {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "buildAppx.log")}",
                 !Application.isBatchMode,
                 cancellationToken);
             AssetDatabase.SaveAssets();

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -12,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
     {
         public static Version MIN_SDK_VERSION = new Version("10.0.18362.0");
         private const string EDITOR_PREF_BUILD_CONFIG = "BuildDeployWindow_BuildConfig";
+        private const string EDITOR_PREF_PLATFORM_TOOLSET = "BuildDeployWindow_PlatformToolset";
         private const string EDITOR_PREF_FORCE_REBUILD = "BuildDeployWindow_ForceRebuild";
         private const string EDITOR_PREF_CONNECT_INFOS = "BuildDeployWindow_DeviceConnections";
         private const string EDITOR_PREF_FULL_REINSTALL = "BuildDeployWindow_FullReinstall";
@@ -26,6 +27,15 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             get => EditorPreferences.Get(EDITOR_PREF_BUILD_CONFIG, "master");
             set => EditorPreferences.Set(EDITOR_PREF_BUILD_CONFIG, value.ToLower());
+        }
+
+        /// <summary>
+        /// The current Build Configuration. (Debug, Release, or Master)
+        /// </summary>
+        public static string PlatformToolset
+        {
+            get => EditorPreferences.Get(EDITOR_PREF_PLATFORM_TOOLSET, string.Empty);
+            set => EditorPreferences.Set(EDITOR_PREF_PLATFORM_TOOLSET, value.ToLower());
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
@@ -25,6 +25,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         public bool RebuildAppx { get; set; } = false;
 
         /// <summary>
+        /// VC Platform Toolset used building the appx bundle
+        /// </summary>
+        public string PlatformToolset { get; set; }
+
+        /// <summary>
         /// If true, the 'Gaze Input' capability will be added to the AppX
         /// manifest after the Unity build.
         /// </summary>


### PR DESCRIPTION
## Overview

The project solution produced by the Unity build step always targets Platform Toolset v141 (Visual Studio 2017), regardless of Visual Studio Version Build Settings or whether Visual Studio 2017 or 2019 is installed. Build failures arise, when there is no Platform Toolset v141 installed, i.e. only Visual Studio 2019 has been installed. 

This issue has been reported already to Unity : https://issuetracker.unity3d.com/issues/uwp-building-project-for-visual-studio-2019-generates-solution-that-targets-build-tools-for-vs-2017-tool-set-v141

Attempts to figure out whether Platform Toolset v141 is installed seem to be non-trivial. For the time being, a convenience workaround is to override the Platform Toolset when invoking MSBuild. For the user this override is exposed as Appx Build Option in the Build Window. It defaults to Platform Toolset v141, but lets the user choose to override it to v142 in case v141 is not installed.