### PR TITLE
 Add Method to encapsule the functionality from StartCommandLineBuild…

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -162,6 +162,13 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// </summary>
         public static async void StartCommandLineBuild()
         {
+            var success = await BuildUnityPlayerSimplified();
+            Debug.Log($"Exiting build...");
+            EditorApplication.Exit(success ? 0 : 1);
+        }
+        
+        public static async Task<bool> BuildUnityPlayerSimplified()
+        {
             // We don't need stack traces on all our logs. Makes things a lot easier to read.
             Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
             Debug.Log($"Starting command line build for {EditorUserBuildSettings.activeBuildTarget}...");
@@ -190,8 +197,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 success = false;
             }
 
-            Debug.Log($"Exiting command line build... Build success? {success}");
-            EditorApplication.Exit(success ? 0 : 1);
+            Debug.Log($"Finished build... Build success? {success}");
+            return success;
         }
 
         internal static bool CheckBuildScenes()


### PR DESCRIPTION
… from Exiting the editor

## Overview

This gives access to the simple unity build function without closing the editor automatically which we needed for our own (simple) CI build.

> When using the approach described in the old pull request, beware of the fact that the '-quit' flag of the unity batchmode will result in the build closing when ever another process ends e.g. the vswhere process or the msbuild process.


## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4889
In the old pull request it was expected that only a synced approach would solve the CI issues. Further research provided that it was the '-quit' flag on the unity batchmode start (see above)

