### PR TITLE
interactable scale theme now relative to gameobject initial scale

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/GrabScaleTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/GrabScaleTheme.asset
@@ -126,6 +126,7 @@ MonoBehaviour:
       ShaderName: 
     customProperties:
     - Name: ScaleMagnifier
+      Tooltip: 
       Type: 6
       Value:
         Name: 
@@ -145,6 +146,7 @@ MonoBehaviour:
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
     - Name: GripTimer
+      Tooltip: 
       Type: 0
       Value:
         Name: 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel-Simple.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel-Simple.asset
@@ -172,7 +172,27 @@ MonoBehaviour:
       ShaderOptions: []
       ShaderOptionNames: []
       ShaderName: 
-    customProperties: []
+    customProperties:
+    - Name: Relative Scale
+      Tooltip: Should the scale be relative to initial Gameobject scale, or absolute
+      Type: 15
+      Value:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        Shader: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
     easing:
       Enabled: 1
       Curve:

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/HolographicButtonSeeItSayItLabel.asset
@@ -172,7 +172,27 @@ MonoBehaviour:
       ShaderOptions: []
       ShaderOptionNames: []
       ShaderName: 
-    customProperties: []
+    customProperties:
+    - Name: Relative Scale
+      Tooltip: Should the scale be relative to initial Gameobject scale, or absolute
+      Type: 15
+      Value:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        Shader: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
     easing:
       Enabled: 1
       Curve:

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
@@ -124,7 +124,27 @@ MonoBehaviour:
       ShaderOptions: []
       ShaderOptionNames: []
       ShaderName: 
-    customProperties: []
+    customProperties:
+    - Name: Relative Rotation
+      Tooltip: Should the rotation be added to initial Gameobject rotation, or absolute
+      Type: 15
+      Value:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        Shader: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
     easing:
       Enabled: 1
       Curve:

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeDefinition.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeDefinition.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// Defines configuration properties and settings to use when initializing a class extending InteractableThemeBase
     /// </summary>
     [System.Serializable]
-    public struct ThemeDefinition
+    public struct ThemeDefinition : ISerializationCallbackReceiver
     {
         /// <summary>
         /// Defines the type of Theme to associate with this definition. Type must be a class that extends InteractableThemeBase
@@ -135,6 +135,34 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             return null;
+        }
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize()
+        {
+            //backward compatibility at runtime in case some custom properties have been added in code after first serialization
+            ThemeDefinition defaultDefinition = GetDefaultThemeDefinition(ThemeType).Value;
+
+            if (defaultDefinition.CustomProperties.Count > CustomProperties.Count)
+            {
+                //Debug.LogWarning($"{Name} Theme has inconsistent custom properties, consider forcing serialization. Fixing now by adding default custom properties.");
+                foreach (ThemeProperty prop in defaultDefinition.CustomProperties)
+                {
+                    if (!CustomProperties.Exists(p => p.Name == prop.Name))
+                    {
+                        CustomProperties.Add(new ThemeProperty()
+                        {
+                            Name = prop.Name,
+                            Tooltip = prop.Tooltip,
+                            Type = prop.Type,
+                            Value = prop.Value,
+                        });
+                    }
+                }
+            }
+        }
+
+        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        {
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeDefinition.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeDefinition.cs
@@ -137,6 +137,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return null;
         }
 
+        #region ISerializationCallbackReceiver implementation
+
+        ///<inheritdoc/>
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
             //backward compatibility at runtime in case some custom properties have been added in code after first serialization
@@ -144,7 +147,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (defaultDefinition.CustomProperties.Count > CustomProperties.Count)
             {
-                //Debug.LogWarning($"{Name} Theme has inconsistent custom properties, consider forcing serialization. Fixing now by adding default custom properties.");
                 foreach (ThemeProperty prop in defaultDefinition.CustomProperties)
                 {
                     if (!CustomProperties.Exists(p => p.Name == prop.Name))
@@ -161,8 +163,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
+        ///<inheritdoc/>
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
         }
+
+        #endregion
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeProperty.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeProperty.cs
@@ -4,16 +4,31 @@
 namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
-    /// A simple property with name value and type, used for serialization
+    /// A simple property with name, tooltip, value and type, used for serialization
     /// The custom settings are used in themes to expose properties needed to enhance theme functionality
     /// </summary>
 
     [System.Serializable]
     public class ThemeProperty
     {
+        /// <summary>
+        /// Dispalyed as Label in Inspector
+        /// </summary>
         public string Name;
+
+        /// <summary>
+        /// Tooltip associated with Name
+        /// </summary>
         public string Tooltip;
+
+        /// <summary>
+        /// inner type for that property
+        /// </summary>
         public ThemePropertyTypes Type;
+
+        /// <summary>
+        /// inner value, filled for corresponding Type
+        /// </summary>
         public ThemePropertyValue Value;
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeProperty.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/Core/ThemeProperty.cs
@@ -12,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class ThemeProperty
     {
         public string Name;
+        public string Tooltip;
         public ThemePropertyTypes Type;
         public ThemePropertyValue Value;
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableOffsetTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableOffsetTheme.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 {
     public class InteractableOffsetTheme : InteractableThemeBase
     {
-        private Vector3 startPosition;
+        private Vector3 originalPosition;
         private Transform hostTransform;
 
         public InteractableOffsetTheme()
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             base.Init(host, settings);
             hostTransform = Host.transform;
-            startPosition = hostTransform.localPosition;
+            originalPosition = hostTransform.localPosition;
         }
 
         /// <inheritdoc />
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);
+            hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, originalPosition + property.Values[index].Vector3, percentage);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
@@ -12,7 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableRotationTheme : InteractableThemeBase
     {
-        private Transform hostTransform;
+        protected Vector3 originalRotation;
+		protected Transform hostTransform;
 
         public InteractableRotationTheme()
         {
@@ -46,6 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             base.Init(host, settings);
 
             hostTransform = Host.transform;
+			originalRotation = hostTransform.localEulerAngles;
         }
 
         /// <inheritdoc />
@@ -59,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            hostTransform.localRotation = Quaternion.Euler( Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage));
+            hostTransform.localRotation = Quaternion.Euler( Vector3.Lerp(property.StartValue.Vector3, originalRotation + property.Values[index].Vector3, percentage));
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
@@ -37,7 +37,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         Default = new ThemePropertyValue() { Vector3 = Vector3.zero }
                     },
                 },
-                CustomProperties = new List<ThemeProperty>(),
+                CustomProperties = new List<ThemeProperty>()
+                {
+                    new ThemeProperty()
+                    {
+                        Name = "Relative Rotation",
+                        Type = ThemePropertyTypes.Bool,
+                        Value = new ThemePropertyValue() { Bool = false }
+                    },
+                },
             };
         }
 
@@ -61,7 +69,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            hostTransform.localRotation = Quaternion.Euler( Vector3.Lerp(property.StartValue.Vector3, originalRotation + property.Values[index].Vector3, percentage));
+            Vector3 lerpTarget = property.Values[index].Vector3;
+
+            bool relative = Properties[0].Value.Bool;
+            if (relative)
+            {
+                lerpTarget = originalRotation + lerpTarget;
+            }
+
+            hostTransform.localRotation = Quaternion.Euler(Vector3.Lerp(property.StartValue.Vector3, lerpTarget, percentage));
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableRotationTheme : InteractableThemeBase
     {
         protected Vector3 originalRotation;
-		protected Transform hostTransform;
+        protected Transform hostTransform;
 
         public InteractableRotationTheme()
         {
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             base.Init(host, settings);
 
             hostTransform = Host.transform;
-			originalRotation = hostTransform.localEulerAngles;
+            originalRotation = hostTransform.localEulerAngles;
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableRotationTheme.cs
@@ -42,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     new ThemeProperty()
                     {
                         Name = "Relative Rotation",
+                        Tooltip = "Should the rotation be added to initial Gameobject rotation, or absolute",
                         Type = ThemePropertyTypes.Bool,
                         Value = new ThemePropertyValue() { Bool = false }
                     },

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
@@ -37,7 +37,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         Default = new ThemePropertyValue() { Vector3 = Vector3.one}
                     },
                 },
-                CustomProperties = new List<ThemeProperty>(),
+                CustomProperties = new List<ThemeProperty>()
+                {
+                    new ThemeProperty()
+                    {
+                        Name = "Relative Scale",
+                        Type = ThemePropertyTypes.Bool,
+                        Value = new ThemePropertyValue() { Bool = false }
+                    },
+                },
             };
         }
 
@@ -61,7 +69,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(originalScale, property.Values[index].Vector3), percentage);
+            Vector3 lerpTarget = property.Values[index].Vector3;
+
+            bool relative = Properties[0].Value.Bool;
+            if (relative)
+            {
+                lerpTarget = Vector3.Scale(originalScale, lerpTarget);
+            }
+
+            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, lerpTarget, percentage);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
@@ -12,8 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableScaleTheme : InteractableThemeBase
     {
-        protected Vector3 startScale;
-        private Transform hostTransform;
+        protected Vector3 originalScale;
+        protected Transform hostTransform;
 
         public InteractableScaleTheme()
         {
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             base.Init(host, settings);
 
             hostTransform = Host.transform;
-            startScale = hostTransform.localScale;
+            originalScale = hostTransform.localScale;
         }
 
         /// <inheritdoc />
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(startScale, property.Values[index].Vector3), percentage);
+            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(originalScale, property.Values[index].Vector3), percentage);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
@@ -12,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableScaleTheme : InteractableThemeBase
     {
+        protected Vector3 startScale;
         private Transform hostTransform;
 
         public InteractableScaleTheme()
@@ -46,6 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             base.Init(host, settings);
 
             hostTransform = Host.transform;
+            startScale = hostTransform.localScale;
         }
 
         /// <inheritdoc />
@@ -59,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, property.Values[index].Vector3, percentage);
+            hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(startScale, property.Values[index].Vector3), percentage);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableScaleTheme.cs
@@ -42,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     new ThemeProperty()
                     {
                         Name = "Relative Scale",
+                        Tooltip = "Should the scale be relative to initial Gameobject scale, or absolute",
                         Type = ThemePropertyTypes.Bool,
                         Value = new ThemePropertyValue() { Bool = false }
                     },

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
@@ -154,6 +154,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 });
             }
 
+            Debug.Assert(GetDefaultThemeDefinition().StateProperties.Count == StateProperties.Count, $"{Name}  state properties inconsistency with default theme definition, consider reserializing.");
+            Debug.Assert(GetDefaultThemeDefinition().CustomProperties.Count == Properties.Count, $"{Name}  custom properties inconsistency with default theme definition, consider reserializing.");
+
             if (definition.Easing != null)
             {
                 Ease = definition.Easing.Copy();

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
@@ -148,6 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 this.Properties.Add(new ThemeProperty()
                 {
                     Name = prop.Name,
+                    Tooltip = prop.Tooltip,
                     Type = prop.Type,
                     Value = prop.Value,
                 });

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/ScaleOffsetColorTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/ScaleOffsetColorTheme.cs
@@ -16,8 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class ScaleOffsetColorTheme : InteractableColorTheme
     {
-        protected Vector3 startPosition;
-        protected Vector3 startScale;
+        protected Vector3 originalPosition;
+        protected Vector3 originalScale;
         protected Transform hostTransform;
 
         public ScaleOffsetColorTheme()
@@ -67,8 +67,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             base.Init(host, settings);
             hostTransform = Host.transform;
-            startPosition = hostTransform.localPosition;
-            startScale = hostTransform.localScale;
+            originalPosition = hostTransform.localPosition;
+            originalScale = hostTransform.localScale;
         }
 
         /// <inheritdoc />
@@ -99,10 +99,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             switch (property.Name)
             {
                 case "Scale":
-                    hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(startScale, property.Values[index].Vector3), percentage);
+                    hostTransform.localScale = Vector3.Lerp(property.StartValue.Vector3, Vector3.Scale(originalScale, property.Values[index].Vector3), percentage);
                     break;
                 case "Offset":
-                    hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, startPosition + property.Values[index].Vector3, percentage);
+                    hostTransform.localPosition = Vector3.Lerp(property.StartValue.Vector3, originalPosition + property.Values[index].Vector3, percentage);
                     break;
                 case "Color":
                     base.SetValue(property, index, percentage);

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
@@ -224,7 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                             SerializedProperty type = propertyItem.FindPropertyRelative("type");
                             SerializedProperty statePropertyValue = values.GetArrayElementAtIndex(n);
 
-                            RenderValue(statePropertyValue, name.stringValue, (ThemePropertyTypes)type.intValue);
+                            RenderValue(statePropertyValue, new GUIContent(name.stringValue, ""), (ThemePropertyTypes)type.intValue);
                         }
                     }
                 }
@@ -340,18 +340,19 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             {
                 SerializedProperty item = customProperties.GetArrayElementAtIndex(p);
                 SerializedProperty name = item.FindPropertyRelative("Name");
+                SerializedProperty tooltip = item.FindPropertyRelative("Tooltip");
                 SerializedProperty propType = item.FindPropertyRelative("Type");
                 SerializedProperty value = item.FindPropertyRelative("Value");
                 ThemePropertyTypes type = (ThemePropertyTypes)propType.intValue;
 
-                RenderValue(value, name.stringValue, type);
+                RenderValue(value, new GUIContent(name.stringValue, tooltip?.stringValue), type);
             }
         }
 
         /// <summary>
         /// Render a single property value
         /// </summary>
-        public static void RenderValue(SerializedProperty item, string name, ThemePropertyTypes type)
+        public static void RenderValue(SerializedProperty item, GUIContent label, ThemePropertyTypes type)
         {
             SerializedProperty floatValue = item.FindPropertyRelative("Float");
             SerializedProperty vector2Value = item.FindPropertyRelative("Vector2");
@@ -360,72 +361,72 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             switch (type)
             {
                 case ThemePropertyTypes.Float:
-                    floatValue.floatValue = EditorGUILayout.FloatField(name, floatValue.floatValue);
+                    floatValue.floatValue = EditorGUILayout.FloatField(label, floatValue.floatValue);
                     break;
                 case ThemePropertyTypes.Int:
                     SerializedProperty intValue = item.FindPropertyRelative("Int");
-                    intValue.intValue = EditorGUILayout.IntField(name, intValue.intValue);
+                    intValue.intValue = EditorGUILayout.IntField(label, intValue.intValue);
                     break;
                 case ThemePropertyTypes.Color:
                     SerializedProperty colorValue = item.FindPropertyRelative("Color");
-                    colorValue.colorValue = EditorGUILayout.ColorField(name, colorValue.colorValue);
+                    colorValue.colorValue = EditorGUILayout.ColorField(label, colorValue.colorValue);
                     break;
                 case ThemePropertyTypes.ShaderFloat:
-                    floatValue.floatValue = EditorGUILayout.FloatField(name, floatValue.floatValue);
+                    floatValue.floatValue = EditorGUILayout.FloatField(label, floatValue.floatValue);
                     break;
                 case ThemePropertyTypes.ShaderRange:
-                    vector2Value.vector2Value = EditorGUILayout.Vector2Field(name, vector2Value.vector2Value);
+                    vector2Value.vector2Value = EditorGUILayout.Vector2Field(label, vector2Value.vector2Value);
                     break;
                 case ThemePropertyTypes.Vector2:
-                    vector2Value.vector2Value = EditorGUILayout.Vector2Field(name, vector2Value.vector2Value);
+                    vector2Value.vector2Value = EditorGUILayout.Vector2Field(label, vector2Value.vector2Value);
                     break;
                 case ThemePropertyTypes.Vector3:
                     SerializedProperty vector3Value = item.FindPropertyRelative("Vector3");
-                    vector3Value.vector3Value = EditorGUILayout.Vector3Field(name, vector3Value.vector3Value);
+                    vector3Value.vector3Value = EditorGUILayout.Vector3Field(label, vector3Value.vector3Value);
                     break;
                 case ThemePropertyTypes.Vector4:
                     SerializedProperty vector4Value = item.FindPropertyRelative("Vector4");
-                    vector4Value.vector4Value = EditorGUILayout.Vector4Field(name, vector4Value.vector4Value);
+                    vector4Value.vector4Value = EditorGUILayout.Vector4Field(label, vector4Value.vector4Value);
                     break;
                 case ThemePropertyTypes.Quaternion:
                     SerializedProperty quaternionValue = item.FindPropertyRelative("Quaternion");
                     Vector4 vect4 = new Vector4(quaternionValue.quaternionValue.x, quaternionValue.quaternionValue.y, quaternionValue.quaternionValue.z, quaternionValue.quaternionValue.w);
-                    vect4 = EditorGUILayout.Vector4Field(name, vect4);
+                    vect4 = EditorGUILayout.Vector4Field(label, vect4);
                     quaternionValue.quaternionValue = new Quaternion(vect4.x, vect4.y, vect4.z, vect4.w);
                     break;
                 case ThemePropertyTypes.Texture:
                     SerializedProperty texture = item.FindPropertyRelative("Texture");
-                    EditorGUILayout.PropertyField(texture, new GUIContent(name, ""), false);
+                    EditorGUILayout.PropertyField(texture, label, false);
                     break;
                 case ThemePropertyTypes.Material:
                     SerializedProperty material = item.FindPropertyRelative("Material");
-                    EditorGUILayout.PropertyField(material, new GUIContent(name, ""), false);
+                    EditorGUILayout.PropertyField(material, label, false);
                     break;
                 case ThemePropertyTypes.AudioClip:
                     SerializedProperty audio = item.FindPropertyRelative("AudioClip");
-                    EditorGUILayout.PropertyField(audio, new GUIContent(name, ""), false);
+                    EditorGUILayout.PropertyField(audio, label, false);
                     break;
                 case ThemePropertyTypes.Animaiton:
                     SerializedProperty animation = item.FindPropertyRelative("Animation");
-                    EditorGUILayout.PropertyField(animation, new GUIContent(name, ""), false);
+                    EditorGUILayout.PropertyField(animation, label, false);
                     break;
                 case ThemePropertyTypes.GameObject:
                     SerializedProperty gameObjectValue = item.FindPropertyRelative("GameObject");
-                    EditorGUILayout.PropertyField(gameObjectValue, new GUIContent(name, ""), false);
+                    EditorGUILayout.PropertyField(gameObjectValue, label, false);
                     break;
                 case ThemePropertyTypes.String:
-                    stringValue.stringValue = EditorGUILayout.TextField(name, stringValue.stringValue);
+                    stringValue.stringValue = EditorGUILayout.TextField(label, stringValue.stringValue);
                     break;
                 case ThemePropertyTypes.Bool:
                     SerializedProperty boolValue = item.FindPropertyRelative("Bool");
-                    boolValue.boolValue = EditorGUILayout.Toggle(name, boolValue.boolValue);
+                    boolValue.boolValue = EditorGUILayout.Toggle(label, boolValue.boolValue);
                     break;
                 case ThemePropertyTypes.AnimatorTrigger:
-                    stringValue.stringValue = EditorGUILayout.TextField(name, stringValue.stringValue);
+                    stringValue.stringValue = EditorGUILayout.TextField(label, stringValue.stringValue);
                     break;
                 case ThemePropertyTypes.Shader:
                     SerializedProperty shaderObjectValue = item.FindPropertyRelative("Shader");
-                    EditorGUILayout.PropertyField(shaderObjectValue, new GUIContent(name, ""), false);
+                    EditorGUILayout.PropertyField(shaderObjectValue, label, false);
                     break;
                 default:
                     break;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// tests that the rotation theme with "Relative Rotation" custom property keeps the initial rotation of target gameobject
+        /// Tests that the rotation theme with "Relative Rotation" custom property keeps the initial rotation of target GameObject.
         /// </summary>
         [UnityTest]
         public IEnumerator TestRelativeRotationTheme()

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
@@ -126,6 +126,41 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
+        public IEnumerator TestRelativeRotationTheme()
+        {
+            GameObject host = new GameObject();
+            Vector3 hostInitialRotation = new Vector3(42f, 130f, 12.5f);
+            host.transform.localEulerAngles = hostInitialRotation;
+
+            Vector3 state0 = Quaternion.LookRotation(Vector3.up).eulerAngles;
+            Vector3 state1 = Quaternion.LookRotation(Vector3.down).eulerAngles;
+
+            Vector3 expectedState0 = new Vector3(hostInitialRotation.x + state0.x, hostInitialRotation.y + state0.y, hostInitialRotation.z + state0.z);
+            Vector3 expectedState1 = new Vector3(hostInitialRotation.x + state1.x, hostInitialRotation.y + state1.y, hostInitialRotation.z + state1.z);
+
+            var defaultStateValues = new List<List<ThemePropertyValue>>()
+            {
+                new List<ThemePropertyValue>()
+                {
+                    new ThemePropertyValue() { Vector3 = state0 },
+                    new ThemePropertyValue() { Vector3 = state1 },
+                }
+            };
+
+            List<ThemeProperty> defaultCustomProperties = new List<ThemeProperty>()
+            {
+                new ThemeProperty()
+                {
+                    Value = new ThemePropertyValue() { Bool = true },
+                }
+            };
+
+            yield return TestTheme<InteractableRotationTheme, MeshRenderer>(host, defaultStateValues, defaultCustomProperties,
+                  (theme) => { Assert.IsTrue(AreEulerEquals(expectedState0, theme.Host.transform.rotation.eulerAngles)); },
+                  (theme) => { Assert.IsTrue(AreEulerEquals(expectedState1, theme.Host.transform.rotation.eulerAngles)); });
+        }
+
+        [UnityTest]
         public IEnumerator TestScaleTheme()
         {
             Vector3 state0 = Vector3.one * 4.0f;
@@ -143,6 +178,42 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return TestTheme<InteractableScaleTheme, MeshRenderer>(defaultStateValues,
                 (theme) => { Assert.AreEqual(state0, theme.Host.transform.localScale); },
                 (theme) => { Assert.AreEqual(state1, theme.Host.transform.localScale); });
+        }
+
+        [UnityTest]
+        public IEnumerator TestRelativeScaleTheme()
+        {
+            GameObject host = new GameObject();
+            Vector3 hostInitialScale = new Vector3(1f, 3f, 0.5f);
+            host.transform.localScale = hostInitialScale;
+
+            Vector3 state0 = Vector3.one * 4.0f;
+            Vector3 state1 = Vector3.one;
+
+            Vector3 expectedState0 = new Vector3(hostInitialScale.x * state0.x, hostInitialScale.y * state0.y, hostInitialScale.z * state0.z);
+            Vector3 expectedState1 = new Vector3(hostInitialScale.x * state1.x, hostInitialScale.y * state1.y, hostInitialScale.z * state1.z);
+
+
+            var defaultStateValues = new List<List<ThemePropertyValue>>()
+            {
+                new List<ThemePropertyValue>()
+                {
+                    new ThemePropertyValue() { Vector3 = state0 },
+                    new ThemePropertyValue() { Vector3 = state1 },
+                }
+            };
+
+            List<ThemeProperty> defaultCustomProperties = new List<ThemeProperty>()
+            {
+                new ThemeProperty()
+                {
+                    Value = new ThemePropertyValue() { Bool = true },
+                }
+            };
+
+            yield return TestTheme<InteractableScaleTheme, MeshRenderer>(host, defaultStateValues, defaultCustomProperties,
+                (theme) => { Assert.AreEqual(expectedState0, theme.Host.transform.localScale); },
+                (theme) => { Assert.AreEqual(expectedState1, theme.Host.transform.localScale); });
         }
 
         [UnityTest]
@@ -320,7 +391,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             where T : InteractableThemeBase
             where C : UnityEngine.Component
         {
-            yield return TestTheme<T,C>(new GameObject("TestObject"), stateValues, stateTests);
+            yield return TestTheme<T, C>(new GameObject("TestObject"), stateValues, new List<ThemeProperty>() { }, stateTests);
+        }
+
+        private IEnumerator TestTheme<T, C>(
+            List<List<ThemePropertyValue>> stateValues,
+            List<ThemeProperty> customProperties,
+            params Action<InteractableThemeBase>[] stateTests)
+            where T : InteractableThemeBase
+            where C : UnityEngine.Component
+        {
+            yield return TestTheme<T, C>(new GameObject("TestObject"), stateValues, customProperties, stateTests);
         }
 
         private IEnumerator TestTheme<T, C>(
@@ -330,7 +411,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             where T : InteractableThemeBase
             where C : UnityEngine.Component
         {
-            foreach (var values in stateValues)
+            yield return TestTheme<T, C>(host, stateValues, new List<ThemeProperty>() { }, stateTests);
+        }
+
+        private IEnumerator TestTheme<T, C>(
+            GameObject host,
+            List<List<ThemePropertyValue>> stateValues,
+            List<ThemeProperty> customProperties,
+            params Action<InteractableThemeBase>[] stateTests)
+            where T : InteractableThemeBase
+            where C : UnityEngine.Component
+        {
+            foreach (List<ThemePropertyValue> values in stateValues)
             {
                 Assert.AreEqual(values.Count, stateTests.Length);
             }
@@ -339,6 +431,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             for (int i = 0; i < stateValues.Count; i++)
             {
                 themeDefinition.StateProperties[i].Values = stateValues[i];
+            }
+
+            for (int i = 0; i < customProperties.Count; i++)
+            {
+                themeDefinition.CustomProperties[i] = customProperties[i];
             }
 
             yield return TestTheme<C>(host, themeDefinition, stateTests);
@@ -384,6 +481,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             yield return TestTheme<T, AudioSource>(targetHost, stateValues,convertedStateTests);
+        }
+
+        private bool AreEulerEquals(Vector3 eulerA, Vector3 eulerB)
+        {
+            return Mathf.Abs(Quaternion.Angle(Quaternion.Euler(eulerA), Quaternion.Euler(eulerB))) < Mathf.Epsilon;
         }
 
         #endregion

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// tests that the scale theme with "Relative Scale" custom property also take into account the initial scale of target gameobject
+        /// Tests that the scale theme with "Relative Scale" custom property also takes into account the initial scale of target GameObject.
         /// </summary>
         [UnityTest]
         public IEnumerator TestRelativeScaleTheme()

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
@@ -125,6 +125,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 (theme) => { Assert.AreEqual(state1, theme.Host.transform.rotation.eulerAngles); });
         }
 
+        /// <summary>
+        /// tests that the rotation theme with "Relative Rotation" custom property keeps the initial rotation of target gameobject
+        /// </summary>
         [UnityTest]
         public IEnumerator TestRelativeRotationTheme()
         {
@@ -135,8 +138,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 state0 = Quaternion.LookRotation(Vector3.up).eulerAngles;
             Vector3 state1 = Quaternion.LookRotation(Vector3.down).eulerAngles;
 
-            Vector3 expectedState0 = new Vector3(hostInitialRotation.x + state0.x, hostInitialRotation.y + state0.y, hostInitialRotation.z + state0.z);
-            Vector3 expectedState1 = new Vector3(hostInitialRotation.x + state1.x, hostInitialRotation.y + state1.y, hostInitialRotation.z + state1.z);
+            Vector3 expectedState0 = hostInitialRotation + state0;
+            Vector3 expectedState1 = hostInitialRotation + state1;
 
             var defaultStateValues = new List<List<ThemePropertyValue>>()
             {
@@ -180,6 +183,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 (theme) => { Assert.AreEqual(state1, theme.Host.transform.localScale); });
         }
 
+        /// <summary>
+        /// tests that the scale theme with "Relative Scale" custom property also take into account the initial scale of target gameobject
+        /// </summary>
         [UnityTest]
         public IEnumerator TestRelativeScaleTheme()
         {
@@ -190,9 +196,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 state0 = Vector3.one * 4.0f;
             Vector3 state1 = Vector3.one;
 
-            Vector3 expectedState0 = new Vector3(hostInitialScale.x * state0.x, hostInitialScale.y * state0.y, hostInitialScale.z * state0.z);
-            Vector3 expectedState1 = new Vector3(hostInitialScale.x * state1.x, hostInitialScale.y * state1.y, hostInitialScale.z * state1.z);
-
+            Vector3 expectedState0 = Vector3.Scale(hostInitialScale, state0);
+            Vector3 expectedState1 = Vector3.Scale(hostInitialScale, state1);
 
             var defaultStateValues = new List<List<ThemePropertyValue>>()
             {

--- a/Assets/MixedRealityToolkit.Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
+++ b/Assets/MixedRealityToolkit.Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
@@ -27,6 +28,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             var array = GetAssets("t:Material t:Texture");
             AssetDatabase.ForceReserializeAssets(array);
+        }
+
+        [MenuItem("Assets/Mixed Reality Toolkit/Reserialize Selection")]
+        public static void ReserializeSelection()
+        {
+            Object[] selectedAssets = Selection.GetFiltered(typeof(Object), SelectionMode.DeepAssets);
+
+            //transform asset object to asset paths
+            List<string> assetsPath = new List<string>();
+            foreach (Object asset in selectedAssets)
+            {
+                assetsPath.Add(AssetDatabase.GetAssetPath(asset));
+            }
+
+            string[] array = assetsPath.ToArray();
+            AssetDatabase.ForceReserializeAssets(array);
+            Debug.Log($"Reserialized {assetsPath.Count} assets.");
         }
 
         private static string[] GetAssets(string filter)

--- a/Assets/MixedRealityToolkit.Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
+++ b/Assets/MixedRealityToolkit.Tools/ReserializeAssetsUtility/ReserializeAssetsUtility.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             Object[] selectedAssets = Selection.GetFiltered(typeof(Object), SelectionMode.DeepAssets);
 
-            //transform asset object to asset paths
+            // Transform asset object to asset paths.
             List<string> assetsPath = new List<string>();
             foreach (Object asset in selectedAssets)
             {


### PR DESCRIPTION
## Overview
Make scale theme consistent with other themes by having a scale relative to initial object scale and not absolute.

## Changes
- Fixes: #6459


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
