### PR TITLE
Fix objects jumping when manipulating with VR controllers in editor.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -212,6 +212,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     break;
             }
 
+            // If an XRDevice is present, the user will not be able to control the camera
+            // as it is controlled by the device. We therefore disable camera controls in
+            // this case.
+            // This was causing issues while simulating in editor for VR, as the UpDown
+            // camera movement is mapped to controller AXIS_3, which happens to be the 
+            // select trigger for WMR controllers.
             if (profile.IsCameraControlEnabled && !XRDevice.isPresent)
             {
                 EnableCameraControl();

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using UnityEngine;
+using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -211,7 +212,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     break;
             }
 
-            if (profile.IsCameraControlEnabled)
+            if (profile.IsCameraControlEnabled && !XRDevice.isPresent)
             {
                 EnableCameraControl();
             }


### PR DESCRIPTION
## Overview
This is a very simple change that disables camera controls when an XR device is present. Without this change, the camera position, returned by the camera cache, would jump upwards when the VR controller trigger was pulled. You can see this in the gifs below, as the profiling panel jumps up and down with the head position as the trigger is pulled.

When the head position jumped upwards, it was suddenly closer or further from the controller. This distance is used in `TwoHandMoveLogic` to scale the distance between the controller and the object. This was then causing the object to jump.

### In editor before change:
![HMD_inEditor](https://user-images.githubusercontent.com/47415945/66119109-eb4a0b00-e5cf-11e9-9d99-6d73ecf00adb.gif)

### Built for x64 running on local machine:
![HMD_built](https://user-images.githubusercontent.com/47415945/66119130-f43adc80-e5cf-11e9-914d-2fcf7636405d.gif)

### In editor after change:
![HMD_possibleFix](https://user-images.githubusercontent.com/47415945/66119623-e76ab880-e5d0-11e9-8122-4d3d251f5a2f.gif)

## Changes
- Disabled camera controls when an XR device is present (equivalent to disabling `IsCameraControlEnabled` in the input simulation profile)

- Fixes: #6108
