### PR TITLE
Update the README's docs and API reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MRTK-Unity is a Microsoft driven project that provides a set of components and f
 
 # Getting Started with MRTK
 
-| [![Getting Started](Documentation/Images/MRTK_Icon_GettingStarted.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)<br/>[MRTK Getting Started Guide](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)| [![Getting Started](Documentation/Images/MRTK_Icon_Documentation.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/)<br/>[MRTK Documentation](https://microsoft.github.io/MixedRealityToolkit-Unity/)|
+| [![Getting Started and Documentation](Documentation/Images/MRTK_Icon_GettingStarted.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)<br/>[Getting Started Guide and Documentation](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)| [![Getting Started and Documentation](Documentation/Images/MRTK_Icon_Documentation.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/api/Microsoft.MixedReality.Toolkit.html)<br/>[API Reference](https://microsoft.github.io/MixedRealityToolkit-Unity/api/Microsoft.MixedReality.Toolkit.html)|
 |:---|:---|
 
 # Build Status


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4968

As the linked issue suggestions, the current "documentation" link is really confusing because it basically is a circular reference - it brings you right back to the curent page.

The tricky part here is that the Getting started guide is probably the best landing page for the documentation we have - it is still helpful to have a reference to the API, so the second link should probably be "API Reference"

If you want to see what this is addressing, go to the readme (on github) and just click the documentation image - it will keep bringing you right to the same place (as the README.md that it took you from)