### PR TITLE
Add a CODEOWNERS to the MRTK.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,27 @@
+# This file contains information about the code owners for various
+# files in the MRTK codebase.
+#
+# For more information on CODEOWNERS, see:
+# https://help.github.com/en/articles/about-code-owners
+#
+# For syntax, see:
+# https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+#
+# The intent of this file is to list, on a per-file/per-area basis:
+# 1) Who is the most familiar with an area of code.
+# OR
+# 2) Who can take a first pass at pull request review, or delegate the review
+# to someone else who may be more appropriate.
+#
+# Note that order in this file is EXTREMELY important - the last matching
+# rule will win. This means that the most general rules should be listed
+# first in this file, followed by more specific rules.
+
+# Build / CI Pipeline YAML
+/pipelines/ @wiwei @MenelvagorMilsom @macborow
+
+# Build / CI C#
+/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/ @wiwei @MenelvagorMilsom @macborow
+
+# Build / CI Powershell Scripts
+/scripts/ci/ @wiwei @MenelvagorMilsom @macborow


### PR DESCRIPTION
CODEOWNERS is a handy way to both:
1. Provide insight into who knows most about an area of the code.
2. Automatically assign PRs to individuals based on previously determined ownership (i.e. the CODEOWNERS file)

This reduces the guesswork (i.e. "who should I include on this review?") and is especially interesting for external contributors (i.e. those who don't have rights to assign reviewers)

This change adds the beginnings of a CODEOWNERS file covering the relatively critical Build / CI area. This is an area that must be reviewed by someone who has been working on the Build / CI tooling.