### PR TITLE
Add namespace to SolverInspector

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/SolverInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/SolverInspector.cs
@@ -3,43 +3,45 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using UnityEditor;
-using UnityEngine;
 
-[CustomEditor(typeof(Solver))]
-[CanEditMultipleObjects]
-public class SolverInspector : UnityEditor.Editor
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 {
-    private SerializedProperty updateLinkedTransformProperty;
-    private SerializedProperty moveLerpTimeProperty;
-    private SerializedProperty rotateLerpTimeProperty;
-    private SerializedProperty scaleLerpTimeProperty;
-    private SerializedProperty maintainScaleProperty;
-    private SerializedProperty smoothingProperty;
-    private SerializedProperty lifetimeProperty;
-
-    protected virtual void OnEnable()
+    [CustomEditor(typeof(Solver))]
+    [CanEditMultipleObjects]
+    public class SolverInspector : UnityEditor.Editor
     {
-        updateLinkedTransformProperty = serializedObject.FindProperty("updateLinkedTransform");
-        moveLerpTimeProperty = serializedObject.FindProperty("moveLerpTime");
-        rotateLerpTimeProperty = serializedObject.FindProperty("rotateLerpTime");
-        scaleLerpTimeProperty = serializedObject.FindProperty("scaleLerpTime");
-        maintainScaleProperty = serializedObject.FindProperty("maintainScale");
-        smoothingProperty = serializedObject.FindProperty("smoothing");
-        lifetimeProperty = serializedObject.FindProperty("lifetime");
-    }
+        private SerializedProperty updateLinkedTransformProperty;
+        private SerializedProperty moveLerpTimeProperty;
+        private SerializedProperty rotateLerpTimeProperty;
+        private SerializedProperty scaleLerpTimeProperty;
+        private SerializedProperty maintainScaleProperty;
+        private SerializedProperty smoothingProperty;
+        private SerializedProperty lifetimeProperty;
 
-    public override void OnInspectorGUI()
-    {
-        serializedObject.Update();
+        protected virtual void OnEnable()
+        {
+            updateLinkedTransformProperty = serializedObject.FindProperty("updateLinkedTransform");
+            moveLerpTimeProperty = serializedObject.FindProperty("moveLerpTime");
+            rotateLerpTimeProperty = serializedObject.FindProperty("rotateLerpTime");
+            scaleLerpTimeProperty = serializedObject.FindProperty("scaleLerpTime");
+            maintainScaleProperty = serializedObject.FindProperty("maintainScale");
+            smoothingProperty = serializedObject.FindProperty("smoothing");
+            lifetimeProperty = serializedObject.FindProperty("lifetime");
+        }
 
-        EditorGUILayout.PropertyField(updateLinkedTransformProperty);
-        EditorGUILayout.PropertyField(moveLerpTimeProperty);
-        EditorGUILayout.PropertyField(rotateLerpTimeProperty);
-        EditorGUILayout.PropertyField(scaleLerpTimeProperty);
-        EditorGUILayout.PropertyField(maintainScaleProperty);
-        EditorGUILayout.PropertyField(smoothingProperty);
-        EditorGUILayout.PropertyField(lifetimeProperty);
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
 
-        serializedObject.ApplyModifiedProperties();
+            EditorGUILayout.PropertyField(updateLinkedTransformProperty);
+            EditorGUILayout.PropertyField(moveLerpTimeProperty);
+            EditorGUILayout.PropertyField(rotateLerpTimeProperty);
+            EditorGUILayout.PropertyField(scaleLerpTimeProperty);
+            EditorGUILayout.PropertyField(maintainScaleProperty);
+            EditorGUILayout.PropertyField(smoothingProperty);
+            EditorGUILayout.PropertyField(lifetimeProperty);
+
+            serializedObject.ApplyModifiedProperties();
+        }
     }
 }


### PR DESCRIPTION
Updates to build automation identified SolverInspector as not being in the correct namespace. In fact, it was not in _any_ namespace.

This change adds the class to the Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers namespace with other, related, inspectors.