### PR TITLE
add build rule for android and ios players

### DIFF
--- a/NuGet/BuildSource.proj
+++ b/NuGet/BuildSource.proj
@@ -10,6 +10,12 @@
     </MSBuild>
   </Target>
 
+  <Target Name="BuildWSAEditor">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=InEditor;Platform=WSA;BuildProjectReferences=false">
+      <Output TaskParameter="TargetOutputs" ItemName="BuildWSAEditorOutputs" /><!--AssembliesBuiltByChildProjects-->
+    </MSBuild>
+  </Target>
+
   <Target Name="BuildStandalonePlayer">
     <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WindowsStandalone32;BuildProjectReferences=false">
       <Output TaskParameter="TargetOutputs" ItemName="BuildStandalonePlayerOutputs" />
@@ -18,13 +24,13 @@
 
   <Target Name="BuildAndroidPlayer">
     <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=Android;BuildProjectReferences=false">
-      <Output TaskParameter="TargetOutputs" ItemName="BuildStandalonePlayerOutputs" />
+      <Output TaskParameter="TargetOutputs" ItemName="BuildAndroidPlayerOutputs" />
     </MSBuild>
   </Target>
   
   <Target Name="BuildIOSPlayer">
     <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=IOS;BuildProjectReferences=false">
-      <Output TaskParameter="TargetOutputs" ItemName="BuildStandalonePlayerOutputs" />
+      <Output TaskParameter="TargetOutputs" ItemName="BuildIOSPlayerOutputs" />
     </MSBuild>
   </Target>
 

--- a/NuGet/BuildSource.proj
+++ b/NuGet/BuildSource.proj
@@ -16,6 +16,18 @@
     </MSBuild>
   </Target>
 
+  <Target Name="BuildAndroidPlayer">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=Android;BuildProjectReferences=false">
+      <Output TaskParameter="TargetOutputs" ItemName="BuildStandalonePlayerOutputs" />
+    </MSBuild>
+  </Target>
+  
+  <Target Name="BuildIOSPlayer">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=IOS;BuildProjectReferences=false">
+      <Output TaskParameter="TargetOutputs" ItemName="BuildStandalonePlayerOutputs" />
+    </MSBuild>
+  </Target>
+
   <Target Name="BuildWSAPlayer">
     <MSBuild Projects="@(ProjectReferences)" Targets="Restore;Build" Properties="Configuration=Player;Platform=WSA;BuildProjectReferences=false;MSBuildExtensionsPathOverride=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild">
       <Output TaskParameter="TargetOutputs" ItemName="BuildWSAPlayerOutputs" />

--- a/pipelines/templates/compilemsbuild.yml
+++ b/pipelines/templates/compilemsbuild.yml
@@ -39,6 +39,42 @@ steps:
     solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     msbuildArchitecture: 'x64'
     platform: 'WSA'
+    configuration: 'InEditor'
+    createLogFile: true
+    restoreNugetPackages: false
+    msbuildVersion: '15.0'
+    msbuildArguments: '/p:BuildProjectReferences=false'
+  displayName: 'Build InEditor WSA'
+
+- task: MSBuild@1
+  inputs:
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
+    msbuildArchitecture: 'x64'
+    platform: 'Android'
+    configuration: 'Player'
+    createLogFile: true
+    restoreNugetPackages: false
+    msbuildVersion: '15.0'
+    msbuildArguments: '/p:BuildProjectReferences=false'
+  displayName: 'Build Player Android'
+
+- task: MSBuild@1
+  inputs:
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
+    msbuildArchitecture: 'x64'
+    platform: 'iOS'
+    configuration: 'Player'
+    createLogFile: true
+    restoreNugetPackages: false
+    msbuildVersion: '15.0'
+    msbuildArguments: '/p:BuildProjectReferences=false'
+  displayName: 'Build Player iOS'
+
+- task: MSBuild@1
+  inputs:
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
+    msbuildArchitecture: 'x64'
+    platform: 'WSA'
     configuration: 'Player'
     createLogFile: true
     restoreNugetPackages: false

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -75,7 +75,7 @@ try
             Write-Error "Building InEditor WindowsStandalone32 Failed! See log file for more information $(Get-Location)\Logs\Build.InEditor.WindowsStandalone32.$($Version).log";
         exit($lastexitcode)
     }
-    Write-Output "============ Building InEditor USA ============ "
+    Write-Output "============ Building InEditor WSA ============ "
     dotnet msbuild .\BuildSource.proj -target:BuildWSAEditor > "Logs\Build.InEditor.WSA.$($Version).log"
     if ($lastexitcode -ge 1)
     {

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -82,6 +82,20 @@ try
         Write-Error "Building Player WindowsStandalone32 Failed! See log file for more information $(Get-Location)\Logs\Build.Player.WindowsStandalone32.$($Version).log";
         exit($lastexitcode)
     }
+    Write-Output "============ Building Player Android ============ "
+    dotnet msbuild .\BuildSource.proj -target:BuildAndroidPlayer > "Logs\Build.Player.Android.$($Version).log"
+    if ($lastexitcode -ge 1)
+    {
+        Write-Error "Building Player Android Failed! See log file for more information $(Get-Location)\Logs\Build.Player.Android.$($Version).log";
+        exit($lastexitcode)
+    }
+    Write-Output "============ Building Player iOS  ============ "
+    dotnet msbuild .\BuildSource.proj -target:BuildIOSPlayer > "Logs\Build.Player.iOS.$($Version).log"
+    if ($lastexitcode -ge 1)
+    {
+        Write-Error "Building Player iOS Failed! See log file for more information $(Get-Location)\Logs\Build.Player.iOS.$($Version).log";
+        exit($lastexitcode)
+    }
     Write-Output "============ Building Player WSA ============ "
     dotnet msbuild .\BuildSource.proj -target:BuildWSAPlayer  > "Logs\Build.Player.WSA.$($Version).log"
     if ($lastexitcode -ge 1)

--- a/scripts/packaging/createnugetpackages.ps1
+++ b/scripts/packaging/createnugetpackages.ps1
@@ -75,6 +75,13 @@ try
             Write-Error "Building InEditor WindowsStandalone32 Failed! See log file for more information $(Get-Location)\Logs\Build.InEditor.WindowsStandalone32.$($Version).log";
         exit($lastexitcode)
     }
+    Write-Output "============ Building InEditor USA ============ "
+    dotnet msbuild .\BuildSource.proj -target:BuildWSAEditor > "Logs\Build.InEditor.WSA.$($Version).log"
+    if ($lastexitcode -ge 1)
+    {
+            Write-Error "Building InEditor WSA Failed! See log file for more information $(Get-Location)\Logs\Build.InEditor.WSA.$($Version).log";
+        exit($lastexitcode)
+    }
     Write-Output "============ Building Player WindowsStandalone32 ============ "
     dotnet msbuild .\BuildSource.proj -target:BuildStandalonePlayer > "Logs\Build.Player.WindowsStandalone32.$($Version).log"
     if ($lastexitcode -ge 1)


### PR DESCRIPTION
With the addition of the experimental Unity AR camera settings provider, MRTK has a need for precompiled Android and iOS players, when distributing via NuGet.

This change enables the build rules for these players. Once approved and merged, the nuspec files will be updated to include these player builds.

This is part 1 of the change that will resolve #6441