### PR TITLE
Documentation and Code cleanup work

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -89,11 +89,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region InputSystemGlobalHandlerListener Implementation
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityControllerPoseSynchronizer>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityControllerPoseSynchronizer>(this);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DictationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/DictationHandler.cs
@@ -77,11 +77,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region InputSystemGlobalHandlerListener Implementation
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityDictationHandler>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityDictationHandler>(this);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -186,12 +186,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             OnEyeFocusStop();
         }
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
             InputSystem?.RegisterHandler<IMixedRealitySpeechHandler>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/InputActionHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/InputActionHandler.cs
@@ -33,11 +33,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region InputSystemGlobalHandlerListener Implementation
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityInputActionHandler>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityInputActionHandler>(this);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/PointerClickHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/PointerClickHandler.cs
@@ -31,11 +31,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region InputSystemGlobalHandlerListener Implementation
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -16,11 +16,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnClick";
         }
 
+        /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             // using onClick
         }
 
+        /// <inheritdoc />
         public override void OnClick(InteractableStates state, Interactable source, IMixedRealityPointer pointer = null)
         {
             uEvent.Invoke();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -22,6 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnFocus";
         }
 
+        /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             bool changed = state.CurrentState() != lastState;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnGrab";
         }
 
+        /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             bool hasGrab = state.GetState(InteractableStates.InteractableStateEnum.Grab).Value > 0;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -24,6 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnHold";
         }
 
+        /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             if (state.GetState(InteractableStates.InteractableStateEnum.Pressed).Value > 0 && !hasDown)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -53,6 +53,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
         }
+
+        /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             bool changed = state.CurrentState() != lastState;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -20,11 +20,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnSelect";
         }
 
+        /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             // using onClick 
         }
 
+        /// <inheritdoc />
         public override void OnClick(InteractableStates state, Interactable source, IMixedRealityPointer pointer = null)
         {
             int currentIndex = source.GetDimensionIndex();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStates.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/States/InteractableStates.cs
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return GetState((int)state);
         }
 
-        // compares all the state values and returns a state based on bitwise comparison
+        /// <inheritdoc />
         public override State CompareStates()
         {
             int bit = GetBit();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableActivateTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableActivateTheme.cs
@@ -24,8 +24,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     Default = new InteractableThemePropertyValue() { Bool = true }
                 });
         }
-        
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -33,6 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             Host.SetActive(property.Values[index].Bool);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAnimatorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableAnimatorTheme.cs
@@ -29,12 +29,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
             controller = Host.GetComponent<Animator>();
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -42,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             if(lastIndex != index)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorChildrenTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorChildrenTheme.cs
@@ -32,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -59,6 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue color = new InteractableThemePropertyValue();
@@ -74,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return color;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             Color color = Color.Lerp(property.StartValue.Color, property.Values[index].Color, percentage);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableColorTheme.cs
@@ -38,11 +38,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue color = new InteractableThemePropertyValue();
@@ -88,6 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             Color color = Color.Lerp(property.StartValue.Color, property.Values[index].Color, percentage);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableGrabScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableGrabScaleTheme.cs
@@ -49,6 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             };
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -61,6 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             timer = Ease.LerpTime;
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             if (Host == null)
@@ -74,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return prop;
         }
 
+        /// <inheritdoc />
         public override void OnUpdate(int state, Interactable source, bool force = false)
         {
             base.OnUpdate(state, source, force);
@@ -128,6 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             if (!hasGrab && Host != null)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableMaterialTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableMaterialTheme.cs
@@ -34,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -43,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             Host.SetActive(property.Values[index].Bool);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableOffsetTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableOffsetTheme.cs
@@ -26,6 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -33,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             startPosition = hostTransform.localPosition;
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -40,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableRotationTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableRotationTheme.cs
@@ -25,6 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -32,6 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             hostTransform = Host.transform;
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -39,6 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             hostTransform.localRotation = Quaternion.Euler( Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage));

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableScaleTheme.cs
@@ -32,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -39,6 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableShaderTheme.cs
@@ -31,6 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -50,6 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             renderer = Host.GetComponent<Renderer>();
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             if (Host == null)
@@ -80,6 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             renderer.SetPropertyBlock(propertyBlock);
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             if (Host == null)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableStringTheme.cs
@@ -32,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -40,6 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             text = Host.GetComponent<Text>();
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -58,6 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             if(mesh != null)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableTextureTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Themes/InteractableTextureTheme.cs
@@ -27,6 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
         }
 
+        /// <inheritdoc />
         public override void Init(GameObject host, InteractableThemePropertySettings settings)
         {
             base.Init(host, settings);
@@ -34,6 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             renderer = Host.GetComponent<Renderer>();
         }
 
+        /// <inheritdoc />
         public override InteractableThemePropertyValue GetProperty(InteractableThemeProperty property)
         {
             InteractableThemePropertyValue start = new InteractableThemePropertyValue();
@@ -41,6 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return start;
         }
 
+        /// <inheritdoc />
         public override void SetValue(InteractableThemeProperty property, int index, float percentage)
         {
             propertyBlock.SetTexture("_MainTex", property.Values[index].Texture);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/WindowsMixedRealityControllerVisualizer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/WindowsMixedRealityControllerVisualizer.cs
@@ -10,6 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         private readonly Quaternion inverseRotation = Quaternion.Euler(0f, 180f, 0f);
 
+        /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<MixedRealityPose> eventData)
         {
             if (UseSourcePoseData &&

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -158,6 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return obj.GetHashCode();
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             unchecked
@@ -293,6 +294,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region InputSystemGlobalHandlerListener Implementation
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityInputHandler>(this);
@@ -300,6 +302,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityInputHandler>(this);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -201,6 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             lineBase.LastPoint = endPoint;
         }
 
+        /// <inheritdoc />
         public override bool IsInteractionEnabled =>
                 // If IsTracked is not true, then we don't have position data yet (or have stale data),
                 // so remain disabled until we know where to appear (not just at the origin).

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -30,8 +30,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         protected override string ControllerName => "Spatial Mouse Pointer";
 
+        /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
             // screenspace to ray conversion
@@ -67,6 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         public override void OnInputChanged(InputEventData<MixedRealityPose> eventData)
         {
             if (eventData.SourceId == Controller?.InputSource.SourceId)
@@ -114,6 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Cursor.lockState = CursorLockMode.Locked;
         }
 
+        /// <inheritdoc />
         protected override void SetVisibility(bool visible)
         {
             base.SetVisibility(visible);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -110,6 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return (closestProximityTouchable != null); }
         }
 
+        /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
             if (Rays == null)
@@ -202,6 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return closest != null;
         }
 
+        /// <inheritdoc />
         public override void OnPostSceneQuery()
         {
             base.OnPostSceneQuery();
@@ -250,6 +252,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             PreviousPosition = Position;
         }
 
+        /// <inheritdoc />
         public override void OnPreCurrentPointerTargetChange()
         {
             // We need to raise the event now, since the pointer's focused object or touchable will change
@@ -363,18 +366,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
             base.OnSourceLost(eventData);
         }
 
+        /// <inheritdoc />
         public override void OnSourceDetected(SourceStateEventData eventData)
         {
             base.OnSourceDetected(eventData);
             PreviousPosition = Position;
         }
 
+        /// <inheritdoc />
         public override void OnInputDown(InputEventData eventData)
         {
             // Poke pointer should not respond when a button is pressed or hand is pinched
             // It should only dispatch events based on collision with touchables.
         }
 
+        /// <inheritdoc />
         public override void OnInputUp(InputEventData eventData)
         {
             // Poke pointer should not respond when a button is released or hand is un-pinched

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ScreenSpaceMousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ScreenSpaceMousePointer.cs
@@ -15,6 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         private Vector2 lastMousePosition;
 
+        /// <inheritdoc />
         protected override string ControllerName => "ScreenSpace Mouse Pointer";
 
         /// <inheritdoc />
@@ -45,6 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             transform.rotation = Quaternion.LookRotation(ray.direction);
         }
 
+        /// <inheritdoc />
         protected override void SetVisibility(bool visible)
         {
             base.SetVisibility(visible);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -62,6 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         protected override void SetLinePoints(Vector3 startPoint, Vector3 endPoint, float distance)
         {
             LineBase.FirstPoint = startPoint;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         private SceneQueryType raycastMode = SceneQueryType.SphereOverlap;
 
+        /// <inheritdoc />
         public override SceneQueryType SceneQueryType { get { return raycastMode; } set { raycastMode = value; } }
 
         [SerializeField]
@@ -58,6 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         public override bool IsInteractionEnabled
         {
             get

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -209,6 +209,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             }
         }
 
+        /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
             if (LineBase == null)
@@ -240,6 +241,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             GravityDistorter.enabled = (TeleportSurfaceResult == TeleportSurfaceResult.HotSpot);
         }
 
+        /// <inheritdoc />
         public override void OnPostSceneQuery()
         {
             if (IsSelectPressed)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
@@ -106,6 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        /// <inheritdoc />
         protected override void UpdateMovingVisualsPosition()
         {
             base.UpdateMovingVisualsPosition();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -750,7 +750,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
 
         #region BaseFocusHandler Methods
+        
+        /// <inheritdoc />
         public override void OnFocusEnter(FocusEventData eventData) { }
+
+        /// <inheritdoc />
         public override void OnFocusExit(FocusEventData eventData)
         {
             EndAllTouches();

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/InBetween.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/InBetween.cs
@@ -102,6 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             UpdateSecondSolverHandler();
         }
 
+        /// <inheritdoc />
         public override void SolverUpdate()
         {
             if (SolverHandler != null && secondSolverHandler != null)

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Orbital.cs
@@ -90,6 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
         }
 
+        /// <inheritdoc />
         public override void SolverUpdate()
         {
             Vector3 desiredPos = SolverHandler.TransformTarget != null ? SolverHandler.TransformTarget.position : Vector3.zero;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Overlap.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/Overlap.cs
@@ -8,6 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     /// </summary>
     public class Overlap : Solver
     {
+        /// <inheritdoc />
         public override void SolverUpdate()
         {
             var target = SolverHandler.TransformTarget;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -424,6 +424,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
         }
 
+        /// <inheritdoc />
         public override void SolverUpdate()
         {
             // Pass-through by default

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             dimensionIndex = serializedObject.FindProperty("dimensionIndex");
             dimensions = serializedObject.FindProperty("Dimensions");
 
-            showProfiles = EditorPrefs.GetBool(ShowProfilesPrefKey, showProfiles);
+            showProfiles = SessionState.GetBool(ShowProfilesPrefKey, showProfiles);
 
             SetupEventOptions();
             SetupThemeOptions();
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             if (showProfiles != isProfilesOpen)
             {
                 showProfiles = isProfilesOpen;
-                EditorPrefs.SetBool(ShowProfilesPrefKey, showProfiles);
+                SessionState.SetBool(ShowProfilesPrefKey, showProfiles);
             }
 
             if (profileList.arraySize < 1)
@@ -178,11 +178,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                                 hadDefault.boolValue = true;
 
                                 string prefKey = themeItem.objectReferenceValue.name + "Profiles" + i + "_Theme" + t + "_Edit";
-                                bool showSettingsPref = EditorPrefs.GetBool(prefKey, true);
+                                bool showSettingsPref = SessionState.GetBool(prefKey, true);
                                 bool show = InspectorUIUtility.DrawSectionFoldout(themeItem.objectReferenceValue.name + " (Click to edit)", showSettingsPref, FontStyle.Normal);
                                 if (show != showSettingsPref)
                                 {
-                                    EditorPrefs.SetBool(prefKey, show);
+                                    SessionState.SetBool(prefKey, show);
                                 }
 
                                 if (show)
@@ -307,7 +307,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             if (showEvents != isEventsOpen)
             {
                 showEvents = isEventsOpen;
-                EditorPrefs.SetBool(ShowEventsPrefKey, showEvents);
+                SessionState.SetBool(ShowEventsPrefKey, showEvents);
             }
 
             EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -30,6 +30,9 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         private BoundaryEventData boundaryEventData = null;
 
         /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Boundary System";
+
+        /// <inheritdoc/>
         public override void Initialize()
         {
             if (!Application.isPlaying) { return; }

--- a/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -25,6 +25,9 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         {
         }
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Camera System";
+
         /// <summary>
         /// Is the current camera displaying on an Opaque (AR) device or a VR / immersive device
         /// </summary>

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -17,6 +17,9 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             MixedRealityDiagnosticsProfile profile) : base(registrar, profile)
         { }
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Diagnostics System";
+
         /// <summary>
         /// The parent object under which all visualization game objects will be placed.
         /// </summary>

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -76,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             ArticulatedHandPose.LoadGesturePoses();
         }
 
+        /// <inheritdoc />
         public override void Destroy()
         {
             ArticulatedHandPose.ResetGesturePoses();

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedArticulatedHand.cs
@@ -46,11 +46,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             new MixedRealityInteractionMapping(4, "Index Finger Pose", AxisType.SixDof, DeviceInputType.IndexFinger, MixedRealityInputAction.None),
         };
 
+        /// <inheritdoc />
         public override void SetupDefaultInteractions(Handedness controllerHandedness)
         {
             AssignControllerMappings(DefaultInteractions);
         }
 
+        /// <inheritdoc />
         protected override void UpdateInteractions(SimulatedHandData handData)
         {
             lastPointerPose = currentPointerPose;

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         new[] { Handedness.Left, Handedness.Right })]
     public class SimulatedGestureHand : SimulatedHand
     {
+        /// <inheritdoc />
         public override HandSimulationMode SimulationMode => HandSimulationMode.Gestures;
 
         private bool initializedFromProfile = false;
@@ -111,11 +112,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             new MixedRealityInteractionMapping(1, "Grip Pose", AxisType.SixDof, DeviceInputType.SpatialGrip, MixedRealityInputAction.None),
         };
 
+        /// <inheritdoc />
         public override void SetupDefaultInteractions(Handedness controllerHandedness)
         {
             AssignControllerMappings(DefaultInteractions);
         }
 
+        /// <inheritdoc />
         protected override void UpdateInteractions(SimulatedHandData handData)
         {
             EnsureProfileSettings();

--- a/Assets/MixedRealityToolkit.Services/InputSystem/DefaultRaycastProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/DefaultRaycastProvider.cs
@@ -17,6 +17,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             MixedRealityInputSystemProfile profile) : base(registrar, profile)
         { }
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Default Raycast Provider";
+
         /// <inheritdoc />
         public bool Raycast(RayStep step, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo)
         {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -37,9 +37,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly int maxQuerySceneResults = 128;
         private bool focusIndividualCompoundCollider = false;
 
-        /// <inheritdoc/>
-        public override string Name { get; protected set; } = "Focus Provider";
-
         public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators => pointerMediators;
 
         /// <summary>
@@ -88,8 +85,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IFocusProvider Properties
 
-        /// <inheritdoc />
-        public override string Name => "Focus Provider";
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Focus Provider";
 
         /// <inheritdoc />
         public override uint Priority => 2;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -498,6 +498,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         public override void Destroy()
         {
             if (primaryPointerSelector != null)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -37,6 +37,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private readonly int maxQuerySceneResults = 128;
         private bool focusIndividualCompoundCollider = false;
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Focus Provider";
+
         public IReadOnlyDictionary<uint, IMixedRealityPointerMediator> PointerMediators => pointerMediators;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -260,6 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
+            /// <inheritdoc />
             public override void OnPreCurrentPointerTargetChange() { }
 
             /// <inheritdoc />
@@ -313,6 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -324,6 +326,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         protected override async void Start()
         {
             base.Start();
@@ -399,6 +402,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         protected override void OnDisable()
         {
             base.OnDisable();
@@ -415,11 +419,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region InputSystemGlobalHandlerListener Implementation
 
+        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             InputSystem?.RegisterHandler<IMixedRealityInputHandler>(this);
         }
 
+        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             InputSystem?.UnregisterHandler<IMixedRealityInputHandler>(this);

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputModule.cs
@@ -71,6 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         public override void ActivateModule()
         {
             base.ActivateModule();
@@ -89,6 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc />
         public override void DeactivateModule()
         {
             if (InputSystem != null)

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -25,6 +25,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Input System";
+
         /// <inheritdoc />
         public event Action InputEnabled;
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs
@@ -106,6 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             bounds.y = Mathf.Max(bounds.y, 0);
         }
 
+        /// <inheritdoc />
         public override float DistanceToTouchable(Vector3 samplePoint, out Vector3 normal)
         {
             normal = Forward;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableUnityUI.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableUnityUI.cs
@@ -24,6 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             rectTransform = GetComponent<RectTransform>();
         }
 
+        /// <inheritdoc />
         public override float DistanceToTouchable(Vector3 samplePoint, out Vector3 normal)
         {
             normal = -transform.forward;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
@@ -19,6 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [UnityEditor.CustomEditor(typeof(NearInteractionTouchableVolume))]
         public class Editor : UnityEditor.Editor
         {
+            /// <inheritdoc />
             public override void OnInspectorGUI()
             {
                 base.OnInspectorGUI();
@@ -33,6 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 #endif
 
+        /// <inheritdoc />
         public override float DistanceToTouchable(Vector3 samplePoint, out Vector3 normal)
         {
             Vector3 closest = TouchableCollider.ClosestPoint(samplePoint);

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -55,6 +55,9 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         // Lighting executor instance
         private SceneLightingExecutor lightingExecutor;
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Scene System";
+
         #region Actions
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -26,6 +26,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             }
         }
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Spatial Awareness System";
+
         #region IMixedRealityCapabilityCheck Implementation
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Services/TeleportSystem/MixedRealityTeleportSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/TeleportSystem/MixedRealityTeleportSystem.cs
@@ -38,6 +38,9 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
         #region IMixedRealityService Implementation
 
+        /// <inheritdoc/>
+        public override string Name { get; protected set; } = "Mixed Reality Teleport System";
+
         /// <inheritdoc />
         public override void Initialize()
         {

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/MixedRealityPose.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/MixedRealityPose.cs
@@ -128,6 +128,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return obj is MixedRealityPose ? ((MixedRealityPose)obj).GetHashCode() : 0;
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -224,14 +224,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             bool state = currentState;
             if (isValidPreferenceKey)
             {
-                state = EditorPrefs.GetBool(preferenceKey, currentState);
+                state = SessionState.GetBool(preferenceKey, currentState);
             }
 
             currentState = EditorGUILayout.Foldout(state, title, true, MixedRealityStylesUtility.BoldFoldoutStyle);
 
             if (isValidPreferenceKey && currentState != state)
             {
-                EditorPrefs.SetBool(preferenceKey, currentState);
+                SessionState.SetBool(preferenceKey, currentState);
             }
 
             if (currentState)

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityToolkitConfigurationProfileInspector.cs
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Editor settings
             useServiceInspectors = serializedObject.FindProperty("useServiceInspectors");
 
-            SelectedProfileTab = EditorPrefs.GetInt(SelectedTabPreferenceKey, SelectedProfileTab);
+            SelectedProfileTab = SessionState.GetInt(SelectedTabPreferenceKey, SelectedProfileTab);
 
             if (this.RenderProfileFuncs == null)
             {
@@ -286,11 +286,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.Width(100));
             GUI.enabled = true; // Force enable so we can view profile defaults
 
-            int prefsSelectedTab = EditorPrefs.GetInt(SelectedTabPreferenceKey);
+            int prefsSelectedTab = SessionState.GetInt(SelectedTabPreferenceKey, 0);
             SelectedProfileTab = GUILayout.SelectionGrid(prefsSelectedTab, ProfileTabTitles, 1, EditorStyles.boldLabel, GUILayout.MaxWidth(125));
             if (SelectedProfileTab != prefsSelectedTab)
             {
-                EditorPrefs.SetInt(SelectedTabPreferenceKey, SelectedProfileTab);
+                SessionState.SetInt(SelectedTabPreferenceKey, SelectedProfileTab);
             }
 
             GUI.enabled = isGUIEnabled;

--- a/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
+++ b/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
@@ -181,6 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return obj.GetHashCode();
         }
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             unchecked

--- a/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
@@ -29,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <inheritdoc />
         public override void Enable()
         {
             base.Enable();
@@ -39,6 +40,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <inheritdoc />
         public override void Update()
         {
             base.Update();
@@ -49,6 +51,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <inheritdoc />
         public override void LateUpdate()
         {
             base.LateUpdate();

--- a/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
@@ -253,6 +253,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <inheritdoc />
         public override void Destroy()
         {
             if(!enableDanglingHandlerDiagnostics)

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BezierDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/BezierDataProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             public Vector3 Point4;
         }
 
+        /// <inheritdoc />
         public override int PointCount { get { return 4; } }
 
         [Header("Bezier Settings")]
@@ -37,6 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private Vector3 localOffset;
 
+        /// <inheritdoc />
         protected override Vector3 GetPointInternal(int pointIndex)
         {
             switch (pointIndex)
@@ -97,12 +99,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     break;
             }
         }
-
+        
+        /// <inheritdoc />
         protected override Vector3 GetPointInternal(float normalizedDistance)
         {
             return LineUtility.InterpolateBezierPoints(controlPoints.Point1, controlPoints.Point2, controlPoints.Point3, controlPoints.Point4, normalizedDistance);
         }
 
+        /// <inheritdoc />
         protected override float GetUnClampedWorldLengthInternal()
         {
             float distance = 0f;
@@ -115,6 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return distance;
         }
 
+        /// <inheritdoc />
         protected override Vector3 GetUpVectorInternal(float normalizedLength)
         {
             // Bezier up vectors just use transform up

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
@@ -86,6 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             lineRenderer.enabled = false;
         }
 
+        /// <inheritdoc />
         protected override void UpdateLine()
         {
             if (LineDataSource == null)

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/ParticleSystemLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/ParticleSystemLineRenderer.cs
@@ -175,6 +175,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+        /// <inheritdoc />
         protected override void UpdateLine()
         {
             if (!LineDataSource.enabled)

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
@@ -98,6 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+        /// <inheritdoc />
         protected override void UpdateLine()
         {
             if (stripMeshRenderer == null)

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/DistorterBulge.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/DistorterBulge.cs
@@ -86,6 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             return point;
         }
 
+        /// <inheritdoc />
         protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
         {
             float distanceToCenter = Vector3.Distance(point, BulgeWorldCenter);

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/DistorterSphere.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/DistorterSphere.cs
@@ -29,12 +29,14 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         [SerializeField]
         private float radius = 2f;
 
+        /// <inheritdoc />
         protected override Vector3 DistortPointInternal(Vector3 point, float strength)
         {
             Vector3 direction = (point - SphereCenter).normalized;
             return Vector3.Lerp(point, SphereCenter + (direction * radius), strength);
         }
 
+        /// <inheritdoc />
         protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
         {
             return Vector3.one;

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/DistorterWiggly.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/DistorterWiggly.cs
@@ -81,6 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             set { axisOffset = value; }
         }
 
+        /// <inheritdoc />
         protected override Vector3 DistortPointInternal(Vector3 point, float strength)
         {
             Vector3 wiggly = point;
@@ -91,6 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             return point + (wiggly * strength);
         }
 
+        /// <inheritdoc />
         protected override Vector3 DistortScaleInternal(Vector3 point, float strength)
         {
             return point;

--- a/Assets/MixedRealityToolkit/Utilities/Physics/GazeStabilizer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/GazeStabilizer.cs
@@ -32,8 +32,8 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <summary>
         /// The stabilized rotation.
         /// </summary>
-        private Quaternion stableRotation;
         public override Quaternion StableRotation => stableRotation;
+        private Quaternion stableRotation;
 
         /// <summary>
         /// The stabilized position.

--- a/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingBox.cs
+++ b/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingBox.cs
@@ -15,11 +15,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private int clipBoxSizeID;
         private int clipBoxInverseTransformID;
 
+        /// <inheritdoc />
         protected override string Keyword
         {
             get { return "_CLIPPING_BOX"; }
         }
 
+        /// <inheritdoc />
         protected override string ClippingSideProperty
         {
             get { return "_ClipBoxSide"; }
@@ -34,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+        /// <inheritdoc />
         protected override void Initialize()
         {
             base.Initialize();

--- a/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingPlane.cs
+++ b/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingPlane.cs
@@ -14,11 +14,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     {
         private int clipPlaneID;
 
+        /// <inheritdoc />
         protected override string Keyword
         {
             get { return "_CLIPPING_PLANE"; }
         }
 
+        /// <inheritdoc />
         protected override string ClippingSideProperty
         {
             get { return "_ClipPlaneSide"; }
@@ -34,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+        /// <inheritdoc />
         protected override void Initialize()
         {
             base.Initialize();
@@ -41,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             clipPlaneID = Shader.PropertyToID("_ClipPlane");
         }
 
+        /// <inheritdoc />
         protected override void UpdateShaderProperties(MaterialPropertyBlock materialPropertyBlock)
         {
             Vector3 up = transform.up;

--- a/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingSphere.cs
+++ b/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingSphere.cs
@@ -26,11 +26,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private int clipSphereID;
 
+        /// <inheritdoc />
         protected override string Keyword
         {
             get { return "_CLIPPING_SPHERE"; }
         }
 
+        /// <inheritdoc />
         protected override string ClippingSideProperty
         {
             get { return "_ClipSphereSide"; }
@@ -44,6 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+        /// <inheritdoc />
         protected override void Initialize()
         {
             base.Initialize();
@@ -51,6 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             clipSphereID = Shader.PropertyToID("_ClipSphere");
         }
 
+        /// <inheritdoc />
         protected override void UpdateShaderProperties(MaterialPropertyBlock materialPropertyBlock)
         {
             Vector3 position = transform.position;


### PR DESCRIPTION
## Overview

This changes performs some clean up work

1) There are some cases where we are using EditorPrefs that save preferences to the registry and this is not necessary. Particularly for saving if a inspector foldout should be visible or not. Saving this kind of information for just the current session is perfectly sufficient. This change modifies some use of EditorPrefs to SessionState

2) Many overrides are not marked as /// <inheritdoc /> so docfx lists no information for them on our documentation pages. 

3) Core Systems do not set or override the IMixedRealityService.Name property. Thus, when one receives an IMixedRealityService reference, it is just a blank name. Thanks to @julenka for finding this

## Changes
- Fixes: # .


## Verification
All tests pass

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
