### PR TITLE
Update the eye tracking sample docs to reference the Gaze Input capability

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
+++ b/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
@@ -64,8 +64,8 @@ We provide basic examples for logging and loading eye tracking data and examples
 
 ### Prerequisites
 
-Note that using the eye tracking samples on device requires a device that supports
-eye tracking and a sample app package that is built with the "Gaze Input" capability
+Note that using the eye tracking samples on device requires a HoloLens 2
+and a sample app package that is built with the "Gaze Input" capability
 on the package's AppXManifest.
 
 In order to use these eye tracking samples on device, make sure to follow

--- a/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
+++ b/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
@@ -62,6 +62,16 @@ We provide basic examples for logging and loading eye tracking data and examples
 
 ## Setting up the MRTK eye tracking samples
 
+### Prerequisites
+
+Note that using the eye tracking samples on device requires a device that supports
+eye tracking and a sample app package that is built with the "Gaze Input" capability
+on the package's AppXManifest.
+
+In order to use these eye tracking samples on device, make sure to follow
+[these steps](EyeTracking_BasicSetup.md#testing-your-unity-app-on-a-hololens-2)
+prior to building the app in Visual Studio.
+
 ### 1. Load EyeTrackingDemo-00-RootScene.unity
 The *EyeTrackingDemo-00-RootScene* is the base (_root_) scene that has all the core MRTK components included.
 This is the scene that you need to load first and from which you will run the eye tracking demos. 


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4960

Just like building an eye tracking app from scratch, using the samples also requires the Gaze Input capability, but it isn't mentioned in the docs. As a result, people using the samples on device will wonder why it doesn't work (because we didn't tell them to use that special capability)