### PR TITLE
PressableButton MovingButtonVisuals inspector fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -50,6 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // Convert world to local distances and vice versa whenever we switch the mode
                 if (value != distanceSpaceMode)
                 {
+                    // NOTE: This code is copied/pasted in PressableButtonInspector because
+                    // the inspector can only modify the serialized field and not the property
                     distanceSpaceMode = value;
                     float scale = (distanceSpaceMode == SpaceMode.Local) ? WorldToLocalScale : LocalToWorldScale;
                     startPushDistance *= scale;
@@ -209,7 +211,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get { return movingButtonVisuals != null ? movingButtonVisuals.transform : transform; }
         }
 
-        private float WorldToLocalScale
+        /// <summary>
+        /// Transform for world to local space in the world direction of press
+        /// Multiply world scale positions by this value to convert to local space
+        /// </summary>
+        public float WorldToLocalScale
         {
             get
             {
@@ -217,7 +223,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
-        private float LocalToWorldScale
+        /// <summary>
+        /// Transform for local to world space in the world direction of a press
+        /// Multiply local scale positions by this value to convert to world space
+        /// </summary>
+        public float LocalToWorldScale
         {
             get
             {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -50,8 +50,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // Convert world to local distances and vice versa whenever we switch the mode
                 if (value != distanceSpaceMode)
                 {
-                    // NOTE: This code is copied/pasted in PressableButtonInspector because
-                    // the inspector can only modify the serialized field and not the property
                     distanceSpaceMode = value;
                     float scale = (distanceSpaceMode == SpaceMode.Local) ? WorldToLocalScale : LocalToWorldScale;
                     startPushDistance *= scale;
@@ -215,7 +213,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Transform for world to local space in the world direction of press
         /// Multiply world scale positions by this value to convert to local space
         /// </summary>
-        public float WorldToLocalScale
+        private float WorldToLocalScale
         {
             get
             {
@@ -227,7 +225,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Transform for local to world space in the world direction of a press
         /// Multiply local scale positions by this value to convert to world space
         /// </summary>
-        public float LocalToWorldScale
+        private float LocalToWorldScale
         {
             get
             {

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -254,9 +254,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.PropertyField(movingButtonVisuals);
             EditorGUILayout.LabelField("Press Settings", EditorStyles.boldLabel);
 
+            serializedObject.ApplyModifiedProperties();
+
             var pos = EditorGUILayout.GetControlRect();
-            // Utilize EditorGUI.BeginProperty to keep prefab bolding and other editor field tracking
-            EditorGUI.BeginProperty(pos, DistanceSpaceModeLabel, distanceSpaceMode);
+            // Utilize EditorGUI.PropertyScope to keep prefab bolding and other editor field tracking
+            using (var propertyScope = new EditorGUI.PropertyScope(pos, DistanceSpaceModeLabel, distanceSpaceMode))
             {
                 PressableButton.SpaceMode currentMode = button.DistanceSpaceMode;
                 // If user changes space mode, we want to call the property which will update the distance value appropriately
@@ -267,7 +269,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     distanceSpaceMode.enumValueIndex = (int)spaceMode;
                 }
             }
-            EditorGUI.EndProperty();
 
             // Leveraging button.DistanceSpaceMode setter modifies other component properties that need to be refreshed
             serializedObject.Update();

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -255,8 +255,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.LabelField("Press Settings", EditorStyles.boldLabel);
 
             EditorGUI.BeginChangeCheck();
+            var currentMode = distanceSpaceMode.intValue;
             EditorGUILayout.PropertyField(distanceSpaceMode);
-            if (EditorGUI.EndChangeCheck())
+            if (EditorGUI.EndChangeCheck() && currentMode != distanceSpaceMode.intValue)
             {
                 // Changing the DistanceSpaceMode requires updating the plane distance values so they stay in the same relative ratio positions
                 // NOTE: This is redundant code with the PressableButton.DistanceSpaceMode setter

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -262,16 +262,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (EditorGUI.EndChangeCheck() && currentMode != distanceSpaceMode.intValue)
             {
                 // Changing the DistanceSpaceMode requires updating the plane distance values so they stay in the same relative ratio positions
-                // NOTE: This is redundant code with the PressableButton.DistanceSpaceMode setter
-                // Unfortunately, the SerializedObject modifies the private serialized field and not the setter so we have to do the scaling manually
-                float scale = ((PressableButton.SpaceMode)distanceSpaceMode.enumValueIndex == PressableButton.SpaceMode.Local) ? button.WorldToLocalScale : button.LocalToWorldScale;
-
-                startPushDistance.floatValue *= scale;
-                maxPushDistance.floatValue *= scale;
-                pressDistance.floatValue *= scale;
-                releaseDistanceDelta.floatValue *= scale;
-
-                serializedObject.ApplyModifiedProperties();
+                Undo.RecordObject(target, string.Concat("Trigger Plane Distance Conversion of ", button.name));
+                button.DistanceSpaceMode = (PressableButton.SpaceMode)distanceSpaceMode.enumValueIndex;
+                serializedObject.Update();
             }
 
             DrawPropertiesExcluding(serializedObject, excludeProperties);

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -178,8 +178,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 Undo.RecordObject(target, string.Concat("Modify Button Planes of ", button.name));
 
-                Debug.Log("Modify button planes");
-
                 startPushDistance.floatValue = info.StartPushDistance;
                 maxPushDistance.floatValue = info.MaxPushDistance; 
                 pressDistance.floatValue = info.PressDistance;

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -257,11 +257,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUI.BeginChangeCheck();
             var currentMode = distanceSpaceMode.intValue;
             EditorGUILayout.PropertyField(distanceSpaceMode);
+            // EndChangeCheck returns true when something was selected in the dropdown, but
+            // doesn't necessarily mean that the value itself changed. Check for that too.
             if (EditorGUI.EndChangeCheck() && currentMode != distanceSpaceMode.intValue)
             {
                 // Changing the DistanceSpaceMode requires updating the plane distance values so they stay in the same relative ratio positions
                 // NOTE: This is redundant code with the PressableButton.DistanceSpaceMode setter
-                // Unfortunately, the serializedobject modifies the private serialized field and not the setter so we have to do the scaling manually
+                // Unfortunately, the SerializedObject modifies the private serialized field and not the setter so we have to do the scaling manually
                 float scale = ((PressableButton.SpaceMode)distanceSpaceMode.enumValueIndex == PressableButton.SpaceMode.Local) ? button.WorldToLocalScale : button.LocalToWorldScale;
 
                 startPushDistance.floatValue *= scale;


### PR DESCRIPTION
## Overview
Fixes an issue where you could not modify the Moving Button Visuals on a PressableButton.

## Changes
The call to serializedObject.Update() seems to revert the value, so to fix the issue I've called serializedObject.ApplyModifiedProperties() just after the EditorGUILayout.PropertyField() call which draws and modifies the Moving Button Visuals.  It's a bit unconventional to call ApplyModifiedProperties twice in a single call to OnInspectorGUI, but I don't think it will cause any issues.

@Troy-Ferrell, you introduced the call to serializedObject.Update() about a week ago.  I'm open to alternative suggestions for how to fix it if you have any concerns.

Also switch to PropertyScope instead of Begin/EndProperty