### PR TITLE
Fix 5993 - Remove Usage of Shared Materials with Clipping Primitives

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/ClippingBoxInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingBoxInspector.cs
@@ -7,6 +7,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
+    /// <summary>
+    /// A custom editor for the ClippingBox to allow for specification of the framing bounds.
+    /// </summary>
     [CustomEditor(typeof(ClippingBox))]
     public class ClippingBoxEditor : ClippingPrimitiveEditor
     {

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingBoxInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingBoxInspector.cs
@@ -8,11 +8,10 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
     [CustomEditor(typeof(ClippingBox))]
-    public class ClippingBoxEditor : UnityEditor.Editor
+    public class ClippingBoxEditor : ClippingPrimitiveEditor
     {
-        private bool HasFrameBounds() { return true; }
-
-        private Bounds OnGetFrameBounds()
+        /// <inheritdoc/>
+        protected override Bounds OnGetFrameBounds()
         {
             var primitive = target as ClippingBox;
             Debug.Assert(primitive != null);

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPlaneInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPlaneInspector.cs
@@ -8,11 +8,10 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
     [CustomEditor(typeof(ClippingPlane))]
-    public class ClippingPlaneEditor : UnityEditor.Editor
+    public class ClippingPlaneEditor : ClippingPrimitiveEditor
     {
-        private bool HasFrameBounds() { return true; }
-
-        private Bounds OnGetFrameBounds()
+        /// <inheritdoc/>
+        protected override Bounds OnGetFrameBounds()
         {
             var primitive = target as ClippingPlane;
             Debug.Assert(primitive != null);

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPlaneInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPlaneInspector.cs
@@ -7,6 +7,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
+    /// <summary>
+    /// A custom editor for the ClippingPlaneEditor to allow for specification of the framing bounds.
+    /// </summary>
     [CustomEditor(typeof(ClippingPlane))]
     public class ClippingPlaneEditor : ClippingPrimitiveEditor
     {

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    [CustomEditor(typeof(ClippingPrimitive))]
+    public abstract class ClippingPrimitiveEditor : UnityEditor.Editor
+    {
+        /// <summary>
+        /// Notifies the editor that this object has custom frame bounds.
+        /// </summary>
+        /// <returns>True for all clipping primitives.</returns>
+        private bool HasFrameBounds()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the bounds the editor should focus on.
+        /// </summary>
+        /// <returns>The bounds of the clipping primitive.</returns>
+        protected abstract Bounds OnGetFrameBounds();
+
+        /// <summary>
+        /// Looks for changes to the list of renderers and gracefully adds and removes them.
+        /// </summary>
+        public override void OnInspectorGUI()
+        {
+            var clippingPrimitive = (ClippingPrimitive)target;
+
+            var previousRenderers = clippingPrimitive.GetRenderersCopy();
+            DrawDefaultInspector();
+            var currentRenderers = clippingPrimitive.GetRenderersCopy();
+
+            // Add or remove and renderers that were added or removed via the inspector.
+            foreach (var renderer in previousRenderers.Except(currentRenderers))
+            {
+                clippingPrimitive.RemoveRenderer(renderer);
+            }
+
+            foreach (var renderer in currentRenderers.Except(previousRenderers))
+            {
+                clippingPrimitive.AddRenderer(renderer);
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs
@@ -8,6 +8,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
+    /// <summary>
+    /// An abstract editor component to improve the editor experience with ClippingPrimitives.
+    /// </summary>
     [CustomEditor(typeof(ClippingPrimitive))]
     public abstract class ClippingPrimitiveEditor : UnityEditor.Editor
     {

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00b3a9914942baf42b886607218f3ee6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingSphereInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingSphereInspector.cs
@@ -7,6 +7,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
+    /// <summary>
+    /// A custom editor for the ClippingSphere to allow for specification of the framing bounds.
+    /// </summary>
     [CustomEditor(typeof(ClippingSphere))]
     public class ClippingSphereEditor : ClippingPrimitiveEditor
     {

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingSphereInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingSphereInspector.cs
@@ -8,11 +8,10 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
     [CustomEditor(typeof(ClippingSphere))]
-    public class ClippingSphereEditor : UnityEditor.Editor
+    public class ClippingSphereEditor : ClippingPrimitiveEditor
     {
-        private bool HasFrameBounds() { return true; }
-
-        private Bounds OnGetFrameBounds()
+        /// <inheritdoc/>
+        protected override Bounds OnGetFrameBounds()
         {
             var primitive = target as ClippingSphere;
             Debug.Assert(primitive != null);

--- a/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingPrimitive.cs
@@ -36,15 +36,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { clippingSide = value; }
         }
 
-
-        /// <summary>
-        /// Toggles whether the primitive will use the Camera OnPreRender event 
-        /// </summary>
-        /// <remarks>This is especially helpful if you're trying to clip dynamically created objects that may be added to the scene after LateUpdate such as OnWillRender</remarks>
         [SerializeField]
         [Tooltip("Toggles whether the primitive will use the Camera OnPreRender event")]
         private bool useOnPreRender;
 
+        /// <summary>
+        /// Toggles whether the primitive will use the Camera OnPreRender event.
+        /// </summary>
+        /// <remarks>This is especially helpful if you're trying to clip dynamically created objects that may be added to the scene after LateUpdate such as OnWillRender</remarks>
         public bool UseOnPreRender
         {
             get { return useOnPreRender; }
@@ -68,55 +67,70 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
-
         protected abstract string Keyword { get; }
         protected abstract string ClippingSideProperty { get; }
 
         protected MaterialPropertyBlock materialPropertyBlock;
-        protected Dictionary<Material, bool> modifiedMaterials = new Dictionary<Material, bool>();
-        protected List<Material> allocatedMaterials = new List<Material>();
+        protected static Dictionary<Material, Material> materialClones = new Dictionary<Material, Material>();
 
         private int clippingSideID;
-
-        [SerializeField]
-        [HideInInspector]
         private CameraEventRouter cameraMethods;
 
+        /// <summary>
+        /// Adds a renderer to the list of objects this clipping primitive clips.
+        /// </summary>
+        /// <param name="_renderer"></param>
         public void AddRenderer(Renderer _renderer)
         {
-            if (_renderer != null && !renderers.Contains(_renderer))
+            if (!renderers.Contains(_renderer))
             {
                 renderers.Add(_renderer);
+            }
 
-                Material material = GetMaterial(_renderer, false);
+            var material = GetMaterial(_renderer);
 
-                if (material != null)
-                {
-                    ToggleClippingFeature(material, true);
-                }
+            if (material != null)
+            {
+                ToggleClippingFeature(material, true);
             }
         }
 
+        /// <summary>
+        /// Removes a renderer to the list of objects this clipping primitive clips.
+        /// </summary>
         public void RemoveRenderer(Renderer _renderer)
         {
-            if (renderers.Contains(_renderer))
+            renderers.Remove(_renderer);
+
+            // Restore the original material.
+            var material = GetMaterial(_renderer);
+
+            if (material != null)
             {
-                Material material = GetMaterial(_renderer, false);
+                _renderer.sharedMaterial = materialClones[material];
+                materialClones.Remove(material);
 
-                if (material != null)
+                if (Application.isPlaying)
                 {
-                    ToggleClippingFeature(material, false);
+                    Destroy(material);
                 }
-
-                renderers.Remove(_renderer);
+                else
+                {
+                    DestroyImmediate(material);
+                }
             }
         }
 
-        protected void OnValidate()
+        /// <summary>
+        /// Returns a copy of the current list of renderers.
+        /// </summary>
+        /// <returns>The current list of renderers.</returns>
+        public IEnumerable<Renderer> GetRenderersCopy()
         {
-            ToggleClippingFeature(true);
-            RestoreUnassignedMaterials();
+            return new List<Renderer>(renderers);
         }
+
+        #region MonoBehaviour Implementation
 
         protected void OnEnable()
         {
@@ -139,15 +153,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             if (cameraMethods != null)
             {
                 cameraMethods.OnCameraPreRender -= OnCameraPreRender;
-            }
-        }
-
-        protected void Start()
-        {
-            if (useOnPreRender)
-            {
-                cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
-                cameraMethods.OnCameraPreRender += OnCameraPreRender;
             }
         }
 
@@ -189,29 +194,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 return;
             }
 
-            for (int i = 0; i < renderers.Count; ++i)
+            while (renderers.Count != 0)
             {
-                Material material = GetMaterial(renderers[i]);
-
-                if (material != null)
-                {
-                    bool clippingPlaneOn;
-
-                    if (modifiedMaterials.TryGetValue(material, out clippingPlaneOn))
-                    {
-                        ToggleClippingFeature(material, clippingPlaneOn);
-                        modifiedMaterials.Remove(material);
-                    }
-                }
-            }
-
-            RestoreUnassignedMaterials();
-
-            for (int i = 0; i < allocatedMaterials.Count; ++i)
-            {
-                Destroy(allocatedMaterials[i]);
+                RemoveRenderer(renderers[0]);
             }
         }
+
+        #endregion MonoBehaviour Implementation
 
         protected virtual void Initialize()
         {
@@ -226,9 +215,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 return;
             }
 
-            for (int i = 0; i < renderers.Count; ++i)
+            for (var i = 0; i < renderers.Count; ++i)
             {
-                Renderer _renderer = renderers[i];
+                var _renderer = renderers[i];
 
                 if (_renderer == null)
                 {
@@ -251,18 +240,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 return;
             }
 
-            for (int i = 0; i < renderers.Count; ++i)
+            for (var i = 0; i < renderers.Count; ++i)
             {
-                Material material = GetMaterial(renderers[i]);
+                var material = GetMaterial(renderers[i]);
 
                 if (material != null)
                 {
-                    // Cache the initial keyword state of the material.
-                    if (!modifiedMaterials.ContainsKey(material))
-                    {
-                        modifiedMaterials[material] = material.IsKeywordEnabled(Keyword);
-                    }
-
                     ToggleClippingFeature(material, keywordOn);
                 }
             }
@@ -280,51 +263,30 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
-        protected Material GetMaterial(Renderer _renderer, bool trackAllocations = true)
+        protected Material GetMaterial(Renderer _renderer)
         {
-            if (_renderer == null)
-            {
-                return null;
-            }
+            Material output = null;
 
-            if (Application.isEditor && !Application.isPlaying)
+            if (_renderer != null)
             {
-                return _renderer.sharedMaterial;
-            }
-            else
-            {
-                Material material = _renderer.material;
+                var material = _renderer.sharedMaterial;
 
-                if (trackAllocations && !allocatedMaterials.Contains(material))
+                if (material != null && !materialClones.TryGetValue(material, out output))
                 {
-                    allocatedMaterials.Add(material);
+                    // Maintain a clone of the material much like renderer.material does while
+                    // the app is playing.
+                    output = new Material(material);
+                    output.name += " (Clone)";
+                    materialClones.Add(output, material);
+                    _renderer.sharedMaterial = output;
                 }
-
-                return material;
-            }
-        }
-
-        protected void RestoreUnassignedMaterials()
-        {
-            List<Material> toRemove = new List<Material>();
-
-            foreach (var modifiedMaterial in modifiedMaterials)
-            {
-                if (modifiedMaterial.Key == null)
+                else
                 {
-                    toRemove.Add(modifiedMaterial.Key);
-                }
-                else if (renderers.Find(x => (GetMaterial(x) == modifiedMaterial.Key)) == null)
-                {
-                    ToggleClippingFeature(modifiedMaterial.Key, modifiedMaterial.Value);
-                    toRemove.Add(modifiedMaterial.Key);
+                    output = material;
                 }
             }
 
-            foreach (var material in toRemove)
-            {
-                modifiedMaterials.Remove(material);
-            }
+            return output;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MixedRealityToolkit/Utilities/StandardShader/ClippingPrimitive.cs
@@ -273,8 +273,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
                 if (material != null && !materialClones.TryGetValue(material, out output))
                 {
-                    // Maintain a clone of the material much like renderer.material does while
-                    // the app is playing.
+                    // Create a material clone. This keeps the code path the same at edit time and 
+                    // run time since renderer.material cannot be invoked when editing.
                     output = new Material(material);
                     output.name += " (Clone)";
                     materialClones.Add(output, material);


### PR DESCRIPTION
## Overview
This change fixes an issue where clipping primitives were modifying a renderers shared material in the editor. Materials are now cloned (much like how renderer.material works at run time). This was done to support edit time manipulation without leaking materials into the scene.

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6001 relies on this change.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5993

## Verification
Please try using a scene that uses primitive clipping such as the ClippingExamples or MaterialGallery scenes.

>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
