### PR TITLE
Allow developers to rename GameObjects with MRTK

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -677,7 +677,14 @@ namespace Microsoft.MixedReality.Toolkit
             // Update instance's Name so it's clear who is the active instance
             for (int i = toolkitInstances.Count - 1; i >= 0; i--)
             {
-                toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? activeInstanceGameObjectName : inactiveInstanceGameObjectName;
+                if (toolkitInstances[i] == null)
+                {
+                    toolkitInstances.RemoveAt(i);
+                }
+                else
+                {
+                    toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? activeInstanceGameObjectName : inactiveInstanceGameObjectName;
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -673,6 +673,12 @@ namespace Microsoft.MixedReality.Toolkit
                 activeInstance.DestroyAllServices();
                 activeInstance.InitializeInstance();
             }
+
+            // Update instance's Name so it's clear who is the active instance
+            for (int i = toolkitInstances.Count - 1; i >= 0; i--)
+            {
+                toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? activeInstanceGameObjectName : inactiveInstanceGameObjectName;
+            }
         }
 
         private static void UnregisterInstance(MixedRealityToolkit toolkitInstance)
@@ -1346,23 +1352,24 @@ namespace Microsoft.MixedReality.Toolkit
                         for (int i = toolkitInstances.Count - 1; i >= 0; i--)
                         {
                             if (toolkitInstances[i] == null)
-                            {   // If it has been destroyed, remove it
+                            {
+                                // If it has been destroyed, remove it
                                 toolkitInstances.RemoveAt(i);
                             }
                         }
 
                         // If the active instance is null, it may not have been set, or it may have been deleted.
                         if (activeInstance == null)
-                        {   // Do a search for a new active instance
+                        {
+                            // Do a search for a new active instance
                             MixedRealityToolkit instanceCheck = Instance;
                         }
                     }
 
                     for (int i = toolkitInstances.Count - 1; i >= 0; i--)
-                    {  // Make sure it's not parented under anything
+                    {
+                        // Make sure MRTK is not parented under anything
                         Debug.Assert(toolkitInstances[i].transform.parent == null, "MixedRealityToolkit instances should not be parented under any other GameObject.");
-                        // Name instances so it's clear when it's the active instance
-                        toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? MixedRealityToolkit.activeInstanceGameObjectName : MixedRealityToolkit.inactiveInstanceGameObjectName;
                     }
                 };
             }

--- a/Assets/MixedRealityToolkit/Utilities/Facades/ServiceFacade.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Facades/ServiceFacade.cs
@@ -16,41 +16,35 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         public static Dictionary<Type, ServiceFacade> FacadeServiceLookup = new Dictionary<Type, ServiceFacade>();
         public static List<ServiceFacade> ActiveFacadeObjects = new List<ServiceFacade>();
 
-        public IMixedRealityService Service { get { return service; } }
-        public Type ServiceType { get { return serviceType; } }
-        public bool Destroyed { get { return destroyed; } }
+        public IMixedRealityService Service { get; private set; } = null;
+        public Type ServiceType { get; private set; } = null;
+        public bool Destroyed { get; private set; } = false;
 
-        private IMixedRealityService service = null;
-        private Type serviceType = null;
-        private bool destroyed = false;
-        private Transform facadeParent;
-
-        public void SetService(IMixedRealityService service, Transform facadeParent)
+        public void SetService(IMixedRealityService service)
         {
-            this.service = service;
-            this.facadeParent = facadeParent;
+            this.Service = service;
 
             if (service == null)
             {
-                serviceType = null;
+                ServiceType = null;
                 name = "(Destroyed)";
                 gameObject.SetActive(false);
                 return;
             }
             else
             {
-                this.serviceType = service.GetType();
+                this.ServiceType = service.GetType();
 
-                name = serviceType.Name;
+                name = ServiceType.Name;
                 gameObject.SetActive(true);
 
-                if (!FacadeServiceLookup.ContainsKey(serviceType))
+                if (!FacadeServiceLookup.ContainsKey(ServiceType))
                 {
-                    FacadeServiceLookup.Add(serviceType, this);
+                    FacadeServiceLookup.Add(ServiceType, this);
                 }
                 else
                 {
-                    FacadeServiceLookup[serviceType] = this;
+                    FacadeServiceLookup[ServiceType] = this;
                 }
 
                 if (!ActiveFacadeObjects.Contains(this))
@@ -60,28 +54,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             }
         }
 
-        public void CheckIfStillValid()
-        {
-            if (service == null || transform.parent != facadeParent)
-            {
-                if (Application.isPlaying)
-                {
-                    GameObject.Destroy(gameObject);
-                }
-                else
-                {
-                    GameObject.DestroyImmediate(gameObject);
-                }
-            }
-        }
-
         private void OnDestroy()
         {
-            destroyed = true;
+            Destroyed = true;
 
-            if (FacadeServiceLookup != null && serviceType != null)
+            if (FacadeServiceLookup != null && ServiceType != null)
             {
-                FacadeServiceLookup.Remove(serviceType);
+                FacadeServiceLookup.Remove(ServiceType);
             }
 
             ActiveFacadeObjects.Remove(this);


### PR DESCRIPTION
## Overview
With MRTK in the scene and possibly with SceneSystem enable for service facades, developers were not able to F2 or right click and rename any gameobject in a scene. 

This was caused by two operations happening repeatedly while in editor.
1) MRTK static class would call hierarchyChanged callback and auto-update the name of every MRTK instance. This name update would cause hierarchyChanged to be called again resulting in a never ending sort of recursive operation.

2) ServiceFacadeHandler would update all gameobjects every editorapplication.update. Not only was this excessive but it would cause the heirachy to change when trying to rename another GameObject. 

Both of these operations have been refactored to only execute when an actual change has occurred. 

## Changes
- Fixes: #5062 


## Verification
Tested service facade in editor and MRTK gameobject in editor to rename another GameObject
All tests passed

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
