### PR TITLE
Fix and simplify HandConstraint solver tracking

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/PalmUpHandMenu.prefab
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Prefabs/PalmUpHandMenu.prefab
@@ -46,6 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf12ee76e7e00a44a9a84256760020e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  nodeList: []
   ignoreInactiveTransforms: 1
   sortType: 0
   surfaceType: 1
@@ -226,6 +227,12 @@ MonoBehaviour:
   rotationBehavior: 2
   onHandActivate:
     m_PersistentCalls:
+      m_Calls: []
+  onHandDeactivate:
+    m_PersistentCalls:
+      m_Calls: []
+  onFirstHandDetected:
+    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 4650336336463898692}
         m_MethodName: SetActive
@@ -238,9 +245,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  onHandDeactivate:
+  onLastHandLost:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 4650336336463898692}
@@ -254,18 +259,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  onFirstHandDetected:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  onLastHandLost:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   facingThreshold: 75
   requireFlatHand: 0
   flatHandThreshold: 45
@@ -366,11 +359,10 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: m_Mesh
+    - target: {fileID: 1911902820, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
+      propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2100000, guid: 85b164de2cfcb854cbbcb9c82670749d, type: 2}
     - target: {fileID: 937783104, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -383,10 +375,11 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1911902820, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
-      propertyPath: m_Materials.Array.data[0]
+    - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 2100000, guid: 85b164de2cfcb854cbbcb9c82670749d, type: 2}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
 --- !u!4 &4650336336337354715 stripped
@@ -460,11 +453,10 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: m_Mesh
+    - target: {fileID: 1911902820, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
+      propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2100000, guid: e6ab953dc933471489f5ebff6791a886, type: 2}
     - target: {fileID: 937783104, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -477,10 +469,11 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1911902820, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
-      propertyPath: m_Materials.Array.data[0]
+    - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 2100000, guid: e6ab953dc933471489f5ebff6791a886, type: 2}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
 --- !u!4 &4650336336418689529 stripped
@@ -554,11 +547,6 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 937783104, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -570,6 +558,11 @@ PrefabInstance:
     - target: {fileID: 937783102, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}
       propertyPath: m_isInputParsingRequired
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2406973081839446391, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 45fd0ad89d6d17b4fbe68eb48dbe9de9, type: 3}

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/InputRayUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/InputRayUtils.cs
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Gets the <seealso cref="IMixedRealityController"/> instance matching the specified source type and hand.
+        /// Gets the first <seealso cref="IMixedRealityController"/> instance matching the specified source type and hand.
         /// </summary>
         /// <param name="sourceType">Type of the input source</param>
         /// <param name="hand">The handedness of the controller</param>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/PointerUtils.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (var pointer in CoreServices.InputSystem.FocusProvider.GetPointers<T>())
             {
-                if ((pointer.Controller?.ControllerHandedness & handedness) != 0)
+                if (pointer.Controller?.ControllerHandedness.IsMatch(handedness) == true)
                 {
                     return pointer;
                 }
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             foreach (var pointer in GetPointers())
             {
                 if (pointer is T pointerConcrete
-                    && (pointer.Controller?.ControllerHandedness & handedness) != 0)
+                    && pointer.Controller?.ControllerHandedness.IsMatch(handedness) == true)
                 {
                     yield return pointerConcrete;
                 }
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             foreach (var pointer in GetPointers<T>(handedness))
             {
-                if ((pointer.Controller?.ControllerHandedness & handedness) != 0
+                if (pointer.Controller?.ControllerHandedness.IsMatch(handedness) == true
                     && pointer.InputSourceParent.SourceType == sourceType)
                 {
                     yield return pointer;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     /// This solver is intended to work with <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand"/> but also works with <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityController"/>. 
     /// </summary>
     [RequireComponent(typeof(HandBounds))]
-    public class HandConstraint : Solver//, IMixedRealitySourceStateHandler
+    public class HandConstraint : Solver
     {
         /// <summary>
         /// Specifies a zone that is safe for the constraint to solve to without intersecting the hand.

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -251,6 +251,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 OnHandActivate.Invoke();
             }
 
+            previousHandedness = newHandedness;
+
             /*
             // Determine the new active hand.
             IMixedRealityController newActivehand = null;
@@ -292,6 +294,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// <returns>True if this hand should be used from tracking.</returns>
         protected virtual bool IsValidController(IMixedRealityController controller)
         {
+            if (controller == null)
+            {
+                return false;
+            }
+
             /* TODO: Troy
             // If transitioning between hands is not allowed, make sure the TrackedObjectType matches the hand.
             if (!autoTransitionBetweenHands)

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -58,18 +58,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// Determines if a hand meets the requirements for use with constraining the tracked object and determines if the 
         /// palm is currently facing the user.
         /// </summary>
-        /// <param name="hand">The hand to check against.</param>
+        /// <param name="controller">The hand to check against.</param>
         /// <returns>True if this hand should be used from tracking.</returns>
-        protected override bool IsHandActive(IMixedRealityController hand)
+        protected override bool IsValidController(IMixedRealityController controller)
         {
-            if (!base.IsHandActive(hand))
+            if (!base.IsValidController(controller))
             {
                 return false;
             }
 
             MixedRealityPose palmPose;
 
-            var jointedHand = hand as IMixedRealityHand;
+            var jointedHand = controller as IMixedRealityHand;
 
             if (jointedHand != null)
             {

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         /// <summary>
-        /// Determines if a hand meets the requirements for use with constraining the tracked object and determines if the 
+        /// Determines if a controller meets the requirements for use with constraining the tracked object and determines if the 
         /// palm is currently facing the user.
         /// </summary>
         /// <param name="controller">The hand to check against.</param>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -489,7 +489,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             // If we were tracking a particular hand, check that our transform is still valid
             // The HandJointService does not destroy it's own hand joint tracked GameObjects even when a hand is no longer tracked
             // Those HandJointService's GameObjects though are the parents of our tracked transform and thus will not be null/destroyed
-            if (TrackedTargetType == TrackedObjectType.HandJoint && currentTrackedHandedness != Handedness.None)
+            if (TrackedTargetType == TrackedObjectType.HandJoint && !currentTrackedHandedness.IsNone())
             {
                 bool trackingLeft = HandJointService.IsHandTracked(Handedness.Left);
                 bool trackingRight = HandJointService.IsHandTracked(Handedness.Right);

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -250,6 +250,31 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
         }
 
+        // Stores controller side to favor if TrackedHandedness is set to both
+        protected Handedness preferredTrackedHandedness = Handedness.Left;
+
+        /// <summary>
+        /// Controller side to favor and pick first if TrackedHandedness is set to both
+        /// </summary>
+        /// /// <remarks>
+        /// Only possible values, Left or Right
+        /// </remarks>
+        public Handedness PreferredTrackedHandedness
+        {
+            get => preferredTrackedHandedness;
+            set
+            {
+                if (TrackedHandness == Handedness.Both &&
+                    (value == Handedness.Left || value == Handedness.Right) 
+                    && preferredTrackedHandedness != value)
+                {
+                    preferredTrackedHandedness = value;
+                    RefreshTrackedObject();
+                }
+            }
+        }
+
+
         // Hidden GameObject managed by this component and attached as a child to the tracked target type (i.e head, hand etc)
         private GameObject trackingTarget;
 
@@ -378,22 +403,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 if (this.TrackedHandness == Handedness.Both)
                 {
-                    this.currentTrackedHandedness = Handedness.Left;
-                    target = GetControllerRay(Handedness.Left);
+                    currentTrackedHandedness = PreferredTrackedHandedness;
+                    target = GetControllerRay(currentTrackedHandedness);
                     if (target == null)
                     {
-                        this.currentTrackedHandedness = Handedness.Right;
-                        target = GetControllerRay(Handedness.Right);
+                        currentTrackedHandedness = currentTrackedHandedness == Handedness.Left ? Handedness.Right : Handedness.Left;
+                        target = GetControllerRay(currentTrackedHandedness);
                         if (target == null)
                         {
-                            this.currentTrackedHandedness = Handedness.None;
+                            currentTrackedHandedness = Handedness.None;
                         }
                     }
                 }
                 else
                 {
-                    this.currentTrackedHandedness = this.TrackedHandness;
-                    target = GetControllerRay(this.TrackedHandness);
+                    currentTrackedHandedness = TrackedHandness;
+                    target = GetControllerRay(TrackedHandness);
                 }
             }
             else if (TrackedTargetType == TrackedObjectType.HandJoint)

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -428,16 +428,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 if (HandJointService != null)
                 {
-                    currentTrackedHandedness = PreferredTrackedHandedness;
+                    currentTrackedHandedness = TrackedHandness;
                     if (currentTrackedHandedness == Handedness.Both)
                     {
-                        if (HandJointService.IsHandTracked(Handedness.Left))
+                        if (HandJointService.IsHandTracked(PreferredTrackedHandedness))
                         {
-                            currentTrackedHandedness = Handedness.Left;
+                            currentTrackedHandedness = PreferredTrackedHandedness;
                         }
-                        else if (HandJointService.IsHandTracked(Handedness.Right))
+                        else if (HandJointService.IsHandTracked(PreferredTrackedHandedness.GetOppositeHandedness()))
                         {
-                            currentTrackedHandedness = Handedness.Right;
+                            currentTrackedHandedness = PreferredTrackedHandedness.GetOppositeHandedness();
                         }
                         else
                         {

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -265,11 +265,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             set
             {
                 if (TrackedHandness == Handedness.Both &&
-                    (value == Handedness.Left || value == Handedness.Right) 
+                    (value.IsLeft() || value.IsRight()) 
                     && preferredTrackedHandedness != value)
                 {
                     preferredTrackedHandedness = value;
-                    RefreshTrackedObject();
+                    // TODO: Troy -> might want to refresh tracked object manually?
+                    //RefreshTrackedObject();
                 }
             }
         }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -428,7 +428,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 if (HandJointService != null)
                 {
-                    this.currentTrackedHandedness = this.TrackedHandness;
+                    currentTrackedHandedness = PreferredTrackedHandedness;
                     if (currentTrackedHandedness == Handedness.Both)
                     {
                         if (HandJointService.IsHandTracked(Handedness.Left))

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     /// This class handles the solver components that are attached to this <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Solver.html")]
-    public class SolverHandler : MonoBehaviour, IMixedRealitySourceStateHandler
+    public class SolverHandler : MonoBehaviour
     {
         [SerializeField]
         [Tooltip("Tracked object to calculate position and orientation from. If you want to manually override and use a scene object, use the TransformTarget field.")]
@@ -310,18 +310,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             RefreshTrackedObject();
         }
 
-        protected virtual void OnEnable()
-        {
-            CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
-        }
-
-        protected virtual void OnDisable()
-        {
-            CoreServices.InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
-        }
-
         protected virtual void Update()
         {
+            if (IsInvalidTracking())
+            {
+                RefreshTrackedObject();
+            }
+
             DeltaTime = Time.realtimeSinceStartup - lastUpdateTime;
             lastUpdateTime = Time.realtimeSinceStartup;
         }
@@ -517,25 +512,5 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             return type == TrackedObjectType.Head || type >= TrackedObjectType.ControllerRay;
         }
-
-        #region IMixedRealitySourceStateHandler Implementation
-
-        public void OnSourceDetected(SourceStateEventData eventData)
-        {
-            if (IsInvalidTracking())
-            {
-                RefreshTrackedObject();
-            }
-        }
-
-        public void OnSourceLost(SourceStateEventData eventData)
-        {
-            if (IsInvalidTracking())
-            {
-                RefreshTrackedObject();
-            }
-        }
-
-        #endregion IMixedRealitySourceStateHandler Implementation
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -264,8 +264,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             get => preferredTrackedHandedness;
             set
             {
-                if (TrackedHandness == Handedness.Both &&
-                    (value.IsLeft() || value.IsRight()) 
+                if ((value.IsLeft() || value.IsRight()) 
                     && preferredTrackedHandedness != value)
                 {
                     preferredTrackedHandedness = value;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -269,8 +269,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     && preferredTrackedHandedness != value)
                 {
                     preferredTrackedHandedness = value;
-                    // TODO: Troy -> might want to refresh tracked object manually?
-                    //RefreshTrackedObject();
                 }
             }
         }
@@ -398,7 +396,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         protected virtual void AttachToNewTrackedObject()
         {
-            this.currentTrackedHandedness = Handedness.None;
+            currentTrackedHandedness = Handedness.None;
 
             Transform target = null;
             if (TrackedTargetType == TrackedObjectType.Head)
@@ -407,13 +405,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             }
             else if (TrackedTargetType == TrackedObjectType.ControllerRay)
             {
-                if (this.TrackedHandness == Handedness.Both)
+                if (TrackedHandness == Handedness.Both)
                 {
                     currentTrackedHandedness = PreferredTrackedHandedness;
                     target = GetControllerRay(currentTrackedHandedness);
                     if (target == null)
                     {
-                        currentTrackedHandedness = currentTrackedHandedness == Handedness.Left ? Handedness.Right : Handedness.Left;
+                        currentTrackedHandedness = currentTrackedHandedness.GetOppositeHandedness();
                         target = GetControllerRay(currentTrackedHandedness);
                         if (target == null)
                         {
@@ -497,8 +495,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 bool trackingLeft = HandJointService.IsHandTracked(Handedness.Left);
                 bool trackingRight = HandJointService.IsHandTracked(Handedness.Right);
 
-                return (currentTrackedHandedness == Handedness.Left && !trackingLeft) ||
-                       (currentTrackedHandedness == Handedness.Right && !trackingRight);
+                return (currentTrackedHandedness.IsLeft() && !trackingLeft) ||
+                       (currentTrackedHandedness.IsRight() && !trackingRight);
             }
 
             return false;

--- a/Assets/MixedRealityToolkit/Extensions/HandednessExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/HandednessExtensions.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+
+namespace Microsoft.MixedReality.Toolkit
+{
+    /// <summary>
+    /// <see cref=" Microsoft.MixedReality.Toolkit.Utilities.Handedness"/> type method extensions.
+    /// </summary>
+    public static class HandednessExtensions
+    {
+        /// <summary>
+        /// Gets the opposite "hand" flag for the current Handedness value.
+        /// </summary>
+        /// <remarks>
+        /// If current = Left, returns Right.
+        /// If current = Right, returns Left.
+        /// Otherwise, returns None
+        /// </remarks>
+        public static Handedness GetOppositeHandedness(this Handedness current)
+        {
+            if (current == Handedness.Left)
+            {
+                return Handedness.Right;
+            }
+            else if (current == Handedness.Right)
+            {
+                return Handedness.Left;
+            }
+            else
+            {
+                return Handedness.None;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the current Handedness is the Right (i.e == Handedness.Right), false otherwise
+        /// </summary>
+        public static bool IsRight(this Handedness current)
+        {
+            return current == Handedness.Right;
+        }
+
+        /// <summary>
+        /// Returns true if the current Handedness is the Right (i.e == Handedness.Right), false otherwise
+        /// </summary>
+        public static bool IsLeft(this Handedness current)
+        {
+            return current == Handedness.Left;
+        }
+
+        /// <summary>
+        /// Returns true if the current Handedness is the Right (i.e == Handedness.Right), false otherwise
+        /// </summary>
+        public static bool IsNone(this Handedness current)
+        {
+            return current == Handedness.None;
+        }
+
+        /// <summary>
+        /// Returns true if the current Handedness flags are a match with the comparison Handedness flags, false otherwise
+        /// </summary>
+        public static bool IsMatch(this Handedness current, Handedness compare)
+        {
+            return (current & compare) != 0;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Extensions/HandednessExtensions.cs.meta
+++ b/Assets/MixedRealityToolkit/Extensions/HandednessExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fb5bfd4f80d7174c81d4778748ba924
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/Hands/HandJointUtils.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/HandJointUtils.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var hand = detectedController as T;
                 if (hand != null)
                 {
-                    if ((detectedController.ControllerHandedness & handedness) != 0)
+                    if (detectedController.ControllerHandedness.IsMatch(handedness))
                     {
                         return hand;
                     }


### PR DESCRIPTION
## Overview
HandConstraint is simplified to follow properties set in SolverHandler instead of overriding and tracking hands itself. Further, the UnityEvents have been updated to fire properly.


- HandConstraint now leverages SolverHandler's ability to track/switch between particular hands. 
- HandConstraint can choose to ignore the tracked hand if it considers it not valid or request SolverHandler to switch hands (if possible) via PreferredTrackedHandedness
- Added PreferredTrackedHandedness property which indicates which hand to default to when both are available
- UnityEvents now allocated by default so easier extension via code
- OnHandActivate/Deactivate fire whenever a hand is supported or not
- Created HandednessExtensions to simplify code interaction
- HandMenu prefab updated to hide onFirstHandFound and onLastHandLost

Related PR: #6311 

## Changes
- Fixes: #6430

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
