### PR TITLE
Cursor scaling relativity fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   rotationLerpTime: 0.01
   lookRotationBlend: 0
   resizeCursorWithDistance: 1
-  cursorAngularScale: 0.65
+  cursorAngularScale: 60
   PrimaryCursorVisual: {fileID: 4000014090385390}
   SourceDownIds: 
   defaultCursorDistance: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   rotationLerpTime: 0.01
   lookRotationBlend: 0
   resizeCursorWithDistance: 1
-  cursorAngularScale: 60
+  cursorAngularScale: 50
   PrimaryCursorVisual: {fileID: 4000014090385390}
   SourceDownIds: 
   defaultCursorDistance: 2

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)")]
-        private float cursorAngularScale = 60.0f;
+        private float cursorAngularScale = 50.0f;
 
         [Header("Transform References")]
         [SerializeField]

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -115,13 +116,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)
         /// </summary>
+        [Obsolete("Property obsolete. Use CursorAngularSize instead")]
+        public float CursorAngularScale
+        {
+            get { return CursorAngularSize; }
+            set { CursorAngularSize = value; }
+        }
+
+        /// <summary>
+        /// The angular size of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)
+        /// </summary>
         public float CursorAngularSize
         {
             get { return cursorAngularSize; }
             set { cursorAngularSize = value; }
         }
-
-        [SerializeField]
+        
+        [SerializeField, FormerlySerializedAs("cursorAngularScale")]
         [Tooltip("The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)")]
         private float cursorAngularSize = 50.0f;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool ResizeCursorWithDistance
         {
-            get { return ResizeCursorWithDistance; }
+            get { return resizeCursorWithDistance; }
             set { resizeCursorWithDistance = value; }
         }
 
@@ -115,15 +115,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)
         /// </summary>
-        public float CursorAngularScale
+        public float CursorAngularSize
         {
-            get { return cursorAngularScale; }
-            set { cursorAngularScale = value; }
+            get { return cursorAngularSize; }
+            set { cursorAngularSize = value; }
         }
 
         [SerializeField]
         [Tooltip("The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)")]
-        private float cursorAngularScale = 50.0f;
+        private float cursorAngularSize = 50.0f;
 
         [Header("Transform References")]
         [SerializeField]
@@ -491,7 +491,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Vector3 ComputeScaleWithAngularScale(Vector3 targetPosition)
         {
             float cursorDistance = Vector3.Distance(CameraCache.Main.transform.position, targetPosition);
-            float desiredScale = MathUtilities.AngularScaleFromDistance(cursorAngularScale, cursorDistance);
+            float desiredScale = MathUtilities.ScaleFromAngularSizeAndDistance(cursorAngularSize, cursorDistance);
             return Vector3.one * desiredScale;
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -113,7 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private bool resizeCursorWithDistance = false;
 
         /// <summary>
-        /// The value, in angle, of expected cursor size in relation to Main Camera
+        /// The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)
         /// </summary>
         public float CursorAngularScale
         {
@@ -122,8 +122,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [SerializeField]
-        [Tooltip("The value, in angle, of expected cursor size in relation to Main Camera")]
-        private float cursorAngularScale = 0.65f;
+        [Tooltip("The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)")]
+        private float cursorAngularScale = 60.0f;
 
         [Header("Transform References")]
         [SerializeField]
@@ -147,8 +147,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected Vector3 targetPosition;
         protected Vector3 targetScale;
         protected Quaternion targetRotation;
-
-        private Bounds cursorBounds = new Bounds();
 
         #region IMixedRealityCursor Implementation
 
@@ -347,7 +345,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected virtual void Start()
         {
             RegisterManagers();
-            CalculateBounds();
         }
 
         private void Update()
@@ -494,30 +491,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Vector3 ComputeScaleWithAngularScale(Vector3 targetPosition)
         {
             float cursorDistance = Vector3.Distance(CameraCache.Main.transform.position, targetPosition);
-            float cursorStartSize = (cursorBounds.extents - cursorBounds.center).magnitude * 2;
-            float desiredScale = MathUtilities.AngularScaleFromDistance(cursorAngularScale, cursorDistance) / cursorStartSize;
+            float desiredScale = MathUtilities.AngularScaleFromDistance(cursorAngularScale, cursorDistance);
             return Vector3.one * desiredScale;
-        }
-
-        /// <summary>
-        /// On start, calculates world space mesh bounds of cursor in order to correctly size it when using resizeCursorWithDistance 
-        /// </summary>
-        private void CalculateBounds()
-        {
-            Vector3 cachedScale = transform.localScale;
-            transform.localScale = Vector3.one;
-
-            var combinedBounds = new Bounds(transform.position, Vector3.zero);
-            var renderers = GetComponentsInChildren<Renderer>();
-
-            for (var i = 0; i < renderers.Length; i++)
-            {
-                combinedBounds.Encapsulate(renderers[i].bounds);
-            }
-
-            cursorBounds = combinedBounds;
-
-            transform.localScale = cachedScale;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -335,29 +335,61 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
+
         public IEnumerator CursorScaling()
         {
+            // Finding or initializing necessary objects
             Camera cam = GameObject.FindObjectOfType<Camera>();
-
-            cube.transform.position = Vector3.forward;
-
-            yield return new WaitForFixedUpdate();
-            yield return null;
 
             BaseCursor baseCursor = GameObject.FindObjectOfType<BaseCursor>();
             Assert.IsNotNull(baseCursor);
 
-            Renderer renderer = baseCursor.GetComponentInChildren<Renderer>();
-            Assert.IsNotNull(renderer);
+            // Make sure resizing is turned on
+            Assert.IsTrue(baseCursor.ResizeCursorWithDistance);
 
-            float firstAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, baseCursor.transform.position.z);
+            // Set CursorAngularScale for hardcoded calculations
+            baseCursor.CursorAngularSize = 50.0f;
+
+            cube.transform.position = Vector3.forward * 2.0f;
+
+            // Wait for cursor to resize/move
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // Part one tests cursor size against precalculated values at two different distances
+
+            // FIRST DISTANCE
+            float precalculatedScale = 2.0f * Vector3.Distance(cam.transform.position, baseCursor.transform.position) * Mathf.Tan(baseCursor.CursorAngularSize * Mathf.Deg2Rad * 0.5f);
+            Assert.IsTrue(Mathf.Approximately(precalculatedScale, baseCursor.transform.localScale.y));
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            cube.transform.position = Vector3.forward;
+
+            // Wait for cursor to resize/move
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // SECOND DISTANCE
+            precalculatedScale = 2.0f * Vector3.Distance(cam.transform.position, baseCursor.transform.position) * Mathf.Tan(baseCursor.CursorAngularSize * Mathf.Deg2Rad * 0.5f);
+            Assert.IsTrue(Mathf.Approximately(precalculatedScale, baseCursor.transform.localScale.y));
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            //Part two tests if precalculated angularSize matches what is returned in baseCursor.ComputeScaleWithAngularScale() at two different distances
+
+            // FIRST DISTANCE
+            float firstAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, Vector3.Distance(cam.transform.position, baseCursor.transform.position));
 
             cube.gameObject.SetActive(false);
 
             yield return new WaitForFixedUpdate();
             yield return null;
 
-            float secondAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, baseCursor.transform.position.z);
+            // SECOND DISTANCE
+            float secondAngularScale = 2 * Mathf.Atan2(baseCursor.LocalScale.y * 0.5f, Vector3.Distance(cam.transform.position, baseCursor.transform.position));
 
             Assert.IsTrue(Mathf.Approximately(firstAngularScale, secondAngularScale));
         }

--- a/Assets/MixedRealityToolkit/Utilities/MathUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MathUtilities.cs
@@ -55,6 +55,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return scale;
         }
 
+        [System.Obsolete("Method obsolete. Use ScaleFromAngularSizeAndDistance instead")]
+        public static float AngularScaleFromDistance(float angle, float distance)
+        {
+            return ScaleFromAngularSizeAndDistance(angle, distance);
+        }
+
         /// <summary>
         /// Takes a ray in the coordinate space specified by the "from" transform and transforms it to be the correct ray in the coordinate space specified by the "to" transform
         /// </summary>

--- a/Assets/MixedRealityToolkit/Utilities/MathUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MathUtilities.cs
@@ -49,10 +49,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// Retrieve angular measurement describing how large a sphere or circle appears from a given point of view.
         /// Takes an angle (at given point of view) and a distance and returns the actual diameter of the object.
         /// </summary>
-        public static float AngularScaleFromDistance(float angle, float distance)
+        public static float ScaleFromAngularSizeAndDistance(float angle, float distance)
         {
-            float angularScale = 2.0f * distance * Mathf.Tan(angle * Mathf.Deg2Rad * 0.5f);            
-            return angularScale;
+            float scale = 2.0f * distance * Mathf.Tan(angle * Mathf.Deg2Rad * 0.5f);            
+            return scale;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

The current implementation of cursor scaling based on distance is achieved by an angular scale calculation. The calculation (2 * distance * Tan(angle * 0.5f)) assumes the object has a diameter of 1 unit. In order to make this calculation relevant to the child meshes under the DefaultCursor prefab, I initially (in Commit 7ea09f90c718208e832bd9c41cd79f3c0d739dc6) calculate the bounds of the active child mesh on Start() and divide the results by 2 * magnitude of the bounding box of the mesh. In other words, the approximate diagonal diameter of the mesh. This works as expected and gives a relativity to the original angular scale calculation. At first, this seemed like the right way to go. 

However, due to an error I made in calculating the bounding box diagonal magnitude, adding additional cursors to the scene after scene initialization when the user has moved from the world origin, the scaling of the new cursors is not correct. The fix for this was to calculate the bounding box diagonal on the mesh itself via mesh.bounds (local space) rather than the current method of renderer.bounds (world space). The issue becomes more pronounced the further they are from the origin. 

Instead of pushing that fix, I believe this issue and future issues can be avoided by using the angular scale function without a denominator. This would make things easier for a third party developer to grasp as well. Any child meshes underneath the DefaultCursor prefab, added dynamically or by default, will be assumed to have a bounds of (1,1,1). The calculation of an initial bounding box was unnecessary to begin with for the amount of difficulty it might cause in the future.

This PR is a pretty straight forward. It removes the denominator and no longer calculates any bounding boxes. Any child meshes under the DefaultCursor prefab will be scaled according to their localScale in the hierarchy, as opposed to their model-space bounding box scale. The only effective difference is a default value of 50.0 instead of 0.65 in the public CursorAngularScale variable. All appearances are the same as 7ea09f90c718208e832bd9c41cd79f3c0d739dc6, hence no screenshots.

## Changes
- Fixes: # https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6365
