### PR TITLE
Update the build tooling to correctly set the Minimum Platform Version and Target SDK Version separately and correctly.

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -311,7 +311,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             if (string.IsNullOrWhiteSpace(EditorUserBuildSettings.wsaMinUWPSDK))
             {
-                EditorUserBuildSettings.wsaMinUWPSDK = UwpBuildDeployPreferences.MIN_SDK_VERSION.ToString();
+                EditorUserBuildSettings.wsaMinUWPSDK = UwpBuildDeployPreferences.MIN_PLATFORM_VERSION.ToString();
             }
 
             string minVersion = EditorUserBuildSettings.wsaMinUWPSDK;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -10,7 +10,28 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 {
     public static class UwpBuildDeployPreferences
     {
+        /// <summary>
+        /// The mininum Windows SDK that must be present on the build machine in order
+        /// for a build to be successful.
+        /// </summary>
+        /// <remarks>
+        /// This controls the version of the Windows SDK that is build against on the local
+        /// machine, NOT the version of the OS that must be present on the device that
+        /// the built application is deployed to (this other aspect is controlled by
+        /// MIN_PLATFORM_VERSION)
+        /// </remarks>
         public static Version MIN_SDK_VERSION = new Version("10.0.18362.0");
+
+        /// <summary>
+        /// The minimum version of the OS that must exist on the device that the application
+        /// is deployed to.
+        /// </summary>
+        /// <remarks>
+        /// This is intentionally set to a very low version, so that the application can be
+        /// deployed to variety of different devices which may be on older OS versions.
+        /// </remarks>
+        public static Version MIN_PLATFORM_VERSION = new Version("10.0.10240.0");
+
         private const string EDITOR_PREF_BUILD_CONFIG = "BuildDeployWindow_BuildConfig";
         private const string EDITOR_PREF_PLATFORM_TOOLSET = "BuildDeployWindow_PlatformToolset";
         private const string EDITOR_PREF_FORCE_REBUILD = "BuildDeployWindow_ForceRebuild";


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5818

It looks like our build tooling has been setting the "Minimum Platform Version" to 18362, something that we actually recommend people don't do when building apps (regardless of their target device). We recommend people set the version to 10240 (per the getting started page/build page). Nevertheless, we still get occasional bug reports about why the app isn't deployable to hololens 1.

It turns out our tooling was doing the wrong thing. This makes it update the right things (i.e. the Target SDK version) while providing a good default (and warning if deviation of the default occurs) for the Minimum Platform Version.