### PR TITLE
Fix Platform Toolset selection not applied for msbuild

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -1078,6 +1078,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 RebuildAppx = UwpBuildDeployPreferences.ForceRebuild,
                 Configuration = UwpBuildDeployPreferences.BuildConfig,
                 BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
+                PlatformToolset = UwpBuildDeployPreferences.PlatformToolset,
                 OutputDirectory = BuildDeployPreferences.BuildDirectory,
                 AutoIncrement = BuildDeployPreferences.IncrementBuildVersion,
                 Multicore = UwpBuildDeployPreferences.MulticoreAppxBuildEnabled,

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         }
 
         /// <summary>
-        /// The current Build Configuration. (Debug, Release, or Master)
+        /// The current Platform Toolset. (Solution, v141, or v142)
         /// </summary>
         public static string PlatformToolset
         {


### PR DESCRIPTION
## Overview

This is a follow up fix for #5360. The `PlatformToolset` property of the `UwpBuildInfo` wasn't set when starting an appx build. Leaving it to the default empty string value, `/p:PlatformToolset` was ommited during msbuild invokation.

In addition, this PR also contains an fix for the copy-pasted `PlatformToolset` preferences API in-code documentation.

## Changes
- Follow up fix for #5360