### PR TITLE
Fix #5626: Discover and set virtual reality SDK(s) for the target platform

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -158,6 +158,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
         }
 
+        /// <summary>
+        /// Discover and set the appropriate XR Settings for the current build target.
+        /// </summary>
         private static void ApplyXRSettings()
         {
             BuildTargetGroup targetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Boo.Lang;
 using Microsoft.MixedReality.Toolkit.Editor;
 using System;
 using System.IO;
@@ -124,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         case 0:
                             EditorSettings.serializationMode = SerializationMode.ForceText;
                             EditorSettings.externalVersionControl = "Visible Meta Files";
-                            PlayerSettings.virtualRealitySupported = true;
+                            ApplyXRSettings();
                             PlayerSettings.stereoRenderingPath = StereoRenderingPath.Instancing;
                             refresh = true;
                             break;
@@ -154,6 +155,26 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             if (restart)
             {
                 EditorApplication.OpenProject(Directory.GetParent(Application.dataPath).ToString());
+            }
+        }
+
+        private static void ApplyXRSettings()
+        {
+            BuildTargetGroup targetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
+
+            List<string> targetSDKs = new List<string>();
+            foreach (string sdk in PlayerSettings.GetAvailableVirtualRealitySDKs(targetGroup))
+            {
+                if (sdk.Contains("OpenVR") || sdk.Contains("Windows"))
+                {
+                    targetSDKs.Add(sdk);
+                }
+            }
+
+            if (targetSDKs.Count != 0)
+            {
+                PlayerSettings.SetVirtualRealitySDKs(targetGroup, targetSDKs.ToArray());
+                PlayerSettings.SetVirtualRealitySupported(targetGroup, true);
             }
         }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Boo.Lang;
 using Microsoft.MixedReality.Toolkit.Editor;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;


### PR DESCRIPTION
This change asks Unity for the set of supported virtual reality SDKs for the currently selected target platform and then explicitly sets those that are supported by MRTK v2.

Unity 2018 set default SDKs, 2019 appers to no longer do so.

Fixes: #5626 

Verification:
* Clean Unity 2018 and 2019 projects
* Import private test foundation package
* Apply settings via dialog
* Confirm correct settings
* Switch platform (to uwp or to sdk based on original setting)
* Reload project
* Apply settings via dialog
* Confirm correct settings