### PR TITLE
Ux/sluggish ggv yaxis

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity
@@ -2470,7 +2470,7 @@ MonoBehaviour:
   oneHandRotationModeNear: 6
   oneHandRotationModeFar: 6
   releaseBehavior: -1
-  constraintOnRotation: 0
+  constraintOnRotation: 2
   constraintOnMovement: 0
   smoothingActive: 1
   smoothingAmountOneHandManip: 0.000001

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
@@ -13369,7 +13369,7 @@ MonoBehaviour:
   oneHandRotationModeNear: 6
   oneHandRotationModeFar: 6
   releaseBehavior: -1
-  constraintOnRotation: 0
+  constraintOnRotation: 2
   constraintOnMovement: 0
   smoothingActive: 1
   smoothingAmountOneHandManip: 0.0001
@@ -23401,7 +23401,7 @@ MonoBehaviour:
   oneHandRotationModeNear: 1
   oneHandRotationModeFar: 1
   releaseBehavior: 3
-  constraintOnRotation: 0
+  constraintOnRotation: 2
   constraintOnMovement: 0
   smoothingActive: 1
   smoothingAmountOneHandManip: 0.001
@@ -25418,7 +25418,7 @@ MonoBehaviour:
   oneHandRotationModeNear: 6
   oneHandRotationModeFar: 6
   releaseBehavior: 3
-  constraintOnRotation: 0
+  constraintOnRotation: 2
   constraintOnMovement: 0
   smoothingActive: 1
   smoothingAmountOneHandManip: 0.001

--- a/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Cheese.prefab
+++ b/Assets/MixedRealityToolkit.Examples/StandardAssets/Prefabs/Cheese.prefab
@@ -206,7 +206,7 @@ MonoBehaviour:
   oneHandRotationModeNear: 5
   oneHandRotationModeFar: 5
   releaseBehavior: 3
-  constraintOnRotation: 0
+  constraintOnRotation: 2
   constraintOnMovement: 0
   smoothingActive: 1
   smoothingAmountOneHandManip: 0.001

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -199,12 +199,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // This caused issues when the head rotated, but the hand stayed where it was.
                 // Now we're returning a rotation based on the vector from the camera position
                 // to the hand. This rotation is not affected by rotating your head.
-                //
-                // The y value is set to 0 here as we want the rotation to be about the y axis.
-                // Without this, one-hand manipulating an object would give it unwanted x/z 
-                // rotations as you move your hand up and down.
                 Vector3 look = Position - CameraCache.Main.transform.position;
-                look.y = 0;
                 return Quaternion.LookRotation(look);
             }
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -826,22 +826,29 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 originalHandPosition = new Vector3(0, 0, 0.5f);
             TestHand hand = new TestHand(Handedness.Right);
             const int numHandSteps = 1;
-
+            
             // Grab cube
             yield return hand.Show(originalHandPosition);
-            yield return null;
+
+            // Hand position is not exactly the pointer position, this correction applies the delta
+            // from the hand to the pointer.
+            Vector3 correction = originalHandPosition - hand.GetPointer<GGVPointer>().Position;
+            yield return hand.Move(correction, numHandSteps);
+
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
 
             // Rotate Head and readjust hand
             int numRotations = 10;
             for (int i = 0; i < numRotations; i++)
             {
                 MixedRealityPlayspace.Transform.Rotate(Vector3.up, 180 / numRotations);
-                yield return hand.MoveTo(originalHandPosition, numHandSteps);
+                correction = originalHandPosition - hand.GetPointer<GGVPointer>().Position;
+                yield return hand.Move(correction, numHandSteps);
                 yield return null;
 
                 // Test Object hasn't moved
-                TestUtilities.AssertAboutEqual(initialObjectPosition, testObject.transform.position, "Object moved while rotating head");
+                TestUtilities.AssertAboutEqual(initialObjectPosition, testObject.transform.position, "Object moved while rotating head", 0.01f);
                 TestUtilities.AssertAboutEqual(initialObjectRotation, testObject.transform.rotation, "Object rotated while rotating head", 0.25f);
             }
 
@@ -877,40 +884,39 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var manipHandler = testObject.AddComponent<ManipulationHandler>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-
-            Vector3 cameraPosition = CameraCache.Main.transform.position;
+            
             TestHand hand = new TestHand(Handedness.Right);
             const int numHandSteps = 1;
             
-            float expectedDist = Vector3.Distance(testObject.transform.position, cameraPosition);
+            float expectedDist = Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position);
             
-            yield return hand.Show(cameraPosition);
+            yield return hand.Show(CameraCache.Main.transform.position);
             yield return null;
 
             // Hand position is not exactly the pointer position, this correction applies the delta
             // from the hand to the pointer.
-            Vector3 correction = hand.GetPointer<GGVPointer>().Position - cameraPosition;
-            yield return hand.Move(-correction, numHandSteps);
+            Vector3 correction = CameraCache.Main.transform.position - hand.GetPointer<GGVPointer>().Position;
+            yield return hand.Move(correction, numHandSteps);
             yield return null;
 
-            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return null;
 
-            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);
 
             Vector3 delta = new Vector3(0.2f, 0, 0);
             MixedRealityPlayspace.Transform.Translate(delta);
             yield return hand.Move(delta, numHandSteps);
             yield return null;
 
-            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 2.5f);
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             yield return null;
 
-            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, cameraPosition), 0.01f);
+            Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);
 
             // Restore the input simulation profile
             iss.InputSimulationProfile = oldIsp;


### PR DESCRIPTION
## Overview
As part of [this PR](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5645), I changed how GGV rotation worked. As part of my change, I zeroed the y value of the look rotation vector. Before I did this, moving your hand up and down would impart pitch rotation on manipulated objects in much the same way that moving you hand left and right would impart yaw rotation. I wasn't sure at the time if this was something we wanted. 

These changes remove this line where the y value is zeroed. As a result, vertical manipulation no longer feels sluggish in GGV, but you will also impart some pitch rotations on the manipulated object. It is possible to counteract this by setting a y-axis only rotation constraint on manipulation handler.

### Before
![zeroY](https://user-images.githubusercontent.com/47415945/64431237-f46bb900-d0b1-11e9-9e97-c39c349dfe7e.gif)

### After
![noZeroY](https://user-images.githubusercontent.com/47415945/64431258-ffbee480-d0b1-11e9-806f-2e240d084666.gif)

## Changes
- Fixes: #5775.
