### PR TITLE
Fix error when interactable asset has invalid even receivers

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/InteractableEvent.cs
@@ -79,10 +79,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private List<InspectorPropertySetting> Settings = new List<InspectorPropertySetting>();
 
         /// <summary>
-        /// Create the event and setup the values from the inspector
+        /// Create the event and setup the values from the inspector. If the asset is invalid,
+        /// returns null.
         /// </summary>
         public static ReceiverBase CreateReceiver(InteractableEvent iEvent)
         {
+            if (string.IsNullOrEmpty(iEvent.ClassName))
+            {
+                // If the class name of this event is empty, the asset is invalid and loading types will throw errors. Return null.
+                return null;
+            }
+
             // Temporary workaround
             // This is to fix a bug in GA where the AssemblyQualifiedName was never actually saved. Functionality would work in editor...but never on device player
             if (iEvent.ReceiverType == null)

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -712,8 +712,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             for (int i = 0; i < InteractableEvents.Count; i++)
             {
-                InteractableEvents[i].Receiver = InteractableEvent.CreateReceiver(InteractableEvents[i]);
-                InteractableEvents[i].Receiver.Host = this;
+                var receiver = InteractableEvent.CreateReceiver(InteractableEvents[i]);
+                if (receiver != null)
+                {
+                    InteractableEvents[i].Receiver = receiver;
+                    InteractableEvents[i].Receiver.Host = this;
+                }
+                else
+                {
+                    Debug.LogWarning($"Empty event receiver found on {gameObject.name}, you may want to re-create this asset." );
+                }
             }
         }
 


### PR DESCRIPTION
## Overview
It's possible for Interactable to be working fine but to have some event receivers with empty `iEvent.ClassName` fields. When this happens, the Interactable works, but logs an error which can be disruptive to users (shows up in error console on HoloLens, for example). Since this is not actually breaking functionality and it is not clear how to fix this asset issue without rebuilding an asset. Since this is not actually an error customers can do anything about, log this as a warning instead.

The net result is after this change users no longer see error messages in their console window when using interactable, but will see warnings in the logs. Interactable functionality is not impacted.

## Tests
I did not add tests for this bug fix because it's unclear how to actually get assets into this error state, and this change does not actually change behavior -- it just turns an error into a warning. Reason to turn this into a warning is when it is an error the logs end up being visible to the user and there's not much customers can do about the error without modifying the interactable code (since it's not clear how to fix the asset).

## Changes
- Fixes: #6464 


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
