### PR TITLE
Fix error when the number of hand mesh vertices decreases

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8aa19e1a38ace94484a13c1fe6c6707
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9dce9d382d9d7e4c98aa4927e2480cf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3bbd26f8d7408741b7ffb55a1fc7397
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using System.Collections;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using UnityEngine;
+using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine.EventSystems;
+using Microsoft.MixedReality.Toolkit.Utilities;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class BaseHandVisualizerTests
+    {
+        /// <summary>
+        /// A mock IMixedRealityInputSource, used to test BaseHandVisualizer::OnHandMeshUpdated.
+        /// </summary>
+        private class MockInputSource : IMixedRealityInputSource
+        {
+            public IMixedRealityPointer[] Pointers => throw new System.NotImplementedException();
+            public InputSourceType SourceType => throw new System.NotImplementedException();
+            public uint SourceId => 0;
+
+            public string SourceName => throw new System.NotImplementedException();
+
+            public new bool Equals(object x, object y)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public int GetHashCode(object obj)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        private class MockController : IMixedRealityController
+        {
+            public bool Enabled { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+            public TrackingState TrackingState => throw new System.NotImplementedException();
+
+            public Handedness ControllerHandedness => Handedness.None;
+
+            public IMixedRealityInputSource InputSource => throw new System.NotImplementedException();
+
+            public IMixedRealityControllerVisualizer Visualizer => throw new System.NotImplementedException();
+
+            public bool IsPositionAvailable => throw new System.NotImplementedException();
+
+            public bool IsPositionApproximate => throw new System.NotImplementedException();
+
+            public bool IsRotationAvailable => throw new System.NotImplementedException();
+
+            public MixedRealityInteractionMapping[] Interactions => throw new System.NotImplementedException();
+
+            public Vector3 AngularVelocity => throw new System.NotImplementedException();
+
+            public Vector3 Velocity => throw new System.NotImplementedException();
+
+            public bool IsInPointingPose => throw new System.NotImplementedException();
+        }
+
+        [SetUp]
+        public void Init()
+        {
+            TestUtilities.InitializeMixedRealityToolkit(true);
+        }
+
+        [TearDown]
+        public void Shutdown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+        }
+
+        /// <summary>
+        /// Validates that OnHandMeshUpdated can be called with hand mesh vertices of different
+        /// lengths and not crash.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestOnHandMeshUpdated()
+        {
+            // First invoke OnHandMeshUpdated with a hand mesh corresponding
+            // to a triangle, and then invoke it again with a hand mesh
+            // corresponding to a quad. The intent to is to verify that
+            // the hand visualizer can be called with different sized
+            // input meshes and not crash (which is required on some platforms)
+            var baseHandVisualizer = new BaseHandVisualizer
+            {
+                Controller = new MockController()
+            };
+            baseHandVisualizer.OnHandMeshUpdated(CreateTriangleInputEventData());
+            baseHandVisualizer.OnHandMeshUpdated(CreateQuadInputEventData());
+            yield return null;
+        }
+
+        private static InputEventData<HandMeshInfo> CreateTriangleInputEventData()
+        {
+            HandMeshInfo handMeshInfo = new HandMeshInfo
+            {
+                vertices = new Vector3[]
+                {
+                    new Vector3(0, 0, 0),
+                    new Vector3(1, 0, 0),
+                    new Vector3(0, 1, 0),
+                },
+                normals = new Vector3[]
+                {
+                    -Vector3.forward,
+                    -Vector3.forward,
+                    -Vector3.forward,
+                },
+                triangles = new int[]
+                {
+                    0, 2, 1
+                }
+            };
+            var inputEventData = new InputEventData<HandMeshInfo>(EventSystem.current);
+            inputEventData.Initialize(new MockInputSource(), Handedness.None, MixedRealityInputAction.None, handMeshInfo);
+            return inputEventData;
+        }
+
+        private static InputEventData<HandMeshInfo> CreateQuadInputEventData()
+        {
+            HandMeshInfo handMeshInfo = new HandMeshInfo
+            {
+                vertices = new Vector3[]
+                {
+                    new Vector3(0, 0, 0),
+                    new Vector3(1, 0, 0),
+                    new Vector3(0, 1, 0),
+                    new Vector3(1, 1, 0),
+                 },
+                normals = new Vector3[]
+                {
+                    -Vector3.forward,
+                    -Vector3.forward,
+                    -Vector3.forward,
+                    -Vector3.forward,
+                },
+                triangles = new int[]
+                {
+                    0, 2, 1,
+                    2, 3, 1
+                }
+            };
+            var inputEventData = new InputEventData<HandMeshInfo>(EventSystem.current);
+            inputEventData.Initialize(new MockInputSource(), Handedness.None, MixedRealityInputAction.None, handMeshInfo);
+            return inputEventData;
+        }
+    }
+}
+
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs
@@ -91,16 +91,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator TestOnHandMeshUpdated()
         {
             // First invoke OnHandMeshUpdated with a hand mesh corresponding
-            // to a triangle, and then invoke it again with a hand mesh
-            // corresponding to a quad. The intent to is to verify that
+            // to a quad, and then invoke it again with a hand mesh
+            // corresponding to a triangle. The intent to is to verify that
             // the hand visualizer can be called with different sized
             // input meshes and not crash (which is required on some platforms)
             var baseHandVisualizer = new BaseHandVisualizer
             {
                 Controller = new MockController()
             };
-            baseHandVisualizer.OnHandMeshUpdated(CreateTriangleInputEventData());
             baseHandVisualizer.OnHandMeshUpdated(CreateQuadInputEventData());
+            baseHandVisualizer.OnHandMeshUpdated(CreateTriangleInputEventData());
             yield return null;
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Providers/Hands/BaseHandVisualizerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33a4486286f14fb4fa999050a2f47e8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
@@ -176,6 +176,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Mesh mesh = handMeshFilter.mesh;
 
+                // On some platforms, mesh length counts may change as the hand mesh is updated.
+                // In order to update the vertices when the array sizes change, the mesh
+                // must be cleared per instructions here:
+                // https://docs.unity3d.com/ScriptReference/Mesh.html
+                if ((mesh.vertices?.Length ?? 0) != 0 &&
+                    mesh.vertices?.Length != eventData.InputData.vertices?.Length)
+                {
+                    mesh.Clear();
+                }
+
                 mesh.vertices = eventData.InputData.vertices;
                 mesh.normals = eventData.InputData.normals;
                 mesh.triangles = eventData.InputData.triangles;
@@ -184,6 +194,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     mesh.uv = eventData.InputData.uvs;
                 }
+
+                mesh.RecalculateBounds();
 
                 handMeshFilter.transform.position = eventData.InputData.position;
                 handMeshFilter.transform.rotation = eventData.InputData.rotation;

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
@@ -18,6 +18,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected readonly Dictionary<TrackedHandJoint, Transform> joints = new Dictionary<TrackedHandJoint, Transform>();
         protected MeshFilter handMeshFilter;
 
+        // This member stores the last set of hand mesh vertices, to avoid using
+        // handMeshFilter.mesh.vertices, which does a copy of the vertices.
+        private Vector3[] lastHandMeshVertices;
+
         private IMixedRealityInputSystem inputSystem = null;
 
         /// <summary>
@@ -59,6 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (handMeshFilter != null)
             {
                 Destroy(handMeshFilter.gameObject);
+                handMeshFilter = null;
             }
         }
 
@@ -170,6 +175,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 InputSystem?.InputSystemProfile?.HandTrackingProfile?.HandMeshPrefab != null)
             {
                 handMeshFilter = Instantiate(InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
+                lastHandMeshVertices = handMeshFilter.mesh.vertices;
             }
 
             if (handMeshFilter != null)
@@ -180,8 +186,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // In order to update the vertices when the array sizes change, the mesh
                 // must be cleared per instructions here:
                 // https://docs.unity3d.com/ScriptReference/Mesh.html
-                if ((mesh.vertices?.Length ?? 0) != 0 &&
-                    mesh.vertices?.Length != eventData.InputData.vertices?.Length)
+                if (lastHandMeshVertices.Length != 0 &&
+                    lastHandMeshVertices.Length != eventData.InputData.vertices?.Length)
                 {
                     mesh.Clear();
                 }
@@ -189,6 +195,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 mesh.vertices = eventData.InputData.vertices;
                 mesh.normals = eventData.InputData.normals;
                 mesh.triangles = eventData.InputData.triangles;
+                lastHandMeshVertices = eventData.InputData.vertices;
 
                 if (eventData.InputData.uvs != null && eventData.InputData.uvs.Length > 0)
                 {


### PR DESCRIPTION
On certain platforms it's possible for hand mesh vertex array sizes to decrease between events, and the current infrastructure doesn't support that.

This addresses it (using the fix provided in https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4607) and adds a test that shows it working.