### PR TITLE
Added Interactable enabled check to PhysicalPressEventRouter - fix for 5833

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PhysicalPressEventRouter.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PhysicalPressEventRouter.cs
@@ -32,9 +32,19 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        private bool CanRouteInput()
+        {
+            return routingTarget != null && routingTarget.Enabled;
+        }
+
+        /// <summary>
+        /// Gets called when the TouchBegin event is invoked within the default PressableButton and 
+        /// PressableButtonHoloLens2 components. When the physical touch with a 
+        /// hand has begun, set physical touch state within Interactable. 
+        /// </summary>
         public void OnHandPressTouched()
         {
-            if (routingTarget != null)
+            if (CanRouteInput())
             {
                 routingTarget.SetPhysicalTouch(true);
                 if (InteractableOnClick == PhysicalPressEventBehavior.EventOnTouch)
@@ -46,9 +56,14 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <summary>
+        /// Gets called when the TouchEnd event is invoked within the default PressableButton and 
+        /// PressableButtonHoloLens2 components. Once the physical touch with a hand is removed, set
+        /// the physical touch and possibly press state within Interactable.
+        /// </summary>
         public void OnHandPressUntouched()
         {
-            if (routingTarget != null)
+            if (CanRouteInput())
             {
                 routingTarget.SetPhysicalTouch(false);
                 if (InteractableOnClick == PhysicalPressEventBehavior.EventOnTouch)
@@ -58,9 +73,14 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <summary>
+        /// Gets called when the ButtonPressed event is invoked within the default PressableButton and 
+        /// PressableButtonHoloLens2 components. When the physical press with a hand is triggered, set 
+        /// the physical touch and press state within Interactable. 
+        /// </summary>
         public void OnHandPressTriggered()
         {
-            if (routingTarget != null)
+            if (CanRouteInput())
             {
                 routingTarget.SetPhysicalTouch(true);
                 routingTarget.SetPress(true);
@@ -71,9 +91,14 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        /// <summary>
+        /// Gets called when the ButtonReleased event is invoked within the default PressableButton and 
+        /// PressableButtonHoloLens2 components.  Once the physical press with a hand is completed, set
+        /// the press and physical touch states within Interactable
+        /// </summary>
         public void OnHandPressCompleted()
         {
-            if (routingTarget != null)
+            if (CanRouteInput())
             {
                 routingTarget.SetPhysicalTouch(true);
                 routingTarget.SetPress(true);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -633,6 +633,42 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             method.Invoke(button, new object[0]);
         }
 
+
+        /// <summary>
+        /// Tests if Interactable is internally disabled, then the PhysicalPressEventRouter
+        /// should not invoke events in Interactable.  Addresses issue 5833.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator CheckPhysicalPressableRouterEventsOnDisableInteractable()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            GameObject testButton = InstantiateDefaultPressableButton("PressableButtonHoloLens2.prefab");
+            testButton.transform.position = new Vector3(0, 0, 1);
+            testButton.transform.localScale = Vector3.one * 1.5f;
+
+            Interactable interactable = testButton.GetComponent<Interactable>();
+            Assert.IsNotNull(interactable);
+
+            bool wasClicked = false;
+            interactable.OnClick.AddListener(() => { wasClicked = true; } );
+
+            yield return PressButtonWithHand();
+
+            Assert.True(wasClicked, "Interactable is enabled, and should recieve click events");
+            wasClicked = false;
+
+            // Disable Interactable, should not recieve click events
+            interactable.Enabled = false;
+
+            yield return PressButtonWithHand();
+
+            // Check if events were raised if interactable is not enabled
+            Assert.False(wasClicked, "Interactable is disabled, we should not recieve a click event");
+
+            GameObject.Destroy(testButton);
+        }
+
         #endregion
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -655,7 +655,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return PressButtonWithHand();
 
-            Assert.True(wasClicked, "Interactable is enabled, and should recieve click events");
+            Assert.True(wasClicked, "Interactable is enabled, and should receive click events");
             wasClicked = false;
 
             // Disable Interactable, should not recieve click events


### PR DESCRIPTION
## Overview
Fix for issue #5833 where near interaction events were triggered when Interactable was disabled.

Added the fix by Julia to PhysicalPressEventRouter which only sets states and triggers near interaction events if Interactable is enabled.

Video of HandInteractionExample scene after the fix:
[Issue 5833 Fix](https://youtu.be/AhKWyaPgiH0)

## Changes
- Added CanRouteInput() to PhysicalPressEventRouter
- Added doc comments to public methods
- Added a test to PressableButtonTests

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
