### PR TITLE
Filter out HL2 for the remoting select bug

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
@@ -342,7 +342,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             // remoting binaries.
 #if UNITY_EDITOR
             if (interactionSourceState.source.kind == InteractionSourceKind.Hand &&
-                UnityEngine.XR.WSA.HolographicRemoting.ConnectionState == UnityEngine.XR.WSA.HolographicStreamerConnectionState.Connected)
+                UnityEngine.XR.WSA.HolographicRemoting.ConnectionState == UnityEngine.XR.WSA.HolographicStreamerConnectionState.Connected &&
+                !interactionSourceState.source.supportsGrasp) // Check that we're not remoting to a HoloLens 2
             {
                 // This workaround is safe as long as all these assumptions hold:
                 Debug.Assert(!interactionSourceState.selectPressed, "Unity issue #1033526 seems to have been resolved. Please remove this workaround!");


### PR DESCRIPTION
## Overview
This remoting bug, where the state of select pressed isn't properly remoted, is only valid for HL1. This adds a check for the source supporting grasp, which, since we already filter for hands, is only valid for HL2 in WMR devices.

## Changes
- Part of adding remoting support for HL2 hands (breaking some initials small changes out)