### PR TITLE
Update unsafe code build tool to only run when contextually relevant

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -382,14 +382,21 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                             UwpBuildDeployPreferences.ResearchModeCapabilityEnabled = newResearchModeCapabilityEnabled;
                         }
 
-                        // Allow unsafe code
-                        bool curAllowUnsafeCode = UwpBuildDeployPreferences.AllowUnsafeCode;
-                        bool newAllowUnsafeCode = EditorGUILayout.ToggleLeft(allowUnsafeCode, curAllowUnsafeCode);
-
-                        if (newAllowUnsafeCode != curAllowUnsafeCode)
+#if !UNITY_2019_1_OR_NEWER
+                        // To prevent potential confusion, only show this when C# projects will be generated
+                        if (EditorUserBuildSettings.wsaGenerateReferenceProjects &&
+                            PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA) == ScriptingImplementation.WinRTDotNET)
                         {
-                            UwpBuildDeployPreferences.AllowUnsafeCode = newAllowUnsafeCode;
+                            // Allow unsafe code
+                            bool curAllowUnsafeCode = UwpBuildDeployPreferences.AllowUnsafeCode;
+                            bool newAllowUnsafeCode = EditorGUILayout.ToggleLeft(allowUnsafeCode, curAllowUnsafeCode);
+
+                            if (newAllowUnsafeCode != curAllowUnsafeCode)
+                            {
+                                UwpBuildDeployPreferences.AllowUnsafeCode = newAllowUnsafeCode;
+                            }
                         }
+#endif // !UNITY_2019_1_OR_NEWER
                     }
 
                     GUILayout.FlexibleSpace();

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -335,8 +335,17 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// Updates 'Assembly-CSharp.csproj' file according to the values set in buildInfo.
         /// </summary>
         /// <param name="buildInfo">An IBuildInfo containing a valid OutputDirectory</param>
+        /// <remarks>Only used with the .NET backend in Unity 2018 or older, with Unity C# Projects enabled.</remarks>
         public static void UpdateAssemblyCSharpProject(IBuildInfo buildInfo)
         {
+#if !UNITY_2019_1_OR_NEWER
+            if (!EditorUserBuildSettings.wsaGenerateReferenceProjects ||
+                PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA) != ScriptingImplementation.WinRTDotNET)
+            {
+                // Assembly-CSharp.csproj is only generated when the above is true
+                return;
+            }
+
             string projectFilePath = GetAssemblyCSharpProjectFilePath(buildInfo);
             if (projectFilePath == null)
             {
@@ -347,16 +356,13 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var uwpBuildInfo = buildInfo as UwpBuildInfo;
             Debug.Assert(uwpBuildInfo != null);
 
-            if (
-#if !UNITY_2019_1_OR_NEWER
-            EditorUserBuildSettings.wsaGenerateReferenceProjects &&
-#endif
-            uwpBuildInfo.AllowUnsafeCode)
+            if (uwpBuildInfo.AllowUnsafeCode)
             {
                 AllowUnsafeCode(rootElement);
             }
 
             rootElement.Save(projectFilePath);
+#endif // !UNITY_2019_1_OR_NEWER
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -122,8 +122,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         }
 
         /// <summary>
-        /// If true, the appx will be build with multicore support enabled in the
-        /// msbuild process.
+        /// If true, the appx will be built with multicore support enabled in the
+        /// MSBuild process.
         /// </summary>
         public static bool MulticoreAppxBuildEnabled
         {

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -86,14 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     var uwpBuildInfo = innerBuildInfo as UwpBuildInfo;
                     Debug.Assert(uwpBuildInfo != null);
                     UwpAppxBuildTools.AddCapabilities(uwpBuildInfo);
-
-#if !UNITY_2019_1_OR_NEWER
-                    if (EditorUserBuildSettings.wsaGenerateReferenceProjects &&
-                        PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA) == ScriptingImplementation.WinRTDotNET)
-                    {
-                        UwpAppxBuildTools.UpdateAssemblyCSharpProject(uwpBuildInfo);
-                    }
-#endif //!UNITY_2019_1_OR_NEWER
+                    UwpAppxBuildTools.UpdateAssemblyCSharpProject(uwpBuildInfo);
 
                     if (showDialog &&
                         !EditorUtility.DisplayDialog(PlayerSettings.productName, "Build Complete", "OK", "Build AppX"))

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpPlayerBuildTools.cs
@@ -86,7 +86,14 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     var uwpBuildInfo = innerBuildInfo as UwpBuildInfo;
                     Debug.Assert(uwpBuildInfo != null);
                     UwpAppxBuildTools.AddCapabilities(uwpBuildInfo);
-                    UwpAppxBuildTools.UpdateAssemblyCSharpProject(uwpBuildInfo);
+
+#if !UNITY_2019_1_OR_NEWER
+                    if (EditorUserBuildSettings.wsaGenerateReferenceProjects &&
+                        PlayerSettings.GetScriptingBackend(BuildTargetGroup.WSA) == ScriptingImplementation.WinRTDotNET)
+                    {
+                        UwpAppxBuildTools.UpdateAssemblyCSharpProject(uwpBuildInfo);
+                    }
+#endif //!UNITY_2019_1_OR_NEWER
 
                     if (showDialog &&
                         !EditorUtility.DisplayDialog(PlayerSettings.productName, "Build Complete", "OK", "Build AppX"))

--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
@@ -243,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// Gets the assembly definition file that best matches the folder name pattern and the file names.
         /// </summary>
         /// <param name="root"><see href="https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo"/>DirectoryInfo</see> that describes the package cache root folder.</param>
-        /// <param name="folderName">The name of the folder in which to find the requested file. A wildcard ('*') can be specifid to match a partial name.</param>
+        /// <param name="folderName">The name of the folder in which to find the requested file. A wildcard ('*') can be specified to match a partial name.</param>
         /// <param name="fileName">The name of the assembly definition file.</param>
         /// <returns>
         /// A <see href="https://docs.microsoft.com/en-us/dotnet/api/system.io.fileinfo"/>FileInfo</see> object that describes the assembly definition file or null.


### PR DESCRIPTION
## Overview
The build configuration added in #5891 sometimes ran in contexts where it shouldn't, like IL2CPP builds where additional C# projects aren't generated.

I wrapped all calls, including making the checkbox visible, in a check for both .NET as the scripting backend and Unity C# Projects enabled.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6308