### PR TITLE
Use correct center point for computing touchable normal inside a coll…

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (normal == Vector3.zero)
             {
                 // inside object, use vector to centre as normal
-                normal = samplePoint - transform.TransformVector(TouchableCollider.bounds.center);
+                normal = samplePoint - TouchableCollider.bounds.center;
                 normal.Normalize();
                 return 0;
             }


### PR DESCRIPTION
## Overview

Fix incorrect normal calculation for NearInteractionTouchableVolume in the case of casting from within a collider.

## Changes
- Fixes: #5836
