### PR TITLE
Fix the broken CI build.

### DIFF
--- a/pipelines/templates/compilemsbuild.yml
+++ b/pipelines/templates/compilemsbuild.yml
@@ -6,13 +6,13 @@ steps:
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
   inputs:
     command: 'restore'
-    restoreSolution: '$(Build.SourcesDirectory)\MSBuild\Projects\MRTK.sln'
+    restoreSolution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     feedsToUse: 'select'
   displayName: "Nuget Restore"
 
 - task: MSBuild@1
   inputs:
-    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MRTK.sln'
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     msbuildArchitecture: 'x64'
     platform: 'WindowsStandalone32'
     configuration: 'InEditor'
@@ -24,7 +24,7 @@ steps:
 
 - task: MSBuild@1
   inputs:
-    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MRTK.sln'
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     msbuildArchitecture: 'x64'
     platform: 'WindowsStandalone32'
     configuration: 'Player'
@@ -36,7 +36,7 @@ steps:
 
 - task: MSBuild@1
   inputs:
-    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MRTK.sln'
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     msbuildArchitecture: 'x64'
     platform: 'WSA'
     configuration: 'Player'
@@ -48,7 +48,7 @@ steps:
 
 - task: MSBuild@1
   inputs:
-    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MRTK.sln'
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     msbuildArchitecture: 'x64'
     platform: 'WSA'
     configuration: 'Player'


### PR DESCRIPTION
Previous PR https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5516 updated the way that the solution got named, but missed the pipelines YAML file that also referenced the same thing.

This should fix the build where it's failing at this step:

https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=3969

MSBUILD : error MSB1009: Project file does not exist.
Switch: f:\aipmragent_work\9\s\MSBuild\Projects\MRTK.sln