### PR TITLE
Fix the HandConstraint solver to only consider controllers with handedness != None to be valid targets.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -503,6 +503,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             return false;
         }
 
+        /// <summary>
+        /// Returns true if the given controller is a valid target for this solver.
+        /// </summary>
+        /// <remarks>
+        /// Certain types of controllers (i.e. Xbox controllers) do not contain a handedness
+        /// and should not trigger the HandConstraint to show its corresponding UX.
+        /// </remarks>
+        private static bool IsApplicableController(IMixedRealityController controller)
+        {
+            return controller.ControllerHandedness != Handedness.None;
+        }
+
         #region MonoBehaviour Implementation
 
         protected override void Awake()
@@ -540,7 +552,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             var hand = eventData.Controller;
 
-            if (hand != null && !handStack.Contains(hand))
+            if (hand != null && IsApplicableController(hand) && !handStack.Contains(hand))
             {
                 if (handStack.Count == 0)
                 {
@@ -556,7 +568,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             var hand = eventData.Controller;
 
-            if (hand != null)
+            if (hand != null && IsApplicableController(hand))
             {
                 handStack.Remove(hand);
 


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5749

The Xbox controller is an IMixedRealityController, that, when plugged in, will trigger the hand menu because it's considered a valid target for the hand constraint solver.

This change makes it so that the solver will filter out any controllers that don't have a handedness specified (i.e. they should be left/right/any/both)