### PR TITLE
Compute correct hostTransform position when rotating with one hand.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -575,47 +575,50 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             Quaternion targetRotation = Quaternion.identity;
             RotateInOneHandType rotateInOneHandType = isNearManipulation ? oneHandRotationModeNear : oneHandRotationModeFar;
-            if (rotateInOneHandType == RotateInOneHandType.MaintainOriginalRotation)
+            switch (rotateInOneHandType)
             {
-                targetRotation = hostTransform.rotation;
-            }
-            else if (rotateInOneHandType == RotateInOneHandType.MaintainRotationToUser)
-            {
-                Vector3 euler = CameraCache.Main.transform.rotation.eulerAngles;
-                // don't use roll (feels awkward) - just maintain yaw / pitch angle
-                targetRotation = Quaternion.Euler(euler.x, euler.y, 0) * startObjectRotationCameraSpace;
-            }
-            else if (rotateInOneHandType == RotateInOneHandType.GravityAlignedMaintainRotationToUser)
-            {
-                var cameraForwardFlat = CameraCache.Main.transform.forward;
-                cameraForwardFlat.y = 0;
-                targetRotation = Quaternion.LookRotation(cameraForwardFlat, Vector3.up) * startObjectRotationFlatCameraSpace;
-            }
-            else if (rotateInOneHandType == RotateInOneHandType.FaceUser)
-            {
-                Vector3 directionToTarget = hostTransform.position - CameraCache.Main.transform.position;
-                targetRotation = Quaternion.LookRotation(-directionToTarget);
-            }
-            else if (rotateInOneHandType == RotateInOneHandType.FaceAwayFromUser)
-            {
-                Vector3 directionToTarget = hostTransform.position - CameraCache.Main.transform.position;
-                targetRotation = Quaternion.LookRotation(directionToTarget);
-            }
-            else
-            {
-                targetRotation = pointer.Rotation * objectToHandRotation;
-                switch (constraintOnRotation)
+                case RotateInOneHandType.MaintainOriginalRotation:
+                    targetRotation = hostTransform.rotation;
+                    break;
+                case RotateInOneHandType.MaintainRotationToUser:
+                    Vector3 euler = CameraCache.Main.transform.rotation.eulerAngles;
+                    // don't use roll (feels awkward) - just maintain yaw / pitch angle
+                    targetRotation = Quaternion.Euler(euler.x, euler.y, 0) * startObjectRotationCameraSpace;
+                    break;
+                case RotateInOneHandType.GravityAlignedMaintainRotationToUser:
+                    var cameraForwardFlat = CameraCache.Main.transform.forward;
+                    cameraForwardFlat.y = 0;
+                    targetRotation = Quaternion.LookRotation(cameraForwardFlat, Vector3.up) * startObjectRotationFlatCameraSpace;
+                    break;
+                case RotateInOneHandType.FaceUser:
                 {
-                    case RotationConstraintType.XAxisOnly:
-                        targetRotation.eulerAngles = Vector3.Scale(targetRotation.eulerAngles, Vector3.right);
-                        break;
-                    case RotationConstraintType.YAxisOnly:
-                        targetRotation.eulerAngles = Vector3.Scale(targetRotation.eulerAngles, Vector3.up);
-                        break;
-                    case RotationConstraintType.ZAxisOnly:
-                        targetRotation.eulerAngles = Vector3.Scale(targetRotation.eulerAngles, Vector3.forward);
-                        break;
+                    Vector3 directionToTarget = pointerData.GrabPoint - CameraCache.Main.transform.position;
+                    // Vector3 directionToTarget = hostTransform.position - CameraCache.Main.transform.position;
+                    targetRotation = Quaternion.LookRotation(-directionToTarget);
+                    break;
                 }
+                case RotateInOneHandType.FaceAwayFromUser:
+                {
+                    Vector3 directionToTarget = pointerData.GrabPoint - CameraCache.Main.transform.position;
+                    targetRotation = Quaternion.LookRotation(directionToTarget);
+                    break;
+                }
+                case RotateInOneHandType.RotateAboutObjectCenter:
+                case RotateInOneHandType.RotateAboutGrabPoint:
+                    targetRotation = pointer.Rotation * objectToHandRotation;
+                    switch (constraintOnRotation)
+                    {
+                        case RotationConstraintType.XAxisOnly:
+                            targetRotation.eulerAngles = Vector3.Scale(targetRotation.eulerAngles, Vector3.right);
+                            break;
+                        case RotationConstraintType.YAxisOnly:
+                            targetRotation.eulerAngles = Vector3.Scale(targetRotation.eulerAngles, Vector3.up);
+                            break;
+                        case RotationConstraintType.ZAxisOnly:
+                            targetRotation.eulerAngles = Vector3.Scale(targetRotation.eulerAngles, Vector3.forward);
+                            break;
+                    }
+                    break;
             }
 
             Vector3 targetPosition;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -330,11 +330,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 TestUtilities.PlayspaceToOriginLookingForward();
 
                 yield return hand.Show(initialHandPosition);
+                var pointer = hand.GetPointer<SpherePointer>();
+                Assert.IsNotNull(pointer);
+
                 yield return hand.MoveTo(initialGrabPosition, numHandSteps);
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
                 // save relative pos grab point to object
-                Vector3 initialOffsetGrabToObjPivot = MixedRealityPlayspace.InverseTransformPoint(initialGrabPosition) - MixedRealityPlayspace.InverseTransformPoint(testObject.transform.position);
+                Vector3 initialGrabPointInObject = testObject.transform.InverseTransformPoint(pointer.Position);
 
                 // full circle
                 const int degreeStep = 360 / numCircleSteps;
@@ -359,8 +362,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                     yield return hand.MoveTo(newHandPosition, numHandSteps);
 
                     // make sure that the offset between grab point and object pivot hasn't changed while rotating
-                    Vector3 offsetRotated = MixedRealityPlayspace.InverseTransformPoint(newHandPosition) - MixedRealityPlayspace.InverseTransformPoint(testObject.transform.position);
-                    TestUtilities.AssertAboutEqual(offsetRotated, initialOffsetGrabToObjPivot, "Grab point on object changed during rotation");
+                    Vector3 grabPoint = pointer.Position;
+                    Vector3 cornerRotated = testObject.transform.TransformPoint(initialGrabPointInObject);
+                    TestUtilities.AssertAboutEqual(cornerRotated, grabPoint, "Grab point on object changed during rotation");
                 }
 
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);


### PR DESCRIPTION
## Overview

The host object position with one-handed near interaction was computed incorrectly, leading to the object drifting off the grab point when rotating.

The host position `P_h` should be computed such that the GrabPoint `P_g` of the controller stays fixed in space. For that purpose the _initial_ grab point (at the start of the manipulation) is computed in local host space:

```
L_g = R_h^T * (P_g - P_h)
```

where `R_h^T` is the inverse host rotation. The local grab point `L_g` is constant during manipulation, since we want the object to remain grabbed in the same place.

During manipulation the host rotation `R_h` is computed first. To then get the world space position `P_h` of the host can use the given world space grab point:

```
    P_g = R_h * L_g + P_h
<=> P_h = P_g - R_h * L_g
```

## Changes
- Fixes: #4126 .


## Verification
Make sure that existing manipulation tests still work or are update where needed.