### PR TITLE
Expose configuration in FocusProvider to target colliders instead of rigid bodies

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -469,7 +469,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             RaycastHit result;
 
             // Do the cast!
-            isHit = MixedRealityRaycaster.RaycastSimplePhysicsStep(rayStep, maxRaycastDistance, magneticSurfaces, out result);
+            isHit = MixedRealityRaycaster.RaycastSimplePhysicsStep(rayStep, maxRaycastDistance, magneticSurfaces, false, out result);
 
             OnSurface = isHit;
 
@@ -501,7 +501,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             // Do the cast!
             float size = ScaleOverride > 0 ? ScaleOverride : transform.lossyScale.x * sphereSize;
-            isHit = MixedRealityRaycaster.RaycastSpherePhysicsStep(rayStep, size, maxRaycastDistance, magneticSurfaces, out result);
+            isHit = MixedRealityRaycaster.RaycastSpherePhysicsStep(rayStep, size, maxRaycastDistance, magneticSurfaces, false, out result);
 
             OnSurface = isHit;
 
@@ -549,7 +549,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             Vector3[] normals;
             bool[] hits;
 
-            if (MixedRealityRaycaster.RaycastBoxPhysicsStep(rayStep, extents, transform.position, targetMatrix, maxRaycastDistance, magneticSurfaces, boxRaysPerEdge, orthographicBoxCast, out positions, out normals, out hits))
+            if (MixedRealityRaycaster.RaycastBoxPhysicsStep(rayStep, extents, transform.position, targetMatrix, maxRaycastDistance, magneticSurfaces, boxRaysPerEdge, orthographicBoxCast, out positions, out normals, false, out hits))
             {
                 Plane plane;
                 float distance;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -549,7 +549,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             Vector3[] normals;
             bool[] hits;
 
-            if (MixedRealityRaycaster.RaycastBoxPhysicsStep(rayStep, extents, transform.position, targetMatrix, maxRaycastDistance, magneticSurfaces, boxRaysPerEdge, orthographicBoxCast, out positions, out normals, false, out hits))
+            if (MixedRealityRaycaster.RaycastBoxPhysicsStep(rayStep, extents, transform.position, targetMatrix, maxRaycastDistance, magneticSurfaces, boxRaysPerEdge, orthographicBoxCast, false, out positions, out normals, out hits))
             {
                 Plane plane;
                 float distance;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/DefaultRaycastProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/DefaultRaycastProvider.cs
@@ -18,17 +18,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         { }
 
         /// <inheritdoc />
-        public bool Raycast(RayStep step, LayerMask[] prioritizedLayerMasks, out MixedRealityRaycastHit hitInfo)
+        public bool Raycast(RayStep step, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo)
         {
-            bool result = MixedRealityRaycaster.RaycastSimplePhysicsStep(step, step.Length, prioritizedLayerMasks, out RaycastHit physicsHit);
+            bool result = MixedRealityRaycaster.RaycastSimplePhysicsStep(step, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out RaycastHit physicsHit);
             hitInfo = new MixedRealityRaycastHit(result, physicsHit);
             return result;
         }
 
         /// <inheritdoc />
-        public bool SphereCast(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, out MixedRealityRaycastHit hitInfo)
+        public bool SphereCast(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo)
         {
-            var result = MixedRealityRaycaster.RaycastSpherePhysicsStep(step, radius, step.Length, prioritizedLayerMasks, out RaycastHit physicsHit);
+            var result = MixedRealityRaycaster.RaycastSpherePhysicsStep(step, radius, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out RaycastHit physicsHit);
             hitInfo = new MixedRealityRaycastHit(result, physicsHit);
             return result;
         }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             MixedRealityInputSystemProfile profile) : base(registrar, profile)
         {
             maxQuerySceneResults = profile.FocusQueryBufferSize;
+            focusIndividualCompoundCollider = profile.FocusIndividualCompoundCollider;
         }
 
         private readonly HashSet<PointerData> pointers = new HashSet<PointerData>();
@@ -34,6 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly PointerHitResult hitResultUi = new PointerHitResult();
 
         private readonly int maxQuerySceneResults = 128;
+        private bool focusIndividualCompoundCollider = false;
 
         public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators => pointerMediators;
 
@@ -537,7 +539,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var raycastProvider = InputSystem.RaycastProvider;
                 LayerMask[] prioritizedLayerMasks = (gazeProviderPointingData.Pointer.PrioritizedLayerMasksOverride ?? FocusLayerMasks);
                 QueryScene(gazeProviderPointingData.Pointer, raycastProvider, prioritizedLayerMasks,
-                    hitResult3d, maxQuerySceneResults);
+                    hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
                 gazeHitResult = hitResult3d;
             }
 
@@ -896,7 +898,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // Perform raycast to determine focused object
                     var raycastProvider = InputSystem.RaycastProvider;
                     hitResult3d.Clear();
-                    QueryScene(pointerData.Pointer, raycastProvider, prioritizedLayerMasks, hitResult3d, maxQuerySceneResults);
+                    QueryScene(pointerData.Pointer, raycastProvider, prioritizedLayerMasks, hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
 
                     if (pointerData.Pointer.PointerId == gazeProviderPointingData.Pointer.PointerId)
                     {
@@ -1043,7 +1045,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         /// <param name="pointerData"></param>
         /// <param name="prioritizedLayerMasks"></param>
-        private static void QueryScene(IMixedRealityPointer pointer, IMixedRealityRaycastProvider raycastProvider, LayerMask[] prioritizedLayerMasks, PointerHitResult hit, int maxQuerySceneResults)
+        private static void QueryScene(IMixedRealityPointer pointer, IMixedRealityRaycastProvider raycastProvider, LayerMask[] prioritizedLayerMasks, PointerHitResult hit, int maxQuerySceneResults, bool focusIndividualCompoundCollider)
         {
             float rayStartDistance = 0;
             MixedRealityRaycastHit hitInfo;
@@ -1067,7 +1069,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 switch (pointer.SceneQueryType)
                 {
                     case SceneQueryType.SimpleRaycast:
-                        if (raycastProvider.Raycast(pointerRays[i], prioritizedLayerMasks, out hitInfo))
+                        if (raycastProvider.Raycast(pointerRays[i], prioritizedLayerMasks, focusIndividualCompoundCollider, out hitInfo))
                         {
                             hit.Set(hitInfo, pointerRays[i], i, rayStartDistance + hitInfo.distance);
                             return;
@@ -1077,7 +1079,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         Debug.LogWarning("Box Raycasting Mode not supported for pointers.");
                         break;
                     case SceneQueryType.SphereCast:
-                        if (raycastProvider.SphereCast(pointerRays[i], pointer.SphereCastRadius, prioritizedLayerMasks, out hitInfo))
+                        if (raycastProvider.SphereCast(pointerRays[i], pointer.SphereCastRadius, prioritizedLayerMasks, focusIndividualCompoundCollider, out hitInfo))
                         {
                             hit.Set(hitInfo, pointerRays[i], i, rayStartDistance + hitInfo.distance);
                             return;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -235,12 +235,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <summary>
             /// Set hit focus information from a physics raycast.
             /// </summary>
-            public void Set(MixedRealityRaycastHit hit, RayStep ray, int rayStepIndex, float rayDistance)
+            public void Set(MixedRealityRaycastHit hit, RayStep ray, int rayStepIndex, float rayDistance, bool focusIndividualCompoundCollider)
             {
                 raycastHit = hit;
                 graphicsRaycastResult = default(RaycastResult);
 
-                hitObject = hit.transform.gameObject;
+                hitObject = focusIndividualCompoundCollider? hit.collider.gameObject : hit.transform.gameObject;
                 hitPointOnObject = hit.point;
                 hitNormalOnObject = hit.normal;
 
@@ -1071,7 +1071,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     case SceneQueryType.SimpleRaycast:
                         if (raycastProvider.Raycast(pointerRays[i], prioritizedLayerMasks, focusIndividualCompoundCollider, out hitInfo))
                         {
-                            hit.Set(hitInfo, pointerRays[i], i, rayStartDistance + hitInfo.distance);
+                            hit.Set(hitInfo, pointerRays[i], i, rayStartDistance + hitInfo.distance, focusIndividualCompoundCollider);
                             return;
                         }
                         break;
@@ -1081,7 +1081,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     case SceneQueryType.SphereCast:
                         if (raycastProvider.SphereCast(pointerRays[i], pointer.SphereCastRadius, prioritizedLayerMasks, focusIndividualCompoundCollider, out hitInfo))
                         {
-                            hit.Set(hitInfo, pointerRays[i], i, rayStartDistance + hitInfo.distance);
+                            hit.Set(hitInfo, pointerRays[i], i, rayStartDistance + hitInfo.distance, focusIndividualCompoundCollider);
                             return;
                         }
                         break;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/DefaultRaycastProviderTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/DefaultRaycastProviderTest.cs
@@ -26,8 +26,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             RayStep step = new RayStep(Vector3.zero, Vector3.up);
             LayerMask[] layerMasks = new LayerMask[] { UnityEngine.Physics.DefaultRaycastLayers };
             MixedRealityRaycastHit hitInfo;
-            Assert.IsFalse(defaultRaycastProvider.Raycast(step, layerMasks, out hitInfo));
+            Assert.IsFalse(defaultRaycastProvider.Raycast(step, layerMasks, false, out hitInfo));
             Assert.IsFalse(hitInfo.raycastValid);
+            Assert.IsFalse(hitInfo.collider != null);
             yield return null;
         }
 

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -67,6 +67,19 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private int focusQueryBufferSize = 128;
 
         [SerializeField]
+        [Tooltip("In case of a compound collider, does the individual collider receive focus")]
+        private bool focusIndividualCompoundCollider = false;
+
+        /// <summary>
+        /// In case of a compound collider, does the individual collider receive focus
+        /// </summary>
+        public bool FocusIndividualCompoundCollider
+        {
+            get { return focusIndividualCompoundCollider; }
+            internal set { focusIndividualCompoundCollider = value; }
+        }
+
+        [SerializeField]
         [Tooltip("Input System Action Mapping profile for wiring up Controller input to Actions.")]
         private MixedRealityInputActionsProfile inputActionsProfile;
 

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -21,6 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Transform transform;
         public Vector2 lightmapCoord;
         public bool raycastValid;
+        public Collider collider;
 
         public MixedRealityRaycastHit(bool raycastValid, RaycastHit hitInfo)
         {
@@ -36,6 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 textureCoord2 = hitInfo.textureCoord2;
                 transform = hitInfo.transform;
                 lightmapCoord = hitInfo.lightmapCoord;
+                collider = hitInfo.collider;
             }
             else
             {
@@ -48,6 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 textureCoord2 = Vector2.zero;
                 transform = null;
                 lightmapCoord = Vector2.zero;
+                collider = null;
             }
         }
     }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -25,6 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private SerializedProperty focusProviderType;
         private SerializedProperty focusQueryBufferSize;
         private SerializedProperty raycastProviderType;
+        private SerializedProperty focusIndividualCompoundCollider;
 
         private static bool showPointerProperties = false;
         private const string ShowInputSystem_Pointers_PreferenceKey = "ShowInputSystem_Pointers_PreferenceKey";
@@ -65,6 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             focusProviderType = serializedObject.FindProperty("focusProviderType");
             focusQueryBufferSize = serializedObject.FindProperty("focusQueryBufferSize");
             raycastProviderType = serializedObject.FindProperty("raycastProviderType");
+            focusIndividualCompoundCollider = serializedObject.FindProperty("focusIndividualCompoundCollider");
             inputActionsProfile = serializedObject.FindProperty("inputActionsProfile");
             inputActionRulesProfile = serializedObject.FindProperty("inputActionRulesProfile");
             pointerProfile = serializedObject.FindProperty("pointerProfile");
@@ -94,6 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 EditorGUILayout.PropertyField(focusProviderType);
                 EditorGUILayout.PropertyField(focusQueryBufferSize);
                 EditorGUILayout.PropertyField(raycastProviderType);
+                EditorGUILayout.PropertyField(focusIndividualCompoundCollider);
                 changed |= EditorGUI.EndChangeCheck();
 
                 EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityRaycastProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityRaycastProvider.cs
@@ -21,13 +21,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Performs a raycast using the specified <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>.
         /// </summary>
         /// <returns>Whether or not the raycast hit something.</returns>
-        bool Raycast(RayStep step, LayerMask[] prioritizedLayerMasks, out MixedRealityRaycastHit hitInfo);
+        bool Raycast(RayStep step, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo);
 
         /// <summary>
         /// Performs a sphere cast with the specified <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/> and radius.
         /// </summary>
         /// <returns>Whether or not the SphereCast hit something.</returns>
-        bool SphereCast(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, out MixedRealityRaycastHit hitInfo);
+        bool SphereCast(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo);
 
         /// <summary>
         /// Performs a graphics raycast against the specified layerMasks.

--- a/Assets/MixedRealityToolkit/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/MixedRealityRaycaster.cs
@@ -16,9 +16,9 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <param name="prioritizedLayerMasks"></param>
         /// <param name="physicsHit"></param>
         /// <returns>Whether or not the raycast hit something.</returns>
-        public static bool RaycastSimplePhysicsStep(RayStep step, LayerMask[] prioritizedLayerMasks, out RaycastHit physicsHit)
+        public static bool RaycastSimplePhysicsStep(RayStep step, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
-            return RaycastSimplePhysicsStep(step, step.Length, prioritizedLayerMasks, out physicsHit);
+            return RaycastSimplePhysicsStep(step, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <param name="prioritizedLayerMasks"></param>
         /// <param name="physicsHit"></param>
         /// <returns>Whether or not the raycast hit something.</returns>
-        public static bool RaycastSimplePhysicsStep(RayStep step, float maxDistance, LayerMask[] prioritizedLayerMasks, out RaycastHit physicsHit)
+        public static bool RaycastSimplePhysicsStep(RayStep step, float maxDistance, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
             Debug.Assert(maxDistance > 0, "Length must be longer than zero!");
             Debug.Assert(step.Direction != Vector3.zero, "Invalid step direction!");
@@ -38,14 +38,14 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 // If there is only one priority, don't prioritize
                 ? UnityEngine.Physics.Raycast(step.Origin, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0])
                 // Raycast across all layers and prioritize
-                : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.RaycastAll(step.Origin, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, out physicsHit);
+                : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.RaycastAll(step.Origin, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
         }
 
         /// <summary>
         /// Box raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>.
         /// </summary>
         /// <returns>Whether or not the raycast hit something.</returns>
-        public static bool RaycastBoxPhysicsStep(RayStep step, Vector3 extents, Vector3 targetPosition, Matrix4x4 matrix, float maxDistance, LayerMask[] prioritizedLayerMasks, int raysPerEdge, bool isOrthographic, out Vector3[] points, out Vector3[] normals, out bool[] hits)
+        public static bool RaycastBoxPhysicsStep(RayStep step, Vector3 extents, Vector3 targetPosition, Matrix4x4 matrix, float maxDistance, LayerMask[] prioritizedLayerMasks, int raysPerEdge, bool isOrthographic, out Vector3[] points, out Vector3[] normals, bool focusIndividualCompoundCollider,out bool[] hits)
         {
             if (Application.isEditor && DebugEnabled)
             {
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                     }
 
                     RaycastHit rayHit;
-                    hits[index] = RaycastSimplePhysicsStep(new RayStep(origin, direction.normalized * maxDistance), prioritizedLayerMasks, out rayHit);
+                    hits[index] = RaycastSimplePhysicsStep(new RayStep(origin, direction.normalized * maxDistance), prioritizedLayerMasks, focusIndividualCompoundCollider, out rayHit);
 
                     if (hits[index])
                     {
@@ -116,9 +116,9 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <param name="prioritizedLayerMasks"></param>
         /// <param name="physicsHit"></param>
         /// <returns>Whether or not the raycast hit something.</returns>
-        public static bool RaycastSpherePhysicsStep(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, out RaycastHit physicsHit)
+        public static bool RaycastSpherePhysicsStep(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
-            return RaycastSpherePhysicsStep(step, radius, step.Length, prioritizedLayerMasks, out physicsHit);
+            return RaycastSpherePhysicsStep(step, radius, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
         }
 
         /// <summary>
@@ -130,13 +130,13 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <param name="prioritizedLayerMasks"></param>
         /// <param name="physicsHit"></param>
         /// <returns>Whether or not the raycast hit something.</returns>
-        public static bool RaycastSpherePhysicsStep(RayStep step, float radius, float maxDistance, LayerMask[] prioritizedLayerMasks, out RaycastHit physicsHit)
+        public static bool RaycastSpherePhysicsStep(RayStep step, float radius, float maxDistance, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
             return prioritizedLayerMasks.Length == 1
                 // If there is only one priority, don't prioritize
                 ? UnityEngine.Physics.SphereCast(step.Origin, radius, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0])
                 // Raycast across all layers and prioritize
-                : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.SphereCastAll(step.Origin, radius, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, out physicsHit);
+                : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.SphereCastAll(step.Origin, radius, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <param name="priorityLayers"></param>
         /// <param name="raycastHit"></param>
         /// <returns>The minimum distance hit within the first layer that has hits.</returns>
-        public static bool TryGetPrioritizedPhysicsHit(RaycastHit[] hits, LayerMask[] priorityLayers, out RaycastHit raycastHit)
+        public static bool TryGetPrioritizedPhysicsHit(RaycastHit[] hits, LayerMask[] priorityLayers, bool focusIndividualCompoundCollider, out RaycastHit raycastHit)
         {
             raycastHit = default(RaycastHit);
 
@@ -163,7 +163,12 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 for (int hitIdx = 0; hitIdx < hits.Length; hitIdx++)
                 {
                     RaycastHit hit = hits[hitIdx];
-                    if (hit.transform.gameObject.layer.IsInLayerMask(priorityLayers[layerMaskIdx]) &&
+                    GameObject targetGameObject = hit.transform.gameObject;
+                    if (focusIndividualCompoundCollider)
+                    {
+                        targetGameObject = hit.collider.gameObject;
+                    }
+                    if (targetGameObject.layer.IsInLayerMask(priorityLayers[layerMaskIdx]) &&
                         (minHit == null || hit.distance < minHit.Value.distance))
                     {
                         minHit = hit;

--- a/Assets/MixedRealityToolkit/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/MixedRealityRaycaster.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// Box raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>.
         /// </summary>
         /// <returns>Whether or not the raycast hit something.</returns>
-        public static bool RaycastBoxPhysicsStep(RayStep step, Vector3 extents, Vector3 targetPosition, Matrix4x4 matrix, float maxDistance, LayerMask[] prioritizedLayerMasks, int raysPerEdge, bool isOrthographic, out Vector3[] points, out Vector3[] normals, bool focusIndividualCompoundCollider,out bool[] hits)
+        public static bool RaycastBoxPhysicsStep(RayStep step, Vector3 extents, Vector3 targetPosition, Matrix4x4 matrix, float maxDistance, LayerMask[] prioritizedLayerMasks, int raysPerEdge, bool isOrthographic, bool focusIndividualCompoundCollider, out Vector3[] points, out Vector3[] normals, out bool[] hits)
         {
             if (Application.isEditor && DebugEnabled)
             {
@@ -163,11 +163,8 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 for (int hitIdx = 0; hitIdx < hits.Length; hitIdx++)
                 {
                     RaycastHit hit = hits[hitIdx];
-                    GameObject targetGameObject = hit.transform.gameObject;
-                    if (focusIndividualCompoundCollider)
-                    {
-                        targetGameObject = hit.collider.gameObject;
-                    }
+                    GameObject targetGameObject = focusIndividualCompoundCollider ? hit.collider.gameObject : hit.transform.gameObject;
+
                     if (targetGameObject.layer.IsInLayerMask(priorityLayers[layerMaskIdx]) &&
                         (minHit == null || hit.distance < minHit.Value.distance))
                     {


### PR DESCRIPTION
## Overview

This PR addresses issue #5391. 

## Changes
This change introduces a configuration property in the Input System Settings in MRTK profiles - "FocusIndividualCompoundCollider". This configurable property is passed as a argument to the Raycast provider implementation and ultimately propagates to the TryGetPrioritizedPhysicsHit logic to determines, if the raycast hit result should pick individual colliders or the root rigidbody transform.

When the hit is determined, the profile property is again used to determine which gameobject to set as the rayast hit object .

![image](https://user-images.githubusercontent.com/17660747/62901989-0c4e5800-bd13-11e9-977f-625f4209b55d.png)

## Verification
Validation requested from @anuraag016  via product integration.

Created a local scene with a rigidbody and compound colliders and verified that the correct item is focused.

FocusIndividualCompoundCollider = false;
![colliderfalse](https://user-images.githubusercontent.com/17660747/62902926-f2fadb00-bd15-11e9-9d0f-7ab1e9e8fcb6.gif)

FocusIndividualCompoundCollider = true
![collider](https://user-images.githubusercontent.com/17660747/62902874-cb0b7780-bd15-11e9-9b46-d11d78163d89.gif)
;
