### PR TITLE
Unity button updates don't work reliably outside the viewport.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Support/Scripts/BaseServiceManager.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Support/Scripts/BaseServiceManager.cs
@@ -61,6 +61,25 @@ namespace Microsoft.MixedReality.Toolkit.Experimental
             }
         }
 
+        private void FixedUpdate()
+        {
+            if (Application.isPlaying)
+            {
+                if (Application.isPlaying)
+                {
+                    foreach (IMixedRealityService service in registeredServices.Values)
+                    {
+                        service.FixedUpdate();
+                    }
+
+                    for (int i = 0; i < dataProviders.Count; i++)
+                    {
+                        dataProviders[i].FixedUpdate();
+                    }
+                }
+            }
+        }
+
 
         protected virtual void OnEnable()
         {

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -117,10 +117,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (profile.IsCameraControlEnabled)
             {
                 EnableCameraControl();
-                if (CameraCache.Main)
-                {
-                    cameraControl.UpdateTransform(CameraCache.Main.transform);
-                }
             }
             else
             {
@@ -178,6 +174,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
 
                     lastHandUpdateTimestamp = currentTime.Ticks;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public override void FixedUpdate()
+        {
+            var profile = InputSimulationProfile;
+
+            if (profile.IsCameraControlEnabled)
+            {
+                if (CameraCache.Main)
+                {
+                    cameraControl.UpdateTransform(CameraCache.Main.transform);
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityService.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Services/IMixedRealityService.cs
@@ -55,6 +55,11 @@ namespace Microsoft.MixedReality.Toolkit
         void LateUpdate();
 
         /// <summary>
+        /// Optional FixedUpdate function to that is called during the FixedUpdate (physics) step.
+        /// </summary>
+        void FixedUpdate();
+
+        /// <summary>
         /// Optional Disable function to pause the service.
         /// </summary>
         void Disable();

--- a/Assets/MixedRealityToolkit/Services/BaseService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseService.cs
@@ -39,6 +39,9 @@ namespace Microsoft.MixedReality.Toolkit
         public virtual void LateUpdate() { }
 
         /// <inheritdoc />
+        public virtual void FixedUpdate() { }
+
+        /// <inheritdoc />
         public virtual void Disable() { }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -675,6 +675,14 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        private void FixedUpdate()
+        {
+            if (IsActiveInstance)
+            {
+                FixedUpdateAllServices();
+            }
+        }
+
         private void OnDisable()
         {
             if (IsActiveInstance)
@@ -980,6 +988,27 @@ namespace Microsoft.MixedReality.Toolkit
             foreach (var service in registeredMixedRealityServices)
             {
                 service.Item2.LateUpdate();
+            }
+        }
+
+        private void FixedUpdateAllServices()
+        {
+            // If the Mixed Reality Toolkit is not configured, stop.
+            if (activeProfile == null) { return; }
+
+            // If the Mixed Reality Toolkit is not initialized, stop.
+            if (!IsInitialized) { return; }
+
+            // Update all systems
+            foreach (var system in activeSystems)
+            {
+                system.Value.FixedUpdate();
+            }
+
+            // Update all registered runtime services
+            foreach (var service in registeredMixedRealityServices)
+            {
+                service.Item2.FixedUpdate();
             }
         }
 


### PR DESCRIPTION
## Overview

Looks like this is a Unity bug (or call it undocumented behavior if you like): The [GetMouseButton](https://docs.unity3d.com/ScriptReference/Input.GetMouseButton.html) function does not work reliably outside the viewport window when called in the [Update](https://docs.unity3d.com/ScriptReference/MonoBehaviour.Update.html) function. Doing this in the [FixedUpdate](https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html) function instead seems to work, although i could only find vague hints in forum posts and all official documentation seems to indicate that Update() should be working.

## Changes
- Fixes: #5485 .
