### PR TITLE
Cherry-pick pull request #6097 from Railboy/tooltip_inspector_fixes

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
@@ -171,8 +171,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             serializedObject.ApplyModifiedProperties();
+        }
 
-            EditorUtility.SetDirty(connector);
+        public override bool RequiresConstantRepaint()
+        {
+            return true;
         }
 
         private ConnectorPivotDirection DrawPivotDirection(ConnectorPivotDirection selection)

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Tooltips/ToolTipInspector.cs
@@ -210,8 +210,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             serializedObject.ApplyModifiedProperties();
+        }
 
-            EditorUtility.SetDirty(toolTip);
+        public override bool RequiresConstantRepaint()
+        {
+            return true;
         }
 
         protected virtual void OnSceneGUI()


### PR DESCRIPTION
Stops ToolTip inspectors from continuously refreshing
