### PR TITLE
Fix 5641 - SceneSystem defined as a data provider

### DIFF
--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// This part handles the runtime parts of the service.
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SceneSystem/SceneSystemGettingStarted.html")]
-    public partial class MixedRealitySceneSystem : BaseCoreSystem, IMixedRealitySceneSystem
+    public partial class MixedRealitySceneSystem : BaseCoreSystem
     {
         /// <summary>
         /// Async load operation progress amount indicating that we're ready to activate a scene.

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// This part handles the runtime parts of the service.
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SceneSystem/SceneSystemGettingStarted.html")]
-    public partial class MixedRealitySceneSystem : BaseCoreSystem
+    public partial class MixedRealitySceneSystem : BaseCoreSystem, IMixedRealitySceneSystem
     {
         /// <summary>
         /// Async load operation progress amount indicating that we're ready to activate a scene.

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystem.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// The scene actions provided improve on unity's SceneManagement events by ensuring that scenes
     /// are considered valid before the action is invoked.
     /// </summary>
-    public interface IMixedRealitySceneSystem : IMixedRealityEventSystem, IMixedRealityEventSource, IMixedRealityService
+    public interface IMixedRealitySceneSystem : IMixedRealityEventSystem, IMixedRealityEventSource
     {
         #region Actions
 

--- a/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SceneSystem/IMixedRealitySceneSystem.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
     /// The scene actions provided improve on unity's SceneManagement events by ensuring that scenes
     /// are considered valid before the action is invoked.
     /// </summary>
-    public interface IMixedRealitySceneSystem : IMixedRealityEventSystem, IMixedRealityEventSource, IMixedRealityDataProvider
+    public interface IMixedRealitySceneSystem : IMixedRealityEventSystem, IMixedRealityEventSource, IMixedRealityService
     {
         #region Actions
 


### PR DESCRIPTION
IMixedRealitySceneSystem was defines as both a CoreSytem (inherits BaseCoreSystem) and an IMixedRealityDataProvider.

This is incorrect and was preventing the scene service from being loadable.