### PR TITLE
Fix for spatial awareness allowing only mesh observers to be registered (#5835)

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/MixedRealitySpatialObserverConfiguration.cs
+++ b/Assets/MixedRealityToolkit/Definitions/MixedRealitySpatialObserverConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     public struct MixedRealitySpatialObserverConfiguration : IMixedRealityServiceConfiguration
     {
         [SerializeField]
-        [Implements(typeof(IMixedRealitySpatialAwarenessMeshObserver), TypeGrouping.ByNamespaceFlat)]
+        [Implements(typeof(IMixedRealitySpatialAwarenessObserver), TypeGrouping.ByNamespaceFlat)]
         private SystemType componentType;
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Base input device manager to inherit from.
+    /// Class providing a base implementation of the <see cref="IMixedRealityInputDeviceManager"/> interface.
     /// </summary>
     public abstract class BaseInputDeviceManager : BaseDataProvider, IMixedRealityInputDeviceManager
     {

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
@@ -7,7 +7,10 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 {
-    public class BaseSpatialObserver : BaseDataProvider, IMixedRealitySpatialAwarenessObserver
+    /// <summary>
+    /// Class providing a base implementation of the <see cref="IMixedRealitySpatialAwarenessObserver"/> interface.
+    /// </summary>
+    public abstract class BaseSpatialObserver : BaseDataProvider, IMixedRealitySpatialAwarenessObserver
     {
         /// <summary>
         /// Constructor.


### PR DESCRIPTION
## Overview
The spatial awareness system was incorrectly configured to only allow registration of mesh observers. This blocks support for non-mesh observers (ex: future platform growth).

The fix was to filter based on IMixedRealitySpatialAwarenessObserver instead of the more restrictive IMixedRealitySpatialAwarenessMeshObserver.

This change also pointed out that BaseSpatialObserver was mistakenly NOT marked as abstract. It does not provide any observation functionality and is suitable only as a base class (the original intent).

As a part of this change, the class doc comments for BaseInputDeviceManager and BaseSpatialObserver were improved or added.

## Changes
- Fixes: #5835.

## Verification
- Confirmed non-mesh observer is discovered and can be added.
- Confirmed that the base class does not appear in available observers