### PR TITLE
Assign material to Reticle.prefab

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Reticle.prefab
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Reticle.prefab
@@ -57,7 +57,7 @@ MeshRenderer:
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: fb75c6d6284995a4fb60596bbfb6dae8, type: 2}
+  - {fileID: 2100000, guid: 835cb4a58f172d7478801db95e510f56, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
## Overview
The Reticle's material was deleted, but its reference wasn't updated. This updates it to the MRTK_Standard_Gray shader.

![image](https://user-images.githubusercontent.com/3580640/62806722-7dd69e00-baa8-11e9-9d97-e26823b55afd.png)


![image](https://user-images.githubusercontent.com/3580640/62806675-5f70a280-baa8-11e9-92e2-f615f58f2c89.png)
