### PR TITLE
Fixes SceneTransitionService glitches when using single pass instanced rendering in 2019.2.6+

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Profiles/MRTKExamplesHubSceneTransitionServiceProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Profiles/MRTKExamplesHubSceneTransitionServiceProfile.asset
@@ -24,3 +24,4 @@ MonoBehaviour:
   cameraFaderType:
     reference: Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions.CameraFaderQuad,
       Assembly-CSharp
+  cameraFaderMaterial: {fileID: 2100000, guid: 625ee7fe9fc9cb549b4f5ee443687d00, type: 2}

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Assets/CameraFaderMaterial.mat
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Assets/CameraFaderMaterial.mat
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CameraFaderMaterial
+  m_Shader: {fileID: 211, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHABLEND_ON
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - ALWAYS
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BlendOp: 0
+    - _BumpScale: 1
+    - _CameraFadingEnabled: 0
+    - _CameraFarFadeDistance: 2
+    - _CameraNearFadeDistance: 1
+    - _ColorMode: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DistortionBlend: 0.5
+    - _DistortionEnabled: 0
+    - _DistortionStrength: 1
+    - _DistortionStrengthScaled: 0
+    - _DstBlend: 10
+    - _EmissionEnabled: 0
+    - _FlipbookMode: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _LightingEnabled: 0
+    - _Metallic: 0
+    - _Mode: 2
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SoftParticlesEnabled: 0
+    - _SoftParticlesFarFadeDistance: 1
+    - _SoftParticlesNearFadeDistance: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}
+    - _Color: {r: 0, g: 0, b: 0, a: 1}
+    - _ColorAddSubDiff: {r: 0, g: 0, b: 0, a: 0}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SoftParticleFadeParams: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Assets/CameraFaderMaterial.mat.meta
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Assets/CameraFaderMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 625ee7fe9fc9cb549b4f5ee443687d00
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/DefaultSceneTransitionServiceProfile.asset
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/DefaultSceneTransitionServiceProfile.asset
@@ -24,3 +24,4 @@ MonoBehaviour:
   cameraFaderType:
     reference: Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions.CameraFaderQuad,
       Assembly-CSharp
+  cameraFaderMaterial: {fileID: 2100000, guid: 625ee7fe9fc9cb549b4f5ee443687d00, type: 2}

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionService.cs
@@ -405,6 +405,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
             }
 
             cameraFader = (ICameraFader)Activator.CreateInstance(sceneTransitionServiceProfile.CameraFaderType.Type);
+            cameraFader.Initialize(sceneTransitionServiceProfile);
 
             if (cameraFader == null)
             {

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
@@ -20,6 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         public float FadeOutTime => fadeOutTime;
         public float FadeInTime => fadeInTime;
         public CameraFaderTargets FadeTargets => fadeTargets;
+        public Material CameraFaderMaterial => cameraFaderMaterial;
 
         [Header("Progress Indicator Options")]
         [SerializeField]
@@ -59,5 +60,11 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         [Implements(typeof(ICameraFader), TypeGrouping.ByNamespaceFlat)]
         [Tooltip("Which `ICameraFader` class to use for applying a fade effect to cameras.")]
         private SystemType cameraFaderType = default(SystemType);
+
+        [Header("Optional Assets")]
+
+        [SerializeField]
+        [Tooltip("Optional material for your CameraFader class. If an implementation does not use a material, this will be ignored.")]
+        private Material cameraFaderMaterial = null;
     }
 }

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/CameraFaderQuad.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/CameraFaderQuad.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
     /// </summary>
     public class CameraFaderQuad : ICameraFader
     {
-        const string QuadMaterialShaderName = "Sprites/Default";
+        const string QuadMaterialShaderName = "Particles/Standard Unlit";
         const string QuadMaterialColorName = "_Color";
 
         /// <summary>
@@ -66,6 +66,15 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                 try
                 {
                     quadMaterial = new Material(Shader.Find(QuadMaterialShaderName));
+                    // Set to fade
+                    quadMaterial.SetInt("_Mode", 2);
+                    quadMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+                    quadMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+                    quadMaterial.SetInt("_ZWrite", 0);
+                    quadMaterial.DisableKeyword("_ALPHATEST_ON");
+                    quadMaterial.EnableKeyword("_ALPHABLEND_ON");
+                    quadMaterial.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    quadMaterial.renderQueue = 3000;
                 }
                 catch (Exception e)
                 {
@@ -75,6 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                 }
             }
 
+            quadMaterial.enableInstancing = true;
             quadMaterial.SetColor(QuadMaterialColorName, currentColor);
 
             // Create our quads
@@ -192,14 +202,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
             {
                 if (quad.Renderer != null)
                 {
-                    if (Application.isPlaying)
-                    {
-                        GameObject.Destroy(quad.Renderer.gameObject);
-                    }
-                    else
-                    {
-                        GameObject.DestroyImmediate(quad.Renderer.gameObject);
-                    }
+                    GameObjectExtensions.DestroyGameObject(quad.Renderer.gameObject);
                 }
             }
 

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/CameraFaderQuad.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/CameraFaderQuad.cs
@@ -35,6 +35,14 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         private Color fadeInColor;
         private Color currentColor;
         private Material quadMaterial;
+        private Material quadMaterialTemplate;
+
+        /// <inheritdoc />
+        public void Initialize(SceneTransitionServiceProfile profile)
+        {
+            // If the profile includes a camera fader material, use that
+            quadMaterialTemplate = profile.CameraFaderMaterial;
+        }
 
         /// <inheritdoc />
         public async Task FadeOutAsync(float fadeOutTime, Color color, IEnumerable<Camera> targets)
@@ -65,16 +73,26 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
             {
                 try
                 {
-                    quadMaterial = new Material(Shader.Find(QuadMaterialShaderName));
-                    // Set to fade
-                    quadMaterial.SetInt("_Mode", 2);
-                    quadMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
-                    quadMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-                    quadMaterial.SetInt("_ZWrite", 0);
-                    quadMaterial.DisableKeyword("_ALPHATEST_ON");
-                    quadMaterial.EnableKeyword("_ALPHABLEND_ON");
-                    quadMaterial.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                    quadMaterial.renderQueue = 3000;
+                    if (quadMaterialTemplate != null)
+                    {   // If we have a template, use the template
+                        quadMaterial = new Material(quadMaterialTemplate);
+                    }
+                    else
+                    {   // Otherwise, create a material from scratch
+                        // These keyword variants may not be available depending on what materials were included in the build
+                        // If quad material does not display correctly, try setting the profile's CameraFaderMaterial with a template material
+                        quadMaterial = new Material(Shader.Find(QuadMaterialShaderName));
+                        // Set to fade
+                        quadMaterial.SetInt("_Mode", 2);
+                        quadMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+                        quadMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+                        quadMaterial.SetInt("_ZWrite", 0);
+                        quadMaterial.DisableKeyword("_ALPHATEST_ON");
+                        quadMaterial.EnableKeyword("_ALPHABLEND_ON");
+                        quadMaterial.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                        quadMaterial.renderQueue = 3000;
+
+                    }
                 }
                 catch (Exception e)
                 {

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/ICameraFader.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/ICameraFader.cs
@@ -15,6 +15,12 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         CameraFaderState State { get; }
 
         /// <summary>
+        /// Initializes the camera fader class with a transition profile.
+        /// </summary>
+        /// <param name="profile"></param>
+        void Initialize(SceneTransitionServiceProfile profile);
+
+        /// <summary>
         /// Applies a fade-out effect over time.
         /// </summary>
         /// <param name="fadeOutTime">The duration of the fade</param>

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/ICameraFader.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Scripts/ICameraFader.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         /// <summary>
         /// Initializes the camera fader class with a transition profile.
         /// </summary>
-        /// <param name="profile"></param>
+        /// <param name="profile">The scene transition service profile.</param>
         void Initialize(SceneTransitionServiceProfile profile);
 
         /// <summary>


### PR DESCRIPTION
## Overview
Updates CameraFaderQuad to use an unlit particle shader instead of the default sprite shader.

Also adds an optional camera fader material field to the scene transition profile to get around the issue of required shader variants not being included in the build.

## Changes
- Fixes: #6136

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch

This has been tested in editor and on HL2 devices.
