### PR TITLE
Fix ray sticking to slate when panning HandInteractionPanZoom or UnityUI

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -290,8 +290,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool IsFocusLocked { get; set; }
 
-        /// <inheritdoc />
-        public bool IsTargetPositionLockedOnFocusLock { get; set; }
+        /// <summary>
+        /// Specifies whether the pointer's target position (cursor) is locked to the target object when focus is locked.
+        /// Most pointers want the cursor to "stick" to the object when manipulating, so set this to true by default.
+        /// </summary>
+        public virtual bool IsTargetPositionLockedOnFocusLock { get; set; } = true;
 
         [SerializeField]
         private bool overrideGlobalPointerExtent = false;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseMousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/BaseMousePointer.cs
@@ -59,7 +59,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected abstract string ControllerName { get; }
 
-
         private IMixedRealityController controller;
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -387,6 +387,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnEnable();
 
+            IsTargetPositionLockedOnFocusLock = false;
+
             Debug.Assert(line != null, "No line renderer found in PokePointer.");
             Debug.Assert(visuals != null, "No visuals object found in PokePointer.");
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -790,7 +790,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
             oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
-            eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
+            if (! (eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
+            {
+                eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
+            }
             SetAffordancesActive(false);
             EndTouch(eventData.SourceId);
             SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer,  false);

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -150,6 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Dictionary<uint, HandPanData> handDataMap = new Dictionary<uint, HandPanData>();
         List<Vector2> uvs = new List<Vector2>();
         List<Vector2> uvsOrig = new List<Vector2>();
+        private bool oldIsTargetPositionLockedOnFocusLock;
         #endregion Private Properties
 
         /// <summary>
@@ -788,6 +789,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
+            oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
+            eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
             SetAffordancesActive(false);
             EndTouch(eventData.SourceId);
             SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer,  false);
@@ -795,6 +798,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
         public void OnPointerUp(MixedRealityPointerEventData eventData)
         {
+            eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
             EndTouch(eventData.SourceId);
             eventData.Use();
         }    

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
@@ -12,8 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public static class PointerUtils
     {
         /// <summary>
-        /// Tries to get the end point of a hand ray by calling 
-        /// TryGetPointerEndPoint<LineRenderer>()
+        /// Tries to get the end point of a hand ray.
         /// If no hand ray of given handedness is found, returns false and sets result to zero.
         /// </summary>
         /// <param name="handedness">Handedness of ray</param>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
@@ -3,48 +3,77 @@
 
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     public static class PointerUtils
     {
-
         /// <summary>
-        /// Tries to get the end point of a hand ray
+        /// Tries to get the end point of a hand ray by calling 
+        /// TryGetPointerEndPoint<LineRenderer>()
         /// If no hand ray of given handedness is found, returns false and sets result to zero.
         /// </summary>
-        /// <param name="handedness"></param>
-        /// <param name="endPoint"></param>
-        /// <returns></returns>
+        /// <param name="handedness">Handedness of ray</param>
+        /// <param name="endPoint">The output position</param>
+        /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
         public static bool TryGetHandRayEndPoint(Handedness handedness, out Vector3 endPoint)
         {
-            return TryGetPointerEndpoint<LinePointer>(handedness, out endPoint);
+            return TryGetEndpoint(handedness, InputSourceType.Hand, out endPoint);
         }
 
         /// <summary>
-        /// Tries to get the end point of a line pointer
+        /// Tries to get the end point of a motion controller 
         /// If no pointer of given handedness is found, returns false and sets result to zero.
         /// </summary>
-        /// <param name="handedness"></param>
-        /// <param name="endPoint"></param>
-        /// <returns></returns>
-        public static bool TryGetLinePointerEndPoint(Handedness handedness, out Vector3 endPoint)
+        /// <param name="handedness">Handedness of ray</param>
+        /// <param name="endPoint">The output position</param>
+        /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
+        public static bool TryGetMotionControllerEndPoint(Handedness handedness, out Vector3 endPoint)
         {
-            return TryGetPointerEndpoint<LinePointer>(handedness, out endPoint);
+            return TryGetEndpoint(handedness, InputSourceType.Controller, out endPoint);
         }
 
         /// <summary>
-        /// Tries to get the end point of a pointer of a given type and handedness.
+        /// Tries to get the end point of a pointer by source type and handedness
+        /// If no pointer of given handedness is found, returns false and sets result to zero.
+        /// </summary>
+        /// <param name="handedness">Handedness of pointer</param>
+        /// <param name="inputType">input type of pointer</param>
+        /// <param name="endPoint">output point position</param>
+        /// <returns></returns>
+        public static bool TryGetEndpoint(Handedness handedness, InputSourceType inputType, out Vector3 endPoint)
+        {
+            foreach (var pointer in GetPointers<IMixedRealityPointer>(handedness, InputSourceType.Hand))
+            {
+                if (pointer is IMixedRealityNearPointer)
+                {
+                    continue;
+                }
+                FocusDetails? details = pointer?.Result?.Details;
+                if (details.HasValue)
+                {
+                    endPoint = details.Value.Point;
+                    return true;
+                }
+            }
+            endPoint = Vector3.zero;
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to get the end point of a pointer of a pointer type and handedness.
         /// If no pointer of given handedness is found, returns false and sets result to zero.
         /// </summary>
         /// <typeparam name="T">Type of pointer to query</typeparam>
         /// <param name="handedness">Handedness of pointer</param>
         /// <param name="endPoint">The output point position</param>
         /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
-        public static bool TryGetPointerEndpoint<T>(Handedness handedness, out Vector3 endPoint) where T : class, IMixedRealityPointer
+        public static bool TryGetEndpoint<T>(Handedness handedness, out Vector3 endPoint) where T : class, IMixedRealityPointer
         {
-            T pointer = FindPointer<T>(handedness);
+            T pointer = GetPointer<T>(handedness);
             FocusDetails? details = pointer?.Result?.Details;
             if (!details.HasValue)
             {
@@ -56,20 +85,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Find the first detected line pointer with matching handedness.
-        /// </summary>
-        /// <remarks>
-        /// The given handedness should be either Handedness.Left or Handedness.Right.
-        /// </remarks>
-        public static IMixedRealityPointer FindLinePointer(Handedness handedness)
-        {
-            return FindPointer<LinePointer>(handedness);
-        }
-
-        /// <summary>
         /// Find the first detected pointer of the given type with matching handedness.
         /// </summary>
-        public static T FindPointer<T>(Handedness handedness) where T : class, IMixedRealityPointer
+        public static T GetPointer<T>(Handedness handedness) where T : class, IMixedRealityPointer
         {
             foreach (var pointer in CoreServices.InputSystem.FocusProvider.GetPointers<T>())
             {
@@ -79,6 +97,56 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// Returns iterator over all pointers of specific type, with specific handedness
+        /// </summary>
+        /// <typeparam name="T">Return only pointers with this input type</typeparam>
+        /// <param name="handedness">Handedness of pointer</param>
+        /// <returns></returns>
+        public static IEnumerable<T> GetPointers<T>(Handedness handedness = Handedness.Any) where T : IMixedRealityPointer
+        {
+            foreach (var pointer in GetPointers())
+            {
+                if (pointer is T pointerConcrete
+                    && (pointer.Controller?.ControllerHandedness & handedness) != 0)
+                {
+                    yield return pointerConcrete;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns all pointers with given handedness and input type
+        /// </summary>
+        /// <param name="handedness">Handedness of pointer</param>
+        /// <param name="sourceType">Only return pointers of this input source type</param>
+        /// <returns>Iterator over all pointers that match the source type</returns>
+        public static IEnumerable<T> GetPointers<T>(Handedness handedness, InputSourceType sourceType) where T : IMixedRealityPointer
+        {
+            foreach (var pointer in GetPointers<T>(handedness))
+            {
+                if ((pointer.Controller?.ControllerHandedness & handedness) != 0
+                    && pointer.InputSourceParent.SourceType == sourceType)
+                {
+                    yield return pointer;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Iterate over all pointers in the input system. May contain duplicates.
+        /// </summary>
+        public static IEnumerable<IMixedRealityPointer> GetPointers()
+        {
+            foreach (var inputSource in CoreServices.InputSystem.DetectedInputSources)
+            {
+                foreach (var pointer in inputSource.Pointers)
+                {
+                    yield return pointer;
+                }
+            }
         }
     }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
@@ -19,9 +19,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="handedness">Handedness of ray</param>
         /// <param name="endPoint">The output position</param>
         /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
-        public static bool TryGetHandRayEndPoint<LinePointer>(Handedness handedness, out Vector3 endPoint)
+        public static bool TryGetHandRayEndPoint(Handedness handedness, out Vector3 endPoint)
         {
-            return TryGetPointerEndpoint(handedness, InputSourceType.Hand, out endPoint);
+            return TryGetPointerEndpoint<LinePointer>(handedness, InputSourceType.Hand, out endPoint);
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
@@ -19,9 +19,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="handedness">Handedness of ray</param>
         /// <param name="endPoint">The output position</param>
         /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
-        public static bool TryGetHandRayEndPoint(Handedness handedness, out Vector3 endPoint)
+        public static bool TryGetHandRayEndPoint<LinePointer>(Handedness handedness, out Vector3 endPoint)
         {
-            return TryGetEndpoint(handedness, InputSourceType.Hand, out endPoint);
+            return TryGetPointerEndpoint(handedness, InputSourceType.Hand, out endPoint);
         }
 
         /// <summary>
@@ -33,25 +33,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
         public static bool TryGetMotionControllerEndPoint(Handedness handedness, out Vector3 endPoint)
         {
-            return TryGetEndpoint(handedness, InputSourceType.Controller, out endPoint);
+            return TryGetPointerEndpoint<LinePointer>(handedness, InputSourceType.Controller, out endPoint);
         }
 
         /// <summary>
         /// Tries to get the end point of a pointer by source type and handedness
         /// If no pointer of given handedness is found, returns false and sets result to zero.
         /// </summary>
+        /// <typeparam name="T">Type of pointer to query</typeparam>
         /// <param name="handedness">Handedness of pointer</param>
         /// <param name="inputType">input type of pointer</param>
         /// <param name="endPoint">output point position</param>
         /// <returns></returns>
-        public static bool TryGetEndpoint(Handedness handedness, InputSourceType inputType, out Vector3 endPoint)
+        public static bool TryGetPointerEndpoint<T>(Handedness handedness, InputSourceType inputType, out Vector3 endPoint) where T: IMixedRealityPointer
         {
-            foreach (var pointer in GetPointers<IMixedRealityPointer>(handedness, InputSourceType.Hand))
+            foreach (var pointer in GetPointers<IMixedRealityPointer>(handedness, inputType))
             {
-                if (pointer is IMixedRealityNearPointer)
-                {
-                    continue;
-                }
                 FocusDetails? details = pointer?.Result?.Details;
                 if (details.HasValue)
                 {
@@ -71,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="handedness">Handedness of pointer</param>
         /// <param name="endPoint">The output point position</param>
         /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
-        public static bool TryGetEndpoint<T>(Handedness handedness, out Vector3 endPoint) where T : class, IMixedRealityPointer
+        public static bool TryGetPointerEndpoint<T>(Handedness handedness, out Vector3 endPoint) where T : class, IMixedRealityPointer
         {
             T pointer = GetPointer<T>(handedness);
             FocusDetails? details = pointer?.Result?.Details;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Physics;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    public static class PointerUtils
+    {
+
+        /// <summary>
+        /// Tries to get the end point of a hand ray
+        /// If no hand ray of given handedness is found, returns false and sets result to zero.
+        /// </summary>
+        /// <param name="handedness"></param>
+        /// <param name="endPoint"></param>
+        /// <returns></returns>
+        public static bool TryGetHandRayEndPoint(Handedness handedness, out Vector3 endPoint)
+        {
+            return TryGetPointerEndpoint<LinePointer>(handedness, out endPoint);
+        }
+
+        /// <summary>
+        /// Tries to get the end point of a line pointer
+        /// If no pointer of given handedness is found, returns false and sets result to zero.
+        /// </summary>
+        /// <param name="handedness"></param>
+        /// <param name="endPoint"></param>
+        /// <returns></returns>
+        public static bool TryGetLinePointerEndPoint(Handedness handedness, out Vector3 endPoint)
+        {
+            return TryGetPointerEndpoint<LinePointer>(handedness, out endPoint);
+        }
+
+        /// <summary>
+        /// Tries to get the end point of a pointer of a given type and handedness.
+        /// If no pointer of given handedness is found, returns false and sets result to zero.
+        /// </summary>
+        /// <typeparam name="T">Type of pointer to query</typeparam>
+        /// <param name="handedness">Handedness of pointer</param>
+        /// <param name="endPoint">The output point position</param>
+        /// <returns>true if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
+        public static bool TryGetPointerEndpoint<T>(Handedness handedness, out Vector3 endPoint) where T : class, IMixedRealityPointer
+        {
+            T pointer = FindPointer<T>(handedness);
+            FocusDetails? details = pointer?.Result?.Details;
+            if (!details.HasValue)
+            {
+                endPoint = Vector3.zero;
+                return false;
+            }
+            endPoint = details.Value.Point;
+            return true;
+        }
+
+        /// <summary>
+        /// Find the first detected line pointer with matching handedness.
+        /// </summary>
+        /// <remarks>
+        /// The given handedness should be either Handedness.Left or Handedness.Right.
+        /// </remarks>
+        public static IMixedRealityPointer FindLinePointer(Handedness handedness)
+        {
+            return FindPointer<LinePointer>(handedness);
+        }
+
+        /// <summary>
+        /// Find the first detected pointer of the given type with matching handedness.
+        /// </summary>
+        public static T FindPointer<T>(Handedness handedness) where T : class, IMixedRealityPointer
+        {
+            foreach (var pointer in CoreServices.InputSystem.FocusProvider.GetPointers<T>())
+            {
+                if ((pointer.Controller?.ControllerHandedness & handedness) != 0)
+                {
+                    return pointer;
+                }
+            }
+            return null;
+        }
+    }
+
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9868275c85fe0ac48b9bdf076c1602ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿s// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Physics;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -1,4 +1,4 @@
-﻿s// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Physics;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Utilities/CanvasUtility.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Utilities/CanvasUtility.cs
@@ -3,6 +3,7 @@
 
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace Microsoft.MixedReality.Toolkit.Input.Utilities
 {
@@ -11,24 +12,37 @@ namespace Microsoft.MixedReality.Toolkit.Input.Utilities
     /// </summary>
     [DisallowMultipleComponent]
     [RequireComponent(typeof(Canvas))]
-    public class CanvasUtility : MonoBehaviour
+    public class CanvasUtility : MonoBehaviour, IMixedRealityPointerHandler
     {
-        private IMixedRealityInputSystem inputSystem = null;
+        private Vector3 previousHitPosition;
+        private RectTransform rectTransform;
 
-        /// <summary>
-        /// The active instance of the input system.
-        /// </summary>
-        private IMixedRealityInputSystem InputSystem => inputSystem ?? (inputSystem = CoreServices.InputSystem);
+        public void OnPointerClicked(MixedRealityPointerEventData eventData) {}
+
+        public void OnPointerDown(MixedRealityPointerEventData eventData)
+        {
+            previousHitPosition = eventData.Pointer.Result.Details.Point;
+        }
+
+        public void OnPointerDragged(MixedRealityPointerEventData eventData)
+        {
+            if (canvas.)
+        }
+
+        public void OnPointerUp(MixedRealityPointerEventData eventData)
+        {
+        }
 
         private void Start()
         {
+            rectTransform = GetComponent<RectTransform>();
             Canvas canvas = GetComponent<Canvas>();
             Debug.Assert(canvas != null);
 
             if (canvas.worldCamera == null)
             {
-                Debug.Assert(InputSystem?.FocusProvider?.UIRaycastCamera != null, this);
-                canvas.worldCamera = InputSystem?.FocusProvider?.UIRaycastCamera;
+                Debug.Assert(CoreServices.InputSystem?.FocusProvider?.UIRaycastCamera != null, this);
+                canvas.worldCamera = CoreServices.InputSystem?.FocusProvider?.UIRaycastCamera;
 
                 if (EventSystem.current == null)
                 {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Utilities/CanvasUtility.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Utilities/CanvasUtility.cs
@@ -20,7 +20,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.Utilities
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
             oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
-            eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
+            if (!(eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
+            {
+                eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
+            }
         }
 
         public void OnPointerDragged(MixedRealityPointerEventData eventData) { }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Utilities/CanvasUtility.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Utilities/CanvasUtility.cs
@@ -14,28 +14,24 @@ namespace Microsoft.MixedReality.Toolkit.Input.Utilities
     [RequireComponent(typeof(Canvas))]
     public class CanvasUtility : MonoBehaviour, IMixedRealityPointerHandler
     {
-        private Vector3 previousHitPosition;
-        private RectTransform rectTransform;
-
+        private bool oldIsTargetPositionLockedOnFocusLock = false;
         public void OnPointerClicked(MixedRealityPointerEventData eventData) {}
 
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            previousHitPosition = eventData.Pointer.Result.Details.Point;
+            oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
+            eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
         }
 
-        public void OnPointerDragged(MixedRealityPointerEventData eventData)
-        {
-            if (canvas.)
-        }
+        public void OnPointerDragged(MixedRealityPointerEventData eventData) { }
 
         public void OnPointerUp(MixedRealityPointerEventData eventData)
         {
+            eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
         }
 
         private void Start()
         {
-            rectTransform = GetComponent<RectTransform>();
             Canvas canvas = GetComponent<Canvas>();
             Debug.Assert(canvas != null);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
@@ -79,11 +79,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 screenPoint = CameraCache.Main.ViewportToScreenPoint(new Vector3(0.5f, 0.25f, 0.5f));
             yield return h.Show(CameraCache.Main.ScreenToWorldPoint(screenPoint));
 
+            Assert.True(PointerUtils.TryGetHandRayEndPoint(Handedness.Right, out Vector3 hitPointStart));
+
             yield return h.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return h.Move(new Vector3(0, -0.05f, 0), 10);
+            Assert.True(PointerUtils.TryGetHandRayEndPoint(Handedness.Right, out Vector3 hitPointEnd));
             yield return h.SetGesture(ArticulatedHandPose.GestureId.Open);
 
+            TestUtilities.AssertNotAboutEqual(hitPointStart, hitPointEnd, "ray should not stick on slate scrolling");
             Assert.AreEqual(0.1, totalPanDelta.y, 0.05, "pan delta is not correct");
+
+
 
             yield return h.Hide();
         }


### PR DESCRIPTION
## Overview
The hand ray cursor should not get stuck on flat UI like UnityUI and the slate (backed by `HandIteractionPanZoom`). This change updates fixes this by setting `IsTargetPositionLockedOnFocusLocked = false` when using hand rays or motion controllers. Old value gets restored on pointer up.

Also added tests to prevent regression, and some utilities for accessing common pointer info.

### Old Behavior
![PanStic](https://user-images.githubusercontent.com/168492/60872020-e5fa5000-a26e-11e9-9fa9-006e925e82a1.gif)

### New Behavior
![PanStic_actual](https://user-images.githubusercontent.com/168492/60872008-e397f600-a26e-11e9-9735-a2836439f080.gif)


## Changes
- Fixes: #5236
- Add test to verify fix does not regress
- Add a few pointer utility functions (related to #5280)

## Verification
- Tested in editor, articulated hands
- Need to test that HoloLens1 behavior remains as before
