### PR TITLE
Fingertip cursor translation/alignment

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -231,7 +231,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // not translate to the finger pad if the user is poking with a horizontal finger
             float fingerSurfaceDot = Vector3.Dot(tipNormal, -surfaceNormal);
 
-            // Lerping an agular measurement from 0 degrees (default cursor position at tip of finger) to
+            // Lerping an angular measurement from 0 degrees (default cursor position at tip of finger) to
             // 90 degrees (a new position on the fingertip pad) around the fingertip's X axis.
             Quaternion degreesRelative = Quaternion.AngleAxis((1f - t) * 90f * (1f - fingerSurfaceDot), indexFingerRingRenderer.transform.right);
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -97,6 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             nearPointer.TryGetNormalToNearestSurface(out surfaceNormal))
                         {
                             RotateToSurfaceNormal(indexFingerRingRenderer.transform, surfaceNormal, indexFingerRotation, distance);
+                            TranslateFromTipToPad(indexFingerRingRenderer.transform, indexFingerPosition, indexKnucklePosition, distance);
                         }
                         else
                         {
@@ -216,6 +217,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
             var t = distance / alignWithSurfaceDistance;
             var targetRotation = Quaternion.LookRotation(-surfaceNormal);
             target.rotation = Quaternion.Slerp(targetRotation, pointerRotation, t);
+        }
+
+        private void TranslateFromTipToPad(Transform target, Vector3 fingerPosition, Vector3 knucklePosition, float distance)
+        {
+            var t = distance / alignWithSurfaceDistance;
+            Vector3 tipPosition = fingerPosition + (fingerPosition - knucklePosition).normalized * skinSurfaceOffset;
+            Vector3 tipOffset = tipPosition - fingerPosition;
+
+            // Lerping an agular measurement from 0 degrees (default cursor position at tip of finger) to
+            // 90 degrees (a new position on the fingertip pad) around the fingertip's X axis.
+            Quaternion degreesRelative = Quaternion.AngleAxis((1f - t) * 90f, indexFingerRingRenderer.transform.right);
+
+            Vector3 tipToPadPosition = fingerPosition + degreesRelative * tipOffset;
+            indexFingerRingRenderer.transform.position = tipToPadPosition;
         }
     }
 }


### PR DESCRIPTION
## Overview

Currently, the fingertip cursor rotates to a target surface orientation while approaching touchable UI. It does not translate and is stationary at a location slightly above the fingertip. This only partially matches shell behavior. In the shell, the cursor rotates and translates to the pad of the fingertip while approaching UI. The amount it translates is relative to the perpendicularity of the fingertip's direction and the normal of the surface. 

Contained in this PR is functionality that translates the fingertip cursor in relation to touchable UI. See below for behavior comparison:

| Current behavior | Suggested behavior |
| ------------- | ------------- |
| ![FingertipCursorPre_Trim](https://user-images.githubusercontent.com/16657884/68256793-e5d44c00-ffe5-11e9-9b66-572f675e8edd.gif)  | ![FingertipCursorPost_Trim](https://user-images.githubusercontent.com/16657884/68256795-e836a600-ffe5-11e9-9aab-ea5ae5687417.gif)  |

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6478
