### PR TITLE
SceneSystem / SceneInfo Improvements

### DIFF
--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -251,7 +251,15 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <inheritdoc />
         public async Task UnloadContentByTag(string tag)
         {
-            await UnloadScenesInternal(profile.GetContentSceneNamesByTag(tag), SceneType.Content);
+            try
+            {
+                await UnloadScenesInternal(profile.GetContentSceneNamesByTag(tag), SceneType.Content);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to unload content by tag " + tag);
+                Debug.LogException(e);
+            }
         }
 
         /// <inheritdoc />
@@ -266,15 +274,38 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
             IEnumerable<string> loadedContentScenes;
             if (mode == LoadSceneMode.Single && GetLoadedContentScenes(out loadedContentScenes))
             {
-                await UnloadScenesInternal(loadedContentScenes, SceneType.Content, 0, 0.5f, true);
-                await LoadScenesInternal(scenesToLoad, SceneType.Content, activationToken, 0.5f, 1f, false);
+                try
+                {
+                    await UnloadScenesInternal(loadedContentScenes, SceneType.Content, 0, 0.5f, true);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Error when attempting to unload content " + String.Join(", ", loadedContentScenes));
+                    Debug.LogException(e);
+                }
+
+                try
+                {
+                    await LoadScenesInternal(scenesToLoad, SceneType.Content, activationToken, 0.5f, 1f, false);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Error when attempting to load content" + String.Join(", ", scenesToLoad));
+                    Debug.LogException(e);
+                }
             }
             else
             {
-                await LoadScenesInternal(scenesToLoad, SceneType.Content, activationToken);
+                try
+                {
+                    await LoadScenesInternal(scenesToLoad, SceneType.Content, activationToken);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Error when attempting to load content" + String.Join(", ", scenesToLoad));
+                    Debug.LogException(e);
+                }
             }
-
-            await LoadScenesInternal(scenesToLoad, SceneType.Content, activationToken);
         }
 
         /// <inheritdoc />
@@ -286,7 +317,15 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 return;
             }
 
-            await UnloadScenesInternal(scenesToUnload, SceneType.Content);
+            try
+            {
+                await UnloadScenesInternal(scenesToUnload, SceneType.Content);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to unload content " + String.Join(", ", scenesToUnload));
+                Debug.LogException(e);
+            }
         }
 
         /// <inheritdoc />
@@ -316,8 +355,8 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
             RuntimeSunlightSettings sunSettings = default(RuntimeSunlightSettings);
             if (!string.IsNullOrEmpty(newLightingSceneName) && !profile.GetLightingSceneSettings(
                 newLightingSceneName,
-                out lightingScene, 
-                out lightingSettings, 
+                out lightingScene,
+                out lightingSettings,
                 out renderSettings,
                 out sunSettings))
             {   // Make sure we don't try to load a non-existent scene
@@ -345,11 +384,27 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 }
             }
 
-            // Load the new lighting scene immediately
-            await LoadScenesInternal(new string[] { newLightingSceneName }, SceneType.Lighting, null, 0f, 0.5f, true);
+            try
+            {
+                // Load the new lighting scene immediately
+                await LoadScenesInternal(new string[] { newLightingSceneName }, SceneType.Lighting, null, 0f, 0.5f, true);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Exception when attempting to load lighting scene " + newLightingSceneName);
+                Debug.LogException(e);
+            }
 
-            // Unload the other lighting scenes
-            await UnloadScenesInternal(lightingSceneNames, SceneType.Lighting, 0.5f, 1f, false);
+            try
+            {
+                // Unload the other lighting scenes
+                await UnloadScenesInternal(lightingSceneNames, SceneType.Lighting, 0.5f, 1f, false);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Exception when attempting to unload lighting scene " + string.Join(", ", lightingSceneNames));
+                Debug.LogException(e);
+            }
         }
 
         /// <summary>
@@ -363,7 +418,15 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 return;
             }
 
-            await LoadScenesInternal(new string[] { managerSceneName }, SceneType.Manager);
+            try
+            {
+                await LoadScenesInternal(new string[] { managerSceneName }, SceneType.Manager);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to set manager scene " + managerSceneName);
+                Debug.LogException(e);
+            }
         }
 
         /// <summary>
@@ -469,7 +532,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                     activationToken?.SetReadyToProceed(readyToProceed);
 
                     sceneOpProgress = Mathf.Clamp01(SceneOperationProgress / totalSceneOps);
-                    
+
                     SetSceneOpProgress(true, Mathf.Lerp(progressOffset, progressTarget, sceneOpProgress), sceneType);
 
                     await Task.Yield();
@@ -499,7 +562,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             // We're done!
             SetSceneOpProgress(sceneOpInProgressWhenFinished, progressTarget, sceneType);
-            
+
             InvokeLoadedActions(validNames, sceneType);
         }
 
@@ -507,7 +570,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// Internal method to handles scene unloads
         /// </summary>
         private async Task UnloadScenesInternal(
-            IEnumerable<string> scenesToUnload, 
+            IEnumerable<string> scenesToUnload,
             SceneType sceneType,
             float progressOffset = 0,
             float progressTarget = 1,
@@ -609,9 +672,9 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
             SetSceneOpProgress(sceneOpInProgressWhenFinished, progressTarget, sceneType);
 
             // Invoke our actions
-            InvokeUnloadedActions(validNames, sceneType);          
+            InvokeUnloadedActions(validNames, sceneType);
         }
-        
+
         private void SetSceneOpProgress(bool inProgress, float progress, SceneType sceneType)
         {
             switch (sceneType)
@@ -656,108 +719,140 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
         private void InvokeLoadedActions(List<string> sceneNames, SceneType sceneType)
         {
-            foreach (string sceneName in sceneNames)
-            {  // Announce scenes individually regardless of type
-                OnSceneLoaded?.Invoke(sceneName);
-            }
-
-            switch (sceneType)
+            try
             {
-                case SceneType.Content:
-                    // Announce content as a set
-                    OnContentLoaded?.Invoke(sceneNames);
-                    break;
+                foreach (string sceneName in sceneNames)
+                {  // Announce scenes individually regardless of type
+                    OnSceneLoaded?.Invoke(sceneName);
+                }
 
-                case SceneType.Lighting:
-                    // We only handle lighting scenes one at a time
-                    Debug.Assert(sceneNames.Count == 1);
-                    OnLightingLoaded?.Invoke(sceneNames[0]);
-                    break;
+                switch (sceneType)
+                {
+                    case SceneType.Content:
+                        // Announce content as a set
+                        OnContentLoaded?.Invoke(sceneNames);
+                        break;
 
-                default:
-                    // Don't announce other types of scenes invidually
-                    break;
+                    case SceneType.Lighting:
+                        // We only handle lighting scenes one at a time
+                        Debug.Assert(sceneNames.Count == 1);
+                        OnLightingLoaded?.Invoke(sceneNames[0]);
+                        break;
+
+                    default:
+                        // Don't announce other types of scenes invidually
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to invoke loaded actions for " + string.Join(", ", sceneNames));
+                Debug.LogException(e);
             }
         }
 
         private void InvokeWillLoadActions(List<string> sceneNames, SceneType sceneType)
         {
-            foreach (string sceneName in sceneNames)
-            {   // Announce scenes individually regardless of type
-                OnWillLoadScene?.Invoke(sceneName);
-            }
-
-            switch (sceneType)
+            try
             {
-                case SceneType.Content:
-                    // Announce content as a set
-                    OnWillLoadContent?.Invoke(sceneNames);
-                    break;
+                foreach (string sceneName in sceneNames)
+                {   // Announce scenes individually regardless of type
+                    OnWillLoadScene?.Invoke(sceneName);
+                }
 
-                case SceneType.Lighting:
-                    // We only handle lighting scenes one at a time
-                    Debug.Assert(sceneNames.Count == 1);
-                    OnWillLoadLighting?.Invoke(sceneNames[0]);
-                    break;
+                switch (sceneType)
+                {
+                    case SceneType.Content:
+                        // Announce content as a set
+                        OnWillLoadContent?.Invoke(sceneNames);
+                        break;
 
-                default:
-                    // Don't announce other types of scenes invidually
-                    break;
+                    case SceneType.Lighting:
+                        // We only handle lighting scenes one at a time
+                        Debug.Assert(sceneNames.Count == 1);
+                        OnWillLoadLighting?.Invoke(sceneNames[0]);
+                        break;
+
+                    default:
+                        // Don't announce other types of scenes invidually
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to invoke will load actions for " + string.Join(", ", sceneNames));
+                Debug.LogException(e);
             }
         }
 
         private void InvokeWillUnloadActions(List<string> sceneNames, SceneType sceneType)
         {
-            foreach (string sceneName in sceneNames)
-            {  // Announce scenes individually regardless of type
-                OnWillUnloadScene?.Invoke(sceneName);
-            }
-
-            switch (sceneType)
+            try
             {
-                case SceneType.Content:
-                    // Announce content as a set
-                    OnWillUnloadContent?.Invoke(sceneNames);
-                    break;
+                foreach (string sceneName in sceneNames)
+                {  // Announce scenes individually regardless of type
+                    OnWillUnloadScene?.Invoke(sceneName);
+                }
 
-                case SceneType.Lighting:
-                    // We only handle lighting scenes one at a time
-                    Debug.Assert(sceneNames.Count == 1);
-                    OnWillUnloadLighting?.Invoke(sceneNames[0]);
-                    break;
+                switch (sceneType)
+                {
+                    case SceneType.Content:
+                        // Announce content as a set
+                        OnWillUnloadContent?.Invoke(sceneNames);
+                        break;
 
-                default:
-                    // Don't announce other types of scenes invidually
-                    break;
+                    case SceneType.Lighting:
+                        // We only handle lighting scenes one at a time
+                        Debug.Assert(sceneNames.Count == 1);
+                        OnWillUnloadLighting?.Invoke(sceneNames[0]);
+                        break;
+
+                    default:
+                        // Don't announce other types of scenes invidually
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to invoke will unload actions for " + string.Join(", ", sceneNames));
+                Debug.LogException(e);
             }
         }
 
         private void InvokeUnloadedActions(List<string> sceneNames, SceneType sceneType)
         {
-            foreach (string sceneName in sceneNames)
-            {  // Announce scenes individually regardless of type
-                OnSceneUnloaded?.Invoke(sceneName);
-            }
-
-            switch (sceneType)
+            try
             {
-                case SceneType.Content:
-                    // Announce content as a set
-                    OnContentUnloaded?.Invoke(sceneNames);
-                    break;
+                foreach (string sceneName in sceneNames)
+                {  // Announce scenes individually regardless of type
+                    OnSceneUnloaded?.Invoke(sceneName);
+                }
 
-                case SceneType.Lighting:
-                    // We only handle lighting scenes one at a time
-                    Debug.Assert(sceneNames.Count == 1);
-                    OnLightingUnloaded?.Invoke(sceneNames[0]);
-                    break;
+                switch (sceneType)
+                {
+                    case SceneType.Content:
+                        // Announce content as a set
+                        OnContentUnloaded?.Invoke(sceneNames);
+                        break;
 
-                default:
-                    // Don't announce other types of scenes invidually
-                    break;
+                    case SceneType.Lighting:
+                        // We only handle lighting scenes one at a time
+                        Debug.Assert(sceneNames.Count == 1);
+                        OnLightingUnloaded?.Invoke(sceneNames[0]);
+                        break;
+
+                    default:
+                        // Don't announce other types of scenes invidually
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when attempting to invoke unloaded actions for " + string.Join(", ", sceneNames));
+                Debug.LogException(e);
             }
         }
-        
+
         #endregion
 
         #region Utilities
@@ -818,7 +913,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         #endregion
 
         #region Utility Classes
-        
+
         /// <summary>
         /// A utility class used to track which content scenes are loaded, and which should come next / before.
         /// This logic could live in the service itself, but there may be cases where devs want to change how content is tracked without changing anything else.
@@ -826,11 +921,11 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// </summary>
         private sealed class SceneContentTracker
         {
-            public SceneContentTracker (MixedRealitySceneSystemProfile profile)
+            public SceneContentTracker(MixedRealitySceneSystemProfile profile)
             {
                 this.profile = profile;
 
-                CacheSortedContent();               
+                CacheSortedContent();
             }
 
             private MixedRealitySceneSystemProfile profile;
@@ -935,7 +1030,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         private sealed class SceneLightingExecutor
         {
             public void StartTransition(
-                RuntimeLightingSettings targetLightingSettings, 
+                RuntimeLightingSettings targetLightingSettings,
                 RuntimeRenderSettings targetRenderSettings,
                 RuntimeSunlightSettings targetSunlightSettings,
                 LightingSceneTransitionType transitionType = LightingSceneTransitionType.None,
@@ -997,7 +1092,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                         currentSunlightSettings = RuntimeSunlightSettings.Lerp(prevSunlightSettings, targetSunlightSettings, transitionProgress);
                         break;
 
-                    case LightingSceneTransitionType.FadeToBlack: 
+                    case LightingSceneTransitionType.FadeToBlack:
                         // If we're in the first half of our transition, fade out to black
                         if (transitionProgress < 0.5f)
                         {
@@ -1044,25 +1139,25 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             public void ApplySettings()
             {
-                RenderSettings.ambientEquatorColor                  = currentRenderSettings.AmbientEquatorColor;
-                RenderSettings.ambientGroundColor                   = currentRenderSettings.AmbientGroundColor;
-                RenderSettings.ambientIntensity                     = currentRenderSettings.AmbientIntensity;
-                RenderSettings.ambientLight                         = currentRenderSettings.AmbientLight;
-                RenderSettings.ambientMode                          = (AmbientMode)currentRenderSettings.AmbientMode;
-                RenderSettings.ambientSkyColor                      = currentRenderSettings.AmbientSkyColor;
-                RenderSettings.customReflection                     = currentRenderSettings.CustomReflection;
-                RenderSettings.defaultReflectionMode                = (DefaultReflectionMode)currentRenderSettings.DefaultReflectionMode;
-                RenderSettings.defaultReflectionResolution          = currentRenderSettings.DefaultReflectionResolution;
-                RenderSettings.fog                                  = currentRenderSettings.Fog;
-                RenderSettings.fogColor                             = currentRenderSettings.FogColor;
-                RenderSettings.fogDensity                           = currentRenderSettings.FogDensity;
-                RenderSettings.fogEndDistance                       = currentRenderSettings.LinearFogEnd;
-                RenderSettings.fogMode                              = currentRenderSettings.FogMode;
-                RenderSettings.fogStartDistance                     = currentRenderSettings.LinearFogStart;
-                RenderSettings.reflectionBounces                    = currentRenderSettings.ReflectionBounces;
-                RenderSettings.reflectionIntensity                  = currentRenderSettings.ReflectionIntensity;
-                RenderSettings.skybox                               = currentRenderSettings.SkyboxMaterial;
-                RenderSettings.subtractiveShadowColor               = currentRenderSettings.SubtractiveShadowColor;
+                RenderSettings.ambientEquatorColor = currentRenderSettings.AmbientEquatorColor;
+                RenderSettings.ambientGroundColor = currentRenderSettings.AmbientGroundColor;
+                RenderSettings.ambientIntensity = currentRenderSettings.AmbientIntensity;
+                RenderSettings.ambientLight = currentRenderSettings.AmbientLight;
+                RenderSettings.ambientMode = (AmbientMode)currentRenderSettings.AmbientMode;
+                RenderSettings.ambientSkyColor = currentRenderSettings.AmbientSkyColor;
+                RenderSettings.customReflection = currentRenderSettings.CustomReflection;
+                RenderSettings.defaultReflectionMode = (DefaultReflectionMode)currentRenderSettings.DefaultReflectionMode;
+                RenderSettings.defaultReflectionResolution = currentRenderSettings.DefaultReflectionResolution;
+                RenderSettings.fog = currentRenderSettings.Fog;
+                RenderSettings.fogColor = currentRenderSettings.FogColor;
+                RenderSettings.fogDensity = currentRenderSettings.FogDensity;
+                RenderSettings.fogEndDistance = currentRenderSettings.LinearFogEnd;
+                RenderSettings.fogMode = currentRenderSettings.FogMode;
+                RenderSettings.fogStartDistance = currentRenderSettings.LinearFogStart;
+                RenderSettings.reflectionBounces = currentRenderSettings.ReflectionBounces;
+                RenderSettings.reflectionIntensity = currentRenderSettings.ReflectionIntensity;
+                RenderSettings.skybox = currentRenderSettings.SkyboxMaterial;
+                RenderSettings.subtractiveShadowColor = currentRenderSettings.SubtractiveShadowColor;
 
                 if (currentSunlightSettings.UseSunlight)
                 {

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -1139,25 +1139,25 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             public void ApplySettings()
             {
-                RenderSettings.ambientEquatorColor = currentRenderSettings.AmbientEquatorColor;
-                RenderSettings.ambientGroundColor = currentRenderSettings.AmbientGroundColor;
-                RenderSettings.ambientIntensity = currentRenderSettings.AmbientIntensity;
-                RenderSettings.ambientLight = currentRenderSettings.AmbientLight;
-                RenderSettings.ambientMode = (AmbientMode)currentRenderSettings.AmbientMode;
-                RenderSettings.ambientSkyColor = currentRenderSettings.AmbientSkyColor;
-                RenderSettings.customReflection = currentRenderSettings.CustomReflection;
-                RenderSettings.defaultReflectionMode = (DefaultReflectionMode)currentRenderSettings.DefaultReflectionMode;
-                RenderSettings.defaultReflectionResolution = currentRenderSettings.DefaultReflectionResolution;
-                RenderSettings.fog = currentRenderSettings.Fog;
-                RenderSettings.fogColor = currentRenderSettings.FogColor;
-                RenderSettings.fogDensity = currentRenderSettings.FogDensity;
-                RenderSettings.fogEndDistance = currentRenderSettings.LinearFogEnd;
-                RenderSettings.fogMode = currentRenderSettings.FogMode;
-                RenderSettings.fogStartDistance = currentRenderSettings.LinearFogStart;
-                RenderSettings.reflectionBounces = currentRenderSettings.ReflectionBounces;
-                RenderSettings.reflectionIntensity = currentRenderSettings.ReflectionIntensity;
-                RenderSettings.skybox = currentRenderSettings.SkyboxMaterial;
-                RenderSettings.subtractiveShadowColor = currentRenderSettings.SubtractiveShadowColor;
+                RenderSettings.ambientEquatorColor                  = currentRenderSettings.AmbientEquatorColor;
+                RenderSettings.ambientGroundColor                   = currentRenderSettings.AmbientGroundColor;
+                RenderSettings.ambientIntensity                     = currentRenderSettings.AmbientIntensity;
+                RenderSettings.ambientLight                         = currentRenderSettings.AmbientLight;
+                RenderSettings.ambientMode                          = (AmbientMode)currentRenderSettings.AmbientMode;
+                RenderSettings.ambientSkyColor                      = currentRenderSettings.AmbientSkyColor;
+                RenderSettings.customReflection                     = currentRenderSettings.CustomReflection;
+                RenderSettings.defaultReflectionMode                = (DefaultReflectionMode)currentRenderSettings.DefaultReflectionMode;
+                RenderSettings.defaultReflectionResolution          = currentRenderSettings.DefaultReflectionResolution;
+                RenderSettings.fog                                  = currentRenderSettings.Fog;
+                RenderSettings.fogColor                             = currentRenderSettings.FogColor;
+                RenderSettings.fogDensity                           = currentRenderSettings.FogDensity;
+                RenderSettings.fogEndDistance                       = currentRenderSettings.LinearFogEnd;
+                RenderSettings.fogMode                              = currentRenderSettings.FogMode;
+                RenderSettings.fogStartDistance                     = currentRenderSettings.LinearFogStart;
+                RenderSettings.reflectionBounces                    = currentRenderSettings.ReflectionBounces;
+                RenderSettings.reflectionIntensity                  = currentRenderSettings.ReflectionIntensity;
+                RenderSettings.skybox                               = currentRenderSettings.SkyboxMaterial;
+                RenderSettings.subtractiveShadowColor               = currentRenderSettings.SubtractiveShadowColor;
 
                 if (currentSunlightSettings.UseSunlight)
                 {

--- a/Assets/MixedRealityToolkit/Definitions/SceneSystem/SceneInfo.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SceneSystem/SceneInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.SceneSystem
 {

--- a/Assets/MixedRealityToolkit/Definitions/SceneSystem/SceneInfo.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SceneSystem/SceneInfo.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using UnityEngine;
+using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.SceneSystem
 {
@@ -45,26 +45,22 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <summary>
         /// Name of the scene. Set by the property drawer.
         /// </summary>
-        [HideInInspector]
         public string Name;
 
         /// <summary>
         /// Path of the scene. Set by the property drawer.
         /// </summary>
-        [HideInInspector]
         public string Path;
 
         /// <summary>
         /// True if scene is included in build (NOT necessarily enabled)
         /// </summary>
-        [HideInInspector]
         public bool Included;
 
         /// <summary>
         /// Build index of the scene. If included in build settings and enabled, this will be a value greater than zero.
         /// If not included or disabled, this will be -1
         /// </summary>
-        [HideInInspector]
         public int BuildIndex;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -116,12 +116,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Updates all the serialized properties for a SceneInfo struct.
         /// </summary>
-        /// <param name="asset"></param>
-        /// <param name="nameProperty"></param>
-        /// <param name="pathProperty"></param>
-        /// <param name="buildIndexProperty"></param>
-        /// <param name="includedProperty"></param>
-        /// <param name="tagProperty"></param>
         /// <returns>True if a property has changed.</returns>
         public static bool RefreshSceneInfo(
             UnityEngine.Object asset,

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -1,0 +1,342 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.SceneSystem;
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Microsoft.MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// Class responsible for updating scene info structs to reflect changes made to scene assets.
+    /// Extends AssetPostprocessor.
+    /// </summary>
+    public class SceneInfoUtils : AssetPostprocessor
+    {
+        /// <summary>
+        /// Cached scenes used by SceneInfoDrawer to keep property drawer performant.
+        /// </summary>
+        public static EditorBuildSettingsScene[] CachedScenes => cachedScenes;
+
+        private static EditorBuildSettingsScene[] cachedScenes = new EditorBuildSettingsScene[0];
+
+        /// <summary>
+        /// The frame of the last update. Used to ensure we don't spam the system with updates.
+        /// </summary>
+        private static int frameScriptableObjectsLastUpdated;
+        private static int frameScenesLastUpdated;
+
+        /// <summary>
+        /// Call this when you make a change to the build settings and need those changes to be reflected immedately.
+        /// </summary>
+        public static void RefreshCachedScenes()
+        {
+            cachedScenes = EditorBuildSettings.scenes;
+        }
+
+        /// <summary>
+        /// Finds all relative properties of a SceneInfo struct.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <param name="assetProperty"></param>
+        /// <param name="nameProperty"></param>
+        /// <param name="pathProperty"></param>
+        /// <param name="buildIndexProperty"></param>
+        /// <param name="includedProperty"></param>
+        /// <param name="tagProperty"></param>
+        public static void GetSceneInfoRelativeProperties(
+            SerializedProperty property,
+            out SerializedProperty assetProperty,
+            out SerializedProperty nameProperty,
+            out SerializedProperty pathProperty,
+            out SerializedProperty buildIndexProperty,
+            out SerializedProperty includedProperty,
+            out SerializedProperty tagProperty)
+        {
+            assetProperty = property.FindPropertyRelative("Asset");
+            nameProperty = property.FindPropertyRelative("Name");
+            pathProperty = property.FindPropertyRelative("Path");
+            buildIndexProperty = property.FindPropertyRelative("BuildIndex");
+            includedProperty = property.FindPropertyRelative("Included");
+            tagProperty = property.FindPropertyRelative("Tag");
+        }
+
+        /// <summary>
+        /// Finds a missing scene asset reference for a SceneInfo struct.
+        /// </summary>
+        /// <param name="nameProperty"></param>
+        /// <param name="pathProperty"></param>
+        /// <param name="asset"></param>
+        /// <returns>True if scene was found.</returns>
+        public static bool FindScene(SerializedProperty nameProperty, SerializedProperty pathProperty, ref UnityEngine.Object asset)
+        {
+            // Attempt to load via the scene path
+            SceneAsset newSceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(pathProperty.stringValue);
+            if (newSceneAsset != null)
+            {
+                Debug.Log("Found missing scene at path " + pathProperty.stringValue);
+                asset = newSceneAsset;
+                return true;
+            }
+            else
+            {
+                // If we didn't find it this way, search for all scenes in the project and try a name match
+                foreach (string sceneGUID in AssetDatabase.FindAssets("t:Scene"))
+                {
+                    string scenePath = AssetDatabase.GUIDToAssetPath(sceneGUID);
+                    string sceneName = System.IO.Path.GetFileNameWithoutExtension(scenePath);
+
+                    if (sceneName == nameProperty.stringValue)
+                    {
+                        pathProperty.stringValue = scenePath;
+                        newSceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(scenePath);
+                        if (newSceneAsset != null)
+                        {
+                            Debug.Log("Found missing scene at path " + scenePath);
+                            asset = newSceneAsset;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Updates all the serialized properties for a SceneInfo struct.
+        /// </summary>
+        /// <param name="asset"></param>
+        /// <param name="nameProperty"></param>
+        /// <param name="pathProperty"></param>
+        /// <param name="buildIndexProperty"></param>
+        /// <param name="includedProperty"></param>
+        /// <param name="tagProperty"></param>
+        /// <returns>True if a property has changed.</returns>
+        public static bool RefreshSceneInfo(
+            UnityEngine.Object asset,
+            SerializedProperty nameProperty,
+            SerializedProperty pathProperty,
+            SerializedProperty buildIndexProperty,
+            SerializedProperty includedProperty,
+            SerializedProperty tagProperty)
+        {
+            bool changed = false;
+
+            if (asset == null)
+            {
+                // Leave the name and path alone, but reset the build index
+                if (buildIndexProperty.intValue >= 0)
+                {
+                    buildIndexProperty.intValue = -1;
+                    changed = true;
+                }
+            }
+            else
+            {
+                // Refreshing these values is very expensive
+                // Especially getting build scenes
+                // We may want to move this out of the property drawer
+                if (nameProperty.stringValue != asset.name)
+                {
+                    nameProperty.stringValue = asset.name;
+                    changed = true;
+                }
+
+                string scenePath = AssetDatabase.GetAssetPath(asset);
+                if (pathProperty.stringValue != scenePath)
+                {
+                    pathProperty.stringValue = scenePath;
+                    changed = true;
+                }
+
+                // This method is no longer reliable
+                // so we're using out cached scenes instead
+                //Scene scene = EditorSceneManager.GetSceneByPath(scenePath);
+                //int buildIndex = scene.buildIndex;
+
+                int buildIndex = -1;
+                int sceneCount = 0;
+                bool included = false;
+                for (int i = 0; i < cachedScenes.Length; i++)
+                {
+                    if (cachedScenes[i].path == scenePath)
+                    {   // If it's in here it's included, even if it's not enabled
+                        included = true;
+                        if (cachedScenes[i].enabled)
+                        {   // Only store the build index if it's enabled
+                            buildIndex = sceneCount;
+                        }
+                    }
+
+                    if (cachedScenes[i].enabled)
+                    {   // Disabled scenes don't count toward scene count
+                        sceneCount++;
+                    }
+                }
+
+                if (buildIndex != buildIndexProperty.intValue)
+                {
+                    buildIndexProperty.intValue = buildIndex;
+                    changed = true;
+                }
+
+                if (included != includedProperty.boolValue)
+                {
+                    includedProperty.boolValue = included;
+                    changed = true;
+                }
+            }
+
+            if (string.IsNullOrEmpty(tagProperty.stringValue))
+            {
+                tagProperty.stringValue = "Untagged";
+                changed = true;
+            }
+
+            return changed;
+        }
+
+
+        /// <summary>
+        /// Searches for all components in a scene and refreshes any SceneInfo fields found.
+        /// </summary>
+        [PostProcessSceneAttribute]
+        public static void OnPostProcessScene()
+        {
+            Debug.Log("OnPostProcessScene");
+
+            foreach (Component source in GameObject.FindObjectsOfType<Component>())
+            {
+                foreach (FieldInfo fieldInfo in source.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+                {
+                    if (fieldInfo.FieldType == typeof(SceneInfo))
+                    {
+                        Debug.Log("Found scene info type in " + source.name + ": " + fieldInfo.Name);
+
+                        SerializedObject serializedObject = new SerializedObject(source);
+                        SerializedProperty property = serializedObject.FindProperty(fieldInfo.Name);
+                        SerializedProperty assetProperty, nameProperty, pathProperty, buildIndexProperty, includedProperty, tagProperty;
+                        GetSceneInfoRelativeProperties(property, out assetProperty, out nameProperty, out pathProperty, out buildIndexProperty, out includedProperty, out tagProperty);
+                        RefreshSceneInfo(source, nameProperty, pathProperty, buildIndexProperty, includedProperty, tagProperty);
+                    }
+                }
+            }
+        }
+
+        [InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
+        {
+            Debug.Log("InitializeOnLoad");
+
+            EditorBuildSettings.sceneListChanged += SceneListChanged;
+            EditorSceneManager.sceneOpened += SceneOpened;
+
+            frameScriptableObjectsLastUpdated = -1;
+            frameScenesLastUpdated = -1;
+
+            RefreshCachedScenes();
+            RefreshSceneInfoFieldsInScriptableObjects();
+            RefreshSceneInfoFieldsInScenes();
+        }
+
+        private static void SceneOpened(Scene scene, OpenSceneMode mode)
+        {
+            Debug.Log("Scene Opened");
+
+            RefreshSceneInfoFieldsInScenes();
+        }
+
+        /// <summary>
+        /// Updates the cached scene array when build settings change.
+        /// </summary>
+        private static void SceneListChanged()
+        {
+            Debug.Log("SceneListChanged");
+
+            RefreshCachedScenes();
+            RefreshSceneInfoFieldsInScriptableObjects();
+            RefreshSceneInfoFieldsInScenes();
+        }
+
+        /// <summary>
+        /// Calls RefreshSceneInfoFieldsInScriptableObjects when an asset is modified.
+        /// </summary>
+        /// <param name="importedAssets"></param>
+        /// <param name="deletedAssets"></param>
+        /// <param name="movedAssets"></param>
+        /// <param name="movedFromAssetPaths"></param>
+        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+        {
+            Debug.Log("OnPostprocessAllAssets");
+
+            RefreshSceneInfoFieldsInScriptableObjects();
+            RefreshSceneInfoFieldsInScenes();
+        }
+
+        /// <summary>
+        /// Searches through all ScriptableObject instances and refreshes any SceneInfo fields found.
+        /// </summary>
+        private static void RefreshSceneInfoFieldsInScriptableObjects()
+        {
+            if (Time.frameCount == frameScriptableObjectsLastUpdated)
+            {   // Don't udpate more than once per frame
+                Debug.Log("(Already updated, skipping frame " + frameScriptableObjectsLastUpdated + ")");
+                return;
+            }
+
+            Debug.Log("Refreshing scene info properties");
+            foreach (ScriptableObject source in ScriptableObjectExtensions.GetAllInstances<ScriptableObject>())
+            {
+                foreach (FieldInfo fieldInfo in source.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+                {
+                    if (fieldInfo.FieldType == typeof(SceneInfo))
+                    {
+                        Debug.Log("Found scene info type in " + source.name + ": " + fieldInfo.Name);
+
+                        SerializedObject serializedObject = new SerializedObject(source);
+                        SerializedProperty property = serializedObject.FindProperty(fieldInfo.Name);
+                        SerializedProperty assetProperty, nameProperty, pathProperty, buildIndexProperty, includedProperty, tagProperty;
+                        GetSceneInfoRelativeProperties(property, out assetProperty, out nameProperty, out pathProperty, out buildIndexProperty, out includedProperty, out tagProperty);
+                        RefreshSceneInfo(source, nameProperty, pathProperty, buildIndexProperty, includedProperty, tagProperty);
+                    }
+                }
+            }
+
+            frameScriptableObjectsLastUpdated = Time.frameCount;
+        }
+
+        private static void RefreshSceneInfoFieldsInScenes()
+        {
+            if (Time.frameCount == frameScenesLastUpdated)
+            {   // Don't udpate more than once per frame
+                Debug.Log("(Already updated scenes, skipping frame " + frameScenesLastUpdated + ")");
+                return;
+            }
+
+            foreach (ScriptableObject source in ScriptableObjectExtensions.GetAllInstances<ScriptableObject>())
+            {
+                foreach (FieldInfo fieldInfo in source.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+                {
+                    if (fieldInfo.FieldType == typeof(SceneInfo))
+                    {
+                        Debug.Log("Found scene info type in " + source.name + ": " + fieldInfo.Name);
+
+                        SerializedObject serializedObject = new SerializedObject(source);
+                        SerializedProperty property = serializedObject.FindProperty(fieldInfo.Name);
+                        SerializedProperty assetProperty, nameProperty, pathProperty, buildIndexProperty, includedProperty, tagProperty;
+                        GetSceneInfoRelativeProperties(property, out assetProperty, out nameProperty, out pathProperty, out buildIndexProperty, out includedProperty, out tagProperty);
+                        RefreshSceneInfo(source, nameProperty, pathProperty, buildIndexProperty, includedProperty, tagProperty);
+                    }
+                }
+            }
+
+            frameScenesLastUpdated = Time.frameCount;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -232,7 +232,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     foreach (FieldInfo f in t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(f => f.FieldType == typeof(SceneInfo)))
                     {
                         cachedComponentTypes.Add(new Tuple<Type, FieldInfo>(t, f));
-                        Debug.Log("Found component type " + t.Name + " with field " + f.Name);
                     }
                 }
             }

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs.meta
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa77b15c9cb8f8d4797e0f299cd66e2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Ensures that SceneInfo fields found in ScriptableObjects and Components are kept up-to-date when assets are modified, when editor scene settings change, or when building. Previously these fields were only updated when they were drawn by an editor, which was leading to stale settings.

SceneInfo-related operations have been moved out of SceneInfoDrawer and into SceneInfoUtility.

This also adds better error handling / reporting to SceneSystem operations to make troubleshooting scene-related errors easier in general.

## Changes
- Fixes: #6060

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
