### PR TITLE
Fixes two omissions in the ExtensionServiceCreator

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -517,10 +517,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             try
             {
-                ScriptableObject profileInstance = ScriptableObject.CreateInstance(DefaultExtensionNamespace + "." + ProfileName);
+                ScriptableObject profileInstance = ScriptableObject.CreateInstance(Namespace + "." + ProfileName);
                 if (profileInstance == null)
                 {
-                    creationLog.Add("Couldn't create instance of profile class " + DefaultExtensionNamespace + "." + ProfileName + " - aborting");
+                    creationLog.Add("Couldn't create instance of profile class " + Namespace + "." + ProfileName + " - aborting");
                     Result = CreateResult.Error;
                     return;
                 }
@@ -587,7 +587,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             scriptContents = scriptContents.Replace(InterfaceNameSearchString, InterfaceName);
             scriptContents = scriptContents.Replace(ProfileNameSearchString, ProfileName);
             scriptContents = scriptContents.Replace(ProfileFieldNameSearchString, ProfileFieldName);
-            scriptContents = scriptContents.Replace(ExtensionNamespaceSearchString, DefaultExtensionNamespace);
+            scriptContents = scriptContents.Replace(ExtensionNamespaceSearchString, Namespace);
 
             List<string> platformValues = new List<string>();
             foreach (SupportedPlatforms platform in Enum.GetValues(typeof(SupportedPlatforms)))

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -444,10 +444,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             // This delay is purely for visual flow
             await Task.Delay(100);
-            string inspectorAsset = CreateTextAssetFromTemplate(InspectorTemplate);
-            WriteTextAssetToDisk(inspectorAsset, InspectorName, InspectorFolderPath);
-            if (Result == CreateResult.Error)
-                return;
+            if (UsesInspector)
+            {
+                string inspectorAsset = CreateTextAssetFromTemplate(InspectorTemplate);
+                WriteTextAssetToDisk(inspectorAsset, InspectorName, InspectorFolderPath);
+                if (Result == CreateResult.Error)
+                    return;
+            }
 
             // This delay is purely for visual flow
             await Task.Delay(100);

--- a/ExtensionTemplates/ExtensionInspectorTemplate.txt
+++ b/ExtensionTemplates/ExtensionInspectorTemplate.txt
@@ -1,7 +1,7 @@
 #if UNITY_EDITOR
 using System;
 using Microsoft.MixedReality.Toolkit.Editor;
-using Microsoft.MixedReality.Toolkit.Extensions;
+using Microsoft.MixedReality.Toolkit;
 using UnityEngine;
 using UnityEditor;
 

--- a/ExtensionTemplates/ExtensionInterfaceTemplate.txt
+++ b/ExtensionTemplates/ExtensionInterfaceTemplate.txt
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.MixedReality.Toolkit.Extensions;
+using Microsoft.MixedReality.Toolkit;
 
 namespace #NAMESPACE#
 {

--- a/ExtensionTemplates/ExtensionProfileTemplate.txt
+++ b/ExtensionTemplates/ExtensionProfileTemplate.txt
@@ -1,6 +1,6 @@
 using System;
 using UnityEngine;
-using Microsoft.MixedReality.Toolkit.Extensions;
+using Microsoft.MixedReality.Toolkit;
 
 namespace #NAMESPACE#
 {

--- a/ExtensionTemplates/ExtensionScriptTemplate.txt
+++ b/ExtensionTemplates/ExtensionScriptTemplate.txt
@@ -1,6 +1,6 @@
 using System;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Extensions;
+using Microsoft.MixedReality.Toolkit;
 
 namespace #NAMESPACE#
 {


### PR DESCRIPTION
## Overview
1. ExtensionServiceCreator ignores namespace supplied by user, always takes default instead
2. ExtensionServiceCreator creates inspector even when "Generate Inspector" is unselected

## Changes
1. ExtensionServiceCreator now uses NameSpace in stead of DefaultExtensionNamespace while creating the files. This also required adaption of the template files as those now have a missing "using" on top now they are no long in Microsoft.MixedReality.Toolkit.Extensions;
2. Added simple "if(UsesInspector)" around creation of inspector. This was read from the UI and clearly intended to use for this, but was not checked