### PR TITLE
Provide a way to override the gaze cursor visibility

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/GazeProvider.cs
@@ -120,6 +120,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public GameObject GazeCursorPrefab { private get; set; }
 
         /// <inheritdoc />
+        public bool? GazeCursorVisibilityOverride
+        {
+            // Note that set doesn't call GazeCursor.SetVisible because visibility
+            // of the gaze cursor is reevaluated on each Update() tick.
+            get; set;
+        } = null;
+
+        /// <inheritdoc />
         public IMixedRealityCursor GazeCursor => GazePointer.BaseCursor;
 
         /// <inheritdoc />
@@ -354,11 +362,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Debug.DrawRay(GazeOrigin, (HitPosition - GazeOrigin), Color.white);
             }
+            UpdateGazeCursorVisibility();
+        }
 
+        private void UpdateGazeCursorVisibility()
+        {
+            // If the gaze cursor visibility is currently overridden, honor that over other
+            // gaze cursor visibility states.
+            if (GazeCursorVisibilityOverride != null)
+            {
+                GazeCursor.SetVisibility(GazeCursorVisibilityOverride.Value);
+            }
             // If flagged to do so (setCursorInvisibleWhenFocusLocked) and active (IsInteractionEnabled), set the visibility to !IsFocusLocked,
             // but don't touch the visibility when not active or not flagged.
-            if (setCursorInvisibleWhenFocusLocked && gazePointer != null &&
-                gazePointer.IsInteractionEnabled && GazeCursor != null && gazePointer.IsFocusLocked == GazeCursor.IsVisible)
+            else if (setCursorInvisibleWhenFocusLocked && gazePointer != null &&
+                     gazePointer.IsInteractionEnabled && GazeCursor != null && gazePointer.IsFocusLocked == GazeCursor.IsVisible)
             {
                 GazeCursor.SetVisibility(!gazePointer.IsFocusLocked);
             }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/GazeProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/GazeProviderTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine.TestTools;
+using Microsoft.MixedReality.Toolkit.Utilities;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.Input
+{
+    public class GazeProviderTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+        }
+
+        /// <summary>
+        /// Verifies that when there is no gaze cursor visibility override
+        /// set, that the cursor visibility rules follow the typical state
+        /// machine transitions.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestNullGazeCursorVisibilityOverride()
+        {
+            // The gaze cursor should be initially visible
+            Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Showing the hand should cause the gaze cursor to be not visible.
+            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
+
+            // Verify that since the hand is shown, the gaze cursor is not visible.
+            Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+        }
+
+        /// <summary>
+        /// Verifies that when the gaze cursor visibility override is set to false,
+        /// the gaze cursor is hidden (regardless of the current state) and that
+        /// setting it back to null will undo the hidden transition.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestFalseGazeCursorVisibilityOverride()
+        {
+            // The gaze cursor should be initially visible
+            Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Set the override to false, and then wait a frame in order for the
+            // internal state machine to reconcile this property change.
+            CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = false;
+            yield return null;
+            Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Clear the override and validate that the cursor shows up again.
+            CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = null;
+            yield return null;
+            Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+        }
+
+        /// <summary>
+        /// Verifies that when the gaze cursor visibility override is set to true,
+        /// the gaze cursor is visible (regardless of the current state) and that
+        /// setting it back to null will undo the visible transition.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTrueGazeCursorVisibilityOverride()
+        {
+            // The gaze cursor should be initially visible
+            Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Showing the hand should cause the gaze cursor to be not visible.
+            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
+
+            // Verify that since the hand is shown, the gaze cursor is not visible.
+            Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Set the override to true, and then wait a frame in order for the
+            // internal state machine to reconcile this property change.
+            CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = false;
+            yield return null;
+            Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
+            // Clear the override - since the cursor would have been invisible without
+            // the override, it should now be hidden.
+            CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = null;
+            yield return null;
+            Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+        }
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/GazeProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/GazeProviderTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
             // Set the override to true, and then wait a frame in order for the
             // internal state machine to reconcile this property change.
-            CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = false;
+            CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = true;
             yield return null;
             Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/GazeProviderTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/GazeProviderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f766a97b3d42b9428a3fa55eac2a5da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityGazeProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityGazeProvider.cs
@@ -33,7 +33,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The Gaze Cursor for the provider.
         /// </summary>
+        /// <remarks>
+        /// Note that calling GazeCursor.SetVisibility will not do anything, because the eye gaze provider
+        /// controls the visibility of the gaze cursor based on its own internal business logic.
+        /// In order to override this behavior use the GazeCursorVisibilityOverride property.
+        /// </remarks>
         IMixedRealityCursor GazeCursor { get; }
+
+        /// <summary>
+        /// The override for the GazeCursor visibility
+        /// </summary>
+        /// <remarks>
+        /// If null, there is no override for the GazeCursor visibility, and the visibility of the cursor
+        /// will be driven by the gaze provider's internal state machine.
+        /// If true, the gaze cursor will always be visible.
+        /// If false, the gaze cursor will always be hidden.
+        /// </remarks>
+        bool? GazeCursorVisibilityOverride { get; set; }
 
         /// <summary>
         /// The game object that is currently being gazed at, if any.

--- a/Documentation/Input/Gaze.md
+++ b/Documentation/Input/Gaze.md
@@ -73,3 +73,26 @@ void LogGazeDirectionOrigin()
 }
 ```
 
+### How to override the gaze cursor visibility
+
+The visibility of the gaze cursor is driven by the internal state machine of the GazeProvider itself.
+As a result, calling GazeCursor.SetVisibility(true) doesn't accomplish anything because the visibility
+state will be erased on the next update loop.
+
+The sample below shows how to force the gaze cursor to always be hidden (or always be visible)
+
+```csharp
+void HideGazeCursorAlways()
+{
+    CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = false;
+}
+
+void ShowGazeCursorAlways()
+{
+    CoreServices.InputSystem.GazeProvider.GazeCursorVisibilityOverride = true;
+}
+```
+
+This will not cause the cursor to immediately show/hide - it will show/hide on the next update tick.
+
+For more examples of how this is used, see the [`GazeProviderTests`](xref:Microsoft.MixedReality.Toolkit.Tests.Input.GazeProviderTests)


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5395

This updates IMixedRealityGazeProvider to provide an override for the gaze cursor visibility.

Note that this doesn't fix the issue by making GazeCursor.SetVisibility "just work", because the thing that controls the gaze cursor visibility is a state machine controlled by higher level concepts than the cursor itself. I thought about adding some sort of mediation/more complicated set of flags (i.e. IMixedRealityCursor.SetVisibilityOverride) but found that doing such a thing would end up making things more complicated on that level (i.e. it introduces complexity in an area that SHOULD be simple, rather than building complexity at the more appropriate layers)

This change adds tests to show that it works, and then also adds docs to explain how to use this.