### PR TITLE
Add translation constraints to the Manipulation Handler

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Assets.MixedRealityToolkit.Definitions;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -147,6 +148,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get => constraintOnMovement;
             set => constraintOnMovement = value;
+        }
+
+        [EnumFlags]
+        [SerializeField]
+        [Tooltip("Identifies the set of axes that translation is allowed on. Defaults to every axis. " +
+            "Only used if 'Constraint on Movement' is set to 'TranslationAxes'")]
+        private AxisPreference translationAxes = AxisPreference.X | AxisPreference.Y | AxisPreference.Z;
+
+        /// <summary>
+        /// Identifies the set of axes that translation is allowed on. Defaults to every axis.
+        /// Only used if 'Constraint on Movement' is set to 'TranslationAxes'
+        /// </summary>
+        public AxisPreference TranslationAxes
+        {
+            get => translationAxes;
+            set => translationAxes = value;
         }
 
         [Header("Smoothing")]
@@ -593,7 +610,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if ((currentState & State.Moving) > 0)
             {
                 MixedRealityPose pose = GetAveragePointerPose();
-                targetPosition = moveLogic.Update(pose, targetRotationTwoHands, targetScale, IsNearManipulation(), true, constraintOnMovement);
+                targetPosition = moveLogic.Update(pose, targetRotationTwoHands, targetScale, IsNearManipulation(), true, constraintOnMovement, translationAxes);
             }
 
             float lerpAmount = GetLerpAmount();
@@ -672,7 +689,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             targetRotation = ApplyConstraints(targetRotation);
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
-            Vector3 targetPosition = moveLogic.Update(pointerPose, targetRotation, hostTransform.localScale, IsNearManipulation(), rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter, constraintOnMovement);
+            Vector3 targetPosition = moveLogic.Update(
+                pointerPose, targetRotation, hostTransform.localScale, IsNearManipulation(),
+                rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter, constraintOnMovement, translationAxes);
 
             float lerpAmount = GetLerpAmount();
             Quaternion smoothedRotation = Quaternion.Lerp(hostTransform.rotation, targetRotation, lerpAmount);

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Assets.MixedRealityToolkit.Definitions;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using System;
 using System.Collections.Generic;
+using Assets.MixedRealityToolkit.Definitions;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
@@ -970,6 +971,232 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Restore the input simulation profile
             iss.HandSimulationMode = oldHandSimMode;
             yield return null;
+        }
+
+        /// <summary>
+        /// Verifies that the movement is constrained to the X-axis only, near and
+        /// far manipulation will be restricted to the X-axis
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerMoveTranslationAxesXOnly()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+            GameObject testObject = CreateTestCube();
+            ManipulationHandler manipHandler = testObject.GetComponent<ManipulationHandler>();
+            manipHandler.TranslationAxes = AxisPreference.X;
+
+            // First test near interaction.
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(new Vector3(0, 0, 1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the X axis only, X should be roughly ~1
+            // because it was at zero before, and Y and Z should be unchanged (0 and 1
+            // respectively).
+            AssertHelpers.AlmostEquals(new Vector3(1, 0, 1), testObject.transform.position, .1f);
+
+            // Repeat the same test with far interaction.
+            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            yield return hand.Show(new Vector3(0.04f, -0.18f, 0.3f)); // Grabs the lower right corner of the cube.
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the X axis only, X should be roughly ~3.1f due
+            // magnification of movement based on hand location and far manipulation.
+            // Y and Z should be unchanged (0 and 1 respectively).
+            AssertHelpers.AlmostEquals(new Vector3(3.1f, 0, 1), testObject.transform.position, .1f);
+
+            GameObject.Destroy(testObject);
+        }
+
+        /// <summary>
+        /// Verifies that the movement is constrained to the Y-axis only, near and
+        /// far manipulation will be restricted to the Y-axis
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerMoveTranslationAxesYOnly()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+            GameObject testObject = CreateTestCube();
+            ManipulationHandler manipHandler = testObject.GetComponent<ManipulationHandler>();
+            manipHandler.TranslationAxes = AxisPreference.Y;
+
+            // First test near interaction.
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(new Vector3(0, 0, 1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the Y axis only, Y should be roughly ~1
+            // because it was at zero before, and X and Z should be unchanged (0 and 1
+            // respectively).
+            AssertHelpers.AlmostEquals(new Vector3(0, 1, 1), testObject.transform.position, .1f);
+
+            // Repeat the same test with far interaction.
+            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            yield return hand.Show(new Vector3(0.04f, -0.18f, 0.3f)); // Grabs the lower right corner of the cube.
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the Y axis only, Y should be roughly ~3.1f due
+            // magnification of movement based on hand location and far manipulation.
+            // X and Z should be unchanged (0 and 1 respectively).
+            AssertHelpers.AlmostEquals(new Vector3(0, 3.1f, 1), testObject.transform.position, .1f);
+
+            GameObject.Destroy(testObject);
+        }
+
+        /// <summary>
+        /// Verifies that the movement is constrained to the Z-axis only, near and
+        /// far manipulation will be restricted to the Z-axis
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerMoveTranslationAxesZOnly()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+            GameObject testObject = CreateTestCube();
+            ManipulationHandler manipHandler = testObject.GetComponent<ManipulationHandler>();
+            manipHandler.TranslationAxes = AxisPreference.Z;
+
+            // First test near interaction.
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(new Vector3(0, 0, 1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the Z axis only, Z should be roughly ~2.2
+            // because it was at 1 before, and Y and Z should be unchanged (both zero).
+            AssertHelpers.AlmostEquals(new Vector3(0, 0, 2.2f), testObject.transform.position, .1f);
+
+            // Repeat the same test with far interaction.
+            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            yield return hand.Show(new Vector3(0.04f, -0.18f, 0.3f)); // Grabs the lower right corner of the cube.
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the Z axis only, Z should be roughly ~3.1f due
+            // magnification of movement based on hand location and far manipulation.
+            // X and Y should be unchanged (both zero).
+            AssertHelpers.AlmostEquals(new Vector3(0, 0, 3.6f), testObject.transform.position, .1f);
+
+            GameObject.Destroy(testObject);
+        }
+
+        /// <summary>
+        /// Verifies that the movement is constrained to the X and Y axes only, near and
+        /// far manipulation will be restricted to the X and Y axes
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerMoveTranslationAxesXYOnly()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+            GameObject testObject = CreateTestCube();
+            ManipulationHandler manipHandler = testObject.GetComponent<ManipulationHandler>();
+            manipHandler.TranslationAxes = AxisPreference.X | AxisPreference.Y;
+
+            // First test near interaction.
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(new Vector3(0, 0, 1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the X and Y axes, X and Y should be roughly ~1
+            // because it was at zero before, and Z should be unchanged (it was 1 before).
+            AssertHelpers.AlmostEquals(new Vector3(1, 1, 1), testObject.transform.position, .1f);
+
+            // Repeat the same test with far interaction.
+            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            yield return hand.Show(new Vector3(0.04f, -0.18f, 0.3f)); // Grabs the lower right corner of the cube.
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.Move(new Vector3(1.1f, 1.1f, 1.1f));
+            yield return null;
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Since this is restricted to the X and Y axes, X and Y should be roughly ~3.1f due
+            // magnification of movement based on hand location and far manipulation.
+            // Z should be unchanged.
+            AssertHelpers.AlmostEquals(new Vector3(3.1f, 3.1f, 1), testObject.transform.position, .1f);
+
+            GameObject.Destroy(testObject);
+        }
+
+        private static GameObject CreateTestCube()
+        {
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            testObject.transform.position = new Vector3(0f, 0f, 1f);
+            testObject.AddComponent<NearInteractionGrabbable>();
+
+            var manipHandler = testObject.AddComponent<ManipulationHandler>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+            manipHandler.ConstraintOnMovement = MovementConstraintType.TranslationAxes;
+
+            return testObject;
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -19,7 +19,6 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using System;
 using System.Collections.Generic;
-using Assets.MixedRealityToolkit.Definitions;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utilities.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 798c6a312c082b94eb4db2543eb49e93
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utilities/AssertHelpers.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utilities/AssertHelpers.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    /// <summary>
+    /// Test helpers that help with assertions of non-trivial object types.
+    /// </summary>
+    public class AssertHelpers
+    {
+        /// <summary>
+        /// Validates that the given Vector3s are almost equal, in particular that the corresponding
+        /// X, Y, and Z values of the two vectors differ by at most the specified tolerance (which
+        /// defaults to .02)
+        /// </summary>
+        /// <remarks>
+        /// Note that the tolerance is not based on the total summed delta - if any of the individual
+        /// parts exceed the tolerance this assert will fail the test.
+        /// </remarks>
+        public static void AlmostEquals(Vector3 expected, Vector3 actual, float tolerance = 0.02f)
+        {
+            if (Math.Abs(expected.x - actual.x) > tolerance ||
+                Math.Abs(expected.y - actual.y) > tolerance ||
+                Math.Abs(expected.z - actual.z) > tolerance)
+            {
+                Assert.Fail($"Actual Vector3 value: {actual} differs from expected Vector3 value: {expected}");
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utilities/AssertHelpers.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utilities/AssertHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1513b1e55e8fb86478918ad4b1bb806c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/AxisPreference.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/AxisPreference.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Assets.MixedRealityToolkit.Definitions
+namespace Microsoft.MixedReality.Toolkit.Utilities
 {
     /// <summary>
     /// Defines the X, Y, and Z Axes as flag-based preferences.

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/AxisPreference.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/AxisPreference.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Assets.MixedRealityToolkit.Definitions
+{
+    /// <summary>
+    /// Defines the X, Y, and Z Axes as flag-based preferences.
+    /// </summary>
+    /// <remarks>
+    /// Useful in scenarios where constraints need to be applied to specific
+    /// combinations of axes.
+    /// Note that the mechanics of whether or not these values are used as
+    /// a constraint (the presence of the X flag means X is not immobile)
+    /// or a freedom (the presence of the X flag means X is the only free axis)
+    /// is up to the caller/user of this enum.
+    /// </remarks>
+    public enum AxisPreference
+    {
+        X = 1 << 0,
+        Y = 1 << 1,
+        Z = 1 << 2,
+    }
+}

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/AxisPreference.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/AxisPreference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 833e8728c955e1044a66bf379724afde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/MovementConstraintType.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/MovementConstraintType.cs
@@ -6,6 +6,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     public enum MovementConstraintType
     {
         None,
-        FixDistanceFromHead
+        FixDistanceFromHead,
+
+        /// <summary>
+        /// This constraint type indicates that the manipulation handler's
+        /// "Translation Axes" preferences will be used to restrict the set of axes
+        /// that translation/movement can occur on.
+        /// </summary>
+        TranslationAxes,
     }
 }

--- a/Documentation/README_ManipulationHandler.md
+++ b/Documentation/README_ManipulationHandler.md
@@ -78,6 +78,15 @@ Specifies on which axis the object will rotate when interacted with.
 **Constraints on Movement**
 * *None*
 * *Fix distance from head*
+* *Translation Axes* - If this option is selected, movement will be constrained to the axes specified in "Translation Axes"
+
+**Translation Axes**
+This will only be used if "Constraints on Movement" is set to "Translation Axes." These axes indicate
+the Axes on which translation are allowed. By default, this is set to "everything" (X, Y, and Z) indicating
+that movement is allowed to happen on all axes.
+
+Changing this value such that only X is selected, for example, will restrict motion to the X-axis. Changing the value
+such that both X and Y are selected will restrict motion to the XY plane.
 
 **Smoothing Active**
 Specifies whether smoothing is active.


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4154

This change introduces movement constraints on the manipulation handler, so that objects can be configured to only move in a specific axis or plane.

This is implemented with a "permissive" model (i.e. an object can be configured to have free movement on certain axis). The set of free axes are configured via a flag-based parameter (Translation Axes).

Adds some test coverage (not fully exhaustive, just checking the main cases i.e. each axis and a single plane)

Other thoughts:
It's kinda weird that you can select X, Y, and Z at the same time (basically no-oping the constraints). I wanted to add a more specific warning here but without this PR in (https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5955/files) it would involve adding a custom inspector as well. First it's not that big a deal, but also if we want to deal with it once the other PR is in that would be fairly easy (just add a warning block to the inspector code + conditional showing of the parameter)

I opted to not bake this into ConstraintOnMovement because I didn't want to explode a bunch of different options (i.e. X only, Y only, Z only, XY only, YZ only, XZ only), and I think that this general type of "Axis Constraint" exists elsewhere (it does if we look at rotation). I opted to name this somewhat generically so that it can be used in other scenarios that have axis-flag type behaviors.