### PR TITLE
Coding guidelines: copyright, [experimental] tag

### DIFF
--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -38,14 +38,6 @@ MRTK is a community project, modified by a diverse range of contributors. These 
 When you fix a bug, write a test to ensure it does not regress in the future. If adding a feature, write tests that verify your feature works. This is required for all UX features except experimental features.
 
 ## Coding Conventions
-### Script license information headers
-
-All scripts posted to the MRTK should have the standard License header attached, exactly as shown below:
-
-```c#
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-```
 
 ### Function / Method summary headers
 All public classes, structs, enums, functions, properties, fields posted to the MRTK should be described as to it's purpose and use, exactly as shown below:

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -38,6 +38,15 @@ MRTK is a community project, modified by a diverse range of contributors. These 
 When you fix a bug, write a test to ensure it does not regress in the future. If adding a feature, write tests that verify your feature works. This is required for all UX features except experimental features.
 
 ## Coding Conventions
+### Script license information headers
+
+All Microsoft employees contributing new files should add the following standard License header at the top of any new files, exactly as shown below:
+
+```c#
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+```
+
 
 ### Function / Method summary headers
 All public classes, structs, enums, functions, properties, fields posted to the MRTK should be described as to it's purpose and use, exactly as shown below:

--- a/Documentation/Contributing/ExperimentalFeatures.md
+++ b/Documentation/Contributing/ExperimentalFeatures.md
@@ -33,6 +33,9 @@ if your component is part of solvers at `Microsoft.MixedReality.Toolkit.Utilitie
 
 See [this PR](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4532) for an example. 
 
+### Experimental features should have an [Experimental] attribute
+Add an `[Experimental]` attribute above one of your fields to have a small dialog appear in the component editor that mentions your feature is experimental and subject to significant changes.
+
 ### Minimize impact to MRTK code
 While your MRTK change might get your experiment to work, it could impact other people in ways you do not expect.
 Any regressions you make to the MRTK core code would result in your pull request getting reverted. 


### PR DESCRIPTION
## Overview
Make a few improvements to coding, experimental guidelines:

1) Remove requirement about copyright block, it's no longer required: https://docs.opensource.microsoft.com/content/releasing/copyright-headers.html#copyright-headers-in-microsoft-oss-project

2) Add section about adding [Experimental] tag to experimental features.

## Changes
- Fixes: #6198 


## Verification
