### PR TITLE
Fix 5557 - Hand / controller input broken

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -245,12 +245,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
+            // Ensure data providers are enabled (performed by the base class)
+            base.Enable();
+
             InputEnabled?.Invoke();
         }
 
         /// <inheritdoc />
         public override void Reset()
         {
+            base.Reset();
             Disable();
             Initialize();
             Enable();
@@ -259,6 +263,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void Disable()
         {
+            base.Disable();
+
             // Input System adds a gaze provider component on the main camera, which needs to be removed when the input system is disabled/removed.
             // Otherwise the component would keep references to dead objects.
             // Unity's way to remove component is to destroy it.

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -89,8 +89,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc/>
         public override void Enable()
         {
-            base.Enable();
-
             MixedRealitySpatialAwarenessSystemProfile profile = ConfigurationProfile as MixedRealitySpatialAwarenessSystemProfile;
 
             if ((GetDataProviders<IMixedRealitySpatialAwarenessObserver>().Count == 0) && (profile != null))
@@ -107,11 +105,15 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
                         args);
                 }
             }
+
+            // Ensure data providers are enabled (performed by the base class)
+            base.Enable();
         }
 
         /// <inheritdoc/>
         public override void Reset()
         {
+            base.Reset();
             Disable();
             Initialize();
             Enable();
@@ -145,6 +147,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
                     spatialAwarenessObjectParent = null;
                 }
             }
+
+            base.Destroy();
         }
 
         #endregion IMixedRealityToolkitService Implementation

--- a/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             foreach (var provider in dataProviders)
             {
-                provider.Reset();
+                provider.Enable();
             }
         }
 


### PR DESCRIPTION
Recently, a regression was introduced that caused data providers to not be enabled. Windows Mixed Reality controllers (including hands) rely on Enable to register for platform events.

This PR fixes this and a related error in the new core service base class.

Added calls to base class methods in input and spatial awareness systems.

Fixes: #5557

Verified running on Windows Mixed Reality immersive device.