### PR TITLE
CI Build Fix

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
@@ -18,8 +18,10 @@
     <BuildFolder>$(MSBuildThisFileDirectory)$(RelativeBuildFolder)</BuildFolder>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--NOTE: Currently one of the Unity packages has a * in AssemblyVersion identifier in the AssemblyInfo file, so have to do this.-->
-    <Deterministic>false</Deterministic>
-    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <Deterministic>false</Deterministic>   
+    <_TargetFrameworkDirectories />
+    <FrameworkPathOverride />
+    <TargetFrameworkDirectory />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishOutputPath)'==''">

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
@@ -19,6 +19,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--NOTE: Currently one of the Unity packages has a * in AssemblyVersion identifier in the AssemblyInfo file, so have to do this.-->
     <Deterministic>false</Deterministic>
+	<AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishOutputPath)'==''">

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
@@ -18,10 +18,7 @@
     <BuildFolder>$(MSBuildThisFileDirectory)$(RelativeBuildFolder)</BuildFolder>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--NOTE: Currently one of the Unity packages has a * in AssemblyVersion identifier in the AssemblyInfo file, so have to do this.-->
-    <Deterministic>false</Deterministic>   
-    <_TargetFrameworkDirectories />
-    <FrameworkPathOverride />
-    <TargetFrameworkDirectory />
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishOutputPath)'==''">
@@ -77,6 +74,9 @@
 
   <!--IMPORT SDK.props manually to be able to set the BaseIntermediateOutputPath above path-->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+      <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};{RawFileName};</AssemblySearchPaths>
+  </PropertyGroup>
   
   <Import Project="##PLATFORM_PROPS_FOLDER_PATH_TOKEN##\$(UnityPlatform).$(UnityConfiguration).props"/>
 
@@ -94,6 +94,7 @@
   
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes)obj;bin;*.asmdef;*.asmdef.meta;*.csmap;</DefaultItemExcludes>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 
 <!--PROJECT_REFERENCE_SET_TEMPLATE_START-->

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template
@@ -19,7 +19,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--NOTE: Currently one of the Unity packages has a * in AssemblyVersion identifier in the AssemblyInfo file, so have to do this.-->
     <Deterministic>false</Deterministic>
-	<AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishOutputPath)'==''">


### PR DESCRIPTION
This change is to fix the CI Build which is failing because the System.Core.dll is being overwritten by MSBuild. The reason for why this started happening recently, is unclear, however, the fix is to set AddAdditionalExplicitAssemblyReferences to false.

Will test a CI build on this change before commiting.