### PR TITLE
Add Interactable event listeners via script

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scripts/CustomInteractablesReceiver.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Scripts/CustomInteractablesReceiver.cs
@@ -29,9 +29,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Coroutine showVoice;
         private int clickCount = 0;
 
-        public CustomInteractablesReceiver(UnityEvent ev) : base(ev)
+        public CustomInteractablesReceiver(UnityEvent ev) : base(ev, "CustomEvent")
         {
-            Name = "CustomEvent";
             HideUnityEvents = true; // hides Unity events in the receiver - meant to be code only
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs
@@ -18,9 +18,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private State lastState;
         
-        public InteractableAudioReceiver(UnityEvent ev) : base(ev)
+        public InteractableAudioReceiver(UnityEvent ev) : base(ev, "AudioEvent")
         {
-            Name = "AudioEvent";
             HideUnityEvents = true; // hides Unity events in the receiver - meant to be code only
         }
         

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs
@@ -17,7 +17,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public AudioClip AudioClip;
 
         private State lastState;
-        
+
+        /// <summary>
+        /// Creates and AudioReceiver, which plays sounds on Click
+        /// </summary>
         public InteractableAudioReceiver(UnityEvent ev) : base(ev, "AudioEvent")
         {
             HideUnityEvents = true; // hides Unity events in the receiver - meant to be code only

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableEvent
     {
         public string Name;
-        public UnityEvent Event;
+        public UnityEvent Event = new UnityEvent();
         public string ClassName;
         public string AssemblyQualifiedName;
         public ReceiverBase Receiver;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnClickReceiver : ReceiverBase
     {
-        public UnityEvent OnClicked { get { return uEvent; } }
+        public UnityEvent OnClicked => uEvent;
         public InteractableOnClickReceiver(UnityEvent ev): base(ev, "OnClick") { }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnClickReceiver : ReceiverBase
     {
+        public UnityEvent OnClicked { get { return uEvent; } }
         public InteractableOnClickReceiver(UnityEvent ev): base(ev)
         {
             Name = "OnClick";

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -12,10 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableOnClickReceiver : ReceiverBase
     {
         public UnityEvent OnClicked { get { return uEvent; } }
-        public InteractableOnClickReceiver(UnityEvent ev): base(ev)
-        {
-            Name = "OnClick";
-        }
+        public InteractableOnClickReceiver(UnityEvent ev): base(ev, "OnClick") { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -12,6 +12,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableOnClickReceiver : ReceiverBase
     {
         public UnityEvent OnClicked => uEvent;
+
+        /// <summary>
+        /// Creates receiver for raising OnClick events
+        /// </summary>
         public InteractableOnClickReceiver(UnityEvent ev): base(ev, "OnClick") { }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -24,10 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get { return onFocusOff; }
         }
 
-        public InteractableOnFocusReceiver() : base()
-        {
-
-        }
+        public InteractableOnFocusReceiver() : this(new UnityEvent()) { }
 
         /// <summary>
         /// Raised when focus has entered the object
@@ -39,10 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool hadFocus;
 
-        public InteractableOnFocusReceiver(UnityEvent ev) : base(ev)
-        {
-            Name = "OnFocus";
-        }
+        public InteractableOnFocusReceiver(UnityEvent ev) : base(ev, "OnFocus") { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -15,7 +15,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public UnityEvent OnFocusOff = new UnityEvent();
 
         private bool hadFocus;
-        private State lastState;
 
         public InteractableOnFocusReceiver(UnityEvent ev) : base(ev)
         {
@@ -25,11 +24,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
-            bool changed = state.CurrentState() != lastState;
-
             bool hasFocus = state.GetState(InteractableStates.InteractableStateEnum.Focus).Value > 0;
 
-            if (hadFocus != hasFocus && changed)
+            if (hadFocus != hasFocus)
             {
                 if (hasFocus)
                 {
@@ -42,7 +39,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             hadFocus = hasFocus;
-            lastState = state.CurrentState();
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using UnityEngine;
 using UnityEngine.Events;
 
 namespace Microsoft.MixedReality.Toolkit.UI
@@ -11,8 +12,30 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnFocusReceiver : ReceiverBase
     {
+        [SerializeField]
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Focus Off", Tooltip = "Focus has left the object")]
-        public UnityEvent OnFocusOff = new UnityEvent();
+        private UnityEvent onFocusOff = new UnityEvent();
+
+        /// <summary>
+        /// Raised when focus has left the object
+        /// </summary>
+        public UnityEvent OnFocusOff
+        {
+            get { return onFocusOff; }
+        }
+
+        public InteractableOnFocusReceiver() : base()
+        {
+
+        }
+
+        /// <summary>
+        /// Raised when focus has entered the object
+        /// </summary>
+        public UnityEvent OnFocusOn
+        {
+            get { return uEvent; }
+        }
 
         private bool hadFocus;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -21,20 +21,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Raised when focus has left the object
         /// </summary>
-        public UnityEvent OnFocusOff
-        {
-            get { return onFocusOff; }
-        }
+        public UnityEvent OnFocusOff => onFocusOff;
 
         public InteractableOnFocusReceiver() : this(new UnityEvent()) { }
 
         /// <summary>
         /// Raised when focus has entered the object
         /// </summary>
-        public UnityEvent OnFocusOn
-        {
-            get { return uEvent; }
-        }
+        public UnityEvent OnFocusOn => uEvent;
 
         private bool hadFocus;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -13,8 +13,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnFocusReceiver : ReceiverBase
     {
+        /// <summary>
+        /// Creates receiver that raises focus enter and exit unity events
+        /// </summary>
         public InteractableOnFocusReceiver() : this(new UnityEvent()) { }
 
+        /// <summary>
+        /// Creates receiver that raises focus enter and exit unity events
+        /// </summary>
         public InteractableOnFocusReceiver(UnityEvent ev) : base(ev, "OnFocusOn") { }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -13,17 +13,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnFocusReceiver : ReceiverBase
     {
-        [SerializeField]
-        [FormerlySerializedAs("OnFocusOff")]
-        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Focus Off", Tooltip = "Focus has left the object")]
-        private UnityEvent onFocusOff = new UnityEvent();
+        public InteractableOnFocusReceiver() : this(new UnityEvent()) { }
+
+        public InteractableOnFocusReceiver(UnityEvent ev) : base(ev, "OnFocusOn") { }
 
         /// <summary>
         /// Raised when focus has left the object
         /// </summary>
-        public UnityEvent OnFocusOff => onFocusOff;
-
-        public InteractableOnFocusReceiver() : this(new UnityEvent()) { }
+        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Focus Off", Tooltip = "Focus has left the object")]
+        public UnityEvent OnFocusOff = new UnityEvent();
 
         /// <summary>
         /// Raised when focus has entered the object
@@ -31,8 +29,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public UnityEvent OnFocusOn => uEvent;
 
         private bool hadFocus;
-
-        public InteractableOnFocusReceiver(UnityEvent ev) : base(ev, "OnFocus") { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -13,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableOnFocusReceiver : ReceiverBase
     {
         [SerializeField]
+        [FormerlySerializedAs("OnFocusOff")]
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Focus Off", Tooltip = "Focus has left the object")]
         private UnityEvent onFocusOff = new UnityEvent();
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnFocusReceiver.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -37,6 +37,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnGrab";
         }
 
+        public InteractableOnGrabReceiver() : base()
+        {
+            Name = "OnGrab";
+        }
+
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -20,8 +20,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "Grab was released")]
         public UnityEvent OnRelease = new UnityEvent();
 
-        public UnityEvent OnRelease => onRelease;
-
         /// <summary>
         /// Invoked on grab start
         /// </summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -22,12 +22,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Invoked on grab release
         /// </summary>
-        public UnityEvent OnRelease { get { return onRelease; } }
+        public UnityEvent OnRelease => onRelease;
 
         /// <summary>
         /// Invoked on grab start
         /// </summary>
-        public UnityEvent OnGrab { get { return uEvent; } }
+        public UnityEvent OnGrab => uEvent;
 
         private bool hadGrab;
         private State lastState;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -12,8 +14,20 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnGrabReceiver : ReceiverBase
     {
+        [SerializeField]
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "Grab was released")]
-        public UnityEvent OnRelease = new UnityEvent();
+        [FormerlySerializedAsAttribute("OnRelease")]
+        private UnityEvent onRelease = new UnityEvent();
+
+        /// <summary>
+        /// Invoked on grab release
+        /// </summary>
+        public UnityEvent OnRelease { get { return onRelease; } }
+
+        /// <summary>
+        /// Invoked on grab start
+        /// </summary>
+        public UnityEvent OnGrab { get { return uEvent; } }
 
         private bool hadGrab;
         private State lastState;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -14,14 +14,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnGrabReceiver : ReceiverBase
     {
-        [SerializeField]
-        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "Grab was released")]
-        [FormerlySerializedAsAttribute("OnRelease")]
-        private UnityEvent onRelease = new UnityEvent();
-
         /// <summary>
         /// Invoked on grab release
         /// </summary>
+        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "Grab was released")]
+        public UnityEvent OnRelease = new UnityEvent();
+
         public UnityEvent OnRelease => onRelease;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -32,15 +32,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool hadGrab;
         private State lastState;
 
-        public InteractableOnGrabReceiver(UnityEvent ev) : base(ev)
-        {
-            Name = "OnGrab";
-        }
+        public InteractableOnGrabReceiver(UnityEvent ev) : base(ev, "OnGrab") { }
 
-        public InteractableOnGrabReceiver() : base()
-        {
-            Name = "OnGrab";
-        }
+        public InteractableOnGrabReceiver() : this( new UnityEvent()) { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -26,10 +26,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public UnityEvent OnGrab => uEvent;
 
         private bool hadGrab;
-        private State lastState;
 
+        /// <summary>
+        /// Creates a receiver that raises grab start and end events.
+        /// </summary>
         public InteractableOnGrabReceiver(UnityEvent ev) : base(ev, "OnGrab") { }
 
+        /// <summary>
+        /// Creates a receiver that raises grab start and end events.
+        /// </summary>
         public InteractableOnGrabReceiver() : this( new UnityEvent()) { }
 
         /// <inheritdoc />
@@ -50,7 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             hadGrab = hasGrab;
-            lastState = state.CurrentState();
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -29,6 +29,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnHold";
         }
 
+        public InteractableOnHoldReceiver() : base()
+        {
+            Name = "OnHold";
+        }
+
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -24,8 +24,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public UnityEvent OnHold => uEvent;
 
+        /// <summary>
+        /// Creates receiver that raises OnHold events
+        /// </summary>
         public InteractableOnHoldReceiver(UnityEvent ev): base(ev, "OnHold") { }
 
+        /// <summary>
+        /// Creates receiver that raises OnHold events
+        /// </summary>
         public InteractableOnHoldReceiver() : this(new UnityEvent()) { }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -19,6 +19,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool hasDown;
 
+        /// <summary>
+        /// Invoked when interactable has been pressed for HoldTime
+        /// </summary>
+        public UnityEvent OnHold { get { return uEvent; } }
+
         public InteractableOnHoldReceiver(UnityEvent ev): base(ev)
         {
             Name = "OnHold";

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Invoked when interactable has been pressed for HoldTime
         /// </summary>
-        public UnityEvent OnHold { get { return uEvent; } }
+        public UnityEvent OnHold => uEvent;
 
         public InteractableOnHoldReceiver(UnityEvent ev): base(ev, "OnHold") { }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -24,15 +24,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public UnityEvent OnHold { get { return uEvent; } }
 
-        public InteractableOnHoldReceiver(UnityEvent ev): base(ev)
-        {
-            Name = "OnHold";
-        }
+        public InteractableOnHoldReceiver(UnityEvent ev): base(ev, "OnHold") { }
 
-        public InteractableOnHoldReceiver() : base()
-        {
-            Name = "OnHold";
-        }
+        public InteractableOnHoldReceiver() : this(new UnityEvent()) { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -14,15 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableOnPressReceiver : ReceiverBase
     {
 
-        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "The button is released")]
-        [SerializeField]
-        [FormerlySerializedAsAttribute("OnRelease")]
-        private UnityEvent onRelease = new UnityEvent();
-
         /// <summary>
         /// Invoked on pointer release
         /// </summary>
-        public UnityEvent OnRelease => onRelease;
+        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "The button is released")]
+        public UnityEvent OnRelease = new UnityEvent();
 
         /// <summary>
         /// Invoked on pointer press

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -43,15 +43,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool isNear = false;
 
-        public InteractableOnPressReceiver(UnityEvent ev) : base(ev)
-        {
-            Name = "OnPress";
-        }
+        public InteractableOnPressReceiver(UnityEvent ev) : base(ev, "OnPress") { }
 
-        public InteractableOnPressReceiver() : base()
-        {
-            Name = "OnPress";
-        }
+        public InteractableOnPressReceiver() : this(new UnityEvent()) { }
 
         /// <summary>
         /// checks if the received interactable state matches the press filter

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -35,12 +35,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public int InteractionFilter = (int)InteractionType.NearAndFar;
 
         private bool hasDown;
-        private State lastState;
 
         private bool isNear = false;
 
+        /// <summary>
+        /// Receiver that raises press and release unity events
+        /// </summary>
         public InteractableOnPressReceiver(UnityEvent ev) : base(ev, "OnPress") { }
 
+        /// <summary>
+        /// Receiver that raises press and release unity events
+        /// </summary>
         public InteractableOnPressReceiver() : this(new UnityEvent()) { }
 
         /// <summary>
@@ -86,8 +91,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                 }
             }
-            
-            lastState = state.CurrentState();
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -48,6 +48,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnPress";
         }
 
+        public InteractableOnPressReceiver() : base()
+        {
+            Name = "OnPress";
+        }
+
         /// <summary>
         /// checks if the received interactable state matches the press filter
         /// </summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -22,12 +22,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Invoked on pointer release
         /// </summary>
-        public UnityEvent OnRelease { get { return onRelease; } }
+        public UnityEvent OnRelease => onRelease;
 
         /// <summary>
         /// Invoked on pointer press
         /// </summary>
-        public UnityEvent OnPress { get { return uEvent; } }
+        public UnityEvent OnPress => uEvent;
         public enum InteractionType
         {
             NearAndFar = 0,
@@ -68,13 +68,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
-            bool changed = state.CurrentState() != lastState;
-
             bool hadDown = hasDown;
             hasDown = state.GetState(InteractableStates.InteractableStateEnum.Pressed).Value > 0;
 
 
-            if (changed && hasDown != hadDown)
+            if (hasDown != hadDown)
             {
                 if (hasDown)
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -14,8 +15,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
     {
 
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Release", Tooltip = "The button is released")]
-        public UnityEvent OnRelease = new UnityEvent();
+        [SerializeField]
+        [FormerlySerializedAsAttribute("OnRelease")]
+        private UnityEvent onRelease = new UnityEvent();
 
+        /// <summary>
+        /// Invoked on pointer release
+        /// </summary>
+        public UnityEvent OnRelease { get { return onRelease; } }
+
+        /// <summary>
+        /// Invoked on pointer press
+        /// </summary>
+        public UnityEvent OnPress { get { return uEvent; } }
         public enum InteractionType
         {
             NearAndFar = 0,

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -25,8 +25,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public UnityEvent OnSelect => uEvent;
 
+        /// <summary>
+        /// Creates a receiver that raises events for toggle button states
+        /// </summary>
         public InteractableOnToggleReceiver(UnityEvent ev) : base(ev, "OnSelect") { }
 
+        /// <summary>
+        /// Creates a receiver that raises events for toggle button states
+        /// </summary>
         public InteractableOnToggleReceiver() : this(new UnityEvent()) { }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using UnityEngine;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -13,7 +15,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableOnToggleReceiver : ReceiverBase
     {
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Deselect", Tooltip = "The toggle is deselected")]
-        public UnityEvent OnDeselect = new UnityEvent();
+        [SerializeField]
+        [FormerlySerializedAsAttribute("OnDeselect")]
+        private UnityEvent onDeselect = new UnityEvent();
+
+        /// <summary>
+        /// Invoked when toggle is deselected
+        /// </summary>
+        public UnityEvent OnDeselect { get => onDeselect; }
+
+        /// <summary>
+        /// Invoked when toggle is checked
+        /// </summary>
+        public UnityEvent OnSelect { get => uEvent; }
 
         public InteractableOnToggleReceiver(UnityEvent ev) : base(ev)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -8,7 +8,7 @@ using UnityEngine.Events;
 namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
-    /// a receiver that listens to toggle events
+    /// A receiver that listens to toggle events
     /// </summary>
     public class InteractableOnToggleReceiver : ReceiverBase
     {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -34,6 +34,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnSelect";
         }
 
+        public InteractableOnToggleReceiver() : base()
+        {
+            Name = "OnSelect";
+        }
+
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -22,12 +22,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Invoked when toggle is deselected
         /// </summary>
-        public UnityEvent OnDeselect { get => onDeselect; }
+        public UnityEvent OnDeselect => onDeselect;
 
         /// <summary>
         /// Invoked when toggle is checked
         /// </summary>
-        public UnityEvent OnSelect { get => uEvent; }
+        public UnityEvent OnSelect => uEvent;
 
         public InteractableOnToggleReceiver(UnityEvent ev) : base(ev, "OnSelect") { }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -14,15 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnToggleReceiver : ReceiverBase
     {
-        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Deselect", Tooltip = "The toggle is deselected")]
-        [SerializeField]
-        [FormerlySerializedAsAttribute("OnDeselect")]
-        private UnityEvent onDeselect = new UnityEvent();
-
         /// <summary>
         /// Invoked when toggle is deselected
         /// </summary>
-        public UnityEvent OnDeselect => onDeselect;
+        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Deselect", Tooltip = "The toggle is deselected")]
+        public UnityEvent OnDeselect = new UnityEvent();
 
         /// <summary>
         /// Invoked when toggle is checked

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -1,11 +1,9 @@
-﻿using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using UnityEngine;
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnToggleReceiver.cs
@@ -29,15 +29,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public UnityEvent OnSelect { get => uEvent; }
 
-        public InteractableOnToggleReceiver(UnityEvent ev) : base(ev)
-        {
-            Name = "OnSelect";
-        }
+        public InteractableOnToggleReceiver(UnityEvent ev) : base(ev, "OnSelect") { }
 
-        public InteractableOnToggleReceiver() : base()
-        {
-            Name = "OnSelect";
-        }
+        public InteractableOnToggleReceiver() : this(new UnityEvent()) { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -22,12 +22,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Invoked when touch has left the object
         /// </summary>
-        public UnityEvent OnTouchEnd { get => onTouchEnd; }
+        public UnityEvent OnTouchEnd => onTouchEnd;
 
         /// <summary>
         /// Invoked when touch begins
         /// </summary>
-        public UnityEvent OnTouchStart { get => uEvent; }
+        public UnityEvent OnTouchStart => uEvent;
 
         private bool hadTouch;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -31,15 +31,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool hadTouch;
 
-        public InteractableOnTouchReceiver(UnityEvent ev) : base(ev)
-        {
-            Name = "OnTouch";
-        }
+        public InteractableOnTouchReceiver(UnityEvent ev) : base(ev, "OnTouch") { }
 
-        public InteractableOnTouchReceiver() : base()
-        {
-            Name = "OnTouch";
-        }
+        public InteractableOnTouchReceiver() : this(new UnityEvent()) { }
 
         public override void OnUpdate(InteractableStates state, Interactable source)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -36,6 +36,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnTouch";
         }
 
+        public InteractableOnTouchReceiver() : base()
+        {
+            Name = "OnTouch";
+        }
+
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             bool hadTouch = state.GetState(InteractableStates.InteractableStateEnum.PhysicalTouch).Value > 0;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -14,15 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableOnTouchReceiver : ReceiverBase
     {
-        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Touch End", Tooltip = "Touch has left the object")]
-        [SerializeField]
-        [FormerlySerializedAs("OnTouchEnd")]
-        private UnityEvent onTouchEnd = new UnityEvent();
-
         /// <summary>
         /// Invoked when touch has left the object
         /// </summary>
-        public UnityEvent OnTouchEnd => onTouchEnd;
+        [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Touch End", Tooltip = "Touch has left the object")]
+        public UnityEvent OnTouchEnd = new UnityEvent();
 
         /// <summary>
         /// Invoked when touch begins

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -13,15 +15,28 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableOnTouchReceiver : ReceiverBase
     {
         [InspectorField(Type = InspectorField.FieldTypes.Event, Label = "On Touch End", Tooltip = "Touch has left the object")]
-        public UnityEvent OnTouchEnd = new UnityEvent();
+        [SerializeField]
+        [FormerlySerializedAs("OnTouchEnd")]
+        private UnityEvent onTouchEnd = new UnityEvent();
+
+        /// <summary>
+        /// Invoked when touch has left the object
+        /// </summary>
+        public UnityEvent OnTouchEnd { get => onTouchEnd; }
+
+        /// <summary>
+        /// Invoked when touch begins
+        /// </summary>
+        public UnityEvent OnTouchStart { get => uEvent; }
 
         private bool hadTouch;
-        private State lastState;
 
         public InteractableOnTouchReceiver(UnityEvent ev) : base(ev)
         {
             Name = "OnTouch";
         }
+
+        public UnityEvent OnTouchEnd { get => onTouchEnd; set => onTouchEnd = value; }
 
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
@@ -40,7 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             this.hadTouch = hadTouch;
-            lastState = state.CurrentState();
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -36,8 +36,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Name = "OnTouch";
         }
 
-        public UnityEvent OnTouchEnd { get => onTouchEnd; set => onTouchEnd = value; }
-
         public override void OnUpdate(InteractableStates state, Interactable source)
         {
             bool hadTouch = state.GetState(InteractableStates.InteractableStateEnum.PhysicalTouch).Value > 0;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -27,8 +27,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool hadTouch;
 
+        /// <summary>
+        /// Receiver for raising touch begin and end events
+        /// </summary>
         public InteractableOnTouchReceiver(UnityEvent ev) : base(ev, "OnTouch") { }
 
+        /// <summary>
+        /// Receiver for raising touch begin and end events
+        /// </summary>
         public InteractableOnTouchReceiver() : this(new UnityEvent()) { }
 
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableOnTouchReceiver.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
+using System;
 using System.Windows.Markup;
 using UnityEngine;
 using UnityEngine.Events;
@@ -29,14 +30,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public MonoBehaviour Host;
 
-        public ReceiverBase()
-        {
-            uEvent = new UnityEvent();
-        }
-
-        public ReceiverBase(UnityEvent ev)
+        /// <summary>
+        /// Constructs an interaction receiver that will raise unity event when triggered.
+        /// </summary>
+        /// <param name="ev">Unity event to invoke. Add more events in deriving class.</param>
+        /// <param name="name">Name of the unity event that will get invoked (visible in editor).</param>
+        public ReceiverBase(UnityEvent ev, String name)
         {
             uEvent = ev;
+            Name = name;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
@@ -22,11 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Each Receiver has a base Event it raises, (in addition to others).
         /// </summary>
-        public UnityEvent Event
-        {
-            get { return uEvent; }
-            set { uEvent = value; }
-        }
+        public UnityEvent Event { get => uEvent; set => uEvent = value; }
 
         public MonoBehaviour Host;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
+using System.Windows.Markup;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -16,7 +17,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public bool HideUnityEvents;
         protected UnityEvent uEvent;
+
+        /// <summary>
+        /// Each Receiver has a base Event it raises, (in addition to others).
+        /// </summary>
+        public UnityEvent Event
+        {
+            get { return uEvent; }
+            set { uEvent = value; }
+        }
+
         public MonoBehaviour Host;
+
+        public ReceiverBase()
+        {
+            uEvent = new UnityEvent();
+        }
 
         public ReceiverBase(UnityEvent ev)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using System;
-using System.Windows.Markup;
 using UnityEngine;
 using UnityEngine.Events;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -128,6 +128,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public bool FocusEnabled { get { return !IsGlobal; } set { IsGlobal = !value; } }
 
         /// <summary>
+        /// Event receivers can be used to listen for different
+        /// events at runtime. This method allows receivers to be dynamically added at runtime.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The new event receiver</returns>
+        public T AddReceiver<T> () where T : ReceiverBase, new()
+        {
+            var interactableEvent = new InteractableEvent();
+            var result = new T();
+            result.Event = interactableEvent.Event;
+            interactableEvent.Receiver = result;
+            Events.Add(interactableEvent);
+            return result;
+        }
+
+        /// <summary>
         /// List of profiles can match themes with gameObjects
         /// </summary>
         public List<InteractableProfileItem> Profiles = new List<InteractableProfileItem>();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>The new event receiver</returns>
-        public T AddReceiver<T> () where T : ReceiverBase, new()
+        public T AddReceiver<T>() where T : ReceiverBase, new()
         {
             var interactableEvent = new InteractableEvent();
             var result = new T();
@@ -141,6 +141,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
             interactableEvent.Receiver = result;
             Events.Add(interactableEvent);
             return result;
+        }
+
+        /// <summary>
+        /// Returns the first receiver of type T on the interactable,
+        /// or null if nothing is found.
+        /// </summary>
+        public T GetReceiver<T>() where T : ReceiverBase
+        {
+            for (int i = 0; i < Events.Count; i++)
+            {
+                if (Events[i] != null && Events[i].Receiver is T)
+                {
+                    return (T) Events[i].Receiver;
+                }
+            }
+            return null;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -131,7 +131,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Event receivers can be used to listen for different
         /// events at runtime. This method allows receivers to be dynamically added at runtime.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <returns>The new event receiver</returns>
         public T AddReceiver<T>() where T : ReceiverBase, new()
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -160,6 +160,23 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
+        /// Returns all receivers of type T on the interactable.
+        /// If nothing is found, returns empty list.
+        /// </summary>
+        public List<T> GetReceivers<T>() where T : ReceiverBase
+        {
+            List<T> result = new List<T>();
+            for (int i = 0; i < Events.Count; i++)
+            {
+                if (Events[i] != null && Events[i].Receiver is T)
+                {
+                    result.Add((T)Events[i].Receiver);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
         /// List of profiles can match themes with gameObjects
         /// </summary>
         public List<InteractableProfileItem> Profiles = new List<InteractableProfileItem>();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableEventTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableEventTests.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Editor;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System.Collections;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    class InteractableEventTests
+    {
+        GameObject cube;
+        Interactable cubeInteractable;
+
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = new Vector3(1, 0, 1);
+
+            cubeInteractable = cube.AddComponent<Interactable>();
+            Assert.NotNull(cubeInteractable, "Failed to add interactable to cube");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GameObject.Destroy(cube);
+            PlayModeTestUtilities.TearDown();
+        }
+
+        /// <summary>
+        /// Tests that an Interactable component can be added to a GameObject
+        /// at runtime, and an OnClick event handler can be added
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestOnClickEvents()
+        {
+            PlayModeTestUtilities.PushHandSimulationProfile();
+            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+
+            // Subscribe to interactable's on click so we know the click went through
+            bool wasClicked = false;
+            cubeInteractable.OnClick.AddListener(() => { wasClicked = true; });
+
+            var testHand = new TestHand(Handedness.Right);
+            yield return testHand.Show(Vector3.zero);
+
+            CameraCache.Main.transform.LookAt(cubeInteractable.transform);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return testHand.Hide();
+
+            Assert.True(wasClicked);
+
+            PlayModeTestUtilities.PopHandSimulationProfile();
+        }
+
+        [UnityTest]
+        public IEnumerator TestGrabEvents()
+        {
+            var grabReceiver = cubeInteractable.AddReceiver<InteractableOnGrabReceiver>();
+            cubeInteractable.gameObject.AddComponent<NearInteractionGrabbable>();
+            bool didGrab = false;
+            grabReceiver.OnGrab.AddListener(() => didGrab = true);
+            bool didRelease = false;
+            grabReceiver.OnRelease.AddListener(() => didRelease = true);
+
+            var testHand = new TestHand(Handedness.Right);
+            yield return testHand.Show(cubeInteractable.transform.position);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return testHand.Hide();
+            Assert.True(didGrab, "Did not receive grab event");
+            Assert.True(didRelease, "Did not receive release event");
+            GameObject.Destroy(cube);
+            yield return null;
+        }
+
+        public IEnumerator TestHoldEvents()
+        {
+            // Hold
+            var holdReceiver = cubeInteractable.AddReceiver<InteractableOnHoldReceiver>();
+            bool didHold = false;
+            holdReceiver.OnHold.AddListener(() => didHold = true);
+
+            var testHand = new TestHand(Handedness.Right);
+            yield return testHand.Show(cubeInteractable.transform.position);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return new WaitForSeconds(holdReceiver.HoldTime);
+            yield return testHand.Hide();
+            Assert.True(didHold, "Did not receive hold event");
+            GameObject.Destroy(cube);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TestPressEvents()
+        {
+            var testHand = new TestHand(Handedness.Right);
+            cubeInteractable.gameObject.AddComponent<NearInteractionGrabbable>();
+            var pressReceiver = cubeInteractable.AddReceiver<InteractableOnPressReceiver>();
+            bool didPress = false;
+            pressReceiver.OnPress.AddListener(() => didPress = true);
+            yield return testHand.Show(Vector3.zero);
+            yield return testHand.MoveTo(cubeInteractable.transform.position);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return testHand.Hide();
+            Assert.True(didPress, "did not receive press event");
+        }
+
+        [UnityTest]
+        public IEnumerator TestToggleEvents()
+        {
+            // Toggle
+            var toggleReceiver = cubeInteractable.AddReceiver<InteractableOnToggleReceiver>();
+            cubeInteractable.transform.position = Vector3.forward * 2f;
+            cubeInteractable.Dimensions = 2;
+            cubeInteractable.CanSelect = true;
+            cubeInteractable.CanDeselect = true;
+            bool didSelect = false;
+            bool didUnselect = false;
+            toggleReceiver.OnSelect.AddListener(() => didSelect = true);
+            toggleReceiver.OnDeselect.AddListener(() => didUnselect = true);
+
+            var testHand = new TestHand(Handedness.Right);
+            yield return testHand.Show(Vector3.forward);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return testHand.Hide();
+            Assert.True(didSelect, "Toggle select did not fire");
+            Assert.True(didUnselect, "Toggle unselect did not fire");
+        }
+
+        [UnityTest]
+        public IEnumerator TestTouchEvents()
+        {
+            cubeInteractable.gameObject.AddComponent<NearInteractionTouchableVolume>();
+            var touchReceiver = cubeInteractable.AddReceiver<InteractableOnTouchReceiver>();
+            bool didTouch = false;
+            bool didUntouch = false;
+            touchReceiver.OnTouchStart.AddListener(() => didTouch = true);
+            touchReceiver.OnTouchEnd.AddListener(() => didUntouch = true);
+
+            var testHand = new TestHand(Handedness.Right);
+            yield return testHand.Show(Vector3.forward);
+            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return testHand.MoveTo(cubeInteractable.transform.position);
+            yield return testHand.MoveTo(Vector3.forward);
+            yield return testHand.Hide();
+            Assert.True(didTouch, "Did not receive touch event");
+            Assert.True(didUntouch, "Did not receive touch end event");
+        }
+
+        /// <summary>
+        /// Tests that an interactable component can be added to a GameObject
+        /// at runtime, and all receivers that extend ReceiverBase
+        /// and have event handlers can easily be added, and work
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestFocusEvents()
+        {
+            var onFocusReceiver = cubeInteractable.AddReceiver<InteractableOnFocusReceiver>();
+
+            bool didHover = false;
+            bool didUnHover = false;
+            onFocusReceiver.OnFocusOn.AddListener(() => didHover = true);
+            onFocusReceiver.OnFocusOff.AddListener(() => didUnHover = true);
+            CameraCache.Main.transform.LookAt(cubeInteractable.transform);
+            yield return null;
+            CameraCache.Main.transform.LookAt(Vector3.forward);
+            yield return null;
+            Assert.True(didHover, "Interactable did not receive hover event");
+            Assert.True(didUnHover, "Interactable did not receive un-hover event");
+
+            yield return null;
+        }
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableEventTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableEventTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57441d2da47d715418921a6e7138c6b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -31,174 +31,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         const string defaultInteractablePrefabAssetPath = "Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab";
         const string radialSetPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab";
 
-        GameObject cube;
-        Interactable interactable;
-        TestHand testHand;
-
         [SetUp]
         public void Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-
-            cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = Vector3.forward;
-
-            interactable = cube.AddComponent<Interactable>();
-            Assert.NotNull(interactable, "Failed to add interactable to cube");
-            testHand = new TestHand(Handedness.Right);
         }
 
         [TearDown]
         public void TearDown()
         {
-            GameObject.Destroy(cube);
             PlayModeTestUtilities.TearDown();
-        }
-
-        /// <summary>
-        /// Tests that an Interactable component can be added to a GameObject
-        /// at runtime, and an OnClick event handler can be added
-        /// </summary>
-        /// <returns></returns>
-        [UnityTest]
-        public IEnumerator TestAddOnClickRuntime()
-        {
-            PlayModeTestUtilities.PushHandSimulationProfile();
-            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
-
-            // This should not throw an exception
-            var interactable = cube.AddComponent<Interactable>();
-
-            // Subscribe to interactable's on click so we know the click went through
-            bool wasClicked = false;
-            interactable.OnClick.AddListener(() => { wasClicked = true; });
-
-            yield return testHand.Show(Vector3.zero);
-
-            CameraCache.Main.transform.LookAt(interactable.transform);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-
-            Assert.True(wasClicked);
-
-            PlayModeTestUtilities.PopHandSimulationProfile();
-        }
-
-        [UnityTest]
-        public IEnumerator TestGrabEvents()
-        {
-            var grabReceiver = interactable.AddReceiver<InteractableOnGrabReceiver>();
-            interactable.gameObject.AddComponent<NearInteractionGrabbable>();
-            bool didGrab = false;
-            grabReceiver.OnGrab.AddListener(() => didGrab = true);
-            bool didRelease = false;
-            grabReceiver.OnRelease.AddListener(() => didRelease = true);
-
-            yield return testHand.Show(interactable.transform.position);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.Hide();
-            Assert.True(didGrab, "Did not receive grab event");
-            Assert.True(didRelease, "Did not receive release event");
-            GameObject.Destroy(cube);
-            yield return null;
-        }
-
-        public IEnumerator TestHoldEvents()
-        {
-            // Hold
-            var holdReceiver = interactable.AddReceiver<InteractableOnHoldReceiver>();
-            bool didHold = false;
-            holdReceiver.OnHold.AddListener(() => didHold = true);
-            yield return testHand.Show(interactable.transform.position);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return new WaitForSeconds(holdReceiver.HoldTime);
-            yield return testHand.Hide();
-            Assert.True(didHold, "Did not receive hold event");
-            GameObject.Destroy(cube);
-            yield return null;
-        }
-
-        [UnityTest]
-        public IEnumerator TestPressEvents()
-        {
-            // Press
-            var pressReceiver = interactable.AddReceiver<InteractableOnPressReceiver>();
-            bool didPress = false;
-            pressReceiver.OnPress.AddListener(() => didPress = true);
-            yield return testHand.Show(interactable.transform.position);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.Hide();
-            Assert.True(didPress, "did not receive press event");
-        }
-
-        [UnityTest]
-        public IEnumerator TestToggleEvents()
-        {
-            // Toggle
-            var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
-            interactable.transform.position = Vector3.forward * 2f;
-            interactable.Dimensions = 2;
-            interactable.CanSelect = true;
-            interactable.CanDeselect = true;
-            bool didSelect = false;
-            bool didUnselect = false;
-            toggleReceiver.OnSelect.AddListener(() => didSelect = true);
-            toggleReceiver.OnDeselect.AddListener(() => didUnselect = true);
-            yield return testHand.Show(Vector3.forward);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return null;
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.Hide();
-            Assert.True(didSelect, "Toggle select did not fire");
-            Assert.True(didUnselect, "Toggle unselect did not fire");
-        }
-
-        [UnityTest]
-        public IEnumerator TestTouchEvents()
-        {
-            interactable.gameObject.AddComponent<NearInteractionTouchableVolume>();
-            var touchReceiver = interactable.AddReceiver<InteractableOnTouchReceiver>();
-            bool didTouch = false;
-            bool didUntouch = false;
-            touchReceiver.OnTouchStart.AddListener(() => didTouch = true);
-            touchReceiver.OnTouchEnd.AddListener(() => didUntouch = true);
-            yield return testHand.Show(Vector3.forward);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.MoveTo(interactable.transform.position);
-            yield return testHand.MoveTo(Vector3.forward);
-            yield return testHand.Hide();
-            Assert.True(didTouch, "Did not receive touch event");
-            Assert.True(didUntouch, "Did not receive touch end event");
-        }
-
-        /// <summary>
-        /// Tests that an interactable component can be added to a GameObject
-        /// at runtime, and all receivers that extend ReceiverBase
-        /// and have event handlers can easily be added, and work
-        /// </summary>
-        /// <returns></returns>
-        [UnityTest]
-        public IEnumerator TestFocusEvents()
-        {
-            var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
-
-            bool didHover = false;
-            bool didUnHover = false;
-            onFocusReceiver.OnFocusOn.AddListener(() => didHover = true);
-            onFocusReceiver.OnFocusOff.AddListener(() => didUnHover = true);
-            CameraCache.Main.transform.LookAt(interactable.transform);
-            yield return null;
-            CameraCache.Main.transform.LookAt(Vector3.forward);
-            yield return null;
-            Assert.True(didHover, "Interactable did not receive hover event");
-            Assert.True(didUnHover, "Interactable did not receive un-hover event");
-
-            yield return null;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -115,16 +115,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
 
             bool didHover = false;
-            onFocusReceiver.OnFocusOn.AddListener(() => didHover = true);
-
             bool didUnHover = false;
+            onFocusReceiver.OnFocusOn.AddListener(() => didHover = true);
             onFocusReceiver.OnFocusOff.AddListener(() => didUnHover = true);
-
             CameraCache.Main.transform.LookAt(interactable.transform);
             yield return null;
             CameraCache.Main.transform.LookAt(Vector3.forward);
             yield return null;
-
             Assert.True(didHover, "Interactable did not receive hover event");
             Assert.True(didUnHover, "Interactable did not receive un-hover event");
 
@@ -143,6 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(didGrab, "Did not receive grab event");
             Assert.True(didRelease, "Did not receive release event");
 
+            // Hold
             var holdReceiver = interactable.AddReceiver<InteractableOnHoldReceiver>();
             bool didHold = false;
             holdReceiver.OnHold.AddListener(() => didHold = true);
@@ -152,6 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Hide();
             Assert.True(didHold, "Did not receive hold event");
 
+            // Press
             var pressReceiver = interactable.AddReceiver<InteractableOnPressReceiver>();
             bool didPress = false;
             pressReceiver.OnPress.AddListener(() => didPress = true);
@@ -160,6 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Hide();
             Assert.True(didPress, "did not receive press event");
 
+            // Toggle
             var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
             interactable.transform.position = Vector3.forward * 2f;
             interactable.Dimensions = 2;
@@ -194,6 +194,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Hide();
             Assert.True(didTouch, "Did not receive touch event");
             Assert.True(didUntouch, "Did not receive touch end event");
+            
             // clean up
             GameObject.Destroy(cube);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -24,7 +24,7 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    class InteractableTests
+    class InteractableTests 
     {
         const float buttonPressAnimationDelay = 0.25f;
         const float buttonReleaseAnimationDelay = 0.25f;
@@ -58,6 +58,42 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // clean up
             GameObject.Destroy(cube);
+            yield return null;
+        }
+
+        /// <summary>
+        /// Tests that an interactable component can be added to a GameObject
+        /// at runtime, and an OnClick event handler can be added
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestAddOnClickRuntime()
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = Vector3.forward;
+            PlayModeTestUtilities.PushHandSimulationProfile();
+            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+
+            // This should not throw an exception
+            var interactable = cube.AddComponent<Interactable>();
+
+            // Subscribe to interactable's on click so we know the click went through
+            bool wasClicked = false;
+            interactable.OnClick.AddListener(() => { wasClicked = true; });
+
+            TestHand th = new TestHand(Handedness.Right);
+            yield return th.Show(Vector3.zero);
+
+            CameraCache.Main.transform.LookAt(interactable.transform);
+            yield return th.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return th.SetGesture(ArticulatedHandPose.GestureId.Open);
+
+            Assert.True(wasClicked);
+
+            // clean up
+            GameObject.Destroy(cube);
+            PlayModeTestUtilities.PopHandSimulationProfile();
+
             yield return null;
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -31,39 +31,46 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         const string defaultInteractablePrefabAssetPath = "Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab";
         const string radialSetPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab";
 
-        GameObject cube;
-        Interactable interactable;
-        TestHand testHand;
-
         [SetUp]
         public void Setup()
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-
-            cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = Vector3.forward;
-
-            interactable = cube.AddComponent<Interactable>();
-            Assert.NotNull(interactable, "Failed to add interactable to cube");
-            testHand = new TestHand(Handedness.Right);
         }
 
         [TearDown]
         public void TearDown()
         {
-            GameObject.Destroy(cube);
             PlayModeTestUtilities.TearDown();
         }
 
         /// <summary>
-        /// Tests that an Interactable component can be added to a GameObject
+        /// Tests that an interactable component can be added to a GameObject
+        /// at runtime.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator TestAddInteractableAtRuntime()
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            // This should not throw an exception
+            var interactable = cube.AddComponent<Interactable>();
+
+            // clean up
+            GameObject.Destroy(cube);
+            yield return null;
+        }
+
+        /// <summary>
+        /// Tests that an interactable component can be added to a GameObject
         /// at runtime, and an OnClick event handler can be added
         /// </summary>
         /// <returns></returns>
         [UnityTest]
         public IEnumerator TestAddOnClickRuntime()
         {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = Vector3.forward;
             PlayModeTestUtilities.PushHandSimulationProfile();
             PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
@@ -74,106 +81,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             bool wasClicked = false;
             interactable.OnClick.AddListener(() => { wasClicked = true; });
 
-            yield return testHand.Show(Vector3.zero);
+            TestHand th = new TestHand(Handedness.Right);
+            yield return th.Show(Vector3.zero);
 
             CameraCache.Main.transform.LookAt(interactable.transform);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return th.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return th.SetGesture(ArticulatedHandPose.GestureId.Open);
 
             Assert.True(wasClicked);
 
+            // clean up
+            GameObject.Destroy(cube);
             PlayModeTestUtilities.PopHandSimulationProfile();
-        }
 
-        [UnityTest]
-        public IEnumerator TestGrabEvents()
-        {
-            var grabReceiver = interactable.AddReceiver<InteractableOnGrabReceiver>();
-            interactable.gameObject.AddComponent<NearInteractionGrabbable>();
-            bool didGrab = false;
-            grabReceiver.OnGrab.AddListener(() => didGrab = true);
-            bool didRelease = false;
-            grabReceiver.OnRelease.AddListener(() => didRelease = true);
-
-            yield return testHand.Show(interactable.transform.position);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.Hide();
-            Assert.True(didGrab, "Did not receive grab event");
-            Assert.True(didRelease, "Did not receive release event");
-            GameObject.Destroy(cube);
             yield return null;
-        }
-
-        public IEnumerator TestHoldEvents()
-        {
-            // Hold
-            var holdReceiver = interactable.AddReceiver<InteractableOnHoldReceiver>();
-            bool didHold = false;
-            holdReceiver.OnHold.AddListener(() => didHold = true);
-            yield return testHand.Show(interactable.transform.position);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return new WaitForSeconds(holdReceiver.HoldTime);
-            yield return testHand.Hide();
-            Assert.True(didHold, "Did not receive hold event");
-            GameObject.Destroy(cube);
-            yield return null;
-        }
-
-        [UnityTest]
-        public IEnumerator TestPressEvents()
-        {
-            // Press
-            var pressReceiver = interactable.AddReceiver<InteractableOnPressReceiver>();
-            bool didPress = false;
-            pressReceiver.OnPress.AddListener(() => didPress = true);
-            yield return testHand.Show(interactable.transform.position);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.Hide();
-            Assert.True(didPress, "did not receive press event");
-        }
-
-        [UnityTest]
-        public IEnumerator TestToggleEvents()
-        {
-            // Toggle
-            var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
-            interactable.transform.position = Vector3.forward * 2f;
-            interactable.Dimensions = 2;
-            interactable.CanSelect = true;
-            interactable.CanDeselect = true;
-            bool didSelect = false;
-            bool didUnselect = false;
-            toggleReceiver.OnSelect.AddListener(() => didSelect = true);
-            toggleReceiver.OnDeselect.AddListener(() => didUnselect = true);
-            yield return testHand.Show(Vector3.forward);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return null;
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.Hide();
-            Assert.True(didSelect, "Toggle select did not fire");
-            Assert.True(didUnselect, "Toggle unselect did not fire");
-        }
-
-        [UnityTest]
-        public IEnumerator TestTouchEvents()
-        {
-            interactable.gameObject.AddComponent<NearInteractionTouchableVolume>();
-            var touchReceiver = interactable.AddReceiver<InteractableOnTouchReceiver>();
-            bool didTouch = false;
-            bool didUntouch = false;
-            touchReceiver.OnTouchStart.AddListener(() => didTouch = true);
-            touchReceiver.OnTouchEnd.AddListener(() => didUntouch = true);
-            yield return testHand.Show(Vector3.forward);
-            yield return testHand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return testHand.MoveTo(interactable.transform.position);
-            yield return testHand.MoveTo(Vector3.forward);
-            yield return testHand.Hide();
-            Assert.True(didTouch, "Did not receive touch event");
-            Assert.True(didUntouch, "Did not receive touch end event");
         }
 
         /// <summary>
@@ -183,8 +104,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </summary>
         /// <returns></returns>
         [UnityTest]
-        public IEnumerator TestFocusEvents()
+        public IEnumerator TestRuntimeEvents()
         {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = Vector3.right;
+
+            var interactable = cube.AddComponent<Interactable>();
+
+            // OnFocus
             var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
 
             bool didHover = false;
@@ -197,6 +124,79 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
             Assert.True(didHover, "Interactable did not receive hover event");
             Assert.True(didUnHover, "Interactable did not receive un-hover event");
+
+            // OnGrab
+            var grabReceiver = interactable.AddReceiver<InteractableOnGrabReceiver>();
+            interactable.gameObject.AddComponent<NearInteractionGrabbable>();
+            bool didGrab = false;
+            grabReceiver.OnGrab.AddListener(() => didGrab = true);
+            bool didRelease = false;
+            grabReceiver.OnRelease.AddListener(() => didRelease = true);
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(interactable.transform.position);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.Hide();
+            Assert.True(didGrab, "Did not receive grab event");
+            Assert.True(didRelease, "Did not receive release event");
+
+            // Hold
+            var holdReceiver = interactable.AddReceiver<InteractableOnHoldReceiver>();
+            bool didHold = false;
+            holdReceiver.OnHold.AddListener(() => didHold = true);
+            yield return hand.Show(interactable.transform.position);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return new WaitForSeconds(holdReceiver.HoldTime);
+            yield return hand.Hide();
+            Assert.True(didHold, "Did not receive hold event");
+
+            // Press
+            var pressReceiver = interactable.AddReceiver<InteractableOnPressReceiver>();
+            bool didPress = false;
+            pressReceiver.OnPress.AddListener(() => didPress = true);
+            yield return hand.Show(interactable.transform.position);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.Hide();
+            Assert.True(didPress, "did not receive press event");
+
+            // Toggle
+            var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
+            interactable.transform.position = Vector3.forward * 2f;
+            interactable.Dimensions = 2;
+            interactable.CanSelect = true;
+            interactable.CanDeselect  = true;
+            bool didSelect = false;
+            bool didUnselect = false;
+            toggleReceiver.OnSelect.AddListener(() => didSelect = true);
+            toggleReceiver.OnDeselect.AddListener(() => didUnselect = true);
+            yield return hand.Show(Vector3.forward);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.Hide();
+            Assert.True(didSelect, "Toggle select did not fire");
+            Assert.True(didUnselect, "Toggle unselect did not fire");
+
+            // Touch
+            interactable.gameObject.AddComponent<NearInteractionTouchableVolume>();
+            var touchReceiver = interactable.AddReceiver<InteractableOnTouchReceiver>();
+            bool didTouch = false;
+            bool didUntouch = false;
+            touchReceiver.OnTouchStart.AddListener(() => didTouch = true);
+            touchReceiver.OnTouchEnd.AddListener(() => didUntouch = true);
+            yield return hand.Show(Vector3.forward);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.MoveTo(interactable.transform.position);
+            yield return hand.MoveTo(Vector3.forward);
+            yield return hand.Hide();
+            Assert.True(didTouch, "Did not receive touch event");
+            Assert.True(didUntouch, "Did not receive touch end event");
+            
+            // clean up
+            GameObject.Destroy(cube);
 
             yield return null;
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -172,7 +172,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Show(Vector3.forward);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             yield return null;
-            yield return PlayModeTestUtilities.WaitForEnterKey();
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
@@ -181,7 +180,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(didSelect, "Toggle select did not fire");
             Assert.True(didUnselect, "Toggle unselect did not fire");
 
-
+            // Touch
+            interactable.gameObject.AddComponent<NearInteractionTouchableVolume>();
+            var touchReceiver = interactable.AddReceiver<InteractableOnTouchReceiver>();
+            bool didTouch = false;
+            bool didUntouch = false;
+            touchReceiver.OnTouchStart.AddListener(() => didTouch = true);
+            touchReceiver.OnTouchEnd.AddListener(() => didUntouch = true);
+            yield return hand.Show(Vector3.forward);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.MoveTo(interactable.transform.position);
+            yield return hand.MoveTo(Vector3.forward);
+            yield return hand.Hide();
+            Assert.True(didTouch, "Did not receive touch event");
+            Assert.True(didUntouch, "Did not receive touch end event");
             // clean up
             GameObject.Destroy(cube);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -112,32 +112,29 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // This should not throw an exception
             var interactable = cube.AddComponent<Interactable>();
-            var ie = new InteractableEvent();
-            var fr = new InteractableOnFocusReceiver(ie.Event);
-            ie.Receiver = fr;
-            interactable.Events.Add(ie);
+            var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
             bool didHover = false;
-            ie.Event.AddListener(() =>
+            onFocusReceiver.OnFocusOn.AddListener(() =>
             {
                 didHover = true;
                 Debug.Log("Hover on " + interactable.StateManager.CurrentState().ToString());
             });
 
             bool didUnHover = false;
-            fr.OnFocusOff.AddListener(() =>
+            onFocusReceiver.OnFocusOff.AddListener(() =>
             {
                 didUnHover = true;
                 Debug.Log("Hover OFF " + interactable.StateManager.CurrentState().ToString());
             });
 
-            yield return null;
+
             CameraCache.Main.transform.LookAt(interactable.transform);
             yield return null;
             CameraCache.Main.transform.LookAt(Vector3.forward);
             yield return null;
 
             Assert.True(didHover, "Interactable did not receive hover event");
-            Assert.True(didUnHover, "Interactable did not receiv un-hover event");
+            Assert.True(didUnHover, "Interactable did not receive un-hover event");
 
             // clean up
             GameObject.Destroy(cube);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
-        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 30, bool waitForFixedUpdate = true)
+        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 10, bool waitForFixedUpdate = true)
         {
             Vector3 oldPosition = position;
             position = newPosition;
@@ -97,6 +97,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 yield return new WaitForFixedUpdate();
             }
+        }
+
+        /// <summary>
+        /// Combined sequence of pinching and unpinching
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerator Click()
+        {
+            yield return SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+            yield return SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/TestHand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
-        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 10, bool waitForFixedUpdate = true)
+        public IEnumerator MoveTo(Vector3 newPosition, int numSteps = 30, bool waitForFixedUpdate = true)
         {
             Vector3 oldPosition = position;
             position = newPosition;

--- a/Documentation/README_Interactable.md
+++ b/Documentation/README_Interactable.md
@@ -143,6 +143,36 @@ Events can be placed on an object to monitor a separate interactable. Use [`Inte
 
 "Search Scope" provides a preferred path to search for an Interactable if one is not explicitly assigned.
 
+### Interactable Events Example
+Listen for focus enter, exit events from an interactable, using [InteractableOnFocusReceiver](xref:Microsoft.MixedReality.Toolkit.UI.InteractableOnFocusReceiver)
+
+```csharp
+public static void AddFocusEvents(Interactable interactable)
+{
+    var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
+
+    onFocusReceiver.OnFocusOn.AddListener(() => Debug.Log("Focus on"));
+    onFocusReceiver.OnFocusOff.AddListener(() => Debug.Log("Focus off"));
+}
+```
+
+Listen for selected, deselected events on a toggle-able interactable.
+```csharp
+public static void AddToggleEvents(Interactable interactable)
+{
+    var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();
+
+    // Make the interactable have toggle capability, from code.
+    // In the gui editor it's much easier 
+    interactable.Dimensions = 2;
+    interactable.CanSelect = true;
+    interactable.CanDeselect  = true;
+
+    toggleReceiver.OnSelect.AddListener(() => Debug.Log("Toggle selected"));
+    toggleReceiver.OnDeselect.AddListener(() => Debug.Log("Toggle un-selected"));
+}
+```
+
 ## States ##
 States are a list of terms that can be used to define interactions phases, like press or observed.
 


### PR DESCRIPTION
## Overview
Most UI frameworks allow for event listeners to be added not only from a GUI editor, but also from code. MRTK currently makes it easy for event listeners on Interactable (except OnClick) to be configured in the editor, but configuring at run-time from script is not possible.

This PR does the following:
1. Fixes bugs preventing adding events at run-time
1. Adds utility scripts to Interactable  to simplify adding Interactable event listeners 
1. Adds tests to verify all event listeners available in interactable by default
1. Adds examples to documentation

### Demo: Old vs. new way to add event listeners
Here's the old way to listen to focus enter/exit events:

```csharp
public static void AddFocusEvents(Interactable interactable)
{
    var ie = new InteractableEvent();
    var fr = new InteractableOnFocusReceiver(ie.Event);
    ie.Receiver = fr;
    interactable.Events.Add(ie);
    ie.Event.AddListener(() => Debug.Log("Focus on"));
    ie.OnFocusOff.AddListener(() => Debug.Log("Focus off"));
}
```

And the new way to add focus enter/exit events:

```csharp
public static void AddFocusEvents(Interactable interactable)
{
    var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
    onFocusReceiver.OnFocusOn.AddListener(() => Debug.Log("Focus on"));
    onFocusReceiver.OnFocusOff.AddListener(() => Debug.Log("Focus off"));
}
```

- Fixes: #5013

## Verification
Verify that new tests pass, and that they did not pass before.