### PR TITLE
Make abstract constructors protected, update some data structures to readonly, and some formatting and comment updates

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/RoomFileFormat/RoomFileSerializer.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/RoomFileFormat/RoomFileSerializer.cs
@@ -50,11 +50,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.RoomFile
         /// <returns>Mesh object read from the stream.</returns>
         private static Mesh ReadMesh(BinaryReader reader)
         {
-            int vertexCount = 0;
-            int triangleIndexCount = 0;
-
             // Read the mesh data.
-            ReadFileHeader(reader, out vertexCount, out triangleIndexCount);
+            ReadFileHeader(reader, out int vertexCount, out int triangleIndexCount);
             Vector3[] vertices = ReadVertices(reader, vertexCount);
             int[] triangleIndices = ReadTriangleIndicies(reader, triangleIndexCount);
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private int confidenceOfSaccade = 0;
         private int confidenceOfSaccadeThreshold = 6; // TODO(https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3767): This value should be adjusted based on the FPS of the ET system
         private Ray saccade_initialGazePoint;
-        private List<Ray> saccade_newGazeCluster = new List<Ray>();
+        private readonly List<Ray> saccade_newGazeCluster = new List<Ray>();
 
         public event Action OnSaccade;
         public event Action OnSaccadeX;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Events/ReceiverBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="ev">Unity event to invoke. Add more events in deriving class.</param>
         /// <param name="name">Name of the unity event that will get invoked (visible in editor).</param>
-        public ReceiverBase(UnityEvent ev, string name)
+        protected ReceiverBase(UnityEvent ev, string name)
         {
             uEvent = ev;
             Name = name;

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -572,11 +572,18 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                 return false;
             }
 
-            commands = CoreServices.InputSystem.InputSystemProfile.SpeechCommandsProfile?.SpeechCommands;
+            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+            if (inputSystemProfile != null && inputSystemProfile.SpeechCommandsProfile != null)
+            {
+                commands = inputSystemProfile.SpeechCommandsProfile.SpeechCommands;
+            }
+            else
+            {
+                commands = null;
+            }
 
             if (commands == null || commands.Length < 1)
             {
-                commands = null;
                 return false;
             }
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
@@ -42,7 +42,11 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         {
             serializedObject.Update();
 
-            themeStates = theme.States?.StateList.ToArray();
+            if (theme != null && theme.States != null)
+            {
+                themeStates = theme.States.StateList.ToArray();
+            }
+
             if (themeStates == null)
             {
                 themeStates = Array.Empty<State>();

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/BaseInputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/BaseInputSimulationService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseInputSimulationService(
+        protected BaseInputSimulationService(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
             string name,
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
-        public BaseInputSimulationService(
+        protected BaseInputSimulationService(
             IMixedRealityInputSystem inputSystem,
             string name,
             uint priority,

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -963,7 +963,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         gazeHitResult = hitResult3d;
                     }
 
-                    int hitResult3dLayer = hitResult3d.hitObject?.layer ?? -1;
+                    int hitResult3dLayer = hitResult3d.hitObject != null ? hitResult3d.hitObject.layer : -1;
                     if (hitResult3dLayer == 0)
                     {
                         // If we have a hit in the highest priority layer, we can go ahead and truncate the pointer before doing the UI raycast

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Components/FocusRaycastTestProxy.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Components/FocusRaycastTestProxy.cs
@@ -40,7 +40,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private void Awake()
         {
-            RayLineData = RayLineData ?? GetComponent<BaseMixedRealityLineDataProvider>();
+            if (RayLineData == null)
+            {
+                RayLineData = GetComponent<BaseMixedRealityLineDataProvider>();
+            }
         }
 
         private void OnDrawGizmos()

--- a/Assets/MixedRealityToolkit/Attributes/SystemTypeAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/SystemTypeAttribute.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         /// <param name="type">Initializes a new instance of the <see cref="SystemTypeAttribute"/> class.</param>
         /// <param name="grouping">Gets or sets grouping of selectable classes. Defaults to <see cref="Utilities.TypeGrouping.ByNamespaceFlat"/> unless explicitly specified.</param>
-        public SystemTypeAttribute(Type type, TypeGrouping grouping = TypeGrouping.ByNamespaceFlat)
+        protected SystemTypeAttribute(Type type, TypeGrouping grouping = TypeGrouping.ByNamespaceFlat)
         {
 #if WINDOWS_UWP && !ENABLE_IL2CPP
             bool isValid = type.IsClass() || type.IsInterface() || type.IsValueType() && !type.IsEnum();

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/BaseMixedRealityProfileInspector.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEditor;
@@ -16,9 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// </summary>
     public abstract class BaseMixedRealityProfileInspector : UnityEditor.Editor
     {
-        private const string IsCustomProfileProperty = "isCustomProfile";
-
-        private static StringBuilder dropdownKeyBuilder = new StringBuilder();
+        private static readonly StringBuilder dropdownKeyBuilder = new StringBuilder();
 
         protected virtual void OnEnable()
         {
@@ -51,9 +48,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     {
                         using (new EditorGUI.IndentLevelScope())
                         {
-                            UnityEditor.Editor subProfileEditor = UnityEditor.Editor.CreateEditor(property.objectReferenceValue);
-                        // If this is a default MRTK configuration profile, ask it to render as a sub-profile
-                        if (typeof(BaseMixedRealityToolkitConfigurationProfileInspector).IsAssignableFrom(subProfileEditor.GetType()))
+                            UnityEditor.Editor subProfileEditor = CreateEditor(property.objectReferenceValue);
+                            // If this is a default MRTK configuration profile, ask it to render as a sub-profile
+                            if (typeof(BaseMixedRealityToolkitConfigurationProfileInspector).IsAssignableFrom(subProfileEditor.GetType()))
                             {
                                 BaseMixedRealityToolkitConfigurationProfileInspector configProfile = (BaseMixedRealityToolkitConfigurationProfileInspector)subProfileEditor;
                                 configProfile.RenderAsSubProfile = true;

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
     public class MixedRealityProjectConfiguratorWindow : EditorWindow
     {
-        private Dictionary<MRConfig, bool> trackToggles = new Dictionary<MRConfig, bool>()
+        private readonly Dictionary<MRConfig, bool> trackToggles = new Dictionary<MRConfig, bool>()
         {
             {MRConfig.ForceTextSerialization, true },
             {MRConfig.VisibleMetaFiles, true },
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private const float Default_Window_Width = 400.0f;
 
         private readonly GUIContent ApplyButtonContent = new GUIContent("Apply", "Apply configurations to this Unity Project");
-        private readonly GUIContent LaterButtonContent = new GUIContent("Later", "Do not show this popup notification until next session");
+        private readonly GUIContent LaterButtonContent = new GUIContent("Later", "Do not show this pop-up notification until next session");
         private readonly GUIContent IgnoreButtonContent = new GUIContent("Ignore", "Modify this preference under Edit > Project Settings > MRTK");
 
         private bool showConfigurations = false;
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         [MenuItem("Mixed Reality Toolkit/Utilities/Configure Unity Project", false, 499)]
         public static void ShowWindow()
         {
-            // There should be only one configurator window open as a "popup". If already open, then just force focus on our instance
+            // There should be only one configurator window open as a "pop-up". If already open, then just force focus on our instance
             if (IsOpen)
             {
                 Instance.Focus();
@@ -69,10 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         public static MixedRealityProjectConfiguratorWindow Instance { get; private set; }
 
-        public static bool IsOpen
-        {
-            get { return Instance != null; }
-        }
+        public static bool IsOpen => Instance != null;
 
         private void OnEnable()
         {
@@ -83,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private void CompilationPipeline_assemblyCompilationStarted(string obj)
         {
-            // There should be only one popup window which is generally tracked by IsOpen
+            // There should be only one pop-up window which is generally tracked by IsOpen
             // However, when recompiling, Unity will call OnDestroy for this window but not actually destroy the editor window
             // This ensure we have a clean close on recompiles when this EditorWindow was open beforehand
             Close();
@@ -183,7 +180,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.LabelField("iOS Settings", EditorStyles.boldLabel);
                 RenderToggle(MRConfig.IOSMinOSVersion, "Set Required OS Version");
                 RenderToggle(MRConfig.IOSArchitecture, "Set Required Architecture");
-                RenderToggle(MRConfig.IOSCameraUsageDescription, "Set Camera Usage Descriptionfs");
+                RenderToggle(MRConfig.IOSCameraUsageDescription, "Set Camera Usage Descriptions");
             }
         }
 

--- a/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseInputDeviceManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseInputDeviceManager(
+        protected BaseInputDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
             string name, 
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
-        public BaseInputDeviceManager(
+        protected BaseInputDeviceManager(
             IMixedRealityInputSystem inputSystem,
             string name,
             uint priority,

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <param name="priority">The registration priority of the data provider.</param>
         /// <param name="profile">The configuration profile for the data provider.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseSpatialObserver(
+        protected BaseSpatialObserver(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
             string name = null,
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <param name="name">The friendly name of the data provider.</param>
         /// <param name="priority">The registration priority of the data provider.</param>
         /// <param name="profile">The configuration profile for the data provider.</param>
-        public BaseSpatialObserver(
+        protected BaseSpatialObserver(
             IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
             string name = null,
             uint priority = DefaultPriority,

--- a/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
+++ b/Assets/MixedRealityToolkit/Providers/GenericPointer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Constructor.
         /// </summary>
-        public GenericPointer(string pointerName, IMixedRealityInputSource inputSourceParent)
+        protected GenericPointer(string pointerName, IMixedRealityInputSource inputSourceParent)
         {
             PointerId = (CoreServices.InputSystem?.FocusProvider != null) ? CoreServices.InputSystem.FocusProvider.GenerateNewPointerId() : 0;
             PointerName = pointerName;

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs
@@ -10,13 +10,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         // Hand ray
         protected HandRay HandRay { get; } = new HandRay();
-        public override bool IsInPointingPose
-        {
-            get
-            {
-                return HandRay.ShouldShowRay;
-            }
-        }
+
+        public override bool IsInPointingPose => HandRay.ShouldShowRay;
 
         // Velocity internal states
         private float deltaTimeStart;

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Constructor.
         /// </summary>
-        public BaseHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
+        protected BaseHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
         }

--- a/Assets/MixedRealityToolkit/Services/BaseCoreSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseCoreSystem.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the service.</param>
         /// <param name="profile">The configuration profile for the service.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseCoreSystem(
+        protected BaseCoreSystem(
             IMixedRealityServiceRegistrar registrar,
             BaseMixedRealityProfile profile = null) : this(profile)
         {
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// Constructor.
         /// </summary>
         /// <param name="profile">The configuration profile for the service.</param>
-        public BaseCoreSystem(
+        protected BaseCoreSystem(
             BaseMixedRealityProfile profile = null) : base()
         {
             ConfigurationProfile = profile;

--- a/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="priority">The registration priority of the data provider.</param>
         /// <param name="profile">The configuration profile for the data provider.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseDataProvider(
+        protected BaseDataProvider(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityService service,
             string name = null,
@@ -37,7 +37,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="name">The friendly name of the data provider.</param>
         /// <param name="priority">The registration priority of the data provider.</param>
         /// <param name="profile">The configuration profile for the data provider.</param>
-        public BaseDataProvider(
+        protected BaseDataProvider(
             IMixedRealityService service,
             string name = null,
             uint priority = DefaultPriority,

--- a/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the service.</param>
         /// <param name="profile">The configuration profile for the service.</param>
         [Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseDataProviderAccessCoreSystem(
+        protected BaseDataProviderAccessCoreSystem(
             IMixedRealityServiceRegistrar registrar,
             BaseMixedRealityProfile profile = null) : this(profile)
         {
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// Constructor.
         /// </summary>
         /// <param name="profile">The configuration profile for the service.</param>
-        public BaseDataProviderAccessCoreSystem(
+        protected BaseDataProviderAccessCoreSystem(
             BaseMixedRealityProfile profile = null) : base(profile)
         { }
 

--- a/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProviderAccessCoreSystem.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public abstract class BaseDataProviderAccessCoreSystem : BaseCoreSystem, IMixedRealityDataProviderAccess
     {
-        private List<IMixedRealityDataProvider> dataProviders = new List<IMixedRealityDataProvider>();
+        private readonly List<IMixedRealityDataProvider> dataProviders = new List<IMixedRealityDataProvider>();
 
         public override void Reset()
         {

--- a/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseExtensionService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="priority">The registration priority of the service.</param>
         /// <param name="profile">The configuration profile for the service.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        public BaseExtensionService(
+        protected BaseExtensionService(
             IMixedRealityServiceRegistrar registrar, 
             string name = null, 
             uint priority = DefaultPriority, 
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="name">The friendly name of the service.</param>
         /// <param name="priority">The registration priority of the service.</param>
         /// <param name="profile">The configuration profile for the service.</param>
-        public BaseExtensionService(
+        protected BaseExtensionService(
             string name = null,
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base()

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -440,7 +440,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (ActiveProfile.RegisteredServiceProvidersProfile != null)
             {
-                for (int i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile?.Configurations?.Length; i++)
+                for (int i = 0; i < ActiveProfile.RegisteredServiceProvidersProfile.Configurations?.Length; i++)
                 {
                     var configuration = ActiveProfile.RegisteredServiceProvidersProfile.Configurations[i];
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
     [InitializeOnLoad]
-    public class EditorProjectUtilities
+    public static class EditorProjectUtilities
     {
         /// <summary>
         /// Static constructor that allows for executing code on project load.
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <returns>True if the directory could be found, false otherwise.</returns>
         public static bool FindRelativeDirectory(string packageDirectory, out string path)
         {
-            return FindRelativeDirectory(UnityEngine.Application.dataPath, packageDirectory, out path);
+            return FindRelativeDirectory(Application.dataPath, packageDirectory, out path);
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             string packageCacheFolderName = @"Library\PackageCache";
 
-            DirectoryInfo projectRoot = new DirectoryInfo(UnityEngine.Application.dataPath).Parent;
+            DirectoryInfo projectRoot = new DirectoryInfo(Application.dataPath).Parent;
             return new DirectoryInfo(Path.Combine(projectRoot.FullName, packageCacheFolderName));
         }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         };
 
         // The check functions for each type of setting
-        private static Dictionary<Configurations, Func<bool>> ConfigurationGetters = new Dictionary<Configurations, Func<bool>>()
+        private static readonly Dictionary<Configurations, Func<bool>> ConfigurationGetters = new Dictionary<Configurations, Func<bool>>()
         {
             { Configurations.LatestScriptingRuntime,  () => { return IsLatestScriptingRuntime(); } },
             { Configurations.ForceTextSerialization,  () => { return IsForceTextSerialization(); } },
@@ -206,7 +206,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         }
 
         /// <summary>
-        /// Checks if current Unity projects uses force text serialziation
+        /// Checks if current Unity projects uses force text serialization
         /// </summary>
         public static bool IsForceTextSerialization()
         {

--- a/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GameObjectCreator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/GameObjectManagement/GameObjectCreator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.GameObjectManagement

--- a/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/Distorter.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/Distorters/Distorter.cs
@@ -16,12 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         [SerializeField]
         private float distortStrength = 1f;
 
-        private bool distortionEnabled;
-
-        public bool DistortionEnabled
-        {
-            get { return distortionEnabled; }
-        }
+        public bool DistortionEnabled { get; private set; }
 
         public float DistortStrength
         {
@@ -84,12 +79,12 @@ namespace Microsoft.MixedReality.Toolkit.Physics
 
         protected virtual void OnEnable()
         {
-            distortionEnabled = true;
+            DistortionEnabled = true;
         }
 
         protected virtual void OnDisable()
         {
-            distortionEnabled = false;
+            DistortionEnabled = false;
         }
 
         #endregion MonoBehaviour Implementation


### PR DESCRIPTION
## Overview
1. Updates constructors of abstract classes to protected, since you can't create an instance of an abstract type.
   1. https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1012?view=vs-2019
1. Update some data structures that don't get reallocated at runtime to readonly
1. Fixed some cases of incorrect null propagation on Unity objects
    1. https://blogs.unity3d.com/2014/05/16/custom-operator-should-we-keep-it/
1. Added `static` to EditorProjectUtilities
    1. https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1052?view=vs-2019
1. Formatting and some comment updates