### PR TITLE
modify BaseCursor to better handle swapping between pointers

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/AnimatedCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/AnimatedCursor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnFocusChanged(eventData);
 
-            if (Pointer.CursorModifier != null)
+            if (Pointer?.CursorModifier != null)
             {
                 if ((Pointer.CursorModifier.CursorParameters != null) && (Pointer.CursorModifier.CursorParameters.Length > 0))
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/AnimatedCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/AnimatedCursor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnFocusChanged(eventData);
 
-            if (Pointer?.CursorModifier != null)
+            if (((Pointer is UnityEngine.Object) ? ((Pointer as UnityEngine.Object) != null) : (Pointer != null)) && Pointer.CursorModifier != null)
             {
                 if ((Pointer.CursorModifier.CursorParameters != null) && (Pointer.CursorModifier.CursorParameters.Length > 0))
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -144,7 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return pointer; }
             set
             {
-                if (ReferenceEquals(pointer?.BaseCursor, this))
+                if (IsPointerValid && ReferenceEquals(pointer.BaseCursor, this))
                 {
                     // if the previous pointer was attached to this cursor, null out the
                     // pointer's cursor reference - that way we don't have multiple pointers
@@ -153,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 pointer = value;
-                if (pointer != null)
+                if (IsPointerValid)
                 {
                     pointer.BaseCursor = this;
                 }
@@ -163,6 +163,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         private IMixedRealityPointer pointer;
+
+        /// <summary>
+        /// Checks whether the associated pointer is null, and if the pointer is a UnityEngine.Object it also checks whether it has been destroyed.
+        /// </summary>
+        protected bool IsPointerValid => (pointer is UnityEngine.Object) ? ((pointer as UnityEngine.Object) != null) : (pointer != null);
 
         /// <inheritdoc />
         public float DefaultCursorDistance
@@ -220,7 +225,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnSourceDetected(SourceStateEventData eventData)
         {
-            if (Pointer != null && eventData.Controller != null)
+            if (IsPointerValid && eventData.Controller != null)
             {
                 for (int i = 0; i < eventData.InputSource.Pointers.Length; i++)
                 {
@@ -243,7 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnSourceLost(SourceStateEventData eventData)
         {
-            if (Pointer != null && eventData.Controller != null)
+            if (IsPointerValid && eventData.Controller != null)
             {
                 for (int i = 0; i < eventData.InputSource.Pointers.Length; i++)
                 {
@@ -271,7 +276,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnBeforeFocusChange(FocusEventData eventData)
         {
-            if (Pointer != null && Pointer.PointerId == eventData.Pointer.PointerId)
+            if (IsPointerValid && Pointer.PointerId == eventData.Pointer.PointerId)
             {
                 TargetedObject = eventData.NewFocusedObject;
             }
@@ -287,7 +292,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            if (Pointer != null)
+            if (IsPointerValid)
             {
                 foreach (var sourcePointer in eventData.InputSource.Pointers)
                 {
@@ -309,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnPointerUp(MixedRealityPointerEventData eventData)
         {
-            if (Pointer != null)
+            if (IsPointerValid)
             {
                 foreach (var sourcePointer in eventData.InputSource.Pointers)
                 {
@@ -484,7 +489,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             SourceDownIds.Clear();
             visibleSourcesCount = 0;
-            if (Pointer != null)
+            if (IsPointerValid)
             {
                 uint cursorPointerId = Pointer.PointerId;
                 foreach (IMixedRealityInputSource inputSource in InputSystem.DetectedInputSources)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -146,6 +146,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (ReferenceEquals(pointer?.BaseCursor, this))
                 {
+                    // if the previous pointer was attached to this cursor, null out the
+                    // pointer's cursor reference - that way we don't have multiple pointers
+                    // trying to use the same cursor
                     pointer.BaseCursor = null;
                 }
 
@@ -253,7 +256,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-                SourceDownIds.Remove(eventData.SourceId);
+            SourceDownIds.Remove(eventData.SourceId);
 
             if (!IsSourceDetected && SetVisibilityOnSourceDetected)
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -259,10 +259,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             SourceDownIds.Remove(eventData.SourceId);
 
             if (!IsSourceDetected && SetVisibilityOnSourceDetected)
-                {
-                    SetVisibility(false);
-                }
+            {
+                SetVisibility(false);
             }
+        }
 
         #endregion IMixedRealitySourceStateHandler Implementation
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -384,7 +384,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // If flagged to do so (setCursorInvisibleWhenFocusLocked) and active (IsInteractionEnabled), set the visibility to !IsFocusLocked,
             // but don't touch the visibility when not active or not flagged.
             if (setCursorInvisibleWhenFocusLocked && gazePointer != null &&
-                gazePointer.IsInteractionEnabled && gazePointer.IsFocusLocked == GazeCursor.IsVisible)
+                gazePointer.IsInteractionEnabled && GazeCursor != null && gazePointer.IsFocusLocked == GazeCursor.IsVisible)
             {
                 GazeCursor.SetVisibility(!gazePointer.IsFocusLocked);
             }


### PR DESCRIPTION
## Overview

We mostly handle cursor management on our own, and use a single cursor instance which gets passed around to whatever pointer is active at a given time. This was causing some problems as some of the cursor code assumes a pretty strong pairing between cursor and pointer, so I've made some changes to hopefully make it a little more flexible without any detrimental effects on the normal usage.

## Changes
1. Various pointer/cursor null-checks so things don't break when they are detached from one another.
2. Make visibleSourcesCount and SourceDownIds refresh at certain points so that they don't get out-of-sync if the cursor missed some source state events.