### PR TITLE
Updating 404 links in porting guide

### DIFF
--- a/Documentation/HTKToMRTKPortingGuide.md
+++ b/Documentation/HTKToMRTKPortingGuide.md
@@ -29,9 +29,9 @@ Some events no longer have unique events and now contain a [MixedRealityInputAct
 
 Related input systems:
 
-* [Input Overview](/Input/Overview.md)
-* [Input Events](/Input/InputEvents.md)
-* [Input Pointers](/Input/Pointers.md)
+* [Input Overview](Input/Overview.md)
+* [Input Events](Input/InputEvents.md)
+* [Input Pointers](Input/Pointers.md)
 
 | HTK 2017 |  MRTK v2  | Action Mapping |
 |----------|-----------|----------------|


### PR DESCRIPTION
Removed the starting "/" in three links that caused them to point to non-existent readme locations
