### PR TITLE
PressableButton inspector warnings

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -14,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// A button that can be pushed via direct touch.
     /// You can use <see cref="Microsoft.MixedReality.Toolkit.PhysicalPressEventRouter"/> to route these events to <see cref="Microsoft.MixedReality.Toolkit.UI.Interactable"/>.
     ///</summary>
+    [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html")]
     public class PressableButton : MonoBehaviour, IMixedRealityTouchHandler
     {
         const string InitialMarkerTransformName = "Initial Marker";

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -292,18 +292,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
             }
 
-            // Ensure that no ancestors have touchables, as this will cause this PressableButton to fail to function.
-            var ancestorTouchable = button.FindAncestorComponent<NearInteractionTouchableSurface>(includeSelf: false);
-            if (ancestorTouchable != null)
-            {
-                EditorGUILayout.HelpBox($"An ancestor of this game object contains a {ancestorTouchable.GetType().Name}, which will cause this {target.GetType().Name} to fail to work properly.  You must remove the {ancestorTouchable.GetType().Name} from the ancestor, {ancestorTouchable.name}", MessageType.Warning);
-
-                if (GUILayout.Button($"Select ancestor"))
-                {
-                    Selection.activeGameObject = ancestorTouchable.gameObject;
-                }
-            }
-
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(movingButtonVisuals);
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -258,6 +259,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
+
+            if (target != null)
+            {
+                var helpURL = target.GetType().GetCustomAttribute<HelpURLAttribute>();
+                if (helpURL != null)
+                {
+                    InspectorUIUtility.RenderDocumentationButton(helpURL.URL);
+                }
+            }
 
             // Ensure there is a touchable.
             if (touchable == null)

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -306,6 +306,25 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(movingButtonVisuals);
+
+            // Ensure that there is a moving button visuals in the UnityUI case.  Even if it is not visible, it must be present to receive GraphicsRaycasts.
+            if (touchable is NearInteractionTouchableUnityUI)
+            {
+                if (movingButtonVisuals.objectReferenceValue == null)
+                {
+                    EditorGUILayout.HelpBox($"When used with a NearInteractionTouchableUnityUI, a MovingButtonVisuals is required, as it receives the GraphicsRaycast that allows pressing the button with near/hand interactions.  It does not need to be visible, but it must be able to receive GraphicsRaycasts.", MessageType.Warning);
+                }
+                else
+                {
+                    var movingVisualGameObject = (GameObject)movingButtonVisuals.objectReferenceValue;
+                    var movingGraphic = movingVisualGameObject.GetComponentInChildren<UnityEngine.UI.Graphic>();
+                    if (movingGraphic == null)
+                    {
+                        EditorGUILayout.HelpBox($"When used with a NearInteractionTouchableUnityUI, the MovingButtonVisuals must contain an Image, RawImage, or other Graphic element so that it can receive a GraphicsRaycast.", MessageType.Warning);
+                    }
+                }
+            }
+
             EditorGUILayout.LabelField("Press Settings", EditorStyles.boldLabel);
 
             EditorGUI.BeginChangeCheck();

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -259,6 +259,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             serializedObject.Update();
 
+            // Ensure there is a touchable.
             if (touchable == null)
             {
                 EditorGUILayout.HelpBox($"{target.GetType().Name} requires a {nameof(NearInteractionTouchableSurface)}-derived component on this game object to function.", MessageType.Warning);
@@ -279,6 +280,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
             }
 
+            // Ensure that the touchable has EventsToReceive set to Touch
             if (touchable.EventsToReceive != TouchableEventType.Touch)
             {
                 EditorGUILayout.HelpBox($"The {nameof(NearInteractionTouchableSurface)}-derived component on this game object currently has its EventsToReceive set to '{touchable.EventsToReceive}'.  It must be set to 'Touch' in order for PressableButton to function propertly.", MessageType.Warning);
@@ -287,6 +289,18 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     Undo.RecordObject(touchable, string.Concat("Set EventsToReceive to Touch on ", touchable.name));
                     touchable.EventsToReceive = TouchableEventType.Touch;
+                }
+            }
+
+            // Ensure that no ancestors have touchables, as this will cause this PressableButton to fail to function.
+            var ancestorTouchable = button.FindAncestorComponent<NearInteractionTouchableSurface>(includeSelf: false);
+            if (ancestorTouchable != null)
+            {
+                EditorGUILayout.HelpBox($"An ancestor of this game object contains a {ancestorTouchable.GetType().Name}, which will cause this {target.GetType().Name} to fail to work properly.  You must remove the {ancestorTouchable.GetType().Name} from the ancestor, {ancestorTouchable.name}", MessageType.Warning);
+
+                if (GUILayout.Button($"Select ancestor"))
+                {
+                    Selection.activeGameObject = ancestorTouchable.gameObject;
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -15,11 +15,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public static class InspectorUIUtility
     {
         //Colors
-        public static readonly Color ColorTint100 = new Color(1f, 1f, 1f);
-        public static readonly Color ColorTint75 = new Color(0.75f, 0.75f, 0.75f);
-        public static readonly Color ColorTint50 = new Color(0.5f, 0.5f, 0.5f);
-        public static readonly Color ColorTint25 = new Color(0.25f, 0.25f, 0.25f);
-        public static readonly Color ColorTint10 = new Color(0.10f, 0.10f, 0.10f);
+        private static readonly Color PersonalThemeColorTint100 = new Color(1f, 1f, 1f);
+        private static readonly Color PersonalThemeColorTint75 = new Color(0.75f, 0.75f, 0.75f);
+        private static readonly Color PersonalThemeColorTint50 = new Color(0.5f, 0.5f, 0.5f);
+        private static readonly Color PersonalThemeColorTint25 = new Color(0.25f, 0.25f, 0.25f);
+        private static readonly Color PersonalThemeColorTint10 = new Color(0.10f, 0.10f, 0.10f);
+
+        private static readonly Color ProfessionalThemeColorTint100 = new Color(0f, 0f, 0f);
+        private static readonly Color ProfessionalThemeColorTint75 = new Color(0.25f, 0.25f, 0.25f);
+        private static readonly Color ProfessionalThemeColorTint50 = new Color(0.5f, 0.5f, 0.5f);
+        private static readonly Color ProfessionalThemeColorTint25 = new Color(0.75f, 0.75f, 0.75f);
+        private static readonly Color ProfessionalThemeColorTint10 = new Color(0.9f, 0.9f, 0.9f);
+
+        public static Color ColorTint100 => EditorGUIUtility.isProSkin ? ProfessionalThemeColorTint100 : PersonalThemeColorTint100;
+        public static Color ColorTint75 => EditorGUIUtility.isProSkin ? ProfessionalThemeColorTint75 : PersonalThemeColorTint75;
+        public static Color ColorTint50 => EditorGUIUtility.isProSkin ? ProfessionalThemeColorTint50 : PersonalThemeColorTint50;
+        public static Color ColorTint25 => EditorGUIUtility.isProSkin ? ProfessionalThemeColorTint25 : PersonalThemeColorTint25;
+        public static Color ColorTint10 => EditorGUIUtility.isProSkin ? ProfessionalThemeColorTint10 : PersonalThemeColorTint10;
 
         // default UI sizes
         public const int TitleFontSize = 14;


### PR DESCRIPTION
## Overview
Show warnings in the Inspector for several cases which will cause PressableButton to fail to function properly.

- A NearInteractionTouchable or NearInteractionTouchableUnityUI must be present.  Decide which to add based on presence of RectTransform.
- The Touchable's EventsToReceive must be Touch.
- In the UnityUI case, there must be a MovingButtonVisuals present with a Graphic (aka, Image, RawImage, etc.) present.

Fixes #6159.

![PressableButtonWarnings](https://user-images.githubusercontent.com/41760870/66004561-f8df8380-e45d-11e9-8c9b-434af793b939.gif)
