### PR TITLE
Update the docs to address a term inconsistency in the MixedRealityConfigurationGuide

### DIFF
--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -144,7 +144,7 @@ An optional but highly useful feature of the MRTK is the plugin diagnostics func
 
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_DiagnosticsSystemSelection.png" width="650px" style="display:block;">
 
-The diagnostics profile provides several simple systems to monitor whilst the project is running, including a handy On/Off switch to enable / disable the display pane in the scene.
+The diagnostics profile provides several simple systems to monitor whilst the project is running, including a handy On/Off switch to enable / disable the display panel in the scene.
 
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_DiagnosticsProfile.png" width="650px" style="display:block;">
 


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5842

The usage of the word "pane" was confusing as highlighted in the issue - pane is technically correct here as well (it is, well, a pane) but looking through the rest of our docs, there isn't any other usage of the term pane so it is inconsistent. Switched to panel to be consistent with the rest of our docs.