### PR TITLE
Update to check for `isCustomProfile: 1` during PR validation (and fix existing incorrect profiles)

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/DefaultSceneTransitionServiceProfile.asset
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/DefaultSceneTransitionServiceProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8d8965cb7573e04429e22a5a476b4703, type: 3}
   m_Name: DefaultSceneTransitionServiceProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   useDefaultProgressIndicator: 1
   defaultProgressIndicatorPrefab: {fileID: 1993071269674472, guid: 57d2436112e7d424da7e9a8e41c608dc,
     type: 3}

--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/Profiles/DefaultObjectMeshObserverProfile.asset
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/Profiles/DefaultObjectMeshObserverProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e3c1af9621e40064b907d18085e21fb7, type: 3}
   m_Name: DefaultObjectMeshObserverProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   startupBehavior: 0
   isStationaryObserver: 0
   observationExtents: {x: 3, y: 3, z: 3}

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputRecordingProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputRecordingProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e721f74104fc5e498856a7c337d6632, type: 3}
   m_Name: DefaultMixedRealityInputRecordingProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   jointPositionThreshold: 0.001
   jointRotationThreshold: 0.02
   cameraPositionThreshold: 0.002

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealitySceneSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealitySceneSystemProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b81dae1d46879b444aa9847f7961649f, type: 3}
   m_Name: DefaultMixedRealitySceneSystemProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   useManagerScene: 1
   managerScene:
     Name: DefaultManagerScene

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealitySpatialAwarenessSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealitySpatialAwarenessSystemProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 19f279aded72cb741b4de89a54359dd4, type: 3}
   m_Name: DefaultMixedRealitySpatialAwarenessSystemProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   observerConfigurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness.WindowsMixedRealitySpatialMeshObserver,

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSimulationProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1InputSimulationProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 78a4b02a0d9e7044fa19c6d432d0cafa, type: 3}
   m_Name: DefaultHoloLens1InputSimulationProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   isCameraControlEnabled: 1
   extraMouseSensitivityScale: 3
   defaultMouseSensitivity: 0.1

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b71cb900fa9dec5488df2deb180db58f, type: 3}
   m_Name: TestMixedRealityInputSystemProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   dataProviderConfigurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Tests.Services.TestInputDataProvider,

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 19f279aded72cb741b4de89a54359dd4, type: 3}
   m_Name: TestMixedRealitySpatialAwarenessSystemProfile
   m_EditorClassIdentifier: 
-  isCustomProfile: 1
+  isCustomProfile: 0
   observerConfigurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Tests.Services.TestSpatialAwarenessDataProvider,


### PR DESCRIPTION
## Overview
This PR extends the script added in #5632 to add a check for `isCustomProfile: 1` in all of our non-Examples assets.

## Changes
- Fixes: #5717, #5679

## Verification
I'll run the mrtk_PR pipeline to validate that this fails, then check in the fixed profiles and validate that this passes.