### PR TITLE
added check for bounds override changed to active part of bounding box update

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1188,7 +1188,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     UpdateBounds();
                     UpdateRigHandles();
                 }
-                else if (!isChildOfTarget && Target.transform.hasChanged)
+                else if ((!isChildOfTarget && Target.transform.hasChanged)
+                    || boundsOverride != null && HasBoundsOverrideChanged())
                 {
                     UpdateBounds();
                     UpdateRigHandles();
@@ -1206,11 +1207,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         HandleProximityScaling();
                     }
                 }
-            }
-            else if (boundsOverride != null && HasBoundsOverrideChanged())
-            {
-                UpdateBounds();
-                UpdateRigHandles();
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1208,6 +1208,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                 }
             }
+            else if (boundsOverride != null && HasBoundsOverrideChanged())
+            {
+                UpdateBounds();
+                UpdateRigHandles();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
Bounds override transform changes were not taken into account in update of bounding box when bounding box was active.

not checking the bounds override changed while bounding box is active will result in the box not adjusting on bounds override transform changes.


## Changes
- Fixes: #5414 


## Verification
tested in bounding box runtime example scene
run bounding box tests