### PR TITLE
Delete MRTKExamplesHub.meta

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Scenes/MRTKExamplesHub.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Scenes/MRTKExamplesHub.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7b0239692b1b399448587194d7a02b5b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
## Overview
This meta appears unused and kept being deleted by Unity.