### PR TITLE
TryUnregisterModuleFolder now returns on path deletion

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -184,7 +184,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private static bool TryUnregisterModuleFolder(string folder)
         {
             string normalizedFolder = NormalizeSeparators(folder);
-            bool found = false;
+
             foreach (var modFolders in mrtkFolders)
             {
                 if (modFolders.Value.Remove(normalizedFolder))
@@ -193,11 +193,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     {
                         mrtkFolders.Remove(modFolders.Key);
                     }
-                    found = true;
+                    return true;
                 }
             }
-
-            return found;
+            return false;
         }
 
         private static string NormalizeSeparators(string path) => path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);


### PR DESCRIPTION
## Overview
The MixedRealityToolkitFiles.cs TryUnregisterModuleFolder iterates a foreach loop and deletes entries within it, but instead of exiting it sets a bool to true which it returns at the end continuing to iterate the loop resulting in an Exception.

## Changes
Now returns on entry find.


## Verification
I recognized that when I moved the MRTK generated folders over to another one and then removed the old folder.