### PR TITLE
Fixes for the NuGet Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ doc/
 /MRTKBuild/
 /MSBuild/
 /PackagesCopy/
+!/scripts/Packaging/NuGetRestoreProject.csproj

--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -27,7 +27,7 @@
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.*" target="Plugins\" />
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Demos.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Examples" />
-    <file src="..\..\Assets\MixedRealityToolkit.Demos\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Demos" />
+    <file src="..\..\..\Assets\MixedRealityToolkit.Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Examples" />
+    <file src="..\..\..\Assets\MixedRealityToolkit.Demos\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Demos" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -28,6 +28,5 @@
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.*" target="Plugins\" />
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Demos.*" target="Plugins\" />
     <file src="..\..\..\Assets\MixedRealityToolkit.Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Examples" />
-    <file src="..\..\..\Assets\MixedRealityToolkit.Demos\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Demos" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
+++ b/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
@@ -26,6 +26,6 @@
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Examples.targets" />
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Extensions.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.Extensions\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Extensions" />
+    <file src="..\..\..\Assets\MixedRealityToolkit.Extensions\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Extensions" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
+++ b/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
@@ -19,7 +19,6 @@
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />
     </contentFiles>
   </metadata>
-  </metadata>
   <files>
     <file src="**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta" target="MRTK\" />
 
@@ -27,6 +26,6 @@
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tests.targets" />
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.Tests\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tests" />
+    <file src="..\..\..\Assets\MixedRealityToolkit.Tests\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tests" />
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
@@ -26,6 +26,6 @@
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Examples.targets" />
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tools.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tools" />
+    <file src="..\..\..\Assets\MixedRealityToolkit.Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tools" />
   </files>
 </package>

--- a/scripts/packaging/NuGetRestoreProject.csproj
+++ b/scripts/packaging/NuGetRestoreProject.csproj
@@ -1,0 +1,25 @@
+<!--
+  The purpose of this project file is to allow you to do a command line restore of a specific nuget package. A NuGet restore
+  is slightly different than using the NuGet.exe CLI "install" command. The restore installs to the machine NuGet cache so that
+  other projects on the machine can consume the package. This can be very handy for locally validating a NuGet package.
+  
+  This command is expected to be used like:
+  dotnet build <this_file> -p:RestorePackageFeed=<path_to_package_folder> -p:RestorePackageId=<NuGet_Package_Id> -p:RestorePackageVersion=<NuGet_Package_Version>
+  
+  Ex:
+  dotnet build NuGetRestoreProject.csproj -p:RestorePackageFeed=D:\MRTK\Artifacts -p:RestorePackageId=Microsoft.MixedReality.Toolkit.Foundation -p:RestorePackageVersion=0.0.0
+  
+  Use the Microsoft.Build.Traversal Sdk so that this project doesn't actually compile anything and doesn't have to specify a TargetFramework.
+  https://github.com/microsoft/MSBuildSdks/tree/master/src/Traversal
+-->
+<Project Sdk="Microsoft.Build.Traversal/2.0.2">
+
+  <PropertyGroup>
+    <RestoreSources>$(RestorePackageFeed)</RestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="$(RestorePackageId)" Version="$(RestorePackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -136,9 +136,6 @@ try
         $restoreProjectPath = [System.IO.Path]::Combine((Split-Path $MyInvocation.MyCommand.Path), 'NuGetRestoreProject.csproj')
         dotnet build $restoreProjectPath -p:RestorePackageFeed=$OutputDirectory -p:RestorePackageId=$packageId -p:RestorePackageVersion=$localVersion
     }
-    
-    # Wait for, receive, and remove all the nuget jobs
-    $nugetJobs | Receive-Job -Wait -AutoRemoveJob
 }
 finally
 {

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -134,7 +134,7 @@ try
         
         # Restore the package by providing the nupkg folder. After this restore the machine global cache will be populated with the package
         $restoreProjectPath = [System.IO.Path]::Combine((Split-Path $MyInvocation.MyCommand.Path), 'NuGetRestoreProject.csproj')
-        dotnet build $restoreProjectPath -p:RestorePackageFeed=$OutputDirectory -p:RestorePackageId=$packageId -p:RestorePackageVersion=$localVersion
+        dotnet build "$restoreProjectPath" -p:RestorePackageFeed="$(convert-path $OutputDirectory)" -p:RestorePackageId=$packageId -p:RestorePackageVersion=$localVersion
     }
 }
 finally


### PR DESCRIPTION
## Overview
The last change to the NuGet packages had a few errors in it and was causing only the main Foundation package to be generated correctly. This change fixes those issues and also adds logic for acquiring NuGet.exe if the machine does not have it installed globally.

## Changes
- I missed checking in a csproj that's used for NuGet restores (it was being gitignored).
- The source paths in nuspecs were not taking into account the depth of the nuspec files
- The script now acquires NuGet if you didn't already have it. In order to support that I did remove the functionality of packing all NuGets in parallel. The Start-Job command causes the inner command to lose the environment variables and context. In this case it means the background jobs couldn't find the local downloaded NuGet.exe. The overall NuGet pack time with this change is still under 45sec.