### PR TITLE
Update asset retargeter to account for anim files with script references

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -250,7 +250,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     }
                     else if (line.Contains(ScriptFileIdConstant))
                     {
-                        throw new InvalidDataException($"Line contains script type but not m_Script: {line}");
+                        throw new InvalidDataException($"Line in file {filePath} contains script type but not m_Script: {line.Trim()}");
                     }
                     //{ fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -234,7 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                             string guid = regexResults.Groups[1].Captures[0].Value;
                             if (remapDictionary.TryGetValue(guid, out Tuple<string, long> tuple))
                             {
-                                line = $"  m_Script: {{fileID: {tuple.Item2}, guid: {tuple.Item1}, type: 3}}";
+                                line = Regex.Replace(line, @"fileID: \d+, guid: \w+", $"fileID: {tuple.Item2}, guid: {tuple.Item1}");
                             }
                             else if (nonClassDictionary.ContainsKey(guid))
                             {

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -209,7 +209,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 {
                     string line = await reader.ReadLineAsync();
                     lineNum++;
-                    if (line.Contains("m_Script"))
+                    if (line.Contains("m_Script") || (filePath.EndsWith(".anim") && line.Contains("script")))
                     {
                         if (!line.Contains('}'))
                         {


### PR DESCRIPTION
## Overview
After #5868 was merged, the asset retargeter failed due to .anim files potentially have script references as `script` instead of `m_Script`. This change accounts for that and improves logging this case to determine the actual file it was hit in.

## Changes
- Fixes: https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=5553

## Verification
I ran this locally and saw that retargeting succeeded.