### PR TITLE
Make sure the isSimulating flag for hands is reset when losing window…

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
@@ -225,24 +225,32 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 IsAlwaysVisibleRight = !IsAlwaysVisibleRight;
             }
 
-            if (UnityEngine.Input.GetKeyDown(profile.LeftHandManipulationKey))
-            {
-                isSimulatingLeft = true;
-            }
-            if (UnityEngine.Input.GetKeyUp(profile.LeftHandManipulationKey))
+            if (!Application.isFocused)
             {
                 isSimulatingLeft = false;
-            }
-
-            if (UnityEngine.Input.GetKeyDown(profile.RightHandManipulationKey))
-            {
-                isSimulatingRight = true;
-            }
-            if (UnityEngine.Input.GetKeyUp(profile.RightHandManipulationKey))
-            {
                 isSimulatingRight = false;
             }
-       
+            else
+            {
+                if (UnityEngine.Input.GetKeyDown(profile.LeftHandManipulationKey))
+                {
+                    isSimulatingLeft = true;
+                }
+                if (UnityEngine.Input.GetKeyUp(profile.LeftHandManipulationKey))
+                {
+                    isSimulatingLeft = false;
+                }
+
+                if (UnityEngine.Input.GetKeyDown(profile.RightHandManipulationKey))
+                {
+                    isSimulatingRight = true;
+                }
+                if (UnityEngine.Input.GetKeyUp(profile.RightHandManipulationKey))
+                {
+                    isSimulatingRight = false;
+                }
+            }
+
             Vector3 mouseDelta = (lastMousePosition.HasValue ? UnityEngine.Input.mousePosition - lastMousePosition.Value : Vector3.zero);
             mouseDelta.z += UnityEngine.Input.GetAxis("Mouse ScrollWheel") * profile.HandDepthMultiplier;
             float rotationDelta = profile.HandRotationSpeed * Time.deltaTime;


### PR DESCRIPTION
## Overview

Reset the "isSimulating" flags for simulated hands when the application loses focus, so that hands are not moving with the mouse when focusing back on the window.

## Changes
- Fixes: #5375


## Verification
1. Go into play mode
1. Hold shift and/or space to bring up simulated hands
1. _While holding shift/space_, alt+tab out of the window.
1. Simulated hands are released and disappear (or stop moving with the mouse if in persistent mode).