### PR TITLE
Fix intermittent voice command failure

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -338,7 +338,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(wasReleased, "interactable not released");
             Assert.True(wasClicked, "Interactable was not clicked.");
         }
-
         /// <summary>
         /// Instantiates a push button prefab and uses simulated voice input events to press it.
         /// </summary>
@@ -358,13 +357,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Subscribe to interactable's on click so we know the click went through
             bool wasClicked = false;
             interactable.OnClick.AddListener(() => { wasClicked = true; });
-
+            
             Vector3 targetStartPosition = translateTargetObject.localPosition;
 
             // Set up its voice command
             interactable.VoiceCommand = "Select";
 
-            yield return null;
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             // Find an input source to associate with the input event (doesn't matter which one)
             IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
@@ -374,12 +373,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             SpeechCommands commands = new SpeechCommands("Select", KeyCode.None, interactable.InputAction);
             CoreServices.InputSystem.RaiseSpeechCommandRecognized(defaultInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(100), System.DateTime.Now, commands);
             // Wait for at least one frame explicitly to ensure the input goes through
-            yield return new WaitForFixedUpdate();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
-            yield return CheckButtonTranslation(targetStartPosition, translateTargetObject);
-
-            // Wait for button press to expire
-            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             Assert.True(wasClicked, "Interactable was not clicked.");
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -375,7 +375,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for at least one frame explicitly to ensure the input goes through
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
-            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             Assert.True(wasClicked, "Interactable was not clicked.");
         }


### PR DESCRIPTION
## Overview
Instead of waiting for a frame, use `PlayModeTestUtilities.WaitForInputSystemUpdate` when using voice to press button.

## Changes
- Fixes: another case in #6058


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
