### PR TITLE
removed version 2.0.1 from dropdown 

### DIFF
--- a/web/version.js
+++ b/web/version.js
@@ -3,7 +3,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; 	// title in the dropdown for the root version of the docs
-	var versionArray = ["releases/2.0.0", "releases/2.0.1"];	// list of all versions in the version folder
+	var versionArray = ["releases/2.0.0"];	// list of all versions in the version folder
 	
 	//--------------------------------------
 


### PR DESCRIPTION
fixes broken link in version dropdown 

readd this entry once the 2.0.1 docs are live 