### PR TITLE
Standardize OpenVR WMR grip press as DeviceInputType.TriggerPress

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/InputActions/InputActions.MixedRealityControllerMappingProfile.asset
@@ -2254,7 +2254,7 @@ MonoBehaviour:
     - id: 2
       description: Grip Press
       axisType: 3
-      inputType: 7
+      inputType: 13
       inputAction:
         id: 7
         description: Grip Press

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         {
             new MixedRealityInteractionMapping(0, "Spatial Pointer", AxisType.SixDof, DeviceInputType.SpatialPointer, MixedRealityInputAction.None),
             new MixedRealityInteractionMapping(1, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip, MixedRealityInputAction.None),
-            new MixedRealityInteractionMapping(2, "Grip Press", AxisType.SingleAxis, DeviceInputType.ButtonPress, ControllerMappingLibrary.AXIS_12),
+            new MixedRealityInteractionMapping(2, "Grip Press", AxisType.SingleAxis, DeviceInputType.TriggerPress, ControllerMappingLibrary.AXIS_12),
             new MixedRealityInteractionMapping(3, "Trigger Position", AxisType.SingleAxis, DeviceInputType.Trigger, ControllerMappingLibrary.AXIS_10),
             new MixedRealityInteractionMapping(4, "Trigger Touch", AxisType.SingleAxis, DeviceInputType.TriggerTouch, ControllerMappingLibrary.AXIS_10),
             new MixedRealityInteractionMapping(5, "Trigger Press (Select)", AxisType.Digital, DeviceInputType.TriggerPress,  KeyCode.JoystickButton15),

--- a/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityControllerMappingProfile.asset
@@ -1134,7 +1134,7 @@ MonoBehaviour:
         id: 0
         description: None
         axisConstraint: 0
-      keyCode: 346
+      keyCode: 338
       axisCodeX: 
       axisCodeY: 
       invertXAxis: 0
@@ -1360,7 +1360,7 @@ MonoBehaviour:
         id: 0
         description: None
         axisConstraint: 0
-      keyCode: 347
+      keyCode: 339
       axisCodeX: 
       axisCodeY: 
       invertXAxis: 0
@@ -2254,7 +2254,7 @@ MonoBehaviour:
     - id: 2
       description: Grip Press
       axisType: 3
-      inputType: 7
+      inputType: 13
       inputAction:
         id: 7
         description: Grip Press

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        internal bool UpdateInteractionMappings()
+        internal bool UpdateInteractionSettingsFromDefault()
         {
             bool updatedMappings = false;
 

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs
@@ -127,20 +127,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         internal void SetDefaultInteractionMapping(bool overwrite = false)
         {
-            if (Activator.CreateInstance(controllerType, TrackingState.NotTracked, handedness, null, null) is BaseController detectedController
-                && (interactions == null || interactions.Length == 0 || overwrite))
+            if (interactions == null || interactions.Length == 0 || overwrite)
             {
-                switch (handedness)
+                MixedRealityInteractionMapping[] defaultMappings = GetDefaultInteractionMappings();
+
+                if (defaultMappings != null)
                 {
-                    case Handedness.Left:
-                        interactions = detectedController.DefaultLeftHandedInteractions;
-                        break;
-                    case Handedness.Right:
-                        interactions = detectedController.DefaultRightHandedInteractions;
-                        break;
-                    default:
-                        interactions = detectedController.DefaultInteractions;
-                        break;
+                    interactions = defaultMappings;
                 }
             }
         }
@@ -149,22 +142,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             bool updatedMappings = false;
 
-            if (Activator.CreateInstance(controllerType, TrackingState.NotTracked, handedness, null, null) is BaseController detectedController
-                && interactions?.Length > 0)
+            if (interactions?.Length > 0)
             {
-                MixedRealityInteractionMapping[] newDefaultInteractions;
+                MixedRealityInteractionMapping[] newDefaultInteractions = GetDefaultInteractionMappings();
 
-                switch (handedness)
+                if (newDefaultInteractions == null)
                 {
-                    case Handedness.Left:
-                        newDefaultInteractions = detectedController.DefaultLeftHandedInteractions;
-                        break;
-                    case Handedness.Right:
-                        newDefaultInteractions = detectedController.DefaultRightHandedInteractions;
-                        break;
-                    default:
-                        newDefaultInteractions = detectedController.DefaultInteractions;
-                        break;
+                    return updatedMappings;
                 }
 
                 for (int i = 0; i < newDefaultInteractions.Length; i++)
@@ -193,6 +177,24 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             return updatedMappings;
+        }
+
+        private MixedRealityInteractionMapping[] GetDefaultInteractionMappings()
+        {
+            if (Activator.CreateInstance(controllerType, TrackingState.NotTracked, handedness, null, null) is BaseController detectedController)
+            {
+                switch (handedness)
+                {
+                    case Handedness.Left:
+                        return detectedController.DefaultLeftHandedInteractions;
+                    case Handedness.Right:
+                        return detectedController.DefaultRightHandedInteractions;
+                    default:
+                        return detectedController.DefaultInteractions;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -133,6 +133,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         Array.Resize(ref mixedRealityControllerMappingProfiles, idx + 1);
                         mixedRealityControllerMappingProfiles[idx] = newMapping;
                     }
+                    else
+                    {
+                        mixedRealityControllerMappingProfiles[idx].UpdateInteractionMappings();
+                    }
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -135,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                     else
                     {
-                        mixedRealityControllerMappingProfiles[idx].UpdateInteractionMappings();
+                        mixedRealityControllerMappingProfiles[idx].UpdateInteractionSettingsFromDefault();
                     }
                 }
             }


### PR DESCRIPTION
## Overview
It was `TriggerPress` for one hand and `ButtonPress` for the other
#5874 assumes `TriggerPress`, so I standardized on that.

This PR also adds code to allow profiles to double check their default interaction mappings to update when axes / buttons / etc change.