### PR TITLE
Update to InteractableToggleCollection - Fix for 6274

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -13,6 +13,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class InteractableToggleCollection : MonoBehaviour
     {
         [Tooltip("Array of Interactables that will be managed by this controller")]
+        /// <summary>
+        /// Array of Interactables that will be managed by this controller
+        /// </summary>
         public Interactable[] ToggleList;
 
 
@@ -76,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 currentIndex = index;
 
-                UpdateToggleVisual(index);
+                OnSelection(index);
             }
 
             if (fireOnClick)
@@ -87,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         // Update the visual appearance and set the states of the selected and unselected toggles within 
         // Interactable
-        protected virtual void UpdateToggleVisual(int index)
+        protected virtual void OnSelection(int index, bool force = false)
         {
             int length = ToggleList.Length;
             for (int i = 0; i < length; ++i)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -11,70 +12,94 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     public class InteractableToggleCollection : MonoBehaviour
     {
-        [Tooltip("Interactables that will be managed by this controller")]
+        [Tooltip("Array of Interactables that will be managed by this controller")]
         public Interactable[] ToggleList;
 
-        [Tooltip("Currently selected index or default starting index")]
-        public int CurrentIndex;
 
-        [Tooltip("exposed selection changed event")]
-        public UnityEvent OnSelectionEvents;
+        [Tooltip("Currently selected index in the ToggleList, default is 0")]
+        [SerializeField]
+        private int currentIndex;
+
+        /// <summary>
+        /// The current index in the array of interactable toggles
+        /// </summary>
+        public int CurrentIndex
+        {
+            get
+            {
+                return currentIndex;
+            }
+            set
+            {
+                SetSelection(value, false, true);
+            }
+        }
+
+        [Tooltip("This event is triggered when any of the toggles in the ToggleList are selected")]
+        public UnityEvent OnSelectionEvents = new UnityEvent();
 
         private void Start()
         {
-            for (int i = 0; i < ToggleList.Length; ++i)
+            if (ToggleList != null)
             {
-                int itemIndex = i;
-                // add selection event handler to each button
-                ToggleList[i].OnClick.AddListener(() => OnSelection(itemIndex));
-                ToggleList[i].CanDeselect = false;
+                // Add listeners to each toggle in ToggleList
+                for (int i = 0; i < ToggleList.Length; ++i)
+                {
+                    int itemIndex = i;
+                    ToggleList[i].OnClick.AddListener(() => SetSelection(itemIndex, true, false));
+                    ToggleList[i].CanDeselect = false;
+                }
+
+                SetSelection(CurrentIndex, true, true);
             }
-
-            OnSelection(CurrentIndex, true);
-        }
-
-        private void OnEnable()
-        {
-            OnSelection(CurrentIndex, true);
         }
 
         /// <summary>
-        /// Sets the selected index and selected Interactive
+        /// Set the selection of a an element in the toggle collection based on index.
+        /// <param name="index">Index of an element in ToggleList</param>
+        /// <param name="force">Force update currentIndex</param>
+        /// <param name="fireOnClick">The manual trigger of the OnClick event. OnClick event is manually triggered 
+        /// when the CurrentIndex is updated via script or inspector</param>
         /// </summary>
-        public void SetSelection(int index)
+        public void SetSelection(int index, bool force = false, bool fireOnClick = false)
         {
-            if (!isActiveAndEnabled ||
-                (index < 0 || ToggleList.Length <= index))
+            if (index < 0 || ToggleList.Length <= index)
             {
+                Debug.LogWarning("Index out of range of ToggleList: " + index);
                 return;
             }
 
-            OnSelection(index, true);
+            if (CurrentIndex != index || force)
+            {
+                currentIndex = index;
+
+                UpdateToggleVisual(index);
+            }
+
+            if (fireOnClick)
+            {
+                ToggleList[index].TriggerOnClick();
+            }
         }
 
-        /// <summary>
-        /// Set the toggle state of each button based on the selected item
-        /// </summary>
-        protected virtual void OnSelection(int index, bool force = false)
+        // Update the visual appearance and set the states of the selected and unselected toggles within 
+        // Interactable
+        protected virtual void UpdateToggleVisual(int index)
         {
-            for (int i = 0; i < ToggleList.Length; ++i)
+            int length = ToggleList.Length;
+            for (int i = 0; i < length; ++i)
             {
                 if (i != index)
                 {
                     ToggleList[i].IsToggled = false;
                 }
+                else
+                {
+                    ToggleList[i].IsToggled = true;
+                }
             }
 
-            CurrentIndex = index;
-
-            if (force)
-            {
-                ToggleList[index].IsToggled = true;
-            }
-            else
-            {
-                OnSelectionEvents.Invoke();
-            }
+            OnSelectionEvents.Invoke();
         }
 
         private void OnDestroy()
@@ -82,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             for (int i = 0; i < ToggleList.Length; ++i)
             {
                 int itemIndex = i;
-                ToggleList[i].OnClick.RemoveListener(() => OnSelection(itemIndex));
+                ToggleList[i].OnClick.RemoveListener(() => SetSelection(itemIndex, true, false));
             }
         }
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -36,6 +36,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [Tooltip("This event is triggered when any of the toggles in the ToggleList are selected")]
+        /// <summary>
+        /// This event is triggered when any of the toggles in the ToggleList are selected
+        /// </summary>
         public UnityEvent OnSelectionEvents = new UnityEvent();
 
         private void Start()

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableToggleCollectionInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableToggleCollectionInspector.cs
@@ -13,7 +13,10 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.UI.Editor
 {
     [CustomEditor(typeof(InteractableToggleCollection))]
-    public class InteractableToggleCollectionInspector : UnityEditor.Editor
+    /// <summary>
+    /// Custom inspector for InteractableToggleCollection
+    /// </summary>
+    internal class InteractableToggleCollectionInspector : UnityEditor.Editor
     {
         protected InteractableToggleCollection instance;
 
@@ -26,25 +29,18 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         {
             base.OnInspectorGUI();
 
-            if (Application.isPlaying)
+            if (Application.isPlaying && instance != null && GUI.changed)
             {
-                if (instance != null)
+                int index = instance.CurrentIndex;
+                if (index >= instance.ToggleList.Length || index < 0)
                 {
-                    if (GUI.changed)
-                    {
-                        if (instance.CurrentIndex <= instance.ToggleList.Length)
-                        {
-                            instance.SetSelection(instance.CurrentIndex, false, true);
-                        }
-                        else
-                        {
-                            Debug.LogError("Index out of range");
-                        }
-
-                    }
+                    Debug.Log("Index out of range: " + index);
                 }
+                else
+                {
+                    instance.SetSelection(instance.CurrentIndex, true, true);
+                }  
             }
         }
-
     }
 }

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableToggleCollectionInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableToggleCollectionInspector.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.UI.Editor
+{
+    [CustomEditor(typeof(InteractableToggleCollection))]
+    public class InteractableToggleCollectionInspector : UnityEditor.Editor
+    {
+        protected InteractableToggleCollection instance;
+
+        protected virtual void OnEnable()
+        {
+            instance = (InteractableToggleCollection)target;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            if (Application.isPlaying)
+            {
+                if (instance != null)
+                {
+                    if (GUI.changed)
+                    {
+                        if (instance.CurrentIndex <= instance.ToggleList.Length)
+                        {
+                            instance.SetSelection(instance.CurrentIndex, false, true);
+                        }
+                        else
+                        {
+                            Debug.LogError("Index out of range");
+                        }
+
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string RadialSetPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab";
         private const string PressableHoloLens2TogglePrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Toggle.prefab";
         private const string RadialPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Radial.prefab";
-        private const string ToggleSwitchPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/ToggleSwitch.prefab";
 
         private readonly Color DefaultColor = Color.blue;
         private readonly Color FocusColor = Color.yellow;
@@ -647,12 +646,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             int[] onClickEventCalled = new int[numRadials];
 
-            int index = 0;
-            foreach (var radial in toggleList)
+            // Add listener to each toggle in the toggle collection
+            for (int i = 0; i < toggleList.Length; i++)
             {
-                int indexRadial = index;
-                radial.OnClick.AddListener(() => { onClickEventCalled[indexRadial] = 1; });
-                index++;
+                int indexClick = i;
+                toggleList[i].OnClick.AddListener(() => { onClickEventCalled[indexClick] = 1; });
             }
 
             for (int j = 0; j < numRadials; j++)
@@ -663,17 +661,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 // If the CurrentIndex is changed the toggle should be visually updated and events should be triggered
                 for (int i = 0; i < numRadials; i++)
                 {
-                    if (i == interactableToggleCollection.CurrentIndex)
-                    {
-                        Assert.True(interactableToggleCollection.ToggleList[i].IsToggled);
+                    bool shouldBeSelected = (i == interactableToggleCollection.CurrentIndex);
+                    Assert.AreEqual(shouldBeSelected, interactableToggleCollection.ToggleList[i].IsToggled);
 
-                        // Make sure OnClick event is called on index update
-                        Assert.True(onClickEventCalled[i] == 1);
-                    }
-                    else
-                    {
-                        Assert.False(interactableToggleCollection.ToggleList[i].IsToggled);
-                    }
+                    int expectedClickCount = (i <= j ? 1 : 0);
+                    Assert.AreEqual(onClickEventCalled[i], expectedClickCount);
                 }
             }
 


### PR DESCRIPTION
## Overview

Fix for issue #6274 

Changing the CurrentIndex property in InteractableToggleCollection via script or the inspector did not update toggle states within the group.  

The changes added get/set methods to the CurrentIndex property and updated SetSelection to trigger an OnClick event. 

## InteractableToggleCollection Behavior BEFORE 
![BeforeITCRefactor](https://user-images.githubusercontent.com/53493796/68235292-d8a06880-ffb7-11e9-9444-07e8c3fcab8a.gif)

## InteractableToggleCollection Behavior AFTER 
![AfterITCRefactor](https://user-images.githubusercontent.com/53493796/68235326-eb1aa200-ffb7-11e9-9d34-f5c4d37ef4fb.gif)

## Changes
- Added custom inspector for InteractableToggleCollection
- Updated InteractableToggleCollection.cs
- Added Test for the changes in InteractableTests

## Verification
- pull the changes
- open unity project
- add MRTK to the unity project
- add the RadialSet prefab
- press play and change the index in the InteractableToggleCollection, the toggle should be updated to match the index input

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
