### PR TITLE
Fixing an issue where CreateInstances could be called before Awake

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Rendering/MaterialInstance.cs
@@ -123,6 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         [SerializeField, HideInInspector]
         private Material[] defaultMaterials = null;
         private Material[] instanceMaterials = null;
+        private bool initialized = false;
         private bool materialsInstanced = false;
         private HashSet<Object> materialOwners = new HashSet<Object>();
 
@@ -132,18 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
         private void Awake()
         {
-            if (CachedRenderer != null)
-            {
-                // Cache the default materials if ones do not already exist.
-                if (defaultMaterials == null || defaultMaterials.Length == 0)
-                {
-                    defaultMaterials = CachedRenderer.sharedMaterials;
-                }
-                else if (!materialsInstanced) // Restore the clone to it's initial state.
-                {
-                    CachedRenderer.sharedMaterials = defaultMaterials;
-                }
-            }
+            Initialize();
         }
 
         private void Update()
@@ -187,7 +177,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
         private void OnDestroy()
         {
-            if (CachedRenderer != null)
+            if (CachedRenderer != null && defaultMaterials != null)
             {
                 CachedRenderer.sharedMaterials = defaultMaterials;
             }
@@ -197,6 +187,24 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         }
 
 #endregion MonoBehaviour Implementation
+
+        private void Initialize()
+        {
+            if (!initialized && CachedRenderer != null)
+            {
+                // Cache the default materials if ones do not already exist.
+                if (!HasValidMaterial(defaultMaterials))
+                {
+                    defaultMaterials = CachedRenderer.sharedMaterials;
+                }
+                else if (!materialsInstanced) // Restore the clone to it's initial state.
+                {
+                    CachedRenderer.sharedMaterials = defaultMaterials;
+                }
+
+                initialized = true;
+            }
+        }
 
         private void AcquireInstances()
         {
@@ -211,10 +219,13 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
 
         private void CreateInstances()
         {
+            // Initialize must get called to set the defaultMaterials in case CreateInstances get's invoked before Awake.
+            Initialize();
+
             DestroyMaterials(instanceMaterials);
             instanceMaterials = InstanceMaterials(defaultMaterials);
 
-            if (CachedRenderer != null)
+            if (CachedRenderer != null && instanceMaterials != null)
             {
                 CachedRenderer.sharedMaterials = instanceMaterials;
             }
@@ -277,6 +288,22 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private static bool IsInstanceMaterial(Material material)
         {
             return ((material != null) && material.name.Contains(instancePostfix));
+        }
+
+        private static bool HasValidMaterial(Material[] materials)
+        {
+            if (materials != null)
+            {
+                foreach (var material in materials)
+                {
+                    if (material != null)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private static void DestorySafe(UnityEngine.Object toDestroy)


### PR DESCRIPTION
# Overview
Fixing an issue where CreateInstances could be called before Awake. Which would in turn try and set the shared materials to null.

This would only occur in scenes with very specific hierarchy setups where a clipping primitive was placed in the hierarchy after a renderer it reference which is also initially disabled.

Issue found by @radicalad.

## Verification
Please test scenes and scripts which heavily use ClippingPrimitives.
