### PR TITLE
fixed button highlights for buttons that use themes on leaving button sideways and disabling button

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -452,6 +452,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (focusingPointers.Count == 0)
             {
                 ResetBaseStates();
+                ForceUpdateThemes();
             }
         }
 
@@ -893,7 +894,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             SetObservation(false);
             SetObservationTargeted(false);
             SetInteractive(false);
-            SetCustom(false);
             SetTargeted(false);
             SetToggled(false);
             SetVisited(false);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PhysicalPressEventRouter.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PhysicalPressEventRouter.cs
@@ -48,11 +48,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 
         public void OnHandPressUntouched()
         {
-            if (InteractableOnClick == PhysicalPressEventBehavior.EventOnTouch &&
-                routingTarget != null)
+            if (routingTarget != null)
             {
                 routingTarget.SetPhysicalTouch(false);
-                routingTarget.SetPress(true);
+                if (InteractableOnClick == PhysicalPressEventBehavior.EventOnTouch)
+                {
+                    routingTarget.SetPress(true);
+                }
             }
         }
 
@@ -80,6 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
                     routingTarget.TriggerOnClick();
                 }
                 routingTarget.SetPress(false);
+                routingTarget.SetPhysicalTouch(false);
             }
         }
     }


### PR DESCRIPTION
-added forcethemeupdate in interactable OnEnable to ensure the right theme is used on reenabling an interactable

-added missing physicaltouch set in handPressCompleted of physicalPressEventRouter
- rearranged if in untouched event in event router so it's behaving like the other events in that class


## Changes
- Fixes: #4528


## Verification
- run tests
- todo: device tests