### PR TITLE
Fix typo in ci template

### DIFF
--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -10,5 +10,5 @@ steps:
   - template: tasks/unitypackages.yml
   - template: package.yml
   - ${{ if eq(parameters.packagePublishing, true) }}:
-    - $template: publishpackages.yml
+    - template: publishpackages.yml
 - template: end.yml


### PR DESCRIPTION
There was an errant $ character in the ci template file that was merged from the stabilization branch.

Stabilization did not hit this as it does not publish packages as part of CI. Will cherry-pick this change there as well.