### PR TITLE
Fix proximity effect 

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -67,8 +67,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     indexKnucklePosition = transform.position;
                 }
-
-                if (nearPointer.IsNearObject)
+                
+                if (!nearPointer.IsInteractionEnabled)
+                {
+                    // If the pointer is disabled, make sure to turn the ring cursor off
+                    // but still want show the proximity effect on bounding content
+                    if (indexFingerRingRenderer != null)
+                    {
+                        UpdateVisuals(indexFingerRingRenderer, 1, false);
+                    }
+                }
+                else if (nearPointer.IsNearObject)
                 {
                     // If the pointer is near an object translate the primary ring to the index finger tip and rotate to surface normal if close.
                     // The secondary ring should be hidden.

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -209,9 +209,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnPostSceneQuery();
 
-            // This ensures that we actually hide the finger cursor if the poke pointer is off
-            BaseCursor?.SetVisibility(IsInteractionEnabled);
-
             if (!IsActive)
             {
                 return;


### PR DESCRIPTION
## Overview
In #5920 I modified PokePointer to disable the finger cursor when poke pointer was not enabled (IsInteractionEnabled == false). Turns out, the finger cursor drives the proximity effect, so disabling it causes not only the finger cursor to not show up, but for all proximity effects to stop working. 

A longer term fix would be to ensure that the proximity effect is running even when poke interactions are off, or when the poke pointer is not present. A short term fix is just to always have the finger cursor on, and to just turn off the visual if interaction is not enabled.

## Changes
- Fixes: #5962


## Verification
Note: when hand is near a grabbable, the cursor is still off. In the shell the cursor is on even when you are near a grabbable but not a touchable. I think this is a bug in the shell, since the finger cursor is meant to communicate "you're near a touchable thing"

> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
