### PR TITLE
Add Android and iOS support to the configuration dialog

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private readonly GUIContent LaterButtonContent = new GUIContent("Later", "Do not show this popup notification until next session");
         private readonly GUIContent IgnoreButtonContent = new GUIContent("Ignore", "Modify this preference under Edit > Project Settings > MRTK");
 
-        private bool showConfigurations = true;
+        private bool showConfigurations = false;
 
         /// <summary>
         /// Show the MRTK Project Configurator utility window or focus if already opened

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -30,6 +30,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // Android Settings
             {MRConfig.AndroidMultiThreadedRendering, true },
             {MRConfig.AndroidMinSdkVersion, true },
+
+            // iOS Settings
+            {MRConfig.IOSMinOSVersion, true },
+            {MRConfig.IOSArchitecture, true },
+            {MRConfig.IOSRequiresARKit, true },
+            {MRConfig.IOSCameraUsageDescription, true },
         };
 
         private const string WindowKey = "_MixedRealityToolkit_Editor_MixedRealityProjectConfiguratorWindow";
@@ -40,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private readonly GUIContent LaterButtonContent = new GUIContent("Later", "Do not show this popup notification until next session");
         private readonly GUIContent IgnoreButtonContent = new GUIContent("Ignore", "Modify this preference under Edit > Project Settings > MRTK");
 
-        private bool showConfigurations = false;
+        private bool showConfigurations = true;
 
         /// <summary>
         /// Show the MRTK Project Configurator utility window or focus if already opened
@@ -136,7 +142,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
             RenderToggle(MRConfig.ForceTextSerialization, "Enable Force Text Serialization");
             RenderToggle(MRConfig.VisibleMetaFiles, "Enable Visible meta files");
-            RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR Supported");
+            if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS())
+            {
+                RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR Supported");
+            }
             RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path");
             RenderToggle(MRConfig.SpatialAwarenessLayer, "Set Default Spatial Awareness Layer");
 
@@ -168,6 +177,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.LabelField("Android Settings", EditorStyles.boldLabel);
                 RenderToggle(MRConfig.AndroidMultiThreadedRendering, "Disable Multi-Threaded Rendering");
                 RenderToggle(MRConfig.AndroidMinSdkVersion, "Set Minimum API Level");
+            }
+
+            if (MixedRealityOptimizeUtils.IsBuildTargetIOS())
+            {
+                EditorGUILayout.LabelField("iOS Settings", EditorStyles.boldLabel);
+                RenderToggle(MRConfig.IOSMinOSVersion, "Set Required OS Version");
+                RenderToggle(MRConfig.IOSArchitecture, "Set Required Architecture");
+                // todo RenderToggle(MRConfig.IOSRequiresARKit, "Set Requires ARKit");
+                RenderToggle(MRConfig.IOSCameraUsageDescription, "Set Camera Usage Descriptionfs");
             }
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -20,12 +20,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {MRConfig.VirtualRealitySupported, true },
             {MRConfig.SinglePassInstancing, true },
             {MRConfig.SpatialAwarenessLayer, true },
+            // UWP Capabilities
             {MRConfig.MicrophoneCapability, true },
             {MRConfig.InternetClientCapability, true },
             {MRConfig.SpatialPerceptionCapability, true },
 #if UNITY_2019_3_OR_NEWER
             {MRConfig.EyeTrackingCapability, true },
 #endif
+            // Android Settings
+            {MRConfig.AndroidMultiThreadedRendering, true },
+            {MRConfig.AndroidMinSdkVersion, true },
         };
 
         private const string WindowKey = "_MixedRealityToolkit_Editor_MixedRealityProjectConfiguratorWindow";
@@ -157,6 +161,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
                 trackToggles[MRConfig.EyeTrackingCapability] = false;
 #endif
+            }
+
+            if (MixedRealityOptimizeUtils.IsBuildTargetAndroid())
+            {
+                EditorGUILayout.LabelField("Android Settings", EditorStyles.boldLabel);
+                RenderToggle(MRConfig.AndroidMultiThreadedRendering, "Disable Multi-Threaded Rendering");
+                RenderToggle(MRConfig.AndroidMinSdkVersion, "Set Minimum API Level");
             }
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // iOS Settings
             {MRConfig.IOSMinOSVersion, true },
             {MRConfig.IOSArchitecture, true },
-            {MRConfig.IOSRequiresARKit, true },
             {MRConfig.IOSCameraUsageDescription, true },
         };
 
@@ -184,7 +183,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.LabelField("iOS Settings", EditorStyles.boldLabel);
                 RenderToggle(MRConfig.IOSMinOSVersion, "Set Required OS Version");
                 RenderToggle(MRConfig.IOSArchitecture, "Set Required Architecture");
-                // todo RenderToggle(MRConfig.IOSRequiresARKit, "Set Requires ARKit");
                 RenderToggle(MRConfig.IOSCameraUsageDescription, "Set Camera Usage Descriptionfs");
             }
         }

--- a/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityOptimizeUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityOptimizeUtils.cs
@@ -143,6 +143,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return EditorUserBuildSettings.activeBuildTarget == BuildTarget.WSAPlayer;
         }
 
+        public static bool IsBuildTargetAndroid()
+        {
+            return EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android;
+        }
+
+        public static bool IsBuildTargetIOS()
+        {
+            return EditorUserBuildSettings.activeBuildTarget == BuildTarget.iOS;
+        }
+
         public static void ChangeProperty(SerializedObject target, string name, Action<SerializedProperty> changer)
         {
             var prop = target.FindProperty(name);

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -47,7 +47,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // iOS Settings
             IOSMinOSVersion,
             IOSArchitecture,
-            IOSRequiresARKit,
             IOSCameraUsageDescription,
         };
 
@@ -78,7 +77,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     string versionString = PlayerSettings.iOS.targetOSVersionString;
                     return (versionString == "11" || versionString.StartsWith("11.")); } },
             { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequiredIosArchitecture; } },
-            // todo { Configurations.IOSRequiresARKit, () => { ; } },
             { Configurations.IOSCameraUsageDescription, () => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); } },
         };
 
@@ -107,7 +105,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // iOS Settings
             { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = "11.0"; } },
             { Configurations.IOSArchitecture, () => { PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequiredIosArchitecture); } },
-            // todo { Configurations.IOSRequiresARKit, () => { ; } },
             { Configurations.IOSCameraUsageDescription, () => { PlayerSettings.iOS.cameraUsageDescription = IosCameraUsageDescription; } },
         };
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -16,7 +16,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public class MixedRealityProjectConfigurator
     {
         private const int SpatialAwarenessDefaultLayer = 31;
-        private const AndroidSdkVersions MinAndroidSdk = AndroidSdkVersions.AndroidApiLevel24;
+        private const AndroidSdkVersions MinAndroidSdk = AndroidSdkVersions.AndroidApiLevel24; // Android 7.0
+        private const int RequiredIosArchitecture = 1; // Per https://docs.unity3d.com/ScriptReference/PlayerSettings.SetArchitecture.html, 1 == ARM64
+        private const string IosCameraUsageDescription = "Required for augmented reality support.";
 
         /// <summary>
         /// List of available configurations to check and configure with this utility
@@ -41,6 +43,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // Android Settings
             AndroidMultiThreadedRendering,
             AndroidMinSdkVersion,
+
+            // iOS Settings
+            IOSMinOSVersion,
+            IOSArchitecture,
+            IOSRequiresARKit,
+            IOSCameraUsageDescription,
         };
 
         // The check functions for each type of setting
@@ -53,6 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.SinglePassInstancing,  () => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); } },
             { Configurations.SpatialAwarenessLayer,  () => { return HasSpatialAwarenessLayer(); } },
 
+            // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.SpatialPerception); } },
             { Configurations.MicrophoneCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.Microphone); } },
             { Configurations.InternetClientCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.InternetClient); } },
@@ -60,8 +69,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.EyeTrackingCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.GazeInput); } },
 #endif
 
+            // Android Settings
             { Configurations.AndroidMultiThreadedRendering, () => { return PlayerSettings.GetMobileMTRendering(BuildTargetGroup.Android) == false; } },
             { Configurations.AndroidMinSdkVersion, () => { return PlayerSettings.Android.minSdkVersion >= MinAndroidSdk; } },
+
+            // iOS Settings
+            { Configurations.IOSMinOSVersion, () => {
+                    string versionString = PlayerSettings.iOS.targetOSVersionString;
+                    return (versionString == "11" || versionString.StartsWith("11.")); } },
+            { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequiredIosArchitecture; } },
+            // todo { Configurations.IOSRequiresARKit, () => { ; } },
+            { Configurations.IOSCameraUsageDescription, () => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); } },
         };
 
         // The configure functions for each type of setting
@@ -74,6 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.SinglePassInstancing,  () => { MixedRealityOptimizeUtils.SetSinglePassInstanced(); } },
             { Configurations.SpatialAwarenessLayer,  () => { SetSpatialAwarenessLayer(); } },
 
+            // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true); } },
             { Configurations.MicrophoneCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.Microphone, true); } },
             { Configurations.InternetClientCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.InternetClient, true); } },
@@ -81,8 +100,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.EyeTrackingCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.GazeInput, true); } },
 #endif
 
+            // Android Settings
             { Configurations.AndroidMultiThreadedRendering, () => { PlayerSettings.SetMobileMTRendering(BuildTargetGroup.Android, false); } },
             { Configurations.AndroidMinSdkVersion, () => { PlayerSettings.Android.minSdkVersion = MinAndroidSdk; } },
+
+            // iOS Settings
+            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = "11.0"; } },
+            { Configurations.IOSArchitecture, () => { PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequiredIosArchitecture); } },
+            // todo { Configurations.IOSRequiresARKit, () => { ; } },
+            { Configurations.IOSCameraUsageDescription, () => { PlayerSettings.iOS.cameraUsageDescription = IosCameraUsageDescription; } },
         };
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -18,6 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private const int SpatialAwarenessDefaultLayer = 31;
         private const AndroidSdkVersions MinAndroidSdk = AndroidSdkVersions.AndroidApiLevel24; // Android 7.0
         private const int RequiredIosArchitecture = 1; // Per https://docs.unity3d.com/ScriptReference/PlayerSettings.SetArchitecture.html, 1 == ARM64
+        private const float IosMinOsVersion = 11.0f;
         private const string IosCameraUsageDescription = "Required for augmented reality support.";
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             SpatialAwarenessLayer,
 
             // WSA Capabilities
-            SpatialPerceptionCapability,
+            SpatialPerceptionCapability = 1000,
             MicrophoneCapability,
             InternetClientCapability,
 #if UNITY_2019_3_OR_NEWER
@@ -41,11 +42,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #endif
 
             // Android Settings
-            AndroidMultiThreadedRendering,
+            AndroidMultiThreadedRendering = 2000,
             AndroidMinSdkVersion,
 
             // iOS Settings
-            IOSMinOSVersion,
+            IOSMinOSVersion = 3000,
             IOSArchitecture,
             IOSCameraUsageDescription,
         };
@@ -74,8 +75,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             // iOS Settings
             { Configurations.IOSMinOSVersion, () => {
-                    string versionString = PlayerSettings.iOS.targetOSVersionString;
-                    return (versionString == "11" || versionString.StartsWith("11.")); } },
+                    float version;
+                    if (!float.TryParse(PlayerSettings.iOS.targetOSVersionString, out version)) { return false; }
+                    return version >= IosMinOsVersion; } },
             { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequiredIosArchitecture; } },
             { Configurations.IOSCameraUsageDescription, () => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); } },
         };
@@ -103,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.AndroidMinSdkVersion, () => { PlayerSettings.Android.minSdkVersion = MinAndroidSdk; } },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = "11.0"; } },
+            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = IosMinOsVersion.ToString(); } },
             { Configurations.IOSArchitecture, () => { PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequiredIosArchitecture); } },
             { Configurations.IOSCameraUsageDescription, () => { PlayerSettings.iOS.cameraUsageDescription = IosCameraUsageDescription; } },
         };

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public class MixedRealityProjectConfigurator
     {
         private const int SpatialAwarenessDefaultLayer = 31;
+        private const AndroidSdkVersions MinAndroidSdk = AndroidSdkVersions.AndroidApiLevel24;
 
         /// <summary>
         /// List of available configurations to check and configure with this utility
@@ -36,6 +37,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
             EyeTrackingCapability,
 #endif
+
+            // Android Settings
+            AndroidMultiThreadedRendering,
+            AndroidMinSdkVersion,
         };
 
         // The check functions for each type of setting
@@ -54,6 +59,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
             { Configurations.EyeTrackingCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.GazeInput); } },
 #endif
+
+            { Configurations.AndroidMultiThreadedRendering, () => { return PlayerSettings.GetMobileMTRendering(BuildTargetGroup.Android) == false; } },
+            { Configurations.AndroidMinSdkVersion, () => { return PlayerSettings.Android.minSdkVersion >= MinAndroidSdk; } },
         };
 
         // The configure functions for each type of setting
@@ -72,6 +80,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
             { Configurations.EyeTrackingCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.GazeInput, true); } },
 #endif
+
+            { Configurations.AndroidMultiThreadedRendering, () => { PlayerSettings.SetMobileMTRendering(BuildTargetGroup.Android, false); } },
+            { Configurations.AndroidMinSdkVersion, () => { PlayerSettings.Android.minSdkVersion = MinAndroidSdk; } },
         };
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -17,9 +17,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     {
         private const int SpatialAwarenessDefaultLayer = 31;
         private const AndroidSdkVersions MinAndroidSdk = AndroidSdkVersions.AndroidApiLevel24; // Android 7.0
-        private const int RequiredIosArchitecture = 1; // Per https://docs.unity3d.com/ScriptReference/PlayerSettings.SetArchitecture.html, 1 == ARM64
-        private const float IosMinOsVersion = 11.0f;
-        private const string IosCameraUsageDescription = "Required for augmented reality support.";
+        private const int RequirediOSArchitecture = 1; // Per https://docs.unity3d.com/ScriptReference/PlayerSettings.SetArchitecture.html, 1 == ARM64
+        private const float iOSMinOsVersion = 11.0f;
+        private const string iOSCameraUsageDescription = "Required for augmented reality support.";
 
         /// <summary>
         /// List of available configurations to check and configure with this utility
@@ -77,8 +77,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.IOSMinOSVersion, () => {
                     float version;
                     if (!float.TryParse(PlayerSettings.iOS.targetOSVersionString, out version)) { return false; }
-                    return version >= IosMinOsVersion; } },
-            { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequiredIosArchitecture; } },
+                    return version >= iOSMinOsVersion; } },
+            { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture; } },
             { Configurations.IOSCameraUsageDescription, () => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); } },
         };
 
@@ -105,9 +105,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.AndroidMinSdkVersion, () => { PlayerSettings.Android.minSdkVersion = MinAndroidSdk; } },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = IosMinOsVersion.ToString(); } },
-            { Configurations.IOSArchitecture, () => { PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequiredIosArchitecture); } },
-            { Configurations.IOSCameraUsageDescription, () => { PlayerSettings.iOS.cameraUsageDescription = IosCameraUsageDescription; } },
+            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = iOSMinOsVersion.ToString(); } },
+            { Configurations.IOSArchitecture, () => { PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequirediOSArchitecture); } },
+            { Configurations.IOSCameraUsageDescription, () => { PlayerSettings.iOS.cameraUsageDescription = iOSCameraUsageDescription; } },
         };
 
         /// <summary>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -164,7 +164,7 @@ PlayerSettings:
   buildNumber:
     iOS: 0
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 16
+  AndroidMinSdkVersion: 24
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -179,7 +179,7 @@ PlayerSettings:
   StripUnusedMeshComponents: 0
   VertexChannelCompressionMask: 214
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 9.0
+  iOSTargetOSVersionString: 11
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 9.0
@@ -327,7 +327,7 @@ PlayerSettings:
     m_Enabled: 0
     m_Devices: []
   - m_BuildTarget: iOS
-    m_Enabled: 0
+    m_Enabled: 1
     m_Devices: []
   - m_BuildTarget: tvOS
     m_Enabled: 0
@@ -337,6 +337,7 @@ PlayerSettings:
   openGLRequireES31AEP: 0
   m_TemplateCustomTags: {}
   mobileMTRendering:
+    Android: 0
     iPhone: 1
     tvOS: 1
   m_BuildTargetGroupLightmapEncodingQuality:
@@ -353,7 +354,7 @@ PlayerSettings:
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
-  cameraUsageDescription: 
+  cameraUsageDescription: Required for augmented reality support.
   locationUsageDescription: 
   microphoneUsageDescription: 
   switchNetLibKey: 
@@ -573,7 +574,8 @@ PlayerSettings:
   scriptingDefineSymbols:
     1: 
     14: 
-  platformArchitecture: {}
+  platformArchitecture:
+    iOS: 1
   scriptingBackend:
     Metro: 1
     Standalone: 1


### PR DESCRIPTION
This change adds support for configuring the Android and iOS player settings required for building AR Foundation applications.

The new settings being configured are:

- Android
    - Disable Multi-Threaded Rendering
    - Min SDK version == 7.0
- iOS
    - Min OS version == 11.0
    - Architecture == ARM64
    - Set Camera Usage Description

This change completes the work required for #6256

Validated by opening switching between Android, iOS and UWP platforms to ensure the correct settings are displayed in the dialog and modified on completion.