### PR TITLE
apply same workaround as in EditorSceneUtils

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Scenes/RuntimeSceneUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scenes/RuntimeSceneUtils.cs
@@ -48,6 +48,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             for (int i = 0; i < SceneManager.sceneCount; i++)
             {
                 Scene loadedScene = SceneManager.GetSceneAt(i);
+                if (!loadedScene.isLoaded)
+                {   // Oh, Unity.
+                    continue;
+                }
+
                 foreach (GameObject rootGameObject in loadedScene.GetRootGameObjects())
                 {
                     yield return rootGameObject;

--- a/Assets/MixedRealityToolkit/Utilities/Scenes/RuntimeSceneUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scenes/RuntimeSceneUtils.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 Scene loadedScene = SceneManager.GetSceneAt(i);
                 if (!loadedScene.isLoaded)
-                {   // Oh, Unity.
+                {
                     continue;
                 }
 


### PR DESCRIPTION
## Overview
fixes a rare bug where it's possible to have 0 scene loaded when managing scenes from code.

## Changes
- Fixes: # . https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5895

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch

the `GetRootGameObjectsInLoadedScenes` function is duplicated in both EditorSceneUtils and RuntimeSceneUtils, both code are identical (EditorSceneManager calls could just be SceneManager), so  we could only keep and call one function here (the RuntimeSceneUtils one).
Let me know if i should add  this change, or if we just do the minimal fix proposed here.
