### PR TITLE
Fixed BoundingBox Bounds calculation

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1739,7 +1739,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                     else
                     {
-                        continue;
+                        colliderByTransform = new KeyValuePair<Transform, Collider>();
                     }
                 }
 
@@ -1752,7 +1752,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                     else
                     {
-                        continue;
+                        rendererBoundsByTransform = new KeyValuePair<Transform, Bounds>();
                     }
                 }
 
@@ -1793,6 +1793,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AddRendererBoundsToTarget(KeyValuePair<Transform, Bounds> rendererBoundsByTarget)
         {
+            if (rendererBoundsByTarget.Key == null) { return; }
+
             Vector3[] cornersToWorld = null;
             rendererBoundsByTarget.Value.GetCornerPositions(rendererBoundsByTarget.Key, ref cornersToWorld);
             totalBoundsCorners.AddRange(cornersToWorld);
@@ -1800,7 +1802,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AddColliderBoundsToTarget(KeyValuePair<Transform, Collider> colliderByTransform)
         {
-            BoundsExtensions.GetColliderBoundsPoints(colliderByTransform.Value, totalBoundsCorners, 0);
+            if (colliderByTransform.Key != null)
+            {
+                BoundsExtensions.GetColliderBoundsPoints(colliderByTransform.Value, totalBoundsCorners, 0);
+            }
         }
 
         private void SetMaterials()


### PR DESCRIPTION
## Overview
The current, newly implemented algorithm for calculating BoundingBox bounds has a bug this fix addresses.
The code was written in a way that if a gameobject considered for bounds calculation did not have a collider, it skipped the MeshRenderer completely, even though the default configuration is "RendererOverCollider".
This means, meshes without colliders resulted in a zero bounds calculation.

This fixes that problem.

P.S.: the fact that every combination of Renderers and Colliders is possible, one or both must be fetched and then applied in according order. Continuing anything here was a mistake.