### PR TITLE
Update TextMesh Pro version to 1.4.1 in the Package manifest file

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.collab-proxy": "1.2.15",
     "com.unity.package-manager-ui": "2.0.3",
     "com.unity.purchasing": "2.0.3",
-    "com.unity.textmeshpro": "1.3.0",
+    "com.unity.textmeshpro": "1.4.1",
     "com.unity.xr.openvr.standalone": "1.0.2",
     "com.unity.xr.windowsmr.metro": "1.0.12",
     "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
## Overview
Our Packages/manifest.json file has old TextMesh Pro version (1.3.0) which causes alignment issues on certain cases. Manually updating through Unity Package Manager resolves the issue.
Since there is no specific reason for keeping 1.3.0, updating it to the latest version 1.4.1.

## Changes
- Fixes: #5600 

![2019-08-12 15_24_38-](https://user-images.githubusercontent.com/13754172/62903336-25590800-bd17-11e9-8af4-268d67b935f7.png)
