### PR TITLE
Overlap does not check for SolverHandler.TransformTarget null

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Overlap.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Overlap.cs
@@ -10,8 +10,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     {
         public override void SolverUpdate()
         {
-            GoalPosition = SolverHandler.TransformTarget.position;
-            GoalRotation = SolverHandler.TransformTarget.rotation;
+            var target = SolverHandler.TransformTarget;
+            if (target != null)
+            {
+                GoalPosition = target.position;
+                GoalRotation = target.rotation;
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview
Overlap solver was not updated to check if TransformTarget could be null (i.e no hand is shown). This fix adds that check and adds SolverTest for this type of Solver

## Changes
- Fixes: #5604 

## Verification
All tests pass

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
