### PR TITLE
Fix serialized property name in the inspector that was broken due to property rename

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             isGlobal = serializedObject.FindProperty("isGlobal");
             canSelect = serializedObject.FindProperty("CanSelect");
             canDeselect = serializedObject.FindProperty("CanDeselect");
-            startDimensionIndex = serializedObject.FindProperty("StartDimensionIndex");
+            startDimensionIndex = serializedObject.FindProperty("startDimensionIndex");
             dimensionIndex = serializedObject.FindProperty("dimensionIndex");
             dimensions = serializedObject.FindProperty("dimensions");
 


### PR DESCRIPTION
## Overview
Property rename introduced in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6104
resulted in a regressions in Interactable Editor experience. This prevents users from setting an intractable as Toggle/MultiDimensional selection mode.

## Changes
- Fixes: # .https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6161


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
