### PR TITLE
Added SetTouchableCollider() method in NearInteractionTouchable

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs
@@ -78,8 +78,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         [SerializeField]
         [FormerlySerializedAs("collider")]
-        private BoxCollider touchableCollider;
-        public BoxCollider TouchableCollider => touchableCollider;
+        private Collider touchableCollider;
+        public Collider TouchableCollider => touchableCollider;
 
         protected override void OnValidate()
         {
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             base.OnValidate();
 
-            touchableCollider = GetComponent<BoxCollider>();
+            touchableCollider = GetComponent<Collider>();
 
             Debug.Assert(localForward.magnitude > 0);
             Debug.Assert(localUp.magnitude > 0);

--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionTouchable.cs
@@ -78,8 +78,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         [SerializeField]
         [FormerlySerializedAs("collider")]
-        private Collider touchableCollider;
-        public Collider TouchableCollider => touchableCollider;
+        private BoxCollider touchableCollider;
+        public BoxCollider TouchableCollider => touchableCollider;
 
         protected override void OnValidate()
         {
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             base.OnValidate();
 
-            touchableCollider = GetComponent<Collider>();
+            touchableCollider = GetComponent<BoxCollider>();
 
             Debug.Assert(localForward.magnitude > 0);
             Debug.Assert(localUp.magnitude > 0);
@@ -127,6 +127,32 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public void SetBounds(Vector2 newBounds)
         {
             bounds = newBounds;
+        }
+
+        /// <summary>
+        /// Adjust the bounds, local center and local forward to match a given box collider
+        /// </summary>
+        public void SetTouchableCollider(BoxCollider newCollider)
+        {
+            if (newCollider != null)
+            {
+                touchableCollider = newCollider;
+
+                Vector2 adjustedSize = new Vector2(
+                            Math.Abs(Vector3.Dot(newCollider.size, LocalRight)),
+                            Math.Abs(Vector3.Dot(newCollider.size, LocalUp)));
+
+                bounds = adjustedSize;
+                localForward = new Vector3(0, 0,-1);
+
+                // Set x and y center to match the newCollider but change the position of the
+                // z axis so the plane is always in front of the object
+                localCenter = newCollider.center + Vector3.Scale(newCollider.size / 2.0f, LocalForward);
+            }
+            else
+            {
+                Debug.Assert(newCollider != null, "BoxCollider is null, cannot set bounds");
+            }
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -589,6 +589,60 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return PlayModeTestUtilities.HideHand(handedness, inputSim);
         }
+
+
+        /// <summary>
+        /// Test the SetTouchableCollider(BoxCollider collider) method by changing the size of the new
+        /// box collider and rotating the object. This test is checking if the NearInteractionTouchable plane
+        /// is the same size as the box collider and in front of the object.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator NearInteractionTouchableSetTouchableCollider()
+        {
+            GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = new Vector3(0, 0, 1.5f);
+            cube.transform.localScale = new Vector3(0.3f, 0.3f, 0.3f);
+
+            cube.AddComponent<NearInteractionTouchable>();
+
+            var nearIT = cube.GetComponent<NearInteractionTouchable>();
+            var boxCollider = cube.GetComponent<BoxCollider>();
+
+            // SetTouchableCollider to a new Box Collider
+            nearIT.SetTouchableCollider(boxCollider);
+
+            Assert.AreEqual(nearIT.Bounds.x, boxCollider.size.x);
+            Assert.AreEqual(nearIT.Bounds.y,boxCollider.size.y);
+            Assert.AreEqual(nearIT.LocalCenter.x, boxCollider.center.x);
+            Assert.AreEqual(nearIT.LocalCenter.y, boxCollider.center.y);
+            Assert.AreEqual(nearIT.LocalCenter.z, boxCollider.center.z - (boxCollider.size.z / 2));
+
+            yield return null;
+
+            // Change Size of Box Collider
+            boxCollider.size = new Vector3(2, 3, 4);
+            nearIT.SetTouchableCollider(boxCollider);
+
+            Assert.AreEqual(nearIT.Bounds.x, boxCollider.size.x);
+            Assert.AreEqual(nearIT.Bounds.y, boxCollider.size.y);
+            Assert.AreEqual(nearIT.LocalCenter.x, boxCollider.center.x);
+            Assert.AreEqual(nearIT.LocalCenter.y, boxCollider.center.y);
+            Assert.AreEqual(nearIT.LocalCenter.z, boxCollider.center.z - (boxCollider.size.z / 2));
+
+            yield return null;
+
+            // Rotate and change size of Box collider
+            cube.transform.Rotate(0, 45, 0);
+            boxCollider.size = new Vector3(3, 2, 0.5f);
+
+            nearIT.SetTouchableCollider(boxCollider);
+
+            Assert.AreEqual(nearIT.Bounds.x, boxCollider.size.x);
+            Assert.AreEqual(nearIT.Bounds.y, boxCollider.size.y);
+            Assert.AreEqual(nearIT.LocalCenter.x, boxCollider.center.x);
+            Assert.AreEqual(nearIT.LocalCenter.y, boxCollider.center.y);
+            Assert.AreEqual(nearIT.LocalCenter.z, boxCollider.center.z - (boxCollider.size.z / 2));
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Overview
This PR addresses a fix for #5825 by adding a method `SetTouchableCollider(BoxCollider collider)`. `SetTouchableCollider` allows you to set the bounds of NearInteractionTouchable at runtime to match the box collider given.

## Changes
- Added `SetTouchableCollider(BoxCollider collider)` method to NearInteractionTouchable.cs
- Added a test `NearInteractionTouchableSetTouchableCollider()` in NearInteractionTouchableTests.cs to test the method

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
