### PR TITLE
Fix MRTK asset menu layout / remove duplicate menu

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
 {
     [MixedRealityServiceProfile(typeof(ISceneTransitionService))]
-    [CreateAssetMenu(fileName = "SceneTransitionServiceProfile", menuName = "MixedRealityToolkit/SceneTransitionService Configuration Profile")]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
     public class SceneTransitionServiceProfile : BaseMixedRealityProfile
     {
         public bool UseDefaultProgressIndicator => useDefaultProgressIndicator;

--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfile.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
     /// <summary>
     /// Configuration profile for the spatial object mesh observer.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Object Mesh Observer Profile", fileName = "ObjectMeshObserverProfile", order = 1000)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Spatial Object Mesh Observer Profile", fileName = "SpatialObjectMeshObserverProfile", order = 100)]
     public class SpatialObjectMeshObserverProfile : MixedRealitySpatialAwarenessMeshObserverProfile
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/MixedRealityInputRecordingProfile.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/MixedRealityInputRecordingProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// <summary>
     /// Settings for recording input animation assets.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Mixed Reality Input Recording Profile", fileName = "MixedRealityInputRecordingProfile", order = (int)CreateProfileMenuItemIndices.Input)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Input Recording Profile", fileName = "MixedRealityInputRecordingProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     [MixedRealityServiceProfile(typeof(IMixedRealityInputRecordingService))]
     public class MixedRealityInputRecordingProfile : BaseMixedRealityProfile
     {


### PR DESCRIPTION
This change consolidates duplicate asset menus and places all profile options into the profile menu.

Before:
![image](https://user-images.githubusercontent.com/13281406/61667055-d545d300-ac8d-11e9-80f7-affd0f40775b.png)

After
![image](https://user-images.githubusercontent.com/13281406/61667068-da0a8700-ac8d-11e9-8f2a-8baaf75f9c36.png)
