### PR TITLE
Avoid blocking developer when ActiveProfile null in Editor

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -14,6 +14,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private int currentPickerWindow = -1;
         private bool checkChange = false;
 
+        // Utility to show object picker for ActiveProfile property since Show command must be called in OnGUI()
+        private static bool forceShowProfilePicker = false;
+
         private void OnEnable()
         {
             activeProfile = serializedObject.FindProperty("activeProfile");
@@ -51,41 +54,46 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.PropertyField(activeProfile);
             bool changed = EditorGUI.EndChangeCheck();
             string commandName = Event.current.commandName;
-            var allConfigProfiles = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitConfigurationProfile>();
 
-            if (activeProfile.objectReferenceValue == null && currentPickerWindow == -1 && checkChange && !BuildPipeline.isBuildingPlayer)
+            // If not profile is assigned, then warn user
+            if (activeProfile.objectReferenceValue == null)
             {
-                if (allConfigProfiles.Length > 1)
+                EditorGUILayout.HelpBox("MixedRealityToolkit cannot initialize unless an Active Profile is assigned!", MessageType.Error);
+
+                if (GUILayout.Button("Assign MixedRealityToolkit Profile") || forceShowProfilePicker)
                 {
-                    EditorUtility.DisplayDialog("Attention!", "You must choose a profile for the Mixed Reality Toolkit.", "OK");
-                    currentPickerWindow = GUIUtility.GetControlID(FocusType.Passive);
+                    forceShowProfilePicker = false;
+
+                    var allConfigProfiles = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitConfigurationProfile>();
+
                     // Shows the list of MixedRealityToolkitConfigurationProfiles in our project,
                     // selecting the default profile by default (if it exists).
-                    EditorGUIUtility.ShowObjectPicker<MixedRealityToolkitConfigurationProfile>(MixedRealityInspectorUtility.GetDefaultConfigProfile(allConfigProfiles), false, string.Empty, currentPickerWindow);
-                }
-                else if (allConfigProfiles.Length == 1)
-                {
-                    activeProfile.objectReferenceValue = allConfigProfiles[0];
-                    changed = true;
-                    Selection.activeObject = allConfigProfiles[0];
-                    EditorGUIUtility.PingObject(allConfigProfiles[0]);
-                }
-                else
-                {
-                    if (EditorUtility.DisplayDialog("Attention!", "No profiles were found for the Mixed Reality Toolkit.\n\n" +
-                                                                  "Would you like to create one now?", "OK", "Later"))
+                    if (allConfigProfiles.Length > 1)
                     {
-                        ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
-                        profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles");
-                        activeProfile.objectReferenceValue = profile;
-                        Selection.activeObject = profile;
-                        EditorGUIUtility.PingObject(profile);
+                        currentPickerWindow = GUIUtility.GetControlID(FocusType.Passive);
+
+                        var defaultMRTKProfile = MixedRealityInspectorUtility.GetDefaultConfigProfile(allConfigProfiles);
+                        activeProfile.objectReferenceValue = defaultMRTKProfile;
+
+                        EditorGUIUtility.ShowObjectPicker<MixedRealityToolkitConfigurationProfile>(defaultMRTKProfile, false, string.Empty, currentPickerWindow);
+                    }
+                    else
+                    {
+                        if (EditorUtility.DisplayDialog("Attention!", "No profiles were found for the Mixed Reality Toolkit.\n\n" +
+                                                                      "Would you like to create one now?", "OK", "Later"))
+                        {
+                            ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
+                            profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles");
+                            activeProfile.objectReferenceValue = profile;
+                            //Selection.activeObject = profile;
+                            EditorGUIUtility.PingObject(profile);
+                        }
                     }
                 }
 
-                checkChange = false;
             }
 
+            // If user selects a new MRTK Active Profile, then update configuration
             if (EditorGUIUtility.GetObjectPickerControlID() == currentPickerWindow)
             {
                 switch (commandName)
@@ -98,8 +106,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         activeProfile.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
                         currentPickerWindow = -1;
                         changed = true;
-                        Selection.activeObject = activeProfile.objectReferenceValue;
-                        EditorGUIUtility.PingObject(activeProfile.objectReferenceValue);
                         break;
                 }
             }
@@ -123,6 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();
             EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
+            forceShowProfilePicker = true;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -85,7 +85,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
                             profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles");
                             activeProfile.objectReferenceValue = profile;
-                            //Selection.activeObject = profile;
                             EditorGUIUtility.PingObject(profile);
                         }
                     }
@@ -128,8 +127,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         public static void CreateMixedRealityToolkitGameObject()
         {
             MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();
+            Selection.activeObject = MixedRealityToolkit.Instance;
             EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
-            forceShowProfilePicker = true;
+
+            if (!MixedRealityToolkit.Instance.HasActiveProfile)
+            {
+                forceShowProfilePicker = true;
+            }
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -12,7 +12,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     {
         private SerializedProperty activeProfile;
         private int currentPickerWindow = -1;
-        private bool checkChange = false;
 
         // Utility to show object picker for ActiveProfile property since Show command must be called in OnGUI()
         private static bool forceShowProfilePicker = false;
@@ -21,7 +20,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             activeProfile = serializedObject.FindProperty("activeProfile");
             currentPickerWindow = -1;
-            checkChange = activeProfile.objectReferenceValue == null;
         }
 
         public override void OnInspectorGUI()
@@ -68,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                     // Shows the list of MixedRealityToolkitConfigurationProfiles in our project,
                     // selecting the default profile by default (if it exists).
-                    if (allConfigProfiles.Length > 1)
+                    if (allConfigProfiles.Length > 0)
                     {
                         currentPickerWindow = GUIUtility.GetControlID(FocusType.Passive);
 


### PR DESCRIPTION
## Overview
Currently, if the ActiveProfile field is null for the active MRTK instance, then the MRTK system will frustratingly do two things at the editor level:

1) Block the user from entering play mode ever 
2) Spam user to select a profile whenever the MRTK object is selected in the inspector

This change addresses the issue by warning the user but allowing them to continue unimpeded. 

- The entering playmode is only aborted if the developer selects "OK" with the new dialog warning
---> If user selects Ignore, then warning dialog will never be shown again for this Unity session
- The profile object picker is only shown if the user clicks the "Assign MRTK profile" button or they click "Add mrtk to scene & configure". 
- If ActiveProfile is null, then an error message is rendered in the inspector

## Changes
- Fixes: #5476 


## Verification
Test MRTK object without Active Profile & enter play mode
Test adding MRTK gameobject to scene repeatedly
Test "Assign MRTK profile" button

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
