### PR TITLE
provide multicore appx build capabillity

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -634,6 +634,16 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 UwpBuildDeployPreferences.ForceRebuild = newForceRebuildAppx;
             }
 
+            // Multicore Appx Build
+            EditorGUIUtility.labelWidth = 90;
+            bool curMulticoreAppxBuildEnabled = UwpBuildDeployPreferences.MulticoreAppxBuildEnabled;
+            bool newMulticoreAppxBuildEnabled = EditorGUILayout.Toggle("Multicore Build", curMulticoreAppxBuildEnabled);
+
+            if (newMulticoreAppxBuildEnabled != curMulticoreAppxBuildEnabled)
+            {
+                UwpBuildDeployPreferences.MulticoreAppxBuildEnabled = newMulticoreAppxBuildEnabled;
+            }
+
             // Restore previous label width
             EditorGUIUtility.labelWidth = previousLabelWidth;
 
@@ -1070,6 +1080,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
                 OutputDirectory = BuildDeployPreferences.BuildDirectory,
                 AutoIncrement = BuildDeployPreferences.IncrementBuildVersion,
+                Multicore = UwpBuildDeployPreferences.MulticoreAppxBuildEnabled,
             };
 
             EditorAssemblyReloadManager.LockReloadAssemblies = true;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             // Now that NuGet packages have been restored, we can run the actual build process.
             exitCode = await Run(msBuildPath, 
-                $"\"{solutionProjectPath}\" /t:{(buildInfo.RebuildAppx ? "Rebuild" : "Build")} /p:Configuration={buildInfo.Configuration} /p:Platform={buildInfo.BuildPlatform} {(string.IsNullOrEmpty(buildInfo.PlatformToolset) ? string.Empty : $"/p:PlatformToolset={buildInfo.PlatformToolset}")} {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "buildAppx.log")}",
+                $"\"{solutionProjectPath}\" {(buildInfo.Multicore ? "/m /nr:false" : "")} /t:{(buildInfo.RebuildAppx ? "Rebuild" : "Build")} /p:Configuration={buildInfo.Configuration} /p:Platform={buildInfo.BuildPlatform} {(string.IsNullOrEmpty(buildInfo.PlatformToolset) ? string.Empty : $"/p:PlatformToolset={buildInfo.PlatformToolset}")} {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "buildAppx.log")}",
                 !Application.isBatchMode,
                 cancellationToken);
             AssetDatabase.SaveAssets();

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -19,6 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private const string EDITOR_PREF_USE_SSL = "BuildDeployWindow_UseSSL";
         private const string EDITOR_PREF_PROCESS_ALL = "BuildDeployWindow_ProcessAll";
         private const string EDITOR_PREF_GAZE_INPUT_CAPABILITY_ENABLED = "BuildDeployWindow_GazeInputCapabilityEnabled";
+        private const string EDITOR_PREF_MULTICORE_APPX_BUILD_ENABLED = "BuildDeployWindow_MulticoreAppxBuildEnabled";
 
         /// <summary>
         /// The current Build Configuration. (Debug, Release, or Master)
@@ -95,6 +96,16 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             get => EditorPreferences.Get(EDITOR_PREF_GAZE_INPUT_CAPABILITY_ENABLED, false);
             set => EditorPreferences.Set(EDITOR_PREF_GAZE_INPUT_CAPABILITY_ENABLED, value);
+        }
+
+        /// <summary>
+        /// If true, the appx will be build with multicore support enabled in the
+        /// msbuild process.
+        /// </summary>
+        public static bool MulticoreAppxBuildEnabled
+        {
+            get => EditorPreferences.Get(EDITOR_PREF_MULTICORE_APPX_BUILD_ENABLED, false);
+            set => EditorPreferences.Set(EDITOR_PREF_MULTICORE_APPX_BUILD_ENABLED, value);
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
@@ -34,5 +34,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// manifest after the Unity build.
         /// </summary>
         public bool GazeInputCapabilityEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Use multiple cores for building the appx bundle?
+        /// </summary>
+        public bool Multicore { get; set; } = false;
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -63,6 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 BuildAppx = !showDialog,
                 BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
                 GazeInputCapabilityEnabled = UwpBuildDeployPreferences.GazeInputCapabilityEnabled,
+                Multicore = UwpBuildDeployPreferences.MulticoreAppxBuildEnabled,
 
                 // Configure a post build action that will compile the generated solution
                 PostBuildAction = PostBuildAction


### PR DESCRIPTION
## Overview

Introduces the usage of the msbuild multicore related flags for appx build.
Usage is available via UwpBuildInfo and through the BuildWindow.
Preference gets saved via EditorPrefs.

> Evolution of pull request: https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4889
> Isolation of changes to the multicore feature
> related to feature request: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4890

## Changes

If multicore build option gets enabled, the build process will add the necessary flags to the msbuild.exe call for creating the appx.

