### PR TITLE
Add MRTK Profile tests: Default and HL1 profile

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -482,7 +482,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (Application.isPlaying)
             {
                 Debug.Assert(uiRaycastCamera == null);
-                FindOrCreateUiRaycastCamera();
+                CreateUiRaycastCamera();
             }
 
             var primaryPointerSelectorType = InputSystem?.InputSystemProfile.PointerProfile.PrimaryPointerSelector.Type;
@@ -606,19 +606,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Utility for creating the UIRaycastCamera.
         /// </summary>
         /// <returns>The UIRaycastCamera</returns>
-        private void FindOrCreateUiRaycastCamera()
+        private void CreateUiRaycastCamera()
         {
             GameObject cameraObject = null;
 
-            var existingUiRaycastCameraObject = GameObject.Find("UIRaycastCamera");
-            if (existingUiRaycastCameraObject != null)
-            {
-                cameraObject = existingUiRaycastCameraObject;
-            }
-            else
-            {
-                cameraObject = new GameObject { name = "UIRaycastCamera" };
-            }
+            cameraObject = new GameObject { name = "UIRaycastCamera" };
 
             uiRaycastCamera = cameraObject.EnsureComponent<Camera>();
             uiRaycastCamera.enabled = false;
@@ -900,7 +892,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     hitResult3d.Clear();
                     QueryScene(pointerData.Pointer, raycastProvider, prioritizedLayerMasks, hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
 
-                    if (pointerData.Pointer.PointerId == gazeProviderPointingData.Pointer.PointerId)
+                    if (pointerData.Pointer.PointerId == gazeProviderPointingData?.Pointer.PointerId)
                     {
                         gazeHitResult = hitResult3d;
                     }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -482,7 +482,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (Application.isPlaying)
             {
                 Debug.Assert(uiRaycastCamera == null);
-                CreateUiRaycastCamera();
+                FindOrCreateUiRaycastCamera();
             }
 
             var primaryPointerSelectorType = InputSystem?.InputSystemProfile.PointerProfile.PrimaryPointerSelector.Type;
@@ -606,11 +606,19 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Utility for creating the UIRaycastCamera.
         /// </summary>
         /// <returns>The UIRaycastCamera</returns>
-        private void CreateUiRaycastCamera()
+        private void FindOrCreateUiRaycastCamera()
         {
             GameObject cameraObject = null;
 
-            cameraObject = new GameObject { name = "UIRaycastCamera" };
+            var existingUiRaycastCameraObject = GameObject.Find("UIRaycastCamera");
+            if (existingUiRaycastCameraObject != null)
+            {
+                cameraObject = existingUiRaycastCameraObject;
+            }
+            else
+            {
+                cameraObject = new GameObject { name = "UIRaycastCamera" };
+            }
 
             uiRaycastCamera = cameraObject.EnsureComponent<Camera>();
             uiRaycastCamera.enabled = false;
@@ -892,7 +900,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     hitResult3d.Clear();
                     QueryScene(pointerData.Pointer, raycastProvider, prioritizedLayerMasks, hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
 
-                    if (pointerData.Pointer.PointerId == gazeProviderPointingData?.Pointer.PointerId)
+                    if (pointerData.Pointer.PointerId == gazeProviderPointingData.Pointer.PointerId)
                     {
                         gazeHitResult = hitResult3d;
                     }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.MixedReality.Toolkit.UI;
+using UnityEditor;
+using Microsoft.MixedReality.Toolkit.Editor;
+using System.Linq;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class ProfileTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            TestUtilities.InitializeMixedRealityToolkit(true);
+            TestUtilities.PlayspaceToOriginLookingForward();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+        }
+
+        private const string HoloLens1ProfileName = "DefaultHoloLens1ConfigurationProfile";
+        /// <summary>
+        /// Test that HoloLens 1 profile acts as expected (e.g. when hands are up there are no hand rays)
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestHL1Profile()
+        {
+            var hl1Profile = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitConfigurationProfile>()
+                .FirstOrDefault(x => x.name.Equals(HoloLens1ProfileName));
+            MixedRealityToolkit.Instance.ActiveProfile = hl1Profile;
+
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(Vector3.forward);
+
+            // https://nunit.org/docs/2.5.5/collectionConstraints.html
+            foreach(var i in CoreServices.InputSystem.DetectedInputSources)
+            {
+                Assert.That(i.Pointers, Has.Some.InstanceOf(typeof(GGVPointer)));
+                Assert.That(i.Pointers, Has.No.InstanceOf(typeof(ShellHandRayPointer)));
+            }
+        }
+    }
+}
+
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs
@@ -17,8 +17,6 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using System.Collections;
 using System.Collections.Generic;
-using Microsoft.MixedReality.Toolkit.UI;
-using UnityEditor;
 using Microsoft.MixedReality.Toolkit.Editor;
 using System.Linq;
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs
@@ -24,11 +24,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class ProfileTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-        }
-
         [TearDown]
         public void TearDown()
         {

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ProfileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d11fded332d4b8446a9b10751a9e4399
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             InitializeMixedRealityToolkit(useDefaultProfile);
         }
 
-        public static void InitializeMixedRealityToolkit(bool useDefaultProfile = false)
+        public static void InitializeMixedRealityToolkit(MixedRealityToolkitConfigurationProfile configuration)
         {
             if (!MixedRealityToolkit.IsInitialized)
             {
@@ -154,19 +154,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 BaseEventSystem.enableDanglingHandlerDiagnostics = true;
             }
 
-            // Tests
             Assert.IsTrue(MixedRealityToolkit.IsInitialized);
             Assert.IsNotNull(MixedRealityToolkit.Instance);
-            if (!MixedRealityToolkit.Instance.HasActiveProfile)
-            {
-                var configuration = useDefaultProfile
-                    ? GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>()
-                    : ScriptableObject.CreateInstance<MixedRealityToolkitConfigurationProfile>();
 
-                Assert.IsTrue(configuration != null, "Failed to find the Default Mixed Reality Configuration Profile");
-                MixedRealityToolkit.Instance.ActiveProfile = configuration;
-                Assert.IsTrue(MixedRealityToolkit.Instance.ActiveProfile != null);
-            }
+
+            MixedRealityToolkit.Instance.ActiveProfile = configuration;
+            Assert.IsTrue(MixedRealityToolkit.Instance.ActiveProfile != null);
+        }
+
+        public static void InitializeMixedRealityToolkit(bool useDefaultProfile = false)
+        {
+            var configuration = useDefaultProfile
+                ? GetDefaultMixedRealityProfile<MixedRealityToolkitConfigurationProfile>()
+                : ScriptableObject.CreateInstance<MixedRealityToolkitConfigurationProfile>();
+
+            Assert.IsTrue(configuration != null, "Failed to find the Default Mixed Reality Configuration Profile");
+            InitializeMixedRealityToolkit(configuration);
         }
 
         public static void ShutdownMixedRealityToolkit()


### PR DESCRIPTION
## Overview
Add test to ensure we don't hit issue #5671 again. The test just loads up MRTK with the default & HoloLens 1 profiles, and ensures that when hands show up that the rays do / do not show up as well.

## Changes
- Fixes: #5671


## Verification
Verified that playmode and editmode tests pass locally.
