### PR TITLE
Regenerate some GUIDs to prevent HTK -> MRTK collisions

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/ClippingExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/ClippingExamples.unity
@@ -320,91 +320,91 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1723500072}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_Name
       value: GrabMeText
       objectReference: {fileID: 0}
-    - target: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.030000007
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.030000001
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.030000001
       objectReference: {fileID: 0}
-    - target: {fileID: 102000010767390410, guid: c07f18faebebb2d409b2f26d63cad856,
+    - target: {fileID: 102000010767390410, guid: e765e6ff063d7a54c8f7efa4da96fb52,
         type: 3}
       propertyPath: m_Text
       value: Grab Me!
       objectReference: {fileID: 0}
-    - target: {fileID: 102000010767390410, guid: c07f18faebebb2d409b2f26d63cad856,
+    - target: {fileID: 102000010767390410, guid: e765e6ff063d7a54c8f7efa4da96fb52,
         type: 3}
       propertyPath: m_FontSize
       value: 72
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
 --- !u!4 &167134279 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 167134278}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &167134280 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 167134278}
   m_PrefabAsset: {fileID: 0}
@@ -424,7 +424,7 @@ MonoBehaviour:
   targetTransform: {fileID: 0}
 --- !u!23 &167134283 stripped
 MeshRenderer:
-  m_CorrespondingSourceObject: {fileID: 23000013318538408, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 23000013318538408, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 167134278}
   m_PrefabAsset: {fileID: 0}
@@ -435,82 +435,82 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 135874843}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_Name
       value: GrabMeText
       objectReference: {fileID: 0}
-    - target: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.019999998
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.019999998
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.019999998
       objectReference: {fileID: 0}
-    - target: {fileID: 102000010767390410, guid: c07f18faebebb2d409b2f26d63cad856,
+    - target: {fileID: 102000010767390410, guid: e765e6ff063d7a54c8f7efa4da96fb52,
         type: 3}
       propertyPath: m_Text
       value: Grab Me!
       objectReference: {fileID: 0}
-    - target: {fileID: 102000010767390410, guid: c07f18faebebb2d409b2f26d63cad856,
+    - target: {fileID: 102000010767390410, guid: e765e6ff063d7a54c8f7efa4da96fb52,
         type: 3}
       propertyPath: m_FontSize
       value: 72
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
 --- !u!4 &762087327 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8503270331930508642, guid: c0931c4da6d91ea429abedb10290dd16,
@@ -810,13 +810,13 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1321168700 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 656919215}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1321168701 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 656919215}
   m_PrefabAsset: {fileID: 0}
@@ -836,7 +836,7 @@ MonoBehaviour:
   targetTransform: {fileID: 0}
 --- !u!23 &1321168703 stripped
 MeshRenderer:
-  m_CorrespondingSourceObject: {fileID: 23000013318538408, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 23000013318538408, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 656919215}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Slate/SlateExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Slate/SlateExample.unity
@@ -1593,7 +1593,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!102 &1029155711 stripped
 TextMesh:
-  m_CorrespondingSourceObject: {fileID: 102000010767390410, guid: adce165054b90864492ee4f57710e214,
+  m_CorrespondingSourceObject: {fileID: 102000010767390410, guid: 2d145caa42b44bd42aac79a42eba3d7c,
     type: 3}
   m_PrefabInstance: {fileID: 1282683681}
   m_PrefabAsset: {fileID: 0}
@@ -2221,68 +2221,68 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 1000013198843976, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawik
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.2363844
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalPosition.y
       value: 2.382383
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 6.8603997
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0.29752332
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.9547146
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: -34.618
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.061599996
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.061599996
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.061599996
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: adce165054b90864492ee4f57710e214, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
 --- !u!1 &1322208236
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Text/Scenes/TextPrefabExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Text/Scenes/TextPrefabExamples.unity
@@ -119,59 +119,59 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 251773535}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 1000013198843976, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawikBold
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.029999997
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
 --- !u!4 &83666595 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54,
     type: 3}
   m_PrefabInstance: {fileID: 83666594}
   m_PrefabAsset: {fileID: 0}
@@ -274,69 +274,69 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 251773535}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 1000013198843976, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawikBold (1)
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.136
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+    - target: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 102000010767390410, guid: 92c82c17afbf2754393680f3ab0a1849,
+    - target: {fileID: 102000010767390410, guid: f6038dfbe1e1bd14dac07b1405ccda54,
         type: 3}
       propertyPath: m_Text
       value: 3D Text Prefabs
       objectReference: {fileID: 0}
-    - target: {fileID: 102000010767390410, guid: 92c82c17afbf2754393680f3ab0a1849,
+    - target: {fileID: 102000010767390410, guid: f6038dfbe1e1bd14dac07b1405ccda54,
         type: 3}
       propertyPath: m_FontSize
       value: 79
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 92c82c17afbf2754393680f3ab0a1849, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: f6038dfbe1e1bd14dac07b1405ccda54, type: 3}
 --- !u!4 &176756777 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: 92c82c17afbf2754393680f3ab0a1849,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: f6038dfbe1e1bd14dac07b1405ccda54,
     type: 3}
   m_PrefabInstance: {fileID: 176756776}
   m_PrefabAsset: {fileID: 0}
@@ -609,59 +609,59 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 251773535}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 1000013198843976, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawikLight
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.0000000027939677
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+    - target: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4b130d74b0f8d5549b85e26ef52813fc, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 670aca8db3bb6294581d6493f3e32380, type: 3}
 --- !u!4 &384816103 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: 4b130d74b0f8d5549b85e26ef52813fc,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: 670aca8db3bb6294581d6493f3e32380,
     type: 3}
   m_PrefabInstance: {fileID: 384816102}
   m_PrefabAsset: {fileID: 0}
@@ -1422,59 +1422,59 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 251773535}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 1000013198843976, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawikSemibold
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.030000001
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+    - target: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c3180659337f41c4c9f172bb44b0f867, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8, type: 3}
 --- !u!4 &1257128278 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: c3180659337f41c4c9f172bb44b0f867,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: 29877fc622b4aaa46b04a0a7c1cfcdb8,
     type: 3}
   m_PrefabInstance: {fileID: 1257128277}
   m_PrefabAsset: {fileID: 0}
@@ -1667,59 +1667,59 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 251773535}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 1000013198843976, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawik
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.059999995
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214, type: 3}
+    - target: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: adce165054b90864492ee4f57710e214, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 2d145caa42b44bd42aac79a42eba3d7c, type: 3}
 --- !u!4 &1499136695 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: adce165054b90864492ee4f57710e214,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: 2d145caa42b44bd42aac79a42eba3d7c,
     type: 3}
   m_PrefabInstance: {fileID: 1499136694}
   m_PrefabAsset: {fileID: 0}
@@ -1912,59 +1912,59 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 251773535}
     m_Modifications:
-    - target: {fileID: 1000013198843976, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 1000013198843976, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_Name
       value: 3DTextSelawikSemilight
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.060000002
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+    - target: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c07f18faebebb2d409b2f26d63cad856, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: e765e6ff063d7a54c8f7efa4da96fb52, type: 3}
 --- !u!4 &1741344962 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: c07f18faebebb2d409b2f26d63cad856,
+  m_CorrespondingSourceObject: {fileID: 4000010330146594, guid: e765e6ff063d7a54c8f7efa4da96fb52,
     type: 3}
   m_PrefabInstance: {fileID: 1741344961}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 37870ab7a81bfb74b9fa277cf45b06d2
+guid: 78999378ebb59c542bc13f557c09b8a0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Materials/ProgressIndicatorLoadingBarEmpty.mat.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Materials/ProgressIndicatorLoadingBarEmpty.mat.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 360c90aa3bc85c9438a05d511deb80ae
-timeCreated: 1435687483
-licenseType: Pro
+guid: 49f2e3951c260b041bd8fcefbe639705
 NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Materials/ProgressIndicatorLoadingBarFilled.mat.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Materials/ProgressIndicatorLoadingBarFilled.mat.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 97b73006130d05b4c90034845c44e88d
-timeCreated: 1435687483
-licenseType: Pro
+guid: fc087f02f2268a2469e7b85f72816d61
 NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab
@@ -57,7 +57,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
+  - {fileID: 2100000, guid: fc087f02f2268a2469e7b85f72816d61, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -374,7 +374,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 360c90aa3bc85c9438a05d511deb80ae, type: 2}
+  - {fileID: 2100000, guid: 49f2e3951c260b041bd8fcefbe639705, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -676,7 +676,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1993071269674472}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9d4e997c97265844a812b493be820fa, type: 3}
+  m_Script: {fileID: 11500000, guid: 5357240299d36f34f95eb2a99d588911, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   progressBar: {fileID: 4772221039067804}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ee519d5fb10a6db4f84d116e66f872b6
+guid: 57d2436112e7d424da7e9a8e41c608dc
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab
@@ -43,7 +43,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_GeneratorAsset: {fileID: 0}
-  m_Script: {fileID: 11500000, guid: f26f823a09a994040b6713d14df62844, type: 3}
+  m_Script: {fileID: 11500000, guid: 649807d744f031041b1569ebeadb4d97, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   scaleTargetObject: {fileID: 6440870716634389772}
@@ -163,7 +163,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 97b73006130d05b4c90034845c44e88d, type: 2}
+  - {fileID: 2100000, guid: fc087f02f2268a2469e7b85f72816d61, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 618bf808bd514c94dbe92e33f7196490
+guid: 274fde8ad8cd85a4a88acb4c2c892028
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab
@@ -43,7 +43,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_GeneratorAsset: {fileID: 0}
-  m_Script: {fileID: 11500000, guid: 84168829751123045887f94604384d71, type: 3}
+  m_Script: {fileID: 11500000, guid: 85ea0aad098b6e64091df1a56ed35494, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   orbs:

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8769cb43fa542914f8aaceee4736c815
+guid: 65fa42bb01c733c42b05a4e91628f494
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorLoadingBar.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorLoadingBar.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a9d4e997c97265844a812b493be820fa
+guid: 5357240299d36f34f95eb2a99d588911
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorObjectDisplay.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorObjectDisplay.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f26f823a09a994040b6713d14df62844
+guid: 649807d744f031041b1569ebeadb4d97
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 84168829751123045887f94604384d71
+guid: 85ea0aad098b6e64091df1a56ed35494
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0447581e7bd59f64fbb28151c65a3dc4
+guid: 9d39383dde055ba408347dc05d1101e5
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7e7c962b9eb9dfa44993d5b2f2576752
+guid: 019ea231fcd4127409ae7906b2996ee1
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1HandTrackingProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1HandTrackingProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e445e6fda57508c46935bb141b7673a7
+guid: c6b38e012ccfbbb48b20644ee8ad4076
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSystemProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bec5ceabcd10992439d51532332137f9
+guid: 5f9481a954567f340b13bd8802aa3fac
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawik.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawik.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adce165054b90864492ee4f57710e214
+guid: 2d145caa42b44bd42aac79a42eba3d7c
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikBold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikBold.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 92c82c17afbf2754393680f3ab0a1849
+guid: f6038dfbe1e1bd14dac07b1405ccda54
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikLight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikLight.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4b130d74b0f8d5549b85e26ef52813fc
+guid: 670aca8db3bb6294581d6493f3e32380
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemibold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemibold.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c3180659337f41c4c9f172bb44b0f867
+guid: 29877fc622b4aaa46b04a0a7c1cfcdb8
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemilight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/3DTextSelawikSemilight.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c07f18faebebb2d409b2f26d63cad856
+guid: e765e6ff063d7a54c8f7efa4da96fb52
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawik.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawik.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7ea8eb39469b42d4faf18a5d262f6d66
+guid: df8fcda444f30864dadb44d21f057e61
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikBold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikBold.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e4e5794f301cf54481a9551940961cb
+guid: c5337f2ec5db84a468cfc45ab910bef4
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikLight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikLight.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6ff8b82e3bd96854bb810f387edfe000
+guid: 30adaec244b8c8949bd5aa7a6b642663
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemibold.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemibold.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4dc7c4982b8b66f45a374ad4fbf5b0da
+guid: 49decb0e244f5d44bb735bcc4ebf67a5
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemilight.prefab.meta
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text/UITextSelawikSemilight.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fa5b294186aedf84bb82749c797e1821
+guid: 2368ebf887d15654b9c093ac1a4f378e
 PrefabImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
## Overview
A few files from the HoloToolkit were migrated to MRTK v2 post RC2.1 without their GUIDs being regenerated. This PR regenerates them and replaces their references.

Also regenerates the profile GUIDs added in #5431, which matched their HL2 profile counterparts.

This would be a breaking change for anybody actively consuming the dev branch, but does not break anybody using RC2.1

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5122#issuecomment-514980114