### PR TITLE
Add back a parameterless constructor to DefaultPointerMediator

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -187,36 +187,32 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 unassignedPointer.IsActive = true;
             }
-
         }
 
         private void ApplyCustomPointerBehaviors()
         {
             if (pointerPreferences != null)
             {
-                if (CoreServices.InputSystem.FocusProvider is FocusProvider focusProvider)
-                {
-                    Action<IMixedRealityPointer, PointerBehavior> setPointerState =
-                        (ptr, behavior) =>
-                        {
-                            if (behavior == PointerBehavior.Default)
-                            {
-                                return;
-                            }
-
-                            bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
-                            ptr.IsActive = isPointerOn;
-                            if (ptr is GenericPointer genericPtr)
-                            {
-                                genericPtr.IsInteractionEnabled = isPointerOn;
-                            }
-                            unassignedPointers.Remove(ptr);
-                        };
-
-                    foreach (IMixedRealityPointer pointer in allPointers)
+                Action<IMixedRealityPointer, PointerBehavior> setPointerState =
+                    (ptr, behavior) =>
                     {
-                        setPointerState(pointer, pointerPreferences.GetPointerBehavior(pointer));
-                    }
+                        if (behavior == PointerBehavior.Default)
+                        {
+                            return;
+                        }
+
+                        bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
+                        ptr.IsActive = isPointerOn;
+                        if (ptr is GenericPointer genericPtr)
+                        {
+                            genericPtr.IsInteractionEnabled = isPointerOn;
+                        }
+                        unassignedPointers.Remove(ptr);
+                    };
+
+                foreach (IMixedRealityPointer pointer in allPointers)
+                {
+                    setPointerState(pointer, pointerPreferences.GetPointerBehavior(pointer));
                 }
             }
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -17,6 +17,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected readonly Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>> pointerByInputSourceParent = new Dictionary<IMixedRealityInputSource, HashSet<IMixedRealityPointer>>();
 
         private IPointerPreferences pointerPreferences;
+
+        public DefaultPointerMediator()
+            : this(null)
+        {
+        }
+
         public DefaultPointerMediator(IPointerPreferences pointerPrefs)
         {
             this.pointerPreferences = pointerPrefs;
@@ -182,27 +188,31 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void ApplyCustomPointerBehaviors()
         {
-            if (CoreServices.InputSystem.FocusProvider is FocusProvider focusProvider)
+            if (this.pointerPreferences != null)
             {
-                Action<IMixedRealityPointer, PointerBehavior> setPointerState =
-                    (ptr, behavior) =>
-                    {
-                        if (behavior == PointerBehavior.Default)
-                        {
-                            return;
-                        }
-
-                        bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
-                        ptr.IsActive = isPointerOn;
-                        if (ptr is GenericPointer genericPtr)
-                        {
-                            genericPtr.IsInteractionEnabled = isPointerOn;
-                        }
-                        unassignedPointers.Remove(ptr);
-                    };
-                foreach (IMixedRealityPointer pointer in allPointers)
+                if (CoreServices.InputSystem.FocusProvider is FocusProvider focusProvider)
                 {
-                    setPointerState(pointer, pointerPreferences.GetPointerBehavior(pointer));
+                    Action<IMixedRealityPointer, PointerBehavior> setPointerState =
+                        (ptr, behavior) =>
+                        {
+                            if (behavior == PointerBehavior.Default)
+                            {
+                                return;
+                            }
+
+                            bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
+                            ptr.IsActive = isPointerOn;
+                            if (ptr is GenericPointer genericPtr)
+                            {
+                                genericPtr.IsInteractionEnabled = isPointerOn;
+                            }
+                            unassignedPointers.Remove(ptr);
+                        };
+
+                    foreach (IMixedRealityPointer pointer in allPointers)
+                    {
+                        setPointerState(pointer, pointerPreferences.GetPointerBehavior(pointer));
+                    }
                 }
             }
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 
@@ -25,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public DefaultPointerMediator(IPointerPreferences pointerPrefs)
         {
-            this.pointerPreferences = pointerPrefs;
+            pointerPreferences = pointerPrefs;
         }
 
         public virtual void RegisterPointers(IMixedRealityPointer[] pointers)
@@ -188,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void ApplyCustomPointerBehaviors()
         {
-            if (this.pointerPreferences != null)
+            if (pointerPreferences != null)
             {
                 if (CoreServices.InputSystem.FocusProvider is FocusProvider focusProvider)
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -6,6 +6,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
+    /// <summary>
+    /// The default implementation for pointer mediation in MRTK which is responsible for
+    /// determining which pointers are active based on the state of all pointers.
+    /// For example, one of the key things this class does is disable far pointers when a near pointer is close to an object.
+    /// </summary>
     public class DefaultPointerMediator : IMixedRealityPointerMediator
     {
         protected readonly HashSet<IMixedRealityPointer> allPointers = new HashSet<IMixedRealityPointer>();


### PR DESCRIPTION
## Overview
A constructor was recently added to DefaultPointerMediator.  This removed the implicit parameterless constructor, which was a breaking change that affected one of my projects.

## Changes
- Fixes: #5989 .
- Adds an explicit parameterless constructor which passes null.  Also then added null checks where appropriate.