### PR TITLE
Added test to verify that pointer is valid for first frame after hand appears - issue 5053

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var distance = Vector3.Distance(initialPos, linePointerOrigin);
             Assert.LessOrEqual(distance, 0.005f);
 
-            // Check that the angle between the line pointer ray and camera forward does not exceed 50 degrees
+            // Check that the angle between the line pointer ray and camera forward does not exceed 40 degrees
             float angle = Vector3.Angle(linePointer.Rays[0].Direction, Camera.main.transform.forward);
             Assert.LessOrEqual(angle, 40.0f);
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -2,6 +2,14 @@
 // Licensed under the MIT License.
 
 #if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
@@ -12,6 +20,7 @@ using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
+    // Tests to verify pointer state and pointer direction
     class PointerTests 
     {
         [SetUp]

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -1,0 +1,88 @@
+﻿#if !WINDOWS_UWP
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    class PointerTests 
+    {
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+        }
+
+        #region Tests
+
+        /// <summary>
+        /// Tests that right after being instantiated, the pointer's direction 
+        /// is in the same general direction as the forward direction of the camera
+        /// </summary>
+        /// <returns></returns>
+        /// 
+        [UnityTest]
+        public IEnumerator TestPointerDirectionMatchesCameraDirectionFirstFrame()
+        {
+            var inputSystem = PlayModeTestUtilities.GetInputSystem();
+
+            // Raise the hand
+            var rightHand = new TestHand(Handedness.Right);
+
+            //Position 1 show hand
+            Vector3 initialPos = new Vector3(0.01f, 0.1f, 0.5f);
+            yield return rightHand.Show(initialPos);
+
+            //return first hand controller that is right and source type hand
+            var handController = inputSystem.DetectedControllers.First(x => x.ControllerHandedness == Utilities.Handedness.Right && x.InputSource.SourceType == InputSourceType.Hand);
+            Assert.IsNotNull(handController);
+
+            // Get the line pointer from the hand controller
+            var linePointer = handController.InputSource.Pointers.First(x => x is LinePointer);
+            Assert.IsNotNull(linePointer);
+
+            // Take dot product of camera forward and line pointer
+            float dot = Vector3.Dot(linePointer.Rays[0].Direction, Camera.main.transform.forward);
+
+            // Making sure the pointer is pointing in the same general direction as the camera
+            // A dot of 1 means the pointer and camera forward point in the exact same direction 
+            // but greater than 0.5 is same general direction
+            Assert.GreaterOrEqual(dot, 0.5f);
+
+            // Position 2
+            yield return new WaitForSeconds(1);
+            yield return rightHand.MoveTo(new Vector3(-1.0f, 0, 2.0f));
+
+            float dot2 = Vector3.Dot(linePointer.Rays[0].Direction, Camera.main.transform.forward);
+            Assert.GreaterOrEqual(dot2, 0.5f);
+
+            // Position 3 
+            yield return new WaitForSeconds(1);
+            yield return rightHand.MoveTo(new Vector3(1.0f, -1.0f, 2.0f));
+
+            float dot3 = Vector3.Dot(linePointer.Rays[0].Direction, Camera.main.transform.forward);
+            Assert.GreaterOrEqual(dot3, 0.5f);
+
+            // Position 4 
+            yield return new WaitForSeconds(1);
+            yield return rightHand.MoveTo(new Vector3(1.0f, 1.0f, 2.0f));
+
+            float dot4 = Vector3.Dot(linePointer.Rays[0].Direction, Camera.main.transform.forward);
+            Assert.GreaterOrEqual(dot4, 0.5f);
+        }
+        #endregion
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a91412168127ff943b9578939f970ce5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
This PR addresses issue #5053.
This test checks whether the pointer is valid for the first frame.  It also checks if the pointer direction is facing the same general direction as camera forward.

[Video of Pointer Test](https://youtu.be/FRWSFsgt6PI)

## Changes
- Added PointerTests.cs to Assets/MixedRealityToolkit.Tests/PlayModeTests/

## Verification
- In Unity: Window -> General -> TestRunner
- Select PlayMode at the top of the window
- Select PointerTests and then Run Selected

<img width="354" alt="issue_5053_RunTests" src="https://user-images.githubusercontent.com/53493796/64643783-04dba680-d3c6-11e9-8a3d-9748ebba4836.png">

