### PR TITLE
Add workaround for hands/eyes on .NET Native

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
@@ -23,10 +23,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         /// <summary>
         /// Helps marshal WinRT IInspectable objects that have been passed to managed code as an IntPtr.
+        /// </summary>
+        /// <remarks>
         /// On .NET Native, IInspectable pointers cannot be marshaled from native to managed code using Marshal.GetObjectForIUnknown.
         /// This class calls into a native method that specifically marshals the type as a specific WinRT interface, which
         /// is supported by the marshaller on both .NET Core and .NET Native.
-        /// </summary>    
+        /// Please see https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/InputSystem/HandTracking.html#net-native for more info.
+        /// </remarks>
         private static SpatialCoordinateSystem GetSpatialCoordinateSystem(IntPtr nativePtr)
         {
             try

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #if WINDOWS_UWP
+#if ENABLE_DOTNET
+using System;
+#endif // ENABLE_DOTNET
 using System.Runtime.InteropServices;
 using UnityEngine.XR.WSA;
 using Windows.Perception.Spatial;
@@ -12,7 +15,34 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
     public static class WindowsMixedRealityUtilities
     {
 #if WINDOWS_UWP
+#if ENABLE_DOTNET
+        [DllImport("DotNetNativeWorkaround.dll", EntryPoint = "MarshalIInspectable")]
+        private static extern void GetSpatialCoordinateSystem(IntPtr nativePtr, out SpatialCoordinateSystem coordinateSystem);
+
+        public static SpatialCoordinateSystem SpatialCoordinateSystem => spatialCoordinateSystem ?? (spatialCoordinateSystem = GetSpatialCoordinateSystem(WorldManager.GetNativeISpatialCoordinateSystemPtr()));
+
+        /// <summary>
+        /// Helps marshal WinRT IInspectable objects that have been passed to managed code as an IntPtr.
+        /// On .NET Native, IInspectable pointers cannot be marshaled from native to managed code using Marshal.GetObjectForIUnknown.
+        /// This class calls into a native method that specifically marshals the type as a specific WinRT interface, which
+        /// is supported by the marshaller on both .NET Core and .NET Native.
+        /// </summary>    
+        private static SpatialCoordinateSystem GetSpatialCoordinateSystem(IntPtr nativePtr)
+        {
+            try
+            {
+                GetSpatialCoordinateSystem(nativePtr, out SpatialCoordinateSystem coordinateSystem);
+                return coordinateSystem;
+            }
+            catch
+            {
+                UnityEngine.Debug.LogError("Call to the DotNetNativeWorkaround plug-in failed. The plug-in is required for correct behavior when using .NET Native compilation");
+                return Marshal.GetObjectForIUnknown(nativePtr) as SpatialCoordinateSystem;
+            }
+        }
+#else
         public static SpatialCoordinateSystem SpatialCoordinateSystem => spatialCoordinateSystem ?? (spatialCoordinateSystem = Marshal.GetObjectForIUnknown(WorldManager.GetNativeISpatialCoordinateSystemPtr()) as SpatialCoordinateSystem);
+#endif
         private static SpatialCoordinateSystem spatialCoordinateSystem = null;
 #endif // WINDOWS_UWP
 

--- a/Documentation/InputSystem/HandTracking.md
+++ b/Documentation/InputSystem/HandTracking.md
@@ -168,7 +168,9 @@ public class MyHandMeshEventHandler : IMixedRealityHandMeshHandler
 
 There is currently a known issue with Master builds using the .NET backend. In .NET Native, `IInspectable` pointers cannot be marshaled from native to managed code using `Marshal.GetObjectForIUnknown`. The MRTK uses this to obtain the `SpatialCoordinateSystem` in order to recieve hand and eye data from the platform.
 
-We've provided DLL source as a workaround for this issue, in [the native Mixed Reality Toolkit repo](https://github.com/microsoft/MixedRealityToolkit/tree/master/DotNetNativeWorkaround). Please follow the instructions in the README there and copy the resulting binaries into a Plugins folder in your Unity assets. After that, the WindowsMixedRealityUtilities script provided in the MRTK will resolve the workaround for you.
+We've provided DLL source as a workaround for this issue, in [the native Mixed Reality Toolkit repo](https://github.com/microsoft/MixedRealityToolkit/tree/master/DotNetNativeWorkaround).
+Please follow the instructions in the README there and copy the resulting binaries into a Plugins folder in your Unity assets.
+After that, the WindowsMixedRealityUtilities script provided in the MRTK will resolve the workaround for you.
 
 If you want to create your own DLL or include this workaround in an existing one, the core of the workaround is:
 

--- a/Documentation/InputSystem/HandTracking.md
+++ b/Documentation/InputSystem/HandTracking.md
@@ -166,7 +166,7 @@ public class MyHandMeshEventHandler : IMixedRealityHandMeshHandler
 
 ### .NET Native
 
-There is currently a known issue with Master builds using the .NET backend. In .NET Native, `IInspectable` pointers cannot be marshaled from native to managed code using `Marshal.GetObjectForIUnknown`. The MRTK uses this to obtain the `SpatialCoordinateSystem` in order to recieve hand and eye data from the platform.
+There is currently a known issue with Master builds using the .NET backend. In .NET Native, `IInspectable` pointers cannot be marshaled from native to managed code using `Marshal.GetObjectForIUnknown`. The MRTK uses this to obtain the `SpatialCoordinateSystem` in order to receive hand and eye data from the platform.
 
 We've provided DLL source as a workaround for this issue, in [the native Mixed Reality Toolkit repo](https://github.com/microsoft/MixedRealityToolkit/tree/master/DotNetNativeWorkaround). Please follow the instructions in the README there and copy the resulting binaries into a Plugins folder in your Unity assets. After that, the WindowsMixedRealityUtilities script provided in the MRTK will resolve the workaround for you.
 

--- a/Documentation/InputSystem/HandTracking.md
+++ b/Documentation/InputSystem/HandTracking.md
@@ -168,9 +168,7 @@ public class MyHandMeshEventHandler : IMixedRealityHandMeshHandler
 
 There is currently a known issue with Master builds using the .NET backend. In .NET Native, `IInspectable` pointers cannot be marshaled from native to managed code using `Marshal.GetObjectForIUnknown`. The MRTK uses this to obtain the `SpatialCoordinateSystem` in order to recieve hand and eye data from the platform.
 
-We've provided DLL source as a workaround for this issue, in [the native Mixed Reality Toolkit repo](https://github.com/microsoft/MixedRealityToolkit/tree/master/DotNetNativeWorkaround).
-Please follow the instructions in the README there and copy the resulting binaries into a Plugins folder in your Unity assets.
-After that, the WindowsMixedRealityUtilities script provided in the MRTK will resolve the workaround for you.
+We've provided DLL source as a workaround for this issue, in [the native Mixed Reality Toolkit repo](https://github.com/microsoft/MixedRealityToolkit/tree/master/DotNetNativeWorkaround). Please follow the instructions in the README there and copy the resulting binaries into a Plugins folder in your Unity assets. After that, the WindowsMixedRealityUtilities script provided in the MRTK will resolve the workaround for you.
 
 If you want to create your own DLL or include this workaround in an existing one, the core of the workaround is:
 

--- a/Documentation/InputSystem/HandTracking.md
+++ b/Documentation/InputSystem/HandTracking.md
@@ -13,7 +13,7 @@ Joint prefabs are visualized using simple prefabs. The _Palm_ and _Index Finger_
 By default the hand joint prefabs are simple geometric primitives. These can be replaced if desired. If no prefab is specified at all, empty [GameObjects](href:https://docs.unity3d.com/ScriptReference/GameObject.html) are created instead.
 
 > [!WARNING]
-> Avoid using complex scripts or expensive rendering in joint prefabs, since joint objects are transformed on every frame and can have significant performance cost!**
+> Avoid using complex scripts or expensive rendering in joint prefabs, since joint objects are transformed on every frame and can have significant performance cost!
 
 <img src="../../Documentation/Images/InputSimulation/MRTK_Core_Input_Hands_JointVisualizerPrefabs.png" width="350px"  style="display:block;">
 
@@ -159,5 +159,43 @@ public class MyHandMeshEventHandler : IMixedRealityHandMeshHandler
       // ...
     }
   }
+}
+```
+
+## Known Issues
+
+### .NET Native
+
+There is currently a known issue with Master builds using the .NET backend. In .NET Native, `IInspectable` pointers cannot be marshaled from native to managed code using `Marshal.GetObjectForIUnknown`. The MRTK uses this to obtain the `SpatialCoordinateSystem` in order to recieve hand and eye data from the platform.
+
+We've provided DLL source as a workaround for this issue, in [the native Mixed Reality Toolkit repo](https://github.com/microsoft/MixedRealityToolkit/tree/master/DotNetNativeWorkaround). Please follow the instructions in the README there and copy the resulting binaries into a Plugins folder in your Unity assets. After that, the WindowsMixedRealityUtilities script provided in the MRTK will resolve the workaround for you.
+
+If you want to create your own DLL or include this workaround in an existing one, the core of the workaround is:
+
+```c++
+extern "C" __declspec(dllexport) void __stdcall MarshalIInspectable(IUnknown* nativePtr, IUnknown** inspectable)
+{
+    *inspectable = nativePtr;
+}
+```
+
+And its use in your C# Unity code:
+
+```c#
+[DllImport("DotNetNativeWorkaround.dll", EntryPoint = "MarshalIInspectable")]
+private static extern void GetSpatialCoordinateSystem(IntPtr nativePtr, out SpatialCoordinateSystem coordinateSystem);
+
+private static SpatialCoordinateSystem GetSpatialCoordinateSystem(IntPtr nativePtr)
+{
+    try
+    {
+        GetSpatialCoordinateSystem(nativePtr, out SpatialCoordinateSystem coordinateSystem);
+        return coordinateSystem;
+    }
+    catch
+    {
+        UnityEngine.Debug.LogError("Call to the DotNetNativeWorkaround plug-in failed. The plug-in is required for correct behavior when using .NET Native compilation");
+        return Marshal.GetObjectForIUnknown(nativePtr) as SpatialCoordinateSystem;
+    }
 }
 ```


### PR DESCRIPTION
## Overview
There is currently a known issue with Master builds using the .NET backend. In .NET Native, `IInspectable` pointers cannot be marshaled from native to managed code using `Marshal.GetObjectForIUnknown`. The MRTK uses this to obtain the `SpatialCoordinateSystem` in order to receive hand and eye data from the platform.

Native source PR: https://github.com/microsoft/MixedRealityToolkit/pull/228

We are not shipping the binaries precompiled in this case, but users who need them can compile them themselves from the native source repo.

## Changes
- Fixes: #4340 

## Verification
1. Build the binary from the native repo
2. Include it in your plugins folder
3. Build the .NET backend as Master and deploy to your HL2.
4. Verify that hand joints properly render (the HandInteractions example scene is good for this).