### PR TITLE
Resolve MSBuildForUnity conflicts with published package

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 306544e0493cb274face4f1d0da1a82b
+guid: 098b58cc849a1c6418a4bb9b5735ddda
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Editor.InEditor.Template.props.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Editor.InEditor.Template.props.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8def3fcad821a5e42a02cccd03f83418
+guid: 2c479541dcca2b142925cf0216cae3e3
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Platform.Configuration.Template.props.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Platform.Configuration.Template.props.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c1d76f92257ccf4a9b60463e50e2e26
+guid: d5ba895ce0e599f4399f032bdb323a50
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Editor.meta.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Editor.meta.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9ed72d591ca99e14aaa5df3a22fb6da1
+guid: 805d5ace0d748c94b885a211de811414
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Standalone.meta.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Standalone.meta.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fc687b0a55916b04da014bab1b2c55c2
+guid: b5b070681f1773e4c9289d06706b5852
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.WSA.meta.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.WSA.meta.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ffcf2df19abf66141ae13aa914bbd9eb
+guid: 067fa8a4b4beef64b930a1ace507595d
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SDKProjectTemplate.csproj.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 44aac6db18cfcb04ab402e9aec2fa19c
+guid: b5bde7c3cd93778458835b0ee72a437b
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SolutionTemplate.sln.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/SolutionTemplate.sln.template.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 96832ba82c288844d9abe0e08add5c96
+guid: 9ffef504fac39a64c83771cbe84abb68
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Microsoft.MixedReality.Toolkit.MSBuild.asmdef.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Microsoft.MixedReality.Toolkit.MSBuild.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 40c2573e7fd33654a8689802c181677a
+guid: 4c67563a1ef82054ab3a99242b52d9ff
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f543d61caf4380c4cbce31465c58cc49
+guid: defd25836bc0b9d489688dcebf7efe1e
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5ea80809122c4d344ac34228c6d8ee54
+guid: b6d134b3ddb51a445b7cad28be6ae792
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         // This is the known Unity-defined script fileId
         private const string ScriptFileIdConstant = "11500000";
 
-        [MenuItem("Assets/Retarget To DLL")]
+        [MenuItem("Mixed Reality Toolkit/MSBuild/Assets/Retarget To DLL")]
         public static void RetargetAssets()
         {
             try

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c68e8bfbe634627468344ccb69d2efd9
+guid: 163ebea743dd97e45ae224a5c56a337e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectDependency.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectDependency.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1f3084948567f1e46bf7a4de2792ab11
+guid: 277cfc2278ae8f643b62245d095c6498
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4fc54644f02a00b4d99903d15e2e5093
+guid: 53d38306e502ad44596482e83a8fb294
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CompilationPlatformInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/CompilationPlatformInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 016cfaf43d227104490f45c6b9797ece
+guid: 4e252e0e08df62c42a34de9c0213bbec
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly string uwpMinPlatformVersion = EditorUserBuildSettings.wsaMinUWPSDK;
         private static readonly string uwpTargetPlatformVersion = EditorUserBuildSettings.wsaUWPSDK;
 
-        [MenuItem("MSBuild/Generate C# SDK Projects")]
+        [MenuItem("Mixed Reality Toolkit/MSBuild/Generate C# SDK Projects")]
         public static void GenerateSDKProjects()
         {
             try

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 51e2cf40536c414429e2ec0724e5a09c
+guid: e043ef6204dd71d4cb36223bdc24460f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/PluginAssemblyInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/PluginAssemblyInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a20b8ececda27954c9dd99f22b54ddf7
+guid: 19c9eea8ddad6a642b86134c5827b803
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/ReferenceItemInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/ReferenceItemInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f5884bcbfa98af7478d1ad04f88227d3
+guid: 90478748cce20384cab792e87f1b998a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/SourceFileInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/SourceFileInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 46aac4ca25790db4c98c3b40e32ee299
+guid: d713f7644f82e574a86639c9a1a6e543
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TargetFramework.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TargetFramework.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 147425c351fa58a4fbeda02291b00a28
+guid: 4733ede7f7bf1b2438752fcccc3af3f3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TemplateFiles.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/TemplateFiles.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fa0e87ba91b9aba4db16a550e8f02f6e
+guid: 68b11f561958b6e4588eb8d552de2386
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/UnityProjectInfo.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/UnityProjectInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a77ab803a8e14ad4bbc0d3e6508d2e79
+guid: 4804e4748eab6e04c9951d54abaebbba
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68149b68cf0632f409fa5d92639d0bf6
+guid: 213208a33f959ed4193036336726afd7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Overview
The MSBuild folder, which itself came from the MSBuildForUnity project, contains some of the same GUIDs, which led to conflicts when both MRTK and the published MSBuildForUnity project were imported.
There were also some menu item conflicts. Both have been resolved in this PR.