### PR TITLE
Turn off hand ray visuals if hands not facing you / interaction is not enabled

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -140,34 +140,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnPostSceneQuery();
 
-            Gradient lineColor = LineColorNoTarget;
+            LineBase.enabled = IsInteractionEnabled;
+            BaseCursor?.SetVisibility(IsInteractionEnabled);
 
-            if (!IsActive)
+            if (!LineBase.enabled) 
             {
-                lineBase.enabled = false;
-                BaseCursor?.SetVisibility(false);
                 return;
             }
 
-            lineBase.enabled = true;
-            BaseCursor?.SetVisibility(true);
-
             // The distance the ray travels through the world before it hits something. Measured in world-units (as opposed to normalized distance).
             float clearWorldLength;
-            // Used to ensure the line doesn't extend beyond the cursor
-            float cursorOffsetWorldLength = (BaseCursor != null) ? BaseCursor.SurfaceCursorDistance : 0;
-
-            // If we hit something
+            Gradient lineColor = LineColorNoTarget;
             if (Result?.CurrentPointerTarget != null)
             {
+                // We hit something
                 clearWorldLength = Result.Details.RayDistance;
-
                 lineColor = LineColorValid;
             }
             else
             {
                 clearWorldLength = DefaultPointerExtent;
-
                 lineColor = IsSelectPressed ? LineColorSelected : LineColorNoTarget;
             }
 
@@ -177,14 +169,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             int maxClampLineSteps = LineCastResolution;
-
             foreach (BaseMixedRealityLineRenderer lineRenderer in lineRenderers)
             {
                 // Renderers are enabled by default if line is enabled
-                lineRenderer.enabled = true;
+                lineRenderer.enabled = IsInteractionEnabled;
                 maxClampLineSteps = Mathf.Max(maxClampLineSteps, lineRenderer.LineStepCount);
                 lineRenderer.LineColor = lineColor;
             }
+
+            // Used to ensure the line doesn't extend beyond the cursor
+            float cursorOffsetWorldLength = (BaseCursor != null) ? BaseCursor.SurfaceCursorDistance : 0;
 
             // If focus is locked, we're sticking to the target
             // So don't clamp the world length
@@ -197,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 // Otherwise clamp the line end by the clear distance
                 float clearLocalLength = lineBase.GetNormalizedLengthFromWorldLength(clearWorldLength - cursorOffsetWorldLength, maxClampLineSteps);
-                lineBase.LineEndClamp = clearLocalLength;
+                LineBase.LineEndClamp = clearLocalLength;
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -172,7 +172,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             foreach (BaseMixedRealityLineRenderer lineRenderer in lineRenderers)
             {
                 // Renderers are enabled by default if line is enabled
-                lineRenderer.enabled = IsInteractionEnabled;
                 maxClampLineSteps = Mathf.Max(maxClampLineSteps, lineRenderer.LineStepCount);
                 lineRenderer.LineColor = lineColor;
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Hide every line renderer except the contextual one
             foreach (BaseMixedRealityLineRenderer lineRenderer in LineRenderers)
             {
-                lineRenderer.enabled = IsInteractionEnabled && lineRenderer == lineToShow;
+                lineRenderer.enabled = lineRenderer == lineToShow;
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -40,81 +40,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnPostSceneQuery()
         {
-            if (IsSelectPressed)
-            {
-                InputSystem.RaisePointerDragged(this, MixedRealityInputAction.None, Handedness);
-            }
+            base.OnPostSceneQuery();
 
-            Gradient lineColor = LineColorNoTarget;
-            BaseMixedRealityLineRenderer contextRenderer = null;
-
-            if (!IsActive)
+            if (!LineBase.enabled) 
             {
-                LineBase.enabled = false;
-                BaseCursor?.SetVisibility(false);
                 return;
             }
 
-            contextRenderer = lineRendererNoTarget;
-            LineBase.enabled = true;
-            BaseCursor?.SetVisibility(true);
 
-            float clearWorldLength;
-            float cursorOffsetWorldLength = (BaseCursor != null) ? BaseCursor.SurfaceCursorDistance : 0;
+            BaseMixedRealityLineRenderer lineToShow = lineRendererNoTarget;
 
-            // If we hit something
-            if (Result?.CurrentPointerTarget != null)
+            if (Result?.CurrentPointerTarget != null || IsSelectPressed )
             {
-                clearWorldLength = Result.Details.RayDistance;
-
-                lineColor = LineColorValid;
-                contextRenderer = lineRendererSelected;
-            }
-            else
-            {
-                clearWorldLength = DefaultPointerExtent;
-
-                lineColor = IsSelectPressed ? LineColorSelected : LineColorNoTarget;
-                contextRenderer = IsSelectPressed ? lineRendererSelected : lineRendererNoTarget;
+                lineToShow = lineRendererSelected;
             }
 
-            if (IsFocusLocked)
-            {
-                lineColor = LineColorLockFocus;
-                contextRenderer = lineRendererSelected;
-            }
-
-            int maxClampLineSteps = LineCastResolution;
-
+            // Hide every line renderer except the contextual one
             foreach (BaseMixedRealityLineRenderer lineRenderer in LineRenderers)
             {
-                // Otherwise, enable the renderer we chose
-                if (lineRenderer == contextRenderer)
-                {
-                    lineRenderer.enabled = true;
-                    maxClampLineSteps = Mathf.Max(maxClampLineSteps, lineRenderer.LineStepCount);
-                }
-                else
-                {
-                    lineRenderer.enabled = false;
-                }
-
-                // Set colors on all line renderers regardless of context
-                lineRenderer.LineColor = lineColor;
-            }
-
-            // If focus and target point is locked, we're sticking to the target
-            // So don't clamp the world length
-            if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
-            {
-                float cursorOffsetLocalLength = LineBase.GetNormalizedLengthFromWorldLength(cursorOffsetWorldLength);
-                LineBase.LineEndClamp = 1 - cursorOffsetLocalLength;
-            }
-            else
-            {
-                // Otherwise clamp the line end by the clear distance
-                float clearLocalLength = LineBase.GetNormalizedLengthFromWorldLength(clearWorldLength - cursorOffsetWorldLength, maxClampLineSteps);
-                LineBase.LineEndClamp = clearLocalLength;
+                lineRenderer.enabled = IsInteractionEnabled && lineRenderer == lineToShow;
             }
         }
 


### PR DESCRIPTION
## Overview
The hand ray / line pointer should not be visible when IsInteractionEnabled == false, otherwise it looks to the user like he/she can manipulation content with rays when she cannot. For example, when hands are facing the user, we set IsInteractionEnabled to false to avoid users grabbing things unintentionally.

This change fixes the LinePointer and ShellPointer code to not render lines when IsInteractionEnabled == false.

## Changes
* Fixes: #4377 
* Don't render line if !InteractionEnabled
* Refactor ShellRayPointer to take advantage of inheritance. Previous code was just a copy/paste of base classes.
* Improve readability by reducing extra lines / logic and moving variable declaration closer to variable use

## Verification
* Tested in editor
* Not yet tested on device (need to test on HL2)