### PR TITLE
Fix pressable button test failures related to missing Text Mesh Pro Essentials

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
@@ -329,17 +329,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
-        internal static void EnsureTextMeshProEssentials()
+        internal static void InstallTextMeshProEssentials()
         {
 #if UNITY_EDITOR
-            // Special handling for TMP Settings and importing Essential Resources
-            if (TMP_Settings.instance == null)
+            // Import the TMP Essential Resources package
+            string packageFullPath = Path.GetFullPath("Packages/com.unity.textmeshpro");
+            if (Directory.Exists(packageFullPath))
             {
-                string packageFullPath = Path.GetFullPath("Packages/com.unity.textmeshpro");
-                if (Directory.Exists(packageFullPath))
-                {
-                    AssetDatabase.ImportPackage(packageFullPath + "/Package Resources/TMP Essential Resources.unitypackage", false);
-                }
+                AssetDatabase.ImportPackage(packageFullPath + "/Package Resources/TMP Essential Resources.unitypackage", false);
             }
 #endif
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PlayModeTestUtilities.cs
@@ -338,6 +338,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 AssetDatabase.ImportPackage(packageFullPath + "/Package Resources/TMP Essential Resources.unitypackage", false);
             }
+            else
+            {
+                Debug.LogError("Unable to locate the Text Mesh Pro package.");
+            }
 #endif
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -24,12 +24,11 @@ using UnityEngine.UI;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
-    public class PressableButtonTests : BasePlayModeTests
+    public class PressableButtonTests : BasePlayModeTests, IPrebuildSetup
     {
-        public override void Setup()
+        void IPrebuildSetup.Setup()
         {
-            base.Setup();
-            PlayModeTestUtilities.EnsureTextMeshProEssentials();
+            PlayModeTestUtilities.InstallTextMeshProEssentials();
         }
 
         #region Utilities


### PR DESCRIPTION
This change ensures that TMP Essentials are imported prior to the pressable button tests being run.

Root cause
These tests have been failing with no data in the logs due to a dependence on TMP. The test attempted to import TMP Essentials as part of the startup method. Packages cannot be imported while Unity is in play mode, so the tests would quietly fail.