### PR TITLE
5856 - improve resiliency, use as instead of c-style cast

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -489,7 +489,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             requiresFocusValueCheck = RequiresFocus;
             isGlobalValueCheck = IsGlobal;
 
-            focusingPointers.RemoveAll((focusingPointer) => (Interactable)focusingPointer.FocusTarget != this);
+            focusingPointers.RemoveAll((focusingPointer) => (focusingPointer.FocusTarget as Interactable) != this);
 
             if (focusingPointers.Count == 0)
             {


### PR DESCRIPTION
This change is a fix for #5856, where we have a report of an invalid cast exception occurring if the focus target is not an Interactable.

The change replaces a c-style cast (which can cause invalid cast exceptions) with the c# as keyword (which results in null instead of an invalid cast).

I was unable to reproduce the reported issue, however @asugaya-apx has offered to help verify the fix.

- Fixes: #5856 
