### PR TITLE
Move the platform capability documentation to the features section.

### DIFF
--- a/Documentation/DetectingPlatformCapabilities.md
+++ b/Documentation/DetectingPlatformCapabilities.md
@@ -1,4 +1,4 @@
-# Determining platform capabilities
+# Detecting platform capabilities
 
 A common question asked of the MRTK involves knowing which specific device (ex: Microsoft HoloLens 2) is being
 used to run an application. Identifying the exact hardware can be challenging on different platforms. The MRTK

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -17,10 +17,6 @@
     href: Architecture/Overview.md
   - name: Framework and Runtime
     href: Architecture/FrameworkAndRuntime.md
-  - name: Cross-platform
-    items:
-    - name: Platform Capabilities
-      href: Architecture/CrossPlatform/DeterminingPlatformCapabilities.md
   - name: Input System
     items:
     - name: Terminology
@@ -93,6 +89,8 @@
       href: README_HandInteractionExamples.md
     - name: Eye Tracking Interaction Example
       href: EyeTracking/EyeTracking_ExamplesOverview.md
+  - name: Detecting Platform Capabilities
+      href: DetectingPlatformCapabilities.md
   - name: MRTK Standard Shader
     href: README_MRTKStandardShader.md
   - name: Spatial Awareness
@@ -162,10 +160,6 @@
     href: Extensions/SceneTransitionService/SceneTransitionServiceOverview.md
   - name: Experimental Features
     href: ExperimentalFeatures.md
-  - name: Advanced topics
-    items:
-    - name: Shared Experiences
-      href: TODO.md
 - name: Contributing
   items:
   - name: Contributing Overview


### PR DESCRIPTION
This page wasn't really about the architecture of the MRTK at all, and interrupted the flow of reading through the architecture section (which is written in a way where each section builds off of the learnings from the previous page)

This also moves it into the root, because there isn't really a great place to stick this (i.e. it would be good to get a "features" folder to match the TOC, but I wanted to keep this particular change scoped) - cross platform was interesting but it doesn't really fulfill the cross-platform notion to consumers (i.e. I would think there would be more about cross-platform information here, but it's just a system capability checker, which exists even if things weren't cross platform)

Also removes references to TODO.md in the TOC