### PR TITLE
Remove TODO.md from the documentation.

### DIFF
--- a/Documentation/Boundary/ConfiguringBoundaryVisualization.md
+++ b/Documentation/Boundary/ConfiguringBoundaryVisualization.md
@@ -111,4 +111,3 @@ The layer on which the boundary walls should be set. The default value is the Ig
 ## See Also
 
 - [Boundary System](BoundarySystemGettingStarted.md)
-- [Using Boundaries in an Application](../TODO.md)

--- a/Documentation/InputSimulation/InputSimulationService.md
+++ b/Documentation/InputSimulation/InputSimulationService.md
@@ -14,7 +14,7 @@ Users can use a conventional keyboard and mouse combination to control simulated
 
 Input simulation is enabled by default in MRTK.
 
-Input simulation is an optional [Mixed Reality service](../MixedRealityServices.md). It can be added as a data provider in the [Input System profile](../TODO.md).
+Input simulation is an optional [Mixed Reality service](../MixedRealityServices.md). It can be added as a data provider in the [Input System profile](../Input/InputProviders.md).
 * __Type__ must be _Microsoft.MixedReality.Toolkit.Input > InputSimulationService_.
 * __Platform(s)__ should always be _Windows Editor_ since the service depends on keyboard and mouse input.
 * __Profile__ has all settings for input simulation.

--- a/Documentation/TODO.md
+++ b/Documentation/TODO.md
@@ -1,2 +1,0 @@
-# Coming Soon!
-We're currently restructuring and improving the MRTK documentation. This content will be available soon. If you have any questions regarding this section please post in our MRTK slack channel.

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -162,10 +162,6 @@
     href: Extensions/SceneTransitionService/SceneTransitionServiceOverview.md
   - name: Experimental Features
     href: ExperimentalFeatures.md
-  - name: Advanced topics
-    items:
-    - name: Shared Experiences
-      href: TODO.md
 - name: Contributing
   items:
   - name: Contributing Overview


### PR DESCRIPTION
A couple of things this changes:
1) Removes TODO.md, which is a catch-all and is a crutch for folks who are writing docs. Inevitablty people forget to update their TODOs and this leads to stale and not-confidence-inspring experiences reading a TODO.
2) Removes existing usages of TODO, either by deleting them outright or updating them to point to the most relevant things that exist on our docs.