### PR TITLE
Updates to fix SurfaceMagnetism orientation

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Solver.cs
@@ -19,17 +19,53 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         [Tooltip("If true, the position and orientation will be calculated, but not applied, for other components to use")]
         private bool updateLinkedTransform = false;
 
+        /// <summary>
+        /// If true, the position and orientation will be calculated, but not applied, for other components to use
+        /// </summary>
+        public bool UpdateLinkedTransform
+        {
+            get => updateLinkedTransform;
+            set => updateLinkedTransform = value;
+        }
+
         [SerializeField]
         [Tooltip("If 0, the position will update immediately.  Otherwise, the greater this attribute the slower the position updates")]
         private float moveLerpTime = 0.1f;
+
+        /// <summary>
+        /// If 0, the position will update immediately.  Otherwise, the greater this attribute the slower the position updates
+        /// </summary>
+        public float MoveLerpTime
+        {
+            get => moveLerpTime;
+            set => moveLerpTime = value;
+        }
 
         [SerializeField]
         [Tooltip("If 0, the rotation will update immediately.  Otherwise, the greater this attribute the slower the rotation updates")]
         private float rotateLerpTime = 0.1f;
 
+        /// <summary>
+        /// If 0, the rotation will update immediately.  Otherwise, the greater this attribute the slower the rotation updates")]
+        /// </summary>
+        public float RotateLerpTime
+        {
+            get => rotateLerpTime;
+            set => rotateLerpTime = value;
+        }
+
         [SerializeField]
         [Tooltip("If 0, the scale will update immediately.  Otherwise, the greater this attribute the slower the scale updates")]
         private float scaleLerpTime = 0;
+
+        /// <summary>
+        /// If 0, the scale will update immediately.  Otherwise, the greater this attribute the slower the scale updates
+        /// </summary>
+        public float ScaleLerpTime
+        {
+            get => scaleLerpTime;
+            set => scaleLerpTime = value;
+        }
 
         [SerializeField]
         [Tooltip("If true, the Solver will respect the object's original scale values")]
@@ -39,6 +75,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         [Tooltip("If true, updates are smoothed to the target. Otherwise, they are snapped to the target")]
         private bool smoothing = true;
 
+        /// <summary>
+        /// If true, updates are smoothed to the target. Otherwise, they are snapped to the target
+        /// </summary>
         public bool Smoothing
         {
             get => smoothing;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             SurfaceNormal = 2,
 
             /// <summary>
-            /// Blend between tracked transform vertical and the surface orientation
+            /// Blend between tracked transform and the surface normal orientation
             /// </summary>
             Blended = 3,
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -264,7 +264,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
-        [Tooltip("How solver will orient model. None = no orieting, TrackedTarget = Face tracked target transform, SurfaceNormal = Aligned to surface normal completely, Blended = blend between tracked transform and surface orientation")]
+        [Tooltip("How solver will orient model. None = no orienting, TrackedTarget = Face tracked target transform, SurfaceNormal = Aligned to surface normal completely, Blended = blend between tracked transform and surface orientation")]
         private OrientationMode orientationMode = OrientationMode.TrackedTarget;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/SurfaceMagnetismInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/SurfaceMagnetismInspector.cs
@@ -29,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
         private SerializedProperty currentRaycastDirectionModeProperty;
         private SerializedProperty orientationModeProperty;
         private SerializedProperty orientationBlendProperty;
+        private SerializedProperty orientationVerticalProperty;
         private SerializedProperty debugEnabledProperty;
 
         private SurfaceMagnetism surfaceMagnetism;
@@ -53,6 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
             currentRaycastDirectionModeProperty = serializedObject.FindProperty("currentRaycastDirectionMode");
             orientationModeProperty = serializedObject.FindProperty("orientationMode");
             orientationBlendProperty = serializedObject.FindProperty("orientationBlend");
+            orientationVerticalProperty = serializedObject.FindProperty("keepOrientationVertical");
             debugEnabledProperty = serializedObject.FindProperty("debugEnabled");
 
             surfaceMagnetism = target as SurfaceMagnetism;
@@ -68,8 +70,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
             EditorGUILayout.LabelField("General Properties", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(surfaceNormalOffsetProperty);
             EditorGUILayout.PropertyField(surfaceRayOffsetProperty);
+
             EditorGUILayout.PropertyField(orientationModeProperty);
-            EditorGUILayout.PropertyField(orientationBlendProperty);
+
+            if (surfaceMagnetism.CurrentOrientationMode != SurfaceMagnetism.OrientationMode.None)
+            {
+                EditorGUILayout.PropertyField(orientationVerticalProperty);
+            }
+
+            if (surfaceMagnetism.CurrentOrientationMode == SurfaceMagnetism.OrientationMode.Blended)
+            {
+                EditorGUILayout.PropertyField(orientationBlendProperty);
+            }
 
             // Raycast properties
             EditorGUILayout.LabelField("Raycast Properties", EditorStyles.boldLabel);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public class SolverTests : BasePlayModeTests
     {
         private const float DistanceThreshold = 1.5f;
-        private const float SolverUpdateWaitTime = 1.0f; //seconds
 
         /// <summary>
         /// Internal class used to store data for setup
@@ -73,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Test orbital around head
             testObjects.handler.TrackedTargetType = TrackedObjectType.Head;
 
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             Assert.LessOrEqual(Vector3.Distance(testObjects.target.transform.position, Camera.main.transform.position), DistanceThreshold);
 
@@ -81,11 +80,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             testObjects.handler.TrackedTargetType = TrackedObjectType.CustomOverride;
             testObjects.handler.TransformOverride = transformOverride.transform;
 
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             Assert.LessOrEqual(Vector3.Distance(testObjects.target.transform.position, customTransformPos), DistanceThreshold);
 
-            yield return null;
+            yield return WaitForFrames(2);
         }
 
         /// <summary>
@@ -104,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 rightHandPos = Vector3.right * 20.0f;
             Vector3 leftHandPos = Vector3.right * -20.0f;
 
-            yield return null;
+            yield return WaitForFrames(2);
 
             InputSimulationService inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
@@ -119,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, Utilities.ArticulatedHandPose.GestureId.Open, rightHandPos);
 
             // Give time for cube to float to hand
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             Vector3 handOrbitalPos = testObjects.target.transform.position;
             Assert.LessOrEqual(Vector3.Distance(handOrbitalPos, leftHandPos), DistanceThreshold);
@@ -145,7 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             wall.transform.Rotate(Vector3.up, 180.0f); // Rotate wall so forward faces camera
             wall.transform.position = Vector3.forward * 10.0f;
 
-            yield return null;
+            yield return WaitForFrames(2);
 
             // Instantiate our test gameobject with solver. 
             // Set layer to ignore raycast so solver doesn't raycast itself (i.e BoxCollider)
@@ -156,7 +155,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var targetTransform = testObjects.target.transform;
             var cameraTransform = CameraCache.Main.transform;
 
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             // Confirm that the surfacemagnetic cube is about on the wall straight ahead
             Assert.LessOrEqual(Vector3.Distance(targetTransform.position, wall.transform.position), DistanceThreshold);
@@ -174,7 +173,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(UnityEngine.Physics.Raycast(Vector3.zero, cameraDir, out hitInfo), "Raycast from camera did not hit wall");
 
             // Let SurfaceMagnetism update
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             // Confirm that the surfacemagnetic cube is on the wall with camera rotated
             Assert.LessOrEqual(Vector3.Distance(targetTransform.position, hitInfo.point), DistanceThreshold);
@@ -185,7 +184,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Change default orientation mode to surface normal
             surfaceMag.CurrentOrientationMode = SurfaceMagnetism.OrientationMode.SurfaceNormal;
 
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             // Test object should now be facing into the wall (i.e Z axis)
             Assert.IsTrue(Mathf.Approximately(1.0f, Vector3.Dot(targetTransform.forward.normalized, Vector3.forward)));
@@ -218,14 +217,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             inBetween.SecondTransformOverride = rightPost.transform;
 
             // Let InBetween update
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             TestUtilities.AssertAboutEqual(testObjects.target.transform.position, Vector3.forward * 10.0f, "InBetween solver did not place object in middle of posts");
 
             inBetween.PartwayOffset = 0.0f;
 
             // Let InBetween update
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             TestUtilities.AssertAboutEqual(testObjects.target.transform.position, rightPost.transform.position, "InBetween solver did not move to the left post");
         }
@@ -237,14 +236,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return PlayModeTestUtilities.ShowHand(hand, inputSimulationService, Utilities.ArticulatedHandPose.GestureId.Open, handPos);
 
             // Give time for cube to float to hand
-            yield return new WaitForSeconds(SolverUpdateWaitTime);
+            yield return WaitForFrames(2);
 
             Vector3 handOrbitalPos = target.transform.position;
             Assert.LessOrEqual(Vector3.Distance(handOrbitalPos, handPos), DistanceThreshold);
 
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
 
-            yield return null;
+            yield return WaitForFrames(2);
         }
 
         private SetupData InstantiateTestSolver<T>() where T: Solver
@@ -270,6 +269,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 target = cube
             };
         }
+
+        private IEnumerator WaitForFrames(int frames)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                yield return null;
+            }
+        }
+
 #endregion
     }
 }

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -143,9 +143,12 @@ Conversely, the *Surface Ray Offset* will place the GameObject a set distance in
 The *Orientation Mode* determines the type of rotation to apply in relation to the normal on the surface.
 
 * *None* - No rotation applied
-* *Vertical* - Object will always be oriented up but face the tracked transform driving the raycast
-* *Full* - Object will align based on normal at hit point on surface
-* *Blended* - Object will align based on normal at hit point on surface AND based on facing the tracked transform. Use *Orientation Blend* property to control balance between two rotation factors
+* *TrackedVertical* - Object will always be oriented up but face the tracked transform driving the raycast
+* *SurfaceNormal* - Object will align based on normal at hit point on surface
+* *Blended* - Object will align based on normal at hit point on surface AND based on facing the tracked transform.
+
+> [!NOTE]
+> Use the *Orientation Blend* property to control the balance between rotation factors when *Orientation Mode* is set to *Blended*. A value of 0.0 will have orientation entirely driven by *TrackedVertical* mode and a value of 1.0 will have orientation driven entirely by *SurfaceNormal*.
 
 ![SurfaceMagnetism Example](../Documentation/Images/Solver/SurfaceMagExample.png)
 

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -143,12 +143,14 @@ Conversely, the *Surface Ray Offset* will place the GameObject a set distance in
 The *Orientation Mode* determines the type of rotation to apply in relation to the normal on the surface.
 
 * *None* - No rotation applied
-* *TrackedVertical* - Object will always be oriented up but face the tracked transform driving the raycast
+* *TrackedTarget* - Object will face the tracked transform driving the raycast
 * *SurfaceNormal* - Object will align based on normal at hit point on surface
 * *Blended* - Object will align based on normal at hit point on surface AND based on facing the tracked transform.
 
+To force the associated GameObject to stay vertical in any mode other than *None*, enable *Keep Orientation Vertical*.
+
 > [!NOTE]
-> Use the *Orientation Blend* property to control the balance between rotation factors when *Orientation Mode* is set to *Blended*. A value of 0.0 will have orientation entirely driven by *TrackedVertical* mode and a value of 1.0 will have orientation driven entirely by *SurfaceNormal*.
+> Use the *Orientation Blend* property to control the balance between rotation factors when *Orientation Mode* is set to *Blended*. A value of 0.0 will have orientation entirely driven by *TrackedTarget* mode and a value of 1.0 will have orientation driven entirely by *SurfaceNormal*.
 
 ![SurfaceMagnetism Example](../Documentation/Images/Solver/SurfaceMagExample.png)
 

--- a/Documentation/UpdatingToGA.md
+++ b/Documentation/UpdatingToGA.md
@@ -155,6 +155,8 @@ Some solver components and the SolverHandler manager class has changed to fix va
 - `MaxDistance` public property deprecated and has been renamed to `MaxRaycastDistance`
 - `CloseDistance` public property deprecated and has been renamed to `ClosestDistance`
 - Default value for `RaycastDirectionMode` is now `TrackedTargetForward` which raycasts in the direction of the tracked target transform forward
+- `OrientationMode` enum values, `Vertical` and `Full`, have been renamed to `TrackedTarget` and `SurfaceNormal` respectively
+- `KeepOrientationVertical` public property has been added to control whether orientation of associated GameObject remains vertical
 
 ### Clipping Sphere
 


### PR DESCRIPTION
## Overview
This change fixes a faulty orientation setting in SurfaceMagnetism as well as provides clearer naming & documentation.

Fixes: 

- The Blended mode for OrientationMode in SurfaceMagnetism is supposed to blend rotation input calculated via the Tracked Transform and the normal at the surface hit point. The code was actually only blending between the current model rotation and the tracked transform rotation. And thus, the OrientationBlend property had no impact what so ever.

- Furthermore, the original OrientationMode *Vertical* in documentation is supposed to face the tracked transform (i.e user etc) but actually faced along the surface normal. 

- To simplify implementation, the property *KeepOrientationVertical* was added to give user's more control for their chosen OrientationMode (see related bug #4800 )

- OrientationMode keeps original values but renamed to be more accurate. 
- Updated SurfaceMagnetismInspector to hide OrientationBlend if not in Blended Mode and to hide both that and KeepOrientationVertical if OrientionMode is None
- All related tooltip/summaries are updated to be both clearer & accurate
- Solver documentation page has been updated accordingly
- Added public properties to Solver for LerpTime etc
- Updated SolverTests to set *LerpTime to 0.0 so we can make test run much faster

## Changes
- Fixes: #4800 

## Verification
All tests pass
SolverExample scene works as expected

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
