### PR TITLE
Fix intermittent test failure

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -42,6 +42,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // will roughly wait for frame to also pass.
             Application.targetFrameRate = 50;
 
+            // Add a second cube in the background, sometimes physics checks fail with just one collider
+            // in scene
+            GameObject backgroundCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            backgroundCube.transform.position = Vector3.forward * 30;
+
             cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.transform.localPosition = new Vector3(0, 0, 2);
             cube.transform.localScale = new Vector3(.2f, .2f, .2f);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
@@ -358,6 +358,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
+        /// <summary>
+        /// Sometimes it take a few frames for inputs raised via InputSystem.OnInput*
+        /// to actually get sent to input handlers. This method waits for enough frames
+        /// to pass so that any events raised actually have time to send to handlers.
+        /// We set it fairly conservatively to ensure that after waiting
+        /// all input events have been sent.
+        /// </summary>
+        internal static IEnumerator WaitForInputSystemUpdate()
+        {
+            const int inputSystemUpdateFrames = 10;
+            for (int i = 0; i < inputSystemUpdateFrames; i++)
+            {
+                yield return null;
+            }
+        }
+
     }
 }
 #endif


### PR DESCRIPTION
Two fixes:

1. Fixing failure `Microsoft.MixedReality.Toolkit.Tests.BaseCursorTests.CursorContextMove`, happened about 2/100 times. Issue seems similar -- Unity sometimes doesn't raycast when there's just one collider in scene. With a second collider, tests pass 100/100

2. Fix failure `Microsoft.MixedReality.Toolkit.Tests.InteractableTests.TestInputActionMenuInput` by adding function that ensures input system updates (all input events raised can get received). Also make the test easier to diagnose by also checking if input has gone down, and up.

## Changes
- Fixes: another failure in #6058


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
