### PR TITLE
fix null reference exception when re-enabling input system

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.Input
+{
+    class DisableEnableInputSystemTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            PlayModeTestUtilities.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+        }
+        
+        [UnityTest]
+        public IEnumerator DisableEnableInputSystem()
+        {
+            yield return null;
+
+            TestContext.Out.WriteLine("Disable the input system");
+            CoreServices.InputSystem.Disable();
+
+            yield return new WaitForSeconds(2);
+
+            TestContext.Out.WriteLine("Enable the input system");
+            CoreServices.InputSystem.Enable();
+
+            TestContext.Out.WriteLine("Display a test hand");
+            TestHand rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(new Vector3(-0.3f, -0.1f, 0.5f));
+        }
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b28fc5f0ce7af84a9904343cfff063b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When the input system initializes, it instantiates the registered gaze provider. When it is disabled, the gaze provider is destroyed. Unfortunately, enable was not re-creating the gaze provider, resulting in null reference exceptions.

This change creates the InstantiateGazeProvider method and calls it from Initialize and, if null, from Enable.


Fixes: #5085


## Verification
Create simple scene in editor. 
Apply the script shown below to any object.
Disable and then re-enable the input system.
Use the input simulation provider to display a hand (ex: spacebar)

```c#
using Microsoft.MixedReality.Toolkit;
using Microsoft.MixedReality.Toolkit.Input;
using System.Collections;
using System.Collections.Generic;
using UnityEngine;

public class EnableDisableSystemTest : MonoBehaviour
{
    private IMixedRealityInputSystem inputSystem = null;
    private IMixedRealityInputSystem InputSystem
    {
        get
        {
            if (inputSystem == null)
            {
                MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
            }
            return inputSystem;
        }
    }

    public void DisableInputSystem()
    {
        InputSystem.Disable();
    }

    public void EnableInputSystem()
    {
        InputSystem.Enable();
    }

    public void Update()
    {
        if (Input.GetKeyDown(KeyCode.Alpha1))
        {
            Debug.Log("Enabling input system");
            EnableInputSystem();
        }
        if (Input.GetKeyDown(KeyCode.Alpha2))
        {
            Debug.Log("Disabling input system");
            DisableInputSystem();
        }
    }
}
```