### PR TITLE
Digital axis for joysticks

### DIFF
--- a/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         {
             Debug.Assert(interactionMapping.AxisType == AxisType.Digital);
 
-            var keyButton = UInput.GetKey(interactionMapping.KeyCode);
+            var keyButton = interactionMapping.KeyCode != KeyCode.None ? UInput.GetKey(interactionMapping.KeyCode) : UInput.GetAxisRaw(interactionMapping.AxisCodeX) == 1;
 
             // Update the interaction data source
             interactionMapping.BoolData = keyButton;


### PR DESCRIPTION
## Overview
The current implementation for the default select InputAction forces Unity InputSystem bases controllers to use digital input like buttons.
Now with the Oculus Quest, there is no such input for the front trigger other than the KeyCode mouse0, which fires for both controllers.
To distinguish between them we need to read an axis as a button.

This PR makes it possible to provice an axis when using Keycode.None for a digital input to read an axis.

## Changes
- Fixes: #5869