### PR TITLE
PokePointer TouchableVolume fix touch up when in middle of volume

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -21,6 +21,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </remarks>
     public class PokePointer : BaseControllerPointer, IMixedRealityNearPointer
     {
+        /// <summary>
+        /// If touchable volumes are larger than this size (meters), pointer will raise
+        /// touch up even when pointer is inside the volume
+        /// </summary>
+        private const int maximumTouchableVolumeSize = 1000;
+
         [SerializeField]
         protected LineRenderer line;
 
@@ -136,8 +142,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (newClosestTouchable != null)
             {
                 // Build ray (poke from in front to the back of the pointer position)
-                Vector3 start = Position + touchableDistance * closestNormal;
-                Vector3 end = Position - touchableDistance * closestNormal;
+                var lengthOfPointerRay = newClosestTouchable is NearInteractionTouchableVolume ?
+                    maximumTouchableVolumeSize : touchableDistance;
+                Vector3 start = Position + lengthOfPointerRay * closestNormal;
+                Vector3 end = Position - lengthOfPointerRay * closestNormal;
                 Rays[0].UpdateRayStep(ref start, ref end);
 
                 line.SetPosition(0, Position);
@@ -216,10 +224,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             if (Result?.CurrentPointerTarget != null && closestProximityTouchable != null)
             {
-                // Start position of the ray is offset by TouchableDistance, subtract to get distance between surface and pointer position.
-                float distToFront = Vector3.Distance(Result.StartPoint, Result.Details.Point) - touchableDistance;
-                bool newIsDown = (distToFront < 0.0f);
-                bool newIsUp = (distToFront > closestProximityTouchable.DebounceThreshold);
+                float distToTouchable;
+                if (closestProximityTouchable is NearInteractionTouchableVolume)
+                {
+                    // Volumes can be arbitrary size, so don't rely on the length of the raycast ray
+                    // instead just have the volume itself give us the distance.
+                    distToTouchable = closestProximityTouchable.DistanceToTouchable(Position, out _);
+                }
+                else
+                {
+                    // Start position of the ray is offset by TouchableDistance, subtract to get distance between surface and pointer position.
+                    distToTouchable = Vector3.Distance(Result.StartPoint, Result.Details.Point) - touchableDistance;
+                }
+
+                bool newIsDown = (distToTouchable < 0.0f);
+                bool newIsUp = (distToTouchable > closestProximityTouchable.DebounceThreshold);
 
                 if (newIsDown)
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -142,6 +142,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (newClosestTouchable != null)
             {
                 // Build ray (poke from in front to the back of the pointer position)
+                // We make a very long ray if we are touching a touchable volume to ensure that we actually 
+                // hit the volume when we are inside of the volume, which could be very large.
                 var lengthOfPointerRay = newClosestTouchable is NearInteractionTouchableVolume ?
                     maximumTouchableVolumeSize : touchableDistance;
                 Vector3 start = Position + lengthOfPointerRay * closestNormal;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
@@ -62,7 +62,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // inside object, use vector to centre as normal
                 normal = samplePoint - TouchableCollider.bounds.center;
                 normal.Normalize();
-                return 0;
+                // Return value less than zero so that poke pointer always considers this a touch down (it checks if distance < 0)
+                return -1;
             }
             else
             {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchableVolume.cs
@@ -62,7 +62,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // inside object, use vector to centre as normal
                 normal = samplePoint - TouchableCollider.bounds.center;
                 normal.Normalize();
-                // Return value less than zero so that poke pointer always considers this a touch down (it checks if distance < 0)
+                // Return value less than zero so that when poke pointer is inside
+                // object, it will not raise a touch up event.
                 return -1;
             }
             else

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 Assert.AreEqual(1, catcher.EventsStarted);
                 Assert.AreEqual(0, catcher.EventsCompleted);
 
-                // No touch up when moving through collider
+                // Ensure no touch up event fires while moving hand/pokepointer through collider to each corner of volume
                 Vector3[] cornerPositions = new Vector3[8];
                 touchable.GetComponent<BoxCollider>().bounds.GetCornerPositions(ref cornerPositions);
                 var currentPos = objectPosition;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -223,13 +223,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 var currentPos = objectPosition;
                 for (int i = 0; i < cornerPositions.Length; i++)
                 {
-                    TestContext.Out.WriteLine("Move hand to " + cornerPositions[i]);
                     yield return PlayModeTestUtilities.MoveHandFromTo(currentPos, cornerPositions[i], numSteps, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSim);
                     currentPos = cornerPositions[i];
-                    Assert.AreEqual(1, catcher.EventsStarted, "Received extra touch down when moving through volume");
-                    Assert.AreEqual(0, catcher.EventsCompleted, "Received extra touch up when moving through volume");
+                    Assert.AreEqual(1, catcher.EventsStarted, "Received extra touch down when moving through volume to position " + currentPos);
+                    Assert.AreEqual(0, catcher.EventsCompleted, "Received extra touch up when moving through volume to position " + currentPos);
                 }
-
 
                 // Touch up when exit collider
                 yield return PlayModeTestUtilities.MoveHandFromTo(currentPos, rightPosition, numSteps, ArticulatedHandPose.GestureId.Pinch, Handedness.Right, inputSim);


### PR DESCRIPTION
## Overview
PokePointers would actually raise up events when in the middle of a touchable volume, for two reasons:

1) The ray that pokepointer was building was too short. When inside a volume, the ray would never actually hit any bounds of the volume, and therefore FocusProvider would thing that the pointer was no longer colliding with something, causing touch up.
2) The distance checks in OnPostSceneQuery were looking at the length of the poke to hit point, which can make sense for touchable planes (you maybe want to raise touch up after you've gone far enough behind a plane), but not for volumes (you only really want to exit when you exit the volume). 

In both cases I fixed this by  special-casing touchable volume in poke pointer, and making the ray longer as well as changing the distance check.

## Changes
- Fixes: #5873 
- Added test to verify we get no touch ups when moving through a touchable volume.


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
