### PR TITLE
removed patch for scaling issue while animating because it's breaking bounding box scaling

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1239,7 +1239,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     UpdateRigHandles();
                 }
                 else if ((!isChildOfTarget && Target.transform.hasChanged)
-                    || boundsOverride != null && HasBoundsOverrideChanged())
+                    || (boundsOverride != null && HasBoundsOverrideChanged()))
                 {
                     UpdateBounds();
                     UpdateRigHandles();
@@ -2117,11 +2117,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 // We move the rigRoot to the scene root to ensure that non-uniform scaling performed
                 // anywhere above the rigRoot does not impact the position of rig corners / edges
-
-                // before detaching the parent we have to store the local scale of rigroot so we can restore it after reattaching.
-                // unity will recompute the localscale based on the parents scale and will return unexptected local scale values
-                // for parents that have a zero scaling value applied.
-                Vector3 prevLocalScale = rigRoot.localScale; 
                 rigRoot.parent = null;
 
                 rigRoot.rotation = Quaternion.identity;
@@ -2172,8 +2167,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 rigRoot.position = TargetBounds.bounds.center;
                 rigRoot.rotation = Target.transform.rotation;
                 rigRoot.parent = transform;
-                // restore local scale
-                rigRoot.localScale =  prevLocalScale;
             }
         }
 


### PR DESCRIPTION
fix for #6088  

I removed a fix I did to compensate for a messed up scaling caused by animating the localscale of the bounding box target object. ( https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6017 )
This fix broke scaling behavior for bounding box children. 
Seems like scale changes to children are not propagated anymore once I set the localScale manually. This didn't show in the objects I tested with because the scaled objects were the target object itself. The broken cheese however has the scaled mesh as a child (same goes for slate, coffee, etc). 

I tried to add a different workaround for the messed up scaling (eg https://answers.unity.com/questions/770240/changing-the-scale-of-the-parent-messes-up-the-chi.html) but that didn't work with the test file I'm using from one of the partners. 
While testing with my own animation files this behavior won't show. 

I don't think the original issue #5006 is something we can fix in MRTK code (the exploding part, not the updating part -> that's already fixed).


nit: added missing parentheses to if