### PR TITLE
Fix missing default types in profile configs when consumed via NuGet

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/TypeReferencePropertyDrawer.cs
@@ -68,13 +68,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static List<Type> GetFilteredTypes(SystemTypeAttribute filter)
         {
             var types = new List<Type>();
-            var assemblies = CompilationPipeline.GetAssemblies();
             var excludedTypes = ExcludedTypeCollectionGetter?.Invoke();
 
+            // We prefer using this over CompilationPipeline.GetAssemblies() because
+            // some types may come from plugins and other sources that have already
+            // been compiled.
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             foreach (var assembly in assemblies)
             {
-                Assembly compiledAssembly = Assembly.Load(assembly.name);
-                FilterTypes(compiledAssembly, filter, excludedTypes, types);
+                FilterTypes(assembly, filter, excludedTypes, types);
             }
 
             types.Sort((a, b) => string.Compare(a.FullName, b.FullName, StringComparison.Ordinal));


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4491

The current type enumeration code uses Unity's assembly CompilationPipeline.GetAssemblies, which only captures things that are going through Unity's compilation pipeline. This doesn't work well when consuming MRTK as compiled binaries - these types are obviously not part of source files at that point.