### PR TITLE
Update the MixedRealityKeyboard doccomments to reflect the platforms it was intended for.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs
@@ -11,8 +11,7 @@ using Windows.UI.ViewManagement;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     /// <summary>
-    /// Class that can launch and hide a system keyboard specifically for Windows Mixed Reality
-    /// devices (HoloLens 2, Windows Mixed Reality).
+    /// Class that can launch and hide a system keyboard specifically for HoloLens 2.
     /// 
     /// Implements a workaround for UWP TouchScreenKeyboard bug which prevents
     /// UWP keyboard from showing up again after it is closed.


### PR DESCRIPTION
It was only designed to handle the HL2 workaround, so we should at least write this down.

Note that there is more work here to make the general system keyboard example script work in immersive/HL1 cases.