### PR TITLE
Update build tools deploy name when HoloLens is attached

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -54,6 +54,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private const string LOCAL_MACHINE = "Local Machine";
 
+        private const string HOLOLENS_USB = "HoloLens over USB";
+
         private const string LOCAL_IP_ADDRESS = "127.0.0.1";
 
         private const string EMPTY_IP_ADDRESS = "0.0.0.0";
@@ -759,12 +761,17 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
             currentConnectionInfoIndex = EditorGUILayout.Popup(currentConnectionInfoIndex, targetIps);
 
-            var currentConnection = portalConnections.Connections[currentConnectionInfoIndex];
+            DeviceInfo currentConnection = portalConnections.Connections[currentConnectionInfoIndex];
             bool currentConnectionIsLocal = IsLocalConnection(currentConnection);
 
             if (currentConnectionIsLocal)
             {
-                currentConnection.MachineName = LOCAL_MACHINE;
+                currentConnection.MachineName = IsHoloLensConnectedUsb ? HOLOLENS_USB : LOCAL_MACHINE;
+
+                if (currentConnection.MachineName != targetIps[0])
+                {
+                    UpdatePortalConnections();
+                }
             }
 
             GUI.enabled = IsValidIpAddress(currentConnection.IP);
@@ -1235,7 +1242,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 currentConnectionInfoIndex = portalConnections.Connections.Count - 1;
             }
 
-            targetIps[0] = LOCAL_MACHINE;
+            targetIps[0] = IsHoloLensConnectedUsb ? HOLOLENS_USB : LOCAL_MACHINE;
             for (int i = 1; i < targetIps.Length; i++)
             {
                 if (string.IsNullOrEmpty(portalConnections.Connections[i].MachineName))

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -83,9 +83,9 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private readonly GUIContent buildDirectoryLabel = new GUIContent("Build Directory", "It's recommended to use 'UWP'");
 
         private readonly GUIContent useCSharpProjectsLabel = new GUIContent("Generate C# Debug", "Generate C# Project References for debugging.\nOnly available in .NET Scripting runtime.");
-        
+
         private readonly GUIContent gazeInputCapabilityLabel =
-            new GUIContent("Gaze Input Capability", 
+            new GUIContent("Gaze Input Capability",
                            "If checked, the 'Gaze Input' capability will be added to the AppX manifest after the Unity build.");
 
         private readonly GUIContent autoIncrementLabel = new GUIContent("Auto Increment", "Increases Version Build Number");
@@ -437,7 +437,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             // Note that this is the 'Target SDK Version' which is required to physically build the
             // code on a build machine, not the minimum platform version.
             string currentSDKVersion = EditorUserBuildSettings.wsaUWPSDK;
-            
+
             Version chosenSDKVersion = null;
             for (var i = 0; i < windowsSdkVersions.Count; i++)
             {
@@ -488,7 +488,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 EditorGUILayout.HelpBox(
                     "Minimum platform version is set to a different value from the recommended value: " +
                         $"{UwpBuildDeployPreferences.MIN_PLATFORM_VERSION}, the generated app may not be deployable to older generation devices. " +
-                        $"Consider updating the 'Minimum Platform Version' in the Build Settings window to match {UwpBuildDeployPreferences.MIN_PLATFORM_VERSION}" ,
+                        $"Consider updating the 'Minimum Platform Version' in the Build Settings window to match {UwpBuildDeployPreferences.MIN_PLATFORM_VERSION}",
                     MessageType.Warning);
             }
 
@@ -580,7 +580,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             {
                 platformToolset = PlatformToolset.Solution;
             }
-            else if(currentPlatformToolsetString.ToLower().Equals(PlatformToolset.v141.ToString().ToLower()))
+            else if (currentPlatformToolsetString.ToLower().Equals(PlatformToolset.v141.ToString().ToLower()))
             {
                 platformToolset = PlatformToolset.v141;
             }
@@ -608,7 +608,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             {
                 UwpBuildDeployPreferences.GazeInputCapabilityEnabled = newGazeInputCapabilityEnabled;
             }
-            
+
             GUILayout.BeginHorizontal();
 
             var prevFieldWidth = EditorGUIUtility.fieldWidth;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -619,7 +619,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             new VSWhereFindOption(
                 $@"/C vswhere -all -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe",
                 ""),
-            // This find option corresponds to the versin of vswhere that ships with VS2017 - this doesn't have
+            // This find option corresponds to the version of vswhere that ships with VS2017 - this doesn't have
             // support for the -find command switch.
             new VSWhereFindOption(
                 $@"/C vswhere -all -products * -requires Microsoft.Component.MSBuild -property installationPath",


### PR DESCRIPTION
## Overview
When a HoloLens is detected attached, the build window will now display "HoloLens over USB" instead of "Local Machine". The IP Address was currently left alone to prevent downstream effects that are currently hardcoded for those words but behave correctly.

![image](https://user-images.githubusercontent.com/3580640/68339695-efb78700-0099-11ea-96c8-3a153d24a342.png)

There is still more work to be done here to improve the build window, currently planned for 2.3.

## Changes
- Helps with #5698 