### PR TITLE
Bounding Box Rig GameObject Management

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -974,7 +974,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region MonoBehaviour Methods
 
-        private void Start()
+        private void OnEnable()
         {
             CreateRig();
             CaptureInitialState();
@@ -996,6 +996,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 Active = true;
                 Active = false;
             }
+        }
+
+        private void OnDisable()
+        {
+            DestroyRig();
         }
 
         private void Update()


### PR DESCRIPTION
#Overview

The bounding box component now manages the rig it creates and destroys the rig on destruction and disablement. This bug is especially apparent when adding/removing bounding boxes dynamically. 

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5383

## Verification
Tested in the BoundingBoxExamples, BoundingBoxRuntimeExample, and HandInteractionExamples scenes.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
