### PR TITLE
Mrtk wireframe shader fix for Android

### DIFF
--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
@@ -115,7 +115,8 @@ Shader "Mixed Reality Toolkit/Wireframe"
                    o.viewPos = i[idx].viewPos;
                    o.inverseW = 1.0 / o.viewPos.w;
                    o.dist = distScale[idx] * o.viewPos.w * wireScale;
-                   UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
+				   UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+				   UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
                    triStream.Append(o);
                 }
             }

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MRTK_Wireframe.shader
@@ -115,8 +115,8 @@ Shader "Mixed Reality Toolkit/Wireframe"
                    o.viewPos = i[idx].viewPos;
                    o.inverseW = 1.0 / o.viewPos.w;
                    o.dist = distScale[idx] * o.viewPos.w * wireScale;
-				   UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-				   UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
+                   UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                   UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
                    triStream.Append(o);
                 }
             }


### PR DESCRIPTION
## Overview
On Android, opening the shader shows this warning;
`Shader error in 'Mixed Reality Toolkit/Wireframe': variable 'o' used without having been completely initialized at line 121 (on gles3)`

The similarity in names of UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO with UNITY_TRANSFER_VERTEX_OUTPUT_STEREO near that error and the corresponding struct definition led me to this page:

https://forum.unity.com/threads/unity-stereo-output-function.470331/

and I just tried adding UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO before the UNITY_TRANSFER_VERTEX_OUTPUT_STEREO cmd and the error was gone.

No idea if that is correct though

Fixes part of: #5844