### PR TITLE
Fix possible division by zero in TwoHandMoveLogic

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -894,6 +894,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Show(cameraPosition);
             yield return null;
 
+            // Hand position is not exactly the pointer position, this correction applies the delta
+            // from the hand to the pointer.
             Vector3 correction = hand.GetPointer<GGVPointer>().Position - cameraPosition;
             yield return hand.Move(-correction, numHandSteps);
             yield return null;
@@ -901,6 +903,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+
+            Vector3 delta = new Vector3(0.2f, 0, 0);
+            MixedRealityPlayspace.Transform.Translate(delta);
+            yield return hand.Move(delta, numHandSteps);
+            yield return null;
+
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             yield return null;
 
             Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -856,6 +856,59 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             iss.InputSimulationProfile = oldIsp;
             yield return null;
         }
+
+        /// <summary>
+        /// For positionless input sources that use gaze, such as xbox controller, pointer position will
+        /// be coincident with the head position. This was causing issues with manipulation handler, as
+        /// the distance between the pointer and the head is taken as part of the move logic. 
+        /// This test simulates a positionless input source by using GGV hands and setting the hand position
+        /// to be the head position. It then ensures that there is no weird behaviour as a result of this.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerPositionlessController()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Switch to Gestures
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            var oldIsp = iss.InputSimulationProfile;
+            var isp = ScriptableObject.CreateInstance<MixedRealityInputSimulationProfile>();
+            isp.HandSimulationMode = HandSimulationMode.Gestures;
+            iss.InputSimulationProfile = isp;
+
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            testObject.transform.position = new Vector3(0f, 0f, 1f);
+
+            var manipHandler = testObject.AddComponent<ManipulationHandler>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+
+            Vector3 cameraPosition = CameraCache.Main.transform.position;
+            TestHand hand = new TestHand(Handedness.Right);
+            const int numHandSteps = 1;
+            
+            float expectedDist = Vector3.Distance(testObject.transform.position, cameraPosition);
+            
+            yield return hand.Show(cameraPosition);
+            yield return null;
+
+            Vector3 correction = hand.GetPointer<GGVPointer>().Position - cameraPosition;
+            yield return hand.Move(-correction, numHandSteps);
+            yield return null;
+
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+
+            // Restore the input simulation profile
+            iss.InputSimulationProfile = oldIsp;
+            yield return null;
+        }
     }
 }
 #endif

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.Physics
     {
         private float pointerRefDistance;
 
+        private bool pointerPosIndependentOfHead = true;
+
         private Vector3 pointerLocalGrabPoint;
         private Vector3 objectLocalGrabPoint;
         private Vector3 pointerToObject;
@@ -35,6 +37,10 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         {
             Vector3 headPosition = CameraCache.Main.transform.position;            
             pointerRefDistance = Vector3.Distance(pointerCentroidPose.Position, headPosition);
+            if (pointerRefDistance == 0)
+            {
+                pointerPosIndependentOfHead = false;
+            }
             
             Quaternion worldToPointerRotation = Quaternion.Inverse(pointerCentroidPose.Rotation);
             pointerLocalGrabPoint = worldToPointerRotation * (grabCentroid - pointerCentroidPose.Position);
@@ -62,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 Vector3 headPosition = CameraCache.Main.transform.position;
                 float distanceRatio = 1.0f;
 
-                if (movementConstraint != MovementConstraintType.FixDistanceFromHead)
+                if (pointerPosIndependentOfHead && movementConstraint != MovementConstraintType.FixDistanceFromHead)
                 {
                     // Compute how far away the object should be based on the ratio of the current to original hand distance
                     var currentHandDistance = Vector3.Magnitude(pointerCentroidPose.Position - headPosition);

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -37,10 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         {
             Vector3 headPosition = CameraCache.Main.transform.position;            
             pointerRefDistance = Vector3.Distance(pointerCentroidPose.Position, headPosition);
-            if (pointerRefDistance == 0)
-            {
-                pointerPosIndependentOfHead = false;
-            }
+            pointerPosIndependentOfHead = pointerRefDistance != 0;
             
             Quaternion worldToPointerRotation = Quaternion.Inverse(pointerCentroidPose.Rotation);
             pointerLocalGrabPoint = worldToPointerRotation * (grabCentroid - pointerCentroidPose.Position);


### PR DESCRIPTION
## Overview
For positionless controllers like xbox controller, the pointer position and the head position were coincident at the head position. This change ensures that if this is the case, we do not perform a division by zero in `TwoHandMoveLogic`, as this was causing objects to disappear into infinity.

## Changes
- Fixes: #5829.
