### PR TITLE
Couple of fixes for the TeleportPointer

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -320,8 +320,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 currentInputPosition = eventData.InputData;
             }
 
-            if (Mathf.Abs(currentInputPosition.y) > inputThreshold ||
-                Mathf.Abs(currentInputPosition.x) > inputThreshold)
+            if (currentInputPosition.sqrMagnitude > Mathf.Pow(inputThreshold, 2f))
             {
                 // Get the angle of the pointer input
                 float angle = Mathf.Atan2(currentInputPosition.x, currentInputPosition.y) * Mathf.Rad2Deg;
@@ -359,7 +358,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                         if (offsetRotationAngle > 0)
                         {
                             // check to make sure we're still under our activation threshold.
-                            if (offsetRotationAngle < rotateActivationAngle)
+                            if (offsetRotationAngle < 2 * rotateActivationAngle)
                             {
                                 canMove = false;
                                 // Rotate the camera by the rotation amount.  If our angle is positive then rotate in the positive direction, otherwise in the opposite direction.
@@ -374,7 +373,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                                 offsetStrafeAngle = absoluteAngle - offsetStrafeAngle;
 
                                 // Check to make sure we're still under our activation threshold.
-                                if (offsetStrafeAngle > 0 && offsetStrafeAngle < backStrafeActivationAngle)
+                                if (offsetStrafeAngle > 0 && offsetStrafeAngle <= backStrafeActivationAngle)
                                 {
                                     canMove = false;
                                     var height = MixedRealityPlayspace.Position.y;


### PR DESCRIPTION
## Overview
The TeleportPointer has a few minor issues this fixes.

1. the input threshold check is a square shaped version. I made it round

2. The rotateActivationAngle is checked only for the pre-90-degree portion of the provided value, past 90, the threshold is not checked. the comments state that "Half the rotation activation angle" is calculated, but the value is actually used twice, as it's "mirrored" around the sides and not just used towards the front.

3. the backStrafeActivationAngle check misses out on 180 backwards exactly.

## Verification
1. use common sense

2. try turning when pressing the analog stick to the slight but slightly to the back

3. try backstepping exactly backwards