### PR TITLE
Fix coffee cup drop and update profile assets

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/GestureEventsConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/GestureEventsConfigurationProfile.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
-  m_Name: HandInteractionGestureEventsMixedRealityToolkitConfigurationProfile
+  m_Name: GestureEventsConfigurationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   targetExperienceScale: 3

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/GestureEventsInputSimulationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/GestureEventsInputSimulationProfile.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 78a4b02a0d9e7044fa19c6d432d0cafa, type: 3}
-  m_Name: HandInteractionGestureEventsMixedRealityInputSimulationProfile
+  m_Name: GestureEventsInputSimulationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   isCameraControlEnabled: 1
@@ -41,7 +41,7 @@ MonoBehaviour:
   rightMouseHandGesture: 0
   handGestureAnimationSpeed: 8
   holdStartDuration: 0.5
-  manipulationStartThreshold: 0.03
+  navigationStartThreshold: 0.03
   defaultHandDistance: 0.5
   handDepthMultiplier: 0.1
   handJitterAmount: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/GestureEventsInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/GestureEventsInputSystemProfile.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b71cb900fa9dec5488df2deb180db58f, type: 3}
-  m_Name: HandInteractionGestureEventsMixedRealityInputSystemProfile
+  m_Name: GestureEventsInputSystemProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   dataProviderConfigurations:
@@ -73,6 +73,7 @@ MonoBehaviour:
     reference: Microsoft.MixedReality.Toolkit.Input.FocusProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   raycastProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultRaycastProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  focusQueryBufferSize: 128
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
     type: 2}
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/RecordArticulatedHandPoseConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/RecordArticulatedHandPoseConfigurationProfile.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
-  m_Name: HandInteractionRecordArticulatedHandPoseMixedRealityToolkitConfigurationProfile
+  m_Name: RecordArticulatedHandPoseConfigurationProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   targetExperienceScale: 3

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/RecordArticulatedHandPoseInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/RecordArticulatedHandPoseInputSystemProfile.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b71cb900fa9dec5488df2deb180db58f, type: 3}
-  m_Name: HandInteractionRecordArticulatedHandPoseMixedRealityInputSystemProfile
+  m_Name: RecordArticulatedHandPoseInputSystemProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   dataProviderConfigurations:
@@ -80,6 +80,7 @@ MonoBehaviour:
     reference: Microsoft.MixedReality.Toolkit.Input.FocusProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   raycastProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultRaycastProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  focusQueryBufferSize: 128
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
     type: 2}
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/RecordArticulatedHandPoseSpeechCommandsProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Profiles/RecordArticulatedHandPoseSpeechCommandsProfile.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1f18fec9b55c4f818e284af454161962, type: 3}
-  m_Name: HandInteractionRecordArticulatedHandPoseMixedRealitySpeechCommandsProfile
+  m_Name: RecordArticulatedHandPoseSpeechCommandsProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 1
   startBehavior: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/TetheredPlacement.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/TetheredPlacement.cs
@@ -16,8 +16,12 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         private Vector3 RespawnPoint;
         private Quaternion RespawnOrientation;
 
+        private Rigidbody rigidBody;
+
         private void Start()
         {
+            rigidBody = GetComponent<Rigidbody>();
+
             LockSpawnPoint();
         }
 
@@ -27,6 +31,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 
             if (distanceSqr > DistanceThreshold * DistanceThreshold)
             {
+                // Reset any velocity from falling or moving when respawning to original location
+                if (rigidBody != null)
+                {
+                    rigidBody.velocity = Vector3.zero;
+                    rigidBody.angularVelocity = Vector3.zero;
+                }
+
                 this.transform.SetPositionAndRotation(RespawnPoint, RespawnOrientation);
             }
         }


### PR DESCRIPTION
## Overview
When resetting the transform of the coffee cup in the HandInteraction example scene, the rigidbody was not being reset and thus whatever velocity/momentum was attained by falling is kept. If the physics breaks and the coffee cup goes so fast it falls through the counter, it will keep never-ending increasing in velocity. 

This change also fixes some asset renames for MRTK profiles from another previous change (See .asset files)

## Changes
- Fixes: #5382 


## Verification
Drop cup and now doesn't retain velocity

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
