### PR TITLE
Made InteractableStringTheme compatible with current button prefabs

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
@@ -36,8 +36,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             base.Init(host, settings);
 
-            mesh = Host.GetComponent<TextMesh>();
-            text = Host.GetComponent<Text>();
+            mesh = Host.GetComponentInChildren<TextMesh>();
+            text = Host.GetComponentInChildren<Text>();
         }
 
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return start;
             }
 
-            if (mesh != null)
+            if (text != null)
             {
                 start.String = text.text;
             }
@@ -65,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 mesh.text = property.Values[index].String;
                 return;
             }
-            if (mesh != null)
+            if (text != null)
             {
                 text.text = property.Values[index].String;
             }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
@@ -13,12 +13,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableStringTheme : InteractableThemeBase
     {
+        private TMPro.TextMeshPro meshPro;
         private TextMesh mesh;
         private Text text;
 
         public InteractableStringTheme()
         {
-            Types = new Type[] { typeof(TextMesh), typeof(Text) };
+            Types = new Type[] { typeof(TMPro.TextMeshPro), typeof(TextMesh), typeof(Text) };
             Name = "String Theme";
             NoEasing = true;
             ThemeProperties.Add(
@@ -36,6 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             base.Init(host, settings);
 
+            meshPro = Host.GetComponentInChildren<TMPro.TextMeshPro>();
             mesh = Host.GetComponentInChildren<TextMesh>();
             text = Host.GetComponentInChildren<Text>();
         }
@@ -44,6 +46,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
             start.String = "";
+
+            if (meshPro != null)
+            {
+                start.String = meshPro.text;
+                return start;
+            }
 
             if (mesh != null)
             {
@@ -60,7 +68,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
-            if(mesh != null)
+            if (meshPro != null)
+            {
+                meshPro.text = property.Values[index].String;
+                return;
+            }
+            if (mesh != null)
             {
                 mesh.text = property.Values[index].String;
                 return;


### PR DESCRIPTION
## Overview
Current button prefabs are making use of TMPro.TextMeshPro and a common principle is to bundle the label text and the label plate game objects in another container game object which is than used as the interactable's host component, e.g. the SeeItSayItLabel in PressableButtonHoloLens2.prefab.
The current version of InteractableStringTheme does not work with these prefabs.

## Changes
- Fixes: null check of optional components.
- Adds: support for text in TMPro.TextMeshPro components
- Adds: support for text components stored in container hierarchies