### PR TITLE
Edited shader variables to more closely resemble shell appearance

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/StandardAssets/Materials/MRTK_FingerTipCursor.mat
+++ b/Assets/MixedRealityToolkit.SDK/StandardAssets/Materials/MRTK_FingerTipCursor.mat
@@ -23,16 +23,16 @@ Material:
     - _Fade_Far_Distance_: 0.2
     - _Fade_Near_Distance_: 0.1
     - _Fall_End_: 1
-    - _Fall_Start_: 0.77
+    - _Fall_Start_: 0.85
     - _Far_Center_Fraction_: 1
     - _Near_Center_Fraction_: 0
     - _Near_Radius_Fraction_: 0.5
     - _Proximity_Distance_: 0.013
-    - _Rise_End_: 0.321
-    - _Rise_Start_: 0
+    - _Rise_End_: 0.25
+    - _Rise_Start_: 0.05
     - _Shrink_Start_Distance_: 0.1
     - _Start_Fall_Fade_: 0.05
     - _Thickness_: 1
     m_Colors:
-    - _Base_Color_: {r: 1, g: 1, b: 1, a: 0.698}
-    - _Edge_Color_: {r: 0.188235, g: 0.188235, b: 0.188235, a: 0.502}
+    - _Base_Color_: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
+    - _Edge_Color_: {r: 0.16981131, g: 0.16981131, b: 0.16981131, a: 1}


### PR DESCRIPTION
## Overview

Quick fix to exposed shader variables on MRTK_FingertipCursor.mat to more closely match the appearance of the shell fingertip cursor.

| Expected appearance  | Current appearance  | Suggested appearance |
| ------------- | ------------- | ------------- |
| ![MicrosoftTeams-image](https://user-images.githubusercontent.com/16657884/67342667-9ff88d80-f4e7-11e9-8f81-6279c7b34c91.png) | ![FingerTipPre](https://user-images.githubusercontent.com/16657884/67342697-c1597980-f4e7-11e9-8ef9-23f2bc7a95e2.PNG) | ![FingerTipPost](https://user-images.githubusercontent.com/16657884/67342714-ce766880-f4e7-11e9-9d5a-2dbd77a22a96.PNG) |

## Changes
- Fixes: #6351 
