### PR TITLE
HandConstraint wrongly set tracked handedness instead of changing current runtime value + trigger missing events

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -404,9 +404,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 if (SolverHandler.TrackedTargetType == TrackedObjectType.HandJoint || 
                     SolverHandler.TrackedTargetType == TrackedObjectType.MotionController)
                 {
-                    if (SolverHandler.TrackedHandness != hand.ControllerHandedness)
+                    if (!SolverHandler.TrackedHandness.HasFlag(hand.ControllerHandedness))
                     {
-                        SolverHandler.TrackedHandness = hand.ControllerHandedness;
+                        SolverHandler.RefreshTrackedObject();
 
                         // Move the currently tracked hand to the top of the stack.
                         handStack.Remove(hand);
@@ -436,6 +436,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 if (trackedHand != null)
                 {
+					SolverHandler.RefreshTrackedObject();
                     StartCoroutine(ToggleCursor(true));
                     trackedHand = null;
                     onHandDeactivate?.Invoke();

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -366,6 +366,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         /// <summary>
+        /// Tells the SolverHandler to refresh its tracked object (hand)
+        /// </summary>
+        /// <remarks>
+        /// delayed 2 frames due to IMixedRealityHandJointService updating during "LateUpdate"
+        /// </remarks>
+        protected IEnumerator DelayedRefreshSolverHandlerTrackedObject()
+        {
+            // frame delay 
+            for(int i=0; i<2; ++i)
+			{
+				yield return null;
+			}
+
+            SolverHandler.RefreshTrackedObject();
+        }
+
+        /// <summary>
         /// Performs an intersection test to see if the left hand is near the right hand or vice versa.
         /// </summary>
         /// <param name="hand">The hand to check against.</param>
@@ -436,7 +453,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 if (trackedHand != null)
                 {
-					SolverHandler.RefreshTrackedObject();
+					StartCoroutine(DelayedRefreshSolverHandlerTrackedObject());
                     StartCoroutine(ToggleCursor(true));
                     trackedHand = null;
                     onHandDeactivate?.Invoke();

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -375,9 +375,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             // frame delay 
             for(int i=0; i<2; ++i)
-			{
-				yield return null;
-			}
+            {
+                yield return null;
+            }
 
             SolverHandler.RefreshTrackedObject();
         }
@@ -453,7 +453,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 if (trackedHand != null)
                 {
-					StartCoroutine(DelayedRefreshSolverHandlerTrackedObject());
+                    StartCoroutine(DelayedRefreshSolverHandlerTrackedObject());
                     StartCoroutine(ToggleCursor(true));
                     trackedHand = null;
                     onHandDeactivate?.Invoke();

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -430,17 +430,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                         handStack.Insert(0, hand);
                     }
 
-                    if (trackedHand == null)
+                    if (trackedHand != null)
                     {
-                        trackedHand = hand;
-                        onHandActivate?.Invoke();
-                    }
-                    else
-                    {
+                        onHandDeactivate?.Invoke();
                         StartCoroutine(ToggleCursor(true));
-                        trackedHand = hand;
                     }
 
+                    trackedHand = hand;
+                    onHandActivate?.Invoke();
+                    
                     // Wait one frame to disable the cursor in case one hasn't been instantiated yet.
                     StartCoroutine(ToggleCursor(false, true));
                 }


### PR DESCRIPTION
## Overview
fix1:Currently, the handconstraint solver is modifying the SolverHandler "Tracked Handness" property during runtime.

This is wrong in case the user wants to track "Both" hands. the "TrackedHandness" property will switch from left and right, and if any outside code is testing this setting, it oculd lead to some bug.

Plus, there is a "CurrentTrackedHandedness" property that is supposed to give the runtime value.


fix 2:  onHandActivate is currently not triggered when Both hands are tracked and the constraint is switching from one hand to the other : 
example in the hand menu: 
- bring hand one to pop the menu (onhandactivate is triggered)
- bring hand two
- hide hand one
=> menu switches to hand two, but no event is triggered (expecting onhanddeactivate and onhandactivate both triggered)
-hide hand two (onhanddeactivate is triggered)

## Changes
(fix1)HandConstraint now trigger a refresh on the solver handler side that will update the CurrentTrackedHandedness property without changing the "TrackedHandness" setting.
plus when no hand is tracked anymore, we call the refresh again to untrack the hand (see verification below for some possible alternative here)

(fix2) correctly trigger onHandActivate and onHandDeactivate events

## Verification

currently have to call the public RefreshTrackedObject() when we only want to 
DetachFromCurrentTrackedObject() (but this function is protected).
problem is the handjointservice updates its tracking hand pointers during LateUpdate, so we have to wait 2 frames before its actually correctly up to date to have the solver correctly detaching tracked hand without attaching it again.
this seems a bit hacky, so any alternative code (make DetachFromCurrentTrackedObject public ??) is welcome.




> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
