### PR TITLE
Don't WaitForFixedUpdate for cursor release

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -110,11 +110,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.Select);
 
             // Release pinch
-            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open, false);
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.Release);
 
             // Wait to transition back to InteractHover
-            yield return new WaitForFixedUpdate();
+            yield return null;
             VerifyCursorStateFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorStateEnum.InteractHover);
 
             // Move back so the cursor is no longer on the object

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
@@ -38,25 +38,34 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             return hand.Velocity;
         }
 
-        public IEnumerator Show(Vector3 position)
+        public IEnumerator Show(Vector3 position, bool waitForFixedUpdate = true)
         {
             this.position = position;
             yield return PlayModeTestUtilities.ShowHand(handedness, simulationService, gestureId, position);
-            yield return new WaitForFixedUpdate();
+            if (waitForFixedUpdate)
+            {
+                yield return new WaitForFixedUpdate();
+            }
         }
 
-        public IEnumerator Hide()
+        public IEnumerator Hide(bool waitForFixedUpdate = true)
         {
             yield return PlayModeTestUtilities.HideHand(handedness, simulationService);
-            yield return new WaitForFixedUpdate();
+            if (waitForFixedUpdate)
+            {
+                yield return new WaitForFixedUpdate();
+            }
         }
 
-        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 30)
+        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 30, bool waitForFixedUpdate = true)
         {
             Vector3 oldPosition = position;
             position = newPosition;
             yield return PlayModeTestUtilities.MoveHandFromTo(oldPosition, newPosition, numSteps, gestureId, handedness, simulationService);
-            yield return new WaitForFixedUpdate();
+            if (waitForFixedUpdate)
+            {
+                yield return new WaitForFixedUpdate();
+            }
         }
 
         public IEnumerator Move(Vector3 delta, int numSteps = 30)
@@ -71,11 +80,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return PlayModeTestUtilities.SetHandRotation(oldRotation, newRotation, position, gestureId, handedness, numSteps, simulationService);
         }
 
-        public IEnumerator SetGesture(ArticulatedHandPose.GestureId newGestureId)
+        public IEnumerator SetGesture(ArticulatedHandPose.GestureId newGestureId, bool waitForFixedUpdate = true)
         {
             gestureId = newGestureId;
             yield return PlayModeTestUtilities.MoveHandFromTo(position, position, 1, gestureId, handedness, simulationService);
-            yield return new WaitForFixedUpdate();
+            if (waitForFixedUpdate)
+            {
+                yield return new WaitForFixedUpdate();
+            }
         }
 
         public IEnumerator GrabAndThrowAt(Vector3 positionToRelease, int numSteps = 30)


### PR DESCRIPTION
## Overview
I think while waiting for fixed update after setting the hand gesture in this test, the cursor state would transition to `Release` and then proceed to change to `InteractHover` before the test got a chance to verify the `Release` state.
This change gives us tighter control of the simulation so the test can verify the `Release` state before it changes again.

## Changes
- Change the TestHand interface so that waiting for fixed update is optional. 
- Change ArticulatedCursorState so that we do not WaitForFixedUpdate when testing for cursor release.

## Verification
- Ran test locally 160 times without changes and got a 6.25% failure rate, which approximately matches what we see on CI.
- Ran test locally 160 times with changes and got a 0% failure rate.
- Need to run PR validation.
