### PR TITLE
Removing  Loop Guidance

### DIFF
--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -422,16 +422,6 @@ Always use private fields and public properties if access to the field is needed
  }
  ```
 
-### Use `for` instead of `foreach` when possible
-
-In some cases a foreach is required, e.g. when looping over an IEnumerable.  But for performance benefit, avoid foreach when you can.
-
-#### Don't
-
-```c#
-foreach(var item in items)
-```
-
 #### Do
 
  ```c#

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -531,5 +531,5 @@ DateTime.UtcNow is faster than DateTime.Now. In previous performance investigati
 Prefer using DateTime.UtcNow unless you actually need the localized times (a legitmate reason may be you wanting to show the current time in the user's time zone). If you are dealing with relative times (i.e. the delta between some last update and now), it's best to use DateTime.UtcNow to avoid the overhead of doing timezone conversions.
 
 
-## Set also
+## See also
  [C# coding conventions from MSDN](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -532,4 +532,4 @@ Prefer using DateTime.UtcNow unless you actually need the localized times (a leg
 
 
 ## See also
- [C# coding conventions from MSDN](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).
+ [C# coding conventions from MSDN](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions)


### PR DESCRIPTION
Removing the section warning about usage of foreach vs for. In Unity ~5.3+ the allocation issues have been resolved: https://forum.unity.com/threads/upgraded-c-compiler-on-5-3-5p8.417363/ And, here is a nice breakdown of memory usage: https://jacksondunstan.com/articles/3805 My general guidance is use foreach when you can to prevent bugs and improve readability, then profile often to find if foreach is an issue in "hot" loops.