### PR TITLE
Fix pointer profile inspector

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/SpeechInputHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/SpeechInputHandlerInspector.cs
@@ -102,93 +102,93 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         private void ShowList(SerializedProperty list)
         {
-            EditorGUI.indentLevel++;
-
-            // remove the keywords already assigned from the registered list
-            var handler = (SpeechInputHandler)target;
-            var availableKeywords = new string[0];
-
-            if (handler.Keywords != null && distinctRegisteredKeywords != null)
+            using (new EditorGUI.IndentLevelScope())
             {
-                availableKeywords = distinctRegisteredKeywords.Except(handler.Keywords.Select(keywordAndResponse => keywordAndResponse.Keyword)).ToArray();
-            }
+                // remove the keywords already assigned from the registered list
+                var handler = (SpeechInputHandler)target;
+                var availableKeywords = new string[0];
 
-            // keyword rows
-            for (int index = 0; index < list.arraySize; index++)
-            {
-                // the element
-                SerializedProperty speechCommandProperty = list.GetArrayElementAtIndex(index);
-                GUILayout.BeginHorizontal();
+                if (handler.Keywords != null && distinctRegisteredKeywords != null)
+                {
+                    availableKeywords = distinctRegisteredKeywords.Except(handler.Keywords.Select(keywordAndResponse => keywordAndResponse.Keyword)).ToArray();
+                }
+
+                // keyword rows
+                for (int index = 0; index < list.arraySize; index++)
+                {
+                    // the element
+                    SerializedProperty speechCommandProperty = list.GetArrayElementAtIndex(index);
+                    GUILayout.BeginHorizontal();
                     bool elementExpanded = EditorGUILayout.PropertyField(speechCommandProperty);
                     GUILayout.FlexibleSpace();
                     // the remove element button
                     bool elementRemoved = GUILayout.Button(RemoveButtonContent, EditorStyles.miniButton, MiniButtonWidth);
 
-                GUILayout.EndHorizontal();
+                    GUILayout.EndHorizontal();
 
-                if (elementRemoved)
-                {
-                    list.DeleteArrayElementAtIndex(index);
-
-                    if (index == list.arraySize)
+                    if (elementRemoved)
                     {
-                        EditorGUI.indentLevel--;
-                        return;
-                    }
-                }
+                        list.DeleteArrayElementAtIndex(index);
 
-                SerializedProperty keywordProperty = speechCommandProperty.FindPropertyRelative("keyword");
-
-                bool invalidKeyword = true;
-                if (distinctRegisteredKeywords != null)
-                {
-                    foreach (string keyword in distinctRegisteredKeywords)
-                    {
-                        if (keyword == keywordProperty.stringValue)
+                        if (index == list.arraySize)
                         {
-                            invalidKeyword = false;
-                            break;
+                            EditorGUI.indentLevel--;
+                            return;
                         }
                     }
-                }
 
-                if (invalidKeyword)
-                {
-                    EditorGUILayout.HelpBox("Registered keyword is not recognized in the speech command profile!", MessageType.Error);
-                }
+                    SerializedProperty keywordProperty = speechCommandProperty.FindPropertyRelative("keyword");
 
-                if (!elementRemoved && elementExpanded)
-                {
-                    string[] keywords = availableKeywords.Concat(new[] { keywordProperty.stringValue }).OrderBy(keyword => keyword).ToArray();
-                    int previousSelection = ArrayUtility.IndexOf(keywords, keywordProperty.stringValue);
-                    int currentSelection = EditorGUILayout.Popup("Keyword", previousSelection, keywords);
-
-                    if (currentSelection != previousSelection)
+                    bool invalidKeyword = true;
+                    if (distinctRegisteredKeywords != null)
                     {
-                        keywordProperty.stringValue = keywords[currentSelection];
+                        foreach (string keyword in distinctRegisteredKeywords)
+                        {
+                            if (keyword == keywordProperty.stringValue)
+                            {
+                                invalidKeyword = false;
+                                break;
+                            }
+                        }
                     }
 
-                    SerializedProperty responseProperty = speechCommandProperty.FindPropertyRelative("response");
-                    EditorGUILayout.PropertyField(responseProperty, true);
+                    if (invalidKeyword)
+                    {
+                        EditorGUILayout.HelpBox("Registered keyword is not recognized in the speech command profile!", MessageType.Error);
+                    }
+
+                    if (!elementRemoved && elementExpanded)
+                    {
+                        string[] keywords = availableKeywords.Concat(new[] { keywordProperty.stringValue }).OrderBy(keyword => keyword).ToArray();
+                        int previousSelection = ArrayUtility.IndexOf(keywords, keywordProperty.stringValue);
+                        int currentSelection = EditorGUILayout.Popup("Keyword", previousSelection, keywords);
+
+                        if (currentSelection != previousSelection)
+                        {
+                            keywordProperty.stringValue = keywords[currentSelection];
+                        }
+
+                        SerializedProperty responseProperty = speechCommandProperty.FindPropertyRelative("response");
+                        EditorGUILayout.PropertyField(responseProperty, true);
+                    }
+                }
+
+                // add button row
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    GUILayout.FlexibleSpace();
+
+                    // the add element button
+                    if (GUILayout.Button(AddButtonContent, EditorStyles.miniButton, MiniButtonWidth))
+                    {
+                        var index = list.arraySize;
+                        list.InsertArrayElementAtIndex(index);
+                        var elementProperty = list.GetArrayElementAtIndex(index);
+                        SerializedProperty keywordProperty = elementProperty.FindPropertyRelative("keyword");
+                        keywordProperty.stringValue = string.Empty;
+                    }
                 }
             }
-
-            // add button row
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-
-            // the add element button
-            if (GUILayout.Button(AddButtonContent, EditorStyles.miniButton, MiniButtonWidth))
-            {
-                var index = list.arraySize;
-                list.InsertArrayElementAtIndex(index);
-                var elementProperty = list.GetArrayElementAtIndex(index);
-                SerializedProperty keywordProperty = elementProperty.FindPropertyRelative("keyword");
-                keywordProperty.stringValue = string.Empty;
-            }
-
-            EditorGUILayout.EndHorizontal();
-            EditorGUI.indentLevel--;
         }
 
         private static string[] GetDistinctRegisteredKeywords()

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -44,7 +44,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
 
         protected bool hasProfileLayout;
 
-        protected GUIStyle boxStyle;
         private const int ThemePropertiesBoxMargin = 30;
 
         private static readonly GUIContent InputActionsLabel = new GUIContent("Input Actions", "The input action filter");

--- a/Assets/MixedRealityToolkit.Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/DependencyWindow/DependencyWindow.cs
@@ -160,7 +160,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             if (EditorSettings.serializationMode != SerializationMode.ForceText)
             {
-                EditorGUILayout.BeginHorizontal();
+                using (new EditorGUILayout.HorizontalScope())
                 {
                     EditorGUILayout.HelpBox("Dependencies can only be tracked with text assets. Please change the project serialization mode to \"Force Text\"", MessageType.Error);
 
@@ -169,13 +169,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         EditorSettings.serializationMode = SerializationMode.ForceText;
                     }
                 }
-                EditorGUILayout.EndHorizontal();
             }
         }
 
         private void DrawDependencyGraphStatistics()
         {
-            EditorGUILayout.BeginHorizontal();
+            using (new EditorGUILayout.HorizontalScope())
             {
                 if (dependencyGraph.Count == 0)
                 {
@@ -191,8 +190,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     RefreshDependencyGraph();
                 }
             }
-            EditorGUILayout.EndHorizontal();
-
             EditorGUILayout.Space();
 
             if (GUI.enabled)
@@ -475,7 +472,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static void DrawDependencyGraphNode(DependencyGraphNode node, int depth, int maxDepth)
         {
-            EditorGUILayout.BeginHorizontal();
+            using (new EditorGUILayout.HorizontalScope())
             {
                 GUILayout.Space(depth * 8);
 
@@ -495,7 +492,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     EditorGUILayout.LabelField("Max display depth was exceeded...");
                 }
             }
-            EditorGUILayout.EndHorizontal();
         }
 
         private static void DrawDependencyGraphNodeRecurse(DependencyGraphNode node, int depth, int maxDepth)

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -103,18 +103,19 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             buttonContent.text = " Services Documentation";
             buttonContent.tooltip = servicesDocumentationURL;
 
-            GUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-
-            if (GUILayout.Button(buttonContent, GUILayout.MaxWidth(docLinkWidth)))
+            using (new EditorGUILayout.HorizontalScope())
             {
-                Application.OpenURL(servicesDocumentationURL);
+                GUILayout.FlexibleSpace();
+
+                if (GUILayout.Button(buttonContent, GUILayout.MaxWidth(docLinkWidth)))
+                {
+                    Application.OpenURL(servicesDocumentationURL);
+                }
+
+                GUILayout.FlexibleSpace();
             }
 
-            GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
             EditorGUILayout.Space();
-
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Choose a name for your service.", EditorStyles.miniLabel);
 
@@ -221,19 +222,20 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.Space();
 
             GUI.color = enabledColor;
-            EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("Back"))
+            using (new EditorGUILayout.HorizontalScope())
             {
-                creator.Stage = ExtensionServiceCreator.CreationStage.SelectNameAndPlatform;
-                creator.StoreState();
+                if (GUILayout.Button("Back"))
+                {
+                    creator.Stage = ExtensionServiceCreator.CreationStage.SelectNameAndPlatform;
+                    creator.StoreState();
+                }
+                GUI.color = readyToProgress ? enabledColor : disabledColor;
+                if (GUILayout.Button("Next") && readyToProgress)
+                {
+                    // Start the async method that will wait for the service to be created
+                    CreateAssetsAsync();
+                }
             }
-            GUI.color = readyToProgress ? enabledColor : disabledColor;
-            if (GUILayout.Button("Next") && readyToProgress)
-            {
-                // Start the async method that will wait for the service to be created
-                CreateAssetsAsync();
-            }
-            EditorGUILayout.EndHorizontal();
         }
 
         private void DrawCreatingAssets()
@@ -316,32 +318,35 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     EditorGUILayout.HelpBox("Toolkit has no RegisteredServiceProvidersProfile. Can't register service.", MessageType.Warning);
                     canRegisterProfile = false;
                 }
+
                 EditorGUILayout.Space();
-                EditorGUILayout.BeginHorizontal();
-                GUI.color = canRegisterProfile ? enabledColor : disabledColor;
-                if (GUILayout.Button("Register") && canRegisterProfile)
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    RegisterServiceWithActiveMixedRealityProfile();
+                    GUI.color = canRegisterProfile ? enabledColor : disabledColor;
+                    if (GUILayout.Button("Register") && canRegisterProfile)
+                    {
+                        RegisterServiceWithActiveMixedRealityProfile();
+                    }
+                    GUI.color = enabledColor;
+                    if (GUILayout.Button("Not Now"))
+                    {
+                        creator.ResetState();
+                        Close();
+                    }
                 }
-                GUI.color = enabledColor;
-                if (GUILayout.Button("Not Now"))
-                {
-                    creator.ResetState();
-                    Close();
-                }
-                EditorGUILayout.EndHorizontal();
             }
             else
             {
                 EditorGUILayout.LabelField("Your service is now registered. Scripts can access this service like so:", EditorStyles.miniLabel);
 
-                EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.TextField(creator.SampleCode);
-                if (GUILayout.Button("Copy Sample Code", EditorStyles.miniButton))
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUIUtility.systemCopyBuffer = creator.SampleCode;
+                    EditorGUILayout.TextField(creator.SampleCode);
+                    if (GUILayout.Button("Copy Sample Code", EditorStyles.miniButton))
+                    {
+                        EditorGUIUtility.systemCopyBuffer = creator.SampleCode;
+                    }
                 }
-                EditorGUILayout.EndHorizontal();
 
                 EditorGUILayout.Space();
                 if (GUILayout.Button("Close"))

--- a/Assets/MixedRealityToolkit.Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -173,20 +173,21 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     onlyUnityShader = EditorGUILayout.ToggleLeft("Only Discover Materials with Unity Standard Shader", onlyUnityShader);
                     EditorGUILayout.Space();
 
-                    EditorGUILayout.BeginHorizontal();
-                    if (GUILayout.Button("Discover Materials in Assets"))
+                    using (new EditorGUILayout.HorizontalScope())
                     {
-                        DiscoverMaterials();
-                    }
+                        if (GUILayout.Button("Discover Materials in Assets"))
+                        {
+                            DiscoverMaterials();
+                        }
 
-                    bool wasGUIEnabled = GUI.enabled;
-                    GUI.enabled = wasGUIEnabled && discoveredMaterials.Count > 0;
-                    if (GUILayout.Button("Convert All Discovered Materials"))
-                    {
-                        ConvertMaterials();
+                        bool wasGUIEnabled = GUI.enabled;
+                        GUI.enabled = wasGUIEnabled && discoveredMaterials.Count > 0;
+                        if (GUILayout.Button("Convert All Discovered Materials"))
+                        {
+                            ConvertMaterials();
+                        }
+                        GUI.enabled = wasGUIEnabled;
                     }
-                    GUI.enabled = wasGUIEnabled;
-                    EditorGUILayout.EndHorizontal();
 
                     if (discoveredMaterials.Count > 0)
                     {
@@ -197,16 +198,18 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             {
                                 EditorGUILayout.LabelField("Discovered " + discoveredMaterials.Count + " materials to convert");
 
-                                EditorGUILayout.BeginHorizontal();
-                                EditorGUILayout.LabelField("Current Shader", EditorStyles.boldLabel);
-                                EditorGUILayout.LabelField("Material Asset", EditorStyles.boldLabel);
-                                EditorGUILayout.EndHorizontal();
+                                using (new EditorGUILayout.HorizontalScope())
+                                {
+                                    EditorGUILayout.LabelField("Current Shader", EditorStyles.boldLabel);
+                                    EditorGUILayout.LabelField("Material Asset", EditorStyles.boldLabel);
+                                }
 
                                 for (int i = 0; i < discoveredMaterials.Count; i++)
                                 {
                                     if (discoveredMaterials[i] != null)
                                     {
-                                        EditorGUILayout.BeginHorizontal();
+                                        using (new EditorGUILayout.HorizontalScope())
+                                        {
                                             EditorGUILayout.LabelField(discoveredMaterials[i].shader.name);
                                             discoveredMaterials[i] = (Material)EditorGUILayout.ObjectField(discoveredMaterials[i], typeof(Material), false);
                                             if (GUILayout.Button(new GUIContent("View", "Selects & views this asset in inspector"), EditorStyles.miniButton, GUILayout.Width(42f)))
@@ -218,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                                 Undo.RecordObject(this.discoveredMaterials[i], "Convert to MRTK Standard shader");
                                                 ConvertMaterial(this.discoveredMaterials[i]);
                                             }
-                                        EditorGUILayout.EndHorizontal();
+                                        }
                                     }
                                 }
                             }
@@ -280,25 +283,27 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         // Mesh Analysis
                         EditorGUILayout.LabelField("Polygon Count Analysis", EditorStyles.boldLabel);
 
-                        EditorGUILayout.BeginHorizontal();
-                        EditorGUILayout.LabelField(TotalPolyCountStr);
-                        EditorGUILayout.LabelField(TotalActivePolyCountStr);
-                        EditorGUILayout.LabelField(TotalInactivePolyCountStr);
-                        EditorGUILayout.EndHorizontal();
+                        using (new EditorGUILayout.HorizontalScope())
+                        {
+                            EditorGUILayout.LabelField(TotalPolyCountStr);
+                            EditorGUILayout.LabelField(TotalActivePolyCountStr);
+                            EditorGUILayout.LabelField(TotalInactivePolyCountStr);
+                        }
 
                         EditorGUILayout.LabelField("Top " + TopListSize + " GameObjects in scene with highest polygon count");
                         for (int i = 0; i < LargestMeshes.Length; i++)
                         {
                             if (LargestMeshes[i] != null)
                             {
-                                EditorGUILayout.BeginHorizontal();
-                                EditorGUILayout.LabelField("Num of Polygons: " + this.LargestMeshSizes[i].ToString("N0"));
-                                EditorGUILayout.ObjectField(this.LargestMeshes[i], typeof(GameObject), true);
-                                if (GUILayout.Button(new GUIContent("View", "Selects & view this asset in inspector"), EditorStyles.miniButton, GUILayout.Width(42f)))
+                                using (new EditorGUILayout.HorizontalScope())
                                 {
-                                    Selection.activeObject = this.LargestMeshes[i];
+                                    EditorGUILayout.LabelField("Num of Polygons: " + this.LargestMeshSizes[i].ToString("N0"));
+                                    EditorGUILayout.ObjectField(this.LargestMeshes[i], typeof(GameObject), true);
+                                    if (GUILayout.Button(new GUIContent("View", "Selects & view this asset in inspector"), EditorStyles.miniButton, GUILayout.Width(42f)))
+                                    {
+                                        Selection.activeObject = this.LargestMeshes[i];
+                                    }
                                 }
-                                EditorGUILayout.EndHorizontal();
                             }
                         }
                     }
@@ -367,13 +372,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 bool isGIEnabled = MixedRealityOptimizeUtils.IsRealtimeGlobalIlluminationEnabled();
                 BuildSection("Real-time Global Illumination", GlobalIllumination_URL, GetTitleIcon(!isGIEnabled), () =>
                 {
-                    EditorGUILayout.BeginHorizontal();
-                    EditorGUILayout.LabelField("Real-time Global Illumination can produce great visual results but at great expense. It is recommended to disable this feature in lighting settings.", EditorStyles.wordWrappedLabel);
-                    if (GUILayout.Button(new GUIContent("View Lighting Settings", "Open Lighting Settings"), EditorStyles.miniButton, GUILayout.Width(160f)))
+                    using (new EditorGUILayout.HorizontalScope())
                     {
-                        EditorApplication.ExecuteMenuItem("Window/Rendering/Lighting Settings");
+                        EditorGUILayout.LabelField("Real-time Global Illumination can produce great visual results but at great expense. It is recommended to disable this feature in lighting settings.", EditorStyles.wordWrappedLabel);
+                        if (GUILayout.Button(new GUIContent("View Lighting Settings", "Open Lighting Settings"), EditorStyles.miniButton, GUILayout.Width(160f)))
+                        {
+                            EditorApplication.ExecuteMenuItem("Window/Rendering/Lighting Settings");
+                        }
                     }
-                    EditorGUILayout.EndHorizontal();
 
                     EditorGUILayout.HelpBox("Note: Real-time Global Illumination is a per-scene setting.", MessageType.Info);
 
@@ -490,10 +496,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);
             // Section Title
-            EditorGUILayout.BeginHorizontal();
+            using (new EditorGUILayout.HorizontalScope())
+            {
                 EditorGUILayout.LabelField(new GUIContent(title, titleIcon), EditorStyles.boldLabel);
                 InspectorUIUtility.RenderDocumentationButton(url);
-            EditorGUILayout.EndHorizontal();
+            }
         }
 
         private static void BuildSection(string title, string url, Texture titleIcon = null, Action renderContent = null)

--- a/Assets/MixedRealityToolkit/Inspectors/ControllerPopupWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ControllerPopupWindow.cs
@@ -391,306 +391,306 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             for (int i = 0; i < interactionList.arraySize; i++)
             {
-                EditorGUILayout.BeginHorizontal();
-                SerializedProperty interaction = interactionList.GetArrayElementAtIndex(i);
-
-                if (useCustomInteractionMapping)
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.LabelField($"{i + 1}", GUILayout.Width(32f));
-                    var inputType = interaction.FindPropertyRelative("inputType");
-                    EditorGUILayout.PropertyField(inputType, GUIContent.none, GUILayout.Width(InputActionLabelWidth));
-                    var axisType = interaction.FindPropertyRelative("axisType");
-                    EditorGUILayout.PropertyField(axisType, GUIContent.none, GUILayout.Width(InputActionLabelWidth));
-                    var invertXAxis = interaction.FindPropertyRelative("invertXAxis");
-                    var invertYAxis = interaction.FindPropertyRelative("invertYAxis");
-                    var interactionAxisConstraint = interaction.FindPropertyRelative("axisType");
+                    SerializedProperty interaction = interactionList.GetArrayElementAtIndex(i);
 
-                    var action = interaction.FindPropertyRelative("inputAction");
-                    var actionId = action.FindPropertyRelative("id");
-                    var actionDescription = action.FindPropertyRelative("description");
-                    var actionConstraint = action.FindPropertyRelative("axisConstraint");
-
-                    GUIContent[] labels;
-                    int[] ids;
-
-                    switch ((AxisType)interactionAxisConstraint.intValue)
+                    if (useCustomInteractionMapping)
                     {
-                        default:
-                        case AxisType.None:
-                            labels = actionLabels;
-                            ids = actionIds;
-                            break;
-                        case AxisType.Raw:
-                            labels = rawActionLabels;
-                            ids = rawActionIds;
-                            break;
-                        case AxisType.Digital:
-                            labels = digitalActionLabels;
-                            ids = digitalActionIds;
-                            break;
-                        case AxisType.SingleAxis:
-                            labels = singleAxisActionLabels;
-                            ids = singleAxisActionIds;
-                            break;
-                        case AxisType.DualAxis:
-                            labels = dualAxisActionLabels;
-                            ids = dualAxisActionIds;
-                            break;
-                        case AxisType.ThreeDofPosition:
-                            labels = threeDofPositionActionLabels;
-                            ids = threeDofPositionActionIds;
-                            break;
-                        case AxisType.ThreeDofRotation:
-                            labels = threeDofRotationActionLabels;
-                            ids = threeDofRotationActionIds;
-                            break;
-                        case AxisType.SixDof:
-                            labels = sixDofActionLabels;
-                            ids = sixDofActionIds;
-                            break;
-                    }
+                        EditorGUILayout.LabelField($"{i + 1}", GUILayout.Width(32f));
+                        var inputType = interaction.FindPropertyRelative("inputType");
+                        EditorGUILayout.PropertyField(inputType, GUIContent.none, GUILayout.Width(InputActionLabelWidth));
+                        var axisType = interaction.FindPropertyRelative("axisType");
+                        EditorGUILayout.PropertyField(axisType, GUIContent.none, GUILayout.Width(InputActionLabelWidth));
+                        var invertXAxis = interaction.FindPropertyRelative("invertXAxis");
+                        var invertYAxis = interaction.FindPropertyRelative("invertYAxis");
+                        var interactionAxisConstraint = interaction.FindPropertyRelative("axisType");
 
-                    EditorGUI.BeginChangeCheck();
-                    actionId.intValue = EditorGUILayout.IntPopup(GUIContent.none, actionId.intValue, labels, ids, GUILayout.Width(InputActionLabelWidth));
+                        var action = interaction.FindPropertyRelative("inputAction");
+                        var actionId = action.FindPropertyRelative("id");
+                        var actionDescription = action.FindPropertyRelative("description");
+                        var actionConstraint = action.FindPropertyRelative("axisConstraint");
 
-                    if (EditorGUI.EndChangeCheck())
-                    {
-                        var inputAction = actionId.intValue == 0 ? MixedRealityInputAction.None : MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
-                        actionDescription.stringValue = inputAction.Description;
-                        actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
-                    }
+                        GUIContent[] labels;
+                        int[] ids;
 
-                    if ((AxisType)axisType.intValue == AxisType.Digital)
-                    {
-                        var keyCode = interaction.FindPropertyRelative("keyCode");
-                        EditorGUILayout.PropertyField(keyCode, GUIContent.none, GUILayout.Width(InputActionLabelWidth));
-                    }
-                    else
-                    {
-                        if ((AxisType)axisType.intValue == AxisType.DualAxis)
+                        switch ((AxisType)interactionAxisConstraint.intValue)
                         {
-                            EditorGUIUtility.labelWidth = InputActionLabelWidth * 0.5f;
-                            EditorGUIUtility.fieldWidth = InputActionLabelWidth * 0.5f;
-
-                            int currentAxisSetting = 0;
-
-                            if (invertXAxis.boolValue)
-                            {
-                                currentAxisSetting += 1;
-                            }
-
-                            if (invertYAxis.boolValue)
-                            {
-                                currentAxisSetting += 2;
-                            }
-
-                            EditorGUI.BeginChangeCheck();
-                            currentAxisSetting = EditorGUILayout.IntPopup(InvertContent, currentAxisSetting, InvertAxisContent, InvertAxisValues, GUILayout.Width(InputActionLabelWidth));
-
-                            if (EditorGUI.EndChangeCheck())
-                            {
-                                switch (currentAxisSetting)
-                                {
-                                    case 0:
-                                        invertXAxis.boolValue = false;
-                                        invertYAxis.boolValue = false;
-                                        break;
-                                    case 1:
-                                        invertXAxis.boolValue = true;
-                                        invertYAxis.boolValue = false;
-                                        break;
-                                    case 2:
-                                        invertXAxis.boolValue = false;
-                                        invertYAxis.boolValue = true;
-                                        break;
-                                    case 3:
-                                        invertXAxis.boolValue = true;
-                                        invertYAxis.boolValue = true;
-                                        break;
-                                }
-                            }
-
-                            EditorGUIUtility.labelWidth = defaultLabelWidth;
-                            EditorGUIUtility.fieldWidth = defaultFieldWidth;
+                            default:
+                            case AxisType.None:
+                                labels = actionLabels;
+                                ids = actionIds;
+                                break;
+                            case AxisType.Raw:
+                                labels = rawActionLabels;
+                                ids = rawActionIds;
+                                break;
+                            case AxisType.Digital:
+                                labels = digitalActionLabels;
+                                ids = digitalActionIds;
+                                break;
+                            case AxisType.SingleAxis:
+                                labels = singleAxisActionLabels;
+                                ids = singleAxisActionIds;
+                                break;
+                            case AxisType.DualAxis:
+                                labels = dualAxisActionLabels;
+                                ids = dualAxisActionIds;
+                                break;
+                            case AxisType.ThreeDofPosition:
+                                labels = threeDofPositionActionLabels;
+                                ids = threeDofPositionActionIds;
+                                break;
+                            case AxisType.ThreeDofRotation:
+                                labels = threeDofRotationActionLabels;
+                                ids = threeDofRotationActionIds;
+                                break;
+                            case AxisType.SixDof:
+                                labels = sixDofActionLabels;
+                                ids = sixDofActionIds;
+                                break;
                         }
-                        else if ((AxisType)axisType.intValue == AxisType.SingleAxis)
+
+                        EditorGUI.BeginChangeCheck();
+                        actionId.intValue = EditorGUILayout.IntPopup(GUIContent.none, actionId.intValue, labels, ids, GUILayout.Width(InputActionLabelWidth));
+
+                        if (EditorGUI.EndChangeCheck())
                         {
-                            invertXAxis.boolValue = EditorGUILayout.ToggleLeft("Invert X", invertXAxis.boolValue, GUILayout.Width(InputActionLabelWidth));
-                            EditorGUIUtility.labelWidth = defaultLabelWidth;
+                            var inputAction = actionId.intValue == 0 ? MixedRealityInputAction.None : MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
+                            actionDescription.stringValue = inputAction.Description;
+                            actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                        }
+
+                        if ((AxisType)axisType.intValue == AxisType.Digital)
+                        {
+                            var keyCode = interaction.FindPropertyRelative("keyCode");
+                            EditorGUILayout.PropertyField(keyCode, GUIContent.none, GUILayout.Width(InputActionLabelWidth));
+                        }
+                        else
+                        {
+                            if ((AxisType)axisType.intValue == AxisType.DualAxis)
+                            {
+                                EditorGUIUtility.labelWidth = InputActionLabelWidth * 0.5f;
+                                EditorGUIUtility.fieldWidth = InputActionLabelWidth * 0.5f;
+
+                                int currentAxisSetting = 0;
+
+                                if (invertXAxis.boolValue)
+                                {
+                                    currentAxisSetting += 1;
+                                }
+
+                                if (invertYAxis.boolValue)
+                                {
+                                    currentAxisSetting += 2;
+                                }
+
+                                EditorGUI.BeginChangeCheck();
+                                currentAxisSetting = EditorGUILayout.IntPopup(InvertContent, currentAxisSetting, InvertAxisContent, InvertAxisValues, GUILayout.Width(InputActionLabelWidth));
+
+                                if (EditorGUI.EndChangeCheck())
+                                {
+                                    switch (currentAxisSetting)
+                                    {
+                                        case 0:
+                                            invertXAxis.boolValue = false;
+                                            invertYAxis.boolValue = false;
+                                            break;
+                                        case 1:
+                                            invertXAxis.boolValue = true;
+                                            invertYAxis.boolValue = false;
+                                            break;
+                                        case 2:
+                                            invertXAxis.boolValue = false;
+                                            invertYAxis.boolValue = true;
+                                            break;
+                                        case 3:
+                                            invertXAxis.boolValue = true;
+                                            invertYAxis.boolValue = true;
+                                            break;
+                                    }
+                                }
+
+                                EditorGUIUtility.labelWidth = defaultLabelWidth;
+                                EditorGUIUtility.fieldWidth = defaultFieldWidth;
+                            }
+                            else if ((AxisType)axisType.intValue == AxisType.SingleAxis)
+                            {
+                                invertXAxis.boolValue = EditorGUILayout.ToggleLeft("Invert X", invertXAxis.boolValue, GUILayout.Width(InputActionLabelWidth));
+                                EditorGUIUtility.labelWidth = defaultLabelWidth;
+                            }
+                            else
+                            {
+                                EditorGUILayout.LabelField(GUIContent.none, GUILayout.Width(InputActionLabelWidth));
+                            }
+                        }
+
+                        if ((AxisType)axisType.intValue == AxisType.SingleAxis ||
+                            (AxisType)axisType.intValue == AxisType.DualAxis)
+                        {
+                            var axisCodeX = interaction.FindPropertyRelative("axisCodeX");
+                            RenderAxisPopup(axisCodeX, InputActionLabelWidth);
                         }
                         else
                         {
                             EditorGUILayout.LabelField(GUIContent.none, GUILayout.Width(InputActionLabelWidth));
                         }
-                    }
 
-                    if ((AxisType)axisType.intValue == AxisType.SingleAxis ||
-                        (AxisType)axisType.intValue == AxisType.DualAxis)
-                    {
-                        var axisCodeX = interaction.FindPropertyRelative("axisCodeX");
-                        RenderAxisPopup(axisCodeX, InputActionLabelWidth);
+                        if ((AxisType)axisType.intValue == AxisType.DualAxis)
+                        {
+                            var axisCodeY = interaction.FindPropertyRelative("axisCodeY");
+                            RenderAxisPopup(axisCodeY, InputActionLabelWidth);
+                        }
+                        else
+                        {
+                            EditorGUILayout.LabelField(GUIContent.none, GUILayout.Width(InputActionLabelWidth));
+                        }
+
+                        if (GUILayout.Button(InteractionMinusButtonContent, EditorStyles.miniButtonRight, GUILayout.ExpandWidth(true)))
+                        {
+                            interactionList.DeleteArrayElementAtIndex(i);
+                        }
                     }
                     else
                     {
-                        EditorGUILayout.LabelField(GUIContent.none, GUILayout.Width(InputActionLabelWidth));
-                    }
+                        var interactionDescription = interaction.FindPropertyRelative("description");
+                        var interactionAxisConstraint = interaction.FindPropertyRelative("axisType");
+                        var action = interaction.FindPropertyRelative("inputAction");
+                        var actionId = action.FindPropertyRelative("id");
+                        var actionDescription = action.FindPropertyRelative("description");
+                        var actionConstraint = action.FindPropertyRelative("axisConstraint");
 
-                    if ((AxisType)axisType.intValue == AxisType.DualAxis)
-                    {
-                        var axisCodeY = interaction.FindPropertyRelative("axisCodeY");
-                        RenderAxisPopup(axisCodeY, InputActionLabelWidth);
-                    }
-                    else
-                    {
-                        EditorGUILayout.LabelField(GUIContent.none, GUILayout.Width(InputActionLabelWidth));
-                    }
+                        GUIContent[] labels;
+                        int[] ids;
 
-                    if (GUILayout.Button(InteractionMinusButtonContent, EditorStyles.miniButtonRight, GUILayout.ExpandWidth(true)))
-                    {
-                        interactionList.DeleteArrayElementAtIndex(i);
+                        switch ((AxisType)interactionAxisConstraint.intValue)
+                        {
+                            default:
+                            case AxisType.None:
+                                labels = actionLabels;
+                                ids = actionIds;
+                                break;
+                            case AxisType.Raw:
+                                labels = rawActionLabels;
+                                ids = rawActionIds;
+                                break;
+                            case AxisType.Digital:
+                                labels = digitalActionLabels;
+                                ids = digitalActionIds;
+                                break;
+                            case AxisType.SingleAxis:
+                                labels = singleAxisActionLabels;
+                                ids = singleAxisActionIds;
+                                break;
+                            case AxisType.DualAxis:
+                                labels = dualAxisActionLabels;
+                                ids = dualAxisActionIds;
+                                break;
+                            case AxisType.ThreeDofPosition:
+                                labels = threeDofPositionActionLabels;
+                                ids = threeDofPositionActionIds;
+                                break;
+                            case AxisType.ThreeDofRotation:
+                                labels = threeDofRotationActionLabels;
+                                ids = threeDofRotationActionIds;
+                                break;
+                            case AxisType.SixDof:
+                                labels = sixDofActionLabels;
+                                ids = sixDofActionIds;
+                                break;
+                        }
+
+                        EditorGUI.BeginChangeCheck();
+
+                        if (currentControllerOption == null || currentControllerTexture == null)
+                        {
+                            bool skip = false;
+                            var description = interactionDescription.stringValue;
+                            if (currentControllerMapping.SupportedControllerType == SupportedControllerType.GGVHand
+                                && currentControllerMapping.Handedness == Handedness.None)
+                            {
+                                if (description != "Select")
+                                {
+                                    skip = true;
+                                }
+                            }
+
+                            if (!skip)
+                            {
+                                actionId.intValue = EditorGUILayout.IntPopup(GUIContent.none, actionId.intValue, labels, ids, GUILayout.Width(80f));
+                                EditorGUILayout.LabelField(description, GUILayout.ExpandWidth(true));
+                            }
+                        }
+                        else
+                        {
+                            var rectPosition = currentControllerOption.InputLabelPositions[i];
+                            var rectSize = InputActionLabelPosition + InputActionDropdownPosition + new Vector2(currentControllerOption.IsLabelFlipped[i] ? 0f : 8f, EditorGUIUtility.singleLineHeight);
+                            GUI.Box(new Rect(rectPosition, rectSize), GUIContent.none, EditorGUIUtility.isProSkin ? "ObjectPickerBackground" : "ObjectPickerResultsEven");
+                            var offset = currentControllerOption.IsLabelFlipped[i] ? InputActionLabelPosition : Vector2.zero;
+                            var popupRect = new Rect(rectPosition + offset, new Vector2(InputActionDropdownPosition.x, EditorGUIUtility.singleLineHeight));
+
+                            actionId.intValue = EditorGUI.IntPopup(popupRect, actionId.intValue, labels, ids);
+                            offset = currentControllerOption.IsLabelFlipped[i] ? Vector2.zero : InputActionDropdownPosition;
+                            var labelRect = new Rect(rectPosition + offset, new Vector2(InputActionLabelPosition.x, EditorGUIUtility.singleLineHeight));
+                            EditorGUI.LabelField(labelRect, interactionDescription.stringValue, currentControllerOption.IsLabelFlipped[i] ? flippedLabelStyle : EditorStyles.label);
+
+                            if (editInputActionPositions)
+                            {
+                                offset = currentControllerOption.IsLabelFlipped[i] ? InputActionLabelPosition + InputActionDropdownPosition + HorizontalSpace : InputActionFlipTogglePosition;
+                                var toggleRect = new Rect(rectPosition + offset, new Vector2(-InputActionFlipTogglePosition.x, EditorGUIUtility.singleLineHeight));
+
+                                EditorGUI.BeginChangeCheck();
+                                currentControllerOption.IsLabelFlipped[i] = EditorGUI.Toggle(toggleRect, currentControllerOption.IsLabelFlipped[i]);
+
+                                if (EditorGUI.EndChangeCheck())
+                                {
+                                    if (currentControllerOption.IsLabelFlipped[i])
+                                    {
+                                        currentControllerOption.InputLabelPositions[i] -= InputActionLabelPosition;
+                                    }
+                                    else
+                                    {
+                                        currentControllerOption.InputLabelPositions[i] += InputActionLabelPosition;
+                                    }
+                                }
+
+                                if (!isMouseInRects.Any(value => value) || isMouseInRects[i])
+                                {
+                                    if (Event.current.type == EventType.MouseDrag && labelRect.Contains(Event.current.mousePosition) && !isMouseInRects[i])
+                                    {
+                                        isMouseInRects[i] = true;
+                                        mouseDragOffset = Event.current.mousePosition - currentControllerOption.InputLabelPositions[i];
+                                    }
+                                    else if (Event.current.type == EventType.Repaint && isMouseInRects[i])
+                                    {
+                                        currentControllerOption.InputLabelPositions[i] = Event.current.mousePosition - mouseDragOffset;
+                                    }
+                                    else if (Event.current.type == EventType.DragUpdated && isMouseInRects[i])
+                                    {
+                                        currentControllerOption.InputLabelPositions[i] = Event.current.mousePosition - mouseDragOffset;
+                                    }
+                                    else if (Event.current.type == EventType.MouseUp && isMouseInRects[i])
+                                    {
+                                        currentControllerOption.InputLabelPositions[i] = Event.current.mousePosition - mouseDragOffset;
+                                        mouseDragOffset = Vector2.zero;
+                                        isMouseInRects[i] = false;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (EditorGUI.EndChangeCheck())
+                        {
+                            MixedRealityInputAction inputAction = actionId.intValue == 0 ?
+                                MixedRealityInputAction.None :
+                                MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
+                            actionId.intValue = (int)inputAction.Id;
+                            actionDescription.stringValue = inputAction.Description;
+                            actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                            interactionList.serializedObject.ApplyModifiedProperties();
+                        }
                     }
                 }
-                else
-                {
-                    var interactionDescription = interaction.FindPropertyRelative("description");
-                    var interactionAxisConstraint = interaction.FindPropertyRelative("axisType");
-                    var action = interaction.FindPropertyRelative("inputAction");
-                    var actionId = action.FindPropertyRelative("id");
-                    var actionDescription = action.FindPropertyRelative("description");
-                    var actionConstraint = action.FindPropertyRelative("axisConstraint");
-
-                    GUIContent[] labels;
-                    int[] ids;
-
-                    switch ((AxisType)interactionAxisConstraint.intValue)
-                    {
-                        default:
-                        case AxisType.None:
-                            labels = actionLabels;
-                            ids = actionIds;
-                            break;
-                        case AxisType.Raw:
-                            labels = rawActionLabels;
-                            ids = rawActionIds;
-                            break;
-                        case AxisType.Digital:
-                            labels = digitalActionLabels;
-                            ids = digitalActionIds;
-                            break;
-                        case AxisType.SingleAxis:
-                            labels = singleAxisActionLabels;
-                            ids = singleAxisActionIds;
-                            break;
-                        case AxisType.DualAxis:
-                            labels = dualAxisActionLabels;
-                            ids = dualAxisActionIds;
-                            break;
-                        case AxisType.ThreeDofPosition:
-                            labels = threeDofPositionActionLabels;
-                            ids = threeDofPositionActionIds;
-                            break;
-                        case AxisType.ThreeDofRotation:
-                            labels = threeDofRotationActionLabels;
-                            ids = threeDofRotationActionIds;
-                            break;
-                        case AxisType.SixDof:
-                            labels = sixDofActionLabels;
-                            ids = sixDofActionIds;
-                            break;
-                    }
-
-                    EditorGUI.BeginChangeCheck();
-
-                    if (currentControllerOption == null || currentControllerTexture == null)
-                    {
-                        bool skip = false;
-                        var description = interactionDescription.stringValue;
-                        if (currentControllerMapping.SupportedControllerType == SupportedControllerType.GGVHand
-                            && currentControllerMapping.Handedness == Handedness.None)
-                        {
-                            if (description != "Select")
-                            {
-                                skip = true;
-                            }
-                        }
-
-                        if (!skip)
-                        {
-                            actionId.intValue = EditorGUILayout.IntPopup(GUIContent.none, actionId.intValue, labels, ids, GUILayout.Width(80f));
-                            EditorGUILayout.LabelField(description, GUILayout.ExpandWidth(true));
-                        }
-                    }
-                    else
-                    {
-                        var rectPosition = currentControllerOption.InputLabelPositions[i];
-                        var rectSize = InputActionLabelPosition + InputActionDropdownPosition + new Vector2(currentControllerOption.IsLabelFlipped[i] ? 0f : 8f, EditorGUIUtility.singleLineHeight);
-                        GUI.Box(new Rect(rectPosition, rectSize), GUIContent.none, EditorGUIUtility.isProSkin ? "ObjectPickerBackground" : "ObjectPickerResultsEven");
-                        var offset = currentControllerOption.IsLabelFlipped[i] ? InputActionLabelPosition : Vector2.zero;
-                        var popupRect = new Rect(rectPosition + offset, new Vector2(InputActionDropdownPosition.x, EditorGUIUtility.singleLineHeight));
-
-                        actionId.intValue = EditorGUI.IntPopup(popupRect, actionId.intValue, labels, ids);
-                        offset = currentControllerOption.IsLabelFlipped[i] ? Vector2.zero : InputActionDropdownPosition;
-                        var labelRect = new Rect(rectPosition + offset, new Vector2(InputActionLabelPosition.x, EditorGUIUtility.singleLineHeight));
-                        EditorGUI.LabelField(labelRect, interactionDescription.stringValue, currentControllerOption.IsLabelFlipped[i] ? flippedLabelStyle : EditorStyles.label);
-
-                        if (editInputActionPositions)
-                        {
-                            offset = currentControllerOption.IsLabelFlipped[i] ? InputActionLabelPosition + InputActionDropdownPosition + HorizontalSpace : InputActionFlipTogglePosition;
-                            var toggleRect = new Rect(rectPosition + offset, new Vector2(-InputActionFlipTogglePosition.x, EditorGUIUtility.singleLineHeight));
-
-                            EditorGUI.BeginChangeCheck();
-                            currentControllerOption.IsLabelFlipped[i] = EditorGUI.Toggle(toggleRect, currentControllerOption.IsLabelFlipped[i]);
-
-                            if (EditorGUI.EndChangeCheck())
-                            {
-                                if (currentControllerOption.IsLabelFlipped[i])
-                                {
-                                    currentControllerOption.InputLabelPositions[i] -= InputActionLabelPosition;
-                                }
-                                else
-                                {
-                                    currentControllerOption.InputLabelPositions[i] += InputActionLabelPosition;
-                                }
-                            }
-
-                            if (!isMouseInRects.Any(value => value) || isMouseInRects[i])
-                            {
-                                if (Event.current.type == EventType.MouseDrag && labelRect.Contains(Event.current.mousePosition) && !isMouseInRects[i])
-                                {
-                                    isMouseInRects[i] = true;
-                                    mouseDragOffset = Event.current.mousePosition - currentControllerOption.InputLabelPositions[i];
-                                }
-                                else if (Event.current.type == EventType.Repaint && isMouseInRects[i])
-                                {
-                                    currentControllerOption.InputLabelPositions[i] = Event.current.mousePosition - mouseDragOffset;
-                                }
-                                else if (Event.current.type == EventType.DragUpdated && isMouseInRects[i])
-                                {
-                                    currentControllerOption.InputLabelPositions[i] = Event.current.mousePosition - mouseDragOffset;
-                                }
-                                else if (Event.current.type == EventType.MouseUp && isMouseInRects[i])
-                                {
-                                    currentControllerOption.InputLabelPositions[i] = Event.current.mousePosition - mouseDragOffset;
-                                    mouseDragOffset = Vector2.zero;
-                                    isMouseInRects[i] = false;
-                                }
-                            }
-                        }
-                    }
-
-                    if (EditorGUI.EndChangeCheck())
-                    {
-                        MixedRealityInputAction inputAction = actionId.intValue == 0 ?
-                            MixedRealityInputAction.None :
-                            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions[actionId.intValue - 1];
-                        actionId.intValue = (int)inputAction.Id;
-                        actionDescription.stringValue = inputAction.Description;
-                        actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
-                        interactionList.serializedObject.ApplyModifiedProperties();
-                    }
-                }
-
-                EditorGUILayout.EndHorizontal();
             }
 
             if (useCustomInteractionMapping)

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -34,16 +34,18 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (!instance.IsActiveInstance)
             {
                 EditorGUILayout.HelpBox("This instance of the toolkit is inactive. There can only be one active instance loaded at any time.", MessageType.Warning);
-                EditorGUILayout.BeginHorizontal();
-                if (GUILayout.Button("Select Active Instance"))
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    UnityEditor.Selection.activeGameObject = MixedRealityToolkit.Instance.gameObject;
+                    if (GUILayout.Button("Select Active Instance"))
+                    {
+                        UnityEditor.Selection.activeGameObject = MixedRealityToolkit.Instance.gameObject;
+                    }
+
+                    if (GUILayout.Button("Make this the Active Instance"))
+                    {
+                        MixedRealityToolkit.SetActiveInstance(instance);
+                    }
                 }
-                if (GUILayout.Button("Make this the Active Instance"))
-                {
-                    MixedRealityToolkit.SetActiveInstance(instance);
-                }
-                EditorGUILayout.EndHorizontal();
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -38,34 +38,34 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <returns></returns>
         public static void RenderReadOnlyProfile(SerializedProperty property)
         {
-            EditorGUILayout.BeginHorizontal();
-
-            EditorGUI.BeginDisabledGroup(true);
-            EditorGUILayout.ObjectField(property.objectReferenceValue != null ? "" : property.displayName, property.objectReferenceValue, typeof(BaseMixedRealityProfile), false, GUILayout.ExpandWidth(true));      
-            EditorGUI.EndDisabledGroup();
-
-            EditorGUILayout.EndHorizontal();
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUILayout.ObjectField(property.objectReferenceValue != null ? "" : property.displayName, property.objectReferenceValue, typeof(BaseMixedRealityProfile), false, GUILayout.ExpandWidth(true));
+                EditorGUI.EndDisabledGroup();
+            }
 
             if (property.objectReferenceValue != null)
             {
                 bool showReadOnlyProfile = SessionState.GetBool(property.name + ".ReadOnlyProfile", false);
 
-                EditorGUI.indentLevel++;
-                RenderFoldout(ref showReadOnlyProfile, property.displayName, () =>
+                using (new EditorGUI.IndentLevelScope())
                 {
-                    using (new EditorGUI.IndentLevelScope())
+                    RenderFoldout(ref showReadOnlyProfile, property.displayName, () =>
                     {
-                        UnityEditor.Editor subProfileEditor = UnityEditor.Editor.CreateEditor(property.objectReferenceValue);
+                        using (new EditorGUI.IndentLevelScope())
+                        {
+                            UnityEditor.Editor subProfileEditor = UnityEditor.Editor.CreateEditor(property.objectReferenceValue);
                         // If this is a default MRTK configuration profile, ask it to render as a sub-profile
                         if (typeof(BaseMixedRealityToolkitConfigurationProfileInspector).IsAssignableFrom(subProfileEditor.GetType()))
-                        {
-                            BaseMixedRealityToolkitConfigurationProfileInspector configProfile = (BaseMixedRealityToolkitConfigurationProfileInspector)subProfileEditor;
-                            configProfile.RenderAsSubProfile = true;
+                            {
+                                BaseMixedRealityToolkitConfigurationProfileInspector configProfile = (BaseMixedRealityToolkitConfigurationProfileInspector)subProfileEditor;
+                                configProfile.RenderAsSubProfile = true;
+                            }
+                            subProfileEditor.OnInspectorGUI();
                         }
-                        subProfileEditor.OnInspectorGUI();
-                    }
-                });
-                EditorGUI.indentLevel--;
+                    });
+                }
 
                 SessionState.SetBool(property.name + ".ReadOnlyProfile", showReadOnlyProfile);
             }
@@ -135,8 +135,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             // Begin the horizontal group
-            EditorGUILayout.BeginHorizontal();
-
+            using (new EditorGUILayout.HorizontalScope())
+            {
                 // Draw the object field with an empty label - label is kept in the foldout
                 property.objectReferenceValue = EditorGUILayout.ObjectField(oldObject != null ? "" : property.displayName, oldObject, profileType, false, GUILayout.ExpandWidth(true));
                 changed = (property.objectReferenceValue != oldObject);
@@ -164,14 +164,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     var renderedProfile = property.objectReferenceValue as BaseMixedRealityProfile;
                     Debug.Assert(renderedProfile != null);
                     Debug.Assert(profile != null, "No profile was set in OnEnable. Did you forget to call base.OnEnable in a derived profile class?");
-                    
+
                     if (GUILayout.Button(new GUIContent("Clone", "Replace with a copy of the default profile."), EditorStyles.miniButton, GUILayout.Width(42f)))
                     {
                         MixedRealityProfileCloneWindow.OpenWindow(profile, renderedProfile, property);
                     }
                 }
-
-            EditorGUILayout.EndHorizontal();
+            }
 
             if (property.objectReferenceValue != null)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -196,10 +196,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
             }
 
-            EditorGUILayout.BeginHorizontal();
+            using (new EditorGUILayout.HorizontalScope())
+            {
                 EditorGUILayout.LabelField(new GUIContent(title, description), EditorStyles.boldLabel, GUILayout.ExpandWidth(true));
                 RenderDocumentation(selectionObject);
-            EditorGUILayout.EndHorizontal();
+            }
 
             EditorGUILayout.LabelField(string.Empty, GUI.skin.horizontalSlider);
         }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -131,113 +131,109 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             using (new GUIEnabledWrapper(isInitialized, false))
             {
                 EditorGUILayout.Space();
-                GUILayout.BeginVertical();
-
-                if (InspectorUIUtility.RenderIndentedButton(AddButtonContent, EditorStyles.miniButton))
+                using (new EditorGUILayout.VerticalScope())
                 {
-                    list.arraySize += 1;
-                    var speechCommand = list.GetArrayElementAtIndex(list.arraySize - 1);
-                    var keyword = speechCommand.FindPropertyRelative("description");
-                    keyword.stringValue = string.Empty;
-                    var gestureType = speechCommand.FindPropertyRelative("gestureType");
-                    gestureType.intValue = (int)GestureInputType.None;
-                    var action = speechCommand.FindPropertyRelative("action");
-                    var actionId = action.FindPropertyRelative("id");
-                    actionId.intValue = 0;
-                    var actionDescription = action.FindPropertyRelative("description");
-                    actionDescription.stringValue = string.Empty;
-                    var actionConstraint = action.FindPropertyRelative("axisConstraint");
-                    actionConstraint.intValue = 0;
-                }
-
-                if (list == null || list.arraySize == 0)
-                {
-                    EditorGUILayout.HelpBox("Define a new Gesture.", MessageType.Warning);
-                    GUILayout.EndVertical();
-                    UpdateGestureLabels();
-                    return;
-                }
-
-                GUILayout.BeginVertical();
-
-                GUILayout.BeginHorizontal();
-                var labelWidth = EditorGUIUtility.labelWidth;
-                EditorGUIUtility.labelWidth = 24f;
-                EditorGUILayout.LabelField(DescriptionContent, GUILayout.ExpandWidth(true));
-                EditorGUILayout.LabelField(GestureTypeContent, GUILayout.Width(80f));
-                EditorGUILayout.LabelField(ActionContent, GUILayout.Width(64f));
-                EditorGUILayout.LabelField(string.Empty, GUILayout.Width(24f));
-                EditorGUIUtility.labelWidth = labelWidth;
-                GUILayout.EndHorizontal();
-
-                var inputActions = GetInputActions();
-
-                for (int i = 0; i < list.arraySize; i++)
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    SerializedProperty gesture = list.GetArrayElementAtIndex(i);
-                    var keyword = gesture.FindPropertyRelative("description");
-                    var gestureType = gesture.FindPropertyRelative("gestureType");
-                    var action = gesture.FindPropertyRelative("action");
-                    var actionId = action.FindPropertyRelative("id");
-                    var actionDescription = action.FindPropertyRelative("description");
-                    var actionConstraint = action.FindPropertyRelative("axisConstraint");
-
-                    EditorGUILayout.PropertyField(keyword, GUIContent.none, GUILayout.ExpandWidth(true));
-
-                    Debug.Assert(allGestureLabels.Length == allGestureIds.Length);
-
-                    var gestureLabels = new GUIContent[allGestureLabels.Length + 1];
-                    var gestureIds = new int[allGestureIds.Length + 1];
-
-                    gestureLabels[0] = new GUIContent(((GestureInputType)gestureType.intValue).ToString());
-                    gestureIds[0] = gestureType.intValue;
-
-                    for (int j = 0; j < allGestureLabels.Length; j++)
+                    if (InspectorUIUtility.RenderIndentedButton(AddButtonContent, EditorStyles.miniButton))
                     {
-                        gestureLabels[j + 1] = allGestureLabels[j];
-                        gestureIds[j + 1] = allGestureIds[j];
+                        list.arraySize += 1;
+                        var speechCommand = list.GetArrayElementAtIndex(list.arraySize - 1);
+                        var keyword = speechCommand.FindPropertyRelative("description");
+                        keyword.stringValue = string.Empty;
+                        var gestureType = speechCommand.FindPropertyRelative("gestureType");
+                        gestureType.intValue = (int)GestureInputType.None;
+                        var action = speechCommand.FindPropertyRelative("action");
+                        var actionId = action.FindPropertyRelative("id");
+                        actionId.intValue = 0;
+                        var actionDescription = action.FindPropertyRelative("description");
+                        actionDescription.stringValue = string.Empty;
+                        var actionConstraint = action.FindPropertyRelative("axisConstraint");
+                        actionConstraint.intValue = 0;
                     }
 
-                    EditorGUI.BeginChangeCheck();
-                    gestureType.intValue = EditorGUILayout.IntPopup(GUIContent.none, gestureType.intValue, gestureLabels, gestureIds, GUILayout.Width(80f));
-
-                    if (EditorGUI.EndChangeCheck())
+                    if (list == null || list.arraySize == 0)
                     {
-                        serializedObject.ApplyModifiedProperties();
+                        EditorGUILayout.HelpBox("Define a new Gesture.", MessageType.Warning);
                         UpdateGestureLabels();
+                        return;
                     }
 
-                    EditorGUI.BeginChangeCheck();
-
-                    actionId.intValue = EditorGUILayout.IntPopup(GUIContent.none, actionId.intValue, actionLabels, actionIds, GUILayout.Width(64f));
-
-                    if (EditorGUI.EndChangeCheck())
+                    using (new EditorGUILayout.HorizontalScope())
                     {
-                        MixedRealityInputAction inputAction = MixedRealityInputAction.None;
-                        int idx = actionId.intValue - 1;
-                        if (idx >= 0 && idx < inputActions.Length)
+                        var labelWidth = EditorGUIUtility.labelWidth;
+                        EditorGUIUtility.labelWidth = 24f;
+                        EditorGUILayout.LabelField(DescriptionContent, GUILayout.ExpandWidth(true));
+                        EditorGUILayout.LabelField(GestureTypeContent, GUILayout.Width(80f));
+                        EditorGUILayout.LabelField(ActionContent, GUILayout.Width(64f));
+                        EditorGUILayout.LabelField(string.Empty, GUILayout.Width(24f));
+                        EditorGUIUtility.labelWidth = labelWidth;
+                    }
+
+                    var inputActions = GetInputActions();
+
+                    for (int i = 0; i < list.arraySize; i++)
+                    {
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            inputAction = inputActions[idx];
+                            SerializedProperty gesture = list.GetArrayElementAtIndex(i);
+                            var keyword = gesture.FindPropertyRelative("description");
+                            var gestureType = gesture.FindPropertyRelative("gestureType");
+                            var action = gesture.FindPropertyRelative("action");
+                            var actionId = action.FindPropertyRelative("id");
+                            var actionDescription = action.FindPropertyRelative("description");
+                            var actionConstraint = action.FindPropertyRelative("axisConstraint");
+
+                            EditorGUILayout.PropertyField(keyword, GUIContent.none, GUILayout.ExpandWidth(true));
+
+                            Debug.Assert(allGestureLabels.Length == allGestureIds.Length);
+
+                            var gestureLabels = new GUIContent[allGestureLabels.Length + 1];
+                            var gestureIds = new int[allGestureIds.Length + 1];
+
+                            gestureLabels[0] = new GUIContent(((GestureInputType)gestureType.intValue).ToString());
+                            gestureIds[0] = gestureType.intValue;
+
+                            for (int j = 0; j < allGestureLabels.Length; j++)
+                            {
+                                gestureLabels[j + 1] = allGestureLabels[j];
+                                gestureIds[j + 1] = allGestureIds[j];
+                            }
+
+                            EditorGUI.BeginChangeCheck();
+                            gestureType.intValue = EditorGUILayout.IntPopup(GUIContent.none, gestureType.intValue, gestureLabels, gestureIds, GUILayout.Width(80f));
+
+                            if (EditorGUI.EndChangeCheck())
+                            {
+                                serializedObject.ApplyModifiedProperties();
+                                UpdateGestureLabels();
+                            }
+
+                            EditorGUI.BeginChangeCheck();
+
+                            actionId.intValue = EditorGUILayout.IntPopup(GUIContent.none, actionId.intValue, actionLabels, actionIds, GUILayout.Width(64f));
+
+                            if (EditorGUI.EndChangeCheck())
+                            {
+                                MixedRealityInputAction inputAction = MixedRealityInputAction.None;
+                                int idx = actionId.intValue - 1;
+                                if (idx >= 0 && idx < inputActions.Length)
+                                {
+                                    inputAction = inputActions[idx];
+                                }
+
+                                actionDescription.stringValue = inputAction.Description;
+                                actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
+                                serializedObject.ApplyModifiedProperties();
+                            }
+
+                            if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                            {
+                                list.DeleteArrayElementAtIndex(i);
+                                serializedObject.ApplyModifiedProperties();
+                                UpdateGestureLabels();
+                            }
                         }
-
-                        actionDescription.stringValue = inputAction.Description;
-                        actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
-                        serializedObject.ApplyModifiedProperties();
                     }
-
-                    if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
-                    {
-                        list.DeleteArrayElementAtIndex(i);
-                        serializedObject.ApplyModifiedProperties();
-                        UpdateGestureLabels();
-                    }
-
-                    EditorGUILayout.EndHorizontal();
                 }
-
-                GUILayout.EndVertical();
-                GUILayout.EndVertical();
             }
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -230,138 +230,137 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                         EditorGUILayout.HelpBox("Base rule must have a valid axis constraint.", MessageType.Warning);
                         break;
                     case AxisType.Digital:
-                        EditorGUILayout.BeginHorizontal();
-                        EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
-                        EditorGUI.BeginChangeCheck();
-                        var boolValue = EditorGUILayout.Toggle(GUIContent.none, criteriaValue?.boolValue ?? currentBoolCriteria, GUILayout.Width(64), GUILayout.ExpandWidth(true));
-
-                        if (EditorGUI.EndChangeCheck())
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            if (criteriaValue != null)
+                            EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
+                            EditorGUI.BeginChangeCheck();
+                            var boolValue = EditorGUILayout.Toggle(GUIContent.none, criteriaValue?.boolValue ?? currentBoolCriteria, GUILayout.Width(64), GUILayout.ExpandWidth(true));
+
+                            if (EditorGUI.EndChangeCheck())
                             {
-                                criteriaValue.boolValue = boolValue;
-                            }
-                            else
-                            {
-                                currentBoolCriteria = boolValue;
+                                if (criteriaValue != null)
+                                {
+                                    criteriaValue.boolValue = boolValue;
+                                }
+                                else
+                                {
+                                    currentBoolCriteria = boolValue;
+                                }
                             }
                         }
-
-                        EditorGUILayout.EndHorizontal();
                         break;
                     case AxisType.SingleAxis:
-                        EditorGUILayout.BeginHorizontal();
-                        EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
-                        EditorGUI.BeginChangeCheck();
-                        var floatValue = EditorGUILayout.FloatField(GUIContent.none, criteriaValue?.floatValue ?? currentSingleAxisCriteria, GUILayout.Width(64), GUILayout.ExpandWidth(true));
-
-                        if (EditorGUI.EndChangeCheck())
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            if (criteriaValue != null)
+                            EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
+                            EditorGUI.BeginChangeCheck();
+                            var floatValue = EditorGUILayout.FloatField(GUIContent.none, criteriaValue?.floatValue ?? currentSingleAxisCriteria, GUILayout.Width(64), GUILayout.ExpandWidth(true));
+
+                            if (EditorGUI.EndChangeCheck())
                             {
-                                criteriaValue.floatValue = floatValue;
-                            }
-                            else
-                            {
-                                currentSingleAxisCriteria = floatValue;
+                                if (criteriaValue != null)
+                                {
+                                    criteriaValue.floatValue = floatValue;
+                                }
+                                else
+                                {
+                                    currentSingleAxisCriteria = floatValue;
+                                }
                             }
                         }
-
-                        EditorGUILayout.EndHorizontal();
                         break;
                     case AxisType.DualAxis:
                         EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
-                        EditorGUI.indentLevel++;
-                        EditorGUI.BeginChangeCheck();
-                        var dualAxisValue = EditorGUILayout.Vector2Field("Position", criteriaValue?.vector2Value ?? currentDualAxisCriteria, GUILayout.Width(64), GUILayout.ExpandWidth(true));
-
-                        if (EditorGUI.EndChangeCheck())
+                        using (new EditorGUI.IndentLevelScope())
                         {
-                            if (criteriaValue != null)
+                            EditorGUI.BeginChangeCheck();
+                            var dualAxisValue = EditorGUILayout.Vector2Field("Position", criteriaValue?.vector2Value ?? currentDualAxisCriteria, GUILayout.Width(64), GUILayout.ExpandWidth(true));
+
+                            if (EditorGUI.EndChangeCheck())
                             {
-                                criteriaValue.vector2Value = dualAxisValue;
-                            }
-                            else
-                            {
-                                currentDualAxisCriteria = dualAxisValue;
+                                if (criteriaValue != null)
+                                {
+                                    criteriaValue.vector2Value = dualAxisValue;
+                                }
+                                else
+                                {
+                                    currentDualAxisCriteria = dualAxisValue;
+                                }
                             }
                         }
-
-                        EditorGUI.indentLevel--;
                         break;
                     case AxisType.ThreeDofPosition:
                         EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
-                        EditorGUI.indentLevel++;
-                        EditorGUI.BeginChangeCheck();
-                        var positionValue = EditorGUILayout.Vector3Field("Position", criteriaValue?.vector3Value ?? currentVectorCriteria, GUILayout.ExpandWidth(true));
-
-                        if (EditorGUI.EndChangeCheck())
+                        using (new EditorGUI.IndentLevelScope())
                         {
-                            if (criteriaValue != null)
+                            EditorGUI.BeginChangeCheck();
+                            var positionValue = EditorGUILayout.Vector3Field("Position", criteriaValue?.vector3Value ?? currentVectorCriteria, GUILayout.ExpandWidth(true));
+
+                            if (EditorGUI.EndChangeCheck())
                             {
-                                criteriaValue.vector3Value = positionValue;
-                            }
-                            else
-                            {
-                                currentVectorCriteria = positionValue;
+                                if (criteriaValue != null)
+                                {
+                                    criteriaValue.vector3Value = positionValue;
+                                }
+                                else
+                                {
+                                    currentVectorCriteria = positionValue;
+                                }
                             }
                         }
-
-                        EditorGUI.indentLevel--;
                         break;
                     case AxisType.ThreeDofRotation:
                         EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
-                        EditorGUI.indentLevel++;
-                        EditorGUI.BeginChangeCheck();
-                        var rotationValue = EditorGUILayout.Vector3Field("Rotation", criteriaValue?.quaternionValue.eulerAngles ?? currentQuaternionCriteria.eulerAngles, GUILayout.ExpandWidth(true));
-
-                        if (EditorGUI.EndChangeCheck())
+                        using (new EditorGUI.IndentLevelScope())
                         {
-                            if (criteriaValue != null)
+                            EditorGUI.BeginChangeCheck();
+                            var rotationValue = EditorGUILayout.Vector3Field("Rotation", criteriaValue?.quaternionValue.eulerAngles ?? currentQuaternionCriteria.eulerAngles, GUILayout.ExpandWidth(true));
+
+                            if (EditorGUI.EndChangeCheck())
                             {
-                                criteriaValue.quaternionValue = Quaternion.Euler(rotationValue);
-                            }
-                            else
-                            {
-                                currentQuaternionCriteria = Quaternion.Euler(rotationValue);
+                                if (criteriaValue != null)
+                                {
+                                    criteriaValue.quaternionValue = Quaternion.Euler(rotationValue);
+                                }
+                                else
+                                {
+                                    currentQuaternionCriteria = Quaternion.Euler(rotationValue);
+                                }
                             }
                         }
-
-                        EditorGUI.indentLevel--;
                         break;
                     case AxisType.SixDof:
                         EditorGUILayout.LabelField(CriteriaContent, GUILayout.Width(128));
-                        EditorGUI.indentLevel++;
-
-                        var posePosition = currentPoseCriteria.Position;
-                        var poseRotation = currentPoseCriteria.Rotation;
-
-                        if (criteriaValue != null)
+                        using (new EditorGUI.IndentLevelScope())
                         {
-                            posePosition = criteriaValue.FindPropertyRelative("position").vector3Value;
-                            poseRotation = criteriaValue.FindPropertyRelative("rotation").quaternionValue;
-                        }
+                            var posePosition = currentPoseCriteria.Position;
+                            var poseRotation = currentPoseCriteria.Rotation;
 
-                        EditorGUI.BeginChangeCheck();
-                        posePosition = EditorGUILayout.Vector3Field("Position", posePosition);
-
-                        poseRotation.eulerAngles = EditorGUILayout.Vector3Field("Rotation", poseRotation.eulerAngles);
-
-                        if (EditorGUI.EndChangeCheck())
-                        {
                             if (criteriaValue != null)
                             {
-                                criteriaValue.FindPropertyRelative("position").vector3Value = posePosition;
-                                criteriaValue.FindPropertyRelative("rotation").quaternionValue = poseRotation;
+                                posePosition = criteriaValue.FindPropertyRelative("position").vector3Value;
+                                poseRotation = criteriaValue.FindPropertyRelative("rotation").quaternionValue;
                             }
-                            else
+
+                            EditorGUI.BeginChangeCheck();
+                            posePosition = EditorGUILayout.Vector3Field("Position", posePosition);
+
+                            poseRotation.eulerAngles = EditorGUILayout.Vector3Field("Rotation", poseRotation.eulerAngles);
+
+                            if (EditorGUI.EndChangeCheck())
                             {
-                                currentPoseCriteria.Position = posePosition;
-                                currentPoseCriteria.Rotation = poseRotation;
+                                if (criteriaValue != null)
+                                {
+                                    criteriaValue.FindPropertyRelative("position").vector3Value = posePosition;
+                                    criteriaValue.FindPropertyRelative("rotation").quaternionValue = poseRotation;
+                                }
+                                else
+                                {
+                                    currentPoseCriteria.Position = posePosition;
+                                    currentPoseCriteria.Rotation = poseRotation;
+                                }
                             }
                         }
-
-                        EditorGUI.indentLevel--;
                         break;
                 }
 
@@ -507,17 +506,16 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 var ruleActionDescription = ruleAction.FindPropertyRelative("description");
                 var ruleActionConstraint = ruleAction.FindPropertyRelative("axisConstraint");
 
-                EditorGUILayout.BeginHorizontal();
-                foldouts[i] = EditorGUILayout.Foldout(foldouts[i], new GUIContent($"{baseActionDescription.stringValue} -> {ruleActionDescription.stringValue}"), true);
-
-                if (GUILayout.Button(RuleMinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    list.DeleteArrayElementAtIndex(i);
-                    EditorGUILayout.EndHorizontal();
-                    return;
-                }
+                    foldouts[i] = EditorGUILayout.Foldout(foldouts[i], new GUIContent($"{baseActionDescription.stringValue} -> {ruleActionDescription.stringValue}"), true);
 
-                EditorGUILayout.EndHorizontal();
+                    if (GUILayout.Button(RuleMinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                    {
+                        list.DeleteArrayElementAtIndex(i);
+                        return;
+                    }
+                }
 
                 if (foldouts[i])
                 {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionsProfileInspector.cs
@@ -54,8 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         private static void RenderList(SerializedProperty list)
         {
-            GUILayout.BeginVertical();
-
+            using (new EditorGUILayout.VerticalScope())
+            {
                 if (InspectorUIUtility.RenderIndentedButton(AddButtonContent, EditorStyles.miniButton))
                 {
                     list.arraySize += 1;
@@ -67,42 +67,41 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                     inputActionDescription.stringValue = $"New Action {inputActionId.intValue = list.arraySize}";
                 }
 
-                GUILayout.BeginVertical();
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    var labelWidth = EditorGUIUtility.labelWidth;
+                    EditorGUIUtility.labelWidth = 36f;
+                    EditorGUILayout.LabelField(ActionContent, GUILayout.ExpandWidth(true));
+                    EditorGUILayout.LabelField(AxisConstraintContent, GUILayout.Width(96f));
+                    EditorGUILayout.LabelField(string.Empty, GUILayout.Width(24f));
+                    EditorGUIUtility.labelWidth = labelWidth;
+                }
 
-                GUILayout.BeginHorizontal();
-                var labelWidth = EditorGUIUtility.labelWidth;
-                EditorGUIUtility.labelWidth = 36f;
-                EditorGUILayout.LabelField(ActionContent, GUILayout.ExpandWidth(true));
-                EditorGUILayout.LabelField(AxisConstraintContent, GUILayout.Width(96f));
-                EditorGUILayout.LabelField(string.Empty, GUILayout.Width(24f));
-                EditorGUIUtility.labelWidth = labelWidth;
-                GUILayout.EndHorizontal();
-
-                scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition,GUILayout.Height(100f));
+                scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, GUILayout.Height(100f));
 
                 for (int i = 0; i < list.arraySize; i++)
                 {
-                    EditorGUILayout.BeginHorizontal();
-                    var previousLabelWidth = EditorGUIUtility.labelWidth;
-                    EditorGUIUtility.labelWidth = 64f;
-                    SerializedProperty inputAction = list.GetArrayElementAtIndex(i);
-                    SerializedProperty inputActionDescription = inputAction.FindPropertyRelative("description");
-                    var inputActionConstraint = inputAction.FindPropertyRelative("axisConstraint");
-                    EditorGUILayout.PropertyField(inputActionDescription, GUIContent.none);
-                    EditorGUILayout.PropertyField(inputActionConstraint, GUIContent.none, GUILayout.Width(96f));
-                    EditorGUIUtility.labelWidth = previousLabelWidth;
-
-                    if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                    using (new EditorGUILayout.HorizontalScope())
                     {
-                        list.DeleteArrayElementAtIndex(i);
-                    }
+                        var previousLabelWidth = EditorGUIUtility.labelWidth;
+                        EditorGUIUtility.labelWidth = 64f;
+                        SerializedProperty inputAction = list.GetArrayElementAtIndex(i);
+                        SerializedProperty inputActionDescription = inputAction.FindPropertyRelative("description");
+                        var inputActionConstraint = inputAction.FindPropertyRelative("axisConstraint");
+                        EditorGUILayout.PropertyField(inputActionDescription, GUIContent.none);
+                        EditorGUILayout.PropertyField(inputActionConstraint, GUIContent.none, GUILayout.Width(96f));
+                        EditorGUIUtility.labelWidth = previousLabelWidth;
 
-                    EditorGUILayout.EndHorizontal();
+                        if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                        {
+                            list.DeleteArrayElementAtIndex(i);
+                        }
+
+                    }
                 }
 
                 EditorGUILayout.EndScrollView();
-                GUILayout.EndVertical();
-            GUILayout.EndVertical();
+            }
             EditorGUILayout.Space();
         }
     }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -184,18 +184,19 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                 {
                                     action.CloneName = EditorGUILayout.TextField("Clone name", action.CloneName);
                                 }
-                                EditorGUILayout.BeginHorizontal();
-                                if (action.TargetFolder == null)
+                                using (new EditorGUILayout.HorizontalScope())
                                 {
-                                    action.TargetFolder = targetFolder;
+                                    if (action.TargetFolder == null)
+                                    {
+                                        action.TargetFolder = targetFolder;
+                                    }
+                                    action.TargetFolder = EditorGUILayout.ObjectField("Target Folder", action.TargetFolder, typeof(DefaultAsset), false);
+                                    if (GUILayout.Button("Put in original folder", EditorStyles.miniButton, GUILayout.MaxWidth(120)))
+                                    {
+                                        string profilePath = AssetDatabase.GetAssetPath(action.Property.objectReferenceValue);
+                                        action.TargetFolder = AssetDatabase.LoadAssetAtPath<Object>(System.IO.Path.GetDirectoryName(profilePath));
+                                    }
                                 }
-                                action.TargetFolder = EditorGUILayout.ObjectField("Target Folder", action.TargetFolder, typeof(DefaultAsset), false);
-                                if (GUILayout.Button("Put in original folder", EditorStyles.miniButton, GUILayout.MaxWidth(120)))
-                                {
-                                    string profilePath = AssetDatabase.GetAssetPath(action.Property.objectReferenceValue);
-                                    action.TargetFolder = AssetDatabase.LoadAssetAtPath<Object>(System.IO.Path.GetDirectoryName(profilePath));
-                                }
-                                EditorGUILayout.EndHorizontal();
                                 break;
 
                             case ProfileCloneBehavior.LeaveEmpty:
@@ -215,31 +216,32 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             GUILayout.FlexibleSpace();
 
             // Get the selected folder in the project window
-            EditorGUILayout.BeginHorizontal();
-            targetFolder = EditorGUILayout.ObjectField("Target Folder", targetFolder, typeof(DefaultAsset), false);
-            if (GUILayout.Button("Put in original folder", EditorStyles.miniButton, GUILayout.MaxWidth(120)))
+            using (new EditorGUILayout.HorizontalScope())
             {
-                string profilePath = AssetDatabase.GetAssetPath(childProfile);
-                targetFolder = AssetDatabase.LoadAssetAtPath<Object>(System.IO.Path.GetDirectoryName(profilePath));
+                targetFolder = EditorGUILayout.ObjectField("Target Folder", targetFolder, typeof(DefaultAsset), false);
+                if (GUILayout.Button("Put in original folder", EditorStyles.miniButton, GUILayout.MaxWidth(120)))
+                {
+                    string profilePath = AssetDatabase.GetAssetPath(childProfile);
+                    targetFolder = AssetDatabase.LoadAssetAtPath<Object>(System.IO.Path.GetDirectoryName(profilePath));
+                }
             }
-            EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.HelpBox("If no folder is provided, the profile will be cloned to the Assets/MixedRealityToolkit.Generated/CustomProfiles folder.", MessageType.Info);
             childProfileAssetName = EditorGUILayout.TextField("Profile Name", childProfileAssetName);
 
-            EditorGUILayout.BeginHorizontal();
-
-            if (GUILayout.Button("Clone"))
+            using (new EditorGUILayout.HorizontalScope())
             {
-                targetFolder = EnsureTargetFolder(targetFolder);
-                CloneMainProfile();
-            }
-            if (GUILayout.Button("Cancel"))
-            {
-                cloneWindow.Close();
-            }
+                if (GUILayout.Button("Clone"))
+                {
+                    targetFolder = EnsureTargetFolder(targetFolder);
+                    CloneMainProfile();
+                }
 
-            EditorGUILayout.EndHorizontal();
+                if (GUILayout.Button("Cancel"))
+                {
+                    cloneWindow.Close();
+                }
+            }   
 
             // If there are no sub profiles, limit the max so the window isn't spawned too large
             if (subProfileActions.Count <= 0 || !AdvancedMode)

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -53,118 +53,107 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void RenderList(SerializedProperty list)
         {
-            EditorGUILayout.Space();
-            GUILayout.BeginVertical();
-
-            if (GUILayout.Button(AddButtonContent, EditorStyles.miniButton))
-            {
-                list.InsertArrayElementAtIndex(list.arraySize);
-                SerializedProperty managerConfig = list.GetArrayElementAtIndex(list.arraySize - 1);
-                var componentName = managerConfig.FindPropertyRelative("componentName");
-                componentName.stringValue = $"New Configuration {list.arraySize - 1}";
-                var priority = managerConfig.FindPropertyRelative("priority");
-                priority.intValue = 10;
-                var runtimePlatform = managerConfig.FindPropertyRelative("runtimePlatform");
-                runtimePlatform.intValue = -1;
-                var configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
-                configurationProfile.objectReferenceValue = null;
-                serializedObject.ApplyModifiedProperties();
-                var componentType = ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[list.arraySize - 1].ComponentType;
-                componentType.Type = null;
-                configFoldouts = new bool[list.arraySize];
-                return;
-            }
-
-            GUILayout.Space(12f);
-
-            if (list == null || list.arraySize == 0)
-            {
-                EditorGUILayout.HelpBox("Register a new Service Provider.", MessageType.Warning);
-                GUILayout.EndVertical();
-                return;
-            }
-
-            GUILayout.BeginVertical();
-
-            GUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField("Configurations", EditorStyles.boldLabel, GUILayout.ExpandWidth(true));
-            GUILayout.EndHorizontal();
-            EditorGUILayout.Space();
-
             bool changed = false;
-
-            for (int i = 0; i < list.arraySize; i++)
+            EditorGUILayout.Space();
+            using (new EditorGUILayout.VerticalScope())
             {
-                SerializedProperty managerConfig = list.GetArrayElementAtIndex(i);
-                var componentName = managerConfig.FindPropertyRelative("componentName");
-                var componentType = managerConfig.FindPropertyRelative("componentType");
-                var priority = managerConfig.FindPropertyRelative("priority");
-                var runtimePlatform = managerConfig.FindPropertyRelative("runtimePlatform");
-                var configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
-
-                GUILayout.BeginVertical();
-                EditorGUILayout.BeginHorizontal();
-
-                configFoldouts[i] = EditorGUILayout.Foldout(configFoldouts[i], componentName.stringValue, true);
-
-                if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                if (GUILayout.Button(AddButtonContent, EditorStyles.miniButton))
                 {
-                    list.DeleteArrayElementAtIndex(i);
+                    list.InsertArrayElementAtIndex(list.arraySize);
+                    SerializedProperty managerConfig = list.GetArrayElementAtIndex(list.arraySize - 1);
+                    var componentName = managerConfig.FindPropertyRelative("componentName");
+                    componentName.stringValue = $"New Configuration {list.arraySize - 1}";
+                    var priority = managerConfig.FindPropertyRelative("priority");
+                    priority.intValue = 10;
+                    var runtimePlatform = managerConfig.FindPropertyRelative("runtimePlatform");
+                    runtimePlatform.intValue = -1;
+                    var configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
+                    configurationProfile.objectReferenceValue = null;
                     serializedObject.ApplyModifiedProperties();
-                    EditorGUILayout.EndHorizontal();
-                    GUILayout.EndVertical();
-                    changed = true;
-                    break;
+                    var componentType = ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[list.arraySize - 1].ComponentType;
+                    componentType.Type = null;
+                    configFoldouts = new bool[list.arraySize];
+                    return;
                 }
 
-                EditorGUILayout.EndHorizontal();
+                EditorGUILayout.Space();
 
-                if (configFoldouts[i] || RenderAsSubProfile)
+                if (list == null || list.arraySize == 0)
                 {
-                    EditorGUI.indentLevel++;
-
-                    EditorGUI.BeginChangeCheck();
-                    EditorGUILayout.PropertyField(componentName);
-                    changed |= EditorGUI.EndChangeCheck();
-
-                    EditorGUI.BeginChangeCheck();
-                    EditorGUILayout.PropertyField(componentType);
-                    if (EditorGUI.EndChangeCheck())
-                    {
-                        // Try to assign default configuration profile when type changes.
-                        serializedObject.ApplyModifiedProperties();
-                        AssignDefaultConfigurationValues(((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, configurationProfile, runtimePlatform);
-                        changed = true;
-
-                        GUILayout.EndVertical();
-                        break;
-                    }
-
-                    EditorGUI.BeginChangeCheck();
-                    EditorGUILayout.PropertyField(priority);
-                    EditorGUILayout.PropertyField(runtimePlatform);
-
-                    changed |= EditorGUI.EndChangeCheck();
-
-                    Type serviceType = null;
-                    if (configurationProfile.objectReferenceValue != null)
-                    {
-                        serviceType = (target as MixedRealityRegisteredServiceProvidersProfile).Configurations[i].ComponentType;
-                    }
-
-                    changed |= RenderProfile(configurationProfile, null, true, true, serviceType);
-
-                    EditorGUI.indentLevel--;
-
-                    serializedObject.ApplyModifiedProperties();
+                    EditorGUILayout.HelpBox("Register a new Service Provider.", MessageType.Warning);
+                    return;
                 }
 
-                GUILayout.EndVertical();
-                GUILayout.Space(12f);
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.LabelField("Configurations", EditorStyles.boldLabel, GUILayout.ExpandWidth(true));
+                }
+                EditorGUILayout.Space();
+
+                for (int i = 0; i < list.arraySize; i++)
+                {
+                    SerializedProperty managerConfig = list.GetArrayElementAtIndex(i);
+                    var componentName = managerConfig.FindPropertyRelative("componentName");
+                    var componentType = managerConfig.FindPropertyRelative("componentType");
+                    var priority = managerConfig.FindPropertyRelative("priority");
+                    var runtimePlatform = managerConfig.FindPropertyRelative("runtimePlatform");
+                    var configurationProfile = managerConfig.FindPropertyRelative("configurationProfile");
+
+                    using (new EditorGUILayout.VerticalScope())
+                    {
+                        using (new EditorGUILayout.HorizontalScope())
+                        {
+                            configFoldouts[i] = EditorGUILayout.Foldout(configFoldouts[i], componentName.stringValue, true);
+
+                            if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
+                            {
+                                list.DeleteArrayElementAtIndex(i);
+                                serializedObject.ApplyModifiedProperties();
+                                changed = true;
+                                break;
+                            }
+                        }
+
+                        if (configFoldouts[i] || RenderAsSubProfile)
+                        {
+                            using (new EditorGUI.IndentLevelScope())
+                            {
+                                EditorGUI.BeginChangeCheck();
+                                EditorGUILayout.PropertyField(componentName);
+                                changed |= EditorGUI.EndChangeCheck();
+
+                                EditorGUI.BeginChangeCheck();
+                                EditorGUILayout.PropertyField(componentType);
+                                if (EditorGUI.EndChangeCheck())
+                                {
+                                    // Try to assign default configuration profile when type changes.
+                                    serializedObject.ApplyModifiedProperties();
+                                    AssignDefaultConfigurationValues(((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, configurationProfile, runtimePlatform);
+                                    changed = true;
+                                    break;
+                                }
+
+                                EditorGUI.BeginChangeCheck();
+                                EditorGUILayout.PropertyField(priority);
+                                EditorGUILayout.PropertyField(runtimePlatform);
+
+                                changed |= EditorGUI.EndChangeCheck();
+
+                                Type serviceType = null;
+                                if (configurationProfile.objectReferenceValue != null)
+                                {
+                                    serviceType = (target as MixedRealityRegisteredServiceProvidersProfile).Configurations[i].ComponentType;
+                                }
+
+                                changed |= RenderProfile(configurationProfile, null, true, true, serviceType);
+                            }
+
+                            serializedObject.ApplyModifiedProperties();
+                        }
+                    }
+                    EditorGUILayout.Space();
+                }
             }
-
-            GUILayout.EndVertical();
-            GUILayout.EndVertical();
 
             if (changed && MixedRealityToolkit.IsInitialized)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -103,8 +103,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             using (new GUIEnabledWrapper(isInitialized, false))
             {
                 EditorGUILayout.Space();
-                EditorGUILayout.BeginVertical();
-
+                using (new EditorGUILayout.VerticalScope())
+                {
                     if (InspectorUIUtility.RenderIndentedButton(AddButtonContent, EditorStyles.miniButton))
                     {
                         list.arraySize += 1;
@@ -120,21 +120,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         actionId.intValue = 0;
                     }
 
-                EditorGUILayout.Space();
+                    EditorGUILayout.Space();
 
-                if (list == null || list.arraySize == 0)
-                {
-                    EditorGUILayout.HelpBox("Create a new Speech Command.", MessageType.Warning);
-                    EditorGUILayout.EndVertical();
-                    return;
-                }
+                    if (list == null || list.arraySize == 0)
+                    {
+                        EditorGUILayout.HelpBox("Create a new Speech Command.", MessageType.Warning);
+                        return;
+                    }
 
                     for (int i = 0; i < list.arraySize; i++)
                     {
-                        EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+                        using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                        {
                             SerializedProperty speechCommand = list.GetArrayElementAtIndex(i);
 
-                            EditorGUILayout.BeginHorizontal();
+                            using (new EditorGUILayout.HorizontalScope())
+                            {
                                 var keyword = speechCommand.FindPropertyRelative("keyword");
                                 EditorGUILayout.PropertyField(keyword, KeywordContent);
                                 if (GUILayout.Button(MinusButtonContent, EditorStyles.miniButtonRight, GUILayout.Width(24f)))
@@ -142,7 +143,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                     list.DeleteArrayElementAtIndex(i);
                                     break;
                                 }
-                            EditorGUILayout.EndHorizontal();
+                            }
 
                             var localizationKey = speechCommand.FindPropertyRelative("localizationKey");
                             EditorGUILayout.PropertyField(localizationKey, LocalizationContent);
@@ -164,10 +165,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                 actionDescription.stringValue = inputAction.Description;
                                 actionConstraint.enumValueIndex = (int)inputAction.AxisConstraint;
                             }
-                        EditorGUILayout.EndVertical();
+                        }
                         EditorGUILayout.Space();
                     }
-                GUILayout.EndVertical();
+                }
             }
         }
     }

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/SceneSystemInspector.cs
@@ -159,84 +159,85 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 foreach (string tag in contentTags)
                 {
-                    EditorGUILayout.BeginVertical(GUILayout.MaxWidth(tagLoadButtonSetWidth));
-                    EditorGUILayout.LabelField(tag, EditorStyles.miniLabel);
-                    EditorGUILayout.BeginHorizontal();
-
-                    if (GUILayout.Button("Load", EditorStyles.miniButton, GUILayout.MaxWidth(maxLoadButtonWidth)))
+                    using (new EditorGUILayout.VerticalScope(GUILayout.MaxWidth(tagLoadButtonSetWidth)))
                     {
-
-                        if (Application.isPlaying)
+                        EditorGUILayout.LabelField(tag, EditorStyles.miniLabel);
+                        using (new EditorGUILayout.HorizontalScope())
                         {
-                            ServiceContentLoadByTag(sceneSystem, tag);
-                        }
-                        else
-                        {
-                            foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
+                            if (GUILayout.Button("Load", EditorStyles.miniButton, GUILayout.MaxWidth(maxLoadButtonWidth)))
                             {
-                                if (contentScene.Tag == tag)
+                                if (Application.isPlaying)
                                 {
-                                    EditorSceneManager.OpenScene(contentScene.Path, OpenSceneMode.Additive);
+                                    ServiceContentLoadByTag(sceneSystem, tag);
+                                }
+                                else
+                                {
+                                    foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
+                                    {
+                                        if (contentScene.Tag == tag)
+                                        {
+                                            EditorSceneManager.OpenScene(contentScene.Path, OpenSceneMode.Additive);
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (GUILayout.Button("Unload", EditorStyles.miniButton, GUILayout.MaxWidth(maxLoadButtonWidth)))
+                            {
+                                if (Application.isPlaying)
+                                {
+                                    ServiceContentUnloadByTag(sceneSystem, tag);
+                                }
+                                else
+                                {
+                                    foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
+                                    {
+                                        if (contentScene.Tag == tag)
+                                        {
+                                            Scene scene = EditorSceneManager.GetSceneByName(contentScene.Name);
+                                            EditorSceneManager.CloseScene(scene, false);
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
-                    if (GUILayout.Button("Unload", EditorStyles.miniButton, GUILayout.MaxWidth(maxLoadButtonWidth)))
-                    {
-                        if (Application.isPlaying)
-                        {
-                            ServiceContentUnloadByTag(sceneSystem, tag);
-                        }
-                        else
-                        {
-                            foreach (SceneInfo contentScene in sceneSystemEditor.ContentScenes)
-                            {
-                                if (contentScene.Tag == tag)
-                                {
-                                    Scene scene = EditorSceneManager.GetSceneByName(contentScene.Name);
-                                    EditorSceneManager.CloseScene(scene, false);
-                                }
-                            }
-                        }
-                    }
-                    EditorGUILayout.EndHorizontal();
-                    EditorGUILayout.EndVertical();
                 }
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Load / Unload by build index order", EditorStyles.miniBoldLabel);
-            EditorGUILayout.BeginHorizontal();
-
-            EditorGUI.BeginDisabledGroup(!sceneSystem.PrevContentExists);
-            if (GUILayout.Button("Load Prev Content", EditorStyles.miniButton))
+            using (new EditorGUILayout.HorizontalScope())
             {
-                if (Application.isPlaying)
+                EditorGUI.BeginDisabledGroup(!sceneSystem.PrevContentExists);
+                if (GUILayout.Button("Load Prev Content", EditorStyles.miniButton))
                 {
-                    ServiceContentLoadPrev(sceneSystem);
+                    if (Application.isPlaying)
+                    {
+                        ServiceContentLoadPrev(sceneSystem);
+                    }
+                    else
+                    {
+                        sceneSystemEditor.EditorLoadPrevContent();
+                    }
                 }
-                else
-                {
-                    sceneSystemEditor.EditorLoadPrevContent();
-                }
-            }
-            EditorGUI.EndDisabledGroup();
+                EditorGUI.EndDisabledGroup();
 
-            EditorGUI.BeginDisabledGroup(!sceneSystem.NextContentExists);
-            if (GUILayout.Button("Load Next Content", EditorStyles.miniButton))
-            {
-                if (Application.isPlaying)
+                EditorGUI.BeginDisabledGroup(!sceneSystem.NextContentExists);
+                if (GUILayout.Button("Load Next Content", EditorStyles.miniButton))
                 {
-                    ServiceContentLoadNext(sceneSystem);
+                    if (Application.isPlaying)
+                    {
+                        ServiceContentLoadNext(sceneSystem);
+                    }
+                    else
+                    {
+                        sceneSystemEditor.EditorLoadNextContent();
+                    }
                 }
-                else
-                {
-                    sceneSystemEditor.EditorLoadNextContent();
-                }
-            }
-            EditorGUI.EndDisabledGroup();
+                EditorGUI.EndDisabledGroup();
 
-            EditorGUILayout.EndHorizontal();
+            }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Load / Unload individually", EditorStyles.miniBoldLabel);

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -224,80 +224,81 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.WSAPlayer)
             {
-                EditorGUILayout.BeginVertical();
-                EditorGUILayout.Space();
-                EditorGUILayout.BeginHorizontal();
-
-                // Build directory (and save setting, if it's changed)
-                string curBuildDirectory = BuildDeployPreferences.BuildDirectory;
-                EditorGUILayout.LabelField(buildDirectoryLabel, GUILayout.Width(96));
-                string newBuildDirectory = EditorGUILayout.TextField(curBuildDirectory, GUILayout.Width(64), GUILayout.ExpandWidth(true));
-
-                if (newBuildDirectory != curBuildDirectory)
+                using (new EditorGUILayout.VerticalScope())
                 {
-                    BuildDeployPreferences.BuildDirectory = newBuildDirectory;
+                    EditorGUILayout.Space();
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        // Build directory (and save setting, if it's changed)
+                        string curBuildDirectory = BuildDeployPreferences.BuildDirectory;
+                        EditorGUILayout.LabelField(buildDirectoryLabel, GUILayout.Width(96));
+                        string newBuildDirectory = EditorGUILayout.TextField(curBuildDirectory, GUILayout.Width(64), GUILayout.ExpandWidth(true));
+
+                        if (newBuildDirectory != curBuildDirectory)
+                        {
+                            BuildDeployPreferences.BuildDirectory = newBuildDirectory;
+                        }
+
+                        GUI.enabled = Directory.Exists(BuildDeployPreferences.AbsoluteBuildDirectory);
+
+                        if (GUILayout.Button("Open Build Directory"))
+                        {
+                            EditorApplication.delayCall += () => Process.Start(BuildDeployPreferences.AbsoluteBuildDirectory);
+                        }
+
+                        GUI.enabled = true;
+
+                        OpenPlayerSettingsGUI();
+                    }
+
+                    EditorGUILayout.Space();
+
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        if (GUILayout.Button("Build Unity Project", GUILayout.Width(192), GUILayout.ExpandWidth(true)))
+                        {
+                            EditorApplication.delayCall += () => UnityPlayerBuildTools.BuildUnityPlayer(new BuildInfo());
+                        }
+
+                        if (GUILayout.Button("Open Unity Build Window", GUILayout.Width(192), GUILayout.ExpandWidth(true)))
+                        {
+                            GetWindow(Type.GetType("UnityEditor.BuildPlayerWindow,UnityEditor"));
+                        }
+                    }
                 }
-
-                GUI.enabled = Directory.Exists(BuildDeployPreferences.AbsoluteBuildDirectory);
-
-                if (GUILayout.Button("Open Build Directory"))
-                {
-                    EditorApplication.delayCall += () => Process.Start(BuildDeployPreferences.AbsoluteBuildDirectory);
-                }
-
-                GUI.enabled = true;
-
-                OpenPlayerSettingsGUI();
-
-                EditorGUILayout.EndHorizontal();
-
-                EditorGUILayout.Space();
-
-                EditorGUILayout.BeginHorizontal();
-
-                if (GUILayout.Button("Build Unity Project", GUILayout.Width(192), GUILayout.ExpandWidth(true)))
-                {
-                    EditorApplication.delayCall += () => UnityPlayerBuildTools.BuildUnityPlayer(new BuildInfo());
-                }
-
-                if (GUILayout.Button("Open Unity Build Window", GUILayout.Width(192), GUILayout.ExpandWidth(true)))
-                {
-                    GetWindow(Type.GetType("UnityEditor.BuildPlayerWindow,UnityEditor"));
-                }
-
-                EditorGUILayout.EndHorizontal();
-                EditorGUILayout.EndVertical();
                 return;
             }
 
-            EditorGUILayout.BeginVertical();
-            EditorGUILayout.Space();
-            GUILayout.Label("Quick Options");
-            EditorGUILayout.BeginHorizontal();
-
-            EditorUserBuildSettings.wsaSubtarget = (WSASubtarget)EditorGUILayout.Popup((int)EditorUserBuildSettings.wsaSubtarget, deviceNames);
-
-            bool canInstall = CanInstall;
-
-            if (EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens && !IsHoloLensConnectedUsb)
+            using (new EditorGUILayout.VerticalScope())
             {
-                canInstall = IsHoloLensConnectedUsb;
+                EditorGUILayout.Space();
+                GUILayout.Label("Quick Options");
+                using (new EditorGUILayout.HorizontalScope())
+                {
+
+                    EditorUserBuildSettings.wsaSubtarget = (WSASubtarget)EditorGUILayout.Popup((int)EditorUserBuildSettings.wsaSubtarget, deviceNames);
+
+                    bool canInstall = CanInstall;
+
+                    if (EditorUserBuildSettings.wsaSubtarget == WSASubtarget.HoloLens && !IsHoloLensConnectedUsb)
+                    {
+                        canInstall = IsHoloLensConnectedUsb;
+                    }
+
+                    GUI.enabled = ShouldBuildSLNBeEnabled;
+
+                    // Build & Run button...
+                    if (GUILayout.Button(CanInstall ? buildAllThenInstallLabel : buildAllLabel, GUILayout.Width(HALF_WIDTH), GUILayout.ExpandWidth(true)))
+                    {
+                        EditorApplication.delayCall += () => BuildAll(canInstall);
+                    }
+
+                    GUI.enabled = true;
+
+                    OpenPlayerSettingsGUI();
+
+                }
             }
-
-            GUI.enabled = ShouldBuildSLNBeEnabled;
-
-            // Build & Run button...
-            if (GUILayout.Button(CanInstall ? buildAllThenInstallLabel : buildAllLabel, GUILayout.Width(HALF_WIDTH), GUILayout.ExpandWidth(true)))
-            {
-                EditorApplication.delayCall += () => BuildAll(canInstall);
-            }
-
-            GUI.enabled = true;
-
-            OpenPlayerSettingsGUI();
-
-            EditorGUILayout.EndHorizontal();
-            EditorGUILayout.EndVertical();
             GUILayout.Space(10);
 
             #endregion Quick Options
@@ -339,67 +340,65 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private void UnityBuildGUI()
         {
-            GUILayout.BeginVertical();
-            EditorGUILayout.BeginHorizontal();
-
-            // Build directory (and save setting, if it's changed)
-            string curBuildDirectory = BuildDeployPreferences.BuildDirectory;
-            EditorGUILayout.LabelField(buildDirectoryLabel, GUILayout.Width(96));
-            string newBuildDirectory = EditorGUILayout.TextField(curBuildDirectory, GUILayout.Width(64), GUILayout.ExpandWidth(true));
-
-            if (newBuildDirectory != curBuildDirectory)
+            using (new EditorGUILayout.VerticalScope())
             {
-                BuildDeployPreferences.BuildDirectory = newBuildDirectory;
-            }
-
-            GUI.enabled = Directory.Exists(BuildDeployPreferences.AbsoluteBuildDirectory);
-
-            if (GUILayout.Button("Open Build Directory", GUILayout.Width(HALF_WIDTH)))
-            {
-                EditorApplication.delayCall += () => Process.Start(BuildDeployPreferences.AbsoluteBuildDirectory);
-            }
-
-            GUI.enabled = true;
-
-            EditorGUILayout.EndHorizontal();
-            EditorGUILayout.BeginHorizontal();
-
-            GUILayout.FlexibleSpace();
-
-            GUI.enabled = ShouldOpenSLNBeEnabled;
-
-            if (GUILayout.Button("Open in Visual Studio", GUILayout.Width(HALF_WIDTH)))
-            {
-                // Open SLN
-                string slnFilename = Path.Combine(BuildDeployPreferences.BuildDirectory, $"{PlayerSettings.productName}.sln");
-
-                if (File.Exists(slnFilename))
+                using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorApplication.delayCall += () => Process.Start(new FileInfo(slnFilename).FullName);
+                    // Build directory (and save setting, if it's changed)
+                    string curBuildDirectory = BuildDeployPreferences.BuildDirectory;
+                    EditorGUILayout.LabelField(buildDirectoryLabel, GUILayout.Width(96));
+                    string newBuildDirectory = EditorGUILayout.TextField(curBuildDirectory, GUILayout.Width(64), GUILayout.ExpandWidth(true));
+
+                    if (newBuildDirectory != curBuildDirectory)
+                    {
+                        BuildDeployPreferences.BuildDirectory = newBuildDirectory;
+                    }
+
+                    GUI.enabled = Directory.Exists(BuildDeployPreferences.AbsoluteBuildDirectory);
+
+                    if (GUILayout.Button("Open Build Directory", GUILayout.Width(HALF_WIDTH)))
+                    {
+                        EditorApplication.delayCall += () => Process.Start(BuildDeployPreferences.AbsoluteBuildDirectory);
+                    }
+
+                    GUI.enabled = true;
                 }
-                else if (EditorUtility.DisplayDialog(
-                    "Solution Not Found",
-                    "We couldn't find the Project's Solution. Would you like to Build the project now?",
-                    "Yes, Build", "No"))
+
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    GUILayout.FlexibleSpace();
+                    GUI.enabled = ShouldOpenSLNBeEnabled;
+
+                    if (GUILayout.Button("Open in Visual Studio", GUILayout.Width(HALF_WIDTH)))
+                    {
+                        // Open SLN
+                        string slnFilename = Path.Combine(BuildDeployPreferences.BuildDirectory, $"{PlayerSettings.productName}.sln");
+
+                        if (File.Exists(slnFilename))
+                        {
+                            EditorApplication.delayCall += () => Process.Start(new FileInfo(slnFilename).FullName);
+                        }
+                        else if (EditorUtility.DisplayDialog(
+                            "Solution Not Found",
+                            "We couldn't find the Project's Solution. Would you like to Build the project now?",
+                            "Yes, Build", "No"))
+                        {
+                            EditorApplication.delayCall += BuildUnityProject;
+                        }
+                    }
+                }
+                EditorGUILayout.Space();
+
+                // Build Unity Player
+                GUI.enabled = ShouldBuildSLNBeEnabled;
+
+                if (GUILayout.Button("Build Unity Project"))
                 {
                     EditorApplication.delayCall += BuildUnityProject;
                 }
+
+                GUI.enabled = true;
             }
-
-            EditorGUILayout.EndHorizontal();
-            EditorGUILayout.Space();
-
-            // Build Unity Player
-            GUI.enabled = ShouldBuildSLNBeEnabled;
-
-            if (GUILayout.Button("Build Unity Project"))
-            {
-                EditorApplication.delayCall += BuildUnityProject;
-            }
-
-            GUI.enabled = true;
-
-            EditorGUILayout.EndVertical();
         }
 
         private void AppxBuildGUI()
@@ -855,111 +854,112 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     string packageName = fullBuildLocation.Substring(lastBackslashIndex + 1);
 
                     GUILayout.Space(2);
-                    EditorGUILayout.BeginHorizontal();
-
-                    GUI.enabled = CanInstall;
-                    if (GUILayout.Button("Install", GUILayout.Width(96)))
+                    using (new EditorGUILayout.HorizontalScope())
                     {
-                        EditorApplication.delayCall += () =>
+
+                        GUI.enabled = CanInstall;
+                        if (GUILayout.Button("Install", GUILayout.Width(96)))
                         {
-                            if (processAll)
-                            {
-                                InstallAppOnDevicesList(fullBuildLocation, portalConnections);
-                            }
-                            else
-                            {
-                                InstallOnTargetDevice(fullBuildLocation, currentConnection);
-                            }
-                        };
-                    }
-
-                    GUI.enabled = true;
-
-                    // Uninstall...
-                    GUI.enabled = CanInstall;
-
-                    if (GUILayout.Button("Uninstall", GUILayout.Width(96)))
-                    {
-                        EditorApplication.delayCall += () =>
-                        {
-                            if (processAll)
-                            {
-                                UninstallAppOnDevicesList(portalConnections);
-                            }
-                            else
-                            {
-                                UninstallAppOnTargetDevice(currentConnection);
-                            }
-                        };
-                    }
-
-                    GUI.enabled = true;
-
-                    bool canLaunchLocal = currentConnectionInfoIndex == 0 && IsHoloLensConnectedUsb;
-                    bool canLaunchRemote = DevicePortalConnectionEnabled && CanInstall && currentConnectionInfoIndex != 0;
-
-                    // Launch app...
-                    GUI.enabled = canLaunchLocal || canLaunchRemote;
-
-                    if (GUILayout.Button(new GUIContent(isAppRunning ? "Kill App" : "Launch App", "These are remote commands only"), GUILayout.Width(96)))
-                    {
-                        EditorApplication.delayCall += () =>
-                        {
-                            if (isAppRunning)
+                            EditorApplication.delayCall += () =>
                             {
                                 if (processAll)
                                 {
-                                    KillAppOnDeviceList(portalConnections);
-                                    isAppRunning = false;
+                                    InstallAppOnDevicesList(fullBuildLocation, portalConnections);
                                 }
                                 else
                                 {
-                                    KillAppOnTargetDevice(currentConnection);
+                                    InstallOnTargetDevice(fullBuildLocation, currentConnection);
                                 }
-                            }
-                            else
+                            };
+                        }
+
+                        GUI.enabled = true;
+
+                        // Uninstall...
+                        GUI.enabled = CanInstall;
+
+                        if (GUILayout.Button("Uninstall", GUILayout.Width(96)))
+                        {
+                            EditorApplication.delayCall += () =>
                             {
                                 if (processAll)
                                 {
-                                    LaunchAppOnDeviceList(portalConnections);
-                                    isAppRunning = true;
+                                    UninstallAppOnDevicesList(portalConnections);
                                 }
                                 else
                                 {
-                                    LaunchAppOnTargetDevice(currentConnection);
+                                    UninstallAppOnTargetDevice(currentConnection);
                                 }
-                            }
-                        };
-                    }
+                            };
+                        }
 
-                    GUI.enabled = true;
+                        GUI.enabled = true;
 
-                    // Log file
-                    string localLogPath = $"%USERPROFILE%\\AppData\\Local\\Packages\\{PlayerSettings.productName}\\TempState\\UnityPlayer.log";
-                    bool localLogExists = File.Exists(localLogPath);
+                        bool canLaunchLocal = currentConnectionInfoIndex == 0 && IsHoloLensConnectedUsb;
+                        bool canLaunchRemote = DevicePortalConnectionEnabled && CanInstall && currentConnectionInfoIndex != 0;
 
-                    GUI.enabled = localLogExists || canLaunchRemote || canLaunchLocal;
+                        // Launch app...
+                        GUI.enabled = canLaunchLocal || canLaunchRemote;
 
-                    if (GUILayout.Button("View Log", GUILayout.Width(96)))
-                    {
-                        EditorApplication.delayCall += () =>
+                        if (GUILayout.Button(new GUIContent(isAppRunning ? "Kill App" : "Launch App", "These are remote commands only"), GUILayout.Width(96)))
                         {
-                            if (processAll)
+                            EditorApplication.delayCall += () =>
                             {
-                                OpenLogFilesOnDeviceList(portalConnections, localLogPath);
-                            }
-                            else
+                                if (isAppRunning)
+                                {
+                                    if (processAll)
+                                    {
+                                        KillAppOnDeviceList(portalConnections);
+                                        isAppRunning = false;
+                                    }
+                                    else
+                                    {
+                                        KillAppOnTargetDevice(currentConnection);
+                                    }
+                                }
+                                else
+                                {
+                                    if (processAll)
+                                    {
+                                        LaunchAppOnDeviceList(portalConnections);
+                                        isAppRunning = true;
+                                    }
+                                    else
+                                    {
+                                        LaunchAppOnTargetDevice(currentConnection);
+                                    }
+                                }
+                            };
+                        }
+
+                        GUI.enabled = true;
+
+                        // Log file
+                        string localLogPath = $"%USERPROFILE%\\AppData\\Local\\Packages\\{PlayerSettings.productName}\\TempState\\UnityPlayer.log";
+                        bool localLogExists = File.Exists(localLogPath);
+
+                        GUI.enabled = localLogExists || canLaunchRemote || canLaunchLocal;
+
+                        if (GUILayout.Button("View Log", GUILayout.Width(96)))
+                        {
+                            EditorApplication.delayCall += () =>
                             {
-                                OpenLogFileForTargetDevice(currentConnection, localLogPath);
-                            }
-                        };
+                                if (processAll)
+                                {
+                                    OpenLogFilesOnDeviceList(portalConnections, localLogPath);
+                                }
+                                else
+                                {
+                                    OpenLogFileForTargetDevice(currentConnection, localLogPath);
+                                }
+                            };
+                        }
+
+                        GUI.enabled = true;
+
+                        GUILayout.Space(8);
+                        GUILayout.Label(new GUIContent($"{packageName} ({directoryDate})"));
                     }
-
-                    GUI.enabled = true;
-
-                    GUILayout.Space(8);
-                    GUILayout.Label(new GUIContent($"{packageName} ({directoryDate})"));
-                    EditorGUILayout.EndHorizontal();
                 }
 
                 GUILayout.EndScrollView();


### PR DESCRIPTION
## Overview
This PR has two changes:

1) The Pointers profile used `ReordableList` to easily draw the inspector which is awesome...but when drawn as a subprofile, the entire inspector is reallocated every draw. Thus there is no way to save state between renders resulting in the bug #5004 . This PR draws the list manually with our own add/delete buttons similar to speech profile and other similar list inspectors in MRTK

2) A lot of old code still uses BeginHorizontal/Vertical which is both problematic and harder to read. Switching to EditorGUILayout.VerticalScope() {} clearly defines what is being draw in this horizontal/vertical and allows valid clean up if the logic returns early

The PR looks more deadly than it is. It's largely because of all the tab formating with the new using() { }

## Changes
- Fixes: #5004 

## Verification
Navigated all pages and browed basic usage
All tests pass

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
