### PR TITLE
Stops ToolTip inspectors from continuously refreshing

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         public override void OnInspectorGUI()
         {
-            //serializedObject.Update();
+            serializedObject.Update();
 
             if (multiLineHelpBoxStyle == null)
             {

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         public override void OnInspectorGUI()
         {
-            serializedObject.Update();
+            //serializedObject.Update();
 
             if (multiLineHelpBoxStyle == null)
             {
@@ -171,8 +171,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             serializedObject.ApplyModifiedProperties();
+        }
 
-            EditorUtility.SetDirty(connector);
+        public override bool RequiresConstantRepaint()
+        {
+            return true;
         }
 
         private ConnectorPivotDirection DrawPivotDirection(ConnectorPivotDirection selection)

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipInspector.cs
@@ -210,8 +210,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             serializedObject.ApplyModifiedProperties();
+        }
 
-            EditorUtility.SetDirty(toolTip);
+        public override bool RequiresConstantRepaint()
+        {
+            return true;
         }
 
         protected virtual void OnSceneGUI()


### PR DESCRIPTION
## Overview
Replaces SetDirty calls in ToolTip inspectors with RequireConstantRepaint.

## Changes
- Fixes: #6096

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
