### PR TITLE
Fixes gesture pinch release mechanics involving two mouse button interactions.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
@@ -335,17 +335,26 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <summary>
+        /// Gets the currenctly active gesture, according to the mouse configuration and mouse button that is down.
+        /// </summary>
         private ArticulatedHandPose.GestureId SelectGesture()
         {
-            if (UnityEngine.Input.GetMouseButton(0))
+            // Each check needs to verify that both:
+            // 1) The corresponding mouse button is down (meaning the gesture, if defined, should be used)
+            // 2) The gesture is defined.
+            // If only #1 is checked and #2 is not checked, it's possible to "miss" transitions in cases where the user has
+            // the left mouse button down and then while it is down, presses the right button, and then lifts the left.
+            // It's not until both mouse buttons lift in that case, that the state finally "rests" to the DefaultHandGesture.
+            if (UnityEngine.Input.GetMouseButton(0) && profile.LeftMouseHandGesture != ArticulatedHandPose.GestureId.None)
             {
                 return profile.LeftMouseHandGesture;
             }
-            else if (UnityEngine.Input.GetMouseButton(1))
+            else if (UnityEngine.Input.GetMouseButton(1) && profile.RightMouseHandGesture != ArticulatedHandPose.GestureId.None)
             {
                 return profile.RightMouseHandGesture;
             }
-            else if (UnityEngine.Input.GetMouseButton(2))
+            else if (UnityEngine.Input.GetMouseButton(2) && profile.MiddleMouseHandGesture != ArticulatedHandPose.GestureId.None)
             {
                 return profile.MiddleMouseHandGesture;
             }
@@ -357,15 +366,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private ArticulatedHandPose.GestureId ToggleGesture(ArticulatedHandPose.GestureId gesture)
         {
-            if (UnityEngine.Input.GetMouseButtonDown(0))
+            // See comments in SelectGesture for why both the button down and gesture are checked.
+            if (UnityEngine.Input.GetMouseButtonDown(0) && profile.LeftMouseHandGesture != ArticulatedHandPose.GestureId.None)
             {
                 return (gesture != profile.LeftMouseHandGesture ? profile.LeftMouseHandGesture : profile.DefaultHandGesture);
             }
-            else if (UnityEngine.Input.GetMouseButtonDown(1))
+            else if (UnityEngine.Input.GetMouseButtonDown(1) && profile.RightMouseHandGesture != ArticulatedHandPose.GestureId.None)
             {
                 return (gesture != profile.RightMouseHandGesture ? profile.RightMouseHandGesture : profile.DefaultHandGesture);
             }
-            else if (UnityEngine.Input.GetMouseButtonDown(2))
+            else if (UnityEngine.Input.GetMouseButtonDown(2) && profile.MiddleMouseHandGesture != ArticulatedHandPose.GestureId.None)
             {
                 return (gesture != profile.MiddleMouseHandGesture ? profile.MiddleMouseHandGesture : profile.DefaultHandGesture);
             }


### PR DESCRIPTION
Prior to this fix, when using gestures (GGV) style interactions, you would run into this bug:

1) Press space bar to engage the hand simulation.
2) Hold down left mouse to engage pinch.
3) Hold down the right mouse to rotate the camera.
4) Lift the left mouse to disengage pinch.

Step #4 wouldn't work (it would stay engaged in the pinch until you lifted the right mouse button) because the existing code would see that the right mouse button was down, and even though it was not configured to do anything (i.e. a configuration of "none" means "don't affect the state of the gesture simulation"). However because the function returned "none", this told the rest of the code to keep doing what it was doing before (which was, simulating the pinch gesture associated with the left mouse click.)

You have to return the default (or open) pose explicitly to get the hand to open, and by making the code change to actually honor the lack of configuration, this all works out.