### PR TITLE
Change GGVPointer rotation to closer match shell

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -194,6 +194,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             get
             {
+                // Previously we were simply returning the InternalGazeProvider rotation here.
+                // This caused issues when the head rotated, but the hand stayed where it was.
+                // Now we're returning a rotation based on the vector from the camera position
+                // to the hand. This rotation is not affected by rotating your head.
+                //
+                // The y value is set to 0 here as we want the rotation to be about the y axis.
+                // Without this, one-hand manipulating an object would give it unwanted x/z 
+                // rotations as you move your hand up and down.
                 Vector3 look = Position - CameraCache.Main.transform.position;
                 look.y = 0;
                 return Quaternion.LookRotation(look);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -190,7 +190,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public virtual Vector3 Position => sourcePosition;
 
         /// <inheritdoc />
-        public virtual Quaternion Rotation => Quaternion.LookRotation(gazeProvider.GazePointer.Rays[0].Direction);
+        public virtual Quaternion Rotation
+        {
+            get
+            {
+                Vector3 look = Position - CameraCache.Main.transform.position;
+                look.y = 0;
+                return Quaternion.LookRotation(look);
+            }
+        }
 
         #endregion
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var endBounds = bbox.GetComponent<BoxCollider>().bounds;
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");
-            TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .567f, "endBounds incorrect size");
+            TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size");
 
             GameObject.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var endBounds = bbox.GetComponent<BoxCollider>().bounds;
             TestUtilities.AssertAboutEqual(endBounds.center, new Vector3(0.033f, 0.033f, 1.467f), "endBounds incorrect center");
-            TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size");
+            TestUtilities.AssertAboutEqual(endBounds.size, Vector3.one * .561f, "endBounds incorrect size", 0.02f);
 
             GameObject.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -800,6 +800,60 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Assert scale at min
             Assert.AreEqual(Vector3.one * scaleHandler.ScaleMinimum, testObject.transform.localScale);
         }
+
+        /// <summary>
+        /// This test rotates the head without moving the hand.
+        /// This test is set up to test using the Gestures input simulation mode as this is
+        /// where we observed issues with this.
+        /// If the head rotates, without moving the hand, the grabbed object should not move.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerRotateHeadGGV()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Switch to Gestures
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldIsp = iss.InputSimulationProfile;
+            var isp = ScriptableObject.CreateInstance<MixedRealityInputSimulationProfile>();
+            isp.HandSimulationMode = HandSimulationMode.Gestures;
+            iss.InputSimulationProfile = isp;
+
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            testObject.transform.position = initialObjectPosition;
+
+            var manipHandler = testObject.AddComponent<ManipulationHandler>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+            
+            Vector3 originalHandPosition = new Vector3(0, 0, 0.5f);
+            TestHand hand = new TestHand(Handedness.Right);
+            const int numHandSteps = 1;
+
+            // Grab cube
+            yield return hand.Show(originalHandPosition);
+            yield return null;
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // Rotate Head and readjust hand
+            int numRotations = 10;
+            for (int i = 0; i < numRotations; i++)
+            {
+                MixedRealityPlayspace.Transform.Rotate(Vector3.up, 180 / numRotations);
+                yield return hand.MoveTo(originalHandPosition, numHandSteps);
+                yield return null;
+
+                // Test Object hasn't moved
+                TestUtilities.AssertAboutEqual(initialObjectPosition, testObject.transform.position, "Object moved while rotating head");
+            }
+
+            // Restore the input simulation profile
+            iss.InputSimulationProfile = oldIsp;
+            yield return null;
+        }
     }
 }
 #endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -823,6 +823,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one * 0.2f;
             Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
+            Quaternion initialObjectRotation = testObject.transform.rotation;
             testObject.transform.position = initialObjectPosition;
 
             var manipHandler = testObject.AddComponent<ManipulationHandler>();
@@ -848,6 +849,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                 // Test Object hasn't moved
                 TestUtilities.AssertAboutEqual(initialObjectPosition, testObject.transform.position, "Object moved while rotating head");
+                TestUtilities.AssertAboutEqual(initialObjectRotation, testObject.transform.rotation, "Object rotated while rotating head", 0.25f);
             }
 
             // Restore the input simulation profile

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -21,9 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public static class TestUtilities
     {
-        const float vector3DistanceEpsilon = 0.01f;
-        const float quaternionAngleEpsilon = 0.01f;
-
         const string primaryTestSceneTemporarySavePath = "Assets/__temp_primary_test_scene.unity";
         const string additiveTestSceneTemporarySavePath = "Assets/__temp_additive_test_scene_#.unity";
         public static Scene primaryTestScene;
@@ -192,28 +189,28 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 #endif
         }
 
-        public static void AssertAboutEqual(Vector3 actual, Vector3 expected, string message)
+        public static void AssertAboutEqual(Vector3 actual, Vector3 expected, string message, float tolerance = 0.01f)
         {
             var dist = (actual - expected).magnitude;
-            Debug.Assert(dist < vector3DistanceEpsilon, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
+            Debug.Assert(dist < tolerance, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
         }
 
-        public static void AssertAboutEqual(Quaternion actual, Quaternion expected, string message)
+        public static void AssertAboutEqual(Quaternion actual, Quaternion expected, string message, float tolerance = 0.01f)
         {
             var angle = Quaternion.Angle(actual, expected);
-            Debug.Assert(angle < quaternionAngleEpsilon, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
+            Debug.Assert(angle < tolerance, $"{message}, expected {expected.ToString("0.000")}, was {actual.ToString("0.000")}");
         }
 
-        public static void AssertNotAboutEqual(Vector3 val1, Vector3 val2, string message)
+        public static void AssertNotAboutEqual(Vector3 val1, Vector3 val2, string message, float tolerance = 0.01f)
         {
             var dist = (val1 - val2).magnitude;
-            Debug.Assert(dist >= vector3DistanceEpsilon, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
+            Debug.Assert(dist >= tolerance, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
         }
 
-        public static void AssertNotAboutEqual(Quaternion val1, Quaternion val2, string message)
+        public static void AssertNotAboutEqual(Quaternion val1, Quaternion val2, string message, float tolerance = 0.01f)
         {
             var angle = Quaternion.Angle(val1, val2);
-            Debug.Assert(angle >= quaternionAngleEpsilon, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
+            Debug.Assert(angle >= tolerance, $"{message}, val1 {val1.ToString("0.000")} almost equals val2 {val2.ToString("0.000")}");
         }
     }
 }


### PR DESCRIPTION
## Overview
- With articulated hands and 6dof controllers the pointer rotation is the hand/controller's rotation. This is used in `TwoHandMoveLogic` (which is also used for one hand) so that the object rotates around the pointer as it rotates:
![image](https://user-images.githubusercontent.com/47415945/63032849-8535e700-beae-11e9-8a84-6a3d5fbd3914.png)
- For GGV hands, the pointer rotation was the `InternalGazePointer` rotation, which meant that as you rotated your head, using the logic above, the object would rotate around your hand:
![image](https://user-images.githubusercontent.com/47415945/63033479-959a9180-beaf-11e9-9f0b-ab9d3b42fb27.png)
- These changes instead create a rotation out of the vector from the head to the hand, which rotates as you rotate your hand around your body but stable is if you only turn your head.
![image](https://user-images.githubusercontent.com/47415945/63034585-7f8dd080-beb1-11e9-9731-fdee1d92e760.png)

## Changes
- Fixes: #5640.