### PR TITLE
fix ?. usages for obvious UnityEngine.Component derived objects

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerHandlerExample.cs
@@ -23,7 +23,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             {
                 if (newPointer != null)
                 {
-                    Transform parentTransform = newPointer.BaseCursor?.GameObjectReference?.transform;
+                    GameObject gameObjectReference = newPointer.BaseCursor?.GameObjectReference;
+                    Transform parentTransform = (gameObjectReference != null) ? gameObjectReference.transform : null;
 
                     // If there's no cursor try using the controller pointer transform instead
                     if (parentTransform == null)

--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfileInspector.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserverProfileInspector.cs
@@ -78,7 +78,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
                 serializedObject.Update();
 
                 EditorGUILayout.PropertyField(spatialMeshObject);
-                MeshFilter[] filters = (spatialMeshObject.objectReferenceValue as GameObject)?.GetComponentsInChildren<MeshFilter>();
+                GameObject parent = spatialMeshObject.objectReferenceValue as GameObject;
+                MeshFilter[] filters = (parent != null) ? parent.GetComponentsInChildren<MeshFilter>() : null;
                 if ((filters == null) ||
                     (filters.Length == 0))
                 {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -293,9 +293,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else
             {
-                if (this.GetComponent<Renderer>()?.material?.mainTexture != null)
+                Renderer renderer = this.GetComponent<Renderer>();
+                Material material = (renderer != null) ? renderer.material : null;
+                if ((material != null) && (material.mainTexture != null))
                 {
-                    this.GetComponent<Renderer>().material.mainTexture.wrapMode = TextureWrapMode.Repeat;
+                    material.mainTexture.wrapMode = TextureWrapMode.Repeat;
                 }
             }
 
@@ -467,8 +469,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 rightPoint.SetActive(affordancesVisible);
             }
 
-            currentMaterial?.SetColor(proximityLightCenterColorID, active ? proximityLightCenterColor : defaultProximityLightCenterColor);
+            if (currentMaterial != null)
+            {
+                currentMaterial.SetColor(proximityLightCenterColorID, active ? proximityLightCenterColor : defaultProximityLightCenterColor);
+            }
         }
+
         private Vector3 GetContactForHand(Handedness hand)
         {
             Vector3 handPoint = Vector3.zero;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -229,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     RefreshTrackedObject();
                 }
 
-                return trackingTarget?.transform;
+                return (trackingTarget != null) ? trackingTarget.transform : null;
             }
         }
 

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             newMesh.Id = meshId;
             newMesh.GameObject = new GameObject(name, requiredMeshComponents);
             newMesh.GameObject.layer = layer;
-            newMesh.GameObject.transform.parent = meshParent?.transform;
+            newMesh.GameObject.transform.parent = (meshParent != null) ? meshParent.transform : null;
 
             newMesh.Filter = newMesh.GameObject.GetComponent<MeshFilter>();
             newMesh.Filter.sharedMesh = mesh;

--- a/Assets/MixedRealityToolkit/Utilities/StandardShader/StandardShaderUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/StandardShader/StandardShaderUtility.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <returns>True if the material is using the Mixed Reality Toolkit/Standard shader</returns>
         public static bool IsUsingMrtkStandardShader(Material material)
         {
-            return IsMrtkStandardShader(material?.shader);
+            return IsMrtkStandardShader((material != null) ? material.shader : null);
         }
 
         /// <summary>


### PR DESCRIPTION
This change is a first-pass update to remove usages of ?. from objects that obviously derive from UnityEngine.Component (ex: GameObject)

Fixes: #6044 

## Validation
- Use HandInteractionExample (in editor) and the InputSimulationService to verify no input related regressions.