### PR TITLE
Update MaterialInstance warning

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Rendering/MaterialInstance.cs
@@ -264,7 +264,10 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             {
                 if (source[i] != null)
                 {
-                    Debug.Assert(!IsInstanceMaterial(source[i]), "A material which is already instanced was instanced multiple times." + source[i].name);
+                    if (IsInstanceMaterial(source[i]))
+                    {
+                        Debug.LogWarning($"A material ({source[i].name}) which is already instanced was instanced multiple times.");
+                    }
 
                     output[i] = new Material(source[i]);
                     output[i].name += instancePostfix;

--- a/Assets/MixedRealityToolkit/Utilities/Rendering/MaterialInstance.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Rendering/MaterialInstance.cs
@@ -125,11 +125,11 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
         private Material[] instanceMaterials = null;
         private bool initialized = false;
         private bool materialsInstanced = false;
-        private HashSet<Object> materialOwners = new HashSet<Object>();
+        private readonly HashSet<Object> materialOwners = new HashSet<Object>();
 
         private const string instancePostfix = " (Instance)";
 
-#region MonoBehaviour Implementation
+        #region MonoBehaviour Implementation
 
         private void Awake()
         {
@@ -186,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             instanceMaterials = null;
         }
 
-#endregion MonoBehaviour Implementation
+        #endregion MonoBehaviour Implementation
 
         private void Initialize()
         {


### PR DESCRIPTION
## Overview
Updates the warning in MaterialInstance according to #6271, to downgrade it from an assert error to a warning. It also updates the message slightly.

I wasn't able to add the `Renderer` name, since this is a static method and the renderer reference requires an instance.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6271