### PR TITLE
Changed MixedRealityRaycastHit to use collider transform instead of RaycastHit.transform

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
@@ -220,7 +220,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="target">The gameObject whose bounding box is desired</param>
         /// <param name="boundsPoints">the array of 8 points that will be filled</param>
-        /// <param name="ignoreLayers">a LayerMask variable</param>
         public static void GetUntransformedCornersFromObject(BoxCollider targetBounds, List<Vector3> boundsPoints)
         {
             Bounds cloneBounds = new Bounds(targetBounds.center, targetBounds.size);

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/BoundingBox/BoundingBoxInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/BoundingBox/BoundingBoxInspector.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEditor;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
@@ -17,6 +19,27 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             if (target != null)
             {
+                // check if rigidbody is attached - if so show warning in case input profile is not configured for individual collider raycast
+                BoundingBox boundingBox = (BoundingBox)target;
+                Rigidbody rigidBody = boundingBox.GetComponent<Rigidbody>();
+
+                if (rigidBody != null)
+                {
+                    MixedRealityInputSystemProfile profile = CoreServices.InputSystem?.InputSystemProfile;
+                    if (profile != null && profile.FocusIndividualCompoundCollider == false)
+                    {
+                        EditorGUILayout.Space();
+                        // show warning and button to reconfigure profile
+                        EditorGUILayout.HelpBox($"When using Bounding Box in combination with Rigidbody 'Focus Individual Compound Collider' must be enabled in Input Profile.", UnityEditor.MessageType.Warning);
+                        if (GUILayout.Button($"Enable 'Focus Individual Compound Collider in Input Profile'"))
+                        {
+                            profile.FocusIndividualCompoundCollider = true;
+                        }
+
+                        EditorGUILayout.Space();
+                    }
+                }
+
                 InspectorUIUtility.RenderHelpURL(target.GetType());
             }
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/BoundingBox/BoundingBoxInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/BoundingBox/BoundingBoxInspector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         EditorGUILayout.Space();
                         // show warning and button to reconfigure profile
                         EditorGUILayout.HelpBox($"When using Bounding Box in combination with Rigidbody 'Focus Individual Compound Collider' must be enabled in Input Profile.", UnityEditor.MessageType.Warning);
-                        if (GUILayout.Button($"Enable 'Focus Individual Compound Collider in Input Profile'"))
+                        if (GUILayout.Button($"Enable 'Focus Individual Compound Collider' in Input Profile"))
                         {
                             profile.FocusIndividualCompoundCollider = true;
                         }

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public bool FocusIndividualCompoundCollider
         {
             get { return focusIndividualCompoundCollider; }
-            internal set { focusIndividualCompoundCollider = value; }
+            set { focusIndividualCompoundCollider = value; }
         }
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 triangleIndex = hitInfo.triangleIndex;
                 textureCoord = hitInfo.textureCoord;
                 textureCoord2 = hitInfo.textureCoord2;
-                transform = hitInfo.collider.transform;
+                transform = hitInfo.collider.transform; // we're using collider transform because hitInfo.transform might point us to a different gameobject in case there's a rigidbody in the hierarchy
                 lightmapCoord = hitInfo.lightmapCoord;
                 collider = hitInfo.collider;
             }

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 triangleIndex = hitInfo.triangleIndex;
                 textureCoord = hitInfo.textureCoord;
                 textureCoord2 = hitInfo.textureCoord2;
-                transform = hitInfo.transform;
+                transform = hitInfo.collider.transform;
                 lightmapCoord = hitInfo.lightmapCoord;
                 collider = hitInfo.collider;
             }

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 triangleIndex = hitInfo.triangleIndex;
                 textureCoord = hitInfo.textureCoord;
                 textureCoord2 = hitInfo.textureCoord2;
-                transform = hitInfo.collider.transform; // we're using collider transform because hitInfo.transform might point us to a different gameobject in case there's a rigidbody in the hierarchy
+                transform = hitInfo.transform;
                 lightmapCoord = hitInfo.lightmapCoord;
                 collider = hitInfo.collider;
             }


### PR DESCRIPTION
changed MixedRealityRaycastHit to use collider transform instead of Unity.RaycastHit.transform because this one potentially returns the transform of the gameobject that has a rigidbody attached instead of the actually collision transform.

This was the cause for not being able to interact with any handles of bounding box whenever a rigidbody component was attached. 

Unitys documentation on RaycastHit.transform is not clear on what's happening. It only states that: "The Transform of the rigidbody or collider that was hit."

While digging around I found other ppl running into this as well:
https://answers.unity.com/questions/190482/raycasthittranslatecollider.html

My observation while debugging confirms what's mentioned in that thread. Whenever we've no rigidbody component attached the transform will be set to the hit colliders transform. Whenever there's a rigidbody component somewhere in hierarchy the transform will be populated with the rigidbody gameobject transform even though the hit result collider will point to a gameobject lower in the hierarchy.

## Changes
- Fixes: #4901 
- Removed obsolete comment I found in BoundingBoxHelper

## Verification
tested modifying bounding box with and without rigid body component attached
run tests