### PR TITLE
Remove concrete GazeProvider reference to allow custom providers

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -30,10 +30,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly Dictionary<GameObject, int> pendingOverallFocusExitSet = new Dictionary<GameObject, int>();
         private readonly List<PointerData> pendingPointerSpecificFocusChange = new List<PointerData>();
         private readonly Dictionary<uint, IMixedRealityPointerMediator> pointerMediators = new Dictionary<uint, IMixedRealityPointerMediator>();
-        private PointerHitResult hitResult3d = new PointerHitResult();
-        private PointerHitResult hitResultUi = new PointerHitResult();
+        private readonly PointerHitResult hitResult3d = new PointerHitResult();
+        private readonly PointerHitResult hitResultUi = new PointerHitResult();
 
-        private int maxQuerySceneResults = 128;
+        private readonly int maxQuerySceneResults = 128;
 
         public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators
         {
@@ -464,7 +464,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private GazePointerVisibilityStateMachine gazePointerStateMachine = new GazePointerVisibilityStateMachine();
+        private readonly GazePointerVisibilityStateMachine gazePointerStateMachine = new GazePointerVisibilityStateMachine();
 
         /// <summary>
         /// Interface used for selecting the primary pointer.

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -525,7 +525,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Updates the the gaze raycast provider even in scenarios where gaze isn't used for focus
+        /// Updates the gaze raycast provider even in scenarios where gaze isn't used for focus
         /// </summary>
         private void UpdateGazeProvider()
         {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -541,7 +541,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 gazeHitResult = hitResult3d;
             }
 
-            ((GazeProvider)InputSystem.GazeProvider).UpdateGazeInfoFromHit(gazeHitResult.raycastHit);
+            InputSystem.GazeProvider.UpdateGazeInfoFromHit(gazeHitResult.raycastHit);
 
             // Zero out value after every use to ensure the hit result is updated every frame.
             gazeHitResult = null;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -35,13 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private readonly int maxQuerySceneResults = 128;
 
-        public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators
-        {
-            get
-            {
-                return pointerMediators;
-            }
-        }
+        public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators => pointerMediators;
 
         /// <summary>
         /// Number of IMixedRealityNearPointers that are active (IsInteractionEnabled == true).
@@ -517,7 +511,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override void Update()
         {
             if (!IsSetupValid) { return; }
-            
+
             UpdatePointers();
 
             if (gazeProviderPointingData?.Pointer != null)
@@ -546,7 +540,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     hitResult3d, maxQuerySceneResults);
                 gazeHitResult = hitResult3d;
             }
-            
+
             ((GazeProvider)InputSystem.GazeProvider).UpdateGazeInfoFromHit(gazeHitResult.raycastHit);
 
             // Zero out value after every use to ensure the hit result is updated every frame.
@@ -927,7 +921,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                         hit = GetPrioritizedHitResult(hit, hitResultUi, prioritizedLayerMasks);
                     }
-                    
+
                     if (hit != hitResult3d || hitResult3dLayer > 0)
                     {
                         // Truncate if we didn't already for this hit

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -492,6 +492,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             GazePointer.BaseCursor?.SetVisibility(true);
         }
 
+        /// <inheritdoc />
         public void UpdateGazeInfoFromHit(MixedRealityRaycastHit raycastHit)
         {
             HitInfo = raycastHit;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -163,8 +163,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private Ray latestEyeGaze = default(Ray);
         private DateTime latestEyeTrackingUpdate = DateTime.MinValue;
-        private bool? isEyeCalibrated = null;
-
         private readonly float maxEyeTrackingTimeoutInSeconds = 2.0f;
 
         #region InternalGazePointer Class
@@ -262,27 +260,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
-            public override void OnPreCurrentPointerTargetChange()
-            {
-            }
+            public override void OnPreCurrentPointerTargetChange() { }
 
             /// <inheritdoc />
-            public override Vector3 Position
-            {
-                get
-                {
-                    return gazeTransform.position;
-                }
-            }
+            public override Vector3 Position => gazeTransform.position;
 
             /// <inheritdoc />
-            public override Quaternion Rotation
-            {
-                get
-                {
-                    return gazeTransform.rotation;
-                }
-            }
+            public override Quaternion Rotation => gazeTransform.rotation;
 
             #endregion IMixedRealityPointer Implementation
 
@@ -550,7 +534,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool userIsEyeCalibrated)
         {
-            this.isEyeCalibrated = userIsEyeCalibrated;
+            this.IsEyeCalibrationValid = userIsEyeCalibrated;
         }
 
         /// <summary>
@@ -563,7 +547,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Boolean to check whether the user went through the eye tracking calibration. 
         /// Initially the parameter will return null until it has received valid information from the eye tracking system.
         /// </summary>
-        public bool? IsEyeCalibrationValid => isEyeCalibrated;
+        public bool? IsEyeCalibrationValid { get; private set; } = null;
         #endregion Utilities
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -492,7 +492,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             GazePointer.BaseCursor?.SetVisibility(true);
         }
 
-        internal void UpdateGazeInfoFromHit(MixedRealityRaycastHit raycastHit)
+        public void UpdateGazeInfoFromHit(MixedRealityRaycastHit raycastHit)
         {
             HitInfo = raycastHit;
             if (raycastHit.transform != null)

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityGazeProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityGazeProvider.cs
@@ -81,5 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Get the GameObject reference for this Gaze Provider.
         /// </summary>
         GameObject GameObjectReference { get; }
+
+        void UpdateGazeInfoFromHit(MixedRealityRaycastHit raycastHit);
     }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityGazeProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityGazeProvider.cs
@@ -82,6 +82,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         GameObject GameObjectReference { get; }
 
+        /// <summary>
+        /// Notifies this gaze provider of its new hit details.
+        /// </summary>
+        /// <remarks>
+        /// For components that care where the user's looking, we need
+        /// to separately update the gaze info even if gaze isn't used for focus.
+        /// </remarks>
         void UpdateGazeInfoFromHit(MixedRealityRaycastHit raycastHit);
     }
 }


### PR DESCRIPTION
## Overview
This PR moves UpdateGazeInfoFromHit into the interface definition to remove a cast in FocusProvider to the concrete type.

It also performs some formatting / comment updates to match current MRTK-style more.

## Changes
- Fixes: #5545 (at least, as far as GazeProvider is concerned. There's also the note about potentially defining custom GazePointers, like other pointers are handled)