### PR TITLE
break out BaseCursor's target lerp functionality to make it accesible to derived classes

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -132,9 +132,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             set { visibleSourcesCount = value; }
         }
 
-        private Vector3 targetPosition;
-        private Vector3 targetScale;
-        private Quaternion targetRotation;
+        protected Vector3 targetPosition;
+        protected Vector3 targetScale;
+        protected Quaternion targetRotation;
 
         #region IMixedRealityCursor Implementation
 
@@ -428,6 +428,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
+            LerpToTargetTransform();
+        }
+
+        protected void LerpToTargetTransform()
+        {
             float deltaTime = useUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;
@@ -436,6 +441,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             transform.position = Vector3.Lerp(transform.position, targetPosition, deltaTime / positionLerpTime);
             transform.localScale = Vector3.Lerp(transform.localScale, targetScale, deltaTime / scaleLerpTime);
             transform.rotation = Quaternion.Lerp(transform.rotation, targetRotation, deltaTime / rotationLerpTime);
+        }
+
+        protected void SnapToTargetTransform()
+        {
+            transform.position = targetPosition;
+            transform.localScale = targetScale;
+            transform.rotation = targetRotation;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/InteractiveMeshCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/InteractiveMeshCursor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private bool hasHand = false;
         private bool isDown = false;
 
-        private new Vector3 targetScale;
+        private float ringDotTargetScale;
         private Vector3 initialScale;
 
         private void Awake()
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             isDown = IsPointerDown;
             hasHover = TargetedObject != null;
 
-            targetScale = Vector3.one * defaultScale;
+            ringDotTargetScale = defaultScale;
             bool showRing = false;
 
             switch (state)
@@ -89,14 +89,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     break;
                 case CursorStateEnum.Interact:
                     showRing = true;
-                    targetScale = Vector3.one * downScale;
+                    ringDotTargetScale = downScale;
                     break;
                 case CursorStateEnum.InteractHover:
                     showRing = true;
-                    targetScale = Vector3.one * upScale;
+                    ringDotTargetScale = upScale;
                     break;
                 case CursorStateEnum.Select:
-                    targetScale = Vector3.one * upScale;
+                    ringDotTargetScale = upScale;
                     break;
                 case CursorStateEnum.Release:
                     break;
@@ -135,8 +135,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     timer = scaleTime;
                 }
 
-                ring.transform.localScale = Vector3.Lerp(Vector3.one * defaultScale, targetScale, timer / scaleTime);
-                dot.transform.localScale = Vector3.Lerp(Vector3.one * defaultScale, targetScale, timer / scaleTime);
+                Vector3 useScale = Vector3.one * Mathf.Lerp(defaultScale, ringDotTargetScale, timer / scaleTime);
+                ring.transform.localScale = useScale;
+                dot.transform.localScale = useScale;
             }
 
             // handle scale of main cursor go

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/InteractiveMeshCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/InteractiveMeshCursor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private bool hasHand = false;
         private bool isDown = false;
 
-        private Vector3 targetScale;
+        private new Vector3 targetScale;
         private Vector3 initialScale;
 
         private void Awake()


### PR DESCRIPTION
## Overview

We override UpdateCursorTransform in some of our custom cursor classes, and I wanted to be able to use the lerp functionality of the BaseCursor class without having to duplicate it. It's a pretty small change, and we can workaround it easily enough if it's not generally useful (but I thought it might be at least).

