### PR TITLE
Fix service inspector creation & HandJointServiceInspector

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionInspectorTemplate.txt
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionInspectorTemplate.txt
@@ -7,7 +7,7 @@ using UnityEditor;
 
 namespace #NAMESPACE#.Editor
 {	
-	[MixedRealityServiceInspector(typeof(#SERVICE_NAME#))]
+	[MixedRealityServiceInspector(typeof(#INTERFACE_NAME#))]
 	public class #INSPECTOR_NAME# : BaseMixedRealityServiceInspector
 	{
 		public override void DrawInspectorGUI(object target)

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/HandJointServiceInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/HandJointServiceInspector.cs
@@ -10,7 +10,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
-    [MixedRealityServiceInspector(typeof(HandJointService))]
+    [MixedRealityServiceInspector(typeof(IMixedRealityHandJointService))]
     public class HandJointServiceInspector : BaseMixedRealityServiceInspector
     {
         private const string ShowHandPreviewInSceneViewKey = "MRTK_HandJointServiceInspector_ShowHandPreviewInSceneViewKey";


### PR DESCRIPTION
## Overview
This PR replaces #5906 and #5907, rebased on mrtk_development

## Changes
- HandJointServiceInspector: create inspector on IMixedRealityHandJointService in stead of MixedRealityHandJointService
- ExtensionInspectorTemplate.txt now references #INTERFACE_NAME# in stead of #SERVICE_NAME# 

