### PR TITLE
Add daily build with ARM64 build flavour

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -260,6 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     case "-x86":
                     case "-x64":
                     case "-arm":
+                    case "-arm64":
                         buildInfo.BuildPlatform = arguments[i].Substring(1);
                         break;
                     case "-debug":

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -237,7 +237,16 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 rootNode.Add(propertyGroupNode);
             }
 
-            propertyGroupNode.Add(new XElement(defaultNamespace + "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch", "None"));
+            var newNode = propertyGroupNode.Element(defaultNamespace + "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch");
+            if (newNode != null)
+            {
+                // If this setting already exists in the project, ensure it's value is "None"
+                newNode.Value = "None";
+            }
+            else
+            {
+                propertyGroupNode.Add(new XElement(defaultNamespace + "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch", "None"));
+            }
 
             rootNode.Save(projectFilePath);
 

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -97,6 +97,15 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 return false;
             }
 
+            // Need to add ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch to MixedRealityToolkit.vcxproj
+            if (buildInfo.BuildPlatform == "arm64")
+            {
+                if (!UpdateVSProj(buildInfo))
+                {
+                    return IsBuilding = false;
+                }
+            }
+
             // Now that NuGet packages have been restored, we can run the actual build process.
             exitCode = await Run(msBuildPath, 
                 $"\"{solutionProjectPath}\" {(buildInfo.Multicore ? "/m /nr:false" : "")} /t:{(buildInfo.RebuildAppx ? "Rebuild" : "Build")} /p:Configuration={buildInfo.Configuration} /p:Platform={buildInfo.BuildPlatform} {(string.IsNullOrEmpty(buildInfo.PlatformToolset) ? string.Empty : $"/p:PlatformToolset={buildInfo.PlatformToolset}")} {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "buildAppx.log")}",
@@ -202,6 +211,37 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             }
 
             return string.Empty;
+        }
+
+        private static bool UpdateVSProj(IBuildInfo buildInfo)
+        {
+            // For ARM64 builds we need to add ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch
+            // to vcxproj file in order to ensure that the build passes
+
+            string projectName = PlayerSettings.productName;
+            string projectFilePath = $"{Path.GetFullPath(buildInfo.OutputDirectory)}\\{projectName}\\{projectName}.vcxproj";
+
+            if (!File.Exists(projectFilePath))
+            {
+                Debug.LogError($"Cannot find project file: {projectFilePath}");
+                return false;
+            }
+
+            var rootNode = XElement.Load(projectFilePath);
+            var defaultNamespace = rootNode.GetDefaultNamespace();
+            var propertyGroupNode = rootNode.Element(defaultNamespace + "PropertyGroup");
+            
+            if (propertyGroupNode == null)
+            {
+                propertyGroupNode = new XElement(defaultNamespace + "PropertyGroup", new XAttribute("Label", "Globals"));
+                rootNode.Add(propertyGroupNode);
+            }
+
+            propertyGroupNode.Add(new XElement(defaultNamespace + "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch", "None"));
+
+            rootNode.Save(projectFilePath);
+
+            return true;
         }
 
         private static bool UpdateAppxManifest(IBuildInfo buildInfo)

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -1,21 +1,23 @@
-# CI build producing developer packages.
+# CI build for developer builds.
 
 variables:
   Unity2018Version: Unity2018.3.7f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.2.0
+  MRTKVersion: 2.0.0
+  packagingEnabled: false
 
 jobs:
 - job: CIDeveloperValidation
   timeoutInMinutes: 90
   pool:
-    name: Analog On-Prem
+    name: On-Prem Unity
     demands:
     - Unity2018.3.7f1
+    - Unity2019.2.0f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
   - template: templates/ci-common.yml
     parameters:
-      packagingEnabled: true
-      packagePublishing: true
+      packagingEnabled: false
+      daily: true

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -7,17 +7,29 @@ variables:
   packagingEnabled: false
 
 jobs:
-- job: CIDeveloperValidation
+- job: DailyUnity2019Validation
+  timeoutInMinutes: 120
+  pool:
+    name: On-Prem Unity
+    demands:
+    - Unity2019.2.0f1
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+  steps:
+  - template: templates/common-Unity2019.yml
+    parameters:
+      packagingEnabled: false
+
+- job: DailyUnity2018Validation
   timeoutInMinutes: 120
   pool:
     name: On-Prem Unity
     demands:
     - Unity2018.3.7f1
-    - Unity2019.2.0f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
   - template: templates/ci-common.yml
     parameters:
       packagingEnabled: false
-      daily: true
+      

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -8,7 +8,7 @@ variables:
 
 jobs:
 - job: CIDeveloperValidation
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   pool:
     name: On-Prem Unity
     demands:

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -1,7 +1,8 @@
 # CI build producing developer packages.
 
 variables:
-  UnityVersion: Unity2018.3.7f1
+  Unity2018Version: Unity2018.3.7f1
+  Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.2.0
 
 jobs:

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -1,7 +1,8 @@
 # CI build producing developer packages.
 
 variables:
-  UnityVersion: Unity2018.3.7f1
+  Unity2018Version: Unity2018.3.7f1
+  Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.2.0
 
 jobs:

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -1,7 +1,8 @@
 # CI build for release packages.
 
 variables:
-  UnityVersion: Unity2018.3.7f1
+  Unity2018Version: Unity2018.3.7f1
+  Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.2.0  # Major.Minor.Patch
   MRTKReleaseTag: 'alpha'  # final version component, e.g. 'RC2.1' or empty string
 

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -1,7 +1,8 @@
 # CI build for developer builds.
 
 variables:
-  UnityVersion: Unity2018.3.7f1
+  Unity2018Version: Unity2018.3.7f1
+  Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.2.0
   packagingEnabled: false
 

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,7 +1,8 @@
 # Build for PR validation.
 
 variables:
-  UnityVersion: Unity2018.3.7f1
+  Unity2018Version: Unity2018.3.7f1
+  Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.2.0
 
 jobs:

--- a/pipelines/templates/assetretargeting.yml
+++ b/pipelines/templates/assetretargeting.yml
@@ -3,7 +3,7 @@
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:$(UnityVersion)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    $outDir = "$(Build.ArtifactStagingDirectory)\build"
    $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -2,12 +2,9 @@
 parameters:
   packagingEnabled: true
   packagePublishing: true
-  daily: false
 
 steps:
 - template: common.yml
-- ${{ if eq(parameters.daily, true) }}:
-  - template: daily.yml
 - template: compilemsbuild.yml
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/unitypackages.yml

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -2,9 +2,12 @@
 parameters:
   packagingEnabled: true
   packagePublishing: true
+  daily: false
 
 steps:
 - template: common.yml
+- ${{ if eq(parameters.daily, true) }}:
+  - template: daily.yml
 - template: compilemsbuild.yml
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/unitypackages.yml

--- a/pipelines/templates/common-Unity2019.yml
+++ b/pipelines/templates/common-Unity2019.yml
@@ -7,5 +7,11 @@ steps:
     Arch: 'arm64'
     Platform: 'UWP'
     PackagingDir: 'ARM64'
-    UnityVer: 'Unity2019'
+    UnityVer: ${Env:$(Unity2019Version)}
     PublishArtifacts: true
+
+- template: tests.yml
+  parameters:
+    UnityVer: ${Env:$(Unity2019Version)}
+
+- template: end.yml

--- a/pipelines/templates/daily.yml
+++ b/pipelines/templates/daily.yml
@@ -1,0 +1,17 @@
+# [Template] Common build tasks shared between CI builds and PR validation.
+
+steps:
+# Build UWP x64.
+- template: tasks/unitybuild.yml
+  parameters:
+    Arch: 'x64'
+    Platform: 'UWP'
+    PublishArtifacts: true
+
+# Build UWP x86 .NET backend
+- template: tasks/unitybuild.yml
+  parameters:
+    Arch: 'x86'
+    Platform: 'UWP'
+    PublishArtifacts: true
+    ScriptingBackend: '.NET'

--- a/pipelines/templates/daily.yml
+++ b/pipelines/templates/daily.yml
@@ -1,17 +1,10 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
 
 steps:
-# Build UWP x64.
+# Build UWP ARM64.
 - template: tasks/unitybuild.yml
   parameters:
-    Arch: 'x64'
+    Arch: 'arm64'
     Platform: 'UWP'
+    Unity2019: true
     PublishArtifacts: true
-
-# Build UWP x86 .NET backend
-- template: tasks/unitybuild.yml
-  parameters:
-    Arch: 'x86'
-    Platform: 'UWP'
-    PublishArtifacts: true
-    ScriptingBackend: '.NET'

--- a/pipelines/templates/daily.yml
+++ b/pipelines/templates/daily.yml
@@ -6,5 +6,6 @@ steps:
   parameters:
     Arch: 'arm64'
     Platform: 'UWP'
-    Unity2019: true
+    PackagingDir: 'ARM64'
+    UnityVer: 'Unity2019'
     PublishArtifacts: true

--- a/pipelines/templates/generateprojects.yml
+++ b/pipelines/templates/generateprojects.yml
@@ -3,7 +3,7 @@
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:$(UnityVersion)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    $outDir = "$(Build.ArtifactStagingDirectory)\build"
    $logFile = New-Item -Path "$outDir\build\projectgeneration_log.log" -ItemType File -Force

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -7,18 +7,18 @@ parameters:
   ScriptingBackend: 'default'  # [optional] default|.NET
   PublishArtifacts: false
   PackagingDir: 'Win32'
-  Unity2019: false
+  UnityVer: 'Unity2018'
 
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   If (${parameters.Unity2019})
-   {
-       $editor = Get-ChildItem ${Env:$(Unity2019Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   }
-   Else
+   If ("${{ parameters.UnityVer }}" -eq "Unity2018")
    {
        $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   }
+   ElseIf ("${{ parameters.UnityVer }}" -eq "Unity2019")
+   {
+       $editor = Get-ChildItem ${Env:$(Unity2019Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    }
    
    # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
@@ -44,7 +44,7 @@ steps:
        $extraArgs += " ${{ parameters.UnityArgs }}"
    }
 
-   If ("${{  parameters.ScriptingBackend }}" -eq ".NET")
+   If ("${{ parameters.ScriptingBackend }}" -eq ".NET")
    {
        $extraArgs += " -scriptingBackend 2"
    }

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -7,19 +7,12 @@ parameters:
   ScriptingBackend: 'default'  # [optional] default|.NET
   PublishArtifacts: false
   PackagingDir: 'Win32'
-  UnityVer: 'Unity2018'
+  UnityVer: ${Env:$(Unity2018Version)}
 
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   If ("${{ parameters.UnityVer }}" -eq "Unity2018")
-   {
-       $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   }
-   ElseIf ("${{ parameters.UnityVer }}" -eq "Unity2019")
-   {
-       $editor = Get-ChildItem ${Env:$(Unity2019Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   }
+   $editor = Get-ChildItem ${{ parameters.UnityVer }} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
    # each build will have a fresh destination folder.

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -7,11 +7,19 @@ parameters:
   ScriptingBackend: 'default'  # [optional] default|.NET
   PublishArtifacts: false
   PackagingDir: 'Win32'
+  Unity2019: false
 
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:$(UnityVersion)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   If (${parameters.Unity2019})
+   {
+       $editor = Get-ChildItem ${Env:$(Unity2019Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   }
+   Else
+   {
+       $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   }
    
    # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
    # each build will have a fresh destination folder.

--- a/pipelines/templates/tests.yml
+++ b/pipelines/templates/tests.yml
@@ -2,7 +2,7 @@
 
 steps:
 - powershell: |
-   $editor = Get-ChildItem ${Env:$(UnityVersion)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    Write-Host "======================= EditMode Tests ======================="
    
@@ -26,7 +26,7 @@ steps:
   displayName: 'Run EditMode tests'
 
 - powershell: |
-   $editor = Get-ChildItem ${Env:$(UnityVersion)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    Write-Host "======================= PlayMode Tests ======================="
    

--- a/pipelines/templates/tests.yml
+++ b/pipelines/templates/tests.yml
@@ -1,8 +1,11 @@
 # [Template] Run MRTK tests.
 
+parameters:
+  UnityVer: ${Env:$(Unity2018Version)}
+
 steps:
 - powershell: |
-   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${{ parameters.UnityVer }} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    Write-Host "======================= EditMode Tests ======================="
    
@@ -26,7 +29,7 @@ steps:
   displayName: 'Run EditMode tests'
 
 - powershell: |
-   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${{ parameters.UnityVer }} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    Write-Host "======================= PlayMode Tests ======================="
    


### PR DESCRIPTION
## Overview
Adds a daily build intended to be scheduled once a day. This build allows us to verify additional build flavours without clogging the main CI and PR pipelines. To begin with, I've added an ARM64 build that only runs on the daily build.
Alongside these changes I needed to modify the build scripts to allow us to build ARM64 on CI. This included adding `ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch` to the VS project. I believe this issue has been seen elsewhere for ARM64 builds.
