### PR TITLE
Fix 2.1.0 docs

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// Parses an asmdef file creating a new instance of <see cref="AssemblyDefinitionInfo"/>.
         /// </summary>
         /// <param name="file">The file representing asmdef.</param>
-        /// <param name="unityProjectInfo">Instance of <see cref="UnityProjectInfo"/>,</param>
+        /// <param name="unityProjectInfo">Instance of <see cref="UnityProjectInfo"/>.</param>
         /// <param name="assembly">The Unity assembly reference.</param>
         /// <param name="isBuiltInPackage">True whether this asmdef lives in the editor installation folder.</param>
         public static AssemblyDefinitionInfo Parse(FileInfo file, UnityProjectInfo unityProjectInfo, Assembly assembly, bool isBuiltInPackage = false)

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.MSBuild
 {
     /// <summary>
-    /// This class represents an AssemblyDefinition file of a Unity project. It can be used to parse the file contents using <see cref="JsonUtility.FromJson{T}(string)"/>.
+    /// This class represents an AssemblyDefinition file of a Unity project. It can be used to parse the file contents using <see href="https://docs.unity3d.com/ScriptReference/JsonUtility.FromJson.html">JsonUtility.FromJson</see>.
     /// </summary>
     public class AssemblyDefinitionInfo
     {

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CompilationPlatformInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CompilationPlatformInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
     public class CompilationPlatformInfo
     {
         /// <summary>
-        /// Given a non-editor <see cref="AssemblyDefinitionPlatform"/> platform, creates an instances of CompilationPlatform fetching defines and references.
+        /// Given a non-editor <see href="https://docs.unity3d.com/ScriptReference/Compilation.AssemblyDefinitionPlatform.html">AssemblyDefinitionPlatform</see> platform, creates an instances of CompilationPlatform fetching defines and references.
         /// </summary>
         /// <param name="platform">The platform to use for parsing.</param>
         /// <returns>The <see cref="CompilationPlatformInfo"/> containing building information for the platform.</returns>

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TargetFramework.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TargetFramework.cs
@@ -42,10 +42,10 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
 
         /// <summary>
-        /// Returns the configured <see cref="TargetFramework"/> for the <see cref="BuildTargetGroup"/>.
+        /// Returns the configured <see cref="TargetFramework"/> for the <see href="https://docs.unity3d.com/ScriptReference/BuildTargetGroup.html">BuildTargetGroup</see>.
         /// </summary>
-        /// <param name="this">The <see cref="BuildTargetGroup"/> to get <see cref="TargetFramework"/> for.</param>
-        /// <returns>The <see cref="TargetFramework"/> configured for given <see cref="BuildTargetGroup"/>.</returns>
+        /// <param name="this">The <see href="https://docs.unity3d.com/ScriptReference/BuildTargetGroup.html">BuildTargetGroup</see> to get <see cref="TargetFramework"/> for.</param>
+        /// <returns>The <see cref="TargetFramework"/> configured for given <see href="https://docs.unity3d.com/ScriptReference/BuildTargetGroup.html">BuildTargetGroup</see>.</returns>
         public static TargetFramework GetTargetFramework(this BuildTargetGroup @this)
         {
             if (@this == BuildTargetGroup.Unknown)

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// </summary>
         /// <param name="assetPath">The path to the asset (not the .meta file).</param>
         /// <param name="guid">The guid extracted.</param>
-        /// <returns>True if the operation was succesful.</returns>
+        /// <returns>True if the operation was successful.</returns>
         public static bool TryGetGuidForAsset(FileInfo assetPath, out Guid guid)
         {
             string metaFile = $"{assetPath.FullName}.meta";
@@ -316,7 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
 
         /// <summary>
-        /// Reads while the predicate is satisifed, returns the line on which it failed.
+        /// Reads while the predicate is satisfied, returns the line on which it failed.
         /// </summary>
         /// <param name="reader">The <see cref="System.IO.StreamReader"/> to use for reading.</param>
         /// <param name="predicate">The predicate that should return false when reading should stop.</param>
@@ -408,7 +408,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     }
                 }
 
-                Thread.Sleep(sleepBetweenRetrie);
+                Thread.Sleep(sleepBetweenRetries);
                 numRetries--;
             } while (numRetries >= 0);
 
@@ -416,7 +416,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
 
         /// <summary>
-        /// Delete directory helper that also waits for delete to completely propogate through the system.
+        /// Delete directory helper that also waits for delete to completely propagate through the system.
         /// </summary>
         public static void DeleteDirectory(string targetDir, bool waitForDirectoryDelete = false)
         {

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
@@ -237,7 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// <summary>
         /// Reads until some contents is encountered, or the end of the stream is reached.
         /// </summary>
-        /// <param name="reader">The <see cref="StreamReader"/> to use for reading.</param>
+        /// <param name="reader">The <see cref="System.IO.StreamReader"/> to use for reading.</param>
         /// <param name="contents">The contents to search for in the lines being read.</param>
         /// <returns>The line on which some of the contents was found.</returns>
         public static string ReadUntil(this StreamReader reader, params string[] contents)
@@ -318,7 +318,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// <summary>
         /// Reads while the predicate is satisifed, returns the line on which it failed.
         /// </summary>
-        /// <param name="reader">The <see cref="StreamReader"/> to use for reading.</param>
+        /// <param name="reader">The <see cref="System.IO.StreamReader"/> to use for reading.</param>
         /// <param name="predicate">The predicate that should return false when reading should stop.</param>
         /// <returns>The line on which the predicate returned false.</returns>
         public static string ReadWhile(this StreamReader reader, System.Func<string, bool> predicate)
@@ -384,7 +384,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// <summary>
         /// Helper to perform an IO operation with retries.
         /// </summary>
-        public static bool TryIOWithRetries(Action operation, int numRetries, TimeSpan sleepBetweenRetrie, bool throwOnLastRetry = false)
+        public static bool TryIOWithRetries(Action operation, int numRetries, TimeSpan sleepBetweenRetries, bool throwOnLastRetry = false)
         {
             do
             {
@@ -555,7 +555,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         }
 
         /// <summary>
-        /// Gets a <see cref="BuildTargetGroup"/> for a specified <see cref="BuildTarget"/>.
+        /// Gets a <see href="https://docs.unity3d.com/ScriptReference/BuildTargetGroup.html">BuildTargetGroup</see> for a specified <see href="https://docs.unity3d.com/ScriptReference/BuildTarget.html">BuildTarget</see>.
         /// </summary>
         public static BuildTargetGroup GetBuildTargetGroup(BuildTarget buildTarget)
         {


### PR DESCRIPTION
## Overview
#6146 broke the stabilization docs build, since the mrtk_docs pipeline isn't running on stabilization PR validation.

## Verification
Built docs locally (since the mrtk_docs pipeline doesn't appear configured for stabilization PR validation.)