### PR TITLE
Add a code validation step to the PR pipeline.

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using Boo.Lang;
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -5,6 +5,7 @@ parameters:
   buildUWPDotNet: true
   buildUWPX86: true
   runTests: true
+  validateCode: true
 
 steps:
 # Build Standalone x86.
@@ -21,6 +22,10 @@ steps:
 # notifications earlier in the CI process.
 - ${{ if eq(parameters.runTests, true) }}:
   - template: tests.yml
+
+# Validate that the code doesn't contain common issues
+- ${{ if eq(parameters.validateCode, true) }}:
+  - template: tasks/validatecode.yml
 
 # Build UWP x86
 - ${{ if eq(parameters.buildUWPX86, true) }}:

--- a/pipelines/templates/tasks/validatecode.yml
+++ b/pipelines/templates/tasks/validatecode.yml
@@ -1,0 +1,8 @@
+steps:
+- task: PowerShell@2
+  displayName: 'Validate code'
+  inputs:
+    targetType: filePath
+    filePath: ./scripts/ci/validatecode.ps1
+    arguments: >
+      -Directory: '$(Build.SourcesDirectory)\Assets'

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -16,6 +16,7 @@
     .\validatecode.ps1 -Directory c:\path\to\MRTK\Assets
 #>
 param(
+    [Parameter(Mandatory=$true)]
     [string]$Directory
 )
 
@@ -35,10 +36,6 @@ function CheckBooLang(
         return $true;
     }
     return $false
-}
-
-if (-not $Directory) {
-    throw "-Directory is a required flag"
 }
 
 function CheckFile(

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Validates the code to check for common patterns and usage that shouldn't be
+    checked in.
+.DESCRIPTION
+    This currently checks:
+
+    - That Boo.Lang isn't used anywhere in the code. This is an autocomplete option
+      that occurs when using Lists and other collections - the right thing to do
+      is to use System.Collections
+
+    Returns 0 if there are no issues, non-zero if there are.
+.PARAMETER Directory
+    The directory containing the code to validate. Only CSharp files
+.EXAMPLE
+    .\validatecode.ps1 -Directory c:\path\to\MRTK\Assets
+#>
+param(
+    [string]$Directory
+)
+
+function CheckBooLang(
+    [string]$FileName,
+    [string[]]$FileContent,
+    [int]$LineNumber
+) {
+    <#
+    .SYNOPSIS
+        Checks if the given file (at the given line number) contains a reference to Boo.Lang
+        Returns true if such a reference exists.
+    #>
+    if ($FileContent[$LineNumber] -match "^using Boo\.Lang;") {
+        Write-Host "An instance of Boo.Lang was found in $FileName at line $LineNumber "
+        Write-Host "Use System.Collections instead."
+        return $true;
+    }
+    return $false
+}
+
+if (-not $Directory) {
+    throw "-Directory is a required flag"
+}
+
+function CheckFile(
+    [string]$FileName
+) {
+    # Each line of each file is checked by all of the validators above - this ensures that in
+    # a single pass, we'll get all of the issues highlighted all at once, rather than
+    # repeatedly running this script, discovering a single issue, fixing it, and then
+    # re-running the script
+    $containsIssue = $false
+    $fileContent = Get-Content $FileName
+    for ($i = 0; $i -lt $fileContent.Length; $i++) {
+        if (CheckBooLang $FileName $fileContent $i) {
+            $containsIssue = $true
+        }
+    }
+    return $containsIssue
+}
+
+Write-Output "Checking $Directory for common code issues"
+
+$codeFiles = Get-ChildItem $Directory *.cs -Recurse | Select-Object FullName
+$containsIssue = $false
+foreach ($codeFile in $codeFiles) {
+    if (CheckFile $codeFile.FullName) {
+        $containsIssue = $true
+    }
+}
+
+if ($containsIssue) {
+    Write-Output "Issues found, please see above for details"
+    exit 1;
+}
+else {
+    Write-Output "No issues found"
+    exit 0;
+}


### PR DESCRIPTION
We've seen a couple of instances of Boo.Lang getting checked in, where we really should be using System.Collections. More generally, there can be other patterns that we may check in inadvertently that we should avoid going forward, and having this be checked by a linter/during the checkin pipeline is better than assuming that all PR will catch it.