### PR TITLE
Convert new array[0] to Array.Empty

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/LogStructure.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/LogStructure.cs
@@ -10,12 +10,12 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
     {
         public virtual string[] GetHeaderColumns()
         {
-            return new string[0];
+            return System.Array.Empty<string>();
         }
 
         public virtual object[] GetData(string inputType, string inputStatus, EyeTrackingTarget intTarget)
         {
-            return new object[0];
+            return System.Array.Empty<object>();
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/SpeechInputHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/SpeechInputHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The keywords to be recognized and optional keyboard shortcuts.")]
-        private KeywordAndResponse[] keywords = new KeywordAndResponse[0];
+        private KeywordAndResponse[] keywords = Array.Empty<KeywordAndResponse>();
 
         [SerializeField]
         [Tooltip("Keywords are persistent across all scenes.  This Speech Input Handler instance will not be destroyed when loading a new scene.")]

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1608,7 +1608,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return States.StateList.ToArray();
             }
 
-            return new State[0];
+            return System.Array.Empty<State>();
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/MeshCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/MeshCursor.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (CursorStateData == null)
             {
-                CursorStateData = new MeshCursorDatum[0];
+                CursorStateData = Array.Empty<MeshCursorDatum>();
             }
 
             if (TargetRenderer == null)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/SpriteCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/SpriteCursor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (CursorStateData == null)
             {
-                CursorStateData = new SpriteCursorDatum[0];
+                CursorStateData = Array.Empty<SpriteCursorDatum>();
             }
 
             if (TargetRenderer == null)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/Theme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/Theme.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return States.StateList.ToArray();
             }
 
-            return new State[0];
+            return Array.Empty<State>();
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableColorChildrenTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableColorChildrenTheme.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public InteractableColorChildrenTheme()
         {
-            Types = new Type[] {  };
+            Types = Array.Empty<Type>();
             Name = "Color Children Theme";
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Types of component this Theme Engine will target on the initialized GameObject or related GameObjects
         /// </summary>
-        public Type[] Types { get; protected set; } = new Type[0];
+        public Type[] Types { get; protected set; } = Array.Empty<Type>();
 
         /// <summary>
         /// Name of Theme Engine

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/SpeechInputHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Input/Handlers/SpeechInputHandlerInspector.cs
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             {
                 // remove the keywords already assigned from the registered list
                 var handler = (SpeechInputHandler)target;
-                var availableKeywords = new string[0];
+                var availableKeywords = System.Array.Empty<string>();
 
                 if (handler.Keywords != null && distinctRegisteredKeywords != null)
                 {

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             themeStates = theme.States?.StateList.ToArray();
             if (themeStates == null)
             {
-                themeStates = new State[0];
+                themeStates = Array.Empty<State>();
             }
 
             // If no theme properties assigned, add a default one

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -570,7 +570,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         }
 
         /// <inheritdoc/>
-        public Edge[] Bounds { get; private set; } = new Edge[0];
+        public Edge[] Bounds { get; private set; } = System.Array.Empty<Edge>();
 
         /// <inheritdoc/>
         public float? FloorHeight { get; private set; } = null;
@@ -892,7 +892,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         private void CalculateBoundaryBounds()
         {
             // Reset the bounds
-            Bounds = new Edge[0];
+            Bounds = System.Array.Empty<Edge>();
             FloorHeight = null;
             rectangularBounds = null;
 

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/BaseInputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/BaseInputSimulationService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Active controllers
         /// </summary>
-        private IMixedRealityController[] activeControllers = new IMixedRealityController[0];
+        private IMixedRealityController[] activeControllers = System.Array.Empty<IMixedRealityController>();
 
         /// <inheritdoc />
         public override IMixedRealityController[] GetActiveControllers()

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Editor/MixedRealityCanvasInspector.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Editor/MixedRealityCanvasInspector.cs
@@ -182,7 +182,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 EditorGUILayout.PropertyField(m_PixelPerfect);
                 EditorGUILayout.PropertyField(m_SortingOrder, Styles.sortingOrder);
-                GUIContent[] displayNames = (GUIContent[]) getDisplayNames.Invoke(null, new object[] { });
+                GUIContent[] displayNames = (GUIContent[]) getDisplayNames.Invoke(null, System.Array.Empty<object>());
                 EditorGUILayout.IntPopup(m_TargetDisplay, displayNames, (int[])getDisplayIndices.Invoke(null, new object[] { }), Styles.targetDisplay);
             }
             EditorGUILayout.EndFadeGroup();

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         public IEnumerable<string> ContentTags => profile.ContentTags;
 
         // Cache these so we're not looking them up constantly
-        private EditorBuildSettingsScene[] cachedBuildScenes = new EditorBuildSettingsScene[0];
+        private EditorBuildSettingsScene[] cachedBuildScenes = Array.Empty<EditorBuildSettingsScene>();
 
         // These get set to dirty based on what events have been received from the editor
         private bool activeSceneDirty = false;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -630,7 +630,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             // Use reflection to invoke a non-public method.
             var method = typeof(PressableButton).GetMethod("UpdateMovingVisualsPosition", BindingFlags.NonPublic | BindingFlags.Instance);
-            method.Invoke(button, new object[0]);
+            method.Invoke(button, System.Array.Empty<object>());
         }
 
 

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         const string primaryTestSceneTemporarySavePath = "Assets/__temp_primary_test_scene.unity";
         const string additiveTestSceneTemporarySavePath = "Assets/__temp_additive_test_scene_#.unity";
         public static Scene primaryTestScene;
-        public static Scene[] additiveTestScenes = new Scene[0];
+        public static Scene[] additiveTestScenes = System.Array.Empty<Scene>();
 
         /// <summary>
         /// Destroys all scene assets that were created over the course of testing.

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs
@@ -584,7 +584,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             MethodInfo getInstalledSDKS = uwpReferences.GetMethod("GetInstalledSDKs", BindingFlags.Static | BindingFlags.Public);
             MethodInfo sdkVersionToString = uwpReferences.GetMethod("SdkVersionToString", BindingFlags.Static | BindingFlags.NonPublic);
 
-            IEnumerable<object> uwpSDKS = (IEnumerable<object>)getInstalledSDKS.Invoke(null, new object[0]);
+            IEnumerable<object> uwpSDKS = (IEnumerable<object>)getInstalledSDKS.Invoke(null, Array.Empty<object>());
 
             return uwpSDKS.Select(t => (Version)t.GetType().GetField("Version", BindingFlags.Instance | BindingFlags.Public).GetValue(t));
 #else

--- a/Assets/MixedRealityToolkit.Tools/TextureCombinerWindow/TextureCombinerWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/TextureCombinerWindow/TextureCombinerWindow.cs
@@ -64,28 +64,28 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             metallicMapChannel = (Channel)EditorGUILayout.EnumPopup("Input Channel", metallicMapChannel);
             GUI.enabled = true;
             metallicUniform = EditorGUILayout.Slider(new GUIContent("Metallic Uniform"), metallicUniform, defaultUniformValue, 1.0f);
-            GUILayout.Box("Output Channel: Red", EditorStyles.helpBox, new GUILayoutOption[0]);
+            GUILayout.Box("Output Channel: Red", EditorStyles.helpBox, System.Array.Empty<GUILayoutOption>());
             EditorGUILayout.Separator();
             GUI.enabled = occlusionUniform < 0.0f;
             occlusionMap = (Texture2D)EditorGUILayout.ObjectField("Occlusion Map", occlusionMap, typeof(Texture2D), false);
             occlusionMapChannel = (Channel)EditorGUILayout.EnumPopup("Input Channel", occlusionMapChannel);
             GUI.enabled = true;
             occlusionUniform = EditorGUILayout.Slider(new GUIContent("Occlusion Uniform"), occlusionUniform, defaultUniformValue, 1.0f);
-            GUILayout.Box("Output Channel: Green", EditorStyles.helpBox, new GUILayoutOption[0]);
+            GUILayout.Box("Output Channel: Green", EditorStyles.helpBox, System.Array.Empty<GUILayoutOption>());
             EditorGUILayout.Separator();
             GUI.enabled = emissionUniform < 0.0f;
             emissionMap = (Texture2D)EditorGUILayout.ObjectField("Emission Map", emissionMap, typeof(Texture2D), false);
             emissionMapChannel = (Channel)EditorGUILayout.EnumPopup("Input Channel", emissionMapChannel);
             GUI.enabled = true;
             emissionUniform = EditorGUILayout.Slider(new GUIContent("Emission Uniform"), emissionUniform, defaultUniformValue, 1.0f);
-            GUILayout.Box("Output Channel: Blue", EditorStyles.helpBox, new GUILayoutOption[0]);
+            GUILayout.Box("Output Channel: Blue", EditorStyles.helpBox, System.Array.Empty<GUILayoutOption>());
             EditorGUILayout.Separator();
             GUI.enabled = smoothnessUniform < 0.0f;
             smoothnessMap = (Texture2D)EditorGUILayout.ObjectField("Smoothness Map", smoothnessMap, typeof(Texture2D), false);
             smoothnessMapChannel = (Channel)EditorGUILayout.EnumPopup("Input Channel", smoothnessMapChannel);
             GUI.enabled = true;
             smoothnessUniform = EditorGUILayout.Slider(new GUIContent("Smoothness Uniform"), smoothnessUniform, defaultUniformValue, 1.0f);
-            GUILayout.Box("Output Channel: Alpha", EditorStyles.helpBox, new GUILayoutOption[0]);
+            GUILayout.Box("Output Channel: Alpha", EditorStyles.helpBox, System.Array.Empty<GUILayoutOption>());
             EditorGUILayout.Separator();
 
             standardMaterial = (Material)EditorGUILayout.ObjectField("Standard Material", standardMaterial, typeof(Material), false);
@@ -110,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 Save();
             }
 
-            GUILayout.Box("Metallic (Red), Occlusion (Green), Emission (Blue), Smoothness (Alpha)", EditorStyles.helpBox, new GUILayoutOption[0]);
+            GUILayout.Box("Metallic (Red), Occlusion (Green), Emission (Blue), Smoothness (Alpha)", EditorStyles.helpBox, System.Array.Empty<GUILayoutOption>());
         }
 
         private void Autopopulate()

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         [Tooltip("The list of controller mappings your application can use.")]
         [FormerlySerializedAs("mixedRealityControllerMappingProfiles")]
-        private MixedRealityControllerMapping[] mixedRealityControllerMappings = new MixedRealityControllerMapping[0];
+        private MixedRealityControllerMapping[] mixedRealityControllerMappings = Array.Empty<MixedRealityControllerMapping>();
 
         /// <summary>
         /// The list of controller mappings your application can use.
@@ -221,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static Handedness[] GetSupportedHandedness(Type controllerType)
         {
             var attribute = MixedRealityControllerAttribute.Find(controllerType);
-            return attribute != null ? attribute.SupportedHandedness : new Handedness[0];
+            return attribute != null ? attribute.SupportedHandedness : Array.Empty<Handedness>();
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [SerializeField]
-        private MixedRealityControllerVisualizationSetting[] controllerVisualizationSettings = new MixedRealityControllerVisualizationSetting[0];
+        private MixedRealityControllerVisualizationSetting[] controllerVisualizationSettings = Array.Empty<MixedRealityControllerVisualizationSetting>();
 
         /// <summary>
         /// The current list of controller visualization settings.

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public class MixedRealityInputSystemProfile : BaseMixedRealityProfile
     {
         [SerializeField]
-        private MixedRealityInputDataProviderConfiguration[] dataProviderConfigurations = new MixedRealityInputDataProviderConfiguration[0];
+        private MixedRealityInputDataProviderConfiguration[] dataProviderConfigurations = System.Array.Empty<MixedRealityInputDataProviderConfiguration>();
 
         /// <summary>
         /// List of input data provider configurations to initialize and manage by the Input System registrar

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The Pointer options for this profile.")]
-        private PointerOption[] pointerOptions = new PointerOption[0];
+        private PointerOption[] pointerOptions = System.Array.Empty<PointerOption>();
 
         /// <summary>
         /// The Pointer options for this profile.

--- a/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealitySpeechCommandsProfile.cs
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The list of Speech Commands users use in your application.")]
-        private SpeechCommands[] speechCommands = new SpeechCommands[0];
+        private SpeechCommands[] speechCommands = System.Array.Empty<SpeechCommands>();
 
         /// <summary>
         /// The list of Speech Commands users use in your application.

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessSystemProfile.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     public class MixedRealitySpatialAwarenessSystemProfile : BaseMixedRealityProfile
     {
         [SerializeField]
-        private MixedRealitySpatialObserverConfiguration[] observerConfigurations = new MixedRealitySpatialObserverConfiguration[0];
+        private MixedRealitySpatialObserverConfiguration[] observerConfigurations = System.Array.Empty<MixedRealitySpatialObserverConfiguration>();
 
         public MixedRealitySpatialObserverConfiguration[] ObserverConfigurations
         {

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -403,7 +403,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 EditorGUI.indentLevel += 2;
                 materialEditor.TexturePropertySingleLine(Styles.channelMap, channelMap);
-                GUILayout.Box("Metallic (Red), Occlusion (Green), Emission (Blue), Smoothness (Alpha)", EditorStyles.helpBox, new GUILayoutOption[0]);
+                GUILayout.Box("Metallic (Red), Occlusion (Green), Emission (Blue), Smoothness (Alpha)", EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
                 EditorGUI.indentLevel -= 2;
             }
 
@@ -516,7 +516,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 (RenderingMode)renderingMode.floatValue != RenderingMode.Cutout)
             {
                 materialEditor.ShaderProperty(blendedClippingWidth, Styles.blendedClippingWidth);
-                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(ClippingPrimitive), "other clipping"), EditorStyles.helpBox, new GUILayoutOption[0]);
+                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(ClippingPrimitive), "other clipping"), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
             }
 
             materialEditor.ShaderProperty(clippingBorder, Styles.clippingBorder);
@@ -525,7 +525,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 materialEditor.ShaderProperty(clippingBorderWidth, Styles.clippingBorderWidth, 2);
                 materialEditor.ShaderProperty(clippingBorderColor, Styles.clippingBorderColor, 2);
-                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(ClippingPrimitive), "other clipping"), EditorStyles.helpBox, new GUILayoutOption[0]);
+                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(ClippingPrimitive), "other clipping"), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
             }
 
             materialEditor.ShaderProperty(nearPlaneFade, Styles.nearPlaneFade);
@@ -550,7 +550,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (PropertyEnabled(hoverLight))
             {
-                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(HoverLight), Styles.hoverLight.text), EditorStyles.helpBox, new GUILayoutOption[0]);
+                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(HoverLight), Styles.hoverLight.text), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
 
                 materialEditor.ShaderProperty(enableHoverColorOverride, Styles.enableHoverColorOverride, 2);
 
@@ -575,7 +575,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 materialEditor.ShaderProperty(proximityLightSubtractive, Styles.proximityLightSubtractive, 2);
                 materialEditor.ShaderProperty(proximityLightTwoSided, Styles.proximityLightTwoSided, 2);
-                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(ProximityLight), Styles.proximityLight.text), EditorStyles.helpBox, new GUILayoutOption[0]);
+                GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(ProximityLight), Styles.proximityLight.text), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
             }
 
             materialEditor.ShaderProperty(borderLight, Styles.borderLight);

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -34,8 +34,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private MixedRealityGesturesProfile thisProfile;
         private static GUIContent[] allGestureLabels;
         private static int[] allGestureIds;
-        private static GUIContent[] actionLabels = new GUIContent[0];
-        private static int[] actionIds = new int[0];
+        private static GUIContent[] actionLabels = Array.Empty<GUIContent>();
+        private static int[] actionIds = Array.Empty<int>();
         private bool isInitialized = false;
 
         protected override void OnEnable()
@@ -247,7 +247,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile == null ||
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {
-                return new MixedRealityInputAction[0];
+                return Array.Empty<MixedRealityInputAction>();
             }
 
             return MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputActionRulesInspector.cs
@@ -31,13 +31,13 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         private SerializedProperty inputActionRulesQuaternionAxis;
         private SerializedProperty inputActionRulesPoseAxis;
 
-        private int[] baseActionIds = new int[0];
-        private string[] baseActionLabels = new string[0];
+        private int[] baseActionIds = System.Array.Empty<int>();
+        private string[] baseActionLabels = System.Array.Empty<string>();
 
         // These are marked as static because this inspector will reset itself every refresh
         // because it can be rendered as a sub-profile and thus OnEnable() is called every time
-        private static int[] ruleActionIds = new int[0];
-        private static string[] ruleActionLabels = new string[0];
+        private static int[] ruleActionIds = System.Array.Empty<int>();
+        private static string[] ruleActionLabels = System.Array.Empty<string>();
 
         private static int selectedBaseActionId = 0;
         private static int selectedRuleActionId = 0;
@@ -557,7 +557,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile == null ||
                 MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {
-                return new MixedRealityInputAction[0];
+                return System.Array.Empty<MixedRealityInputAction>();
             }
 
             return MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile.InputActions;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
@@ -131,7 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     if (useManagerScene.boolValue && profile.ManagerScene.IsEmpty && !Application.isPlaying)
                     {
                         EditorGUILayout.HelpBox("You haven't created a manager scene yet. Click the button below to create one.", MessageType.Warning);
-                        var buttonRect = EditorGUI.IndentedRect(EditorGUILayout.GetControlRect(new GUILayoutOption[] { }));
+                        var buttonRect = EditorGUI.IndentedRect(EditorGUILayout.GetControlRect(System.Array.Empty<GUILayoutOption>()));
                         if (GUI.Button(buttonRect, "Create Manager Scene", EditorStyles.miniButton))
                         {
                             // Create a new manager scene and add it to build settings
@@ -160,7 +160,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     if (useLightingScene.boolValue && profile.NumLightingScenes < 1 && !Application.isPlaying)
                     {
                         EditorGUILayout.HelpBox("You haven't created a lighting scene yet. Click the button below to create one.", MessageType.Warning);
-                        var buttonRect = EditorGUI.IndentedRect(EditorGUILayout.GetControlRect(new GUILayoutOption[] { }));
+                        var buttonRect = EditorGUI.IndentedRect(EditorGUILayout.GetControlRect(System.Array.Empty<GUILayoutOption>()));
                         if (GUI.Button(buttonRect, "Create Lighting Scene", EditorStyles.miniButton))
                         {
                             // Create a new lighting scene and add it to build settings

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealitySpeechCommandsProfileInspector.cs
@@ -27,8 +27,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private static bool showSpeechCommands = true;
         private SerializedProperty speechCommands;
-        private static GUIContent[] actionLabels = new GUIContent[0];
-        private static int[] actionIds = new int[0];
+        private static GUIContent[] actionLabels = System.Array.Empty<GUIContent>();
+        private static int[] actionIds = System.Array.Empty<int>();
         private bool isInitialized = false;
 
         protected override void OnEnable()

--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -25,11 +25,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// <summary>
         /// Cached scenes used by SceneInfoDrawer to keep property drawer performant.
         /// </summary>
-        public static EditorBuildSettingsScene[] CachedScenes => cachedScenes;
+        public static EditorBuildSettingsScene[] CachedScenes { get; private set; } = Array.Empty<EditorBuildSettingsScene>();
 
         public int callbackOrder => 0;
-
-        private static EditorBuildSettingsScene[] cachedScenes = new EditorBuildSettingsScene[0];
 
         /// <summary>
         /// The frame of the last update. Used to ensure we don't spam the system with updates.
@@ -43,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// </summary>
         public static void RefreshCachedScenes()
         {
-            cachedScenes = EditorBuildSettings.scenes;
+            CachedScenes = EditorBuildSettings.scenes;
         }
 
         /// <summary>
@@ -162,18 +160,18 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 int buildIndex = -1;
                 int sceneCount = 0;
                 bool included = false;
-                for (int i = 0; i < cachedScenes.Length; i++)
+                for (int i = 0; i < CachedScenes.Length; i++)
                 {
-                    if (cachedScenes[i].path == scenePath)
+                    if (CachedScenes[i].path == scenePath)
                     {   // If it's in here it's included, even if it's not enabled
                         included = true;
-                        if (cachedScenes[i].enabled)
+                        if (CachedScenes[i].enabled)
                         {   // Only store the build index if it's enabled
                             buildIndex = sceneCount;
                         }
                     }
 
-                    if (cachedScenes[i].enabled)
+                    if (CachedScenes[i].enabled)
                     {   // Disabled scenes don't count toward scene count
                         sceneCount++;
                     }

--- a/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         protected MixedRealityInputSystemProfile InputSystemProfile => InputSystem?.InputSystemProfile;
 
         /// <inheritdoc />
-        public virtual IMixedRealityController[] GetActiveControllers() => new IMixedRealityController[0];
+        public virtual IMixedRealityController[] GetActiveControllers() => System.Array.Empty<IMixedRealityController>();
 
         /// <summary>
         /// Request an array of pointers for the controller type.


### PR DESCRIPTION
## Overview
Instead of allocating 0 length arrays, it's recommended to use the statically allocated empty array instance from `Array.Empty`.

https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1825?view=vs-2019

Not the biggest deal; I'm not sure if this is worth enforcing a coding guideline over, but something I felt like cleaning up.