### PR TITLE
Update the mrtk_pr pipeline to not build the UWP x86 build.

### DIFF
--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -15,4 +15,10 @@ jobs:
     - SDK_18362 -equals TRUE
   steps:
   - template: templates/common.yml
+    parameters:
+      # For mrtk_pr builds, don't build all flavors to reduce the amount of time
+      # taken for each validation run. Note that this flavor is still checked in
+      # the ongoing rolling CI build. This build in particular is highly correlated
+      # the .NET x86 build and ARM IL2CPP build.
+      buildUWPX86: false
   - template: templates/end.yml

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -1,38 +1,49 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
+parameters:
+  buildStandalone: true
+  buildUWPArm: true
+  buildUWPDotNet: true
+  buildUWPX86: true
+  runTests: true
 
 steps:
 # Build Standalone x86.
 # This must happen before tests run, because if the build fails and tests attempt
 # to get run, Unity will hang showing a dialog (even when in batch mode).
 # This is the fastest build, since it doesn't produce an AppX.
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'Standalone'
+- ${{ if eq(parameters.buildStandalone, true) }}:
+  - template: tasks/unitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'Standalone'
 
 # Tests should run earlier in the process, so that engineers can get test failure
 # notifications earlier in the CI process.
-- template: tests.yml
+- ${{ if eq(parameters.runTests, true) }}:
+  - template: tests.yml
 
 # Build UWP x86
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PublishArtifacts: true
+- ${{ if eq(parameters.buildUWPX86, true) }}:
+  - template: tasks/unitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PublishArtifacts: true
 
 # Build UWP ARM
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'arm'
-    Platform: 'UWP'
-    PublishArtifacts: true
-    PackagingDir: 'ARM'
+- ${{ if eq(parameters.buildUWPArm, true) }}:
+  - template: tasks/unitybuild.yml
+    parameters:
+      Arch: 'arm'
+      Platform: 'UWP'
+      PublishArtifacts: true
+      PackagingDir: 'ARM'
 
 # Build UWP x86 .NET backend
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PublishArtifacts: true
-    ScriptingBackend: '.NET'
+- ${{ if eq(parameters.buildUWPDotNet, true) }}:
+  - template: tasks/unitybuild.yml
+    parameters:
+      Arch: 'x86'
+      Platform: 'UWP'
+      PublishArtifacts: true
+      ScriptingBackend: '.NET'


### PR DESCRIPTION
We currently build four different flavors on each mrtk_pr run, each of which can take between 12-17 minutes. This particular build being disabled in mrtk_pr has high correlation with the other x86 .NET build and IL2CPP ARM build.

Note that this is still enabled on the ongoing rolling build, which still needs to validate that everything is good.