### PR TITLE
Renaming deselection fix

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -1356,10 +1356,19 @@ namespace Microsoft.MixedReality.Toolkit
                     }
 
                     for (int i = toolkitInstances.Count - 1; i >= 0; i--)
-                    {  // Make sure it's not parented under anything
-                        Debug.Assert(toolkitInstances[i].transform.parent == null, "MixedRealityToolkit instances should not be parented under any other GameObject.");
+                    {
+                        MixedRealityToolkit currentInstance = toolkitInstances[i];
+
+                        // Make sure it's not parented under anything
+                        Debug.Assert(currentInstance.transform.parent == null, "MixedRealityToolkit instances should not be parented under any other GameObject.");
+
                         // Name instances so it's clear when it's the active instance
-                        toolkitInstances[i].name = toolkitInstances[i].IsActiveInstance ? MixedRealityToolkit.activeInstanceGameObjectName : MixedRealityToolkit.inactiveInstanceGameObjectName;
+                        string instanceName = currentInstance.IsActiveInstance ? activeInstanceGameObjectName : inactiveInstanceGameObjectName;
+
+                        if (!currentInstance.name.Equals(instanceName))
+                        {
+                            currentInstance.name = instanceName;
+                        }
                     }
                 };
             }

--- a/Assets/MixedRealityToolkit/Utilities/Facades/ServiceFacade.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Facades/ServiceFacade.cs
@@ -13,6 +13,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
     [ExecuteAlways]
     public class ServiceFacade : MonoBehaviour
     {
+        private const string DESTROYED = "(Destroyed)";
+
         public static Dictionary<Type, ServiceFacade> FacadeServiceLookup = new Dictionary<Type, ServiceFacade>();
         public static List<ServiceFacade> ActiveFacadeObjects = new List<ServiceFacade>();
 
@@ -33,7 +35,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             if (service == null)
             {
                 serviceType = null;
-                name = "(Destroyed)";
+                if (!name.Equals(DESTROYED))
+                {
+                    name = DESTROYED;
+                }
                 gameObject.SetActive(false);
                 return;
             }
@@ -41,7 +46,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             {
                 this.serviceType = service.GetType();
 
-                name = serviceType.Name;
+                if (!name.Equals(serviceType.Name))
+                {
+                    name = serviceType.Name;
+                }
+
                 gameObject.SetActive(true);
 
                 if (!FacadeServiceLookup.ContainsKey(serviceType))


### PR DESCRIPTION
This fixes an issue where setting the names of GameObjects triggers EditorApplication.hierarchyChanged, which effectively exits edit mode for the rename. This led to recursively renaming affected gameobjects during the whole time the editor ran.

## Changes
- Fixes: #5062
