### PR TITLE
Prevents build failure

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -98,6 +98,18 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 IsBuilding = false;
                 return false;
             }
+            
+            if (string.IsNullOrWhiteSpace(buildInfo.Configuration))
+            {
+                Debug.LogWarning("!!! buildInfo.Configuration is null or whitespace. Using 'master'");
+                buildInfo.Configuration = "master";
+            }
+
+            if (string.IsNullOrWhiteSpace(buildInfo.BuildPlatform))
+            {
+                Debug.LogWarning("!!! buildInfo.BuildPlatform is null or whitespace. Using 'x86'");
+                buildInfo.BuildPlatform = "x86";
+            }
 
             // Now that NuGet packages have been restored, we can run the actual build process.
             exitCode = await Run(msBuildPath, 


### PR DESCRIPTION
## Overview
Prevents build failure when buildInfo.Configuration or buildInfo.BuildPlatform are empty or whitespace. Addresses #5434
Simply adds a couple of null/whitespace checks on the above variables and sets them to safe defaults so that the build can proceed. Warning is displayed in console so dev can debug if necessary.

## Changes
- Fixes: #5434 