### PR TITLE
Fix Debug.Assert when hovering over radial set buttons

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab
@@ -1418,7 +1418,7 @@ MonoBehaviour:
   StartDimensionIndex: 0
   CanSelect: 1
   CanDeselect: 0
-  VoiceCommand: Radial One
+  VoiceCommand: 
   RequiresFocus: 1
   Profiles:
   - Target: {fileID: 1903041749280706}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -5,7 +5,6 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -199,9 +200,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public bool IsVisited { get; private set; }
 
         /// <summary>
-        /// The dimension index is not zero, in a toggled state
+        /// True if SelectionMode is "Toggle" (Dimensions == 2) and the dimension index is not zero.
         /// </summary>
-        public bool IsToggled { get; private set; }
+        public bool IsToggled { get { return Dimensions == 2 && dimensionIndex > 0; } }
 
         /// <summary>
         /// Currently pressed and some movement has occurred
@@ -751,7 +752,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <param name="toggled"></param>
         public virtual void SetToggled(bool toggled)
         {
-            IsToggled = toggled;
             SetState(InteractableStates.InteractableStateEnum.Toggled, toggled);
 
             // if in toggle mode
@@ -940,11 +940,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnFocusEnter(FocusEventData eventData)
         {
-            Debug.Assert(focusingPointers.Count > 0,
-                "OnFocusEnter called but focusingPointers == 0. Most likely caused by the presence of a child object " +
-                "that is handling IMixedRealityFocusChangedHandler");
             if (CanInteract())
             {
+                Debug.Assert(focusingPointers.Count > 0,
+                    "OnFocusEnter called but focusingPointers == 0. Most likely caused by the presence of a child object " +
+                    "that is handling IMixedRealityFocusChangedHandler");
                 SetFocus(true);
             }
         }
@@ -1198,7 +1198,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return false;
             }
 
-            if (Dimensions > 1 && ((dimensionIndex != Dimensions - 1 & !CanSelect) || (dimensionIndex == Dimensions - 1 & !CanDeselect)))
+            if (Dimensions > 1 && ((dimensionIndex != Dimensions - 1 && !CanSelect) || (dimensionIndex == Dimensions - 1 && !CanDeselect)))
             {
                 return false;
             }


### PR DESCRIPTION
## Overview
You should be able to hover over radial buttons without getting debug asserts. I fixed this bug, added a test to verify the fix, fixed another issue highlighted by the test, and fixed a third logic issue I discovered just by reading the code.

## Changes
- Fixes: #5553
- Add test to validate fix (verified that test does not pass without fix, and passes with fix)
- Test uncovered issue: IsToggled returns incorrect value when radial button instantiated. Fixed.
- Fixed another logic issue: bitwise AND was being used instead of boolean AND.

## Verification
* Tested in editor
* Playmode tests pass.