### PR TITLE
Use controller visualizer inspector for child classes

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/MixedRealityControllerVisualizerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/MixedRealityControllerVisualizerInspector.cs
@@ -5,6 +5,6 @@ using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.Input.Editor
 {
-    [CustomEditor(typeof(MixedRealityControllerVisualizer))]
+    [CustomEditor(typeof(MixedRealityControllerVisualizer), true)]
     public class MixedRealityControllerVisualizerInspector : ControllerPoseSynchronizerInspector { }
 }


### PR DESCRIPTION
## Overview
Any classes that derive from our base `MixedRealityControllerVisualizer` class didn't use its special inspector. This lead to some unclear inspectors, even for the WMR-specific visualizer we ship.

This change allows child classes to use the inspector we've specially defined.

Current:
![image](https://user-images.githubusercontent.com/3580640/67608651-0676e900-f73e-11e9-8674-4f5e39a8ca0e.png)

With this PR:
![image](https://user-images.githubusercontent.com/3580640/67608662-1abae600-f73e-11e9-8a68-47ea18ac984d.png)


## Changes
- Related to #5820