### PR TITLE
Fix inspector event removal bug

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -322,7 +322,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                 for (int i = 0; i < events.arraySize; i++)
                 {
                     SerializedProperty eventItem = events.GetArrayElementAtIndex(i);
-                    InteractableReceiverListInspector.RenderEventSettings(eventItem, i, eventOptions, ChangeEvent, RemoveEvent);
+                    if (InteractableReceiverListInspector.RenderEventSettings(eventItem, i, eventOptions, ChangeEvent, RemoveEvent))
+                    {
+                        // If removed, skip rendering rest of list till next redraw
+                        break;
+                    }
                 }
                 GUI.enabled = true;
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs
@@ -18,6 +18,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         // indent tracker
         protected static int indentOnSectionStart = 0;
 
+        private static readonly GUIContent SelectEventLabel = new GUIContent("Select Event Type", "Select the event type from the list");
+
         protected virtual void OnEnable()
         {
             eventList = ((InteractableReceiverList)target).Events;
@@ -48,7 +50,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         removeEventRef = RemoveEvent;
                     }
 
-                    RenderEventSettings(eventItem, i, eventOptions, ChangeEvent, removeEventRef);
+                    if (RenderEventSettings(eventItem, i, eventOptions, ChangeEvent, removeEventRef))
+                    {
+                        // If removed, skip rendering rest of list till next redraw
+                        break;
+                    }
                 }
 
                 if (eventOptions.ClassNames.Length > 1)
@@ -125,66 +131,77 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
-        public static void RenderEventSettings(SerializedProperty eventItem, int index, InteractableTypesContainer options, InspectorUIUtility.MultiListButtonEvent changeEvent, InspectorUIUtility.ListButtonEvent removeEvent)
+        /// <summary>
+        /// Render event properties for the given event item. If item has been removed, returns true. False otherwise
+        /// </summary>
+        /// <param name="eventItem">serialized property of the event item to render properties from</param>
+        /// <param name="index">index of event item in higher order list</param>
+        /// <param name="options">Event type options</param>
+        /// <param name="changeEvent">Function to call if event properties have changed</param>
+        /// <param name="removeEvent">Function to call if event requested to be removed</param>
+        /// <returns>If item has been removed, returns true. False otherwise</returns>
+        public static bool RenderEventSettings(SerializedProperty eventItem, int index, InteractableTypesContainer options, InspectorUIUtility.MultiListButtonEvent changeEvent, InspectorUIUtility.ListButtonEvent removeEvent)
         {
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-
-            SerializedProperty uEvent = eventItem.FindPropertyRelative("Event");
-            SerializedProperty eventName = eventItem.FindPropertyRelative("Name");
-            SerializedProperty className = eventItem.FindPropertyRelative("ClassName");
-            SerializedProperty assemblyQualifiedName = eventItem.FindPropertyRelative("AssemblyQualifiedName");
-            SerializedProperty hideEvents = eventItem.FindPropertyRelative("HideUnityEvents");
-
-            // show event dropdown
-            int id = InspectorUIUtility.ReverseLookup(className.stringValue, options.ClassNames);
-
-            EditorGUILayout.BeginHorizontal();
-
-            Rect position = EditorGUILayout.GetControlRect();
-            GUIContent selectLabel = new GUIContent("Select Event Type", "Select the event type from the list");
-            EditorGUI.BeginProperty(position, selectLabel, className);
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {
-                //int newId = EditorGUI.Popup(position, selectLabel.text, id, options.ClassNames);
-                int newId = EditorGUI.Popup(position, id, options.ClassNames);
+                SerializedProperty uEvent = eventItem.FindPropertyRelative("Event");
+                SerializedProperty eventName = eventItem.FindPropertyRelative("Name");
+                SerializedProperty className = eventItem.FindPropertyRelative("ClassName");
+                SerializedProperty assemblyQualifiedName = eventItem.FindPropertyRelative("AssemblyQualifiedName");
+                SerializedProperty hideEvents = eventItem.FindPropertyRelative("HideUnityEvents");
 
-                if (id != newId || String.IsNullOrEmpty(className.stringValue))
+                // show event dropdown
+                int id = InspectorUIUtility.ReverseLookup(className.stringValue, options.ClassNames);
+
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    className.stringValue = options.ClassNames[newId];
-                    assemblyQualifiedName.stringValue = options.AssemblyQualifiedNames[newId];
+                    Rect position = EditorGUILayout.GetControlRect();
+                    EditorGUI.BeginProperty(position, SelectEventLabel, className);
+                    {
+                        int newId = EditorGUI.Popup(position, id, options.ClassNames);
 
-                    changeEvent(new int[] { index, newId }, eventItem);
+                        if (id != newId || String.IsNullOrEmpty(className.stringValue))
+                        {
+                            className.stringValue = options.ClassNames[newId];
+                            assemblyQualifiedName.stringValue = options.AssemblyQualifiedNames[newId];
+
+                            changeEvent(new int[] { index, newId }, eventItem);
+                        }
+
+                    }
+                    EditorGUI.EndProperty();
+
+                    if (removeEvent != null)
+                    {
+                        if (InspectorUIUtility.FlexButton(new GUIContent("Remove Event"), index, removeEvent))
+                        {
+                            return true;
+                        }
+                    }
+
+                }
+                EditorGUILayout.Space();
+
+                if (!hideEvents.boolValue)
+                {
+                    EditorGUILayout.PropertyField(uEvent, new GUIContent(eventName.stringValue));
                 }
 
-            }
-            EditorGUI.EndProperty();
-
-            if (removeEvent != null)
-            {
-                InspectorUIUtility.FlexButton(new GUIContent("Remove Event"), index, removeEvent);
-            }
-
-            EditorGUILayout.EndHorizontal();
-            EditorGUILayout.Space();
-
-            if (!hideEvents.boolValue)
-            {
-                EditorGUILayout.PropertyField(uEvent, new GUIContent(eventName.stringValue));
-            }
-
-            // show event properties
-            SerializedProperty eventSettings = eventItem.FindPropertyRelative("Settings");
-            for (int j = 0; j < eventSettings.arraySize; j++)
-            {
-                SerializedProperty propertyField = eventSettings.GetArrayElementAtIndex(j);
-                bool isEvent = InspectorFieldsUtility.IsPropertyType(propertyField, InspectorField.FieldTypes.Event);
-
-                if (!hideEvents.boolValue || !isEvent)
+                // show event properties
+                SerializedProperty eventSettings = eventItem.FindPropertyRelative("Settings");
+                for (int j = 0; j < eventSettings.arraySize; j++)
                 {
-                    InspectorFieldsUtility.DisplayPropertyField(eventSettings.GetArrayElementAtIndex(j));
+                    SerializedProperty propertyField = eventSettings.GetArrayElementAtIndex(j);
+                    bool isEvent = InspectorFieldsUtility.IsPropertyType(propertyField, InspectorField.FieldTypes.Event);
+
+                    if (!hideEvents.boolValue || !isEvent)
+                    {
+                        InspectorFieldsUtility.DisplayPropertyField(eventSettings.GetArrayElementAtIndex(j));
+                    }
                 }
             }
 
-            EditorGUILayout.EndVertical();
+            return false;
         }
         
         protected virtual void SetupEventOptions()


### PR DESCRIPTION
## Overview
When removing an interactable event receiver item, the for loop rendering will still proceed thinking the number of items in the list has not changed. Thus resulting in out of bounds index access. 

Fix now breaks out of rendering list till next redraw which happens immediately with changed object.

## Changes
- Fixes: #5634 

## Verification
One can now add and remove interactable event receivers 

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
