### PR TITLE
Fill nullptr in poke pointer

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -90,10 +90,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// the same current closest touchable component's changes (e.g. Unity UI control elements).
         public GameObject CurrentTouchableObjectDown => currentTouchableObjectDown;
 
-        protected override void Start()
+        private void Awake()
         {
-            base.Start();
-
             queryBuffer = new Collider[sceneQueryBufferSize];
         }
 
@@ -163,12 +161,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             closest = null;
             closestDistance = float.PositiveInfinity;
             closestNormal = Vector3.zero;
-
-            if (queryBuffer == null)
-            {
-                // queryBuffer can be null if FindClosestTouchable is called somehow after Start().
-                return false;
-            }
 
             int numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(Position, touchableDistance, queryBuffer, layerMask, triggerInteraction);
             if (numColliders == queryBuffer.Length)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -164,6 +164,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             closestDistance = float.PositiveInfinity;
             closestNormal = Vector3.zero;
 
+            if (queryBuffer == null)
+            {
+                // queryBuffer can be null if FindClosestTouchable is called somehow after Start().
+                return false;
+            }
+
             int numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(Position, touchableDistance, queryBuffer, layerMask, triggerInteraction);
             if (numColliders == queryBuffer.Length)
             {


### PR DESCRIPTION
## Overview
- Fixes: #5760 

It seems its possible for the following to happen:

- pointer added on thread 1
- start gets called, but gets delayed because input system is not ready
- focus provider updates on thread 2
- focus provider touches queryBuffer
- queryBuffer gets initialized

Moving the queryBuffer initilization into Awake should ensure it gets initialized before focusprovider touches the pointer, since I assume Awake gets called before FocusProvider touches the pointer.

Unfortunately, this does not repro in editor (at least, I couldn't figure out how to repro in editor), so for this one I will not be writing a test :-( 

# Verification
@Kjakubzak would it be possible for you to try this fix instead of your nullptr check to verify this fixes the bug? Reason I'd prefer to do this is because in GetNearestTouchables queryBuffer really should not be null, so it's good (in a way) we are throwing an error (it represents invalid state). I'd rather fix the root cause (variable being initialized in the wrong place).