### PR TITLE
Add better support for HoloLens clicker

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityControllerMappingProfile.asset
@@ -157,167 +157,6 @@ MonoBehaviour:
   - controllerType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController,
         Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
-    handedness: 0
-    interactions:
-    - id: 0
-      description: Spatial Pointer
-      axisType: 7
-      inputType: 3
-      inputAction:
-        id: 4
-        description: Pointer Pose
-        axisConstraint: 7
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 1
-      description: Spatial Grip
-      axisType: 7
-      inputType: 14
-      inputAction:
-        id: 3
-        description: Grip Pose
-        axisConstraint: 7
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 2
-      description: Grip Press
-      axisType: 3
-      inputType: 13
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 3
-      description: Trigger Position
-      axisType: 3
-      inputType: 10
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 4
-      description: Trigger Touch
-      axisType: 2
-      inputType: 11
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 5
-      description: Trigger Press (Select)
-      axisType: 2
-      inputType: 25
-      inputAction:
-        id: 1
-        description: Select
-        axisConstraint: 2
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 6
-      description: Touchpad Position
-      axisType: 4
-      inputType: 21
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 7
-      description: Touchpad Touch
-      axisType: 2
-      inputType: 22
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 8
-      description: Touchpad Press
-      axisType: 2
-      inputType: 24
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 9
-      description: Menu Press
-      axisType: 2
-      inputType: 27
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 10
-      description: Thumbstick Position
-      axisType: 4
-      inputType: 17
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 11
-      description: Thumbstick Press
-      axisType: 2
-      inputType: 18
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-  - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController,
-        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
     handedness: 1
     interactions:
     - id: 0
@@ -632,6 +471,37 @@ MonoBehaviour:
         id: 0
         description: None
         axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+  - controllerType:
+      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityGGVHand,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+    handedness: 0
+    interactions:
+    - id: 0
+      description: Select
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 1
+      description: Grip Pose
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 3
+        description: Grip Pose
+        axisConstraint: 7
       keyCode: 0
       axisCodeX: 
       axisCodeY: 
@@ -2710,6 +2580,37 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
+      reference: Microsoft.MixedReality.Toolkit.Services.InputSimulation.SimulatedGestureHand,
+        Microsoft.MixedReality.Toolkit.Services.InputSimulation
+    handedness: 2
+    interactions:
+    - id: 0
+      description: Select
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 1
+      description: Grip Pose
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 3
+        description: Grip Pose
+        axisConstraint: 7
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+  - controllerType:
       reference: Microsoft.MixedReality.Toolkit.OpenVR.Input.GenericOpenVRController,
         Microsoft.MixedReality.Toolkit.Providers.OpenVR
     handedness: 1
@@ -3175,37 +3076,6 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Services.InputSimulation.SimulatedGestureHand,
         Microsoft.MixedReality.Toolkit.Services.InputSimulation
     handedness: 1
-    interactions:
-    - id: 0
-      description: Select
-      axisType: 2
-      inputType: 25
-      inputAction:
-        id: 1
-        description: Select
-        axisConstraint: 2
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 1
-      description: Grip Pose
-      axisType: 7
-      inputType: 14
-      inputAction:
-        id: 3
-        description: Grip Pose
-        axisConstraint: 7
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-  - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.Services.InputSimulation.SimulatedGestureHand,
-        Microsoft.MixedReality.Toolkit.Services.InputSimulation
-    handedness: 2
     interactions:
     - id: 0
       description: Select

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.WindowsMixedReality,
-        new[] { Handedness.Left, Handedness.Right, Handedness.None },
+        new[] { Handedness.Left, Handedness.Right },
         "StandardAssets/Textures/MotionController")]
     public class WindowsMixedRealityController : BaseWindowsMixedRealitySource
     {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 #endif // WINDOWS_UWP
             }
             else // Pre-Windows 10 1903.
-            {                
+            {
                 if (!UnityEngine.XR.WSA.HolographicSettings.IsDisplayOpaque)
                 {
                     // HoloLens supports GGV hands
@@ -519,14 +519,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
             IMixedRealityPointer[] pointers = null;
             InputSourceType inputSourceType = InputSourceType.Other;
-            switch(interactionSource.kind)
+            switch (interactionSource.kind)
             {
                 case InteractionSourceKind.Controller:
                     pointers = RequestPointers(SupportedControllerType.WindowsMixedReality, controllingHand);
                     inputSourceType = InputSourceType.Controller;
                     break;
                 case InteractionSourceKind.Hand:
-                    if(interactionSource.supportsPointing)
+                    if (interactionSource.supportsPointing)
                     {
                         pointers = RequestPointers(SupportedControllerType.ArticulatedHand, controllingHand);
                     }
@@ -549,9 +549,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             var inputSource = inputSystem?.RequestNewGenericInputSource($"Mixed Reality Controller {nameModifier}", pointers, inputSourceType);
 
             BaseWindowsMixedRealitySource detectedController;
-            if (interactionSource.kind == InteractionSourceKind.Hand)
+            if (interactionSource.supportsPointing)
             {
-                if (interactionSource.supportsPointing)
+                if (interactionSource.kind == InteractionSourceKind.Hand)
                 {
                     detectedController = new WindowsMixedRealityArticulatedHand(TrackingState.NotTracked, controllingHand, inputSource);
                     if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityArticulatedHand), inputSourceType))
@@ -561,24 +561,26 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                         return null;
                     }
                 }
-                else
+                else if (interactionSource.kind == InteractionSourceKind.Controller)
                 {
-                    detectedController = new WindowsMixedRealityGGVHand(TrackingState.NotTracked, controllingHand, inputSource);
-                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityGGVHand), inputSourceType))
+                    detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
+                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityController), inputSourceType))
                     {
                         // Controller failed to be setup correctly.
                         // Return null so we don't raise the source detected.
                         return null;
                     }
-
                 }
-
+                else
+                {
+                    Debug.Log($"Unhandled source type {interactionSource.kind} detected.");
+                    return null;
+                }
             }
             else
             {
-                detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
-
-                if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityController), inputSourceType))
+                detectedController = new WindowsMixedRealityGGVHand(TrackingState.NotTracked, controllingHand, inputSource);
+                if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityGGVHand), inputSourceType))
                 {
                     // Controller failed to be setup correctly.
                     // Return null so we don't raise the source detected.

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -522,7 +522,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             switch (interactionSource.kind)
             {
                 case InteractionSourceKind.Controller:
-                    pointers = RequestPointers(SupportedControllerType.WindowsMixedReality, controllingHand);
+                    if (interactionSource.supportsPointing)
+                    {
+                        pointers = RequestPointers(SupportedControllerType.WindowsMixedReality, controllingHand);
+                    }
+                    else
+                    {
+                        pointers = RequestPointers(SupportedControllerType.GGVHand, controllingHand);
+                    }
                     inputSourceType = InputSourceType.Controller;
                     break;
                 case InteractionSourceKind.Hand:

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityGGVHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityGGVHand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.GGVHand,
-        new[] { Handedness.Left, Handedness.Right })]
+        new[] { Handedness.Left, Handedness.Right, Handedness.None })]
     public class WindowsMixedRealityGGVHand : BaseWindowsMixedRealitySource
     {
         public WindowsMixedRealityGGVHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
@@ -157,167 +157,6 @@ MonoBehaviour:
   - controllerType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController,
         Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
-    handedness: 0
-    interactions:
-    - id: 0
-      description: Spatial Pointer
-      axisType: 7
-      inputType: 3
-      inputAction:
-        id: 4
-        description: Pointer Pose
-        axisConstraint: 7
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 1
-      description: Spatial Grip
-      axisType: 7
-      inputType: 14
-      inputAction:
-        id: 3
-        description: Grip Pose
-        axisConstraint: 7
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 2
-      description: Grip Press
-      axisType: 3
-      inputType: 13
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 3
-      description: Trigger Position
-      axisType: 3
-      inputType: 10
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 4
-      description: Trigger Touch
-      axisType: 2
-      inputType: 11
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 5
-      description: Trigger Press (Select)
-      axisType: 2
-      inputType: 25
-      inputAction:
-        id: 1
-        description: Select
-        axisConstraint: 2
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 6
-      description: Touchpad Position
-      axisType: 4
-      inputType: 21
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 7
-      description: Touchpad Touch
-      axisType: 2
-      inputType: 22
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 8
-      description: Touchpad Press
-      axisType: 2
-      inputType: 24
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 9
-      description: Menu Press
-      axisType: 2
-      inputType: 27
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 10
-      description: Thumbstick Position
-      axisType: 4
-      inputType: 17
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 11
-      description: Thumbstick Press
-      axisType: 2
-      inputType: 18
-      inputAction:
-        id: 0
-        description: None
-        axisConstraint: 0
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-  - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController,
-        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
     handedness: 1
     interactions:
     - id: 0
@@ -632,6 +471,37 @@ MonoBehaviour:
         id: 0
         description: None
         axisConstraint: 0
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+  - controllerType:
+      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityGGVHand,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+    handedness: 0
+    interactions:
+    - id: 0
+      description: Select
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 1
+      description: Grip Pose
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 3
+        description: Grip Pose
+        axisConstraint: 7
       keyCode: 0
       axisCodeX: 
       axisCodeY: 
@@ -2710,6 +2580,37 @@ MonoBehaviour:
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
+      reference: Microsoft.MixedReality.Toolkit.Services.InputSimulation.SimulatedGestureHand,
+        Microsoft.MixedReality.Toolkit.Services.InputSimulation
+    handedness: 2
+    interactions:
+    - id: 0
+      description: Select
+      axisType: 2
+      inputType: 25
+      inputAction:
+        id: 1
+        description: Select
+        axisConstraint: 2
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+    - id: 1
+      description: Grip Pose
+      axisType: 7
+      inputType: 14
+      inputAction:
+        id: 3
+        description: Grip Pose
+        axisConstraint: 7
+      keyCode: 0
+      axisCodeX: 
+      axisCodeY: 
+      invertXAxis: 0
+      invertYAxis: 0
+  - controllerType:
       reference: Microsoft.MixedReality.Toolkit.OpenVR.Input.GenericOpenVRController,
         Microsoft.MixedReality.Toolkit.Providers.OpenVR
     handedness: 1
@@ -2879,8 +2780,8 @@ MonoBehaviour:
         description: Grip Pose
         axisConstraint: 7
       keyCode: 0
-      axisCodeX:
-      axisCodeY:
+      axisCodeX: 
+      axisCodeY: 
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
@@ -3053,8 +2954,8 @@ MonoBehaviour:
         description: Grip Pose
         axisConstraint: 7
       keyCode: 0
-      axisCodeX:
-      axisCodeY:
+      axisCodeX: 
+      axisCodeY: 
       invertXAxis: 0
       invertYAxis: 0
   - controllerType:
@@ -3201,37 +3102,6 @@ MonoBehaviour:
       reference: Microsoft.MixedReality.Toolkit.Services.InputSimulation.SimulatedGestureHand,
         Microsoft.MixedReality.Toolkit.Services.InputSimulation
     handedness: 1
-    interactions:
-    - id: 0
-      description: Select
-      axisType: 2
-      inputType: 25
-      inputAction:
-        id: 1
-        description: Select
-        axisConstraint: 2
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-    - id: 1
-      description: Grip Pose
-      axisType: 7
-      inputType: 14
-      inputAction:
-        id: 3
-        description: Grip Pose
-        axisConstraint: 7
-      keyCode: 0
-      axisCodeX: 
-      axisCodeY: 
-      invertXAxis: 0
-      invertYAxis: 0
-  - controllerType:
-      reference: Microsoft.MixedReality.Toolkit.Services.InputSimulation.SimulatedGestureHand,
-        Microsoft.MixedReality.Toolkit.Services.InputSimulation
-    handedness: 2
     interactions:
     - id: 0
       description: Select

--- a/Assets/MixedRealityToolkit/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ControllerPopupWindow.cs
@@ -603,26 +603,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     {
                         bool skip = false;
                         var description = interactionDescription.stringValue;
-                        if (currentControllerMapping.SupportedControllerType == SupportedControllerType.WindowsMixedReality
+                        if (currentControllerMapping.SupportedControllerType == SupportedControllerType.GGVHand
                             && currentControllerMapping.Handedness == Handedness.None)
                         {
-                            if (description == "Grip Press" ||
-                                description == "Trigger Position" ||
-                                description == "Trigger Touch" ||
-                                description == "Touchpad Position" ||
-                                description == "Touchpad Touch" ||
-                                description == "Touchpad Press" ||
-                                description == "Menu Press" ||
-                                description == "Thumbstick Position" ||
-                                description == "Thumbstick Press"
-                                )
+                            if (description != "Select")
                             {
                                 skip = true;
-                            }
-
-                            if (description == "Trigger Press (Select)")
-                            {
-                                description = "Air Tap (Select)";
                             }
                         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -123,8 +123,21 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                                     if (horizontalScope != null) { horizontalScope.Dispose(); horizontalScope = null; }
 
                                     serializedObject.ApplyModifiedProperties();
-                                    thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[0].MixedRealityInputAction = controllerMapping.Interactions[5].MixedRealityInputAction;
-                                    thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[1].MixedRealityInputAction = controllerMapping.Interactions[1].MixedRealityInputAction;
+
+                                    for (int k = 0; k < controllerMapping.Interactions.Length; k++)
+                                    {
+                                        MixedRealityInteractionMapping currentMapping = controllerMapping.Interactions[k];
+
+                                        if (currentMapping.Description.Equals("Trigger Press (Select)"))
+                                        {
+                                            thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[0].MixedRealityInputAction = currentMapping.MixedRealityInputAction;
+                                        }
+                                        else if (currentMapping.Description.Equals("Spatial Grip"))
+                                        {
+                                            thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[1].MixedRealityInputAction = currentMapping.MixedRealityInputAction;
+                                        }
+                                    }
+
                                     serializedObject.Update();
                                     controllerList.DeleteArrayElementAtIndex(i);
                                     EditorUtility.DisplayDialog("Mappings updated", "The \"HoloLens Voice and Clicker\" mappings have been migrated to a new serialization. Please save this asset.", "Okay, thanks!");

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -109,6 +109,32 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                         var controllerMappingProperty = controllerList.GetArrayElementAtIndex(i);
                         var handednessProperty = controllerMappingProperty.FindPropertyRelative("handedness");
 
+                        #region Profile Migration
+
+                        // Between MRTK v2 RC2 and GA, the HoloLens clicker and HoloLens voice select input were migrated from
+                        // SupportedControllerType.WindowsMixedReality && Handedness.None to SupportedControllerType.GGVHand && Handedness.None
+                        if (supportedControllerType == SupportedControllerType.WindowsMixedReality && handedness == Handedness.None)
+                        {
+                            for (int j = 0; j < thisProfile.MixedRealityControllerMappingProfiles.Length; j++)
+                            {
+                                if (thisProfile.MixedRealityControllerMappingProfiles[j].SupportedControllerType == SupportedControllerType.GGVHand &&
+                                    thisProfile.MixedRealityControllerMappingProfiles[j].Handedness == Handedness.None)
+                                {
+                                    if (horizontalScope != null) { horizontalScope.Dispose(); horizontalScope = null; }
+
+                                    serializedObject.ApplyModifiedProperties();
+                                    thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[0].MixedRealityInputAction = controllerMapping.Interactions[5].MixedRealityInputAction;
+                                    thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[1].MixedRealityInputAction = controllerMapping.Interactions[1].MixedRealityInputAction;
+                                    serializedObject.Update();
+                                    controllerList.DeleteArrayElementAtIndex(i);
+                                    EditorUtility.DisplayDialog("Mappings updated", "The \"HoloLens Voice and Clicker\" mappings have been migrated to a new serialization. Please save this asset.", "Okay, thanks!");
+                                    return;
+                                }
+                            }
+                        }
+
+                        #endregion Profile Migration
+
                         if (!useCustomInteractionMappings)
                         {
                             bool skip = false;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -128,11 +128,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                                     {
                                         MixedRealityInteractionMapping currentMapping = controllerMapping.Interactions[k];
 
-                                        if (currentMapping.Description.Equals("Trigger Press (Select)"))
+                                        if (currentMapping.InputType == DeviceInputType.Select)
                                         {
                                             thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[0].MixedRealityInputAction = currentMapping.MixedRealityInputAction;
                                         }
-                                        else if (currentMapping.Description.Equals("Spatial Grip"))
+                                        else if (currentMapping.InputType == DeviceInputType.SpatialGrip)
                                         {
                                             thisProfile.MixedRealityControllerMappingProfiles[j].Interactions[1].MixedRealityInputAction = currentMapping.MixedRealityInputAction;
                                         }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -246,7 +246,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                         }
                         else
                         {
-                            if (supportedControllerType == SupportedControllerType.WindowsMixedReality &&
+                            if (supportedControllerType == SupportedControllerType.GGVHand &&
                                 handedness == Handedness.None)
                             {
                                 controllerTitle = "HoloLens Voice and Clicker";

--- a/Documentation/UpdatingToGA.md
+++ b/Documentation/UpdatingToGA.md
@@ -160,6 +160,10 @@ The ClippingSphere's Radius property is now implicitly calculated based on the t
 
 The `PointerClickHandler` class has been deprecated. The `PointerHandler` should be used instead, it provides the same functionality.
 
+### HoloLens clicker support
+
+- The HoloLens clicker's controller mappings have changed from being an unhanded [`WindowsMixedRealityController`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController) to being an unhanded [`WindowsMixedRealityGGVHand`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityGGVHand). To account for this, an automatic updater will run the first time you open your ControllerMapping profile. Please open your custom profile, if one exists, at least once after upgrading to GA.
+
 ## Assembly name changes
 
 In The GA release, all of the official Mixed Reality Toolkit assembly names and their associated assembly definition (.asmdef) files have been updated to fit the following pattern.

--- a/Documentation/UpdatingToGA.md
+++ b/Documentation/UpdatingToGA.md
@@ -162,7 +162,7 @@ The `PointerClickHandler` class has been deprecated. The `PointerHandler` should
 
 ### HoloLens clicker support
 
-- The HoloLens clicker's controller mappings have changed from being an unhanded [`WindowsMixedRealityController`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController) to being an unhanded [`WindowsMixedRealityGGVHand`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityGGVHand). To account for this, an automatic updater will run the first time you open your ControllerMapping profile. Please open your custom profile, if one exists, at least once after upgrading to GA.
+- The HoloLens clicker's controller mappings have changed from being an unhanded [`WindowsMixedRealityController`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityController) to being an unhanded [`WindowsMixedRealityGGVHand`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityGGVHand). To account for this, an automatic updater will run the first time you open your ControllerMapping profile. Please open any custom profiles at least once after upgrading to GA in order to trigger this one-time migration step.
 
 ## Assembly name changes
 


### PR DESCRIPTION
## Overview
This PR redefines the clicker from an unhanded `WMRController` to an unhanded `GGVHand`, to better define and update the clicker (it's much closer to a HL1 hand to a motion controller). This both prevents irrelevant code (attempting to load the controller model) from running and better scopes the actions a clicker can actually perform.

As part of this, it adds a profile updating step that will run automatically the first time a controller mapping profile is opened.

## Changes
- Fixes: #5397, #5287

## Verification
1. Run on HoloLens 1.
2. Try using a clicker to select objects
3. Try using voice to select objects.
