### PR TITLE
Explicitly use Windows.Storage

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -10,6 +10,11 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Rendering;
 
+#if WINDOWS_UWP
+using Windows.Storage;
+using Windows.Storage.Streams;
+#endif // WINDOWS_UWP
+
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 {
     public static class ConstructGltf
@@ -137,14 +142,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                         {
                             try
                             {
-                                var storageFile = await Windows.Storage.StorageFile.GetFileFromPathAsync(path);
+                                var storageFile = await StorageFile.GetFileFromPathAsync(path);
 
                                 if (storageFile != null)
                                 {
 
-                                    var buffer = await Windows.Storage.FileIO.ReadBufferAsync(storageFile);
+                                    var buffer = await FileIO.ReadBufferAsync(storageFile);
 
-                                    using (Windows.Storage.Streams.DataReader dataReader = Windows.Storage.Streams.DataReader.FromBuffer(buffer))
+                                    using (DataReader dataReader = DataReader.FromBuffer(buffer))
                                     {
                                         imageData = new byte[buffer.Length];
                                         dataReader.ReadBytes(imageData);

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
 using System;
 using System.Collections.Generic;
@@ -10,6 +9,13 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
+
+#if WINDOWS_UWP
+using Windows.Storage;
+using Windows.Storage.Streams;
+#else
+using Microsoft.MixedReality.Toolkit.Utilities;
+#endif
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 {
@@ -71,7 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 {
                     try
                     {
-                        var storageFile = await Windows.Storage.StorageFile.GetFileFromPathAsync(uri);
+                        var storageFile = await StorageFile.GetFileFromPathAsync(uri);
 
                         if (storageFile == null)
                         {
@@ -79,9 +85,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                             return null;
                         }
 
-                        var buffer = await Windows.Storage.FileIO.ReadBufferAsync(storageFile);
+                        var buffer = await FileIO.ReadBufferAsync(storageFile);
 
-                        using (Windows.Storage.Streams.DataReader dataReader = Windows.Storage.Streams.DataReader.FromBuffer(buffer))
+                        using (DataReader dataReader = DataReader.FromBuffer(buffer))
                         {
                             glbData = new byte[buffer.Length];
                             dataReader.ReadBytes(glbData);


### PR DESCRIPTION
## Overview
As part of adding remoting support for HL2, there will be a new `.Windows` namespace. This change helps disambiguate these namespaces ahead of time.

## Changes
- Part of adding remoting support for HL2 hands (breaking some initials small changes out)