### PR TITLE
Fix RotateAboutGrabPoint and RotateAboutObjectCenter far interaction

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -685,12 +685,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     break;
                 }
                 case RotateInOneHandType.RotateAboutObjectCenter:
+                case RotateInOneHandType.RotateAboutGrabPoint:
                     Quaternion gripRotation;
                     TryGetGripRotation(pointer, out gripRotation);
                     targetRotation = gripRotation * objectToGripRotation;
-                    break;
-                case RotateInOneHandType.RotateAboutGrabPoint:
-                    targetRotation = pointer.Rotation * objectToHandRotation;
                     break;
             }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs
@@ -611,7 +611,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if ((currentState & State.Moving) > 0)
             {
                 MixedRealityPose pose = GetAveragePointerPose();
-                targetPosition = moveLogic.Update(pose, targetRotationTwoHands, targetScale, IsNearManipulation(), true, constraintOnMovement);
+                targetPosition = moveLogic.Update(pose, targetRotationTwoHands, targetScale, true, constraintOnMovement);
             }
 
             float lerpAmount = GetLerpAmount();
@@ -694,7 +694,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             targetRotation = ApplyConstraints(targetRotation);
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
-            Vector3 targetPosition = moveLogic.Update(pointerPose, targetRotation, hostTransform.localScale, IsNearManipulation(), rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter, constraintOnMovement);
+            Vector3 targetPosition = moveLogic.Update(pointerPose, targetRotation, hostTransform.localScale, rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter, constraintOnMovement);
 
             float lerpAmount = GetLerpAmount();
             Quaternion smoothedRotation = Quaternion.Lerp(hostTransform.rotation, targetRotation, lerpAmount);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -337,8 +337,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
                 // save relative pos grab point to object
-                Vector3 initialOffsetGrabToObjPivot = pointer.Position - testObject.transform.position;
-                Vector3 initialGrabPointInObject = testObject.transform.InverseTransformPoint(manipHandler.GetPointerGrabPoint(pointer.PointerId));
+                Vector3 initialGrabPoint = manipHandler.GetPointerGrabPoint(pointer.PointerId);
+                Vector3 initialOffsetGrabToObjPivot = initialGrabPoint - testObject.transform.position;
+                Vector3 initialGrabPointInObject = testObject.transform.InverseTransformPoint(initialGrabPoint);
 
                 // full circle
                 const int degreeStep = 360 / numCircleSteps;
@@ -363,8 +364,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                     if (type == ManipulationHandler.RotateInOneHandType.RotateAboutObjectCenter)
                     {
-                        // make sure that the offset between hand and object centre hasn't changed while rotating
-                        Vector3 offsetRotated = pointer.Position - testObject.transform.position;
+                        // make sure that the offset between grab and object centre hasn't changed while rotating
+                        Vector3 grabPoint = manipHandler.GetPointerGrabPoint(pointer.PointerId);
+                        Vector3 offsetRotated = grabPoint - testObject.transform.position;
                         TestUtilities.AssertAboutEqual(offsetRotated, initialOffsetGrabToObjPivot, $"Object offset changed during rotation using {type}");
                     }
                     else
@@ -960,6 +962,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // Apply correction delta again as we have changed hand pose
+            correction = CameraCache.Main.transform.position - hand.GetPointer<GGVPointer>().Position;
+            yield return hand.Move(correction, numHandSteps);
             yield return null;
 
             Assert.AreEqual(expectedDist, Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position), 0.02f);


### PR DESCRIPTION
## Overview
RotateAboutGrabPoint was not applying hand rotations for far interaction, so that you can rotate objects from a distance. This fix enables that.

RotateAboutObjectCenter far interaction was working like RotateAboutGrabPoint was supposed to; objects could be rotated from a distance, but they were rotated about the grab point rather than the object centre.

## Changes
- RotateAboutObjectCenter far interaction now rotates about the object centre as described in #6494.
- RotateAboutGrabPoint far interaction now rotates about the grab point using the hand rotation as described in #6495.
- RotateAboutObjectCenter manipulation is now relative to the hand grab point (between the index finger and thumb) rather than the palm. This makes far rotation feel more natural.
- Fixes: #6494, #6495.