### PR TITLE
Update the .gitignore to ignore the obj.meta file generated due to Unity/docfx interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,13 @@ Assets/StreamingAssets.meta
 # =============== #
 doc/
 
+# This is only needed because docfx chooses the first alphebetically occuring
+# .cs file's folder to create an obj/xdoc cache folder inside.
+# When https://github.com/dotnet/docfx/issues/1156 is addressed, it should be
+# possible to remove the rule on the following line and update our docfx
+# configuration to place its cache in a deterministic folder.
+[Oo]bj.meta
+
 # ============================= #
 # NuGet Build Process Generated #
 # ============================= #


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4237

Running docfx locally will generate an obj/xdoc folder in the same location as the first alphabetically occuring .cs file. This is how docfx's cache system works:

https://github.com/dotnet/docfx/blob/master/Documentation/spec/docfx_incremental.md

Unfortunately there isn't currently a way to pipe this cache to another location (I've tried the application level cache, without much success), so I've added this .gitignore rule.

There are no existing examples of Obj.meta/obj.meta, so this is safe for the time being. I've added a comment as well to the gitignore to highlight why it's there and when/how it can be removed.