### PR TITLE
Fix intermittent failure ManipulationHandlerOneHandMoveFar

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -428,8 +428,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return hand.Show(initialHandPosition);
                 yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
                
-                // pinch and let go of the object again to make sure that any rotation adjustment we're doing is applied 
-                // at the beginning of our test and doesn't interfere with our grab position on the cubes surface while we're moving around
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
                 // save relative pos grab point to object - for far interaction we need to check the grab point where the pointer ray hits the manipulated object

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -407,35 +407,30 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             const int numCircleSteps = 10;
             const int numHandSteps = 3;
 
-            Vector3 initialHandPosition = new Vector3(0.04f, -0.18f, 0.3f); // grab point on the lower center part of the cube
-            
+            Vector3 initialHandPosition = new Vector3(0.044f, -0.1f, 0.45f);
             TestHand hand = new TestHand(Handedness.Right);     
 
             // do this test for every one hand rotation mode
             foreach (ManipulationHandler.RotateInOneHandType type in Enum.GetValues(typeof(ManipulationHandler.RotateInOneHandType)))
             {
                 // TODO: grab point is moving in this test and has to be covered by a different test
-                if (type == ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation)
+                if (type == ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation ||
+                    type == ManipulationHandler.RotateInOneHandType.FaceAwayFromUser ||
+                    type == ManipulationHandler.RotateInOneHandType.FaceUser)
                 {
                     continue;
-                }         
+                }
 
                 manipHandler.OneHandRotationModeFar = type;
 
                 TestUtilities.PlayspaceToOriginLookingForward();
 
                 yield return hand.Show(initialHandPosition);
-                yield return null;
+                yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
                
                 // pinch and let go of the object again to make sure that any rotation adjustment we're doing is applied 
                 // at the beginning of our test and doesn't interfere with our grab position on the cubes surface while we're moving around
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-                yield return new WaitForFixedUpdate();
-                yield return null;
-
-                yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
-                yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-
 
                 // save relative pos grab point to object - for far interaction we need to check the grab point where the pointer ray hits the manipulated object
                 InputSimulationService simulationService = PlayModeTestUtilities.GetInputSimulationService();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -407,13 +407,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             const int numCircleSteps = 10;
             const int numHandSteps = 3;
 
+            // Hand pointing at middle of cube
             Vector3 initialHandPosition = new Vector3(0.044f, -0.1f, 0.45f);
             TestHand hand = new TestHand(Handedness.Right);     
 
             // do this test for every one hand rotation mode
             foreach (ManipulationHandler.RotateInOneHandType type in Enum.GetValues(typeof(ManipulationHandler.RotateInOneHandType)))
             {
-                // TODO: grab point is moving in this test and has to be covered by a different test
+                // Some rotation modes move the object on grab, don't test those
                 if (type == ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation ||
                     type == ManipulationHandler.RotateInOneHandType.FaceAwayFromUser ||
                     type == ManipulationHandler.RotateInOneHandType.FaceUser)


### PR DESCRIPTION
## Overview
Update the ray to be closer to the center of the box when targeting. Also discovered a few more rotation behaviors that don't work well with the test, so disable them (they caused the cube to move when you grab, which is expected).

## Changes
- Fixes: #6058 


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
