### PR TITLE
serialization fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/InputSimulationIndicators.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/InputSimulationIndicators.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 // Input simulation service is only built on editor platforms
-#if UNITY_EDITOR
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
@@ -51,6 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Icon for right hand when untracked.
         /// </summary>
         public Sprite iconHandUntrackedRight = null;
+
+#if UNITY_EDITOR
 
         private IInputSimulationService inputSimService = null;
         private IInputSimulationService InputSimService
@@ -143,7 +144,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             InputSimService.ResetHandRight();
         }
+#endif
     }
 }
-
-#endif


### PR DESCRIPTION
## Overview
InputSimulationIndicators is part of a Prefab referenced in the MRTK profile for simulation purposes. The whole class is wrapped in #if UNITY_EDITOR and as we all know, that's bad if it contains serialized fields.

## Changes
- Fixes: #6033