### PR TITLE
Add warnings for invalid system configurations

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -321,6 +321,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                    profile == MixedRealityToolkit.Instance.ActiveProfile;
         }
 
+        /// <summary>
+        /// Checks if a system is enabled and the service type or validProfile is null, then displays warning message to the user
+        /// </summary>
+        /// <param name="service">name of service being tested</param>
+        /// <param name="systemEnabled">true if checkbox enabled, false otherwise</param>
+        /// <param name="systemType">Selected implementation type for service</param>
+        /// <param name="validProfile">true if profile scriptableobject property is not null, false otherwise</param>
         protected void CheckSystemConfiguration(string service, bool systemEnabled, SystemType systemType, bool validProfile)
         {
             if (systemEnabled)

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -72,6 +72,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 return;
             }
 
+            MixedRealityToolkitConfigurationProfile mrtkConfigProfile = target as MixedRealityToolkitConfigurationProfile;
+
             // Experience configuration
             targetExperienceScale = serializedObject.FindProperty("targetExperienceScale");
             // Camera configuration
@@ -115,16 +117,32 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 this.RenderProfileFuncs = new Func<bool>[]
                 {
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        CheckSystemConfiguration("Camera System", enableCameraSystem.boolValue,
+                            mrtkConfigProfile.CameraSystemType,
+                            mrtkConfigProfile.CameraProfile != null);
+
                         EditorGUILayout.PropertyField(enableCameraSystem);
                         EditorGUILayout.PropertyField(cameraSystemType);
+
                         return RenderProfile(cameraProfile, typeof(MixedRealityCameraProfile), true, false);
                     },
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        CheckSystemConfiguration("Input System", enableInputSystem.boolValue,
+                            mrtkConfigProfile.InputSystemType,
+                            mrtkConfigProfile.InputSystemProfile != null);
+
                         EditorGUILayout.PropertyField(enableInputSystem);
                         EditorGUILayout.PropertyField(inputSystemType);
                         return RenderProfile(inputSystemProfile, null, true, false, typeof(IMixedRealityInputSystem));
                     },
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        CheckSystemConfiguration("Boundary System", enableBoundarySystem.boolValue,
+                            mrtkConfigProfile.BoundarySystemSystemType,
+                            mrtkConfigProfile.BoundaryVisualizationProfile != null);
+
                         var experienceScale = (ExperienceScale)targetExperienceScale.intValue;
                         if (experienceScale != ExperienceScale.Room)
                         {
@@ -138,23 +156,44 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         return RenderProfile(boundaryVisualizationProfile, null, true, false, typeof(IMixedRealityBoundarySystem));
                     },
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        // Teleport System does not have a profile scriptableobject so auto to true
+                        CheckSystemConfiguration("Teleport System", enableTeleportSystem.boolValue,
+                            mrtkConfigProfile.TeleportSystemSystemType, 
+                            true);
+
                         EditorGUILayout.PropertyField(enableTeleportSystem);
                         EditorGUILayout.PropertyField(teleportSystemType);
                         return false;
                     },
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        CheckSystemConfiguration("Spatial Awareness System", enableSpatialAwarenessSystem.boolValue,
+                            mrtkConfigProfile.SpatialAwarenessSystemSystemType,
+                            mrtkConfigProfile.SpatialAwarenessSystemProfile != null);
+
                         EditorGUILayout.PropertyField(enableSpatialAwarenessSystem);
                         EditorGUILayout.PropertyField(spatialAwarenessSystemType);
                         EditorGUILayout.HelpBox("Spatial Awareness settings are configured per observer.", MessageType.Info);
                         return RenderProfile(spatialAwarenessSystemProfile, null, true, false, typeof(IMixedRealitySpatialAwarenessSystem));
                     },
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        CheckSystemConfiguration("Diagnostics System", enableDiagnosticsSystem.boolValue,
+                            mrtkConfigProfile.DiagnosticsSystemSystemType,
+                            mrtkConfigProfile.DiagnosticsSystemProfile != null);
+
                         EditorGUILayout.HelpBox("It is recommended to enable the Diagnostics system during development. Be sure to disable prior to building your shipping product.", MessageType.Warning);
                         EditorGUILayout.PropertyField(enableDiagnosticsSystem);
                         EditorGUILayout.PropertyField(diagnosticsSystemType);
                         return RenderProfile(diagnosticsSystemProfile, typeof(MixedRealityDiagnosticsProfile));
                     },
                     () => {
+                        // Note: cannot use mrtkConfigProfile.Is*SystemEnabled because property checks multiple parameters
+                        CheckSystemConfiguration("Scene System System", enableSceneSystem.boolValue,
+                            mrtkConfigProfile.SceneSystemSystemType,
+                            mrtkConfigProfile.SceneSystemProfile != null);
+
                         EditorGUILayout.PropertyField(enableSceneSystem);
                         EditorGUILayout.PropertyField(sceneSystemType);
                         return RenderProfile(sceneSystemProfile, typeof(MixedRealitySceneSystemProfile), true, true, typeof(IMixedRealitySceneSystem));
@@ -280,6 +319,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             var profile = target as BaseMixedRealityProfile;
             return MixedRealityToolkit.IsInitialized && profile != null &&
                    profile == MixedRealityToolkit.Instance.ActiveProfile;
+        }
+
+        protected void CheckSystemConfiguration(string service, bool systemEnabled, SystemType systemType, bool validProfile)
+        {
+            if (systemEnabled)
+            {
+                if (systemType == null || systemType.Type == null || !validProfile)
+                {
+                    EditorGUILayout.HelpBox(service + " is enabled but will not be initialized because the System Type and/or Profile is not set.", MessageType.Warning);
+                }
+            }
         }
 
         private static string GetExperienceDescription(ExperienceScale experienceScale)

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -255,7 +255,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 if (!MixedRealityOptimizeUtils.IsDepthBufferSharingEnabled())
                 {
                     // If depth buffer sharing not enabled, advise to enable setting
-                    Debug.LogWarning("<b>Depth Buffer Sharing</b> is not enabled to improve hologram stabilization. Consider using 16-bit for performance. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
+                    Debug.LogWarning("<b>Depth Buffer Sharing</b> is not enabled to improve hologram stabilization. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
                 }
 
                 if (!MixedRealityOptimizeUtils.IsWMRDepthBufferFormat16bit())


### PR DESCRIPTION
## Overview
If a core system is enabled but the service type is null or a profile object is not assigned, then the service will not be initialized by the MRTK gameobject. This happens silently without any warning or notice to users.

This change is in the MRTK configuration profile inspector that checks whether a system is enabled but not valid to be initialized. If so, then a warning message is displayed in the MRTK inspector.

![image](https://user-images.githubusercontent.com/25975362/62342168-bd92f980-b49a-11e9-80d4-f64b2332bb30.png)


## Changes
- Fixes: #3094 

## Verification

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
