### PR TITLE
Stabilization plane fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -220,7 +220,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             get
             {
                 var gazeProvider = CoreServices.InputSystem?.GazeProvider;
-                if (gazeProvider?.Enabled == true)
+                if (gazeProvider != null && gazeProvider.Enabled)
                 {
                     return gazeProvider.GazeOrigin;
                 }

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -237,7 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             get
             {
                 var gazeProvider = CoreServices.InputSystem?.GazeProvider;
-                if (gazeProvider?.Enabled == true)
+                if (gazeProvider != null && gazeProvider.Enabled)
                 {
                     return gazeProvider.GazeDirection;
                 }

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         private bool TryGetGazeHitPosition(out Vector3 hitPosition)
         {
             var gazeProvider = CoreServices.InputSystem?.GazeProvider;
-            if (gazeProvider?.Enabled == true &&
+            if (gazeProvider != null && gazeProvider.Enabled &&
                 gazeProvider.HitInfo.raycastValid)
             {
                 hitPosition = gazeProvider.HitPosition;

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/StabilizationPlaneModifier.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using UnityEngine;
@@ -220,9 +219,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         {
             get
             {
-                if (CoreServices.InputSystem != null && CoreServices.InputSystem.GazeProvider.Enabled)
+                var gazeProvider = CoreServices.InputSystem?.GazeProvider;
+                if (gazeProvider?.Enabled == true)
                 {
-                    return CoreServices.InputSystem.GazeProvider.GazeOrigin;
+                    return gazeProvider.GazeOrigin;
                 }
 
                 return CameraCache.Main.transform.position;
@@ -236,9 +236,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         {
             get
             {
-                if (CoreServices.InputSystem != null && CoreServices.InputSystem.GazeProvider.Enabled)
+                var gazeProvider = CoreServices.InputSystem?.GazeProvider;
+                if (gazeProvider?.Enabled == true)
                 {
-                    return CoreServices.InputSystem.GazeProvider.GazeDirection;
+                    return gazeProvider.GazeDirection;
                 }
 
                 return CameraCache.Main.transform.forward;
@@ -252,9 +253,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         /// <returns>True if gaze is supported and an object was hit by gaze, otherwise false.</returns>
         private bool TryGetGazeHitPosition(out Vector3 hitPosition)
         {
-            if (CoreServices.InputSystem.GazeProvider.Enabled)
+            var gazeProvider = CoreServices.InputSystem?.GazeProvider;
+            if (gazeProvider?.Enabled == true &&
+                gazeProvider.HitInfo.raycastValid)
             {
-                hitPosition = CoreServices.InputSystem.GazeProvider.HitPosition;
+                hitPosition = gazeProvider.HitPosition;
                 return true;
             }
 


### PR DESCRIPTION
## Overview
StabilizationPlaneModifier did not check if gaze raycast was valid and actually hit an item in it's plane setting. This change fixes that

## Changes
- Fixes: #6263 


## Verification
Follow steps in bug #6263 and notice gizmo plane now at correct distances in gazemode

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
