### PR TITLE
[NuGet] Examples package: add dependency on Extensions

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -14,6 +14,7 @@
     <tags>Unity MixedReality</tags>
     <dependencies>
       <dependency id="Microsoft.MixedReality.Toolkit.Foundation" version="$version$" />
+      <dependency id="Microsoft.MixedReality.Toolkit.Extensions" version="$version$" />
     </dependencies>
     <contentFiles>
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />


### PR DESCRIPTION
This change adds the extensions package as a dependency of the examples. This is needed to ensure the experimental ExamplesHub has all of the required script files available.