### PR TITLE
Remove SceneManager and LightingManager in default build

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,12 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/MixedRealityToolkit.SDK/StandardAssets/Scenes/DefaultManagerScene.unity
-    guid: ae7bb08d297fb69408695d8de0962524
-  - enabled: 1
-    path: Assets/MixedRealityToolkit.SDK/StandardAssets/Scenes/DefaultLightingScene.unity
-    guid: 7e54e36c44f826c438c95da79f8de638
-  - enabled: 1
     path: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
     guid: 3dd4a396b5225f8469b9a1eb608bfa57
   m_configObjects: {}


### PR DESCRIPTION
## Overview
MRTK devs need to regularly remove these two scenes when building and deploying: 
![image](https://user-images.githubusercontent.com/168492/63189477-ebd71400-c018-11e9-9695-c925136f7cd2.png)

Remove those from the defaults, they don't seem to be needed for day to day development.

- Fixes: #5685
