### PR TITLE
Scale Should Not Influence Smooth Normals

### DIFF
--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -682,6 +682,7 @@ Shader "Mixed Reality Toolkit/Standard"
 #else
                 o.scale.z = length(mul(unity_ObjectToWorld, float4(0.0, 0.0, 1.0, 0.0)));
 #endif
+#if !defined(_VERTEX_EXTRUSION_SMOOTH_NORMALS)
                 // uv3.y will contain a negative value when rendered by a UGUI and ScaleMeshEffect.
                 if (v.uv3.y < 0.0)
                 {
@@ -689,6 +690,7 @@ Shader "Mixed Reality Toolkit/Standard"
                     o.scale.y *= v.uv2.y;
                     o.scale.z *= v.uv3.x;
                 }
+#endif
 #endif
 
                 fixed3 localNormal = v.normal;


### PR DESCRIPTION
## Overview
A recent change broke mesh outling, this fix addresses the issue by making sure scale does nt influence smooth normal.

Before:
![image](https://user-images.githubusercontent.com/13305729/64651141-a4ecfc00-d3d5-11e9-8336-af987fc4e451.png)

After:
![image](https://user-images.githubusercontent.com/13305729/64651175-b7673580-d3d5-11e9-918e-7b49c73d6008.png)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5926

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
