### PR TITLE
Combine multiple TearDown attributes

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
@@ -3,9 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using NUnit.Framework;
-using UnityEngine;
-using System;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.Core

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         public void TearDown()
         {
             TestUtilities.ShutdownMixedRealityToolkit();
+            TestUtilities.EditorTearDownScenes();
         }
 
         #region Service Locator Tests
@@ -492,11 +493,5 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         }
 
         #endregion
-
-        [TearDown]
-        public void CleanupMixedRealityToolkitTests()
-        {
-            TestUtilities.EditorTearDownScenes();
-        }
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
         public void TearDown()
         {
             TestUtilities.ShutdownMixedRealityToolkit();
+            TestUtilities.EditorTearDownScenes();
         }
 
         [Test]
@@ -132,12 +133,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
             Assert.IsNotNull(dataProvider);
             Assert.IsTrue(dataProvider.IsInitialized);
             Assert.IsTrue(dataProvider.IsEnabled);
-        }
-
-        [TearDown]
-        public void CleanupMixedRealityToolkitTests()
-        {
-            TestUtilities.EditorCreateScenes();
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.SpatialAwarenessSystem
         public void TearDown()
         {
             TestUtilities.ShutdownMixedRealityToolkit();
+            TestUtilities.EditorTearDownScenes();
         }
 
         [Test]
@@ -109,12 +110,5 @@ namespace Microsoft.MixedReality.Toolkit.Tests.SpatialAwarenessSystem
             Assert.IsNotNull(dataProvider);
             Assert.IsTrue(dataProvider.IsInitialized);
         }
-
-        [TearDown]
-        public void CleanupMixedRealityToolkitTests()
-        {
-            TestUtilities.EditorCreateScenes();
-        }
-
     }
 }


### PR DESCRIPTION
## Overview
There were a few test scripts with multiple TearDown attributes.
There were also at least two that were calling `EditorCreateScenes` in `CleanupMixedRealityToolkitTests`.