### PR TITLE
Profile Type filtering inspector fix

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -22,6 +22,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         private MixedRealityInputDataProviderConfiguration[] dataProviderConfigurations = new MixedRealityInputDataProviderConfiguration[0];
 
+        /// <summary>
+        /// List of input data provider configurations to intialize and manage by the Input System registar
+        /// </summary>
         public MixedRealityInputDataProviderConfiguration[] DataProviderConfigurations
         {
             get { return dataProviderConfigurations; }

--- a/Assets/MixedRealityToolkit/Definitions/MixedRealitySpatialObserverConfiguration.cs
+++ b/Assets/MixedRealityToolkit/Definitions/MixedRealitySpatialObserverConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         private BaseSpatialAwarenessObserverProfile observerProfile;
 
         /// <summary>
-        /// 
+        /// Spatial Observer specific configuration profile.
         /// </summary>
         public BaseSpatialAwarenessObserverProfile ObserverProfile => observerProfile;
 

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -71,6 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// Renders a <see cref="Microsoft.MixedReality.Toolkit.BaseMixedRealityProfile"/>.
         /// </summary>
         /// <param name="property">the <see cref="Microsoft.MixedReality.Toolkit.BaseMixedRealityProfile"/> property.</param>
+        /// <param name="profileType">Profile type to filter available values to set on the provided property. If null, defaults to type <see cref="Microsoft.MixedReality.Toolkit.BaseMixedRealityProfile"/></param>
         /// <param name="showAddButton">If true, draw the clone button, if false, don't</param>
         /// <param name="renderProfileInBox">if true, render box around profile content, if false, don't</param>
         /// <param name="serviceType">Optional service type to limit available profile types.</param>

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             var oldObject = property.objectReferenceValue;
 
             if (profileType != null && !profileType.IsSubclassOf(typeof(BaseMixedRealityProfile)) && profileType != typeof(BaseMixedRealityProfile))
-            {  
+            {
                 // If they've drag-and-dropped a non-profile scriptable object, set it to null.
                 profileType = null;
             }
@@ -111,23 +111,30 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
             }
 
-            // Find the profile type so we can limit the available object field options
-            if (serviceType != null)
-            {
-                // If GetProfileTypesForService has a count greater than one, then it won't be possible to use
-                // EditorGUILayout.ObjectField to restrict the set of profiles to a single type - in this
-                // case all profiles of BaseMixedRealityProfile will be visible in the picker.
-                // 
-                // However in the case where there is just a single profile type for the service, we can improve
-                // upon the user experience by limiting the set of things that show in the picker by restricting
-                // the set of profiles listed to only that type.
-                profileType = MixedRealityProfileUtility.GetProfileTypesForService(serviceType).FirstOrDefault();
-            }
-
-            // If the profile type is still null, just set it to base profile type
             if (profileType == null)
             {
-                profileType = typeof(BaseMixedRealityProfile);
+                // Find the profile type so we can limit the available object field options
+                if (serviceType != null)
+                {
+                    // If GetProfileTypesForService has a count greater than one, then it won't be possible to use
+                    // EditorGUILayout.ObjectField to restrict the set of profiles to a single type - in this
+                    // case all profiles of BaseMixedRealityProfile will be visible in the picker.
+                    // 
+                    // However in the case where there is just a single profile type for the service, we can improve
+                    // upon the user experience by limiting the set of things that show in the picker by restricting
+                    // the set of profiles listed to only that type.
+                    var availableTypes = MixedRealityProfileUtility.GetProfileTypesForService(serviceType);
+                    if (availableTypes.Count == 1)
+                    {
+                        profileType = availableTypes.First();
+                    }
+                }
+
+                // If the profile type is still null, just set it to base profile type
+                if (profileType == null)
+                {
+                    profileType = typeof(BaseMixedRealityProfile);
+                }
             }
 
             // Draw the profile dropdown

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -273,11 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                                 EditorGUILayout.PropertyField(runtimePlatform, RuntimePlatformContent);
                                 changed |= EditorGUI.EndChangeCheck();
 
-                                System.Type serviceType = null;
-                                if (configurationProfile.objectReferenceValue != null)
-                                {
-                                    serviceType = (target as MixedRealityInputSystemProfile).DataProviderConfigurations[i].ComponentType;
-                                }
+                                System.Type serviceType = (target as MixedRealityInputSystemProfile).DataProviderConfigurations[i].ComponentType;
 
                                 changed |= RenderProfile(configurationProfile, null, true, false, serviceType);
                             }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -139,11 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                                 changed |= EditorGUI.EndChangeCheck();
 
-                                Type serviceType = null;
-                                if (configurationProfile.objectReferenceValue != null)
-                                {
-                                    serviceType = (target as MixedRealityRegisteredServiceProvidersProfile).Configurations[i].ComponentType;
-                                }
+                                Type serviceType = (target as MixedRealityRegisteredServiceProvidersProfile).Configurations[i].ComponentType;
 
                                 changed |= RenderProfile(configurationProfile, null, true, true, serviceType);
                             }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpatialAwarenessSystemProfileInspector.cs
@@ -136,13 +136,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness.Editor
                             EditorGUILayout.PropertyField(runtimePlatform, RuntimePlatformContent);
                             changed |= EditorGUI.EndChangeCheck();
 
-                            System.Type serviceType = null;
-                            if (observerProfile.objectReferenceValue != null)
-                            {
-                                serviceType = (target as MixedRealitySpatialAwarenessSystemProfile).ObserverConfigurations[i].ComponentType;
-                            }
+                            var serviceType = (target as MixedRealitySpatialAwarenessSystemProfile).ObserverConfigurations[i].ComponentType;
 
-                            changed |= RenderProfile(observerProfile, null, true, false, serviceType);
+                            changed |= RenderProfile(observerProfile, typeof(BaseSpatialAwarenessObserverProfile), true, false, serviceType);
 
                             serializedObject.ApplyModifiedProperties();
                         }


### PR DESCRIPTION
## Overview
Two primary bugs here with profile inspectors

1) In RenderProfileInternal, the call to `MixedRealityProfileUtility.GetProfileTypesForService()` was incorrectly utitlized by selecting FirstOrDefault from the available list even if that profile was not a match for the given service type. Further, this call was made even if the profileType argument was already not null

2) Some inspectors were not properly providing a service type to RenderProfile(). They made erroneous checks before setting the serviceType argument.

With this change, now profile drop downs are actually filtered (where applicable like Spatial Mesh Observers) and correct value can now be set unblocking bug referenced below

## Changes
- Fixes: #6294 


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
