### PR TITLE
Update the build system to have a hook to check for validation errors in the MRTK build

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0447581e7bd59f64fbb28151c65a3dc4
+guid: 9d39383dde055ba408347dc05d1101e5
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1CameraProfile.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9d39383dde055ba408347dc05d1101e5
+guid: 0447581e7bd59f64fbb28151c65a3dc4
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -123,6 +123,14 @@ steps:
    }
   displayName: "Build ${{ parameters.Platform }} ${{ parameters.Arch }} ${{ parameters.ScriptingBackend }}"
 
+- task: PowerShell@2
+  displayName: 'Validate build logs'
+  inputs:
+    targetType: filePath
+    filePath: ./scripts/ci/validatebuildlog.ps1
+    arguments: >
+      -LogFile: '$(Build.ArtifactStagingDirectory)\build\${{ parameters.Platform }}_${{ parameters.Arch }}_${{ parameters.ScriptingBackend }}\build\build.log'
+
 - task: PublishBuildArtifacts@1
   enabled: ${{ parameters.PublishArtifacts }}
   displayName: 'Publish ${{ parameters.Platform }} ${{ parameters.Arch }} (${{ parameters.PackagingDir }}) ${{ parameters.ScriptingBackend }}'

--- a/scripts/ci/validatebuildlog.ps1
+++ b/scripts/ci/validatebuildlog.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Validates a build log to check for the presence of non-build related warnings
+    that may negatively affect the quality of the build.
+.DESCRIPTION
+    This script intends to prevent repeats of past issues that have come up
+    (for example, reused GUIDs) which don't get caught in the build itself
+    because they are not build errors.
+
+    Returns 0 if there are no errors, non-zero if there are.
+.PARAMETER LogFile
+    The log file to validate
+.EXAMPLE
+    .\validatebuildlog.ps1 -LogFile c:\path\to\log.txt
+#>
+param(
+    [string]$LogFile
+)
+
+function CheckDuplicateGuids(
+    [string[]]$LogFileContent,
+    [int]$LineNumber
+) {
+    <#
+    .SYNOPSIS
+        Checks if the given log file has a conflict guid at the specified line number.
+        Outputs to console if such an error exists.
+        Returns true if there is a duplicate guid.
+    #>
+    if ($LogFileContent[$LineNumber] -match "GUID \[[a-g0-9]{32}?\] for asset '.*' conflicts with") {
+        for ($i = $LineNumber; $i -lt $LogFileContent.Length; $i++) {
+            if ($LogFileContent[$i] -eq "Assigning a new guid.") {
+                Write-Host "Found duplicated GUID, Unity will non-deterministically use one of them, please manually"
+                    "regenerate the intended one by deleting the .meta file and re-opening the Unity editor locally"
+
+                # Found the end of the guid conflict message - output to the console
+                # all lines between these two locations (including the assigning a new guid message
+                # in case it falls on the same line)
+                for ($j = $LineNumber; $j -le $i; $j++) {
+                    Write-Host $LogFileContent[$j]
+                }
+                return $true
+            }
+        }
+    }
+    return $false
+}
+
+if (-not $LogFile) {
+    throw "-LogFile is a required flag"
+}
+
+Write-Output "Checking $LogFile for build validation errors"
+
+$logFileContent = Get-Content $LogFile
+
+# Each line of the log is checked for issues - the intent is to catch ALL issues in the
+# log file, instead of breaking on the first issue. The idea is to give the reader
+# a full spew of all issues at once, instead of requiring multiple runs to uncover all issues
+# As a result, each check below is NOT short-circuited (i.e. $containsError is ORed at the end)
+$containsError = $false
+for ($i = 0; $i -lt $logFileContent.Length; $i++) {
+    if (CheckDuplicateGuids $logFileContent $i) {
+        $containsError = $true
+    }
+}
+
+if ($containsError) {
+    Write-Output "Validation errors found, please see above for details"
+    exit 1;
+}
+else {
+    Write-Output "No validation errors found"
+    exit 0;
+}

--- a/scripts/ci/validatebuildlog.ps1
+++ b/scripts/ci/validatebuildlog.ps1
@@ -30,8 +30,8 @@ function CheckDuplicateGuids(
     if ($LogFileContent[$LineNumber] -match "GUID \[[a-g0-9]{32}?\] for asset '.*' conflicts with") {
         for ($i = $LineNumber; $i -lt $LogFileContent.Length; $i++) {
             if ($LogFileContent[$i] -eq "Assigning a new guid.") {
-                Write-Host "Found duplicated GUID, Unity will non-deterministically use one of them, please manually"
-                    "regenerate the intended one by deleting the .meta file and re-opening the Unity editor locally"
+                Write-Host "Found duplicated GUID, Unity will non-deterministically use one of them, please manually "
+                Write-Host "regenerate the intended one by deleting the .meta file and re-opening the Unity editor locally."
 
                 # Found the end of the guid conflict message - output to the console
                 # all lines between these two locations (including the assigning a new guid message


### PR DESCRIPTION
Recently we hit an issue in the MRTK where we had duplicate GUIDs checked in for a few different assets:

#5431

The root issue here was that the meta files were copy pasted, instead of being regenerated at the new location. There was a warning in the console but it was ignored, and since Unity will non-deterministically choose one of them (i.e. either of the duplicate GUIDs could be right) - you end up with cases where you will get one or the other of the assets (and hopefully Unity choose correctly for you!)

I looked into doing a custom logger (i.e. catching LogWarning) but found that it doesn't run soon enough (i.e. warnings will show up, this code will get compiled) so this had to resort to editor-log parsing.

In theory this could be extended in the future to other issues that we hit that show up in the console as well.