### PR TITLE
Fix ms build docs and editor checks

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
-using UnityEditor;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
@@ -76,8 +75,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 Transform child = transform.GetChild(i);
 #if UNITY_EDITOR
-                Undo.RecordObject(child, "ObjectCollection modify transform");
-#endif
+                UnityEditor.Undo.RecordObject(child, "ObjectCollection modify transform");
+#endif // UNITY_EDITOR
                 if (!ContainsNode(child) && (child.gameObject.activeSelf || !IgnoreInactiveTransforms))
                 {
                     NodeList.Add(new ObjectCollectionNode { Name = child.name, Transform = child });

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -235,4 +234,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -631,4 +630,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectDependency.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectDependency.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEditor;
 
@@ -39,4 +38,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -342,4 +341,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CompilationPlatformInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CompilationPlatformInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -167,4 +166,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -215,4 +214,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/PluginAssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/PluginAssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -271,4 +270,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/ReferenceItemInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/ReferenceItemInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -74,4 +73,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TargetFramework.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TargetFramework.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using UnityEditor;
 
@@ -73,4 +72,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TemplateFiles.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TemplateFiles.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -168,4 +167,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/UnityProjectInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/UnityProjectInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -369,4 +368,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -439,15 +438,14 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             TryIOWithRetries(() => Directory.Delete(targetDir, false), 2, TimeSpan.FromMilliseconds(100), true);
 
-            if (waitForDirectoryDelete)
+            if (waitForDirectoryDelete && Application.isEditor)
             {
-#if UNITY_EDITOR // Just in case make sure this is forced to be Editor only
+                // Just in case make sure this is forced to be Editor only
                 // Sometimes the delete isn't committed fast enough, lets spin and wait for this to happen
                 for (int i = 0; i < 10 && Directory.Exists(targetDir); i++)
                 {
                     Thread.Sleep(100);
                 }
-#endif
             }
         }
 
@@ -595,4 +593,3 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
     }
 }
-#endif

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityEditorSettings.cs
@@ -35,14 +35,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {
                 if (MixedRealityToolkitFiles.AreFoldersAvailable)
                 {
-#if UNITY_EDITOR
-                    if (MixedRealityToolkitFiles.MRTKDirectories.Count() > 1)
+                    if (Application.isEditor && MixedRealityToolkitFiles.MRTKDirectories.Count() > 1)
                     {
                         Debug.LogError($"A deprecated API '{nameof(MixedRealityEditorSettings)}.{nameof(MixedRealityToolkit_AbsoluteFolderPath)}' " +
                             "is being used, and there are more than one MRTK directory in the project; most likely due to ingestion as NuGet. " +
                             $"Update to use the '{nameof(MixedRealityToolkitFiles)}' APIs.");
                     }
-#endif
 
                     return MixedRealityToolkitFiles.MRTKDirectories.First();
                 }


### PR DESCRIPTION
## Overview
There are quite a few classes in the Microsoft.MixedReality.Toolkit.MSBuild namespace that aren't being picked up by our docs generation.
![image](https://user-images.githubusercontent.com/3580640/65917344-00365c80-e38c-11e9-9f30-e29e90d0ed6e.png)

![image](https://user-images.githubusercontent.com/3580640/65917357-075d6a80-e38c-11e9-8b3f-5752cac4c104.png)

Since these classes are already in an editor-only assembly, we shouldn't need to `#if UNITY_EDITOR` them as well.