### PR TITLE
Fix failure to populate default profile when using NuGet packages

### DIFF
--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
@@ -51,10 +51,12 @@ namespace Microsoft.MixedReality.Toolkit
             get
             {
 #if UNITY_EDITOR
-                string path;
-                if (EditorProjectUtilities.FindRelativeDirectory(PackageFolder, out path))
+                MixedRealityToolkitModuleType moduleType = MixedRealityToolkitFiles.GetModuleFromPackageFolder(PackageFolder);
+
+                string folder = MixedRealityToolkitFiles.MapModulePath(moduleType);
+                if (!string.IsNullOrWhiteSpace(folder))
                 {
-                    return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(path, DefaultProfilePath));
+                    return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
                 }
 
                 Debug.LogError("Unable to find or load the profile.");

--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityExtensionServiceAttribute.cs
@@ -53,12 +53,24 @@ namespace Microsoft.MixedReality.Toolkit
 #if UNITY_EDITOR
                 MixedRealityToolkitModuleType moduleType = MixedRealityToolkitFiles.GetModuleFromPackageFolder(PackageFolder);
 
-                string folder = MixedRealityToolkitFiles.MapModulePath(moduleType);
-                if (!string.IsNullOrWhiteSpace(folder))
+                if (moduleType != MixedRealityToolkitModuleType.None)
                 {
-                    return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
+                    string folder = MixedRealityToolkitFiles.MapModulePath(moduleType);
+                    if (!string.IsNullOrWhiteSpace(folder))
+                    {
+                        return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
+                    }
+                }
+                else
+                {
+                    string folder;
+                    if (EditorProjectUtilities.FindRelativeDirectory(PackageFolder, out folder))
+                    {
+                        return AssetDatabase.LoadAssetAtPath<BaseMixedRealityProfile>(System.IO.Path.Combine(folder, DefaultProfilePath));
+                    }
                 }
 
+                // If we get here, there was an issue finding the profile.
                 Debug.LogError("Unable to find or load the profile.");
 #endif  
                 return null;

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -380,10 +380,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             int separatorIndex = packageFolder.IndexOf('.');
-            if (separatorIndex != -1 )
-            {
-                packageFolder = (separatorIndex != -1) ? packageFolder.Substring(separatorIndex+1) : "Core";
-            }
+            packageFolder = (separatorIndex != -1) ? packageFolder.Substring(separatorIndex+1) : "Core";
 
             MixedRealityToolkitModuleType moduleType;
             return moduleNameMap.TryGetValue(packageFolder, out moduleType) ? moduleType: MixedRealityToolkitModuleType.None;

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -363,6 +363,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return null;
         }
 
+        /// <summary>
+        /// Finds the module type, if found, from the specified package folder name.
+        /// </summary>
+        /// <param name="packageFolder">The asset folder name (ex: MixedRealityToolkit.Providers)</param>
+        /// <returns>
+        /// <see cref="MixedRealityToolkitModuleType"/> associated with the package folder name. Returns
+        /// MixedRealityToolkitModuleType.None if an appropriate module type could not be found.
+        /// </returns>
         public static MixedRealityToolkitModuleType GetModuleFromPackageFolder(string packageFolder)
         {
             if (!packageFolder.StartsWith("MixedRealityToolkit"))

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -363,6 +363,24 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return null;
         }
 
+        public static MixedRealityToolkitModuleType GetModuleFromPackageFolder(string packageFolder)
+        {
+            if (!packageFolder.StartsWith("MixedRealityToolkit"))
+            {
+                // There are no mappings for folders that do not start with "MixedRealityToolkit"
+                return MixedRealityToolkitModuleType.None;
+            }
+
+            int separatorIndex = packageFolder.IndexOf('.');
+            if (separatorIndex != -1 )
+            {
+                packageFolder = (separatorIndex != -1) ? packageFolder.Substring(separatorIndex+1) : "Core";
+            }
+
+            MixedRealityToolkitModuleType moduleType;
+            return moduleNameMap.TryGetValue(packageFolder, out moduleType) ? moduleType: MixedRealityToolkitModuleType.None;
+        }
+
         private static readonly Dictionary<string, MixedRealityToolkitModuleType> moduleNameMap = new Dictionary<string, MixedRealityToolkitModuleType>()
         {
             { "Core", MixedRealityToolkitModuleType.Core },


### PR DESCRIPTION
## Overview
The root cause of this issue was relying on specific folder names instead of using the MixedRealityToolkitFiles lookup.

The solution was to add a reverse lookup (from folder name to module type) that is called by the extension service attribute to find the correct module. This lookup will return a module type of None if the provided folder name does not begin with "MixedRealityToolkit" as the MRTK does not have mappings for third party folders.

## Verification
In editor...
- using c# files (the source tree / .unitypackage file)
    - Add new spatial awareness observer
    - Select object mesh observer
    - Note the profile is populated with the configured default
- using NuGet packages
    - Add new spatial awareness observer
    - Select object mesh observer
    - Note the profile is populated with the configured default