### PR TITLE
Forcing the visual profiler to write depth for improved dLSR support.

### DIFF
--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -192,7 +192,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             if (defaultMaterial == null)
             {
                 defaultMaterial = new Material(Shader.Find("Hidden/Internal-Colored"));
-                defaultMaterial.SetFloat("_ZWrite", 0.0f);
+                defaultMaterial.SetFloat("_ZWrite", 1.0f);
                 defaultMaterial.SetFloat("_ZTest", (float)UnityEngine.Rendering.CompareFunction.Disabled);
                 defaultMaterial.renderQueue = 5000;
             }
@@ -205,7 +205,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                 {
                     defaultInstancedMaterial = new Material(defaultInstancedShader);
                     defaultInstancedMaterial.enableInstancing = true;
-                    defaultInstancedMaterial.SetFloat("_ZWrite", 0.0f);
+                    defaultInstancedMaterial.SetFloat("_ZWrite", 1.0f);
                     defaultInstancedMaterial.SetFloat("_ZTest", (float)UnityEngine.Rendering.CompareFunction.Disabled);
                     defaultInstancedMaterial.renderQueue = 5000;
                 }


### PR DESCRIPTION
## Overview

The visual profiler does not write to the depth buffer which can cause rendering artifacts when using depth buffer sharing on HoloLens 2 (dLSR). To fix this the visual profiler now writes depth. The components in the profiler should still render correctly due to their custom render queues settings.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6302


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
