### PR TITLE
Change IsTracked to not have to be set manually

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Is the controller this Synchronizer is registered to currently tracked?
         /// </summary>
-        public bool IsTracked { get; protected set; } = false;
+        public bool IsTracked => TrackingState == TrackingState.Tracked;
 
         /// <summary>
         /// The current tracking state of the assigned <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityController"/>
@@ -114,7 +114,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (eventData.SourceId == Controller?.InputSource.SourceId &&
                 eventData.Controller?.ControllerHandedness == Handedness)
             {
-                IsTracked = false;
                 TrackingState = TrackingState.NotTracked;
 
                 if (destroyOnSourceLost)
@@ -129,7 +128,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (eventData.SourceId == Controller?.InputSource.SourceId)
             {
-                IsTracked = eventData.SourceData == TrackingState.Tracked;
                 TrackingState = eventData.SourceData;
             }
         }
@@ -150,7 +148,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 eventData.SourceId == Controller?.InputSource.SourceId)
             {
                 TrackingState = eventData.Controller.TrackingState;
-                IsTracked = (TrackingState == TrackingState.Tracked);
                 transform.position = eventData.SourceData.Position;
                 transform.rotation = eventData.SourceData.Rotation;
             }
@@ -180,7 +177,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (!UseSourcePoseData &&
                     PoseAction == eventData.MixedRealityInputAction)
                 {
-                    IsTracked = true;
                     TrackingState = TrackingState.Tracked;
                     transform.position = eventData.InputData;
                 }
@@ -195,7 +191,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (!UseSourcePoseData &&
                     PoseAction == eventData.MixedRealityInputAction)
                 {
-                    IsTracked = true;
                     TrackingState = TrackingState.Tracked;
                     transform.rotation = eventData.InputData;
                 }
@@ -210,7 +205,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (!UseSourcePoseData &&
                     PoseAction == eventData.MixedRealityInputAction)
                 {
-                    IsTracked = true;
                     TrackingState = TrackingState.Tracked;
                     transform.position = eventData.InputData.Position;
                     transform.rotation = eventData.InputData.Rotation;


### PR DESCRIPTION
## Overview
[Not targeting stabilization]
Updates ControllerPoseSynchronizer to not have to set `IsTracked` manually everywhere. It was often simply setting it to the result of `TrackingState == Tracked`, so this simplifies any potential mistaken state management.