### PR TITLE
Change when Tests Package is Deleted

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -82,13 +82,13 @@ jobs:
         version: '$(MRTKVersion)-$(MRTKReleaseTag)'
         packDestination: '$(Build.SourcesDirectory)\artifacts\release'        
 
-  - powershell: |
-      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/Microsoft.MixedReality.Toolkit.Tests.*"
-    displayName: "Delete MixedReality.Toolkit.Tests package from the release artifacts"
-
   - template: templates/tasks/signing.yml
     parameters:
       ConfigName: "$(Build.ArtifactStagingDirectory)/configs/MRTKNuGetSignConfig.xml"
+
+  - powershell: |
+      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/Microsoft.MixedReality.Toolkit.Tests.*"
+    displayName: "Delete MixedReality.Toolkit.Tests package from the release artifacts"
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Packages'


### PR DESCRIPTION
We don't want to publish the tests package for the release pipeline. We use common pipeline paths, so as part of the release processes we need to delete it.

This updates the delete to happen after the signing of the NuGet packages so we don't run into an error.