### PR TITLE
ManipulationHandler: add Pointer field for manipulation started, ended, hover events

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Events/ManipulationEventData.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Events/ManipulationEventData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI
@@ -11,9 +12,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class ManipulationEventData
     {
         /// <summary>
-        /// Source of ManipulationEvent.
+        /// The object being manipulated
         /// </summary>
         public ManipulationHandler ManipulationSource { get; set; }
+
+        /// <summary>
+        /// The pointer manipulating the object or hovering over the object. Will be null for OnManipulationEnded.
+        /// </summary>
+        public IMixedRealityPointer Pointer { get; set; }
 
         /// <summary>
         /// Whether the Manipulation is a NearInteration or not.

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -773,6 +773,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     ManipulationSource = this,
                     IsNearInteraction = isNearManipulation,
+                    Pointer = GetFirstPointer().pointer,
                     PointerCentroid = GetPointersCentroid(),
                     PointerVelocity = GetPointersVelocity(),
                     PointerAngularVelocity = GetPointersAngularVelocity()
@@ -845,6 +846,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     OnHoverEntered.Invoke(new ManipulationEventData
                     {
                         ManipulationSource = this,
+                        Pointer = eventData.Pointer,
                         IsNearInteraction = !isFar
                     });
                 }
@@ -861,6 +863,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     OnHoverExited.Invoke(new ManipulationEventData
                     {
                         ManipulationSource = this,
+                        Pointer = eventData.Pointer,
                         IsNearInteraction = !isFar
                     });
                 }


### PR DESCRIPTION
## Overview
I ran into a case when prototyping where it would be helpful to know which pointer initiated a manipulation start / end or a hover enter / exit. this change adds that field to the manipulation events, and creates a test to verify that field is not null.

## Changes
- Fixes: #6498 


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
