### PR TITLE
cherry-pick teleport pointer fixes from Alexees

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
+using System.IO;
 using UnityEngine;
 using UnityPhysics = UnityEngine.Physics;
 
@@ -22,6 +23,27 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         [Range(0f, 1f)]
         [Tooltip("The threshold amount for joystick input (Dead Zone)")]
         private float inputThreshold = 0.5f;
+
+        private float InputThreshold
+        {
+            get => inputThreshold;
+            set
+            {
+                if (inputThreshold != value)
+                {
+                    inputThresholdChanged = true;
+                    inputThreshold = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether or not the inputThreshold value has been changed (in the inspector or via code).
+        /// </summary>
+        /// <remarks>
+        /// This defaults to true to allow the initial value to be calculated on first use.
+        /// </remarks>
+        private bool inputThresholdChanged = true;
 
         [SerializeField]
         [Range(0f, 360f)]
@@ -75,6 +97,24 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         /// The Gravity Distorter that is affecting the <see cref="Utilities.BaseMixedRealityLineDataProvider"/> attached to this pointer.
         /// </summary>
         public DistorterGravity GravityDistorter => gravityDistorter;
+
+        private float inputThresholdSquared = 0f;
+
+        /// <summary>
+        /// The square of the InputThreshold value.
+        /// </summary>
+        private float InputThresholdSquared
+        {
+            get
+            {
+                if (inputThresholdChanged)
+                {
+                    inputThresholdSquared = Mathf.Pow(InputThreshold, 2f);
+                    inputThresholdChanged = false;
+                }
+                return inputThresholdSquared;
+            }
+        }
 
         protected override void OnEnable()
         {
@@ -320,7 +360,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 currentInputPosition = eventData.InputData;
             }
 
-            if (currentInputPosition.sqrMagnitude > Mathf.Pow(inputThreshold, 2f))
+            if (currentInputPosition.sqrMagnitude > InputThresholdSquared)
             {
                 // Get the angle of the pointer input
                 float angle = Mathf.Atan2(currentInputPosition.x, currentInputPosition.y) * Mathf.Rad2Deg;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             get
             {
-                if (Mathf.Approximately(cachedInputThreshold, inputThreshold))
+                if (!Mathf.Approximately(cachedInputThreshold, inputThreshold))
                 {
                     inputThresholdSquared = Mathf.Pow(inputThreshold, 2f);
                     cachedInputThreshold = inputThreshold;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             get
             {
-                if (cachedInputThreshold != inputThreshold)
+                if (Mathf.Approximately(cachedInputThreshold, inputThreshold))
                 {
                     inputThresholdSquared = Mathf.Pow(inputThreshold, 2f);
                     cachedInputThreshold = inputThreshold;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -320,8 +320,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                 currentInputPosition = eventData.InputData;
             }
 
-            if (Mathf.Abs(currentInputPosition.y) > inputThreshold ||
-                Mathf.Abs(currentInputPosition.x) > inputThreshold)
+            if (currentInputPosition.sqrMagnitude > Mathf.Pow(inputThreshold, 2f))
             {
                 // Get the angle of the pointer input
                 float angle = Mathf.Atan2(currentInputPosition.x, currentInputPosition.y) * Mathf.Rad2Deg;
@@ -359,7 +358,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                         if (offsetRotationAngle > 0)
                         {
                             // check to make sure we're still under our activation threshold.
-                            if (offsetRotationAngle < rotateActivationAngle)
+                            if (offsetRotationAngle < 2 * rotateActivationAngle)
                             {
                                 canMove = false;
                                 // Rotate the camera by the rotation amount.  If our angle is positive then rotate in the positive direction, otherwise in the opposite direction.
@@ -374,7 +373,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                                 offsetStrafeAngle = absoluteAngle - offsetStrafeAngle;
 
                                 // Check to make sure we're still under our activation threshold.
-                                if (offsetStrafeAngle > 0 && offsetStrafeAngle < backStrafeActivationAngle)
+                                if (offsetStrafeAngle > 0 && offsetStrafeAngle <= backStrafeActivationAngle)
                                 {
                                     canMove = false;
                                     var height = MixedRealityPlayspace.Position.y;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -24,27 +24,6 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         [Tooltip("The threshold amount for joystick input (Dead Zone)")]
         private float inputThreshold = 0.5f;
 
-        private float InputThreshold
-        {
-            get => inputThreshold;
-            set
-            {
-                if (inputThreshold != value)
-                {
-                    inputThresholdChanged = true;
-                    inputThreshold = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether or not the inputThreshold value has been changed (in the inspector or via code).
-        /// </summary>
-        /// <remarks>
-        /// This defaults to true to allow the initial value to be calculated on first use.
-        /// </remarks>
-        private bool inputThresholdChanged = true;
-
         [SerializeField]
         [Range(0f, 360f)]
         [Tooltip("If Pressing 'forward' on the thumbstick gives us an angle that doesn't quite feel like the forward direction, we apply this offset to make navigation feel more natural")]
@@ -98,6 +77,8 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         /// </summary>
         public DistorterGravity GravityDistorter => gravityDistorter;
 
+        private float cachedInputThreshold = 0f;
+
         private float inputThresholdSquared = 0f;
 
         /// <summary>
@@ -107,10 +88,10 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
         {
             get
             {
-                if (inputThresholdChanged)
+                if (cachedInputThreshold != inputThreshold)
                 {
-                    inputThresholdSquared = Mathf.Pow(InputThreshold, 2f);
-                    inputThresholdChanged = false;
+                    inputThresholdSquared = Mathf.Pow(inputThreshold, 2f);
+                    cachedInputThreshold = inputThreshold;
                 }
                 return inputThresholdSquared;
             }


### PR DESCRIPTION
This change brings @Alexees' teleport pointer fixes into the 2.2.0 release and reduces the number of calls to Mathf.Pow()