### PR TITLE
Turn off the .NET build

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -32,4 +32,3 @@ jobs:
   - template: templates/ci-common.yml
     parameters:
       packagingEnabled: false
-      

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -22,4 +22,5 @@ jobs:
       # the ongoing rolling CI build. This build in particular is highly correlated
       # the .NET x86 build and ARM IL2CPP build.
       buildUWPX86: false
+      buildUWPDotNet: false
   - template: templates/end.yml

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -5,6 +5,8 @@ parameters:
 
 steps:
 - template: common.yml
+  parameters:
+    buildUWPDotNet: false
 - template: compilemsbuild.yml
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/unitypackages.yml


### PR DESCRIPTION
## Overview
In order to light up more Unity scenarios in our repo, we need to (temporarily?) turn off the .NET build. 

This will unblock #6344.
This will also help #6381.