### PR TITLE
Fix a few issues with PressableButton.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHololens2UnityUI.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHololens2UnityUI.prefab
@@ -77,87 +77,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!114 &1270314221950268463
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3223503683246946314}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f98e7663599230e419addf153615c144, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  movingButtonVisuals: {fileID: 3223503683169235570}
-  distanceSpaceMode: 1
-  startPushDistance: 0
-  maxPushDistance: 14
-  pressDistance: 8.5
-  releaseDistanceDelta: 2
-  returnSpeed: 25
-  releaseOnTouchEnd: 1
-  enforceFrontPush: 1
-  TouchBegin:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  TouchEnd:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  ButtonPressed:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1922179712112255870}
-        m_MethodName: PlayOneShot
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 8300000, guid: 291bf9326e517b0489c2ee53d0a6a63f,
-            type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  ButtonReleased:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1922179712112255870}
-        m_MethodName: PlayOneShot
-        m_Mode: 2
-        m_Arguments:
-          m_ObjectArgument: {fileID: 8300000, guid: 40ae713ddf420714bbc1a3b5c3f2eac1,
-            type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 6229073104108989701}
-        m_MethodName: Submit
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  movingButtonIconText: {fileID: 7813901746064736085}
-  compressableButtonVisuals: {fileID: 4117306204827652223}
-  minCompressPercentage: 0.25
-  highlightPlate: {fileID: 0}
-  highlightPlateAnimationTime: 0.25
 --- !u!1 &4117306204827652223
 GameObject:
   m_ObjectHideFlags: 0
@@ -338,6 +257,87 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1270314221950268463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3223503683246946314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f98e7663599230e419addf153615c144, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  movingButtonVisuals: {fileID: 3223503683169235570}
+  distanceSpaceMode: 1
+  startPushDistance: 0
+  maxPushDistance: 14
+  pressDistance: 8.5
+  releaseDistanceDelta: 2
+  returnSpeed: 25
+  releaseOnTouchEnd: 1
+  enforceFrontPush: 1
+  TouchBegin:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  TouchEnd:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  ButtonPressed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1922179712112255870}
+        m_MethodName: PlayOneShot
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 8300000, guid: 291bf9326e517b0489c2ee53d0a6a63f,
+            type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  ButtonReleased:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1922179712112255870}
+        m_MethodName: PlayOneShot
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 8300000, guid: 40ae713ddf420714bbc1a3b5c3f2eac1,
+            type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 6229073104108989701}
+        m_MethodName: Submit
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  movingButtonIconText: {fileID: 7813901746064736085}
+  compressableButtonVisuals: {fileID: 4117306204827652223}
+  minCompressPercentage: 0.25
+  highlightPlate: {fileID: 0}
+  highlightPlateAnimationTime: 0.25
 --- !u!1 &7813901746064736085
 GameObject:
   m_ObjectHideFlags: 0
@@ -582,15 +582,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 9130116940813133624, guid: df89e360642c6fc46abbc1c2656856f6,
+    - target: {fileID: 5234426576715676748, guid: df89e360642c6fc46abbc1c2656856f6,
         type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5234426577712821812, guid: df89e360642c6fc46abbc1c2656856f6,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
+      propertyPath: m_Name
+      value: PressableButtonHololens2UnityUI
       objectReference: {fileID: 0}
     - target: {fileID: 5234426576715676739, guid: df89e360642c6fc46abbc1c2656856f6,
         type: 3}
@@ -697,25 +692,40 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5234426576715676748, guid: df89e360642c6fc46abbc1c2656856f6,
+    - target: {fileID: 5234426577712821803, guid: df89e360642c6fc46abbc1c2656856f6,
         type: 3}
-      propertyPath: m_Name
-      value: PressableButtonHololens2UnityUI
-      objectReference: {fileID: 0}
-    - target: {fileID: 5234426576715676743, guid: df89e360642c6fc46abbc1c2656856f6,
-        type: 3}
-      propertyPath: m_Material
-      value: 
-      objectReference: {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8, type: 2}
-    - target: {fileID: 5234426577528310576, guid: df89e360642c6fc46abbc1c2656856f6,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
+      propertyPath: m_RootOrder
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5234426577528310583, guid: df89e360642c6fc46abbc1c2656856f6,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 2.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 5234426577712821812, guid: df89e360642c6fc46abbc1c2656856f6,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5234426577712821812, guid: df89e360642c6fc46abbc1c2656856f6,
+        type: 3}
+      propertyPath: m_Name
+      value: FrontPlate
+      objectReference: {fileID: 0}
+    - target: {fileID: 5234426577528310576, guid: df89e360642c6fc46abbc1c2656856f6,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6037486589368256570, guid: df89e360642c6fc46abbc1c2656856f6,
+        type: 3}
+      propertyPath: m_Name
+      value: BackPlate
+      objectReference: {fileID: 0}
+    - target: {fileID: 9130116940813133624, guid: df89e360642c6fc46abbc1c2656856f6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5234426577528310582, guid: df89e360642c6fc46abbc1c2656856f6,
         type: 3}
@@ -737,11 +747,11 @@ PrefabInstance:
       propertyPath: m_margin.y
       value: 22.371887
       objectReference: {fileID: 0}
-    - target: {fileID: 5234426577712821803, guid: df89e360642c6fc46abbc1c2656856f6,
+    - target: {fileID: 5234426576715676743, guid: df89e360642c6fc46abbc1c2656856f6,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: ec72a3a105768f746b556a8dfdae61a8, type: 2}
     m_RemovedComponents:
     - {fileID: 5234426576715676738, guid: df89e360642c6fc46abbc1c2656856f6, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: df89e360642c6fc46abbc1c2656856f6, type: 3}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUI.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUI.prefab
@@ -478,7 +478,7 @@ RectTransform:
   m_GameObject: {fileID: 5234426577712821812}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -15.2}
-  m_LocalScale: {x: 1, y: 1, z: 0.016}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5234426576715676739}
   m_RootOrder: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -18,6 +18,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
     {
         const string InitialMarkerTransformName = "Initial Marker";
 
+        bool hasStarted = false;
+
         /// <summary>
         /// The object that is being pushed.
         /// </summary>
@@ -235,10 +237,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Initial offset from moving visuals to button
         /// </summary>
-        private Vector3 initialOffsetMovingVisuals = Vector3.zero;
+        private Vector3 movingVisualsInitialLocalPosition = Vector3.zero;
 
         /// <summary>
-        /// The position from where the button starts to move. 
+        /// The position from where the button starts to move.  Projected into world space based on the button's current world space position.
         /// </summary>
         private Vector3 InitialPosition
         {
@@ -246,13 +248,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 if (Application.isPlaying && movingButtonVisuals) // we're using a cached position in play mode as the moving visuals will be moved during button interaction
                 {
-                    return PushSpaceSourceParentPosition + initialOffsetMovingVisuals;
+                    return PushSpaceSourceParentPosition + movingButtonVisuals.transform.TransformVector(movingVisualsInitialLocalPosition);
                 }
                 else
                 {
                     return PushSpaceSourceTransform.position;
                 }
-
             }
         }
 
@@ -267,12 +268,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         protected virtual void Start()
         {
+            hasStarted = true;
+
             if (gameObject.layer == 2)
             {
                 Debug.LogWarning("PressableButton will not work if game object layer is set to 'Ignore Raycast'.");
             }
 
-            initialOffsetMovingVisuals = PushSpaceSourceTransform.position - PushSpaceSourceParentPosition;
+            movingVisualsInitialLocalPosition = movingButtonVisuals.transform.localPosition;
+
+            // Ensure everything is set to initial positions correctly.
+            UpdateMovingVisualsPosition();
         }
 
         void OnDisable()
@@ -281,9 +287,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             touchPoints.Clear();
             currentInputSources.Clear();
 
-            // make sure button doesn't stay in a pressed state in case we disable the button while pressing it
-            currentPushDistance = startPushDistance;
-            UpdateMovingVisualsPosition();
+            if (hasStarted)
+            {
+                // make sure button doesn't stay in a pressed state in case we disable the button while pressing it
+                currentPushDistance = startPushDistance;
+                UpdateMovingVisualsPosition();
+            }
         }
 
         private void Update()
@@ -460,7 +469,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return Mathf.Clamp(farthestDistance, startPushDistance, maxPushDistance);
         }
-
 
         private void UpdatePressedState(float pushDistance)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -147,7 +147,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float CurrentPushDistance { get => currentPushDistance; protected set => currentPushDistance = value; }
 
-
         private bool isTouching = false;
 
         ///<summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -102,6 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Some apps will instantiate a button, disable it while they do other setup, then enable it.  This caused a bug where the button front plate would be flattened against the button.
         /// This tests to confirm that this has not regressed.
+        /// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6024
         /// </summary>
         [UnityTest]
         public IEnumerator ButtonInstantiateDisableThenEnableBeforeStart([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
@@ -126,7 +127,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// There was an issue where rotating a button after Start() had executed resulted in the front plate going in the wrong direction.  This tests that it has not regressed.
+        /// There was an issue where rotating a button after Start() had executed resulted in the front plate going in the wrong direction.
+        /// This tests that it has not regressed.
+        /// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6025
         /// </summary>
         [UnityTest]
         public IEnumerator RotateButton([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)


### PR DESCRIPTION
## Overview
This fixes several small issues that affected a consuming app.

## Changes
- Fixes #6024.  The instantiation sequence in the app called OnEnabled(), OnDisabled(), OnEnabled(), Start().  This sequence resulted in OnDisabled flattening the buttons to depth 0, then Start() read in that position as the 'start' position.
   - Now OnDisabled() won't call UpdateVisualsPosition() if Start() has not executed.
- Fixes #6025.  The initial offset was stored as world location.  If you moved/rotated the buttons or their containers after Start(), it would result in the front plates being pushed in the original direction instead of the current direction.
   - This affected the UnityUI-based buttons in the example scene.
   - It did not affect the collider based buttons because:
      - The collider based buttons don't have any visible objects in the MovingButtonVisuals.
      - Also, collider based buttons are centered about the box's centroid.  The UnityUI buttons are centered about the center of the back plate.  And the MovingButtonVisuals in the collider button had a local position of 0.
   - Now the value is stored in local space, then projected in the getter into world space based on the current position/rotation of the parent.
- The PressableButtonUnityUI.prefab's front plate had a very small scale for some reason.  This causes some visual rendering issues.
   - Set it back to 1.
