### PR TITLE
Update the holographic remoting workaround is only limited to editor scenarios.

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
@@ -344,6 +344,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private bool GetSelectPressedWorkaround(InteractionSourceState interactionSourceState)
         {
             bool selectPressed = interactionSourceState.selectPressed;
+            // Only do this workaround inside the Unity editor (in holographic remoting scenarios).
+            // When this is invoked on device, this will display an error attempting to load the
+            // remoting binaries.
+#if UNITY_EDITOR
             if (interactionSourceState.source.kind == InteractionSourceKind.Hand &&
                 UnityEngine.XR.WSA.HolographicRemoting.ConnectionState == UnityEngine.XR.WSA.HolographicStreamerConnectionState.Connected)
             {
@@ -357,6 +361,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                 selectPressed = interactionSourceState.anyPressed;
             }
+#endif // UNITY_EDITOR
             return selectPressed;
         }
 


### PR DESCRIPTION
Running this code in the context of the deployed device will trigger an error (in the console) about failing to load a perception remoting binary. It turns out that calling https://docs.unity3d.com/ScriptReference/XR.WSA.HolographicRemoting.ConnectionState.html (which we do) will trigger this load attempt. Wrapping this in a UNITY_EDITOR ifdef to prevent us from trying to do this on device (where this workaround isn't necessary)