### PR TITLE
Fix extension services registration and documentation link

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/TestFixture_01_MixedRealityToolkitTests.cs
@@ -71,10 +71,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1(null, "Test ExtensionService 1",10, null));
 
             // Retrieve ITestExtensionService1
-            var extensionService1 = MixedRealityToolkit.Instance.GetService<ITestExtensionService1>();
-
-            // Tests
-            Assert.IsNotNull(extensionService1);
+            Assert.IsNotNull(MixedRealityToolkit.Instance.GetService<IMixedRealityExtensionService>());
+            Assert.IsNotNull(MixedRealityToolkit.Instance.GetService<ITestExtensionService1>());
+            Assert.IsNotNull(MixedRealityToolkit.Instance.GetService<TestExtensionService1>());
+            Assert.IsNotNull(MixedRealityToolkit.Instance.GetService<BaseExtensionService>());
             Assert.AreEqual(1, MixedRealityServiceRegistry.GetAllServices().Count);
         }
 
@@ -228,22 +228,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
 
             // Add test ExtensionService 1
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1(null, "Test14-1", 10, null));
+            string service1Name = "Test14-1";
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1(null, service1Name, 10, null));
 
             // Add test ExtensionService 2
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2(null, "Test14-2", 10, null));
+            string service2Name = "Test14-2";
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2(null, service2Name, 10, null));
 
             // Retrieve Test ExtensionService 2-2
-            var extensionService2 = (TestExtensionService2)MixedRealityToolkit.Instance.GetService<ITestExtensionService2>("Test14-2");
-
-            // ExtensionService 2-2 Tests
-            Assert.AreEqual("Test14-2", extensionService2.Name);
+            var extensionService2 = MixedRealityToolkit.Instance.GetService<ITestExtensionService2>(service2Name);
+            Assert.AreEqual(service2Name, extensionService2.Name);
+            Assert.IsNotNull(MixedRealityToolkit.Instance.GetService<IMixedRealityExtensionService>(service2Name));
 
             // Retrieve Test ExtensionService 2-1
-            var extensionService1 = (TestExtensionService1)MixedRealityToolkit.Instance.GetService<ITestExtensionService1>("Test14-1");
-
-            // ExtensionService 2-1 Tests
-            Assert.AreEqual("Test14-1", extensionService1.Name);
+            var extensionService1 = MixedRealityToolkit.Instance.GetService<ITestExtensionService1>(service1Name);
+            Assert.AreEqual(service1Name, extensionService1.Name);
         }
 
         [Test]

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly Color enabledColor = Color.white;
         private static readonly Color disabledColor = Color.gray;
         private static readonly Color readOnlyColor = Color.Lerp(enabledColor, Color.clear, 0.5f);
-        private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Utilities/ExtensionServiceCreationWizard.html";
+        private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Tools/ExtensionServiceCreationWizard.html";
         private static readonly Vector2 minWindowSize = new Vector2(500, 0);
         private const int docLinkWidth = 200;
 


### PR DESCRIPTION
## Overview
Extension services would all register under the interface type key IMixedRealityExtensionService. The MixedRealityServiceRegistry would only check under the interface key provided. This is problematic as a service may inherit and extend multiple interface types. Usage of GetService<MyInterfaceExtensionService>() and similar usage of TryGetService<MyInterfaceExtensionService> were broken.

This change extends the internal Registry TryGet* path to search all bins and return the first service found that matches the interface type and name query given. 

Furthermore, the tests were modified to check for more variety of GetService requests as well as the extension service documentation link fixed.

## Changes
- Fixes: #5644 , #5653 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
