### PR TITLE
Fix manipulation offsets for when origin not mesh centre

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -310,16 +310,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
             MixedRealityPose pose = new MixedRealityPose();
             pose.Position = (hand1.Position + hand2.Position) / 2;
 
-            Vector3 right = hand1.Position - hand2.Position;
-
             // WIP
-            Vector3 forward = Quaternion.AngleAxis(90, Vector3.up) * right;
+            Vector3 right = hand1.Position - hand2.Position;
+            Vector3 forward = (hand1.Rotation * Vector3.forward + hand2.Rotation * Vector3.forward);
             Vector3 up = Vector3.Cross(forward, right);
-            pose.Rotation = rotateLogic.Update(GetHandPositionMap(), targetRotationTwoHands, constraintOnRotation);
+            //pose.Rotation = rotateLogic.Update(GetHandPositionMap(), targetRotationTwoHands, constraintOnRotation);
+            pose.Rotation = Quaternion.LookRotation(forward);
 
             Debug.DrawRay(pose.Position, right.normalized, Color.red);
             Debug.DrawRay(pose.Position, up.normalized, Color.green);
-            Debug.DrawRay(pose.Position, Vector3.Cross(right, up).normalized, Color.blue);
+            Debug.DrawRay(pose.Position, forward.normalized, Color.blue);
 
             return pose;
         }
@@ -575,7 +575,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if ((currentState & State.Moving) > 0)
             {
                 MixedRealityPose pose = GetAveragePointerPose();
-                targetPosition = moveLogic.Update(pose, hostTransform.localScale, true, true);
+                targetPosition = moveLogic.Update(pose, hostTransform.localScale, true);
             }
 
             var handPositionMap = GetHandPositionMap();
@@ -660,7 +660,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             targetRotation = ApplyConstraints(targetRotation);
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
-            Vector3 targetPosition = moveLogic.Update(pointerPose, hostTransform.localScale, rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter, false);
+            Vector3 targetPosition = moveLogic.Update(pointerPose, hostTransform.localScale, rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter);
 
             float lerpAmount = GetLerpAmount();
             Quaternion smoothedRotation = Quaternion.Lerp(hostTransform.rotation, targetRotation, lerpAmount);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -483,15 +483,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Gets the grab point for the given pointer id
+        /// Gets the grab point for the given pointer id.
+        /// Only use if you know that your given pointer id corresponds to a pointer that has grabbed
+        /// this component.
         /// </summary>
         public Vector3 GetPointerGrabPoint(uint pointerId)
         {
-            if (pointerIdToPointerMap.ContainsKey(pointerId))
-            {
-                return pointerIdToPointerMap[pointerId].GrabPoint;
-            }
-            return Vector3.zero;
+            Assert.IsTrue(pointerIdToPointerMap.ContainsKey(pointerId));
+            return pointerIdToPointerMap[pointerId].GrabPoint;
         }
 
         #endregion Public Methods
@@ -664,8 +663,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             targetRotation = ApplyConstraints(targetRotation);
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
             Vector3 targetPosition = moveLogic.Update(pointerPose, targetRotation, hostTransform.localScale, IsNearManipulation(), rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter);
-            //Debug.DrawRay(pointer.Position, Vector3.up, Color.magenta);
-            Debug.DrawRay(pointerData.GrabPoint, Vector3.up, Color.cyan);
 
             float lerpAmount = GetLerpAmount();
             Quaternion smoothedRotation = Quaternion.Lerp(hostTransform.rotation, targetRotation, lerpAmount);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -275,28 +275,23 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private MixedRealityPose GetAveragePointerPose()
         {
-            Debug.Assert(pointerIdToPointerMap.Count > 1);
+            Vector3 sumPos = Vector3.zero;
+            Vector3 sumDir = Vector3.zero;
+            int count = 0;
+            foreach (var p in pointerIdToPointerMap.Values)
+            {
+                sumPos += p.pointer.Position;
+                sumDir += p.pointer.Rotation * Vector3.forward;
+                count++;
+            }
 
-            var handsEnumerator = pointerIdToPointerMap.Values.GetEnumerator();
-            handsEnumerator.MoveNext();
-            var hand1 = handsEnumerator.Current.pointer;
-            handsEnumerator.MoveNext();
-            var hand2 = handsEnumerator.Current.pointer;
-            handsEnumerator.Dispose();
-            
             MixedRealityPose pose = new MixedRealityPose();
-            pose.Position = (hand1.Position + hand2.Position) / 2;
 
-            // WIP
-            Vector3 right = hand1.Position - hand2.Position;
-            Vector3 forward = (hand1.Rotation * Vector3.forward + hand2.Rotation * Vector3.forward);
-            Vector3 up = Vector3.Cross(forward, right);
-            //pose.Rotation = rotateLogic.Update(GetHandPositionMap(), targetRotationTwoHands, constraintOnRotation);
-            pose.Rotation = Quaternion.LookRotation(forward);
-
-            Debug.DrawRay(pose.Position, right.normalized, Color.red);
-            Debug.DrawRay(pose.Position, up.normalized, Color.green);
-            Debug.DrawRay(pose.Position, forward.normalized, Color.blue);
+            if (count > 0)
+            {
+                pose.Position = sumPos / count;
+                pose.Rotation = Quaternion.LookRotation(sumDir / count);
+            }
 
             return pose;
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -671,7 +671,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// 
+        /// This test records the poses and scales of an object after various forms of manipulation,
+        /// once when the object origin is at the mesh centre and again when the origin is offset from the mesh.
+        /// The test then compares these poses and scales in order to ensure that they are about equal. 
         /// </summary>
         [UnityTest]
         public IEnumerator ManipulationHandlerOriginOffset()

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -18,6 +18,7 @@ using UnityEngine.TestTools;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
@@ -336,9 +337,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return hand.MoveTo(initialGrabPosition, numHandSteps);
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
-                yield return new WaitForFixedUpdate();
-                yield return null;
-
                 // save relative pos grab point to object
                 Vector3 initialOffsetGrabToObjPivot = pointer.Position - testObject.transform.position;
                 Vector3 initialGrabPointInObject = testObject.transform.InverseTransformPoint(manipHandler.GetPointerGrabPoint(pointer.PointerId));
@@ -575,6 +573,162 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             yield return hand.Hide();
+        }
+
+        private class OriginOffsetTest
+        {
+            const int numSteps = 1;
+
+            public struct TestData
+            {
+                // transform data
+                public MixedRealityPose pose;
+                public Vector3 scale;
+
+                // used to print where error occurred
+                public string manipDescription;
+            }
+
+            public List<TestData> data = new List<TestData>();
+
+            /// <summary>
+            /// Manipulates the given testObject in a number of ways and records the output here
+            /// </summary>
+            /// <param name="testObject">An unrotated primitive cube at (0, 0, 1) with scale (0.2, 0.2, 0,2)</param>
+            public IEnumerator RecordTransformValues(GameObject testObject)
+            {
+                TestUtilities.PlayspaceToOriginLookingForward();
+
+                float testRotation = 45;
+                Quaternion testQuaternion = Quaternion.Euler(testRotation, testRotation, testRotation);
+
+                Vector3 leftHandNearPos = new Vector3(-0.1f, 0, 1);
+                Vector3 rightHandNearPos = new Vector3(0.1f, 0, 1);
+                Vector3 leftHandFarPos = new Vector3(-0.06f, -0.1f, 0.5f);
+                Vector3 rightHandFarPos = new Vector3(0.06f, -0.1f, 0.5f);
+                TestHand leftHand = new TestHand(Handedness.Left);
+                TestHand rightHand = new TestHand(Handedness.Right);
+
+                // One hand rotate near
+                yield return rightHand.MoveTo(rightHandNearPos, numSteps);
+                yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+                yield return rightHand.SetRotation(testQuaternion, numSteps);
+                RecordTransform(testObject.transform, "one hand rotate near");
+
+                // Two hand rotate/scale near
+                yield return rightHand.SetRotation(Quaternion.identity, numSteps);
+                yield return leftHand.MoveTo(leftHandNearPos, numSteps);
+                yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+                yield return rightHand.Move(new Vector3(0.2f, 0.2f, 0), numSteps);
+                yield return leftHand.Move(new Vector3(-0.2f, -0.2f, 0), numSteps);
+                RecordTransform(testObject.transform, "two hand rotate/scale near");
+
+                // Two hand rotate/scale far
+                yield return rightHand.MoveTo(rightHandNearPos, numSteps);
+                yield return leftHand.MoveTo(leftHandNearPos, numSteps);
+                yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+                yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+                yield return rightHand.MoveTo(rightHandFarPos, numSteps);
+                yield return leftHand.MoveTo(leftHandFarPos, numSteps);
+                yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+                yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+                yield return rightHand.Move(new Vector3(0.2f, 0.2f, 0), numSteps);
+                yield return leftHand.Move(new Vector3(-0.2f, -0.2f, 0), numSteps);
+                RecordTransform(testObject.transform, "two hand rotate/scale far");
+
+                // One hand rotate near
+                yield return rightHand.MoveTo(rightHandFarPos, numSteps);
+                yield return leftHand.MoveTo(leftHandFarPos, numSteps);
+                yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+                yield return leftHand.Hide();
+
+                MixedRealityPlayspace.PerformTransformation(
+                p =>
+                {
+                    p.position = MixedRealityPlayspace.Position;
+                    Vector3 rotatedFwd = Quaternion.AngleAxis(testRotation, Vector3.up) * Vector3.forward;
+                    p.LookAt(rotatedFwd);
+                });
+                yield return null;
+                
+                Vector3 newHandPosition = Quaternion.AngleAxis(testRotation, Vector3.up) * rightHandFarPos;
+                yield return rightHand.MoveTo(newHandPosition, numSteps);
+                RecordTransform(testObject.transform, "one hand rotate far");
+
+                yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+                yield return rightHand.Hide();
+            }
+
+            private void RecordTransform(Transform transform, string description)
+            {
+                data.Add(new TestData
+                {
+                    pose = new MixedRealityPose(transform.position, transform.rotation),
+                    scale = transform.localScale,
+                    manipDescription = description
+                });
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerOriginOffset()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            var manipHandler = testObject.AddComponent<ManipulationHandler>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+            manipHandler.ManipulationType = ManipulationHandler.HandMovementType.OneAndTwoHanded;
+
+            // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
+            testObject.AddComponent<NearInteractionGrabbable>();
+
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            testObject.transform.position = Vector3.forward;
+
+            // Collect data for unmodified cube
+            OriginOffsetTest expectedTest = new OriginOffsetTest();
+            yield return expectedTest.RecordTransformValues(testObject);
+
+            // Modify cube mesh so origin is offset from centre
+            Vector3 offset = Vector3.one * 5;
+
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            testObject.transform.rotation = Quaternion.identity;
+            var mesh = testObject.GetComponent<MeshFilter>().mesh;
+            var vertices = mesh.vertices;
+            for (int i = 0; i < vertices.Length; i++)
+            {
+                vertices[i] += offset;
+            }
+            mesh.vertices = vertices;
+            mesh.RecalculateNormals();
+            testObject.GetComponent<BoxCollider>().center = offset;
+
+            testObject.transform.position = Vector3.forward - testObject.transform.TransformVector(offset);
+
+            // Collect data for modified cube
+            OriginOffsetTest actualTest = new OriginOffsetTest();
+            yield return actualTest.RecordTransformValues(testObject);
+
+            // Test that the results of both tests are equal
+            var expectedData = expectedTest.data;
+            var actualData = actualTest.data;
+            Assert.AreEqual(expectedData.Count, actualData.Count);
+
+            for (int i = 0; i < expectedData.Count; i++)
+            {
+                Vector3 transformedOffset = actualData[i].pose.Rotation * Vector3.Scale(offset, actualData[i].scale);
+                TestUtilities.AssertAboutEqual(expectedData[i].pose.Position, actualData[i].pose.Position + transformedOffset, $"Failed for position of object for {actualData[i].manipDescription}");
+                TestUtilities.AssertAboutEqual(expectedData[i].pose.Rotation, actualData[i].pose.Rotation, $"Failed for rotation of object for {actualData[i].manipDescription}");
+                TestUtilities.AssertAboutEqual(expectedData[i].scale, actualData[i].scale, $"Failed for scale of object for {actualData[i].manipDescription}");
+            }
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -28,6 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public static class TestUtilities
     {
         const float vector3DistanceEpsilon = 0.01f;
+        const float quaternionAngleEpsilon = 0.01f;
 
         const string primaryTestSceneTemporarySavePath = "Assets/__temp_primary_test_scene.unity";
         const string additiveTestSceneTemporarySavePath = "Assets/__temp_additive_test_scene_#.unity";
@@ -203,10 +204,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Debug.Assert(dist < vector3DistanceEpsilon, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
         }
 
+        public static void AssertAboutEqual(Quaternion actual, Quaternion expected, string message)
+        {
+            var angle = Quaternion.Angle(actual, expected);
+            Debug.Assert(angle < quaternionAngleEpsilon, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
+        }
+
         public static void AssertNotAboutEqual(Vector3 val1, Vector3 val2, string message)
         {
             var dist = (val1 - val2).magnitude;
             Debug.Assert(dist >= vector3DistanceEpsilon, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
+        }
+
+        public static void AssertNotAboutEqual(Quaternion val1, Quaternion val2, string message)
+        {
+            var angle = Quaternion.Angle(val1, val2);
+            Debug.Assert(angle >= quaternionAngleEpsilon, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Physics
@@ -17,11 +18,9 @@ namespace Microsoft.MixedReality.Toolkit.Physics
     /// </summary>
     public class TwoHandMoveLogic
     {
-        private static readonly Vector3 offsetPosition = new Vector3(0, -0.2f, 0);
         private readonly MovementConstraintType movementConstraint;
 
-        private float handRefDistance;
-        private float objRefDistance;
+        private float pointerRefDistance;
 
         /// <summary>
         /// Constructor.
@@ -32,82 +31,43 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             this.movementConstraint = movementConstraint;
         }
 
-        /// <summary>
-        /// The initial angle between the hand and the object
-        /// </summary>
-        private Quaternion gazeAngularOffset;
+        Vector3 pointerToGrab;
+        Vector3 grabToObject;
+        Quaternion worldToPointerRotation;
+        Vector3 originalScale;
 
-        private const float NearDistanceScale = 1.0f;
-        private const float FarDistanceScale = 2.0f;
-
-        public void Setup(Vector3 startHandPositionMeters, Vector3 manipulationObjectPosition)
+        public void Setup(MixedRealityPose pointerCentroidPose, Vector3 grabCentroid, Vector3 objectPosition, Vector3 objectScale)
         {
-            var newHandPosition = startHandPositionMeters;
-
-            // The pivot is just below and in front of the head.
-            var pivotPosition = GetHandPivotPosition();
-
-            objRefDistance = Vector3.Distance(manipulationObjectPosition, pivotPosition);
-            handRefDistance = Vector3.Distance(newHandPosition, pivotPosition);
-
-            var objDirection = Vector3.Normalize(manipulationObjectPosition - pivotPosition);
-            var handDirection = Vector3.Normalize(newHandPosition - pivotPosition);
-
-            // We transform the forward vector of the object, the direction of the object, and the direction of the hand
-            // to camera space so everything is relative to the user's perspective.
-            objDirection = CameraCache.Main.transform.InverseTransformDirection(objDirection);
-            handDirection = CameraCache.Main.transform.InverseTransformDirection(handDirection);
-
-            // Store the original rotation between the hand an object
-            gazeAngularOffset = Quaternion.FromToRotation(handDirection, objDirection);
+            Vector3 headPosition = CameraCache.Main.transform.position;
+            
+            pointerRefDistance = Vector3.Distance(pointerCentroidPose.Position, headPosition);
+            
+            worldToPointerRotation = Quaternion.Inverse(pointerCentroidPose.Rotation);
+            pointerToGrab = worldToPointerRotation * (grabCentroid - pointerCentroidPose.Position);
+            grabToObject = worldToPointerRotation * (objectPosition - grabCentroid);
+            originalScale = objectScale;
         }
 
-        public Vector3 Update(Vector3 centroid, bool isNearMode)
+        public Vector3 Update(MixedRealityPose pointerCentroidPose, Vector3 objectScale, bool usePointerRotation, bool isTwoHand)
         {
-            float distanceScale = isNearMode ? NearDistanceScale : FarDistanceScale;
-
-            var newHandPosition = centroid;
-            var pivotPosition = GetHandPivotPosition();
-
-            // Compute the pivot -> hand vector in camera space
-            var newHandDirection = Vector3.Normalize(newHandPosition - pivotPosition);
-            newHandDirection = CameraCache.Main.transform.InverseTransformDirection(newHandDirection);
-
-            // The direction the object should face is the current hand direction rotated by the original hand -> object rotation.
-            var targetDirection = Vector3.Normalize(gazeAngularOffset * newHandDirection);
-            targetDirection = CameraCache.Main.transform.TransformDirection(targetDirection);
-
-            var targetDistance = objRefDistance;
+            Vector3 headPosition = CameraCache.Main.transform.position;
+            float distanceRatio = 1.0f;
 
             if (movementConstraint != MovementConstraintType.FixDistanceFromHead)
             {
                 // Compute how far away the object should be based on the ratio of the current to original hand distance
-                var currentHandDistance = Vector3.Magnitude(newHandPosition - pivotPosition);
-                var distanceRatio = currentHandDistance / handRefDistance;
-                var distanceOffset = distanceRatio > 0 ? (distanceRatio - 1f) * distanceScale : 0;
-                targetDistance += distanceOffset;
+                var currentHandDistance = Vector3.Magnitude(pointerCentroidPose.Position - headPosition);
+                distanceRatio = currentHandDistance / pointerRefDistance;
             }
 
-            var newPosition = pivotPosition + (targetDirection * targetDistance);
-            var newDistance = Vector3.Distance(newPosition, pivotPosition);
-
-            if (newDistance > 4f)
+            Vector3 scaledGrabToObject =  Vector3.Scale(grabToObject, worldToPointerRotation * objectScale.Div(originalScale));
+            Vector3 adjustedPointerToObject = (pointerToGrab * distanceRatio) + scaledGrabToObject;
+            if (isTwoHand || usePointerRotation)
             {
-                newPosition = pivotPosition + Vector3.Normalize(newPosition - pivotPosition) * 4f;
+                adjustedPointerToObject = pointerCentroidPose.Rotation * adjustedPointerToObject;
             }
 
-            return newPosition;
+            return adjustedPointerToObject + pointerCentroidPose.Position;
         }
-
-        /// <summary>
-        /// Get the hand pivot position located a bit lower and behind the camera.
-        /// </summary>
-        /// <returns>A point that is below and just in front of the head.</returns>
-        public static Vector3 GetHandPivotPosition()
-        {
-            Vector3 pivot = CameraCache.Main.transform.position + offsetPosition - CameraCache.Main.transform.forward * 0.2f; // a bit lower and behind
-            return pivot;
-        }
-
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             originalScale = objectScale;
         }
 
-        public Vector3 Update(MixedRealityPose pointerCentroidPose, Vector3 objectScale, bool usePointerRotation, bool isTwoHand)
+        public Vector3 Update(MixedRealityPose pointerCentroidPose, Vector3 objectScale, bool usePointerRotation)
         {
             Vector3 headPosition = CameraCache.Main.transform.position;
             float distanceRatio = 1.0f;
@@ -60,9 +60,9 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 distanceRatio = currentHandDistance / pointerRefDistance;
             }
 
-            Vector3 scaledGrabToObject =  Vector3.Scale(grabToObject, worldToPointerRotation * objectScale.Div(originalScale));
+            Vector3 scaledGrabToObject = worldToPointerRotation * Vector3.Scale(Quaternion.Inverse(worldToPointerRotation) * grabToObject, objectScale.Div(originalScale));
             Vector3 adjustedPointerToObject = (pointerToGrab * distanceRatio) + scaledGrabToObject;
-            if (isTwoHand || usePointerRotation)
+            if (usePointerRotation)
             {
                 adjustedPointerToObject = pointerCentroidPose.Rotation * adjustedPointerToObject;
             }


### PR DESCRIPTION
## Overview
These changes will make it that most manipulation options will rotate around the grab point for all types of interaction. This means that in most cases, it will not matter that the origin is not at the mesh centre. With smoothing this can still look weird if scaling or rotating quickly, however the object ends up where you expect it to go. 

As I've mentioned [here](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4910#issuecomment-513267204) I wasn't convinced that we should take these changes. There are better ways to do this, but they would require an overhaul of the `ManipulationHandler`, which is not a change we can make right now.

## Changes
- Fixes: #4910 
- Overhaul of `TwoHandMoveLogic` so that it works for rotate around grab point.
- New `TwoHandMoveLogic` now works for one handed near interaction. 
- Changes in `ManipulationHandler` to use this new `TwoHandMoveLogic`.
- Some test changes to respond to the changed logic.