### PR TITLE
MaterialInstance Documentation Leak Example

### DIFF
--- a/Documentation/Rendering/MaterialInstance.md
+++ b/Documentation/Rendering/MaterialInstance.md
@@ -25,7 +25,7 @@ public class Leak : MonoBehaviour
 > [!Note]
 > The above Leak behavior **will crash Unity** if ran for too long!
 
-As an alternitve try using the [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) behavior:
+As an alternative try using the [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) behavior:
 
 ```csharp
 public class NoLeak : MonoBehaviour

--- a/Documentation/Rendering/MaterialInstance.md
+++ b/Documentation/Rendering/MaterialInstance.md
@@ -6,6 +6,41 @@ The [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialI
 > [!Note]
 > [MaterialPropertyBlocks](https://docs.unity3d.com/ScriptReference/MaterialPropertyBlock.html) are preferred over material instancing but are not always available  in all scenarios.
 
+Why can using [Renderer.material]("https://docs.unity3d.com/ScriptReference/Renderer-material.html") be an issue? If you add the below code to a Unity scene and hit play memory usage will continue to climb and climb:
+
+```csharp
+public class Leak : MonoBehaviour
+{
+    private void Update()
+    {
+        var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        // Memory leak, the material allocated is not tracked & destroyed.
+        cube.GetComponent<Renderer>().material.color = Color.red;
+        ...
+        Destroy(cube);
+    }
+}
+```
+
+> [!Note]
+> The above Leak behavior **will crash Unity** if ran for too long!
+
+As an alternitve try using the [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) behavior:
+
+```csharp
+public class NoLeak : MonoBehaviour
+{
+    private void Update()
+    {
+        var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        // No memory leak, the material allocated is tracked & destroyed by MaterialInstance.
+        cube.EnsureComponent<MaterialInstance>().Material.color = Color.red;
+        ...
+        Destroy(cube);
+    }
+}
+```
+
 ## Usage
 
 When invoking Unity's [Renderer.material]("https://docs.unity3d.com/ScriptReference/Renderer-material.html")(s), Unity automatically instantiates new materials. It is the caller's responsibility to destroy the materials when a material is no longer needed or the game object is destroyed. The [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) behavior helps avoid material leaks and keeps material allocation paths consistent during edit and run time.


### PR DESCRIPTION
# Overview

Minor change, adding sample code to demonstrate why developers should use MaterialInstance.