### PR TITLE
Removing the 'prerelease' from the NuGet versioning.

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -49,12 +49,12 @@ jobs:
   - ${{ if eq(variables['MRTKReleaseTag'], '') }}:
     - template: templates/package.yml
       parameters:
-        version: '$(MRTKVersion)-$(Build.BuildNumber).prerelease'
+        version: '$(MRTKVersion)-$(Build.BuildNumber)'
         packDestination: '$(Build.SourcesDirectory)\artifacts\prerelease'
   - ${{ if ne(variables['MRTKReleaseTag'], '') }}:
     - template: templates/package.yml
       parameters:
-        version: '$(MRTKVersion)-$(Build.BuildNumber).prerelease.$(MRTKReleaseTag)'
+        version: '$(MRTKVersion)-$(Build.BuildNumber).$(MRTKReleaseTag)'
         packDestination: '$(Build.SourcesDirectory)\artifacts\prerelease'
 
   # Create release packages


### PR DESCRIPTION
For this release I am removing the "prerelease" text string from NuGet package version as that currently isn't supported by NuGetForUnity. This is not necessary for this release.