### PR TITLE
Cosmetic change to MixedRealityPreferences.cs

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityPreferences.cs
@@ -96,8 +96,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             var provider = new SettingsProvider("Project/Mixed Reality Toolkit", SettingsScope.Project)
             {
-                label = "Microsoft Mixed Reality Toolkit",
-
                 guiHandler = GUIHandler,
 
                 keywords = new HashSet<string>(new[] { "Mixed", "Reality", "Toolkit" })
@@ -132,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
 
                 EditorGUI.BeginChangeCheck();
-                var scriptLock = EditorGUILayout.Toggle("Is Script Reloading locked?", EditorAssemblyReloadManager.LockReloadAssemblies);
+                var scriptLock = EditorGUILayout.Toggle("Is script reloading locked?", EditorAssemblyReloadManager.LockReloadAssemblies);
 
                 if (EditorGUI.EndChangeCheck())
                 {


### PR DESCRIPTION
## Overview
Small cosmetic changes to the Project Settings menu item. The full name felt a little long for the default size of the panel, and capitalization of the menu item was inconsistent:

![image](https://user-images.githubusercontent.com/3580640/64394363-b5cef380-d00a-11e9-95e6-17cf3bd5154b.png)
to
![image](https://user-images.githubusercontent.com/3580640/64394342-9afc7f00-d00a-11e9-8e5a-ed841e985184.png)
