### PR TITLE
Fix interactable to change states after setup of statemanager

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -576,13 +576,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 States = GetDefaultInteractableStates();
             }
 
-            IsEnabled = enabledOnStart;
-
             InputAction = ResolveInputAction(InputActionId);
 
             CurrentDimension = startDimensionIndex;
 
             RefreshSetup();
+
+            IsEnabled = enabledOnStart;
         }
 
         protected virtual void OnEnable()


### PR DESCRIPTION
## Overview
We tried to set the enabled state before we had set up a statemanager yet and thus nothing was actually applied

## Changes
- Fixes: #6508 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
