### PR TITLE
Mark ColliderNearInteractionTouchable as obsolete

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Scenes/MRTKExamplesHub.meta
+++ b/Assets/MixedRealityToolkit.Examples/Demos/ExamplesHub/Scenes/MRTKExamplesHub.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7b0239692b1b399448587194d7a02b5b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/BaseNearInteractionTouchable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/BaseNearInteractionTouchable.cs
@@ -45,4 +45,31 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public abstract float DistanceToTouchable(Vector3 samplePoint, out Vector3 normal);
     }
+
+    /// <summary>
+    /// Obsolete base class for all touchables using colliders.
+    /// Use <cref="BaseNearIntearctionTouchable"> instead.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    [System.Obsolete("Use BaseNearIntearctionTouchable instead of ColliderNearInteractionTouchable", true)]
+    public abstract class ColliderNearInteractionTouchable : BaseNearInteractionTouchable
+    {
+        public bool ColliderEnabled { get { return touchableCollider.enabled && touchableCollider.gameObject.activeInHierarchy; } }
+
+        /// <summary>
+        /// The collider used by this touchable.
+        /// </summary>
+        [SerializeField]
+        [FormerlySerializedAs("collider")]
+        private Collider touchableCollider;
+        public Collider TouchableCollider => touchableCollider;
+
+        protected override void OnValidate()
+        {
+            base.OnValidate();
+
+            touchableCollider = GetComponent<Collider>();
+        }
+    }
+
 }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/BaseNearInteractionTouchable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/BaseNearInteractionTouchable.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
     /// <summary>
     /// Obsolete base class for all touchables using colliders.
-    /// Use <cref="BaseNearIntearctionTouchable"> instead.
+    /// Use <see cref="BaseNearInteractionTouchable"/> instead.
     /// </summary>
     [RequireComponent(typeof(Collider))]
     [System.Obsolete("Use BaseNearIntearctionTouchable instead of ColliderNearInteractionTouchable", true)]


### PR DESCRIPTION
## Overview
Adds back ColliderNearInteractionTouchable but marks it as obsolete, use BaseNearInteractionTouchable instead. Also updated #5912 2.1 release notes.

## Changes
- Fixes: #5922
- Also remove lingering meta file.

## Verification
I verified that referencing `ColliderNearInteractionTouchable ` causes compile error with proper migration message. 

Also verified that docfx generation works with no warnings or errors.

> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
