### PR TITLE
Add base class for camera settings providers

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         {
             if (SettingsProfile == null)
             {
-                Debug.LogWarning("A profile was not specified for the XR Camera Settings provider.\nApplying Microsoft Mixed Reality Toolkit default options.");
+                Debug.LogWarning("A profile was not specified for the Unity AR Camera Settings provider.\nApplying Microsoft Mixed Reality Toolkit default options.");
                 return;
             }
 

--- a/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         {
             if (SettingsProfile == null)
             {
-                Debug.LogWarning("A profile was not specified for the Unity AR Camera Settings provider.\nApplying Microsoft Mixed Reality Toolkit default options.");
+                Debug.LogWarning("A profile was not specified for the Unity AR Camera Settings provider.\nUsing Microsoft Mixed Reality Toolkit default options.");
                 return;
             }
 

--- a/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         "Unity AR Foundation Camera Settings",
         "Providers/Experimental/UnityAR/Profiles/DefaultUnityARCameraSettingsProfile.asset",
         "MixedRealityToolkit.Extensions")]
-    public class UnityARCameraSettings : BaseDataProvider, IMixedRealityCameraSettingsProvider
+    public class UnityARCameraSettings : BaseCameraSettingsProvider
     {
         /// <summary>
         /// Constructor.
@@ -37,38 +37,36 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
             string name = null,
             uint priority = DefaultPriority,
             BaseCameraSettingsProfile profile = null) : base(cameraSystem, name, priority, profile)
-        { }
-
-#region IMixedRealityCameraSettings
-
-        /// <inheritdoc/>
-        public bool IsOpaque => false;
-
-        /// <inheritdoc/>
-        public void ApplyDisplaySettings()
         {
-            MixedRealityCameraProfile cameraProfile = (Service as IMixedRealityCameraSystem)?.CameraProfile;
-            if (cameraProfile == null) { return; } 
-
-            if (IsOpaque)
-            {
-                CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsOpaqueDisplay;
-                CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneOpaqueDisplay;
-                CameraCache.Main.farClipPlane = cameraProfile.FarClipPlaneOpaqueDisplay;
-                CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorOpaqueDisplay;
-                QualitySettings.SetQualityLevel(cameraProfile.OpaqueQualityLevel, false);
-            }
-            else
-            {
-                CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsTransparentDisplay;
-                CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorTransparentDisplay;
-                CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneTransparentDisplay;
-                CameraCache.Main.farClipPlane = cameraProfile.FarClipPlaneTransparentDisplay;
-                QualitySettings.SetQualityLevel(cameraProfile.TransparentQualityLevel, false);
-            }
+            ReadProfile();
         }
 
-#endregion IMixedRealityCameraSettings
+        private ArTrackedPose poseSource = ArTrackedPose.ColorCamera;
+        private ArTrackingType trackingType = ArTrackingType.RotationAndPosition;
+        private ArUpdateType updateType = ArUpdateType.UpdateAndBeforeRender;
+
+        private void ReadProfile()
+        {
+            if (SettingsProfile == null)
+            {
+                Debug.LogWarning("A profile was not specified for the XR Camera Settings provider.\nApplying Microsoft Mixed Reality Toolkit default options.");
+                return;
+            }
+
+            poseSource = SettingsProfile.PoseSource;
+            trackingType = SettingsProfile.TrackingType;
+            updateType = SettingsProfile.UpdateType;
+        }
+
+        #region IMixedRealityCameraSettings
+
+        /// <inheritdoc/>
+        public override bool IsOpaque
+        {
+            get => (poseSource != ArTrackedPose.ColorCamera);
+        }
+
+        #endregion IMixedRealityCameraSettings
 
         /// <summary>
         /// The profile used to configure the camera.
@@ -184,34 +182,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 
             trackedPoseDriver = cameraObject.EnsureComponent<TrackedPoseDriver>();
 
-            TrackedPoseDriver.TrackedPose poseSource;
-            TrackedPoseDriver.TrackingType trackingType;
-            TrackedPoseDriver.UpdateType updateType;
-
-            if (SettingsProfile != null)
-            {
-                // Read settings to be applied to the camera.
-                // The enums used by the profile use the same values as those provided by Unity.
-                // We use custom enums to avoid customers needing to include packages and/or namespaces simply to resolve
-                // enum values in the profile.
-                poseSource = ArEnumConversion.ToUnityTrackedPose(SettingsProfile.PoseSource);
-                trackingType = ArEnumConversion.ToUnityTrackingType(SettingsProfile.TrackingType);
-                updateType = ArEnumConversion.ToUnityUpdateType(SettingsProfile.UpdateType);
-            }
-            else
-            {
-                Debug.LogWarning("A profile was not specified for the XR Camera Settings provider.\nApplying Microsoft Mixed Reality Toolkit default options.");
-                // Use default settings.
-                poseSource = TrackedPoseDriver.TrackedPose.ColorCamera;
-                trackingType = TrackedPoseDriver.TrackingType.RotationAndPosition;
-                updateType = TrackedPoseDriver.UpdateType.UpdateAndBeforeRender;
-            }
-
             trackedPoseDriver.SetPoseSource(
                 TrackedPoseDriver.DeviceType.GenericXRDevice,
-                poseSource);
-            trackedPoseDriver.trackingType = trackingType;
-            trackedPoseDriver.updateType = updateType;
+                ArEnumConversion.ToUnityTrackedPose(SettingsProfile.PoseSource));
+            trackedPoseDriver.trackingType = ArEnumConversion.ToUnityTrackingType(SettingsProfile.TrackingType);
+            trackedPoseDriver.updateType = ArEnumConversion.ToUnityUpdateType(SettingsProfile.UpdateType);
             trackedPoseDriver.UseRelativeTransform = false;
 
             isInitialized = true;

--- a/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Extensions/Providers/Experimental/UnityAR/UnityARCameraSettings.cs
@@ -179,7 +179,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 
             arCameraManager = cameraObject.EnsureComponent<ARCameraManager>();
             arCameraBackground = cameraObject.EnsureComponent<ARCameraBackground>();
-
             trackedPoseDriver = cameraObject.EnsureComponent<TrackedPoseDriver>();
 
             trackedPoseDriver.SetPoseSource(

--- a/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
                     {
                         // Apply the display settings
                         IMixedRealityCameraSettingsProvider provider = GetDataProvider<IMixedRealityCameraSettingsProvider>(configuration.ComponentName);
-                        provider?.ApplyDisplaySettings();
+                        provider?.ApplyConfiguration();
                     }
                 }
             }

--- a/Assets/MixedRealityToolkit/Interfaces/CameraSystem/IMixedRealityCameraSettingsProvider.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/CameraSystem/IMixedRealityCameraSettingsProvider.cs
@@ -14,9 +14,8 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
         bool IsOpaque { get; }
 
         /// <summary>
-        /// Applies the display settings (background color, clipping plane distances, etc) based on the
-        /// appropriate <see cref="DisplayType"/>.
+        /// Applies provider specific configuration settings.
         /// </summary>
-        void ApplyDisplaySettings();
+        void ApplyConfiguration();
     }
 }

--- a/Assets/MixedRealityToolkit/Providers/BaseCameraSettingsProvider.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseCameraSettingsProvider.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.CameraSystem
+{
+    public class BaseCameraSettingsProvider : BaseDataProvider, IMixedRealityCameraSettingsProvider
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="cameraSystem">The instance of the camera system which is managing this provider.</param>
+        /// <param name="name">Friendly name of the provider.</param>
+        /// <param name="priority">Provider priority. Used to determine order of instantiation.</param>
+        /// <param name="profile">The provider's configuration profile.</param>
+        public BaseCameraSettingsProvider(
+            IMixedRealityCameraSystem cameraSystem,
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseCameraSettingsProfile profile = null) : base(cameraSystem, name, priority, profile)
+        { }
+
+        /// <inheritdoc/>
+        public virtual bool IsOpaque { get; } = false;
+
+        /// <inheritdoc/>
+        public virtual void ApplyConfiguration()
+        {
+            // It is the responsibility of the camera settings provider to set the display settings (this allows overriding the
+            // default values with per-camera provider values).
+            MixedRealityCameraProfile cameraProfile = (Service as IMixedRealityCameraSystem)?.CameraProfile;
+            if (cameraProfile == null) { return; }
+
+            if (IsOpaque)
+            {
+                CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsOpaqueDisplay;
+                CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneOpaqueDisplay;
+                CameraCache.Main.farClipPlane = cameraProfile.FarClipPlaneOpaqueDisplay;
+                CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorOpaqueDisplay;
+                QualitySettings.SetQualityLevel(cameraProfile.OpaqueQualityLevel, false);
+            }
+            else
+            {
+                CameraCache.Main.clearFlags = cameraProfile.CameraClearFlagsTransparentDisplay;
+                CameraCache.Main.backgroundColor = cameraProfile.BackgroundColorTransparentDisplay;
+                CameraCache.Main.nearClipPlane = cameraProfile.NearClipPlaneTransparentDisplay;
+                CameraCache.Main.farClipPlane = cameraProfile.FarClipPlaneTransparentDisplay;
+                QualitySettings.SetQualityLevel(cameraProfile.TransparentQualityLevel, false);
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Providers/BaseCameraSettingsProvider.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/BaseCameraSettingsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7436e360aeb8e504dacbb3672921d97d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change adds a base class to handle the required properties and methods defined in the IMixedRealityCameraSettingsProvider interface.

The experimental UnityAR provider has been updated (with some other small changes) to use the base class.