### PR TITLE
Update MRTK_Development to Version 2.2.0

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Version.txt
+++ b/Assets/MixedRealityToolkit.Examples/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit.Extensions/Version.txt
+++ b/Assets/MixedRealityToolkit.Extensions/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit.Providers/Version.txt
+++ b/Assets/MixedRealityToolkit.Providers/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit.SDK/Version.txt
+++ b/Assets/MixedRealityToolkit.SDK/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit.Services/Version.txt
+++ b/Assets/MixedRealityToolkit.Services/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Build.Editor
                      xmlns:mobile='http://schemas.microsoft.com/appx/manifest/mobile/windows10'
                      IgnorableNamespaces='uap uap2 uap3 uap4 mp mobile iot'
                      xmlns='http://schemas.microsoft.com/appx/manifest/foundation/windows10'>
-              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.1.0.0' />
+              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.2.0.0' />
               <mp:PhoneIdentity PhoneProductId='85c8bcd4-fbac-44ed-adf6-bfc01242a27f' PhonePublisherId='00000000-0000-0000-0000-000000000000' />
               <Properties>
                 <DisplayName>MixedRealityToolkit</DisplayName>

--- a/Assets/MixedRealityToolkit.Tests/Version.txt
+++ b/Assets/MixedRealityToolkit.Tests/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit.Tools/Version.txt
+++ b/Assets/MixedRealityToolkit.Tools/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Assets/MixedRealityToolkit/Version.txt
+++ b/Assets/MixedRealityToolkit/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.1.0
+Microsoft Mixed Reality Toolkit 2.2.0

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -10,7 +10,8 @@ This document outlines the roadmap of the Mixed Reality Toolkit.
  
 | Product | Description | Timeline | Project board |
 | --- | --- | --- | --- |
-| MRTK V2.1 | Next iteration of MRTK, currently tagged as V2.1 | TBD |  |
+| MRTK V2.1 | Next iteration of MRTK, currently tagged as V2.1 | October 2019 |  |
+| MRTK V2.2 | Next iteration of MRTK, currently tagged as V2.1 | TBD |  |
 
 Release details, including backlog items, can be found on the [GitHub project pages](https://github.com/Microsoft/MixedRealityToolkit-Unity/projects).
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.1.0
+  bundleVersion: 2.2.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -587,7 +587,7 @@ PlayerSettings:
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Microsoft.MixedReality.Toolkit
-  metroPackageVersion: 2.1.0.0
+  metroPackageVersion: 2.2.0.0
   metroCertificatePath: Assets/WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: Microsoft

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -2,7 +2,7 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.1.0
+  MRTKVersion: 2.2.0
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -2,7 +2,7 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.1.0
+  MRTKVersion: 2.2.0
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -2,7 +2,7 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.1.0
+  MRTKVersion: 2.2.0
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -2,7 +2,7 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.1.0  # Major.Minor.Patch
+  MRTKVersion: 2.2.0  # Major.Minor.Patch
   MRTKReleaseTag: 'alpha'  # final version component, e.g. 'RC2.1' or empty string
 
 jobs:

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -2,7 +2,7 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.1.0
+  MRTKVersion: 2.2.0
   packagingEnabled: false
 
 jobs:

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -2,7 +2,7 @@
 
 variables:
   UnityVersion: Unity2018.3.7f1
-  MRTKVersion: 2.1.0
+  MRTKVersion: 2.2.0
 
 jobs:
 - job: PRValidation


### PR DESCRIPTION
Since we branched for stabilization of 2.1, we should update our mrtk_development to 2.2 as it's no longer a 2.1 feature set.