### PR TITLE
Remove the SimulatedHandData timestamps since they prevent changes in…

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -157,14 +157,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // TODO implement custom hand device update frequency here, use 1000/fps instead of 0
                 if (msSinceLastHandUpdate > 0)
                 {
-                    if (HandDataLeft.Timestamp > lastHandUpdateTimestamp)
-                    {
-                        UpdateHandDevice(profile.HandSimulationMode, Handedness.Left, HandDataLeft);
-                    }
-                    if (HandDataRight.Timestamp > lastHandUpdateTimestamp)
-                    {
-                        UpdateHandDevice(profile.HandSimulationMode, Handedness.Right, HandDataRight);
-                    }
+                    UpdateHandDevice(profile.HandSimulationMode, Handedness.Left, HandDataLeft);
+                    UpdateHandDevice(profile.HandSimulationMode, Handedness.Right, HandDataRight);
 
                     lastHandUpdateTimestamp = currentTime.Ticks;
                 }

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHand.cs
@@ -16,10 +16,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         private static readonly int jointCount = Enum.GetNames(typeof(TrackedHandJoint)).Length;
 
-        // Timestamp of hand data, as FileTime, e.g. DateTime.UtcNow.ToFileTime()
-        private long timestamp = 0;
-        public long Timestamp => timestamp;
-
         [SerializeField]
         private bool isTracked = false;
         public bool IsTracked => isTracked;
@@ -51,7 +47,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public void Copy(SimulatedHandData other)
         {
-            timestamp = other.timestamp;
             isTracked = other.isTracked;
             isPinching = other.isPinching; 
             for (int i = 0; i < jointCount; ++i)
@@ -70,21 +65,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <remarks>The timestamp of the hand data will be the current time, see [DateTime.UtcNow](https://docs.microsoft.com/en-us/dotnet/api/system.datetime.utcnow?view=netframework-4.8).</remarks>
         public bool Update(bool isTrackedNew, bool isPinchingNew, HandJointDataGenerator generator)
         {
-            // TODO: DateTime.UtcNow can be quite imprecise, better use Stopwatch.GetTimestamp
-            // https://stackoverflow.com/questions/2143140/c-sharp-datetime-now-precision
-            return UpdateWithTimestamp(DateTime.UtcNow.Ticks, isTrackedNew, isPinchingNew, generator);
-        }
-
-        /// <summary>
-        /// Replace the hand data with the given values.
-        /// </summary>
-        /// <returns>True if the hand data has been changed.</returns>
-        /// <param name="timestampNew">The timestamp for the new hand data. No change will occur if the time stamp is the same as the current one.</param>
-        /// <param name="isTrackedNew">True if the hand is currently tracked.</param>
-        /// <param name="isPinchingNew">True if the hand is in a pinching pose that causes a "Select" action.</param>
-        /// <param name="generator">Generator function that produces joint positions and rotations. The joint data generator is only used when the hand is tracked.</param>
-        public bool UpdateWithTimestamp(long timestampNew, bool isTrackedNew, bool isPinchingNew, HandJointDataGenerator generator)
-        {
             bool handDataChanged = false;
 
             if (isTracked != isTrackedNew || isPinching != isPinchingNew)
@@ -94,14 +74,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 handDataChanged = true;
             }
 
-            if (timestamp != timestampNew)
+            if (isTracked)
             {
-                timestamp = timestampNew;
-                if (isTracked)
-                {
-                    generator(Joints);
-                    handDataChanged = true;
-                }
+                generator(Joints);
+                handDataChanged = true;
             }
 
             return handDataChanged;

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedHandDataProvider.cs
@@ -190,9 +190,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             SimulateUserInput();
 
             bool handDataChanged = false;
-            // TODO: DateTime.UtcNow can be quite imprecise, better use Stopwatch.GetTimestamp
-            // https://stackoverflow.com/questions/2143140/c-sharp-datetime-now-precision
-            long timestamp = DateTime.UtcNow.Ticks;
 
             // Cache the generator delegates so we don't gc alloc every frame
             if (generatorLeft == null)
@@ -205,8 +202,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 generatorRight = HandStateRight.FillCurrentFrame;
             }
 
-            handDataChanged |= handDataLeft.UpdateWithTimestamp(timestamp, HandStateLeft.IsTracked, HandStateLeft.IsPinching, generatorLeft);
-            handDataChanged |= handDataRight.UpdateWithTimestamp(timestamp, HandStateRight.IsTracked, HandStateRight.IsPinching, generatorRight);
+            handDataChanged |= handDataLeft.Update(HandStateLeft.IsTracked, HandStateLeft.IsPinching, generatorLeft);
+            handDataChanged |= handDataRight.Update(HandStateRight.IsTracked, HandStateRight.IsPinching, generatorRight);
 
             return handDataChanged;
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -274,12 +274,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return hand.Show(initialHandPosition);
             yield return hand.MoveTo(initialObjectPosition);
-            yield return hand.GrabAndThrowAt(rightPosition);
+            // Note: don't wait for a physics update after releasing, because it would recompute
+            // the velocity of the hand and make it deviate from the rigid body velocity!
+            yield return hand.GrabAndThrowAt(rightPosition, false);
 
             // With simulated hand angular velocity would not be equal to 0, because of how simulation
             // moves hand when releasing the Pitch. Even though it doesn't directly follow from hand movement, there will always be some rotation.
             Assert.NotZero(rigidBody.angularVelocity.magnitude, "Manipulationhandler should apply angular velocity to rigidBody upon release.");
-            Assert.AreEqual(rigidBody.velocity, hand.GetVelocity(), "Manipulationhandler should apply hand velocity to rigidBody upon release.");
+            Assert.AreEqual(hand.GetVelocity(), rigidBody.velocity, "Manipulationhandler should apply hand velocity to rigidBody upon release.");
 
             // This is just for debugging purposes, so object's movement after release can be seen.
             yield return hand.MoveTo(initialHandPosition);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
@@ -61,7 +61,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             Vector3 oldPosition = position;
             position = newPosition;
-            yield return PlayModeTestUtilities.MoveHandFromTo(oldPosition, newPosition, numSteps, gestureId, handedness, simulationService);
+            for (var iter = PlayModeTestUtilities.MoveHandFromTo(oldPosition, newPosition, numSteps, gestureId, handedness, simulationService); iter.MoveNext(); )
+            {
+                yield return iter.Current;
+            }
             if (waitForFixedUpdate)
             {
                 yield return new WaitForFixedUpdate();
@@ -70,7 +73,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         public IEnumerator Move(Vector3 delta, int numSteps = 30)
         {
-            yield return MoveTo(position + delta, numSteps);
+            for (var iter = MoveTo(position + delta, numSteps); iter.MoveNext(); )
+            {
+                yield return iter.Current;
+            }
         }
 
         public IEnumerator SetRotation(Quaternion newRotation, int numSteps = 30)
@@ -83,18 +89,36 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator SetGesture(ArticulatedHandPose.GestureId newGestureId, bool waitForFixedUpdate = true)
         {
             gestureId = newGestureId;
-            yield return PlayModeTestUtilities.MoveHandFromTo(position, position, 1, gestureId, handedness, simulationService);
+            for (var iter = PlayModeTestUtilities.MoveHandFromTo(position, position, 1, gestureId, handedness, simulationService); iter.MoveNext(); )
+            {
+                yield return iter.Current;
+            }
             if (waitForFixedUpdate)
             {
                 yield return new WaitForFixedUpdate();
             }
         }
 
-        public IEnumerator GrabAndThrowAt(Vector3 positionToRelease, int numSteps = 30)
+        /// <summary>
+        /// Combined sequence of pinching, moving, and releasing.
+        /// </summary>
+        /// <param name="positionToRelease">The position to which the hand moves while pinching</param>
+        /// <param name="waitForFinalFixedUpdate">Wait for a final physics update after releasing</param>
+        /// <param name="numSteps">Number of steps of the hand movement</param>
+        public IEnumerator GrabAndThrowAt(Vector3 positionToRelease, bool waitForFinalFixedUpdate, int numSteps = 30)
         {
-            yield return SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return MoveTo(positionToRelease, numSteps);
-            yield return SetGesture(ArticulatedHandPose.GestureId.Open);
+            for (var iter = SetGesture(ArticulatedHandPose.GestureId.Pinch); iter.MoveNext(); )
+            {
+                yield return iter.Current;
+            }
+            for (var iter = MoveTo(positionToRelease, numSteps); iter.MoveNext(); )
+            {
+                yield return iter.Current;
+            }
+            for (var iter = SetGesture(ArticulatedHandPose.GestureId.Open, waitForFinalFixedUpdate); iter.MoveNext(); )
+            {
+                yield return iter.Current;
+            }
         }
 
         public T GetPointer<T>() where T : class, IMixedRealityPointer


### PR DESCRIPTION
## Overview

Remove the timestamps from SimulatedHandData because they are breaking tests.

These timestamps are supposed to prevent frequent changes, but they do this in tests as well, where multiple changes per frame are possible. Due to the timestamps being based on UtcNow (which is also quite inaccurate) they can prevent updates randomly.

## Changes
- Fixes: Test failures observed in #5264
