### PR TITLE
Config Profile for HoloLens 1

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2385ba3fd0af66146ba74ee7f05d17c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4a1c93114e9437cb75d8b3ee4e0e1ba, type: 3}
+  m_Name: DefaultHoloLens1CameraProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  nearClipPlaneOpaqueDisplay: 0.3
+  farClipPlaneOpaqueDisplay: 1000
+  cameraClearFlagsOpaqueDisplay: 2
+  backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
+  opaqueQualityLevel: 0
+  nearClipPlaneTransparentDisplay: 0.3
+  farClipPlaneTransparentDisplay: 50
+  cameraClearFlagsTransparentDisplay: 2
+  backgroundColorTransparentDisplay: {r: 0, g: 0, b: 0, a: 0}
+  holoLensQualityLevel: 0

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0447581e7bd59f64fbb28151c65a3dc4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7612acbc1a4a4ed0afa5f4ccbe42bee4, type: 3}
+  m_Name: DefaultHoloLens1ConfigurationProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  targetExperienceScale: 3
+  enableCameraSystem: 1
+  cameraProfile: {fileID: 11400000, guid: 0447581e7bd59f64fbb28151c65a3dc4, type: 2}
+  cameraSystemType:
+    reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
+      Microsoft.MixedReality.Toolkit.Services.CameraSystem
+  enableInputSystem: 1
+  inputSystemProfile: {fileID: 11400000, guid: bec5ceabcd10992439d51532332137f9, type: 2}
+  inputSystemType:
+    reference: Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  enableBoundarySystem: 0
+  boundarySystemType:
+    reference: Microsoft.MixedReality.Toolkit.Boundary.MixedRealityBoundarySystem,
+      Microsoft.MixedReality.Toolkit.Services.BoundarySystem
+  boundaryVisualizationProfile: {fileID: 11400000, guid: 6d28cce596b44bd3897ca86f8b24e076,
+    type: 2}
+  enableTeleportSystem: 0
+  teleportSystemType:
+    reference: Microsoft.MixedReality.Toolkit.Teleport.MixedRealityTeleportSystem,
+      Microsoft.MixedReality.Toolkit.Services.TeleportSystem
+  enableSpatialAwarenessSystem: 0
+  spatialAwarenessSystemType:
+    reference: Microsoft.MixedReality.Toolkit.SpatialAwareness.MixedRealitySpatialAwarenessSystem,
+      Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem
+  spatialAwarenessSystemProfile: {fileID: 11400000, guid: 97da727944a3d7b4caf42d2273271a24,
+    type: 2}
+  diagnosticsSystemProfile: {fileID: 11400000, guid: 478436bd1083882479a52d067e98e537,
+    type: 2}
+  enableDiagnosticsSystem: 1
+  diagnosticsSystemType:
+    reference: Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem,
+      Microsoft.MixedReality.Toolkit.Services.DiagnosticsSystem
+  sceneSystemProfile: {fileID: 0}
+  enableSceneSystem: 0
+  sceneSystemType:
+    reference: 
+  registeredServiceProvidersProfile: {fileID: 11400000, guid: efbaf6ea540c69f4fb75415a5d145a53,
+    type: 2}
+  useServiceInspectors: 0

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e7c962b9eb9dfa44993d5b2f2576752
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1HandTrackingProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1HandTrackingProfile.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8275efdbe76bdff49a97a8e82fba118d, type: 3}
+  m_Name: DefaultHoloLens1HandTrackingProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  jointPrefab: {fileID: 1955475817299902, guid: 6a3f88d2571cd234a86d95ee5856b9ec,
+    type: 3}
+  palmPrefab: {fileID: 6797406804172968804, guid: 750bdc3344567a447960aae3eda2b462,
+    type: 3}
+  fingertipPrefab: {fileID: 7094064642998883381, guid: b37dde41a983d664c8a09a91313733e7,
+    type: 3}
+  handMeshPrefab: {fileID: 1887883006053652, guid: a86f479797fea8f4189f924b3b6ad979,
+    type: 3}
+  enableHandMeshVisualization: 0
+  enableHandJointVisualization: 1

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1HandTrackingProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1HandTrackingProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e445e6fda57508c46935bb141b7673a7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSimulationProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSimulationProfile.asset
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78a4b02a0d9e7044fa19c6d432d0cafa, type: 3}
+  m_Name: DefaultHoloLens1InputSimulationProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 1
+  isCameraControlEnabled: 1
+  extraMouseSensitivityScale: 3
+  defaultMouseSensitivity: 0.1
+  mouseLookButton: 1
+  isControllerLookInverted: 1
+  currentControlMode: 0
+  fastControlKey: 305
+  controlSlowSpeed: 0.1
+  controlFastSpeed: 1
+  moveHorizontal: Horizontal
+  moveVertical: Vertical
+  mouseX: Mouse X
+  mouseY: Mouse Y
+  lookHorizontal: AXIS_4
+  lookVertical: AXIS_5
+  simulateEyePosition: 0
+  handSimulationMode: 1
+  toggleLeftHandKey: 116
+  toggleRightHandKey: 121
+  handHideTimeout: 0.2
+  leftHandManipulationKey: 304
+  rightHandManipulationKey: 32
+  defaultHandGesture: 2
+  leftMouseHandGesture: 3
+  middleMouseHandGesture: 0
+  rightMouseHandGesture: 0
+  handGestureAnimationSpeed: 8
+  holdStartDuration: 0.5
+  navigationStartThreshold: 0.03
+  defaultHandDistance: 0.5
+  handDepthMultiplier: 0.1
+  handJitterAmount: 0
+  yawHandCWKey: 101
+  yawHandCCWKey: 113
+  pitchHandCWKey: 102
+  pitchHandCCWKey: 114
+  rollHandCWKey: 120
+  rollHandCCWKey: 122
+  handRotationSpeed: 100

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSimulationProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSimulationProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 427bea38105dc76429738a52f25940ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset
@@ -1,0 +1,112 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b71cb900fa9dec5488df2deb180db58f, type: 3}
+  m_Name: DefaultHoloLens1InputSystemProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  dataProviderConfigurations:
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityDeviceManager,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+    componentName: Windows Mixed Reality Device Manager
+    priority: 0
+    runtimePlatform: 8
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.OpenVR.Input.OpenVRDeviceManager,
+        Microsoft.MixedReality.Toolkit.Providers.OpenVR
+    componentName: OpenVR Device Manager
+    priority: 0
+    runtimePlatform: 7
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.UnityInput.UnityJoystickManager,
+        Microsoft.MixedReality.Toolkit
+    componentName: Unity Joystick Manager
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.UnityInput.UnityTouchDeviceManager,
+        Microsoft.MixedReality.Toolkit
+    componentName: Unity Touch Device Manager
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Windows.Input.WindowsSpeechInputProvider,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
+    componentName: Windows Speech Input
+    priority: 0
+    runtimePlatform: 25
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Windows.Input.WindowsDictationInputProvider,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsVoiceInput
+    componentName: Windows Dictation Input
+    priority: 0
+    runtimePlatform: 25
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.HandJointService, Microsoft.MixedReality.Toolkit
+    componentName: Hand Joint Service
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
+    componentName: Input Simulation Service
+    priority: 0
+    runtimePlatform: 208
+    deviceManagerProfile: {fileID: 11400000, guid: 427bea38105dc76429738a52f25940ce,
+      type: 2}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityEyeGazeDataProvider,
+        Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality
+    componentName: Windows Mixed Reality Eye Gaze Provider
+    priority: 0
+    runtimePlatform: 8
+    deviceManagerProfile: {fileID: 11400000, guid: 2d87dd11b18f700449c9dab320d19b99,
+      type: 2}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.InputRecordingService, Microsoft.MixedReality.Toolkit.Services.InputAnimation
+    componentName: Input Recording Service
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 11400000, guid: d0f5a7f6d1f9f0b4cb6eb35c797a0f04,
+      type: 2}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.InputPlaybackService, Microsoft.MixedReality.Toolkit.Services.InputAnimation
+    componentName: Input Playback Service
+    priority: 0
+    runtimePlatform: -1
+    deviceManagerProfile: {fileID: 0}
+  focusProviderType:
+    reference: Microsoft.MixedReality.Toolkit.Input.FocusProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  raycastProviderType:
+    reference: Microsoft.MixedReality.Toolkit.Input.DefaultRaycastProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  focusQueryBufferSize: 128
+  inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
+    type: 2}
+  inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,
+    type: 2}
+  pointerProfile: {fileID: 11400000, guid: 48aa63a9725047b28d4137fd0834bc31, type: 2}
+  gesturesProfile: {fileID: 11400000, guid: bd7829a9b29409045a745b5a18299291, type: 2}
+  speechCommandsProfile: {fileID: 11400000, guid: e8d0393e66374dae9646851a57dc6bc1,
+    type: 2}
+  enableControllerMapping: 1
+  controllerMappingProfile: {fileID: 11400000, guid: 39ded1fd0711a0c448413d0e1ec4f7f3,
+    type: 2}
+  controllerVisualizationProfile: {fileID: 11400000, guid: 345c06fdf3732db46b96299bd3cba653,
+    type: 2}
+  handTrackingProfile: {fileID: 11400000, guid: e445e6fda57508c46935bb141b7673a7,
+    type: 2}

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bec5ceabcd10992439d51532332137f9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
By default the MRTK config profile assumes articulated hand input using HoloLens 2 style hand rays + direct interaction, however many people using MRTK are still deploying to HoloLens 1. People often ask how they can [simulate HoloLens 1 style interactions in the Unity Editor](https://stackoverflow.com/questions/56821449/hl1-input-for-mrtk-v2-1).

People building and deploying HoloLens 1 apps can use this configuration in their MRTK.

This change adds an MRTK profile that people can use to simulate HoloLens 1 style GGV interactions.

Fixes: #5046 

## Changes
* New profile to simulate HoloLens 1 interations.
* Profile uses "gesture hand" for input simulation, not the articulated hand
* Set Camera Clipping plane for HoloLens 1 to 0.3 per comfort guidelines at https://docs.microsoft.com/en-us/windows/mixed-reality/comfort


