### PR TITLE
Fix build failure due to empty scene paths

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var buildInfo = new UwpBuildInfo
             {
                 OutputDirectory = buildDirectory,
-                Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path),
+                Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled && !string.IsNullOrEmpty(scene.path)).Select(scene => scene.path),
                 BuildAppx = !showDialog,
                 BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
                 GazeInputCapabilityEnabled = UwpBuildDeployPreferences.GazeInputCapabilityEnabled,


### PR DESCRIPTION
## Overview

There are occasions where the EditorBuildSettings enumerates all scenes, regardless whether they are missing or not. In that case the scene is reported as enabled, though has an empty path. The build process later fails, as is cant' find the scene at `""`. Therefore better be safe than sorry and filter out scenes that have an empty path.