### PR TITLE
Cache controller model instead of reallocating each detection

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/BaseWindowsMixedRealitySource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <summary>
         /// Constructor.
         /// </summary>
-        public BaseWindowsMixedRealitySource(TrackingState trackingState, Handedness sourceHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
+        protected BaseWindowsMixedRealitySource(TrackingState trackingState, Handedness sourceHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, sourceHandedness, inputSource, interactions)
         {
         }
@@ -52,8 +52,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private Quaternion currentPointerRotation = Quaternion.identity;
         private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;
 
-        private Vector3 currentGripPosition = Vector3.zero;
-        private Quaternion currentGripRotation = Quaternion.identity;
         private MixedRealityPose currentGripPose = MixedRealityPose.ZeroIdentity;
 
         #region Update data functions

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Extensions/InteractionSourceExtensions.cs
@@ -26,18 +26,20 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
             if (WindowsApiChecker.UniversalApiContractV5_IsAvailable)
             {
+                IReadOnlyList<SpatialInteractionSourceState> sources = null;
+
                 UnityEngine.WSA.Application.InvokeOnUIThread(() =>
                 {
-                    IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView()?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-
-                    for (var i = 0; i < sources.Count; i++)
-                    {
-                        if (sources[i].Source.Id.Equals(interactionSource.id))
-                        {
-                            returnValue = sources[i].Source.Controller.TryGetRenderableModelAsync();
-                        }
-                    }
+                    sources = SpatialInteractionManager.GetForCurrentView()?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
                 }, true);
+
+                for (var i = 0; i < sources?.Count; i++)
+                {
+                    if (sources[i].Source.Id.Equals(interactionSource.id))
+                    {
+                        returnValue = sources[i].Source.Controller.TryGetRenderableModelAsync();
+                    }
+                }
             }
 
             return returnValue;

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Extensions/InteractionSourceExtensions.cs
@@ -1,115 +1,25 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_WSA
-using UnityEngine;
-using UnityEngine.XR.WSA.Input;
+#if WINDOWS_UWP
 using Microsoft.MixedReality.Toolkit.Windows.Utilities;
-
-#if !UNITY_EDITOR
 using System;
 using System.Collections.Generic;
-using Windows.Devices.Haptics;
+using UnityEngine.XR.WSA.Input;
 using Windows.Foundation;
 using Windows.Perception;
 using Windows.Storage.Streams;
 using Windows.UI.Input.Spatial;
-#elif UNITY_EDITOR_WIN
-using System.Runtime.InteropServices;
 #endif
-
-#endif // UNITY_WSA
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Input
 {
     /// <summary>
-    /// Extensions for the InteractionSource class to add haptics and expose the renderable model.
+    /// Extensions for the InteractionSource class to expose the renderable model.
     /// </summary>
     public static class InteractionSourceExtensions
     {
-#if UNITY_EDITOR_WIN && UNITY_WSA
-        [DllImport("EditorMotionController")]
-        private static extern bool StartHaptics([In] uint controllerId, [In] float intensity, [In] float durationInSeconds);
-
-        [DllImport("EditorMotionController")]
-        private static extern bool StopHaptics([In] uint controllerId);
-#endif // UNITY_EDITOR_WIN && UNITY_WSA
-
-        // This value is standardized according to www.usb.org/developers/hidpage/HUTRR63b_-_Haptics_Page_Redline.pdf
-        private const ushort ContinuousBuzzWaveform = 0x1004;
-
-#if UNITY_WSA
-        public static void StartHaptics(this InteractionSource interactionSource, float intensity)
-        {
-            interactionSource.StartHaptics(intensity, float.MaxValue);
-        }
-
-        public static void StartHaptics(this InteractionSource interactionSource, float intensity, float durationInSeconds)
-        {
-            if (!WindowsApiChecker.UniversalApiContractV4_IsAvailable && !Application.isEditor)
-            {
-                return;
-            }
-
-#if !UNITY_EDITOR
-            UnityEngine.WSA.Application.InvokeOnUIThread(() =>
-            {
-                IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView().GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-
-                foreach (SpatialInteractionSourceState sourceState in sources)
-                {
-                    if (sourceState.Source.Id.Equals(interactionSource.id))
-                    {
-                        SimpleHapticsController simpleHapticsController = sourceState.Source.Controller.SimpleHapticsController;
-                        foreach (SimpleHapticsControllerFeedback hapticsFeedback in simpleHapticsController.SupportedFeedback)
-                        {
-                            if (hapticsFeedback.Waveform.Equals(ContinuousBuzzWaveform))
-                            {
-                                if (durationInSeconds.Equals(float.MaxValue))
-                                {
-                                    simpleHapticsController.SendHapticFeedback(hapticsFeedback, intensity);
-                                }
-                                else
-                                {
-                                    simpleHapticsController.SendHapticFeedbackForDuration(hapticsFeedback, intensity, TimeSpan.FromSeconds(durationInSeconds));
-                                }
-                                return;
-                            }
-                        }
-                    }
-                }
-            }, true);
-#elif UNITY_EDITOR_WIN
-            StartHaptics(interactionSource.id, intensity, durationInSeconds);
-#endif // !UNITY_EDITOR
-        }
-
-        public static void StopHaptics(this InteractionSource interactionSource)
-        {
-            if (!WindowsApiChecker.UniversalApiContractV4_IsAvailable && !Application.isEditor)
-            {
-                return;
-            }
-
-#if !UNITY_EDITOR
-            UnityEngine.WSA.Application.InvokeOnUIThread(() =>
-            {
-                IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView().GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-
-                foreach (SpatialInteractionSourceState sourceState in sources)
-                {
-                    if (sourceState.Source.Id.Equals(interactionSource.id))
-                    {
-                        sourceState.Source.Controller.SimpleHapticsController.StopFeedback();
-                    }
-                }
-            }, true);
-#elif UNITY_EDITOR_WIN
-            StopHaptics(interactionSource.id);
-#endif // !UNITY_EDITOR
-        }
-
-#if !UNITY_EDITOR
+#if WINDOWS_UWP
         public static IAsyncOperation<IRandomAccessStreamWithContentType> TryGetRenderableModelAsync(this InteractionSource interactionSource)
         {
             IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
@@ -118,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             {
                 UnityEngine.WSA.Application.InvokeOnUIThread(() =>
                 {
-                    IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView().GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
+                    IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager.GetForCurrentView()?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
 
                     for (var i = 0; i < sources.Count; i++)
                     {
@@ -132,7 +42,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
             return returnValue;
         }
-#endif // !UNITY_EDITOR
-#endif // UNITY_WSA
+#endif // WINDOWS_UWP
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -7,6 +7,7 @@ using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
 using System;
 
 #if UNITY_WSA
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.WSA.Input;
 #endif
@@ -16,6 +17,7 @@ using Windows.Foundation;
 using Windows.Perception;
 using Windows.UI.Input.Spatial;
 using Windows.Storage.Streams;
+using Microsoft.MixedReality.Toolkit.Windows.Input;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
@@ -58,9 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         };
 
 #if UNITY_WSA
-
         private bool controllerModelInitialized = false;
         private bool failedToObtainControllerModel = false;
+
+        private static readonly Dictionary<string, GameObject> controllerDictionary = new Dictionary<string, GameObject>(0);
 
         #region Update data functions
 
@@ -311,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                         else
                         {
                             Debug.LogError("Controller visualization type not defined for controller visualization profile");
-                            GameObject.Destroy(gltfGameObject);
+                            UnityEngine.Object.Destroy(gltfGameObject);
                             gltfGameObject = null;
                         }
                     }
@@ -353,6 +356,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             return returnValue;
         }
 #endif
+
+        private string GenerateKey(InteractionSource source)
+        {
+            return source.vendorId + "/" + source.productId + "/" + source.productVersion + "/" + source.handedness;
+        }
 
         #endregion Controller model functions
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -240,11 +240,20 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void EnsureControllerModel(InteractionSourceState interactionSourceState)
         {
+            GameObject controllerModel;
+
             if (controllerModelInitialized ||
                 GetControllerVisualizationProfile() == null ||
                 !GetControllerVisualizationProfile().GetUseDefaultModelsOverride(GetType(), ControllerHandedness))
             {
                 controllerModelInitialized = true;
+                return;
+            }
+            else if (controllerDictionary.TryGetValue(GenerateKey(interactionSourceState.source), out controllerModel))
+            {
+                controllerModelInitialized = true;
+                TryAddControllerModelToSceneHierarchy(controllerModel);
+                controllerModel.SetActive(true);
                 return;
             }
 
@@ -307,6 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                         {
                             gltfGameObject.AddComponent(visualizationType.Type);
                             TryAddControllerModelToSceneHierarchy(gltfGameObject);
+                            controllerDictionary.Add(GenerateKey(interactionSource), gltfGameObject);
                         }
                         else
                         {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -13,8 +13,8 @@ using UnityEngine.XR.WSA.Input;
 #endif
 
 #if WINDOWS_UWP
-using Windows.Storage.Streams;
 using Microsoft.MixedReality.Toolkit.Windows.Input;
+using Windows.Storage.Streams;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
@@ -314,7 +314,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                         var visualizationType = visualizationProfile.GetControllerVisualizationTypeOverride(GetType(), ControllerHandedness);
                         if (visualizationType != null)
                         {
-                            gltfGameObject.AddComponent(visualizationType.Type);
+                            // Set the platform controller model to not be destroyed when the source is lost. It'll be disabled instead,
+                            // and re-enabled when the same controller is re-detected.
+                            if (gltfGameObject.AddComponent(visualizationType.Type) is IMixedRealityControllerPoseSynchronizer visualizer)
+                            {
+                                visualizer.DestroyOnSourceLost = false;
+                            }
+
                             TryAddControllerModelToSceneHierarchy(gltfGameObject);
                             controllerDictionary.Add(GenerateKey(interactionSource), gltfGameObject);
                         }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityController.cs
@@ -13,9 +13,6 @@ using UnityEngine.XR.WSA.Input;
 #endif
 
 #if WINDOWS_UWP
-using Windows.Foundation;
-using Windows.Perception;
-using Windows.UI.Input.Spatial;
 using Windows.Storage.Streams;
 using Microsoft.MixedReality.Toolkit.Windows.Input;
 #endif
@@ -252,7 +249,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
 
             controllerModelInitialized = true;
-            CreateControllerModelFromPlatformSDK(interactionSourceState.source.id);
+            CreateControllerModelFromPlatformSDK(interactionSourceState.source);
         }
 
         protected override bool TryRenderControllerModel(Type controllerType, InputSourceType inputSourceType)
@@ -272,13 +269,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             return false;
         }
 
-        private async void CreateControllerModelFromPlatformSDK(uint interactionSourceId)
+        private async void CreateControllerModelFromPlatformSDK(InteractionSource interactionSource)
         {
             Debug.Log("Creating controller model from platform SDK");
             byte[] fileBytes = null;
 
 #if WINDOWS_UWP
-            var controllerModelStream = await TryGetRenderableModelAsync(interactionSourceId);
+            var controllerModelStream = await interactionSource.TryGetRenderableModelAsync();
             if (controllerModelStream == null ||
                 controllerModelStream.Size == 0)
             {
@@ -333,29 +330,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 TryRenderControllerModel(GetType(), InputSourceType.Controller);
             }
         }
-
-#if WINDOWS_UWP
-        private IAsyncOperation<IRandomAccessStreamWithContentType> TryGetRenderableModelAsync(uint interactionSourceId)
-        {
-            IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
-            UnityEngine.WSA.Application.InvokeOnUIThread(() =>
-            {
-                var sources = SpatialInteractionManager.GetForCurrentView()?.GetDetectedSourcesAtTimestamp(PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-                if (sources != null)
-                {
-                    foreach (SpatialInteractionSourceState sourceState in sources)
-                    {
-                        if (sourceState.Source.Id.Equals(interactionSourceId))
-                        {
-                            returnValue = sourceState.Source.Controller.TryGetRenderableModelAsync();
-                        }
-                    }
-                }
-            }, true);
-
-            return returnValue;
-        }
-#endif
 
         private string GenerateKey(InteractionSource source)
         {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -652,6 +652,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
+                if (controller.Visualizer != null &&
+                    controller.Visualizer.GameObjectProxy != null)
+                {
+                    controller.Visualizer.GameObjectProxy.SetActive(false);
+                }
+
                 inputSystem?.RaiseSourceLost(controller.InputSource, controller);
 
                 foreach (IMixedRealityPointer pointer in controller.InputSource.Pointers)

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -652,12 +652,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
-                if (controller.Visualizer != null &&
-                    controller.Visualizer.GameObjectProxy != null)
-                {
-                    controller.Visualizer.GameObjectProxy.SetActive(false);
-                }
-
                 inputSystem?.RaiseSourceLost(controller.InputSource, controller);
 
                 foreach (IMixedRealityPointer pointer in controller.InputSource.Pointers)
@@ -666,6 +660,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     {
                         pointer.Controller = null;
                     }
+                }
+
+                if (controller.Visualizer != null &&
+                    controller.Visualizer.GameObjectProxy != null)
+                {
+                    controller.Visualizer.GameObjectProxy.SetActive(false);
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityControllerPoseSynchronizer.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityControllerPoseSynchronizer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         Handedness Handedness { get; }
 
         /// <summary>
-        /// Should this <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> clean itself up when it's controller is lost?
+        /// Should this <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> clean itself up when its controller is lost?
         /// </summary>
         /// <remarks>It's up to the implementation to properly destroy the <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>'s this interface will implement.</remarks>
         bool DestroyOnSourceLost { get; set; }

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -253,12 +253,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         #region MRTK instance helpers
-        protected MixedRealityControllerVisualizationProfile GetControllerVisualizationProfile()
+
+        protected static MixedRealityControllerVisualizationProfile GetControllerVisualizationProfile()
         {
-            return CoreServices.InputSystem?.InputSystemProfile?.ControllerVisualizationProfile;
+            if (CoreServices.InputSystem?.InputSystemProfile != null)
+            {
+                return CoreServices.InputSystem.InputSystemProfile.ControllerVisualizationProfile;
+            }
+
+            return null;
         }
 
-        protected bool IsControllerMappingEnabled()
+        protected static bool IsControllerMappingEnabled()
         {
             if (CoreServices.InputSystem?.InputSystemProfile != null)
             {
@@ -268,9 +274,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
             return false;
         }
 
-        protected MixedRealityControllerMapping[] GetControllerMappings()
+        protected static MixedRealityControllerMapping[] GetControllerMappings()
         {
-            return CoreServices.InputSystem?.InputSystemProfile?.ControllerMappingProfile?.MixedRealityControllerMappings;
+            if (CoreServices.InputSystem?.InputSystemProfile != null &&
+                CoreServices.InputSystem.InputSystemProfile.ControllerMappingProfile != null)
+            {
+                // We can only enable controller profiles if mappings exist.
+                return CoreServices.InputSystem.InputSystemProfile.ControllerMappingProfile.MixedRealityControllerMappings;
+            }
+
+            return null;
         }
 
         #endregion MRTK instance helpers


### PR DESCRIPTION
## Overview
* Adds a controller model cache for platform models, so we aren't reallocating and reloading the glTF model every time the same controller is detected.
* Removes the haptics extensions, as they referenced a DLL we don't currently distribute, so they don't currently work.
* Fixes some null propagation issues
* Removes some duplicate methods

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5437

## Verification
Deploy an MRTK example scene app to your WMR machine. Open the app, and open a slate while inside the immersive experience. Move your controller's pointer between the slate and the immersive experience. You should see the controller flip back and forth between the shell's model and the app model without much delay.