### PR TITLE
Remove extraneous Debug.Log messages

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -114,7 +114,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// </summary>
         public void OnProcessScene(Scene scene, BuildReport report)
         {
-            Debug.Log("Processing scene on build");
             RefreshSceneInfoFieldsInScene(scene);
         }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
@@ -127,9 +127,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private static void ApplyARFoundationUWPCompileFix()
         {
 #if !UNITY_2019_1_OR_NEWER
-
-            Debug.Log("Checking to see if the AR Foundation, UWP, .NET backend workaround needs to be applied.");
-
             bool reloadLocked = EditorAssemblyReloadManager.LockReloadAssemblies;
             if (reloadLocked)
             {
@@ -173,10 +170,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     {
                         asmDef.Save(arFoundation.FullName);
                     }
-                    else
-                    {
-                        Debug.Log($"No changes required for {arFoundation.FullName}.");
-                    }
                 }
 
                 FileInfo arSubsystems = GetPackageCacheAssemblyDefinitionFile(
@@ -209,10 +202,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     if (changed)
                     {
                         asmDef.Save(arSubsystems.FullName);
-                    }
-                    else
-                    {
-                        Debug.Log($"No changes required for {arSubsystems.FullName}.");
                     }
                 }
             }


### PR DESCRIPTION
## Overview
Removes some `Debug.Log` messages when nothing actually changed. All of these have logs for when things change or fail to change, but not when the "regular" path is taken.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6468