### PR TITLE
Fix broken layout in SceneTransitionServiceOverview.md

### DIFF
--- a/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.md
+++ b/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.md
@@ -18,6 +18,7 @@ Controls the color of the fade effect. Alpha is ingored. This setting can be cha
 
 ### Fade Targets
 Controls which cameras will have a fade effect applied to them. This setting can be changed at runtime via the service's `FadeTargets` property.
+
 Setting | Targeted Cameras
 --- | --- | ---
 Main | Applies fade effect to the main camera.


### PR DESCRIPTION
In this documentation, the layout is broken.

https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.html#fade-targets

 
![image](https://user-images.githubusercontent.com/4415085/66626149-24b6f200-ec32-11e9-9ef5-5c3a3eab452f.png)

This PR fixes the problem.

![image](https://user-images.githubusercontent.com/4415085/66626269-8ecf9700-ec32-11e9-8d2b-c82669a76790.png)


