### PR TITLE
Ensure test prep creates a main camera in the scene

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
@@ -29,6 +29,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestDynamicServices()
         {
+            TestUtilities.InitializeCamera();
+
             UnityEngine.Object cameraSystemPrefab = AssetDatabase.LoadAssetAtPath("Assets/MixedRealityToolkit.SDK/Experimental/ServiceManagers/Camera/Prefabs/CameraSystem.prefab", typeof(UnityEngine.Object));
             Assert.IsNull(CoreServices.CameraSystem);
 

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities.cs
@@ -135,8 +135,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             InitializeMixedRealityToolkit(useDefaultProfile);
         }
 
+        public static void InitializeCamera()
+        {
+            if (Camera.main == null)
+            {
+                new GameObject("Main Camera", typeof(Camera), typeof(AudioListener)) { tag = "MainCamera" }.GetComponent<Camera>();
+            }
+        }
+
         public static void InitializeMixedRealityToolkit(MixedRealityToolkitConfigurationProfile configuration)
         {
+            InitializeCamera();
+
             if (!MixedRealityToolkit.IsInitialized)
             {
                 MixedRealityToolkit mixedRealityToolkit = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();


### PR DESCRIPTION
Previously, the play mode tests relied upon behavior in MRTK where it creates a main camera if one cannot be found in the scene.

In preparation of MRTK enforcing correct scene setup by the developer (in 2.3.0), test preparation now ensures a main camera is present in the scene before adding the MRTK object.