### PR TITLE
Add SignCheck step to mrtk_CI-release pipeline

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -83,6 +83,13 @@ jobs:
     parameters:
       ConfigName: "$(Build.ArtifactStagingDirectory)/configs/MRTKNuGetSignConfig.xml"
 
+  - task: PowerShell@2
+    displayName: 'Validate release packages are signed'
+    inputs:
+      targetType: filePath
+      filePath: '$(Build.ArtifactStagingDirectory)\scripts\signCheck.ps1'
+      arguments: '$(Build.SourcesDirectory)\artifacts\release -tmpDir $(Build.ArtifactStagingDirectory)'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Packages'
     inputs:


### PR DESCRIPTION
SignCheck step is currently run as part of the Release Pipeline but we should be running it as part of mrtk_CI-release pipeline that does the signing.