### PR TITLE
Add a script that will check docs for validation errors.

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_TargetSelection.md
+++ b/Documentation/EyeTracking/EyeTracking_TargetSelection.md
@@ -75,7 +75,7 @@ The _IMixedRealityPointerHandler_ interface requires implementing the following 
 _OnPointerUp_, _OnPointerDown_, and _OnPointerClicked_.
 
 In the example below, we change the color of a hologram by looking at it and pinching or saying "select".
-The required action to trigger the event is defined by `eventData.MixedRealityInputAction == selectAction` whereby we can set the type of `selectAction` in the Unity Editor - by default it's the "Select" action. The types of available [MixedRealityInputActions](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/InputActions.html) can be configured in the MRTK Profile via _MRTK Configuration Profile_ -> _Input_ -> _Input Actions_.
+The required action to trigger the event is defined by `eventData.MixedRealityInputAction == selectAction` whereby we can set the type of `selectAction` in the Unity Editor - by default it's the "Select" action. The types of available [MixedRealityInputActions](../Input/InputActions.md) can be configured in the MRTK Profile via _MRTK Configuration Profile_ -> _Input_ -> _Input Actions_.
 
 ```csharp
    public class ColorTap : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityPointerHandler

--- a/Documentation/Tools/ExtensionServiceCreationWizard.md
+++ b/Documentation/Tools/ExtensionServiceCreationWizard.md
@@ -1,7 +1,7 @@
 
 # Extension Service Creation Wizard
 
-Making the transition from singletons to services can be difficult. This wizard can supplement our other documentation and sample code by enabling devs to create new services with (roughly) the same ease as creating a new MonoBehaviour script. To learn about creating services from scratch, see our [Guide to building Registered Services](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html) (Coming soon).
+Making the transition from singletons to services can be difficult. This wizard can supplement our other documentation and sample code by enabling devs to create new services with (roughly) the same ease as creating a new MonoBehaviour script. To learn about creating services from scratch, see our [Guide to building Registered Services](../MixedRealityConfigurationGuide.md) (Coming soon).
 
 ### Launching the wizard
 Launch the wizard from the main menu: **MixedRealityToolkit/Utilities/Create Extension Service** - the wizard will then take you through the process of generating your service script, interface and profile class.
@@ -35,4 +35,4 @@ Generated service scripts include some prompts similar to new MonoBehaviour scri
         }
     }
 
-If you chose to register your service in the wizard, all you have to do is edit this script and your service will automatically be updated. Otherwise you can read about [registering your new service here](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html).
+If you chose to register your service in the wizard, all you have to do is edit this script and your service will automatically be updated. Otherwise you can read about [registering your new service here](../MixedRealityConfigurationGuide.md).

--- a/scripts/ci/validatedocs.ps1
+++ b/scripts/ci/validatedocs.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Validates the docs to check for common patterns and usage that shouldn't be
+    checked in.
+.DESCRIPTION
+    This currently checks:
+
+    - That documentation doesn't contain fully resolved links (i.e. https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation)
+      and are instead relative links. Relative links can be resolved and validated by docfx, and fully resolved links cannot.
+
+    Returns 0 if there are no issues, non-zero if there are.
+.PARAMETER Directory
+    The directory containing the docs to validate.
+.EXAMPLE
+    .\validatedocs.ps1 -Directory c:\path\to\MRTK\Documentation
+#>
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Directory
+)
+
+function CheckDocLinks(
+    [string]$FileName,
+    [string[]]$FileContent,
+    [int]$LineNumber
+) {
+    <#
+    .SYNOPSIS
+        Checks if the given file at the given line contains a fully resolved documentation
+        link. Returns true if found.
+    #>
+    if ($FileContent[$LineNumber] -match "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation") {
+        Write-Host "An non-relative doc link was found in $FileName at line $LineNumber "
+        Write-Host "Avoid doc links containing https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation "
+        Write-Host "and use relative links instead."
+        return $true;
+    }
+    return $false
+}
+
+function CheckDocument(
+    [string]$FileName
+) {
+    # Each line of each script is checked by all of the validators above - this ensures that in
+    # a single pass, we'll get all of the issues highlighted all at once, rather than
+    # repeatedly running this script, discovering a single issue, fixing it, and then
+    # re-running the script
+    $containsIssue = $false
+    $fileContent = Get-Content $FileName
+    for ($i = 0; $i -lt $fileContent.Length; $i++) {
+        if (CheckDocLinks $FileName $fileContent $i) {
+            $containsIssue = $true
+        }
+    }
+    return $containsIssue
+}
+
+Write-Output "Checking $Directory for common doc issues"
+
+$docFiles = Get-ChildItem $Directory *.md -Recurse | Select-Object FullName
+$containsIssue = $false
+foreach ($docFile in $docFiles) {
+    if (CheckDocument $docFile.FullName) {
+        $containsIssue = $true
+    }
+}
+
+if ($containsIssue) {
+    Write-Output "Issues found, please see above for details"
+    exit 1;
+}
+else {
+    Write-Output "No issues found"
+    exit 0;
+}


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5716

Per the linked issue, there are currently a number of places in our docs that have hardcoded, full URLs to the github.io docs, instead of using relative paths. docfx is unable to validate full paths, but are able to validate relative paths, so in order to avoid inadvertently breaking things going forward (and to also ensure that things like doc versions properly point to their matching version), we want to make sure that no one checks in any more full paths.