### PR TITLE
Update the AsyncCoroutineRunner to be properly rooted for DontDestroyOnLoad

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f12985a06ee17c46a0ff0cb18e47b37
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities/Async.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities/Async.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 548c18b15f8491a47806092d23993541
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities/Async/AsyncCoroutineRunnerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities/Async/AsyncCoroutineRunnerTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using UnityEngine.TestTools;
+using UnityEngine;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using System.Collections;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class AsyncCoroutineRunnerTests : BasePlayModeTests
+    {
+        /// <summary>
+        /// Validates that the AsyncCoroutineRunner is automatically
+        /// moved to the root to ensure that it has proper multi-scene lifetime behavior.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestNonRootParenting()
+        {
+            // Set up the AsyncCoroutineRunner to be parented under the MixedRealityWorkspace,
+            // to validate that the runner will correctly unparent it.
+            GameObject asyncCoroutineRunner = new GameObject("AsyncCoroutineRunner");
+            asyncCoroutineRunner.AddComponent<AsyncCoroutineRunner>();
+            GameObject mixedRealityPlayspace = GameObject.Find("MixedRealityPlayspace");
+            asyncCoroutineRunner.transform.parent = mixedRealityPlayspace.transform;
+
+            // Calling AsyncCoroutineRunner.Instance will cause the runner to move
+            // the to root.
+            Assert.IsNotNull(AsyncCoroutineRunner.Instance);
+            Assert.IsNull(asyncCoroutineRunner.transform.parent);
+            yield return null;
+        }
+    }
+}
+
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities/Async/AsyncCoroutineRunnerTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Core/Utilities/Async/AsyncCoroutineRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffa47d2b979deea45b48eea9e09e4f35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Microsoft.MixedReality.Toolkit.Tests.PlayModeTests.asmdef
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Microsoft.MixedReality.Toolkit.Tests.PlayModeTests.asmdef
@@ -10,7 +10,8 @@
         "Microsoft.MixedReality.Toolkit.Services.InputSimulation",
         "Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor",
         "Microsoft.MixedReality.Toolkit.Tests",
-        "Unity.TextMeshPro"
+        "Unity.TextMeshPro",
+        "Microsoft.MixedReality.Toolkit.Async"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Assets/MixedRealityToolkit/Utilities/Async/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Async/Internal/AsyncCoroutineRunner.cs
@@ -29,7 +29,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
-    /// This Async Coroutine Runner is just a object to
+    /// This Async Coroutine Runner is just an object to
     /// ensure that coroutines run properly with async/await.
     /// </summary>
     /// <remarks>

--- a/Assets/MixedRealityToolkit/Utilities/Async/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Async/Internal/AsyncCoroutineRunner.cs
@@ -22,14 +22,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
+[assembly: InternalsVisibleTo("Microsoft.MixedReality.Toolkit.Tests.PlayModeTests")]
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
-    /// This Async Coroutine Runner is just a helper object to
+    /// This Async Coroutine Runner is just a object to
     /// ensure that coroutines run properly with async/await.
     /// </summary>
+    /// <remarks>
+    /// The object that this MonoBehavior is attached to must be a root object in the
+    /// scene, as it will be marked as DontDestroyOnLoad (so that when scenes are changed,
+    /// it will persist instead of being destroyed). The runner will force itself to
+    /// the root of the scene if it's rooted elsewhere.
+    /// </remarks>
     internal sealed class AsyncCoroutineRunner : MonoBehaviour
     {
         private static AsyncCoroutineRunner instance;
@@ -75,10 +83,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 }
 
                 instance.gameObject.hideFlags = HideFlags.None;
-#if !UNITY_EDITOR
-                DontDestroyOnLoad(instance);
-#endif
 
+                // AsyncCoroutineRunner must be at the root so that we can call DontDestroyOnLoad on it.
+                // This is ultimately to ensure that it persists across scene loads/unloads.
+                if (instance.transform.parent != null)
+                {
+                    Debug.LogWarning($"AsyncCoroutineRunner was found as a child of another GameObject {instance.transform.parent}, " +
+                        "it must be a root object in the scene. Moving the AsyncCoroutineRunner to the root.");
+                    instance.transform.parent = null;
+                }
+
+                DontDestroyOnLoad(instance);
                 return instance;
             }
         }


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5900

DontDestroyOnLoad is only valid to be called on an object that is at the root (i.e. it has a null parent). It's possible for the AsyncCoroutineRunner to have been attached to the mixed reality playspace (i.e. if the user manually created one under the playspace or under any other object).

This updates the code to do a one-time at runtime fixup of its location to make sure that it can properly be DontDestroyOnLoad-ed.