### PR TITLE
Provide an option to defer Keyword/Dictation Recognizer construction

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -72,6 +72,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 return;
             }
 
+            if (dictationRecognizer == null && InputSystemProfile.SpeechCommandsProfile.SpeechRecognizerStartBehavior == AutoStartBehavior.ManualStart)
+            {
+                InitializeDictationRecognizer();
+            }
+
             hasFailed = false;
             IsListening = true;
             isTransitioning = true;
@@ -229,6 +234,14 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             inputSource = inputSystem.RequestNewGenericInputSource(Name, sourceType: InputSourceType.Voice);
             dictationResult = string.Empty;
 
+            if (dictationRecognizer == null && InputSystemProfile.SpeechCommandsProfile.SpeechRecognizerStartBehavior == AutoStartBehavior.AutoStart)
+            {
+                InitializeDictationRecognizer();
+            }
+        }
+
+        private void InitializeDictationRecognizer()
+        {
             try
             {
                 if (dictationRecognizer == null)

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -54,7 +54,7 @@ From here you can navigate to all the configuration profiles for the MRTK, inclu
 These configuration profiles are detailed below in their relevant sections:
 
 ---
-<a name="experience"/>
+<a name="experience"></a>
 
 ## Experience settings
 
@@ -63,7 +63,7 @@ Located on the main Mixed Reality Toolkit configuration page, this setting defin
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ExperienceSettings.png" width="650px" style="display:block;">
 
 ---
-<a name="camera"/>
+<a name="camera"></a>
 
 ## Camera settings
 
@@ -73,7 +73,7 @@ The camera settings define how the camera will be setup for your Mixed Reality p
 
 
 ---
-<a name="inputsystem"/>
+<a name="inputsystem"></a>
 
 ## Input system settings
 
@@ -98,7 +98,7 @@ Each of the individual profiles are detailed below:
 
 
 ---
-<a name="boundary"/>
+<a name="boundary"></a>
 
 ## Boundary visualization settings
 
@@ -108,7 +108,7 @@ The boundary system translates the perceived boundary reported by the underlying
 
 
 ---
-<a name="teleportation"/>
+<a name="teleportation"></a>
 
 ## Teleportation system selection
 
@@ -117,7 +117,7 @@ The Mixed Reality Project provides a full featured Teleportation system for mana
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_TeleportationSystemSelection.png" width="650px" style="display:block;">
 
 ---
-<a name="spatialawareness"/>
+<a name="spatialawareness"></a>
 
 ## Spatial awareness settings
 
@@ -136,7 +136,7 @@ This is only applicable for devices that can provide a scanned environment.
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_SpatialAwarenessProfile.png" width="650px" style="display:block;">
 
 ---
-<a name="diagnostic"/>
+<a name="diagnostic"></a>
 
 ## Diagnostics settings
 
@@ -150,7 +150,7 @@ The diagnostics profile provides several simple systems to monitor whilst the pr
 
 
 ---
-<a name="scenesystem"/>
+<a name="scenesystem"></a>
 
 ## Scene system settings
 
@@ -159,7 +159,7 @@ The MRTK provides this optional service to help you manage complex additive scen
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_SceneSystemProfile.png" width="650px" style="display:block;">
 
 ---
-<a name="services"/>
+<a name="services"></a>
 
 ## Additional services settings
 
@@ -173,7 +173,7 @@ Any registered service still gets the full advantage of all of the Unity events,
 
 
 ---
-<a name="inputactions"/>
+<a name="inputactions"></a>
 
 ## Input actions settings
 
@@ -200,7 +200,7 @@ Events utilizing input actions are not limited to physical controllers and can s
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_InputActionsProfile.png" width="650px" style="display:block;">
 
 ---
-<a name="inputactionrules"/>
+<a name="inputactionrules"></a>
 
 ## Input actions rules
 
@@ -215,7 +215,7 @@ Input action Rules can be configured for any of the available input axis. Howeve
 ![](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_InputActionRulesProfile.png)
 
 ---
-<a name="pointer"/>
+<a name="pointer"></a>
 
 ## Pointer configuration
 
@@ -235,7 +235,7 @@ Pointers can also be visualized within the active scene using one of the many li
 There's an additional helper button to quickly jump to the Gaze Provider to override some specific values for Gaze if needed.
 
 ---
-<a name="gestures"/>
+<a name="gestures"></a>
 
 ## Gestures configuration
 
@@ -247,20 +247,22 @@ Gestures are a system specific implementation allowing you to assign input actio
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_GesturesProfile.png" width="650px" style="display:block;">
 
 ---
-<a name="speech"/>
+<a name="speech"></a>
 
 ## Speech Commands
 
-Like gestures, some runtime platforms also provide intelligent "Speech to Text" functionality with the ability to generate commands that can be received by a Unity project. This configuration profile allows you to configure registered "words" and translate them in to input actions that can be received by your project. They can also be attached to keyboard actions if required.
+Like gestures, some runtime platforms also provide intelligent "Speech to Text" functionality with the ability to generate commands that can be received by a Unity project. This configuration profile allows you to configure the following:
+
+1. General Settings - "Start Behavior" set to Auto Start or Manual Start determines whether to initialize KeywordRecognizer at input system startuo or let the project decide when to initialize the KeywordRecognizer. "Recognition Confidence Level" is used to initialize Unity's [KeywordRecognizer API](https://docs.unity3d.com/ScriptReference/Windows.Speech.KeywordRecognizer-ctor.html)
+2. Speech Commands - Registers "words" and translates them in to input actions that can be received by your project. They can also be attached to keyboard actions if required.
 
 > [!IMPORTANT]
 > The system currently only supports speech when running on Windows 10 platforms, e.g. HoloLens and Windows 10 desktop and will be enhanced for other systems as they are added to MRTK in the future (no dates yet).
 
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_SpeechCommandsProfile.png" width="650px" style="display:block;">
 
-
 ---
-<a name="mapping"/>
+<a name="mapping"></a>
 
 ## Controller mapping configuration
 
@@ -289,7 +291,7 @@ Clicking on the Image for any of the pre-built controller systems allows you to 
 There is also an advanced screen for configuring other OpenVR or Unity input controllers that are not identified above.
 
 ---
-<a name="visualization"/>
+<a name="visualization"></a>
 
 ## Controller visualization settings
 
@@ -305,7 +307,7 @@ If your controller representation in the scene needs to be offset from the physi
 <img src="../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ControllerVisualizationProfile.png" width="650px" style="display:block;">
 
 
-<a name="inspectors"/>
+<a name="inspectors"></a>
 
 ## Service Inspectors
 


### PR DESCRIPTION
## Overview
There is an issue with the Hololens devices, that in loud environments the Windows Speech System can end up taking upwards of 20 seconds for initialization. This can result in Quiesce Hangs for the app because of stalled startup or delays. This issue is being tracked here - https://github.com/microsoft/MixedRealityToolkit-Unity/issues/3497

We are hoping for a longer term fix from the HL Platform, but in the meanwhile this PR is being introduced to given consuming apps more control on the Recognizer creations. 

For reference - we are seeing the following callstack appear in our crash dumps - 

ntdll!KiFastSystemCallRet
ntdll!NtWaitForMultipleObjects+0xa
KERNELBASE!WaitForMultipleObjectsEx+0x133
KERNELBASE!WaitForMultipleObjects+0x18
sapi_onecore!CRecognizer::PerformTask+0xe0
sapi_onecore!CRIT_GETPROPERTYGUID::GetPropertyGuid+0x74
sapi_onecore!<lambda_0dab862286bbdc74be80111d98404563>::operator()+0xa0
sapi_onecore!CSharedRecognizer::FinalConstruct+0x65
sapi_onecore!ATL::CComCreator<ATL::CComObject<CSharedRecognizer> >::CreateInstance+0x74
sapi_onecore!ATL::CComCreator2<ATL::CComCreator<ATL::CComObject<CSharedRecognizer> >,ATL::CComCreator<ATL::CComAggObject<CSharedRecognizer> > >::CreateInstance+0x17
sapi_onecore!ATL::CComClassFactory::CreateInstance+0x66
combase!ICoCreateInstanceEx+0x665
combase!CComActivator::DoCreateInstance+0x175
combase!CoCreateInstance+0xad
Windows_Media_Speech!Windows::Media::SpeechRecognition::CSpeechRecognizer::CreateLocalFacility+0x50
Windows_Media_Speech!<lambda_17a7a82cfd4b41f7cc8d42bd33648d46>::operator()+0x2e7
Windows_Media_Speech!Windows::Media::SpeechRecognition::CSpeechRecognizer::RuntimeClassInitialize+0x2b
Windows_Media_Speech!Windows::Media::SpeechRecognition::CSpeechRecognizer::RuntimeClassInitialize+0xa3
Windows_Media_Speech!Windows::Media::SpeechRecognition::CSpeechRecognizerFactory::ActivateInstance+0x57
combase!WinRTActivateInstanceInternal+0x1de
combase!RoActivateInstance+0x9f
UnityPlayer!Unity::PhraseRecognitionSystem::Restart+0xa4
UnityPlayer!Unity::PhraseRecognitionSystem::IncrementEnabledRecognizerCount+0x10
UnityPlayer!Unity::PhraseRecognizer::Start+0xc5
UnityEngineDelegates!PhraseRecognizer_CUSTOM_Start_Internal+0x5d
**[AppName]!$160_UnityEngineProxy::InternalCalls.PhraseRecognizer_CUSTOM_Start_Internal+0x55
[AppName]!$14_Microsoft::MixedReality::Toolkit::Windows::Input::WindowsSpeechInputProvider.StartRecognition+0x2c
[AppName]!$14_Microsoft::MixedReality::Toolkit::Windows::Input::WindowsSpeechInputProvider.Enable+0x1cc
[AppName]!$12_Microsoft::MixedReality::Toolkit::BaseDataProviderAccessCoreSystem.Enable+0x5c
[AppName]!$21_Microsoft::MixedReality::Toolkit::Input::MixedRealityInputSystem.Enable+0x13a
[AppName]!$12_Microsoft::MixedReality::Toolkit::MixedRealityToolkit::<>c.<EnableAllServices>b__59_0+0xf
[AppName]!$12_Microsoft::MixedReality::Toolkit::MixedRealityToolkit.ExecuteOnAllServices+0xa6
[AppName]!$12_Microsoft::MixedReality::Toolkit::MixedRealityToolkit.EnableAllServices+0x61
[AppName]!$12_Microsoft::MixedReality::Toolkit::MixedRealityToolkit.$Invoke42+0x43** 


## Changes
- Workaround for: #3497
-  Leverage the "Manual Start" option of the speech system profile to include the KeywordRecognizer and DictationRecognizer construction. This deferral given the apps more control on when they would like these to get initialized. 
- Updated documentation to elaborate on the speech profile properties. 
- Nit pick MD-Lint fixes in the documentation.

## Verification
Verified that the SpeechInputExample and DictationExample do not have regressions on tweaking  the "Start Behavior" option. 

> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
