### PR TITLE
Fix Appx building from Unity player completion dialog not using correct settings.

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -59,8 +59,14 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 OutputDirectory = buildDirectory,
                 Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled && !string.IsNullOrEmpty(scene.path)).Select(scene => scene.path),
                 BuildAppx = !showDialog,
-                BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
                 GazeInputCapabilityEnabled = UwpBuildDeployPreferences.GazeInputCapabilityEnabled,
+
+                // Configure Appx build preferences for post build action
+                RebuildAppx = UwpBuildDeployPreferences.ForceRebuild,
+                Configuration = UwpBuildDeployPreferences.BuildConfig,
+                BuildPlatform = EditorUserBuildSettings.wsaArchitecture,
+                PlatformToolset = UwpBuildDeployPreferences.PlatformToolset,
+                AutoIncrement = BuildDeployPreferences.IncrementBuildVersion,
                 Multicore = UwpBuildDeployPreferences.MulticoreAppxBuildEnabled,
 
                 // Configure a post build action that will compile the generated solution


### PR DESCRIPTION
## Overview

The `Build Appx` button in the Unity build completion dialog did not trigger the same build as the `Build Appx` button in the Appx build window tab. Specifically most build preferences were not taken into account. 

I compared both `UwpBuildInfo` from `BuildPlayer` and `BuildAppx` and added the missing settings to the former one. Though I am not sure if there are still hidden preferences that must be matched as well. 

## Verification

Start a Unity player build, then in the completion dialog use the `Build Appx` button to build the Appx right away. The Appx should be build using the correct settings from the Appx build tab.