### PR TITLE
Add service extension wizard known issue

### DIFF
--- a/Documentation/KnownIssues.md
+++ b/Documentation/KnownIssues.md
@@ -23,3 +23,14 @@ C:\src\project
 ```
 
 See [this issue](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5469) for more background information.
+
+## Extension Service Wizard
+
+When using the Extension Service Wizard,  *Generate Inspector* and/or *Generate Profile* are not actually optional. Trying to create an extension service with either of these deselected will result in an error on the following page. Furthermore, the extension service created for the user will create a property for the ScriptableObject profile that was not actually created. This results in a compiler error until the property line is removed. 
+
+Current workaround steps:
+
+1) Ignore error message in Extension Service Wizard
+2) Open up the *ExtensionService.cs file created and remove reference to the non-existent profile.
+
+Issue [#5654](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5654) is tracking this problem.


### PR DESCRIPTION
## Overview

Extension Service Wizard is broken for optional inspector and profile. This change adds information to the known issues list for GA

## Changes
Related #5654 


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
