### PR TITLE
Cache spatialInteractionManager on first use, not in constructor

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -34,12 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public WindowsMixedRealityArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
-#if WINDOWS_UWP
-            UnityEngine.WSA.Application.InvokeOnUIThread(() =>
-            {
-                spatialInteractionManager = SpatialInteractionManager.GetForCurrentView();
-            }, true);
-#endif // WINDOWS_UWP
         }
 
         /// <summary>
@@ -103,6 +97,22 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private readonly HandRay handRay = new HandRay();
 
 #if WINDOWS_UWP
+        private SpatialInteractionManager SpatialInteractionManager
+        {
+            get
+            {
+                if (spatialInteractionManager == null)
+                {
+                    UnityEngine.WSA.Application.InvokeOnUIThread(() =>
+                    {
+                        spatialInteractionManager = SpatialInteractionManager.GetForCurrentView();
+                    }, true);
+                }
+
+                return spatialInteractionManager;
+            }
+        }
+
         private SpatialInteractionManager spatialInteractionManager = null;
         private HandMeshObserver handMeshObserver = null;
         private int[] handMeshTriangleIndices = null;
@@ -202,7 +212,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
 
             PerceptionTimestamp perceptionTimestamp = PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now);
-            IReadOnlyList<SpatialInteractionSourceState> sources = spatialInteractionManager?.GetDetectedSourcesAtTimestamp(perceptionTimestamp);
+            IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(perceptionTimestamp);
             foreach (SpatialInteractionSourceState sourceState in sources)
             {
                 if (sourceState.Source.Id.Equals(interactionSourceState.source.id))

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         new[] { Handedness.Left, Handedness.Right })]
     public class WindowsMixedRealityArticulatedHand : BaseWindowsMixedRealitySource, IMixedRealityHand
     {
-    /// <summary>
+        /// <summary>
         /// Constructor.
         /// </summary>
         public WindowsMixedRealityArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)


### PR DESCRIPTION
## Overview
(This is future proofing for when these methods are callable in the Editor)

Due to the possibility of construction of this type at edit time (which is itself potentially a different issue):
https://github.com/microsoft/MixedRealityToolkit-Unity/blob/89fb1f941856963b0012c6755ddaf61a94d4b999/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs#L131

This code is not valid at edit-time, only runtime. This moves caching the interaction manager from the constructor to first-use.
