### PR TITLE
Fix extension services not updating the friendly name and default profile.

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/LostTrackingService.cs
@@ -16,7 +16,11 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
     /// When tracking is lost, the service displays a visual indicator and sets the main camera's culling mask to hide all other objects.
     /// When tracking is restored, the camera mask is restored and the visual indicator is hidden.
     /// </summary>
-    [MixedRealityExtensionService(SupportedPlatforms.WindowsUniversal)]
+    [MixedRealityExtensionService(
+        SupportedPlatforms.WindowsUniversal,
+        "Tracking Lost Service",
+        "LostTrackingService/DefaultLostTrackingServiceProfile.asset",
+        "MixedRealityToolkit.Extensions")]
     public class LostTrackingService : BaseExtensionService, ILostTrackingService, IMixedRealityExtensionService
     {
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionService.cs
@@ -10,7 +10,12 @@ using Microsoft.MixedReality.Toolkit.UI;
 
 namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
 {
-    [MixedRealityExtensionService(SupportedPlatforms.WindowsStandalone|SupportedPlatforms.MacStandalone|SupportedPlatforms.LinuxStandalone|SupportedPlatforms.WindowsUniversal)]
+    [MixedRealityExtensionService(
+        SupportedPlatforms.WindowsStandalone | SupportedPlatforms.MacStandalone |
+        SupportedPlatforms.LinuxStandalone | SupportedPlatforms.WindowsUniversal,
+        "Scene Transition Service",
+        "SceneTransitionService/DefaultSceneTransitionServiceProfile.asset",
+        "MixedRealityToolkit.Extensions")]
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.html")]
     public class SceneTransitionService : BaseExtensionService, ISceneTransitionService, IMixedRealityExtensionService
     {

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -131,7 +131,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                 {
                                     // Try to assign default configuration profile when type changes.
                                     serializedObject.ApplyModifiedProperties();
-                                    AssignDefaultConfigurationValues(((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, configurationProfile, runtimePlatform);
+                                    AssignDefaultConfigurationValues(
+                                        ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, 
+                                        componentName,
+                                        configurationProfile, 
+                                        runtimePlatform);
                                     changed = true;
                                     break;
                                 }
@@ -160,16 +164,29 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
-        private void AssignDefaultConfigurationValues(System.Type componentType, SerializedProperty configurationProfile, SerializedProperty runtimePlatform)
+        private void AssignDefaultConfigurationValues(
+            System.Type componentType,
+            SerializedProperty componentName,
+            SerializedProperty configurationProfile, 
+            SerializedProperty runtimePlatform)
         {
             configurationProfile.objectReferenceValue = null;
             runtimePlatform.intValue = -1;
 
-            if (componentType != null &&
-                MixedRealityExtensionServiceAttribute.Find(componentType) is MixedRealityExtensionServiceAttribute attr)
+            if (componentType != null)
             {
-                configurationProfile.objectReferenceValue = attr.DefaultProfile;
-                runtimePlatform.intValue = (int)attr.RuntimePlatforms;
+                MixedRealityExtensionServiceAttribute attr = MixedRealityExtensionServiceAttribute.Find(componentType) as MixedRealityExtensionServiceAttribute;
+
+                if (attr != null)
+                {
+                    componentName.stringValue = !string.IsNullOrWhiteSpace(attr.Name) ? attr.Name : componentType.Name;
+                    configurationProfile.objectReferenceValue = attr.DefaultProfile;
+                    runtimePlatform.intValue = (int)attr.RuntimePlatforms;
+                }
+                else
+                {
+                    componentName.stringValue = componentType.Name;
+                }
             }
 
             serializedObject.ApplyModifiedProperties();


### PR DESCRIPTION
The current extension services were missing some fields in the MixedRealityExtensionService attribute, specifically:

- Name
- Default profile path 
- Package folder

In addition, the extension services profile inspector was not updating the name from the attribute.

Both are resolved by this change.