### PR TITLE
Turn off material import on certain models

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Models/Avocado/glTF/AvocadoMaterial.mat
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Models/Avocado/glTF/AvocadoMaterial.mat
@@ -71,6 +71,7 @@ Material:
     - _FadeMinValue: 0
     - _FluentLightIntensity: 1
     - _HoverLight: 1
+    - _IgnoreZScale: 0
     - _InnerGlow: 0
     - _InnerGlowPower: 4
     - _InstancedColor: 0

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Models/Cheese.fbx.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Models/Cheese.fbx.meta
@@ -17,12 +17,22 @@ ModelImporter:
     3300002: node_id4 1
     4300000: node_id4
     4300002: node_id4
-  externalObjects: {}
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material_37
+    second: {fileID: 2100000, guid: 71d471797c0e430783230146721c3fcb, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material_38
+    second: {fileID: 2100000, guid: 2e7ee0c64b3021a46be96a51517a1d94, type: 2}
   materials:
     importMaterials: 1
     materialName: 0
     materialSearch: 1
-    materialLocation: 0
+    materialLocation: 1
   animations:
     legacyGenerateAnimations: 4
     bakeSimulation: 0

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Models/EarthCore.fbx.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Models/EarthCore.fbx.meta
@@ -16,12 +16,12 @@ ModelImporter:
       type: UnityEngine:Material
       assembly: UnityEngine.CoreModule
       name: Material_42
-    second: {fileID: 2100000, guid: c72691f7b364d264abdb41ef2f01c706, type: 3}
+    second: {fileID: 2100000, guid: b62873551dfeef943be6324c304cd0ab, type: 2}
   materials:
     importMaterials: 1
     materialName: 0
     materialSearch: 1
-    materialLocation: 0
+    materialLocation: 1
   animations:
     legacyGenerateAnimations: 4
     bakeSimulation: 0

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Models/Tree.fbx.meta
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Models/Tree.fbx.meta
@@ -11,12 +11,17 @@ ModelImporter:
     2300000: node_id30
     3300000: node_id30
     4300000: node_id30
-  externalObjects: {}
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material_42
+    second: {fileID: 2100000, guid: ded4159fdff3e874580aa6c6cf2e0259, type: 2}
   materials:
     importMaterials: 1
     materialName: 0
     materialSearch: 1
-    materialLocation: 0
+    materialLocation: 1
   animations:
     legacyGenerateAnimations: 4
     bakeSimulation: 0


### PR DESCRIPTION
## Overview
This PR changes some models to use their embedded materials instead of trying to re-import them every time.

Specifically, Material_37 and Material_38 kept reimporting themselves from Cheese.fbx. We remapped the cheese's materials in the prefab, so the built-in materials were unused.