### PR TITLE
Port RotateAboutObjectCenter fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -244,6 +244,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
         private Dictionary<uint, PointerData> pointerIdToPointerMap = new Dictionary<uint, PointerData>();
         private Quaternion objectToHandRotation;
+        private Quaternion objectToGripRotation;
         private bool isNearManipulation;
         // This can probably be consolidated so that we use same for one hand and two hands
         private Quaternion targetRotationTwoHands;
@@ -684,6 +685,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     break;
                 }
                 case RotateInOneHandType.RotateAboutObjectCenter:
+                    Quaternion gripRotation;
+                    TryGetGripRotation(pointer, out gripRotation);
+                    targetRotation = gripRotation * objectToGripRotation;
+                    break;
                 case RotateInOneHandType.RotateAboutGrabPoint:
                     targetRotation = pointer.Rotation * objectToHandRotation;
                     break;
@@ -735,6 +740,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // Calculate relative transform from object to hand.
             Quaternion worldToPalmRotation = Quaternion.Inverse(pointer.Rotation);
             objectToHandRotation = worldToPalmRotation * hostTransform.rotation;
+
+            // Calculate relative transform from object to grip.
+            Quaternion gripRotation;
+            TryGetGripRotation(pointer, out gripRotation);
+            Quaternion worldToGripRotation = Quaternion.Inverse(gripRotation);
+            objectToGripRotation = worldToGripRotation * hostTransform.rotation;
 
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
             MixedRealityPose hostPose = new MixedRealityPose(hostTransform.position, hostTransform.rotation);
@@ -881,6 +892,21 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // We may be able to do this without allocating memory.
             // Moving to a method for later investigation.
             return pointerIdToPointerMap.Values.First();
+        }
+
+        private bool TryGetGripRotation(IMixedRealityPointer pointer, out Quaternion rotation)
+        {
+
+            for (int i = 0; i < pointer.Controller.Interactions.Length; i++)
+            {
+                if (pointer.Controller.Interactions[i].InputType == DeviceInputType.SpatialGrip)
+                {
+                    rotation = pointer.Controller.Interactions[i].RotationData;
+                    return true;
+                }
+            }
+            rotation = Quaternion.identity;
+            return false;
         }
 
         #endregion

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -896,7 +896,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private bool TryGetGripRotation(IMixedRealityPointer pointer, out Quaternion rotation)
         {
-
             for (int i = 0; i < pointer.Controller.Interactions.Length; i++)
             {
                 if (pointer.Controller.Interactions[i].InputType == DeviceInputType.SpatialGrip)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -1080,6 +1080,47 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             TestUtilities.AssertAboutEqual(originalObjectPos, testObject.transform.position, "Object moved after it was disabled");
         }
+
+        /// <summary>
+        /// Ensure that a manipulated object has the same rotation as the hand
+        /// when RotateAboutObjectCenter is used
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ManipulationHandlerRotateAboutObjectCenter()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // set up cube with manipulation handler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.transform.localScale = Vector3.one * 0.2f;
+            testObject.transform.position = Vector3.forward;
+
+            var manipHandler = testObject.AddComponent<ManipulationHandler>();
+            manipHandler.HostTransform = testObject.transform;
+            manipHandler.SmoothingActive = false;
+            manipHandler.OneHandRotationModeFar = ManipulationHandler.RotateInOneHandType.RotateAboutObjectCenter;
+
+            Quaternion rotateTo = Quaternion.Euler(45, 45, 45);
+
+            TestHand hand = new TestHand(Handedness.Right);
+            const int numHandSteps = 1;
+
+            // Rotate the hand and test that the rotations are equal
+            yield return hand.Show(new Vector3(0.06f, -0.1f, 0.5f));
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return null;
+
+            yield return hand.SetRotation(rotateTo, numHandSteps);
+            yield return null;
+
+            TestUtilities.AssertAboutEqual(rotateTo, testObject.transform.rotation, "Object moved after it was disabled");
+
+            // Rotate the hand back and test that the rotations still are equal
+            yield return hand.SetRotation(Quaternion.identity, numHandSteps);
+            yield return null;
+
+            TestUtilities.AssertAboutEqual(Quaternion.identity, testObject.transform.rotation, "Object moved after it was disabled");
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Overview
RotateAboutGrabPoint now allows you to rotate an object at a distance using one handed far interaction as described in #5957.

This has been fixed on `feature/ux_refactor` for a few weeks, but we feel like it's worth getting this fix in for 2.2.

## Changes
- `RotateAboutObjectCenter` now uses grip pose rotation, rather than pointer rotation.
- Fixes: #5957.
