### PR TITLE
Fix the backwards-incompatible enum change

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ArticulatedHandPose.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ArticulatedHandPose.cs
@@ -154,10 +154,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             /// </summary>
             Open,
             /// <summary>
-            /// Relaxed hand pose, grab point does not move
-            /// </summary>
-            OpenSteadyGrabPoint,
-            /// <summary>
             /// Index finger and Thumb touching, grab point does not move
             /// </summary>
             Pinch,
@@ -181,6 +177,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             /// Victory sign
             /// </summary>
             Victory,
+            /// <summary>
+            /// Relaxed hand pose, grab point does not move
+            /// </summary>
+            OpenSteadyGrabPoint,
         }
 
         private static readonly Dictionary<GestureId, ArticulatedHandPose> handPoses = new Dictionary<GestureId, ArticulatedHandPose>();


### PR DESCRIPTION
A previous change to this updated an existing enum by adding a value in the middle of the enum - this is backwards incompatible because the same value is persisted in various profiles, where enums are stored as integer values, rather than string values.

This means that something that used to refer to "pinch" now referred to this new thing, and the same off-by-one problem would affect all of the other options below the new enum

See change:
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5495

Original issue:
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5450

Current issue:
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5506