### PR TITLE
[BugFix] Modified TwoHandMoveLogic to have parity with TwoHandRotateLogic in that the MovementConstraintType can change during runtime

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -249,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void Awake()
         {
-            moveLogic = new TwoHandMoveLogic(constraintOnMovement);
+            moveLogic = new TwoHandMoveLogic();
             rotateLogic = new TwoHandRotateLogic();
             scaleLogic = new TwoHandScaleLogic();
         }
@@ -592,7 +592,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if ((currentState & State.Moving) > 0)
             {
                 MixedRealityPose pose = GetAveragePointerPose();
-                targetPosition = moveLogic.Update(pose, targetRotationTwoHands, targetScale, IsNearManipulation(), true);
+                targetPosition = moveLogic.Update(pose, targetRotationTwoHands, targetScale, IsNearManipulation(), true, constraintOnMovement);
             }
 
             float lerpAmount = GetLerpAmount();
@@ -671,7 +671,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             targetRotation = ApplyConstraints(targetRotation);
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
-            Vector3 targetPosition = moveLogic.Update(pointerPose, targetRotation, hostTransform.localScale, IsNearManipulation(), rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter);
+            Vector3 targetPosition = moveLogic.Update(pointerPose, targetRotation, hostTransform.localScale, IsNearManipulation(), rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter, constraintOnMovement);
 
             float lerpAmount = GetLerpAmount();
             Quaternion smoothedRotation = Quaternion.Lerp(hostTransform.rotation, targetRotation, lerpAmount);

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -53,7 +53,6 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <param name="objectScale"></param>
         /// <param name="isNearMode"></param>
         /// <param name="usePointerRotation"></param>
-        /// <param name="objectScale"></param>
         /// <param name="movementConstraint"></param>
         /// <returns>A Vector3 describing the desired position</returns>
         public Vector3 Update(MixedRealityPose pointerCentroidPose, Quaternion objectRotation, Vector3 objectScale, bool isNearMode, bool usePointerRotation, MovementConstraintType movementConstraint)

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -18,23 +18,19 @@ namespace Microsoft.MixedReality.Toolkit.Physics
     /// </summary>
     public class TwoHandMoveLogic
     {
-        private readonly MovementConstraintType movementConstraint;
-
         private float pointerRefDistance;
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="movementConstraint"></param>
-        public TwoHandMoveLogic(MovementConstraintType movementConstraint)
-        {
-            this.movementConstraint = movementConstraint;
-        }
 
         private Vector3 pointerLocalGrabPoint;
         private Vector3 objectLocalGrabPoint;
         private Vector3 pointerToObject;
 
+        /// <summary>
+        /// Setup function
+        /// </summary>
+        /// <param name="pointerCentroidPose"></param>
+        /// <param name="grabCentroid"></param>
+        /// <param name="objectPose"></param>
+        /// <param name="objectScale"></param>
         public void Setup(MixedRealityPose pointerCentroidPose, Vector3 grabCentroid, MixedRealityPose objectPose, Vector3 objectScale)
         {
             Vector3 headPosition = CameraCache.Main.transform.position;            
@@ -49,7 +45,18 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             pointerToObject = objectPose.Position - pointerCentroidPose.Position;
         }
 
-        public Vector3 Update(MixedRealityPose pointerCentroidPose, Quaternion objectRotation, Vector3 objectScale, bool isNearMode, bool usePointerRotation)
+        /// <summary>
+        /// Update the rotation based on input.
+        /// </summary>
+        /// <param name="pointerCentroidPose"></param>
+        /// <param name="objectRotation"></param>
+        /// <param name="objectScale"></param>
+        /// <param name="isNearMode"></param>
+        /// <param name="usePointerRotation"></param>
+        /// <param name="objectScale"></param>
+        /// <param name="movementConstraint"></param>
+        /// <returns>A Vector3 describing the desired position</returns>
+        public Vector3 Update(MixedRealityPose pointerCentroidPose, Quaternion objectRotation, Vector3 objectScale, bool isNearMode, bool usePointerRotation, MovementConstraintType movementConstraint)
         {
             if (!isNearMode || usePointerRotation)
             {


### PR DESCRIPTION

## Overview
Modified the TwoHandMoveLogic class to more closely match the TwoHandRotateLogic class in terms of passing in constraints to the Update function (allowing for a more flexible ManipulationHandler). 

This is needed so that the movement constraint type can be dynamically changed on the ManipulationHelper during runtime, so consumers of the SDK don't need to have several ManipulationHandler components on the same object for different movement constraint types. 

## Changes
- Removed the constructor for TwoHandMoveLogic that passed in and defined the MovementConstraintType for the lifespan of the TwoHandMoveLogic component
- Modified the Update function to require a MovementConstraintType object to be passed in whenever called so it allows developers to use the same component for multiple types of movement constraints (though there are only two right now).
- Fixes #5546 