### PR TITLE
DefaultControllerPointer ray brightness

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
@@ -193,7 +193,7 @@ LineRenderer:
       key3: {r: 0, g: 0, b: 0, a: 0.49803922}
       key4: {r: 0, g: 0, b: 0, a: 0}
       key5: {r: 0, g: 0, b: 0, a: 0}
-      key6: {r: 0, g: 0, b: 0, a: 0.78431374}
+      key6: {r: 0, g: 0, b: 0, a: 0.9411765}
       key7: {r: 0, g: 0, b: 0, a: 0}
       ctime0: 32768
       ctime1: 65535
@@ -203,13 +203,13 @@ LineRenderer:
       ctime5: 0
       ctime6: 0
       ctime7: 0
-      atime0: 0
-      atime1: 7864
-      atime2: 10486
-      atime3: 13107
-      atime4: 19661
-      atime5: 42598
-      atime6: 55705
+      atime0: 4587
+      atime1: 11141
+      atime2: 13762
+      atime3: 16384
+      atime4: 22937
+      atime5: 49151
+      atime6: 58982
       atime7: 65535
       m_Mode: 0
       m_NumColorKeys: 2
@@ -238,9 +238,9 @@ MonoBehaviour:
   lineColor:
     serializedVersion: 2
     key0: {r: 1, g: 1, b: 1, a: 0}
-    key1: {r: 0.5660378, g: 0.5660378, b: 0.5660378, a: 1}
+    key1: {r: 0.8113208, g: 0.8113208, b: 0.8113208, a: 0}
     key2: {r: 0, g: 0, b: 0, a: 1}
-    key3: {r: 0, g: 0, b: 0, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 1}
     key4: {r: 0, g: 0, b: 0, a: 0}
     key5: {r: 0, g: 0, b: 0, a: 0}
     key6: {r: 0, g: 0, b: 0, a: 0}
@@ -254,8 +254,8 @@ MonoBehaviour:
     ctime6: 0
     ctime7: 0
     atime0: 0
-    atime1: 6361
-    atime2: 57632
+    atime1: 4587
+    atime2: 11141
     atime3: 65535
     atime4: 0
     atime5: 0
@@ -322,6 +322,9 @@ MonoBehaviour:
   lineMaterial: {fileID: 2100000, guid: 11727442de02c1d4b8d37a063c748aec, type: 2}
   roundedEdges: 1
   roundedCaps: 1
+  fadeLineBrightnessOnEnable: 1
+  fadeLinePercentage: 0.55
+  fadeLineAnimationTime: 0.65
   lineRenderer: {fileID: 120690711267243118}
   tileMaterialByWorldLength: 0
   tileMaterialScale: 1
@@ -346,7 +349,7 @@ MonoBehaviour:
     key3: {r: 0, g: 0, b: 0, a: 0.49803922}
     key4: {r: 0, g: 0, b: 0, a: 0}
     key5: {r: 0, g: 0, b: 0, a: 0}
-    key6: {r: 0, g: 0, b: 0, a: 0.78431374}
+    key6: {r: 0, g: 0, b: 0, a: 0.9411765}
     key7: {r: 0, g: 0, b: 0, a: 0}
     ctime0: 32768
     ctime1: 65535
@@ -356,13 +359,13 @@ MonoBehaviour:
     ctime5: 0
     ctime6: 0
     ctime7: 0
-    atime0: 0
-    atime1: 7864
-    atime2: 10486
-    atime3: 13107
-    atime4: 19661
-    atime5: 42598
-    atime6: 55705
+    atime0: 4587
+    atime1: 11141
+    atime2: 13762
+    atime3: 16384
+    atime4: 22937
+    atime5: 49151
+    atime6: 58982
     atime7: 65535
     m_Mode: 0
     m_NumColorKeys: 2
@@ -425,6 +428,9 @@ MonoBehaviour:
   lineMaterial: {fileID: 2100000, guid: 876c7e981edab3a44918b5c51482a286, type: 2}
   roundedEdges: 1
   roundedCaps: 1
+  fadeLineBrightnessOnEnable: 1
+  fadeLinePercentage: 0.55
+  fadeLineAnimationTime: 0.65
   lineRenderer: {fileID: 120690711267243118}
   tileMaterialByWorldLength: 0
   tileMaterialScale: 1
@@ -470,9 +476,9 @@ MonoBehaviour:
   LineColorSelected:
     serializedVersion: 2
     key0: {r: 0.990566, g: 0.990566, b: 0.990566, a: 0}
-    key1: {r: 0.8773585, g: 0.8773585, b: 0.8773585, a: 1}
+    key1: {r: 0.8301887, g: 0.8301887, b: 0.8301887, a: 0}
     key2: {r: 0, g: 0, b: 0, a: 1}
-    key3: {r: 0, g: 0, b: 0, a: 0.5647059}
+    key3: {r: 0, g: 0, b: 0, a: 1}
     key4: {r: 0, g: 0, b: 0, a: 0}
     key5: {r: 0, g: 0, b: 0, a: 0}
     key6: {r: 0, g: 0, b: 0, a: 0}
@@ -486,22 +492,22 @@ MonoBehaviour:
     ctime6: 0
     ctime7: 0
     atime0: 0
-    atime1: 2313
-    atime2: 50115
-    atime3: 58982
+    atime1: 4587
+    atime2: 11141
+    atime3: 65535
     atime4: 63029
     atime5: 0
     atime6: 0
     atime7: 0
     m_Mode: 0
     m_NumColorKeys: 2
-    m_NumAlphaKeys: 5
+    m_NumAlphaKeys: 4
   LineColorValid:
     serializedVersion: 2
     key0: {r: 1, g: 1, b: 1, a: 0}
-    key1: {r: 1, g: 1, b: 1, a: 1}
+    key1: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 0}
     key2: {r: 0, g: 0, b: 0, a: 1}
-    key3: {r: 0, g: 0, b: 0, a: 0.6666667}
+    key3: {r: 0, g: 0, b: 0, a: 1}
     key4: {r: 0, g: 0, b: 0, a: 0}
     key5: {r: 0, g: 0, b: 0, a: 0}
     key6: {r: 0, g: 0, b: 0, a: 0}
@@ -515,16 +521,16 @@ MonoBehaviour:
     ctime6: 0
     ctime7: 0
     atime0: 0
-    atime1: 3277
-    atime2: 49922
-    atime3: 61102
+    atime1: 4587
+    atime2: 11141
+    atime3: 65535
     atime4: 63222
     atime5: 0
     atime6: 0
     atime7: 0
     m_Mode: 0
     m_NumColorKeys: 2
-    m_NumAlphaKeys: 5
+    m_NumAlphaKeys: 4
   LineColorInvalid:
     serializedVersion: 2
     key0: {r: 1, g: 0.7971698, b: 0.7971698, a: 0}
@@ -586,9 +592,9 @@ MonoBehaviour:
   LineColorLockFocus:
     serializedVersion: 2
     key0: {r: 1, g: 1, b: 1, a: 0}
-    key1: {r: 1, g: 1, b: 1, a: 1}
+    key1: {r: 0.8679245, g: 0.8679245, b: 0.8679245, a: 0}
     key2: {r: 0, g: 0, b: 0, a: 1}
-    key3: {r: 0, g: 0, b: 0, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 1}
     key4: {r: 0, g: 0, b: 0, a: 0}
     key5: {r: 0, g: 0, b: 0, a: 0}
     key6: {r: 0, g: 0, b: 0, a: 0}
@@ -602,9 +608,9 @@ MonoBehaviour:
     ctime6: 0
     ctime7: 0
     atime0: 0
-    atime1: 4241
-    atime2: 56283
-    atime3: 63415
+    atime1: 4587
+    atime2: 11141
+    atime3: 65535
     atime4: 63415
     atime5: 63415
     atime6: 63415

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
@@ -3,6 +3,8 @@
 
 using UnityEngine;
 using UnityEngine.Rendering;
+using System.Collections;
+using System;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
 {
@@ -43,6 +45,45 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         [SerializeField]
+        [Tooltip("Sets whether the pointer line will animate to a lower brightness level after a hand/controller is recognized.")]
+        private bool fadeLineBrightnessOnEnable = true;
+
+        /// <summary>
+        /// Sets whether the ray line will animate to a lower brightness level after a hand/controller is recognized
+        /// </summary>
+        public bool FadeLineBrightnessOnEnable
+        {
+            get { return fadeLineBrightnessOnEnable; }
+            set { fadeLineBrightnessOnEnable = value; }
+        }
+
+        [SerializeField, Range(0f, 1f)]
+        [Tooltip("The amount the pointer line will fade if fadeLineBrightnessOnEnable is true.")]
+        private float fadeLinePercentage = 0.55f;
+
+        /// <summary>
+        /// The amount the pointer line will fade if fadeLineBrightnessOnEnable is true"
+        /// </summary>
+        public float FadeLinePercentage
+        {
+            get { return fadeLinePercentage; }
+            set { fadeLinePercentage = value; }
+        }
+
+        [SerializeField]
+        [Tooltip("The length of the animation if fadeLineBrightnessOnEnable is true.")]
+        private float fadeLineAnimationTime = 0.65f;
+
+        /// <summary>
+        /// The amount the pointer line will fade if fadeLineBrightnessOnEnable is true"
+        /// </summary>
+        public float FadeLineAnimationTime
+        {
+            get { return fadeLineAnimationTime; }
+            set { fadeLineAnimationTime = value; }
+        }
+
+        [SerializeField]
         [HideInInspector]
         private LineRenderer lineRenderer = null;
 
@@ -57,6 +98,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private float tileMaterialScale = 1f;
 
         private Vector3[] positions;
+
+        private Coroutine fadeLine = null;
+        private GradientAlphaKey[] cachedKeys;
 
         private void OnEnable()
         {
@@ -79,11 +123,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 Debug.LogError("MixedRealityLineRenderer needs a material.");
                 enabled = false;
             }
+
+            fadeLine = StartCoroutine(FadeLine(fadeLinePercentage, fadeLineAnimationTime));
         }
 
         private void OnDisable()
         {
             lineRenderer.enabled = false;
+
+            if (fadeLine != null)
+            {
+                StopCoroutine(fadeLine);
+                fadeLine = null;
+            }
         }
 
         /// <inheritdoc />
@@ -157,6 +209,45 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     lineRenderer.SetPropertyBlock(tilingPropertyBlock);
                 }
             }
+        }
+
+        private IEnumerator FadeLine(float targetAlphaPercentage, float animationLength)
+        {
+            float currentTime = 0f;
+
+            if (cachedKeys == null)
+            {
+                cachedKeys = LineColor.alphaKeys;
+            }
+
+            GradientAlphaKey[] fadedKeys = new GradientAlphaKey[cachedKeys.Length];
+            Array.Copy(cachedKeys, fadedKeys, cachedKeys.Length);
+            float startAlpha = 1f;
+
+            while (currentTime != animationLength)
+            {
+                currentTime += Time.deltaTime;
+
+                if (currentTime > animationLength)
+                {
+                    currentTime = animationLength;
+                }
+
+                float percentageComplete = currentTime / animationLength;
+
+                float scalar = Mathf.Lerp(startAlpha, targetAlphaPercentage, percentageComplete);
+
+                for (int i = 0; i < fadedKeys.Length; i++)
+                {
+                    fadedKeys[i].alpha = cachedKeys[i].alpha * scalar;
+                }
+
+                LineColor.alphaKeys = fadedKeys;
+
+                yield return null;
+            }
+
+            fadeLine = null;
         }
     }
 }


### PR DESCRIPTION
## Overview

This PR consists of changes to the DefaultControllerPointer prefab and MixedRealityLineRenderer.cs. 

Increased parity with shell appearance was made by tweaking public variables in the MixedRealityLineRenderercomponents. All states of the DefaultControllerPointer ray now appear very similar to the shell rays.

In addition to editor changes, I wrote a coroutine that occurs on enable of any DefaultControllerPointer. It dims the ray from 100% to 55% by default (these values are customizable). This animation accomplishes two things:

1. It answers feedback the design team received about the hand ray being too bright.
2. The initial brightness draws attention to the ray and the fade animation to a lower brightness is pleasant, in my opinion :) 

The video below is not a perfect demonstration of the effect, as the mp4 to gif conversion took away a good bit of fidelity/brightness. In headset, the line does not get as dim as it appears in this gif.

![2019-10-3012-35-16_Trim (1)](https://user-images.githubusercontent.com/16657884/67895430-b91cc200-fb17-11e9-8599-d9bf36d62df5.gif)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6432
