### PR TITLE
Add a somewhat helpful message on CreateInstance failure.

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -195,6 +195,14 @@ namespace Microsoft.MixedReality.Toolkit
             catch (Exception e)
             {
                 Debug.LogError($"Failed to register the {concreteType.Name} service: {e.GetType()} - {e.Message}");
+
+                // Failures to create the concrete type generally surface as nested exceptions - just logging
+                // the top level exception itself may not be helpful. If there is a nested exception (for example,
+                // null reference in the constructor of the object itself), it's helpful to also surface those here.
+                if (e.InnerException != null)
+                {
+                    Debug.LogError("Underlying exception information: " + e.InnerException);
+                }
                 return false;
             }
 


### PR DESCRIPTION
It turns out that the existing logging isn't very helpful, because the inner message isn't logged. Thus, if the client here is creating something and has an exception in their code, all they will see right now is a TargetInvocationException, instead of a real callstack associated with their code.

This is SUPER hard to debug (you have to know to turn on all managed exceptions) so hopefully this increased logging will help clients figure out what happened when we try to new their objects up.