### PR TITLE
Resolve the ArgumentException error in MRTK+Unity startup

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -43,13 +43,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                 foreach (string asset in importedAssets.Concat(movedAssets))
                 {
-                    string folder = asset.Replace("Assets", Application.dataPath);
+                    string folder = ResolveFullAssetsPath(asset);
                     TryRegisterModuleFolder(folder);
                 }
 
                 foreach (string asset in deletedAssets.Concat(movedFromAssetPaths))
                 {
-                    string folder = asset.Replace("Assets", Application.dataPath);
+                    string folder = ResolveFullAssetsPath(asset);
                     TryUnregisterModuleFolder(folder);
                 }
             }
@@ -58,6 +58,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private readonly static Dictionary<MixedRealityToolkitModuleType, HashSet<string>> mrtkFolders =
             new Dictionary<MixedRealityToolkitModuleType, HashSet<string>>();
         private readonly static Task searchForFoldersTask;
+
+        /// <summary>
+        /// Resolves the given asset to its full path if and only if the asset belongs to the
+        /// Assets folder (i.e. it is prefixed with "Assets/..."
+        /// </summary>
+        /// <remarks>
+        /// If not associated with the Assets folder, will return the path unchanged.
+        /// </remarks>
+        private static string ResolveFullAssetsPath(string path)
+        {
+            if (path.StartsWith("Assets"))
+            {
+                // asset.Substring(6) represents the characters after the "Assets" string.
+                return Application.dataPath + path.Substring(6);
+            }
+            return path;
+        }
 
         /// <summary>
         /// Returns a collection of MRTK directories found in the project.


### PR DESCRIPTION
When ingesting MRTK for the first time (especially via git) you'll see an ArgumentException warning, which happens as MRTK is figuring out where its files are being placed. This shows as an error but is actualy benign (i.e. it happens in some processing of UPM packages that have no effect on the MRTK).

The cause here was an overly aggressive .Replace call - it replaced ALL instances of "Asset" with the application asset path (even when Asset was showing up much later in the path). It was really only intending to replace the prefix "Asset" string, so this fixes it to only do that.