### PR TITLE
Mrtk spatial mouse cursor amendment

### DIFF
--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -54,16 +54,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                 return;
             }
 
-#if UNITY_EDITOR
-            if (UnityEditor.EditorWindow.focusedWindow != null)
-            {
-                UnityEditor.EditorWindow.focusedWindow.ShowNotification(new GUIContent("Press \"ESC\" to regain mouse control"));
-            }
-#endif
-
-            Cursor.visible = false;
-            Cursor.lockState = CursorLockMode.Locked;
-
             IMixedRealityInputSource mouseInputSource = null;
 
             MixedRealityRaycaster.DebugEnabled = true;


### PR DESCRIPTION
## Overview

While #5242 was approved, a slight mistake slipped in this corrects.
The deleted code lines went into the original MousePointer directly as they are not needed for the new SpatialMousePointer.

Without these gone, the spatial mouse suffers from being disabled and overlayed by the notification