### PR TITLE
Scene System editor features no longer interfere with prefab editing

### DIFF
--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
@@ -253,7 +253,6 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             if (EditorSceneUtils.IsEditingPrefab())
             {   // Never change scene settings while editing a prefab - it will boot you out of the prefab scene stage.
-                Debug.Log("Editing a prefab - not proceeding.");
                 return;
             }
 

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
@@ -251,6 +251,12 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 return;
             }
 
+            if (EditorSceneUtils.IsEditingPrefab())
+            {   // Never change scene settings while editing a prefab - it will boot you out of the prefab scene stage.
+                Debug.Log("Editing a prefab - not proceeding.");
+                return;
+            }
+
             if (updatingSettingsOnEditorChanged || EditorApplication.isPlayingOrWillChangePlaymode || EditorApplication.isCompiling)
             {   // Make sure we don't double up on our updates via events we trigger during updates
                 return;

--- a/Assets/MixedRealityToolkit/Utilities/Scenes/EditorSceneUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scenes/EditorSceneUtils.cs
@@ -250,7 +250,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Returns true if user is currently editing a prefab.
         /// </summary>
-        /// <returns></returns>
         public static bool IsEditingPrefab()
         {
             var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();

--- a/Assets/MixedRealityToolkit/Utilities/Scenes/EditorSceneUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Scenes/EditorSceneUtils.cs
@@ -248,6 +248,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         /// <summary>
+        /// Returns true if user is currently editing a prefab.
+        /// </summary>
+        /// <returns></returns>
+        public static bool IsEditingPrefab()
+        {
+            var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+            return prefabStage != null;
+        }
+
+        /// <summary>
         /// Unloads a scene in the editor and catches any errors that can happen along the way.
         /// </summary>
         public static bool UnloadScene(SceneInfo sceneInfo, bool removeFromHeirarchy)


### PR DESCRIPTION
## Overview
Adds a check to EditorSceneUtils to ensure we don't execute editor scene features while editing a prefab.

## Changes
- Fixes: #6312

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch

Try editing a prefab while the scene system is active and all editor features are enabled.