### PR TITLE
Fix 5625 - fix observer volume

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -679,20 +679,32 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         private void ConfigureObserverVolume()
         {
+            if ((CameraCache.Main == null) ||
+                (CameraCache.Main.transform == null) ||
+                (CameraCache.Main.transform.parent == null))
+            {
+                Debug.LogError("The main camera is not parented. Please ensure the camera is parented before setting the observer volume.");
+                return;
+            }
+
+            // The observer's origin is in world space, we need it in camera space
+            // to set the volume.
+            Vector3 observerOriginCameraSpace = CameraCache.Main.transform.parent.InverseTransformPoint(ObserverOrigin);
+
             // Update the observer
             switch(ObserverVolumeType)
             {
                 case VolumeType.AxisAlignedCube:
-                    observer.SetVolumeAsAxisAlignedBox(ObserverOrigin, ObservationExtents);
+                    observer.SetVolumeAsAxisAlignedBox(observerOriginCameraSpace, ObservationExtents);
                     break;
 
                 case VolumeType.Sphere:
                     // We use the x value of the extents as the sphere radius
-                    observer.SetVolumeAsSphere(ObserverOrigin, ObservationExtents.x);
+                    observer.SetVolumeAsSphere(observerOriginCameraSpace, ObservationExtents.x);
                     break;
 
                 case VolumeType.UserAlignedCube:
-                    observer.SetVolumeAsOrientedBox(ObserverOrigin, ObservationExtents, ObserverRotation);
+                    observer.SetVolumeAsOrientedBox(observerOriginCameraSpace, ObservationExtents, ObserverRotation);
                     break;
 
                 default:

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -679,32 +679,31 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         private void ConfigureObserverVolume()
         {
-            if ((CameraCache.Main == null) ||
-                (CameraCache.Main.transform == null) ||
-                (CameraCache.Main.transform.parent == null))
+            if (MixedRealityPlayspace.Transform == null)
             {
-                Debug.LogError("The main camera is not parented. Please ensure the camera is parented before setting the observer volume.");
+                Debug.LogError("Unexpected failure acquiring MixedRealityPlayspace.");
                 return;
             }
 
-            // The observer's origin is in world space, we need it in camera space
-            // to set the volume.
-            Vector3 observerOriginCameraSpace = CameraCache.Main.transform.parent.InverseTransformPoint(ObserverOrigin);
+            // The observer's origin is in world space, we need it in the camera's parent's space
+            // to set the volume. The MixedRealityPlayspace provides that space that the camera/head moves around in.
+            Vector3 observerOriginPlayspace = MixedRealityPlayspace.InverseTransformPoint(ObserverOrigin);
+            Quaternion observerRotationPlayspace = Quaternion.Inverse(MixedRealityPlayspace.Rotation) * ObserverRotation;
 
             // Update the observer
             switch(ObserverVolumeType)
             {
                 case VolumeType.AxisAlignedCube:
-                    observer.SetVolumeAsAxisAlignedBox(observerOriginCameraSpace, ObservationExtents);
+                    observer.SetVolumeAsAxisAlignedBox(observerOriginPlayspace, ObservationExtents);
                     break;
 
                 case VolumeType.Sphere:
                     // We use the x value of the extents as the sphere radius
-                    observer.SetVolumeAsSphere(observerOriginCameraSpace, ObservationExtents.x);
+                    observer.SetVolumeAsSphere(observerOriginPlayspace, ObservationExtents.x);
                     break;
 
                 case VolumeType.UserAlignedCube:
-                    observer.SetVolumeAsOrientedBox(observerOriginCameraSpace, ObservationExtents, ObserverRotation);
+                    observer.SetVolumeAsOrientedBox(observerOriginPlayspace, ObservationExtents, observerRotationPlayspace);
                     break;
 
                 default:

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessObserver.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessObserver.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         Quaternion ObserverRotation { get; set; }
 
         /// <summary>
-        /// Gets or sets the origin of the observer.
+        /// Gets or sets the origin, in World Space, of the observer.
         /// </summary>
         /// <remarks>
         /// Moving the observer origin allows the spatial awareness system to locate and discard meshes as the user

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessObserver.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/Observers/IMixedRealitySpatialAwarenessObserver.cs
@@ -47,8 +47,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         Vector3 ObservationExtents { get; set; }
 
         /// <summary>
-        /// Gets or sets the orientation of the volume.
+        /// Gets or sets the orientation of the volume in World Space. 
         /// </summary>
+        /// <remarks>
+        /// This is only used when <see cref="ObserverVolumeType"/> is set to <see cref="Microsoft.MixedReality.Toolkit.Utilities.VolumeType.UserAlignedCube"/>
+        /// </remarks>
         Quaternion ObserverRotation { get; set; }
 
         /// <summary>


### PR DESCRIPTION
- Document that the observer origin is in world space.
- Update the observer volume update to properly transform the coordinate space.

@fast-slow-still, can you please validate this change (review the code and test your scenario)?

Fixes: #5625 