### PR TITLE
Fix keyboard show/hide for HL1 and WMR 

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         public void ShowKeyboard()
         {
-            // 8/14/2019: We show the keyboard even when the keyboard is already visible because on HoloLens 1
+            // 2019/08/14: We show the keyboard even when the keyboard is already visible because on HoloLens 1
             // and WMR the events OnKeyboardShowing and OnKeyboardHiding do not fire
             //if (state == KeyboardState.Showing)
             //{

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs
@@ -123,11 +123,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         public void ShowKeyboard()
         {
-            if (state == KeyboardState.Showing)
-            {
-                Debug.Log($"MixedRealityKeyboard.ShowKeyboard called but keyboard already visible");
-                return;
-            }
+            // 8/14/2019: We show the keyboard even when the keyboard is already visible because on HoloLens 1
+            // and WMR the events OnKeyboardShowing and OnKeyboardHiding do not fire
+            //if (state == KeyboardState.Showing)
+            //{
+            //    Debug.Log($"MixedRealityKeyboard.ShowKeyboard called but keyboard already visible.");
+            //    return;
+            //}
 
             State = KeyboardState.Showing;
 


### PR DESCRIPTION
# Overview
We want our windows system keyboard to work not just for HoloLens 2, but also for HoloLens (HL1) and Windows Mixed Reality (WHR). In HL1 and WMR there are OS bugs where the keyboard showing and hiding events do not fire. Our keyboard example was assuming those events fired correctly, and therefore not showing a keyboard in OnShow if the keyboard was visible. Remove this check.

## Changes
- Fixes: #5363


## Verification
Tested on HL1, HL2 and WMR