### PR TITLE
Expose cursor speed and scroll wheel speed to mouse profile. Fix y axis inversion.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -14,21 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public class MousePointer : BaseMousePointer
     {
-        private MixedRealityMouseInputProfile mouseInputProfile = null;
-
-        private MixedRealityMouseInputProfile MouseInputProfile
-        {
-            get
-            {
-                if (mouseInputProfile == null)
-                {
-                    // Get the profile from the input system's registered mouse device manager.
-                    IMixedRealityMouseDeviceManager mouseManager = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityMouseDeviceManager>();
-                    mouseInputProfile = mouseManager?.MouseInputProfile;
-                }
-                return mouseInputProfile;
-            }
-        }
+        private IMixedRealityMouseDeviceManager mouseDeviceManager = null;
 
         /// <inheritdoc />
         protected override string ControllerName => "Spatial Mouse Pointer";
@@ -53,6 +39,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnInputChanged(InputEventData<Vector2> eventData)
         {
+            if (mouseDeviceManager == null)
+            {
+                // Get the instance of the mouse device manager.
+                IMixedRealityDataProviderAccess dataProviderAccess = InputSystem as IMixedRealityDataProviderAccess;
+                mouseDeviceManager = dataProviderAccess?.GetDataProvider<IMixedRealityMouseDeviceManager>();
+            }
+
             if (eventData.SourceId == Controller?.InputSource.SourceId)
             {
                 if (PoseAction == eventData.MixedRealityInputAction && !UseSourcePoseData)
@@ -60,9 +53,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     Vector3 mouseDeltaRotation = Vector3.zero;
                     mouseDeltaRotation.x += eventData.InputData.x;
                     mouseDeltaRotation.y += eventData.InputData.y;
-                    if (MouseInputProfile != null)
+                    if (mouseDeviceManager != null)
                     {
-                        mouseDeltaRotation *= MouseInputProfile.MouseSpeed;
+                        mouseDeltaRotation *= mouseDeviceManager.CursorSpeed;
                     }
                     UpdateMouseRotation(mouseDeltaRotation);
                 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -50,14 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (PoseAction == eventData.MixedRealityInputAction && !UseSourcePoseData)
                 {
-                    Vector3 mouseDeltaRotation = Vector3.zero;
-                    mouseDeltaRotation.x += eventData.InputData.x;
-                    mouseDeltaRotation.y += eventData.InputData.y;
-                    if (mouseDeviceManager != null)
-                    {
-                        mouseDeltaRotation *= mouseDeviceManager.CursorSpeed;
-                    }
-                    UpdateMouseRotation(mouseDeltaRotation);
+                    UpdateMouseRotation(eventData.InputData);
                 }
             }
         }
@@ -92,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 timeoutTimer = 0.0f;
             }
 
-            transform.Rotate(mouseDeltaRotation, Space.World);
+            transform.Rotate(mouseDeltaRotation, Space.World); //  Self);
         }
 
         protected override void Start()

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/MousePointer.cs
@@ -14,8 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public class MousePointer : BaseMousePointer
     {
-        private IMixedRealityMouseDeviceManager mouseDeviceManager = null;
-
         /// <inheritdoc />
         protected override string ControllerName => "Spatial Mouse Pointer";
 
@@ -39,13 +37,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnInputChanged(InputEventData<Vector2> eventData)
         {
-            if (mouseDeviceManager == null)
-            {
-                // Get the instance of the mouse device manager.
-                IMixedRealityDataProviderAccess dataProviderAccess = InputSystem as IMixedRealityDataProviderAccess;
-                mouseDeviceManager = dataProviderAccess?.GetDataProvider<IMixedRealityMouseDeviceManager>();
-            }
-
             if (eventData.SourceId == Controller?.InputSource.SourceId)
             {
                 if (PoseAction == eventData.MixedRealityInputAction && !UseSourcePoseData)
@@ -85,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 timeoutTimer = 0.0f;
             }
 
-            transform.Rotate(mouseDeltaRotation, Space.World); //  Self);
+            transform.Rotate(mouseDeltaRotation, Space.Self);
         }
 
         protected override void Start()

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityMouseInputProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityMouseInputProfile.asset
@@ -13,4 +13,5 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityMouseInputProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  mouseSpeed: 1
+  cursorSpeed: 1
+  wheelSpeed: 1

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityMouseInputProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityMouseInputProfile.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityMouseInputProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  mouseSpeed: 0.25
+  mouseSpeed: 1

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return false;
             }
 
-            var mouseManager = MixedRealityToolkit.Instance.GetService<MouseDeviceManager>(null, false);
+            var mouseManager = MixedRealityToolkit.Instance.GetService<IMixedRealityMouseDeviceManager>(null, false);
             return mouseManager != null && profile == mouseManager.MouseInputProfile;
         }
     }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
@@ -11,14 +11,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [CustomEditor(typeof(MixedRealityMouseInputProfile))]
     public class MixedRealityMouseInputProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
     {
-        private SerializedProperty mouseSpeed;
         private const string ProfileTitle = "Mouse Input Settings";
-        private const string ProfileDescription = "Settings for mouse input in the editor.";
+        private const string ProfileDescription = "Settings used to configure the behavior of mouse controllers.";
+
+        private SerializedProperty cursorSpeed;
+        private SerializedProperty wheelSpeed;
 
         protected override void OnEnable()
         {
             base.OnEnable();
-            mouseSpeed = serializedObject.FindProperty("mouseSpeed");
+            cursorSpeed = serializedObject.FindProperty("cursorSpeed");
+            wheelSpeed = serializedObject.FindProperty("wheelSpeed");
+            if (wheelSpeed == null)
+            {
+                // todo: set a default value if not found
+            }
         }
 
         public override void OnInspectorGUI()
@@ -28,7 +35,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             using (new GUIEnabledWrapper(!IsProfileLock((BaseMixedRealityProfile)target), false))
             {
                 serializedObject.Update();
-                EditorGUILayout.PropertyField(mouseSpeed);
+                EditorGUILayout.PropertyField(cursorSpeed);
+                EditorGUILayout.PropertyField(wheelSpeed);
                 serializedObject.ApplyModifiedProperties();
             }
         }
@@ -42,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             var mouseManager = MixedRealityToolkit.Instance.GetService<IMixedRealityMouseDeviceManager>(null, false);
-            return mouseManager != null && profile == mouseManager.MouseInputProfile;
+            return mouseManager != null && profile == mouseManager.ConfigurationProfile;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityMouseInputProfileInspector.cs
@@ -22,10 +22,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             base.OnEnable();
             cursorSpeed = serializedObject.FindProperty("cursorSpeed");
             wheelSpeed = serializedObject.FindProperty("wheelSpeed");
-            if (wheelSpeed == null)
-            {
-                // todo: set a default value if not found
-            }
         }
 
         public override void OnInspectorGUI()

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
@@ -8,8 +8,17 @@ using Microsoft.MixedReality.Toolkit.Input;
 /// </summary>
 public interface IMixedRealityMouseDeviceManager : IMixedRealityInputDeviceManager
 {
+    // todo: figure out how to remove.... this is only "needed" by the profile inspector...
     /// <summary>
     /// Typed representation of the ConfigurationProfile property.
     /// </summary>
     MixedRealityMouseInputProfile MouseInputProfile { get; }
+
+    /// <summary>
+    /// Gets or sets a multiplier value used to adjust the speed of the mouse cursor.
+    /// </summary>
+    /// <remarks>
+    /// The user's cursor speed, as configured in the operating system, is considered the unity value.
+    /// </remarks>
+    float CursorSpeed { get; set; }
 }

--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
@@ -8,17 +8,12 @@ using Microsoft.MixedReality.Toolkit.Input;
 /// </summary>
 public interface IMixedRealityMouseDeviceManager : IMixedRealityInputDeviceManager
 {
-    // todo: figure out how to remove.... this is only "needed" by the profile inspector...
-    /// <summary>
-    /// Typed representation of the ConfigurationProfile property.
-    /// </summary>
-    MixedRealityMouseInputProfile MouseInputProfile { get; }
-
-    /// <summary>
     /// Gets or sets a multiplier value used to adjust the speed of the mouse cursor.
     /// </summary>
-    /// <remarks>
-    /// The user's cursor speed, as configured in the operating system, is considered the unity value.
-    /// </remarks>
     float CursorSpeed { get; set; }
+
+    /// <summary>
+    /// Gets or sets a multiplier value used to adjust the speed of the mouse wheel.
+    /// </summary>
+    float WheelSpeed { get; set; }
 }

--- a/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IMixedRealityInputSystem inputSystem,
             string name, 
             uint priority, 
-            BaseMixedRealityProfile profile): base(registrar, inputSystem, name, priority, profile)
+            BaseMixedRealityProfile profile) : base(registrar, inputSystem, name, priority, profile)
         {
             if (inputSystem == null)
             {
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             var pointers = new List<IMixedRealityPointer>();
 
-            if ((Service != null) &&
+            if ((InputSystem != null) &&
                 (InputSystemProfile != null) &&
                 InputSystemProfile.PointerProfile != null)
             {

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MixedRealityMouseInputProfile.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MixedRealityMouseInputProfile.cs
@@ -15,7 +15,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [MixedRealityServiceProfile(typeof(MouseDeviceManager))]
     public class MixedRealityMouseInputProfile : BaseMixedRealityProfile
     {
-        [Header("Mouse Input Settings")]
         [SerializeField]
         [Range(0.1f, 10f)]
         [Tooltip("Mouse cursor speed multiplier.")]
@@ -23,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private float cursorSpeed = 1.0f;
 
         /// <summary>
-        /// Defines the mouse cursor speed multiplier that gets applied to the mouse delta before converting to world space.
+        /// Defines the mouse cursor speed multiplier used to scale the mouse cursor delta.
         /// </summary>
         public float CursorSpeed => cursorSpeed;
 
@@ -33,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private float wheelSpeed = 1.0f;
 
         /// <summary>
-        /// Defines the mouse cursor speed multiplier that gets applied to the mouse delta before converting to world space.
+        /// Defines the mouse wheel speed multiplier used to scale the scroll wheel delta.
         /// </summary>
         public float WheelSpeed => wheelSpeed;
 

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MixedRealityMouseInputProfile.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MixedRealityMouseInputProfile.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Input.UnityInput;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -18,11 +19,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         [Range(0.1f, 10f)]
         [Tooltip("Mouse cursor speed multiplier.")]
-        private float mouseSpeed = 0.25f;
+        [FormerlySerializedAsAttribute("mouseSpeed")]
+        private float cursorSpeed = 1.0f;
 
         /// <summary>
         /// Defines the mouse cursor speed multiplier that gets applied to the mouse delta before converting to world space.
         /// </summary>
-        public float CursorSpeed => mouseSpeed;      
+        public float CursorSpeed => cursorSpeed;
+
+        [SerializeField]
+        [Range(0.1f, 10f)]
+        [Tooltip("Mouse wheel speed multiplier.")]
+        private float wheelSpeed = 1.0f;
+
+        /// <summary>
+        /// Defines the mouse cursor speed multiplier that gets applied to the mouse delta before converting to world space.
+        /// </summary>
+        public float WheelSpeed => wheelSpeed;
+
     }
 }

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MixedRealityMouseInputProfile.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MixedRealityMouseInputProfile.cs
@@ -7,19 +7,22 @@ using Microsoft.MixedReality.Toolkit.Input.UnityInput;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Mouse Input Profile", fileName = "MixedRealityMouseInputProfile", order = (int)CreateProfileMenuItemIndices.MouseInput)]
+    [CreateAssetMenu(
+        menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Mouse Input Profile", 
+        fileName = "MixedRealityMouseInputProfile", 
+        order = (int)CreateProfileMenuItemIndices.MouseInput)]
     [MixedRealityServiceProfile(typeof(MouseDeviceManager))]
     public class MixedRealityMouseInputProfile : BaseMixedRealityProfile
     {
         [Header("Mouse Input Settings")]
         [SerializeField]
         [Range(0.1f, 10f)]
-        [Tooltip("Mouse cursor speed multiplier that gets applied to the mouse delta.")]
+        [Tooltip("Mouse cursor speed multiplier.")]
         private float mouseSpeed = 0.25f;
+
         /// <summary>
-        /// Defines the mouse cursor speed. 
-        /// Multiplier that gets applied to the mouse delta before converting to world space.
+        /// Defines the mouse cursor speed multiplier that gets applied to the mouse delta before converting to world space.
         /// </summary>
-        public float MouseSpeed => mouseSpeed;      
+        public float CursorSpeed => mouseSpeed;      
     }
 }

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -17,10 +17,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="trackingState"></param>
-        /// <param name="controllerHandedness"></param>
-        /// <param name="inputSource"></param>
-        /// <param name="interactions"></param>
+        /// <param name="trackingState">The controller's tracking state.</param>
+        /// <param name="controllerHandedness">The handedness (ex: right) of the controller.</param>
+        /// <param name="inputSource">The controller's input souce.</param>
+        /// <param name="interactions">The set of interactions supported by this controller.</param>
         public MouseController(
             TrackingState trackingState, 
             Handedness controllerHandedness, 

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -21,10 +21,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// <param name="controllerHandedness"></param>
         /// <param name="inputSource"></param>
         /// <param name="interactions"></param>
-        public MouseController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
-            : base(trackingState, controllerHandedness, inputSource, interactions)
-        {
-        }
+        public MouseController(
+            TrackingState trackingState, 
+            Handedness controllerHandedness, 
+            IMixedRealityInputSource inputSource = null, 
+            MixedRealityInteractionMapping[] interactions = null) : base(trackingState, controllerHandedness, inputSource, interactions)
+        { }
 
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultInteractions { get; } =
@@ -49,20 +51,22 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
         private MixedRealityPose controllerPose = MixedRealityPose.ZeroIdentity;
 
-        private MixedRealityMouseInputProfile mouseInputProfile = null;
-        private MixedRealityMouseInputProfile MouseInputProfile
-        {
-            get
-            {
-                if (mouseInputProfile == null)
-                {
-                    // Get the profile from the input system's registered mouse device manager.
-                    IMixedRealityMouseDeviceManager mouseManager = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityMouseDeviceManager>();
-                    mouseInputProfile = mouseManager?.MouseInputProfile;
-                }
-                return mouseInputProfile;
-            }
-        }
+        private IMixedRealityMouseDeviceManager mouseDeviceManager = null;
+
+        //private MixedRealityMouseInputProfile mouseInputProfile = null;
+        //private MixedRealityMouseInputProfile MouseInputProfile
+        //{
+        //    get
+        //    {
+        //        if (mouseInputProfile == null)
+        //        {
+        //            // Get the profile from the input system's registered mouse device manager.
+        //            IMixedRealityMouseDeviceManager mouseManager = (InputSystem as IMixedRealityDataProviderAccess)?.GetDataProvider<IMixedRealityMouseDeviceManager>();
+        //            mouseInputProfile = mouseManager?.MouseInputProfile;
+        //        }
+        //        return mouseInputProfile;
+        //    }
+        //}
 
         /// <summary>
         /// Update controller.
@@ -70,6 +74,13 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         public void Update()
         {
             if (!UInput.mousePresent) { return; }
+
+            if (mouseDeviceManager == null)
+            {
+                // Get the instance of the mouse device manager.
+                IMixedRealityDataProviderAccess dataProviderAccess = InputSystem as IMixedRealityDataProviderAccess;
+                mouseDeviceManager = dataProviderAccess?.GetDataProvider<IMixedRealityMouseDeviceManager>();
+            }
 
             // Bail early if our mouse isn't in our game window.
             if (UInput.mousePosition.x < 0 ||
@@ -82,18 +93,16 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
             for (int i = 0; i < Interactions.Length; i++)
             {
-                
-
                 if (Interactions[i].InputType == DeviceInputType.SpatialPointer)
                 {
                     // add mouse delta as rotation
                     var mouseDeltaRotation = Vector3.zero;
                     mouseDeltaRotation.x += -UInput.GetAxis("Mouse Y");
                     mouseDeltaRotation.y += UInput.GetAxis("Mouse X");
-                    
-                    if (MouseInputProfile != null)
+
+                    if (mouseDeviceManager != null)
                     {
-                        mouseDeltaRotation *= MouseInputProfile.MouseSpeed;
+                        mouseDeltaRotation *= mouseDeviceManager.CursorSpeed;
                     }
 
                     MixedRealityPose controllerPose = MixedRealityPose.ZeroIdentity;

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -30,12 +30,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             BaseMixedRealityProfile profile = null) : base(registrar, inputSystem, name, priority, profile)
         { }
 
-        /// <inheritdoc />
-        public MixedRealityMouseInputProfile MouseInputProfile => ConfigurationProfile as MixedRealityMouseInputProfile;
-
-        // Values defining the range of the cursor speed multiplier
-        private readonly float MinCursorSpeed = 0.1f;
-        private readonly float MaxCursorSpeed = 10.0f;
+        // Values defining the range of the cursor and wheel speed multipliers
+        private const float MinSpeedMultiplier = 0.1f;
+        private const float MaxSpeedMultiplier = 10.0f;
 
         private float cursorSpeed = 1.0f;
 
@@ -48,7 +45,23 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             {
                 if (value != cursorSpeed)
                 {
-                    cursorSpeed = Mathf.Clamp(value, MinCursorSpeed, MaxCursorSpeed);
+                    cursorSpeed = Mathf.Clamp(value, MinSpeedMultiplier, MaxSpeedMultiplier);
+                }
+            }
+        }
+
+        private float wheelSpeed = 1.0f;
+
+        /// <inheritdoc />
+        public float WheelSpeed
+        {
+            get => wheelSpeed;
+
+            set
+            {
+                if (value != wheelSpeed)
+                {
+                    wheelSpeed = Mathf.Clamp(value, MinSpeedMultiplier, MaxSpeedMultiplier);
                 }
             }
         }
@@ -60,7 +73,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
         private void ReadProfile()
         {
-            CursorSpeed = MouseInputProfile.CursorSpeed;
+            MixedRealityMouseInputProfile profile = ConfigurationProfile as MixedRealityMouseInputProfile;
+
+            CursorSpeed = profile.CursorSpeed;
+            WheelSpeed = profile.WheelSpeed;
         }
 
         public override void Initialize()


### PR DESCRIPTION
```
NOTE: This is a breaking change that will impact any custom mouse data provider implementations. It was deemed a safe change to make at this time as most known client applications utilize motion controllers and hands, rather than mouse devices. Application code is not impacted unless it references the mouse profile from the IMixedRealityMouseDeviceManager interface.
```

This change updates the mouse device profile to expose the CursorSpeed property (formerly MouseSpeed) and adds a WheelSpeed property to allow for easy configuration at runtime.

To preserve existing profile compatibility, the CursorSpeed property is marked as having been formally serialized as mouseSpeed. The WheelSpeed uses a default value if not present in a profile.

The default value for the cursor speed has been increased from 0.25 to 1.0 as it was feeling very sluggish (lagged behind expected motion - as reported in #5566 and as seen in personal experience).

This change also modified the cursor rotation space from World to Self as it was causing the inversion of the mouse behavior (as reported in #5793).

There was also some related base class and inspector cleanup.

Fixes #5793, #5838.

Verified by enabling the mouse device in the input system and
- Visually verifying the default cursor speed behavior change
- Verifying scroll scaling in via debug.log messages (the current mouse cursor does not respond to scroll wheel behavior)
- Moving the mouse with the camera rotated at 0,0,0 and 0, 180, 0 to confirm the mouse moves as expected.