### PR TITLE
Add controller mapping tests

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -59,10 +59,16 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             new MixedRealityInteractionMapping(11, "Thumbstick Press", AxisType.Digital, DeviceInputType.ButtonPress,  KeyCode.JoystickButton19),
         };
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Setup the default interactions, then update the spatial pointer rotation with the preconfigured offset angle.
+        /// </summary>
         public override void SetupDefaultInteractions(Handedness controllerHandedness)
         {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
+            base.SetupDefaultInteractions(controllerHandedness);
+
+            MixedRealityPose startingRotation = MixedRealityPose.ZeroIdentity;
+            startingRotation.Rotation *= Quaternion.AngleAxis(PointerOffsetAngle, Vector3.left);
+            Interactions[0].PoseData = startingRotation;
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
 {
@@ -65,6 +66,8 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         public override void SetupDefaultInteractions(Handedness controllerHandedness)
         {
             base.SetupDefaultInteractions(controllerHandedness);
+
+            Assert.AreEqual(Interactions[0].Description, "Spatial Pointer", "The first interaction mapping is no longer the Spatial Pointer. Please update.");
 
             MixedRealityPose startingRotation = MixedRealityPose.ZeroIdentity;
             startingRotation.Rotation *= Quaternion.AngleAxis(PointerOffsetAngle, Vector3.left);

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Input.UnityInput;
+using Microsoft.MixedReality.Toolkit.OpenVR.Input;
+using NUnit.Framework;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+{
+    public class ControllerMappingTests
+    {
+        [Test]
+        public void MouseControllerUpdateTest()
+        {
+            MouseController controller = new MouseController(TrackingState.NotApplicable, Utilities.Handedness.Any);
+            controller.SetupDefaultInteractions(Utilities.Handedness.Any);
+
+            // Tests
+            Assert.That(() => controller.Update(), Throws.Nothing);
+        }
+
+        [Test]
+        public void XboxControllerUpdateTest()
+        {
+            XboxController controller = new XboxController(TrackingState.NotApplicable, Utilities.Handedness.None);
+            controller.SetupDefaultInteractions(Utilities.Handedness.None);
+
+            TestGenericJoystickControllerUpdate(controller);
+        }
+
+        [Test]
+        public void GenericOpenVRControllerUpdateTest()
+        {
+            GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+
+            GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+
+            TestGenericJoystickControllerUpdate(leftController);
+            TestGenericJoystickControllerUpdate(rightController);
+        }
+
+        [Test]
+        public void OculusRemoteControllerUpdateTest()
+        {
+            OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None);
+            controller.SetupDefaultInteractions(Utilities.Handedness.None);
+
+            TestGenericJoystickControllerUpdate(controller);
+        }
+
+        [Test]
+        public void OculusTouchControllerUpdateTest()
+        {
+            OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+
+            OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+
+            TestGenericJoystickControllerUpdate(leftController);
+            TestGenericJoystickControllerUpdate(rightController);
+        }
+
+        [Test]
+        public void ViveKnucklesControllerUpdateTest()
+        {
+            ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+
+            ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+
+            TestGenericJoystickControllerUpdate(leftController);
+            TestGenericJoystickControllerUpdate(rightController);
+        }
+
+        [Test]
+        public void ViveWandControllerUpdateTest()
+        {
+            ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+
+            ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+
+            TestGenericJoystickControllerUpdate(leftController);
+            TestGenericJoystickControllerUpdate(rightController);
+        }
+
+        [Test]
+        public void WindowsMixedRealityOpenVRMotionControllerUpdateTest()
+        {
+            WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+
+            WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+
+            TestGenericJoystickControllerUpdate(leftController);
+            TestGenericJoystickControllerUpdate(rightController);
+        }
+
+        private void TestGenericJoystickControllerUpdate(GenericJoystickController controller)
+        {
+            // Test
+            Assert.That(() => controller.UpdateController(), Throws.Nothing);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -9,6 +9,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
 {
     public class ControllerMappingTests
     {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            TestUtilities.InitializeMixedRealityToolkitAndCreateScenes(true);
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            TestUtilities.ShutdownMixedRealityToolkit();
+            TestUtilities.EditorTearDownScenes();
+        }
+
         [Test]
         public void MouseControllerUpdateTest()
         {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a55f9966257414943b81f479265c6df9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
@@ -41,8 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes(true);
 
             // Retrieve Input System
-            IMixedRealityInputSystem inputSystem = null;
-            MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem);
+            MixedRealityServiceRegistry.TryGetService(out IMixedRealityInputSystem inputSystem);
 
             // Tests
             Assert.IsNotNull(inputSystem);
@@ -53,11 +52,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
 
-            // Check for Input System
-            var inputSystemExists = MixedRealityToolkit.Instance.IsServiceRegistered<IMixedRealityInputSystem>();
-
-            // Tests
-            Assert.IsFalse(inputSystemExists);
+            // Tests for Input System
+            Assert.IsFalse(MixedRealityToolkit.Instance.IsServiceRegistered<IMixedRealityInputSystem>());
         }
 
         [Test]
@@ -65,14 +61,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes(true);
 
-            // Check for Input System
-            var inputSystemExists = MixedRealityToolkit.Instance.IsServiceRegistered<IMixedRealityInputSystem>();
-
-            // Tests
-            Assert.IsTrue(inputSystemExists);
+            // Tests for Input System
+            Assert.IsTrue(MixedRealityToolkit.Instance.IsServiceRegistered<IMixedRealityInputSystem>());
         }
 
-        
+
         [Test]
         public void TestEmptyDataProvider()
         {
@@ -82,14 +75,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             var inputSystem = MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>();
 
             var dataProviderAccess = (inputSystem as IMixedRealityDataProviderAccess);
-            Assert.IsNotNull(dataProviderAccess);
 
             // Tests
+            Assert.IsNotNull(dataProviderAccess);
             Assert.IsEmpty(dataProviderAccess.GetDataProviders());
         }
 
         [Test]
-        public void TestDataProviderRegisteration()
+        public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
             MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(TestInputSystemProfilePath);
@@ -115,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             Assert.IsFalse(dataProvider.IsEnabled);
 
             inputSystem.Enable();
-            // We still have reference to old dataprovider, check still disabled
+            // We still have reference to old dataProvider, check still disabled
             Assert.IsFalse(dataProvider.IsEnabled);
 
             // dataProvider has been unregistered in Disable and new one created by Enable.
@@ -143,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
         /// <summary>
         /// Create default Input System Profile
         /// </summary>
-        /// <returns>MixedRealityInputSystemProfile scriptableobject with default settings </returns>
+        /// <returns>MixedRealityInputSystemProfile ScriptableObject with default settings</returns>
         private static MixedRealityInputSystemProfile CreateDefaultInputSystemProfile()
         {
             var inputSystemProfile = ScriptableObject.CreateInstance<MixedRealityInputSystemProfile>();

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef
@@ -11,7 +11,8 @@
         "Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem",
         "Microsoft.MixedReality.Toolkit.Tests",
         "Microsoft.MixedReality.Toolkit.Examples",
-        "Microsoft.MixedReality.Toolkit.Tools"
+        "Microsoft.MixedReality.Toolkit.Tools",
+        "Microsoft.MixedReality.Toolkit.Providers.OpenVR"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -93,13 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public Vector3 Velocity { get; protected set; }
 
-        public virtual bool IsInPointingPose
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public virtual bool IsInPointingPose => true;
 
         #endregion IMixedRealityController Implementation
 
@@ -222,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         controllerModel = GetControllerVisualizationProfile().GlobalRightHandModel;
                     }
                 }
-            
+
                 else if (inputSourceType == InputSourceType.Hand)
                 {
                     if (ControllerHandedness == Handedness.Left &&
@@ -255,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (controllerObject != null)
             {
                 controllerObject.name = $"{ControllerHandedness}_{controllerObject.name}";
-                
+
                 MixedRealityPlayspace.AddChild(controllerObject.transform);
 
                 Visualizer = controllerObject.GetComponent<IMixedRealityControllerVisualizer>();

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// <inheritdoc />
         public override void SetupDefaultInteractions(Handedness controllerHandedness)
         {
-            // Generic unity controller's will not have default interactions
+            // Generic Unity controllers will not have default interactions
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 using UInput = UnityEngine.Input;
-using Microsoft.MixedReality.Toolkit.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 {
@@ -19,12 +18,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// </summary>
         /// <param name="trackingState">The controller's tracking state.</param>
         /// <param name="controllerHandedness">The handedness (ex: right) of the controller.</param>
-        /// <param name="inputSource">The controller's input souce.</param>
+        /// <param name="inputSource">The controller's input source.</param>
         /// <param name="interactions">The set of interactions supported by this controller.</param>
         public MouseController(
-            TrackingState trackingState, 
-            Handedness controllerHandedness, 
-            IMixedRealityInputSource inputSource = null, 
+            TrackingState trackingState,
+            Handedness controllerHandedness,
+            IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null) : base(trackingState, controllerHandedness, inputSource, interactions)
         { }
 


### PR DESCRIPTION
## Overview
Add some tests to check that axes and buttons are properly set based on what the device manager / controller update loop expects. Also formats some things.
Before #6184:
![image](https://user-images.githubusercontent.com/3580640/66089620-f13ede00-e534-11e9-8661-b51f1bb2b85a.png)

After:
![image](https://user-images.githubusercontent.com/3580640/66090844-f5b9c580-e539-11e9-9dbc-798a2709edf2.png)

## Changes
- Fixes: #6164 (and makes it harder for it to happen again)