### PR TITLE
SpatialMesh Editor cleanup fix

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -427,11 +427,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         {
             if (Application.isPlaying)
             {
-                // Cleanup the scene objects are managing
-                if (observedObjectParent != null)
-                {
-                    observedObjectParent.transform.DetachChildren();
-                }
 
                 foreach (SpatialAwarenessMeshObject meshObject in meshes.Values)
                 {

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -81,7 +81,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 
             if (destroyGameObject)
             {
+#if UNITY_EDITOR
+                UnityEngine.Object.DestroyImmediate(meshObject.GameObject);
+#else
                 UnityEngine.Object.Destroy(meshObject.GameObject);
+#endif
                 meshObject.GameObject = null;
                 return;
             }

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -81,11 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 
             if (destroyGameObject)
             {
-#if UNITY_EDITOR
-                UnityEngine.Object.DestroyImmediate(meshObject.GameObject);
-#else
                 UnityEngine.Object.Destroy(meshObject.GameObject);
-#endif
                 meshObject.GameObject = null;
                 return;
             }


### PR DESCRIPTION
## Overview

The problem is that WindowsMixedRealitySpatialMeshObserver's CleanupObservedObjects detaches all children from observedObjectParent, if it exists and then destroys all the gameobjects using regular Destroy. This mix causes the errors and since the Editor should use DestroyImmediate anyways, this fixes it for the case of holographic remoting the Hololens and destroying generated meshes.

## Changes
- Fixes: #4208