### PR TITLE
Update spatial mesh level of detail values, translate in observer

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -236,12 +236,45 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
             {
                 if (value != SpatialAwarenessMeshLevelOfDetail.Custom)
                 {
-                    // For non-custom levels, the enum value is the appropriate triangles per cubic meter.
-                    TrianglesPerCubicMeter = (int)value;
+                    TrianglesPerCubicMeter = LookupTriangleDensity(value);
                 }
 
                 levelOfDetail = value;
             }
+        }
+
+        /// <summary>
+        /// Maps <see cref="SpatialAwarenessMeshLevelOfDetail"/> to <see cref="TrianglesPerCubicMeter"/>.
+        /// </summary>
+        /// <param name="levelOfDetail">The desired level of density for the spatial mesh.</param>
+        /// <returns>
+        /// The number of triangles per cubic meter that will result in the desired level of density.
+        /// </returns>
+        private int LookupTriangleDensity(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        {
+            int triangleDensity = 0;
+
+            switch(levelOfDetail)
+            {
+                case SpatialAwarenessMeshLevelOfDetail.Coarse:
+                    triangleDensity = 0;
+                    break;
+
+                case SpatialAwarenessMeshLevelOfDetail.Medium:
+                    triangleDensity = 400;
+                    break;
+
+                case SpatialAwarenessMeshLevelOfDetail.Fine:
+                    triangleDensity = 200;
+                    break;
+
+                default:
+                    Debug.LogWarning($"There is no triangle density lookup for {levelOfDetail}, defaulting to Coarse");
+                    triangleDensity = 0;
+                    break;
+            }
+
+            return triangleDensity;
         }
 
         private Dictionary<int, SpatialAwarenessMeshObject> meshes = new Dictionary<int, SpatialAwarenessMeshObject>();

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -265,7 +265,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     break;
 
                 case SpatialAwarenessMeshLevelOfDetail.Fine:
-                    triangleDensity = 200;
+                    triangleDensity = 2000;
                     break;
 
                 default:

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshLevelOfDetail.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshLevelOfDetail.cs
@@ -6,14 +6,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// <summary>
     /// Enumeration defining levels of detail for the spatial awareness mesh subsystem.
     /// </summary>
-    /// <remarks>
-    /// The integral values for these levels of detail generally map to triangle density, in triangles per cubic meter.
-    /// </remarks>
     public enum SpatialAwarenessMeshLevelOfDetail
     {
         /// <summary>
         /// The custom level of detail allows specifying a custom value for
-        /// MeshTrianglesPerCubicMeter.
+        /// TrianglesPerCubicMeter.
         /// </summary>
         Custom = -1,
 
@@ -24,9 +21,15 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         Coarse = 0,
 
         /// <summary>
+        /// The medium level of detail is often useful for experiences that
+        /// continually scan the environment (ex: a virtual pet).
+        /// </summary>
+        Medium,
+
+        /// <summary>
         /// The fine level of detail is well suited for using as an occlusion
         /// mesh.
         /// </summary>
-        Fine = 2000
+        Fine
     }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessMeshObserver.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessMeshObserver.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// Gets or sets the level of detail, in triangles per cubic meter, for the returned spatial mesh.
         /// </summary>
         /// <remarks>
-        /// When specifying Coarse or Fine for the <see cref="LevelOfDetail"/>, this value will be automatically overwritten with system default values.
+        /// When specifying a <see cref="LevelOfDetail"/> other than Custom, this value will be automatically overwritten with system default values.
         /// </remarks>
         int TrianglesPerCubicMeter { get; set; }
 


### PR DESCRIPTION
This is a minor breaking change (values in the SpatialMeshLevelOfDetail enum) to eliminate direct triangles per cubic meter encoding in the enum.

This change adds a Medium LOD as well as a lookup method in the windows mesh observer.

Verified by changing the LOD in the observer profile and deploying / running on HoloLens.