### PR TITLE
Daily build was pointing to the wrong MRTK version

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.3.7f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.0.0
+  MRTKVersion: 2.2.0
   packagingEnabled: false
 
 jobs:


### PR DESCRIPTION
## Overview
The daily build had been failing due to not finding the build artifacts. As far as I can tell, it's because it was looking for the wrong version number.