### PR TITLE
Remove Test package from release artifacts

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -69,6 +69,10 @@ jobs:
         version: '$(MRTKVersion)-$(MRTKReleaseTag)'
         packDestination: '$(Build.SourcesDirectory)\artifacts\release'        
 
+  - powershell: |
+      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/MixedReality.Toolkit.Tests.*"
+    displayName: "Delete MixedReality.Toolkit.Tests package from the release artifacts"
+
   - template: templates/tasks/signing.yml
     parameters:
       ConfigName: "$(Build.ArtifactStagingDirectory)/scripts/signconfig/MRTKNuGetSignConfig.xml"

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -70,7 +70,7 @@ jobs:
         packDestination: '$(Build.SourcesDirectory)\artifacts\release'        
 
   - powershell: |
-      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/MixedReality.Toolkit.Tests.*"
+      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/Microsoft.MixedReality.Toolkit.Tests.*"
     displayName: "Delete MixedReality.Toolkit.Tests package from the release artifacts"
 
   - template: templates/tasks/signing.yml


### PR DESCRIPTION
Delete the Test package from artifacts published by the release build as we do not intend to publish them at release time.