### PR TITLE
SolverHandlerInspector Fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/SolverHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/SolverHandlerInspector.cs
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 
             EditorGUI.BeginChangeCheck();
 
-            solverHandler.TrackedTargetType = (TrackedObjectType)EditorGUILayout.EnumPopup(new GUIContent("Tracked Target Type"), solverHandler.TrackedTargetType, null, false);
+            trackedTargetProperty.enumValueIndex = (int)(TrackedObjectType)EditorGUILayout.EnumPopup(new GUIContent("Tracked Target Type"), solverHandler.TrackedTargetType, null, false);
             if (!SolverHandler.IsValidTrackedObjectType(solverHandler.TrackedTargetType))
             {
                 InspectorUIUtility.DrawWarning(" Current Tracked Target Type value of \"" 


### PR DESCRIPTION
## Overview
The current implementation does work on a scene object, but it fails when editing a prefab. I am not sure if that's a bug, at least one of my Unity bug reports considered something similar as not being a bug, but this way the value stays.


## Verification
Without the fix, creating a prefab with the SolverHandler script on it will loose the chosen TrackedTargetType every time you reselect it (deselect -> select).
With this fix, the value is remembered.