### PR TITLE
Add build tooling to ensure that we don't check in more hardcoded paths

### DIFF
--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -1,17 +1,21 @@
 <#
 .SYNOPSIS
-    Validates the code to check for common patterns and usage that shouldn't be
+    Validates the code and assets to check for common patterns and usage that shouldn't be
     checked in.
 .DESCRIPTION
-    This currently checks:
+    This currently checks both CSharp files and Unity serialized assets.
 
     - That Boo.Lang isn't used anywhere in the code. This is an autocomplete option
       that occurs when using Lists and other collections - the right thing to do
       is to use System.Collections
+    - Validates that there are no empty doccomments (e.g. ///<summary></summary>)
+    - All checked in profiles should not be marked custom
+    - There are no references to hardcoded paths
+    - There's only a single MixedRealityWorkspace per scene
 
     Returns 0 if there are no issues, non-zero if there are.
 .PARAMETER Directory
-    The directory containing the code to validate. Only CSharp files
+    The directory containing the code to validate. 
 .EXAMPLE
     .\validatecode.ps1 -Directory c:\path\to\MRTK\Assets
 #>
@@ -50,7 +54,7 @@ function CheckEmptyDoccomment(
         but empty doccomments don't add value to code.
     #>
     $tags = @("param", "returns")
-    $containsEmptyDoccomment = $false;
+    $containsEmptyDoccomment = $false
 
     foreach ($tag in $tags) {
         # This generates regexes that look like:
@@ -62,7 +66,7 @@ function CheckEmptyDoccomment(
             Write-Host "An empty doccomment was found in $FileName at line $LineNumber "
             Write-Host "Delete the line or add a description "
             Write-Host $FileContent[$LineNumber]
-            $containsEmptyDoccomment = $true;
+            $containsEmptyDoccomment = $true
         }
     }
     return $containsEmptyDoccomment
@@ -81,9 +85,81 @@ function CheckCustomProfile(
     if ($FileName -notmatch "Examples" -and $FileContent[$LineNumber] -match "isCustomProfile: 1") {
         Write-Host "An instance of 'isCustomProfile: 1' was found in $FileName at line $LineNumber"
         Write-Host "Please update this to 'isCustomProfile: 0' instead."
-        return $true;
+        return $true
     }
     return $false
+}
+
+# This dictionary contains the list of all allowed hardcoded path exceptions
+# You should NOT add things to this list unless you believe that your scenario should only work
+# when the MRTK is placed in a specific location in the root assets folder. This is only valid
+# in two locations currently:
+# 1) Test code
+# 2) Profile cloning code - this code needs to choose some reasonable default, preferring
+#    "Assets/MixedRealityToolkit.Generated/CustomProfiles" as that default location
+$HardcodedPathExceptions = @{
+    "MixedRealityToolkitConfigurationProfileInspector.cs" = @(
+        'var newProfile = profile.CreateAsset("Assets/MixedRealityToolkit.Generated/CustomProfiles") as MixedRealityToolkitConfigurationProfile;'
+    );
+    # This exception should be deleted once https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6448 is resolved
+    "MRTKExamplesHub.unity" = @(
+        'Path: Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Scenes/MRTKExamplesHubMainMenu.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Scenes/MRTKExamplesHubMainMenu.unity'
+    );
+    # This exception should be deleted once https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6448 is resolved
+    "MRTKExamplesHubMainMenu.unity" = @(
+        'value: Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandMenuExamples.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-04-TargetPositioning.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-02-TargetSelection.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/UX/Slate/SlateExample.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/ClippingExamples.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes/SliderExample.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/UX/BoundingBox/Scenes/BoundingBoxExamples.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-05-Visualizer.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity'
+        'value: Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/MaterialGallery.unity'
+    );
+}
+
+function CheckHardcodedPath(
+    [string]$FileName
+) {
+    <#
+    .SYNOPSIS
+        Checks if the line contains a hardcoded path i.e. "Assets/MixedRealityToolkit.Examples"
+        Hardcoded paths are generally not allowed, except in certain cases such as:
+
+        - Tests cases (tests are not run by consumers of the toolkit)
+        - Default saved location of custom profiles (it will default to a folder in the Assets/ location)
+    #>
+
+    # Some files have total exceptions (i.e. ones that deal with profile cloning or for tests)
+    if ($FileName -match "Assets.MixedRealityToolkit\.Tests" -or
+        $FileName -match "MixedRealityProfileCloneWindow\.cs") {
+        return $false
+    }
+
+    $results = Select-String -Pattern "Assets.MixedRealityToolkit" $FileName -AllMatches
+    $containsIssue = $false
+    $relativeFileName = Split-Path $FileName -leaf
+
+    foreach ($match in $results) {
+        $trimmed = $match.Line.trim()
+        if (-Not $HardcodedPathExceptions.Contains($relativeFileName) -Or
+                ($HardcodedPathExceptions.Contains($relativeFileName) -And
+                 -Not $HardcodedPathExceptions[$relativeFileName].Contains($trimmed))) {
+                     Write-Host $trimmed
+            Write-Host "Hardcoded path detected in $FileName - $trimmed"
+            Write-Host "Please delete usage of hardcoded path or add an exception in HardcodedPathExceptions"
+            Write-Host "if this is a valid hardcoded path usage."
+            $containsIssue = $true
+        }
+    }
+    return $containsIssue
 }
 
 function CheckScript(
@@ -103,6 +179,11 @@ function CheckScript(
             $containsIssue = $true
         }
     }
+
+    if (CheckHardcodedPath $FileName) {
+        $containsIssue = $true
+    }
+
     return $containsIssue
 }
 
@@ -136,6 +217,11 @@ function CheckUnityScene(
         Write-Host "There are multiple MixedRealityPlayspace objects in $FileName, delete the extra playspaces from the unity scene."
         $containsIssue = $true
     }
+
+    if (CheckHardcodedPath $FileName) {
+        $containsIssue = $true
+    }
+
     return $containsIssue
 }
 


### PR DESCRIPTION
We've fixed a number of hardcoded path related issues in the past, and we're still seeing them get checked in. This adds a verifier to ensure that we don't add new ones, while still having a way to have exceptions in cases where they are actually legitimate.

This has exceptions for the existing custom profile generator and test code, along with the scene system .unity files that are breaking arbitrary folder moves.