### PR TITLE
Update run_playmode_tests.ps1

### DIFF
--- a/scripts/test/run_playmode_tests.ps1
+++ b/scripts/test/run_playmode_tests.ps1
@@ -61,7 +61,7 @@ $cnx = $cn["test-run"]
 Write-Output "passed: $($cnx.passed) failed: $($cnx.failed)"
 if ($cnx.failed -gt 0)
 {
-    Write-Output
+    Write-Output ""
     Write-Output "Failed tests:"
     $testcases = $cnx.GetElementsByTagName("test-case")
     foreach ($item in $testcases) {


### PR DESCRIPTION
## Overview
Blank `Write-Host` was causing PowerShell to query the user:

![image](https://user-images.githubusercontent.com/3580640/63727137-42f89800-c814-11e9-9801-6aa91f921317.png)

