### PR TITLE
Cursor resizing based on distance and angular scale

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
@@ -156,6 +156,8 @@ MonoBehaviour:
   scaleLerpTime: 0.01
   rotationLerpTime: 0.01
   lookRotationBlend: 0
+  resizeCursorWithDistance: 1
+  cursorAngularScale: 0.65
   PrimaryCursorVisual: {fileID: 4000014090385390}
   SourceDownIds: 
   defaultCursorDistance: 2
@@ -293,16 +295,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 5387982173894475388, guid: 594ffe039afd6a64dbf45b2a3366a438,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorRest
-      objectReference: {fileID: 0}
-    - target: {fileID: 5387982173894475388, guid: 594ffe039afd6a64dbf45b2a3366a438,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5387982173894238812, guid: 594ffe039afd6a64dbf45b2a3366a438,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -373,6 +365,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 5387982173894475388, guid: 594ffe039afd6a64dbf45b2a3366a438,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorRest
+      objectReference: {fileID: 0}
+    - target: {fileID: 5387982173894475388, guid: 594ffe039afd6a64dbf45b2a3366a438,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 594ffe039afd6a64dbf45b2a3366a438, type: 3}
 --- !u!4 &7827255783330265876 stripped
@@ -388,16 +390,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 6273884922986239398, guid: eab90e525ea183647b99bf5ae3575c72,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorMoveArrowsEastWest
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273884922986239398, guid: eab90e525ea183647b99bf5ae3575c72,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6273884922985941382, guid: eab90e525ea183647b99bf5ae3575c72,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -468,6 +460,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 6273884922986239398, guid: eab90e525ea183647b99bf5ae3575c72,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorMoveArrowsEastWest
+      objectReference: {fileID: 0}
+    - target: {fileID: 6273884922986239398, guid: eab90e525ea183647b99bf5ae3575c72,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: eab90e525ea183647b99bf5ae3575c72, type: 3}
 --- !u!4 &9182950849594962738 stripped
@@ -483,16 +485,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 4178016473676599789, guid: bd972abbae7e3be4bbcabb327fd4291b,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorFocus
-      objectReference: {fileID: 0}
-    - target: {fileID: 4178016473676599789, guid: bd972abbae7e3be4bbcabb327fd4291b,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4178016473676959181, guid: bd972abbae7e3be4bbcabb327fd4291b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -563,6 +555,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 4178016473676599789, guid: bd972abbae7e3be4bbcabb327fd4291b,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorFocus
+      objectReference: {fileID: 0}
+    - target: {fileID: 4178016473676599789, guid: bd972abbae7e3be4bbcabb327fd4291b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd972abbae7e3be4bbcabb327fd4291b, type: 3}
 --- !u!4 &1055065070500362963 stripped
@@ -578,16 +580,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 5687318028320642791, guid: 45f90619388e38541865e0a2ed3fb47e,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorRotateArrowsVertical
-      objectReference: {fileID: 0}
-    - target: {fileID: 5687318028320642791, guid: 45f90619388e38541865e0a2ed3fb47e,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5687318028320869063, guid: 45f90619388e38541865e0a2ed3fb47e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -658,6 +650,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 5687318028320642791, guid: 45f90619388e38541865e0a2ed3fb47e,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorRotateArrowsVertical
+      objectReference: {fileID: 0}
+    - target: {fileID: 5687318028320642791, guid: 45f90619388e38541865e0a2ed3fb47e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 45f90619388e38541865e0a2ed3fb47e, type: 3}
 --- !u!4 &105401231646822886 stripped
@@ -673,16 +675,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 2087522883944475637, guid: dfdf062da9cce5c4ebabe98a14ef5364,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorRotateArrowsHorizontal
-      objectReference: {fileID: 0}
-    - target: {fileID: 2087522883944475637, guid: dfdf062da9cce5c4ebabe98a14ef5364,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2087522883944708053, guid: dfdf062da9cce5c4ebabe98a14ef5364,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -753,6 +745,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 2087522883944475637, guid: dfdf062da9cce5c4ebabe98a14ef5364,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorRotateArrowsHorizontal
+      objectReference: {fileID: 0}
+    - target: {fileID: 2087522883944475637, guid: dfdf062da9cce5c4ebabe98a14ef5364,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfdf062da9cce5c4ebabe98a14ef5364, type: 3}
 --- !u!4 &5076374374945212106 stripped
@@ -768,16 +770,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 6551073264639760439, guid: 15700cca0c876c840a30db2bef89f29f,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorMoveArrowsNorthSouth
-      objectReference: {fileID: 0}
-    - target: {fileID: 6551073264639760439, guid: 15700cca0c876c840a30db2bef89f29f,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6551073264640115735, guid: 15700cca0c876c840a30db2bef89f29f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -848,6 +840,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 6551073264639760439, guid: 15700cca0c876c840a30db2bef89f29f,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorMoveArrowsNorthSouth
+      objectReference: {fileID: 0}
+    - target: {fileID: 6551073264639760439, guid: 15700cca0c876c840a30db2bef89f29f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 15700cca0c876c840a30db2bef89f29f, type: 3}
 --- !u!4 &320842622904144133 stripped
@@ -863,16 +865,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 7747950012503708328, guid: 4a7a428c972d3614ba5cff825c4708c2,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorMoveArrowsNortheastSouthwest
-      objectReference: {fileID: 0}
-    - target: {fileID: 7747950012503708328, guid: 4a7a428c972d3614ba5cff825c4708c2,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7747950012503674504, guid: 4a7a428c972d3614ba5cff825c4708c2,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -943,6 +935,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 7747950012503708328, guid: 4a7a428c972d3614ba5cff825c4708c2,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorMoveArrowsNortheastSouthwest
+      objectReference: {fileID: 0}
+    - target: {fileID: 7747950012503708328, guid: 4a7a428c972d3614ba5cff825c4708c2,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a7a428c972d3614ba5cff825c4708c2, type: 3}
 --- !u!4 &1801719609629730298 stripped
@@ -958,16 +960,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 6018983043162336388, guid: f5f52f7c5c7012743af433bb1a27f3af,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorMoveArrowsNorthwestSoutheast
-      objectReference: {fileID: 0}
-    - target: {fileID: 6018983043162336388, guid: f5f52f7c5c7012743af433bb1a27f3af,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6018983043162566820, guid: f5f52f7c5c7012743af433bb1a27f3af,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1038,6 +1030,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 6018983043162336388, guid: f5f52f7c5c7012743af433bb1a27f3af,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorMoveArrowsNorthwestSoutheast
+      objectReference: {fileID: 0}
+    - target: {fileID: 6018983043162336388, guid: f5f52f7c5c7012743af433bb1a27f3af,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5f52f7c5c7012743af433bb1a27f3af, type: 3}
 --- !u!4 &2639907501957997659 stripped
@@ -1053,16 +1055,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 2817082550597684457, guid: cab2fee02e78ee94eb110dc9a99f892f,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorMoveArrowsMove
-      objectReference: {fileID: 0}
-    - target: {fileID: 2817082550597684457, guid: cab2fee02e78ee94eb110dc9a99f892f,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2817082550597718217, guid: cab2fee02e78ee94eb110dc9a99f892f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1133,6 +1125,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 25
       objectReference: {fileID: 0}
+    - target: {fileID: 2817082550597684457, guid: cab2fee02e78ee94eb110dc9a99f892f,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorMoveArrowsMove
+      objectReference: {fileID: 0}
+    - target: {fileID: 2817082550597684457, guid: cab2fee02e78ee94eb110dc9a99f892f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cab2fee02e78ee94eb110dc9a99f892f, type: 3}
 --- !u!4 &6840172529113620289 stripped
@@ -1148,16 +1150,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4000013316072862}
     m_Modifications:
-    - target: {fileID: 551570965678494914, guid: 5928c86d2f03f4b4ea7e0e5b6a1087ae,
-        type: 3}
-      propertyPath: m_Name
-      value: CursorPress
-      objectReference: {fileID: 0}
-    - target: {fileID: 551570965678494914, guid: 5928c86d2f03f4b4ea7e0e5b6a1087ae,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 551570965678000354, guid: 5928c86d2f03f4b4ea7e0e5b6a1087ae,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1227,6 +1219,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 551570965678494914, guid: 5928c86d2f03f4b4ea7e0e5b6a1087ae,
+        type: 3}
+      propertyPath: m_Name
+      value: CursorPress
+      objectReference: {fileID: 0}
+    - target: {fileID: 551570965678494914, guid: 5928c86d2f03f4b4ea7e0e5b6a1087ae,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5928c86d2f03f4b4ea7e0e5b6a1087ae, type: 3}

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -510,8 +510,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             float cursorDistance = Vector3.Distance(CameraCache.Main.transform.position, targetPosition);
             float cursorStartSize = (cursorBounds.extents - cursorBounds.center).magnitude * 2;
-            float desiredScale = (2.0f * cursorDistance * Mathf.Tan(cursorAngularScale * Mathf.Deg2Rad * 0.5f)) / cursorStartSize;
-
+            float desiredScale = MathUtilities.AngularScaleFromDistance(cursorAngularScale, cursorDistance) / cursorStartSize;
             return Vector3.one * desiredScale;
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -333,6 +333,34 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Object.Destroy(empty);
             Object.Destroy(info);
         }
+
+        [UnityTest]
+        public IEnumerator CursorScaling()
+        {
+            Camera cam = GameObject.FindObjectOfType<Camera>();
+
+            cube.transform.position = Vector3.forward;
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            BaseCursor baseCursor = GameObject.FindObjectOfType<BaseCursor>();
+            Assert.IsNotNull(baseCursor);
+
+            Renderer renderer = baseCursor.GetComponentInChildren<Renderer>();
+            Assert.IsNotNull(renderer);
+
+            float firstAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, baseCursor.transform.position.z);
+
+            cube.gameObject.SetActive(false);
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            float secondAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, baseCursor.transform.position.z);
+
+            Assert.IsTrue(Mathf.Approximately(firstAngularScale, secondAngularScale));
+        }
     }
 }
 

--- a/Assets/MixedRealityToolkit/Utilities/MathUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MathUtilities.cs
@@ -46,6 +46,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         /// <summary>
+        /// Retrieve angular measurement describing how large a sphere or circle appears from a given point of view.
+        /// Takes an angle (at given point of view) and a distance and returns the actual diameter of the object.
+        /// </summary>
+        public static float AngularScaleFromDistance(float angle, float distance)
+        {
+            float angularScale = 2.0f * distance * Mathf.Tan(angle * Mathf.Deg2Rad * 0.5f);            
+            return angularScale;
+        }
+
+        /// <summary>
         /// Takes a ray in the coordinate space specified by the "from" transform and transforms it to be the correct ray in the coordinate space specified by the "to" transform
         /// </summary>
         public static Ray TransformRayFromTo(Transform from, Transform to, Ray rayToConvert)


### PR DESCRIPTION
## Overview

This change adds functionality to dynamically resize DefaultCursor prefab based on distance to hit point (or maximum cursor distance if no object is hit) and a user-defined 'percentage of viewport' property. 

Initially we planned on using the existing Solver ConstantViewSize.cs or writing new functionality ported from the native hkeAngularScalingComponent.cpp class. However, the CursorBase.cs class already had functionality for lerping the scale of the cursor which was stubbed to always pursue a scale of one. Furthermore, it has methods responsible for lerping the position and orientation of the cursor, so I deemed it necessary to add the dynamic scaling directly to CursorBase.cs.

~~The functionality is controlled via two exposed variables on the CursorBase.cs class. One bool, "ResizeCursorWithDistance" and one float "CursorSizeAsPercentageOfViewport." The former toggles the functionality and the latter is a value between 0f-1f that will scale the reticle to 0-100% of the viewport. Default value is 0.0125 which is visually identical to native appearance. I elected to use percent of viewport as opposed to angular size because it is more easily understood. I would be open to critiques on this if anyone feels strongly about angular scale being a more effective method.~~

[EDIT]
I now use angular scale instead, to account for multiple platform differences in VFOV. 

We also explored having different CursorSizeAsPercentageOfViewport values dictated by separate PointerProfiles (i.e. DefaultHololensInputPointerProfile vs. DefaultMixedRealityInputPointerProfile) to make each platform more native-accurate, but decided the added complexity was not worth a slight difference in scale between different hardware. 


![ResizeCursor](https://user-images.githubusercontent.com/16657884/66967645-82827a00-f036-11e9-8705-7b2a4728f586.gif)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4980

