### PR TITLE
Fix build tools generating malformed scripting symbols

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildInfoExtensions.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildInfoExtensions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// <param name="symbolsToRemove">The string collection to remove.</param>
         public static void RemoveSymbols(this IBuildInfo buildInfo, IEnumerable<string> symbolsToRemove)
         {
-            var toKeep = buildInfo.BuildSymbols.Split(';').Except(symbolsToRemove).ToString();
+            string[] toKeep = buildInfo.BuildSymbols.Split(';').Except(symbolsToRemove).ToArray();
 
             if (!toKeep.Any())
             {
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 UnityPlayerBuildTools.BuildSymbolDebug,
                 UnityPlayerBuildTools.BuildSymbolRelease,
                 UnityPlayerBuildTools.BuildSymbolMaster
-            }).ToString());
+            }).ToArray());
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

Due to the changes in #5897, the code to inject the configuration scripting symbols is now properly invoked. Previously it wasn't invoked at all, because the `BuildInfo.Configuration` was never set. However there are some type conversion errors in the code, resulting in scripting symbols along the lines of `debug;System.Linq.Enumerable+<ExceptIterator>d__57'1[System.String]`. Those type errors are fixed in this commit (a good example of `var` hiding a compile time error).

Related to this issue, what is the purpose of the `debug', 'release' and 'master' symbols injected in the first place? Those were never properly injected before and as far as i can tell everything ran fine. So are they obsolete? Maybe this question can be discussed in a separate issue, if there is no definite answer.

## Verification

Checkout this branch, open a project with custom scripting symbols set in the Unity player settings. Build the Unity player using the MRTK build window. Check the scripting symbols in the Unity player settings. 
