### PR TITLE
Update test runner script

### DIFF
--- a/scripts/test/run_playmode_tests.ps1
+++ b/scripts/test/run_playmode_tests.ps1
@@ -15,7 +15,7 @@ param(
     # Path to your Unity Executable
     [ValidateScript({[System.IO.File]::Exists($_) -and $_.EndsWith(".exe") })]
     [string]
-    $unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.1f1\Editor\Unity.exe"
+    $unityExePath = "C:\Program Files\Unity\Hub\Editor\2018.4.6f1\Editor\Unity.exe"
 )
 $dateStr = Get-Date -format "yyyy_MM_dd-HHmmss"
 if (-not (Test-Path $outFolder))

--- a/scripts/test/run_playmode_tests.ps1
+++ b/scripts/test/run_playmode_tests.ps1
@@ -5,12 +5,12 @@
 param(
     # Path to your Unity project
     [Parameter(Position=0)]
-    [ValidateScript({Test-Path $_ -PathType ‘Container’})]
+    [ValidateScript({Test-Path $_ -PathType Container})]
     [string]
     $projectPath = "$PSScriptRoot/../../",
     # Folder that will contain test results output and logs
     [string]
-    [ValidateScript({Test-Path $_ -PathType ‘Container’})]
+    [ValidateScript({Test-Path $_ -PathType Container})]
     $outFolder = "$PSScriptRoot/out/",
     # Path to your Unity Executable
     [ValidateScript({[System.IO.File]::Exists($_) -and $_.EndsWith(".exe") })]


### PR DESCRIPTION
## Overview
I was unable to run the test runner script locally as-is, seeing this:

![image](https://user-images.githubusercontent.com/3580640/63536967-90e66680-c4c9-11e9-9765-ff90832ceb5a.png)

I updated `‘Container’` to `Container` to fix it.

I also updated the version of Unity it looks for the the current version we have checked in to the repo: #5657 