### PR TITLE
add hololens2 inputsimulationprofile

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSimulationProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSimulationProfile.asset
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78a4b02a0d9e7044fa19c6d432d0cafa, type: 3}
+  m_Name: DefaultHoloLens2InputSimulationProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0
+  indicatorsPrefab: {fileID: 0}
+  mouseRotationSensitivity: 0.1
+  mouseX: Mouse X
+  mouseY: Mouse Y
+  mouseScroll: Mouse ScrollWheel
+  doublePressTime: 0.4
+  isCameraControlEnabled: 1
+  mouseLookSpeed: 3
+  mouseLookButton:
+    bindingType: 1
+    code: 1
+  mouseLookToggle: 0
+  isControllerLookInverted: 1
+  currentControlMode: 0
+  fastControlKey:
+    bindingType: 2
+    code: 305
+  controlSlowSpeed: 0.1
+  controlFastSpeed: 1
+  moveHorizontal: Horizontal
+  moveVertical: Vertical
+  moveUpDown: UpDown
+  lookHorizontal: AXIS_4
+  lookVertical: AXIS_5
+  simulateEyePosition: 1
+  defaultHandSimulationMode: 2
+  toggleLeftHandKey:
+    bindingType: 2
+    code: 116
+  toggleRightHandKey:
+    bindingType: 2
+    code: 121
+  handHideTimeout: 0.2
+  leftHandManipulationKey:
+    bindingType: 2
+    code: 304
+  rightHandManipulationKey:
+    bindingType: 2
+    code: 32
+  mouseHandRotationSpeed: 30
+  handRotateButton:
+    bindingType: 2
+    code: 306
+  defaultHandGesture: 2
+  leftMouseHandGesture: 3
+  middleMouseHandGesture: 0
+  rightMouseHandGesture: 0
+  handGestureAnimationSpeed: 8
+  holdStartDuration: 0.5
+  navigationStartThreshold: 0.03
+  defaultHandDistance: 0.5
+  handDepthMultiplier: 0.03
+  handJitterAmount: 0

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSimulationProfile.asset.meta
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSimulationProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65bc2b7825befda438f783c3e055f67c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset
@@ -67,7 +67,7 @@ MonoBehaviour:
     componentName: Input Simulation Service
     priority: 0
     runtimePlatform: 208
-    deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
+    deviceManagerProfile: {fileID: 11400000, guid: 65bc2b7825befda438f783c3e055f67c,
       type: 2}
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityEyeGazeDataProvider,
@@ -95,6 +95,7 @@ MonoBehaviour:
   raycastProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultRaycastProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   focusQueryBufferSize: 128
+  focusIndividualCompoundCollider: 0
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
     type: 2}
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,


### PR DESCRIPTION
## Overview
current Default Hololens2 Input System profile  uses the default inputsimulation profile which does not have eye tracking enabled.

this leads to strange behavior in unity as described in https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6320

so, adding a DefaultHoloLens2InputSimulationProfile
with both eye tracking and articulated hands enabled
