### PR TITLE
added release 2.0.0 / ga to version dropdown in docs

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -51,11 +51,13 @@
       "_disableNavbar": false,
       "_appLogoPath": "Documentation/Images/mrt_logo_icon.png",
       "_appFaviconPath": "Documentation/Images/favicon.ico",
-      // remove this section if you want to restore default behavior which publishes a version of the docs that keeps the "improve this doc" link pointing to the publishing branch
+      // section contribute start
+	  // remove this section if you want to restore default behavior which publishes a version of the docs that keeps the "improve this doc" link pointing to the publishing branch
       "_gitContribute": {
         "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity",
         "branch": "mrtk_development"
       }
+	  // section contribute end
     },
     "markdownEngineName": "markdig",
     "dest": "doc",

--- a/docfx.json
+++ b/docfx.json
@@ -50,12 +50,12 @@
       "_enableSearch": true,
       "_disableNavbar": false,
       "_appLogoPath": "Documentation/Images/mrt_logo_icon.png",
-      "_appFaviconPath": "Documentation/Images/favicon.ico"
+      "_appFaviconPath": "Documentation/Images/favicon.ico",
       // re-add this section if you want to publish a version of the docs that keeps the "improve this doc" link pointing to mrtk_development branch
-      //"_gitContribute": {
-      //  "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity",
-      //  "branch": "mrtk_development"
-      //}
+      "_gitContribute": {
+        "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity",
+        "branch": "mrtk_development"
+      }
     },
     "markdownEngineName": "markdig",
     "dest": "doc",

--- a/docfx.json
+++ b/docfx.json
@@ -51,7 +51,7 @@
       "_disableNavbar": false,
       "_appLogoPath": "Documentation/Images/mrt_logo_icon.png",
       "_appFaviconPath": "Documentation/Images/favicon.ico",
-      // re-add this section if you want to publish a version of the docs that keeps the "improve this doc" link pointing to mrtk_development branch
+      // remove this section if you want to restore default behavior which publishes a version of the docs that keeps the "improve this doc" link pointing to the publishing branch
       "_gitContribute": {
         "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity",
         "branch": "mrtk_development"

--- a/web/version.js
+++ b/web/version.js
@@ -3,7 +3,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; 	// title in the dropdown for the root version of the docs
-	var versionArray = ["2.0.0"];	// list of all versions in the version folder
+	var versionArray = ["prerelease/2.0.0_stabilization"];	// list of all versions in the version folder
 	
 	//--------------------------------------
 

--- a/web/version.js
+++ b/web/version.js
@@ -3,7 +3,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; 	// title in the dropdown for the root version of the docs
-	var versionArray = [];	// list of all versions in the version folder
+	var versionArray = ["2.0.0"];	// list of all versions in the version folder
 	
 	//--------------------------------------
 


### PR DESCRIPTION
-adjusted contribute link to always point to mrtk_development
-added version 2.0.0 ga drop down

