### PR TITLE
Fix intermittent test failures for ScaleViaHoloLens1Interaction and TestGazeProviderTargetNotNull

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -200,6 +200,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             var bbox = InstantiateSceneAndDefaultBbox();
             yield return null;
+            yield return null;
+
             var bounds = bbox.GetComponent<BoxCollider>().bounds;
             var startCenter = new Vector3(0, 0, 1.5f);
             var startSize = new Vector3(.5f, .5f, .5f);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             cube.transform.position = Vector3.forward;
 
             yield return null;
+            yield return null;
 
             Assert.NotNull(CoreServices.InputSystem.GazeProvider.GazeTarget, "GazeProvider target is null when looking at an object");
 


### PR DESCRIPTION
## Overview
Fixes intermittent test failures  #6121: 
- ScaleViaHoloLens1Interaction in BoundingBoxTests.cs
- TestGazeProviderTargetNotNull in FocusProviderTests.cs

ScaleViaHoloLens1Interaction and TestGazeProviderTargetNotNull were tested 200 times with 100% passing with an extra yield return null.

## Changes
- Added extra yield return null for two tests

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
