### PR TITLE
Fix for issue #5423

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
@@ -106,14 +106,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public void UpdateVelocity(InteractionSourceState interactionSourceState)
         {
             Vector3 newVelocity;
-            bool isVelocityValid = interactionSourceState.sourcePose.TryGetVelocity(out newVelocity);
-            if (isVelocityValid)
+            if (interactionSourceState.sourcePose.TryGetVelocity(out newVelocity))
             {
                 Velocity = newVelocity;
             }
             Vector3 newAngularVelocity;
-            bool isAngularVelocityValid = interactionSourceState.sourcePose.TryGetAngularVelocity(out newAngularVelocity);
-            if(isAngularVelocityValid)
+            if (interactionSourceState.sourcePose.TryGetAngularVelocity(out newAngularVelocity))
             {
                 AngularVelocity = newAngularVelocity;
             }
@@ -228,11 +226,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 case AxisType.SixDof:
                 {
-                    interactionSourceState.sourcePose.TryGetPosition(out currentGripPosition, InteractionSourceNode.Grip);
-                    interactionSourceState.sourcePose.TryGetRotation(out currentGripRotation, InteractionSourceNode.Grip);
-
-                    currentGripPose.Position = MixedRealityPlayspace.TransformPoint(currentGripPosition);
-                    currentGripPose.Rotation = Quaternion.Euler(MixedRealityPlayspace.TransformDirection(currentGripRotation.eulerAngles));
+                    // The data queried in UpdateSourceData is the grip pose.
+                    // Reuse that data to save two method calls and transforms.
+                    currentGripPose.Position = currentSourcePosition;
+                    currentGripPose.Rotation = currentSourceRotation;
 
                     // Update the interaction data source
                     interactionMapping.PoseData = currentGripPose;
@@ -347,7 +344,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private bool GetSelectPressedWorkaround(InteractionSourceState interactionSourceState)
         {
             bool selectPressed = interactionSourceState.selectPressed;
-            if (interactionSourceState.source.kind == InteractionSourceKind.Hand && 
+            if (interactionSourceState.source.kind == InteractionSourceKind.Hand &&
                 UnityEngine.XR.WSA.HolographicRemoting.ConnectionState == UnityEngine.XR.WSA.HolographicStreamerConnectionState.Connected)
             {
                 // This workaround is safe as long as all these assumptions hold:

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
@@ -157,8 +156,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 TrackingState = eventData.Controller.TrackingState;
                 IsTracked = (TrackingState == TrackingState.Tracked);
-                transform.localPosition = eventData.SourceData.Position;
-                transform.localRotation = eventData.SourceData.Rotation;
+                transform.position = eventData.SourceData.Position;
+                transform.rotation = eventData.SourceData.Rotation;
             }
         }
 

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -252,7 +252,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             // If we've got a controller model prefab, then create it and place it in the scene.
             GameObject controllerObject = UnityEngine.Object.Instantiate(controllerModel);
-            MixedRealityPlayspace.AddChild(controllerObject.transform);
 
             return TryAddControllerModelToSceneHierarchy(controllerObject);
         }
@@ -262,6 +261,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (controllerObject != null)
             {
                 controllerObject.name = $"{ControllerHandedness}_{controllerObject.name}";
+                
+                MixedRealityPlayspace.AddChild(controllerObject.transform);
 
                 Visualizer = controllerObject.GetComponent<IMixedRealityControllerVisualizer>();
 


### PR DESCRIPTION
Fix for issue #5423 [Controllers shown at original place after teleporting in VR.](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5423)

## Overview
This fix addresses the issue #5423 [Controllers shown at original place after teleporting in VR.](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5423)

## Changes
The fix is in the BaseController.cs file.
In the function:
protected virtual bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)

we add MixedRealityPlayspace.AddChild(controllerObject.transform);

This line should actually be moved inside TryAddControllerModelToSceneHierarchy function

so that even if we use the platform controller visualization, they will be correctly added to under MixedRealityPlaySpace game object.
