### PR TITLE
MRTK Profile Inspector Performance Improvements

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Scenes/MRTKExamplesHub.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Scenes/MRTKExamplesHub.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7b0239692b1b399448587194d7a02b5b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
@@ -71,12 +71,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Gets all the scriptable object instances in the project.
         /// </summary>
-        /// <param name="profileType">The Type of <see href="https://docs.unity3d.com/ScriptReference/ScriptableObject.html">ScriptableObject</see> you're wanting to find instances of.</typeparam></param>
+        /// <param name="assetType">The Type of <see href="https://docs.unity3d.com/ScriptReference/ScriptableObject.html">ScriptableObject</see> you're wanting to find instances of.</typeparam></param>
         /// <returns></returns>
-        public static ScriptableObject[] GetAllInstances(Type profileType)
+        public static ScriptableObject[] GetAllInstances(Type assetType)
         {
             // FindAssets uses tags check documentation for more info
-            string[] guids = AssetDatabase.FindAssets($"t:{profileType.Name}");
+            string[] guids = AssetDatabase.FindAssets($"t:{assetType.Name}");
             var instances = new ScriptableObject[guids.Length];
 
             for (int i = 0; i < guids.Length; i++)

--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
@@ -67,5 +67,25 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             return instances;
         }
+
+        /// <summary>
+        /// Gets all the scriptable object instances in the project.
+        /// </summary>
+        /// <param name="profileType">The Type of <see href="https://docs.unity3d.com/ScriptReference/ScriptableObject.html">ScriptableObject</see> you're wanting to find instances of.</typeparam></param>
+        /// <returns></returns>
+        public static ScriptableObject[] GetAllInstances(Type profileType)
+        {
+            // FindAssets uses tags check documentation for more info
+            string[] guids = AssetDatabase.FindAssets($"t:{profileType.Name}");
+            var instances = new ScriptableObject[guids.Length];
+
+            for (int i = 0; i < guids.Length; i++)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guids[i]);
+                instances[i] = AssetDatabase.LoadAssetAtPath<ScriptableObject>(path);
+            }
+
+            return instances;
+        }
     }
 }

--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Gets all the scriptable object instances in the project.
         /// </summary>
-        /// <param name="assetType">The Type of <see href="https://docs.unity3d.com/ScriptReference/ScriptableObject.html">ScriptableObject</see> you're wanting to find instances of.</typeparam></param>
+        /// <param name="assetType">The Type of <see href="https://docs.unity3d.com/ScriptReference/ScriptableObject.html">ScriptableObject</see> you're wanting to find instances of.</param>
         /// <returns>An Array of instances for the type.</returns>
         public static ScriptableObject[] GetAllInstances(Type assetType)
         {

--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/ScriptableObjectExtensions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// Gets all the scriptable object instances in the project.
         /// </summary>
         /// <param name="assetType">The Type of <see href="https://docs.unity3d.com/ScriptReference/ScriptableObject.html">ScriptableObject</see> you're wanting to find instances of.</typeparam></param>
-        /// <returns></returns>
+        /// <returns>An Array of instances for the type.</returns>
         public static ScriptableObject[] GetAllInstances(Type assetType)
         {
             // FindAssets uses tags check documentation for more info

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitInspector.cs
@@ -11,15 +11,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     public class MixedRealityToolkitInspector : UnityEditor.Editor
     {
         private SerializedProperty activeProfile;
-        private int currentPickerWindow = -1;
-
-        // Utility to show object picker for ActiveProfile property since Show command must be called in OnGUI()
-        private static bool forceShowProfilePicker = false;
 
         private void OnEnable()
         {
             activeProfile = serializedObject.FindProperty("activeProfile");
-            currentPickerWindow = -1;
         }
 
         public override void OnInspectorGUI()
@@ -50,64 +45,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             serializedObject.Update();
-            EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(activeProfile);
-            bool changed = EditorGUI.EndChangeCheck();
-            string commandName = Event.current.commandName;
 
             // If not profile is assigned, then warn user
             if (activeProfile.objectReferenceValue == null)
             {
                 EditorGUILayout.HelpBox("MixedRealityToolkit cannot initialize unless an Active Profile is assigned!", MessageType.Error);
-
-                if (GUILayout.Button("Assign MixedRealityToolkit Profile") || forceShowProfilePicker)
-                {
-                    forceShowProfilePicker = false;
-
-                    var allConfigProfiles = ScriptableObjectExtensions.GetAllInstances<MixedRealityToolkitConfigurationProfile>();
-
-                    // Shows the list of MixedRealityToolkitConfigurationProfiles in our project,
-                    // selecting the default profile by default (if it exists).
-                    if (allConfigProfiles.Length > 0)
-                    {
-                        currentPickerWindow = GUIUtility.GetControlID(FocusType.Passive);
-
-                        var defaultMRTKProfile = MixedRealityInspectorUtility.GetDefaultConfigProfile(allConfigProfiles);
-                        activeProfile.objectReferenceValue = defaultMRTKProfile;
-
-                        EditorGUIUtility.ShowObjectPicker<MixedRealityToolkitConfigurationProfile>(defaultMRTKProfile, false, string.Empty, currentPickerWindow);
-                    }
-                    else
-                    {
-                        if (EditorUtility.DisplayDialog("Attention!", "No profiles were found for the Mixed Reality Toolkit.\n\n" +
-                                                                      "Would you like to create one now?", "OK", "Later"))
-                        {
-                            ScriptableObject profile = CreateInstance(nameof(MixedRealityToolkitConfigurationProfile));
-                            profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles");
-                            activeProfile.objectReferenceValue = profile;
-                            EditorGUIUtility.PingObject(profile);
-                        }
-                    }
-                }
-
             }
 
-            // If user selects a new MRTK Active Profile, then update configuration
-            if (EditorGUIUtility.GetObjectPickerControlID() == currentPickerWindow)
-            {
-                switch (commandName)
-                {
-                    case "ObjectSelectorUpdated":
-                        activeProfile.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
-                        changed = true;
-                        break;
-                    case "ObjectSelectorClosed":
-                        activeProfile.objectReferenceValue = EditorGUIUtility.GetObjectPickerObject();
-                        currentPickerWindow = -1;
-                        changed = true;
-                        break;
-                }
-            }
+            bool changed = MixedRealityInspectorUtility.DrawProfileDropDownList(activeProfile, null, activeProfile.objectReferenceValue, typeof(MixedRealityToolkitConfigurationProfile), false);
 
             serializedObject.ApplyModifiedProperties();
 
@@ -129,11 +74,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             MixedRealityInspectorUtility.AddMixedRealityToolkitToScene();
             Selection.activeObject = MixedRealityToolkit.Instance;
             EditorGUIUtility.PingObject(MixedRealityToolkit.Instance);
-
-            if (!MixedRealityToolkit.Instance.HasActiveProfile)
-            {
-                forceShowProfilePicker = true;
-            }
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -17,8 +17,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     public abstract class BaseMixedRealityProfileInspector : UnityEditor.Editor
     {
         private const string IsCustomProfileProperty = "isCustomProfile";
-        private static readonly GUIContent NewProfileContent = new GUIContent("+", "Create New Profile");
-        private static readonly String BaseMixedRealityProfileClassName = typeof(BaseMixedRealityProfile).Name;
 
         private static StringBuilder dropdownKeyBuilder = new StringBuilder();
 
@@ -107,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // If it isn't, issue a warning.
             if (serviceType != null && oldObject != null)
             {
-                if (!IsProfileForService(oldObject.GetType(), serviceType))
+                if (!MixedRealityProfileUtility.IsProfileForService(oldObject.GetType(), serviceType))
                 {
                     EditorGUILayout.HelpBox("This profile is not supported for " + serviceType.Name + ". Using an unsupported service may result in unexpected behavior.", MessageType.Warning);
                 }
@@ -123,7 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 // However in the case where there is just a single profile type for the service, we can improve
                 // upon the user experience by limiting the set of things that show in the picker by restricting
                 // the set of profiles listed to only that type.
-                profileType = GetProfileTypesForService(serviceType).FirstOrDefault();
+                profileType = MixedRealityProfileUtility.GetProfileTypesForService(serviceType).FirstOrDefault();
             }
 
             // If the profile type is still null, just set it to base profile type
@@ -132,76 +130,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 profileType = typeof(BaseMixedRealityProfile);
             }
 
-            // Begin the horizontal group
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                // Draw the object field with an empty label - label is kept in the foldout
-                property.objectReferenceValue = EditorGUILayout.ObjectField(oldObject != null ? "" : property.displayName, oldObject, profileType, false, GUILayout.ExpandWidth(true));
-                changed = (property.objectReferenceValue != oldObject);
+            // Draw the profile dropdown
+            changed |= MixedRealityInspectorUtility.DrawProfileDropDownList(property, profile, oldObject, profileType, showAddButton);
 
-                // Draw the clone button
-                if (property.objectReferenceValue == null)
-                {
-                    var profileTypeName = property.type.Replace("PPtr<$", string.Empty).Replace(">", string.Empty);
-                    if (showAddButton && IsConcreteProfileType(profileTypeName))
-                    {
-                        if (GUILayout.Button(NewProfileContent, EditorStyles.miniButton, GUILayout.Width(20f)))
-                        {
-                            Debug.Assert(profileTypeName != null, "No Type Found");
+            Debug.Assert(profile != null, "No profile was set in OnEnable. Did you forget to call base.OnEnable in a derived profile class?");
 
-                            ScriptableObject instance = CreateInstance(profileTypeName);
-                            var newProfile = instance.CreateAsset(AssetDatabase.GetAssetPath(Selection.activeObject)) as BaseMixedRealityProfile;
-                            property.objectReferenceValue = newProfile;
-                            property.serializedObject.ApplyModifiedProperties();
-                            changed = true;
-                        }
-                    }
-                }
-                else
-                {
-                    var renderedProfile = property.objectReferenceValue as BaseMixedRealityProfile;
-                    Debug.Assert(renderedProfile != null);
-                    Debug.Assert(profile != null, "No profile was set in OnEnable. Did you forget to call base.OnEnable in a derived profile class?");
-
-                    if (GUILayout.Button(new GUIContent("Clone", "Replace with a copy of the default profile."), EditorStyles.miniButton, GUILayout.Width(42f)))
-                    {
-                        MixedRealityProfileCloneWindow.OpenWindow(profile, renderedProfile, property);
-                    }
-                }
-            }
-
-            if (property.objectReferenceValue != null)
-            {
-                UnityEditor.Editor subProfileEditor = UnityEditor.Editor.CreateEditor(property.objectReferenceValue);
-
-                // If this is a default MRTK configuration profile, ask it to render as a sub-profile
-                if (typeof(BaseMixedRealityToolkitConfigurationProfileInspector).IsAssignableFrom(subProfileEditor.GetType()))
-                {
-                    BaseMixedRealityToolkitConfigurationProfileInspector configProfile = (BaseMixedRealityToolkitConfigurationProfileInspector)subProfileEditor;
-                    configProfile.RenderAsSubProfile = true;
-                }
-
-                var subProfile = property.objectReferenceValue as BaseMixedRealityProfile;
-                if (subProfile != null && !subProfile.IsCustomProfile)
-                {
-                    EditorGUILayout.HelpBox("Clone this default profile to edit properties below", MessageType.Warning); 
-                }
-
-                if (renderProfileInBox)
-                {
-                    EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-                }
-                else
-                {
-                    EditorGUILayout.BeginVertical();
-                }
-
-                    EditorGUILayout.Space();
-                    subProfileEditor.OnInspectorGUI();
-                    EditorGUILayout.Space();
-
-                EditorGUILayout.EndVertical();
-            }
+            // Draw the sub-profile editor
+            MixedRealityInspectorUtility.DrawSubProfileEditor(property.objectReferenceValue, renderProfileInBox);
 
             return changed;
         }
@@ -252,55 +187,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             dropdownKeyBuilder.Append("_");
             dropdownKeyBuilder.Append(property.objectReferenceValue.GetType().Name);
             return dropdownKeyBuilder.ToString();
-        }
-
-        /// <summary>
-        /// Given a service type, finds all sub-classes of BaseMixedRealityProfile that are
-        /// designed to configure that service.
-        /// </summary>
-        private static IReadOnlyCollection<Type> GetProfileTypesForService(Type serviceType)
-        {
-            if (serviceType == null)
-            {
-                return Array.Empty<Type>();
-            }
-
-            // This is a little inefficient in that it has to enumerate all of the mixed reality
-            // profiles in order to make this enumeration. It would be possible to cache the results
-            // of this, but then it would be necessary to listen to file/asset creation/destruction
-            // events in order to refresh the cache. If this ends up being a perf bottleneck
-            // in inspectors this would be one possible way to alleviate the issue.
-            HashSet<Type> allTypes = new HashSet<Type>();
-            BaseMixedRealityProfile[] allProfiles = ScriptableObjectExtensions.GetAllInstances<BaseMixedRealityProfile>();
-            for (int i = 0; i < allProfiles.Length; i++)
-            {
-                BaseMixedRealityProfile profile = allProfiles[i];
-                if (IsProfileForService(profile.GetType(), serviceType))
-                {
-                    allTypes.Add(profile.GetType());
-                }
-            }
-            return allTypes.ToReadOnlyCollection();
-        }
-
-        /// <summary>
-        /// Returns true if the given profile type is designed to configure the given service.
-        /// </summary>
-        private static bool IsProfileForService(Type profileType, Type serviceType)
-        {
-            foreach (MixedRealityServiceProfileAttribute serviceProfileAttribute in profileType.GetCustomAttributes(typeof(MixedRealityServiceProfileAttribute), true))
-            {
-                if (serviceProfileAttribute.ServiceType.IsAssignableFrom(serviceType))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private static bool IsConcreteProfileType(String profileTypeName)
-        {
-            return profileTypeName != BaseMixedRealityProfileClassName;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -517,13 +517,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 ScriptableObject[] profileInstances = MixedRealityProfileUtility.GetProfilesOfType(profileType);
                 GUIContent[] profileContent = MixedRealityProfileUtility.GetProfilePopupOptionsByType(profileType);
                 // Set our selected index to our '(None)' option by default
-                int selectedIndex = profileContent.Length - 1;
+                int selectedIndex = 0;
                 // Find our selected index
                 for (int i = 0; i < profileInstances.Length; i++)
                 {
                     if (profileInstances[i] == oldProfileObject)
-                    {
-                        selectedIndex = i;
+                    {   // Our profile content has a '(None)' option at the start
+                        selectedIndex = i + 1;
                         break;
                     }
                 }
@@ -534,13 +534,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     profileContent,
                     GUILayout.ExpandWidth(true));
 
-                property.objectReferenceValue = (newIndex < profileInstances.Length) ? profileInstances[newIndex] : null;
+                property.objectReferenceValue = (newIndex > 0) ? profileInstances[newIndex - 1] : null;
                 changed = property.objectReferenceValue != oldProfileObject;
 
                 // Draw a button that finds the profile in the project window
                 if (property.objectReferenceValue != null)
                 {
-                    if (GUILayout.Button("View Asset", EditorStyles.miniButton, GUILayout.Width(100)))
+                    if (GUILayout.Button("View Asset", EditorStyles.miniButton, GUILayout.Width(80)))
                     {
                         EditorGUIUtility.PingObject(property.objectReferenceValue);
                     }

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -463,7 +463,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Draws an editor for a profile object.
         /// </summary>
-        /// <param name="objectReferenceValue"></param>
         public static void DrawSubProfileEditor(Object profileObject, bool renderProfileInBox)
         {
             if (profileObject == null)
@@ -507,13 +506,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             EditorGUILayout.EndVertical();
         }
 
+        /// <summary>
+        /// Draws a dropdown with all available profiles of profilyType.
+        /// </summary>
+        /// <returns>True if property was changed.</returns>
         public static bool DrawProfileDropDownList(SerializedProperty property, BaseMixedRealityProfile profile, Object oldProfileObject, Type profileType, bool showAddButton)
         {
             bool changed = false;
 
-            // Begin the horizontal group
             using (new EditorGUILayout.HorizontalScope())
             {
+                // Pull profile instances and profile content from cache
                 ScriptableObject[] profileInstances = MixedRealityProfileUtility.GetProfilesOfType(profileType);
                 GUIContent[] profileContent = MixedRealityProfileUtility.GetProfilePopupOptionsByType(profileType);
                 // Set our selected index to our '(None)' option by default

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -549,14 +549,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // Draw the clone button
                 if (property.objectReferenceValue == null)
                 {
-                    var profileTypeName = property.type.Replace("PPtr<$", string.Empty).Replace(">", string.Empty);
-                    if (showAddButton && MixedRealityProfileUtility.IsConcreteProfileType(profileTypeName))
+                    if (showAddButton && MixedRealityProfileUtility.IsConcreteProfileType(profileType))
                     {
                         if (GUILayout.Button(NewProfileContent, EditorStyles.miniButton, GUILayout.Width(20f)))
                         {
-                            Debug.Assert(profileTypeName != null, "No Type Found");
-
-                            ScriptableObject instance = ScriptableObject.CreateInstance(profileTypeName);
+                            ScriptableObject instance = ScriptableObject.CreateInstance(profileType);
                             var newProfile = instance.CreateAsset(AssetDatabase.GetAssetPath(Selection.activeObject)) as BaseMixedRealityProfile;
                             property.objectReferenceValue = newProfile;
                             property.serializedObject.ApplyModifiedProperties();

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Editor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
+{
+    /// <summary>
+    /// This class has utilities and functions for working with profiles in the Unity editor.
+    /// </summary>
+    public static class MixedRealityProfileUtility
+    {
+        /// <summary>
+        /// Private class that listens for asset modifications and updates caches.
+        /// </summary>
+        private class AssetImportListener : UnityEditor.AssetPostprocessor
+        {
+            public static Action OnAssetsChanged { get; set; }
+
+            private static int lastFrameUpdated;
+
+            public static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+            {
+                if (Application.isPlaying)
+                {
+                    return;
+                }
+                if (deletedAssets.Length > 0 || importedAssets.Length > 0)
+                {   // We only care if profiles are created or destroyed, not moved
+                    if (Time.frameCount > lastFrameUpdated)
+                    {   // Don't spam updates
+                        lastFrameUpdated = Time.frameCount;
+                        OnAssetsChanged?.Invoke();
+                    }
+                }
+            }
+        }
+
+        private static readonly String BaseMixedRealityProfileClassName = typeof(BaseMixedRealityProfile).Name;
+        private static Dictionary<Type, ScriptableObject[]> profileCaches = new Dictionary<Type, ScriptableObject[]>();
+        private static Dictionary<Type, GUIContent[]> profileContentCaches = new Dictionary<Type, GUIContent[]>();
+        private static Dictionary<Type, Type[]> profileTypesForServiceCaches = new Dictionary<Type, Type[]>();
+
+        /// <summary>
+        /// Returns an array of profiles that match profile type.
+        /// </summary>
+        /// <param name="profileType"></param>
+        /// <returns></returns>
+        public static ScriptableObject[] GetProfilesOfType(Type profileType)
+        {
+            ScriptableObject[] profilesOfType = null;
+            if (!profileCaches.TryGetValue(profileType, out profilesOfType))
+            {
+                profilesOfType = ScriptableObjectExtensions.GetAllInstances(profileType);
+                profileCaches.Add(profileType, profilesOfType);
+            }
+            return profilesOfType;
+        }
+
+        /// <summary>
+        /// Returns an array of GUIContent for use in a dropdown for a type of profile.
+        /// Includes a (None) option at the very end. This option will always be one greater than the number of available profiles.
+        /// </summary>
+        /// <param name="profileType"></param>
+        /// <returns></returns>
+        public static GUIContent[] GetProfilePopupOptionsByType(Type profileType)
+        {
+            GUIContent[] profileContent = null;
+            if (!profileContentCaches.TryGetValue(profileType, out profileContent))
+            {
+                ScriptableObject[] profilesOfType = GetProfilesOfType(profileType);
+                profileContent = new GUIContent[profilesOfType.Length + 1];
+                for (int i = 0; i < profilesOfType.Length; i++)
+                {
+                    profileContent[i] = new GUIContent(profilesOfType[i].name);
+                }
+                profileContent[profilesOfType.Length] = new GUIContent("(None)");
+                profileContentCaches.Add(profileType, profileContent);
+            }
+            return profileContent;
+        }
+
+        /// <summary>
+        /// Returns true if the given profile type is designed to configure the given service.
+        /// </summary>
+        public static bool IsProfileForService(Type profileType, Type serviceType)
+        {
+            foreach (MixedRealityServiceProfileAttribute serviceProfileAttribute in profileType.GetCustomAttributes(typeof(MixedRealityServiceProfileAttribute), true))
+            {
+                if (serviceProfileAttribute.ServiceType.IsAssignableFrom(serviceType))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if profile is NOT a BaseMixedRealityProfile class type.
+        /// </summary>
+        /// <param name="profileTypeName"></param>
+        /// <returns></returns>
+        public static bool IsConcreteProfileType(String profileTypeName)
+        {
+            return profileTypeName != BaseMixedRealityProfileClassName;
+        }
+
+        /// <summary>
+        /// Given a service type, finds all sub-classes of BaseMixedRealityProfile that are
+        /// designed to configure that service.
+        /// </summary>
+        public static IReadOnlyCollection<Type> GetProfileTypesForService(Type serviceType)
+        {
+            if (serviceType == null)
+            {
+                return Array.Empty<Type>();
+            }
+
+            Type[] types;
+            if (!profileTypesForServiceCaches.TryGetValue(serviceType, out types))
+            {
+                HashSet<Type> allTypes = new HashSet<Type>();
+                ScriptableObject[] allProfiles = GetProfilesOfType(typeof(BaseMixedRealityProfile));
+                for (int i = 0; i < allProfiles.Length; i++)
+                {
+                    ScriptableObject profile = allProfiles[i];
+                    if (IsProfileForService(profile.GetType(), serviceType))
+                    {
+                        allTypes.Add(profile.GetType());
+                    }
+                }
+                types = allTypes.ToArray();
+                profileTypesForServiceCaches.Add(serviceType, types);
+            }
+
+            return types;
+        }
+
+        [InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
+        {
+            AssetImportListener.OnAssetsChanged += AssetImportListener_OnAssetsChange;
+        }
+
+        private static void AssetImportListener_OnAssetsChange()
+        {
+            RefreshProfileCaches();
+        }
+
+        private static void RefreshProfileCaches()
+        {
+            Debug.Log("RefreshProfileCaches");
+
+            List<Type> cachedTypes = new List<Type>(profileCaches.Keys);
+            foreach (Type profileType in cachedTypes)
+            {
+                profileCaches[profileType] = ScriptableObjectExtensions.GetAllInstances(profileType);
+            }
+
+            foreach (Type profileType in cachedTypes)
+            {
+                GetProfilePopupOptionsByType(profileType);
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
@@ -33,7 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
         }
 
-        private static readonly String BaseMixedRealityProfileClassName = typeof(BaseMixedRealityProfile).Name;
         private static Dictionary<Type, ScriptableObject[]> profileCaches = new Dictionary<Type, ScriptableObject[]>();
         private static Dictionary<Type, GUIContent[]> profileContentCaches = new Dictionary<Type, GUIContent[]>();
         private static Dictionary<Type, Type[]> profileTypesForServiceCaches = new Dictionary<Type, Type[]>();
@@ -99,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <returns></returns>
         public static bool IsConcreteProfileType(Type profileType)
         {
-            return profileType.Name != BaseMixedRealityProfileClassName;
+            return profileType != typeof(BaseMixedRealityProfile);
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
@@ -22,22 +22,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             public static Action OnAssetsChanged { get; set; }
 
-            private static int lastFrameUpdated;
-
             public static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
             {
                 if (Application.isPlaying)
                 {
                     return;
                 }
-                if (deletedAssets.Length > 0 || importedAssets.Length > 0)
-                {   // We only care if profiles are created or destroyed, not moved
-                    if (Time.frameCount > lastFrameUpdated)
-                    {   // Don't spam updates
-                        lastFrameUpdated = Time.frameCount;
-                        OnAssetsChanged?.Invoke();
-                    }
-                }
+
+                OnAssetsChanged?.Invoke();
             }
         }
 
@@ -64,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         /// <summary>
         /// Returns an array of GUIContent for use in a dropdown for a type of profile.
-        /// Includes a (None) option at the very end. This option will always be one greater than the number of available profiles.
+        /// Includes a (None) option at the start. This means that the array length will always be 1 greater than the available profiles.
         /// </summary>
         /// <param name="profileType"></param>
         /// <returns></returns>
@@ -75,11 +67,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {
                 ScriptableObject[] profilesOfType = GetProfilesOfType(profileType);
                 profileContent = new GUIContent[profilesOfType.Length + 1];
+                profileContent[0] = new GUIContent("(None)");
                 for (int i = 0; i < profilesOfType.Length; i++)
                 {
-                    profileContent[i] = new GUIContent(profilesOfType[i].name);
+                    profileContent[i + 1] = new GUIContent(profilesOfType[i].name);
                 }
-                profileContent[profilesOfType.Length] = new GUIContent("(None)");
                 profileContentCaches.Add(profileType, profileContent);
             }
             return profileContent;
@@ -154,17 +146,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static void RefreshProfileCaches()
         {
-            Debug.Log("RefreshProfileCaches");
-
             List<Type> cachedTypes = new List<Type>(profileCaches.Keys);
+            profileContentCaches.Clear();
             foreach (Type profileType in cachedTypes)
             {
                 profileCaches[profileType] = ScriptableObjectExtensions.GetAllInstances(profileType);
-            }
-
-            foreach (Type profileType in cachedTypes)
-            {
-                GetProfilePopupOptionsByType(profileType);
             }
         }
     }

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
@@ -95,11 +95,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Returns true if profile is NOT a BaseMixedRealityProfile class type.
         /// </summary>
-        /// <param name="profileTypeName"></param>
+        /// <param name="profileType"></param>
         /// <returns></returns>
-        public static bool IsConcreteProfileType(String profileTypeName)
+        public static bool IsConcreteProfileType(Type profileType)
         {
-            return profileTypeName != BaseMixedRealityProfileClassName;
+            return profileType.Name != BaseMixedRealityProfileClassName;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
@@ -40,8 +40,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Returns an array of profiles that match profile type.
         /// </summary>
-        /// <param name="profileType"></param>
-        /// <returns></returns>
         public static ScriptableObject[] GetProfilesOfType(Type profileType)
         {
             ScriptableObject[] profilesOfType = null;
@@ -57,8 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// Returns an array of GUIContent for use in a dropdown for a type of profile.
         /// Includes a (None) option at the start. This means that the array length will always be 1 greater than the available profiles.
         /// </summary>
-        /// <param name="profileType"></param>
-        /// <returns></returns>
         public static GUIContent[] GetProfilePopupOptionsByType(Type profileType)
         {
             GUIContent[] profileContent = null;
@@ -94,8 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Returns true if profile is NOT a BaseMixedRealityProfile class type.
         /// </summary>
-        /// <param name="profileType"></param>
-        /// <returns></returns>
         public static bool IsConcreteProfileType(Type profileType)
         {
             return profileType != typeof(BaseMixedRealityProfile);

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36d6219eaecc7f54a9177df046abf5b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Major changes
- Adds the `MixedRealityProfileUtility` class. This class is responsible for listening for asset changes and caching available profiles by type and service type. Prior to this change inspectors were searching for ScriptableObject instances every redraw.
- Changes profiles from object fields to dropdown lists and moves profile drawing from `BaseMixedRealityProfileInspector` to `MixedRealityInspectorUtilities`. The GUIContent for these lists are cached.
- Adds a 'View Asset' button to profile fields - clicking this reveals the ScriptableObject asset in the project view.
- Removes object picker window functionality from MixedRealityToolkitInspector, since dropdowns are effectively the same.

![MRTKInspector](https://user-images.githubusercontent.com/9789716/65798513-ab45dc80-e126-11e9-9668-83274f114a4e.png)

## Changes
- Addresses: #6120

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
