### PR TITLE
[Shell-Parity] Radial Solver update for the 'Follow Me' behavior

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Panels/ToggleFeaturesPanel.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Panels/ToggleFeaturesPanel.prefab
@@ -129,7 +129,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4943773361295851263}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4684083f6dff4a1d8a790bccc354fcf4, type: 3}
   m_Name: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Panels/ToggleFeaturesPanel.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Panels/ToggleFeaturesPanel.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 4546402662010242382}
   - component: {fileID: 3673227729376072232}
   - component: {fileID: 958447895517940439}
-  - component: {fileID: 7272619044281757748}
+  - component: {fileID: 3183098002564305489}
   - component: {fileID: 3232451984617828042}
   - component: {fileID: 1900320861033997991}
   m_Layer: 0
@@ -122,31 +122,37 @@ MonoBehaviour:
   additionalRotation: {x: 0, y: 0, z: 0}
   transformTarget: {fileID: 0}
   updateSolvers: 1
---- !u!114 &7272619044281757748
+--- !u!114 &3183098002564305489
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4943773361295851263}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 14c3d8a4208d4b649529822e217623d4, type: 3}
+  m_Script: {fileID: 11500000, guid: 4684083f6dff4a1d8a790bccc354fcf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   updateLinkedTransform: 0
-  moveLerpTime: 3
-  rotateLerpTime: 0.5
-  scaleLerpTime: 1
-  maintainScale: 0
+  moveLerpTime: 0.3
+  rotateLerpTime: 0.3
+  scaleLerpTime: 0
+  maintainScale: 1
   smoothing: 1
   lifetime: 0
   SolverHandler: {fileID: 958447895517940439}
-  orientationType: 5
-  localOffset: {x: 0, y: 0, z: 0}
-  worldOffset: {x: 0, y: -0.2, z: 0.3}
-  useAngleSteppingForWorldOffset: 1
-  tetherAngleSteps: 24
+  referenceDirection: 1
+  minDistance: 0.4
+  maxDistance: 0.8
+  minViewDegrees: 0
+  maxViewDegrees: 15
+  aspectV: 1
+  ignoreAngleClamp: 0
+  ignoreDistanceClamp: 0
+  useFixedVerticalPosition: 1
+  fixedVerticalPosition: -0.4
+  orientToReferenceDirection: 0
 --- !u!114 &3232451984617828042
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -817,12 +823,12 @@ PrefabInstance:
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1023,12 +1029,12 @@ PrefabInstance:
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnToggleHandMesh
       objectReference: {fileID: 0}
-    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1213,12 +1219,12 @@ PrefabInstance:
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ToggleProfiler
       objectReference: {fileID: 0}
-    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1413,12 +1419,12 @@ PrefabInstance:
       propertyPath: OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnToggleHandJoint
       objectReference: {fileID: 0}
-    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1874729665501627384, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
+    - target: {fileID: 3954648794444109128, guid: 3f1f46cbecbe08e46a303ccfdb5b498a,
         type: 3}
       propertyPath: m_IsActive
       value: 0

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Slate/Slate.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Slate/Slate.prefab
@@ -1036,14 +1036,14 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7779420039263858270}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4684083f6dff4a1d8a790bccc354fcf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   updateLinkedTransform: 0
-  moveLerpTime: 0.3
-  rotateLerpTime: 0.3
+  moveLerpTime: 0.5
+  rotateLerpTime: 0.5
   scaleLerpTime: 0
   maintainScale: 1
   smoothing: 1
@@ -1053,12 +1053,12 @@ MonoBehaviour:
   minDistance: 0.4
   maxDistance: 1
   minViewDegrees: 0
-  maxViewDegrees: 20
+  maxViewDegrees: 25
   aspectV: 1
   ignoreAngleClamp: 0
   ignoreDistanceClamp: 0
   useFixedVerticalPosition: 1
-  fixedVerticalPosition: -0.1
+  fixedVerticalPosition: -0.2
   orientToReferenceDirection: 0
 --- !u!65 &7779420039263858272
 BoxCollider:

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Slate/Slate.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Slate/Slate.prefab
@@ -216,7 +216,6 @@ MonoBehaviour:
   momentumHorizontal: 0.9
   momentumVertical: 0.9
   panZoomSmoothing: 80
-  panEventReceivers: []
   centerPoint: {fileID: 0}
   leftPoint: {fileID: 0}
   rightPoint: {fileID: 0}
@@ -237,8 +236,8 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+    m_TypeName: Microsoft.MixedReality.Toolkit.Input.PanUnityEvent, Microsoft.MixedReality.Toolkit.SDK,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   PanStopped:
     m_PersistentCalls:
       m_Calls:
@@ -254,8 +253,13 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+    m_TypeName: Microsoft.MixedReality.Toolkit.Input.PanUnityEvent, Microsoft.MixedReality.Toolkit.SDK,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  PanUpdated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Microsoft.MixedReality.Toolkit.Input.PanUnityEvent, Microsoft.MixedReality.Toolkit.SDK,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!82 &6890004885709557393
 AudioSource:
   m_ObjectHideFlags: 0
@@ -966,7 +970,7 @@ GameObject:
   - component: {fileID: 7779420039263858271}
   - component: {fileID: 7779420039263858268}
   - component: {fileID: 7779420039263858274}
-  - component: {fileID: 7779420039263858269}
+  - component: {fileID: 6131755083299501832}
   - component: {fileID: 7779420039263858272}
   - component: {fileID: 7779420039263858275}
   m_Layer: 0
@@ -1022,34 +1026,40 @@ MonoBehaviour:
   trackedObjectToReference: 0
   trackedHandJoint: 2
   additionalOffset: {x: 0, y: 0, z: 0}
-  additionalRotation: {x: 35, y: 0, z: 0}
+  additionalRotation: {x: 0, y: 0, z: 0}
   transformTarget: {fileID: 0}
   updateSolvers: 1
---- !u!114 &7779420039263858269
+--- !u!114 &6131755083299501832
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7779420039263858270}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 14c3d8a4208d4b649529822e217623d4, type: 3}
+  m_Script: {fileID: 11500000, guid: 4684083f6dff4a1d8a790bccc354fcf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   updateLinkedTransform: 0
-  moveLerpTime: 1
-  rotateLerpTime: 0.5
-  scaleLerpTime: 1
-  maintainScale: 0
+  moveLerpTime: 0.3
+  rotateLerpTime: 0.3
+  scaleLerpTime: 0
+  maintainScale: 1
   smoothing: 1
   lifetime: 0
   SolverHandler: {fileID: 7779420039263858274}
-  orientationType: 5
-  localOffset: {x: 0, y: 0, z: 0}
-  worldOffset: {x: 0, y: -0.1, z: 0.5}
-  useAngleStepping: 0
-  tetherAngleSteps: 24
+  referenceDirection: 1
+  minDistance: 0.4
+  maxDistance: 1
+  minViewDegrees: 0
+  maxViewDegrees: 20
+  aspectV: 1
+  ignoreAngleClamp: 0
+  ignoreDistanceClamp: 0
+  useFixedVerticalPosition: 1
+  fixedVerticalPosition: -0.1
+  orientToReferenceDirection: 0
 --- !u!65 &7779420039263858272
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1097,9 +1107,11 @@ MonoBehaviour:
   scaleHandleSlatePrefab: {fileID: 3149951711952774397, guid: 21e62edc2485ae94d99e2732627b62db,
     type: 3}
   scaleHandleSize: 0.016
+  scaleHandleColliderPadding: {x: 0.016, y: 0.016, z: 0.016}
   rotationHandlePrefab: {fileID: 1104240504292045578, guid: 00b3339e8f9ea63469792068ce7b2d67,
     type: 3}
   rotationHandleSize: 0.016
+  rotateHandleColliderPadding: {x: 0.016, y: 0.016, z: 0.016}
   rotationHandlePrefabColliderType: 1
   showScaleHandles: 1
   showRotationHandleForX: 1

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -12,25 +12,25 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("An opional object for visualizing the carry mode state")]
         private GameObject visualizationObject = null;
 
-        private Orbital orbital = null;
+        private RadialView radialView = null;
 
         private void Start()
         {
             // Get Orbital Solver component
-            orbital = GetComponent<Orbital>();
+            radialView = GetComponent<RadialView>();
         }
 
         public void ToggleFollowMeBehavior()
         {
-            if (orbital != null)
+            if (radialView != null)
             {
                 // Toggle Orbital Solver component
                 // You can tweak the detailed positioning behavior such as offset, lerping time, orientation type in the Inspector panel
-                orbital.enabled = !orbital.enabled;
+                radialView.enabled = !radialView.enabled;
 
                 if(visualizationObject != null)
                 {
-                    visualizationObject.SetActive(orbital.enabled);
+                    visualizationObject.SetActive(radialView.enabled);
                 }
             }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/FollowMeToggle.cs
@@ -6,17 +6,18 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
+    [RequireComponent(typeof(RadialView))]
     public class FollowMeToggle : MonoBehaviour
     {
         [SerializeField]
-        [Tooltip("An opional object for visualizing the carry mode state")]
+        [Tooltip("An opional object for visualizing the 'Follow Me' mode state")]
         private GameObject visualizationObject = null;
 
         private RadialView radialView = null;
 
         private void Start()
         {
-            // Get Orbital Solver component
+            // Get Radial Solver component
             radialView = GetComponent<RadialView>();
         }
 
@@ -24,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (radialView != null)
             {
-                // Toggle Orbital Solver component
+                // Toggle Radial Solver component
                 // You can tweak the detailed positioning behavior such as offset, lerping time, orientation type in the Inspector panel
                 radialView.enabled = !radialView.enabled;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
@@ -118,6 +118,32 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
+        [Tooltip("Ignore vertical movement and lock the Y position of the object")]
+        private bool useFixedVerticalPosition = false;
+
+        /// <summary>
+        /// Ignore vertical movement and lock the Y position of the object.
+        /// </summary>
+        public bool UseFixedVerticalPosition
+        {
+            get { return useFixedVerticalPosition; }
+            set { useFixedVerticalPosition = value; }
+        }
+
+        [SerializeField]
+        [Tooltip("Offset amount of the vertical position")]
+        private float fixedVerticalPosition = -0.4f;
+
+        /// <summary>
+        /// Offset amount of the vertical position.
+        /// </summary>
+        public float FixedVerticalPosition
+        {
+            get { return fixedVerticalPosition; }
+            set { fixedVerticalPosition = value; }
+        }
+
+        [SerializeField]
         [Tooltip("If true, element will orient to ReferenceDirection, otherwise it will orient to ref position.")]
         private bool orientToReferenceDirection = false;
 
@@ -194,6 +220,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             if (referenceDirection == RadialViewReferenceDirection.GravityAligned)
             {
                 goalRotation.x = goalRotation.z = 0f;
+            }
+
+            if(UseFixedVerticalPosition == true)
+            {
+                goalPosition.y = ReferencePoint.y + FixedVerticalPosition;
             }
 
             GoalPosition = goalPosition;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
@@ -222,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 goalRotation.x = goalRotation.z = 0f;
             }
 
-            if(UseFixedVerticalPosition == true)
+            if (UseFixedVerticalPosition == true)
             {
                 goalPosition.y = ReferencePoint.y + FixedVerticalPosition;
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/RadialView.cs
@@ -222,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 goalRotation.x = goalRotation.z = 0f;
             }
 
-            if (UseFixedVerticalPosition == true)
+            if (UseFixedVerticalPosition)
             {
                 goalPosition.y = ReferencePoint.y + FixedVerticalPosition;
             }


### PR DESCRIPTION
## Overview
To achieve shell-parity 'Follow Me' behavior, added vertical position lock option to the Radial view Solver. Radial view already had min/max distance/degree allowance which allowed shell-style 'lazy following' behavior. We just needed to a way to lock vertical position. With original Radial view, object also moved vertically following the headset movement.

- Applied updated Radial view Solver to Slate.prefab and ToggleFeaturesPanel.prefab
- Optimized the min/max distance/degree allowance of the Radial view Solver to match shell behavior

![2019-07-23 17_09_12-Shell-Parity](https://user-images.githubusercontent.com/13754172/61755517-cd109500-ad6c-11e9-94d6-5f98b49e8e42.png)

Part of #4200 [MRTK Shell Parity] UX Controls Parity with HoloLens 2 Shell

## Fixes
- #5380 Toggle features panel solver moves menu directly in front of face
- #4983 [MRTK Shell Parity] Follow Me behavior does not match the shell
- #5393 [Solver] Add degree/distance range to Orbital or Add Y-pos lock to Radial view

## MRCs
Lazy following with left/right degree values & min max distance values.
![MRTK_FollowMeUpdate1](https://user-images.githubusercontent.com/13754172/61755279-adc53800-ad6b-11e9-952b-701f622b6c82.gif)
![MRTK_FollowMeUpdate2](https://user-images.githubusercontent.com/13754172/61755282-b0279200-ad6b-11e9-9fa2-ee3175fe859e.gif)

