### PR TITLE
Add first draft set of code owners for the non-ci code

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,3 +25,55 @@
 
 # Build / CI Powershell Scripts
 /scripts/ci/ @wiwei @MenelvagorMilsom @macborow
+
+# Packaging files
+*.asmdef @wiwei @davidkline-ms @keveleigh @andreiborodin
+*.nupkg @wiwei @andreiborodin @davidkline-ms
+
+# Foundation
+/Assets/MixedRealityToolkit/Attributes/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit/Definitions/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit/EventDatum/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit/Extensions/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit/Inspectors/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit/Interfaces/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit/Providers/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit.Providers/UnityInput/ @wiwei @davidkline-ms @keveleigh @thalbern
+/Assets/MixedRealityToolkit/Services/ @wiwei @davidkline-ms @Troy-Ferrell
+/Assets/MixedRealityToolkit/Utilities/ @wiwei @davidkline-ms @keveleigh
+
+# Services and Providers
+/Assets/MixedRealityToolkit.Providers/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit.Services/ @wiwei @davidkline-ms @keveleigh
+/Assets/MixedRealityToolkit.Services/InputAnimation/ @wiwei @davidkline-ms @keveleigh @lukastoenneMS
+/Assets/MixedRealityToolkit.Services/InputSimulation/ @wiwei @davidkline-ms @keveleigh @lukastoenneMS
+/Assets/MixedRealityToolkit.Services/InputSystem/ @wiwei @davidkline-ms @keveleigh @lukastoenneMS @julenka @thalbern
+/Assets/MixedRealityToolkit.Services/SceneSystem/ @wiwei @davidkline-ms @keveleigh @Railboy
+
+# SDK
+/Assets/MixedRealityToolkit.SDK/Features/Audio/ @wiwei @davidkline-ms
+/Assets/MixedRealityToolkit.SDK/Features/Experimental/ @wiwei @davidkline-ms
+/Assets/MixedRealityToolkit.SDK/Features/Input/ @wiwei @davidkline-ms @keveleigh @julenka @thalbern
+/Assets/MixedRealityToolkit.SDK/Features/Utilities/ @wiwei @davidkline-ms @keveleigh
+
+# UX
+/Assets/MixedRealityToolkit.SDK/Features/UX/ @wiwei @julenka @thalbern @CDiaz-MS
+
+# Tools
+/Assets/MixedRealityToolkit.Tools/ @wiwei @davidkline-ms @keveleigh @MenelvagorMilsom
+
+# Extensions
+/Assets/MixedRealityToolkit.Extensions/ @wiwei @davidkline-ms @keveleigh
+
+# Standard Assets
+/Assets/MixedRealityToolkit/StandardAssets/ @wiwei @davidkline-ms @cre8ivepark @julenka
+/Assets/MixedRealityToolkit/StandardAssets/Shaders/ @wiwei @Cameron-Micka
+/Assets/MixedRealityToolkit.SDK/StandardAssets/ @wiwei @davidkline-ms @cre8ivepark @julenka
+/Assets/MixedRealityToolkit.SDK/StandardAssets/Shaders/ @wiwei @Cameron-Micka
+/Assets/MixedRealityToolkit.Examples/StandardAssets/ @wiwei @davidkline-ms @cre8ivepark @julenka
+
+# Examples
+/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleight @julenka @CDiaz-MS @thalbern @cre8ivepark
+
+# Tests
+/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleight @julenka @CDiaz-MS @thalbern

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -73,7 +73,7 @@
 /Assets/MixedRealityToolkit.Examples/StandardAssets/ @wiwei @davidkline-ms @cre8ivepark @julenka
 
 # Examples
-/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleight @julenka @CDiaz-MS @thalbern @cre8ivepark
+/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleigh @julenka @CDiaz-MS @thalbern @cre8ivepark
 
 # Tests
 /Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleight @julenka @CDiaz-MS @thalbern

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -73,7 +73,7 @@
 /Assets/MixedRealityToolkit.Examples/StandardAssets/ @wiwei @davidkline-ms @cre8ivepark @julenka
 
 # Examples
-/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleigh @julenka @CDiaz-MS @thalbern @cre8ivepark
+/Assets/MixedRealityToolkit.Examples/ @wiwei @davidkline-ms @keveleigh @julenka @CDiaz-MS @thalbern @cre8ivepark
 
 # Tests
-/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleight @julenka @CDiaz-MS @thalbern
+/Assets/MixedRealityToolkit.Tests/ @wiwei @davidkline-ms @keveleigh @julenka @CDiaz-MS @thalbern


### PR DESCRIPTION
This change assigns as set of code owners to the non-CI / build system portions of the tree. These owners have past experience in these areas and are a good starting point for suggested reviewers.

The collection of individuals is likely to change over time.

Fixes: #6124