### PR TITLE
Interactable inspector polish

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -3,9 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -31,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
 
         protected const string ShowProfilesPrefKey = "InteractableInspectorProfiles";
         protected const string ShowEventsPrefKey = "InteractableInspectorProfiles_ShowEvents";
+        protected const string ShowEventReceiversPrefKey = "InteractableInspectorProfiles_ShowEvents_Receivers";
         protected bool enabled = false;
 
         protected string[] inputActionOptions = null;
@@ -45,6 +44,8 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         private static readonly GUIContent CreateThemeLabel = new GUIContent("Create and Assign New Theme", "Create a new theme");
         private static readonly GUIContent AddThemePropertyLabel = new GUIContent("+ Add Theme Property", "Add Theme Property");
         private static readonly GUIContent SpeechComamndsLabel = new GUIContent("Speech Command", "Speech Commands to use with Interactable, pulled from MRTK/Input/Speech Commands Profile");
+        private static readonly GUIContent OnClickEventLabel = new GUIContent("OnClick", "Fired when this Interactable is triggered by a click.");
+        private static readonly GUIContent AddEventReceiverLabel = new GUIContent("Add Event", "Add event receiver to this Interactable for special event handling.");
 
         protected virtual void OnEnable()
         {
@@ -114,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                 AddProfile(0);
             }
 
-            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Profiles", ShowProfilesPrefKey, MixedRealityStylesUtility.TitleFoldoutStyle))
+            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Profiles", ShowProfilesPrefKey, MixedRealityStylesUtility.BoldTitleFoldoutStyle))
             {
                 // Render all profile items. Profiles are per GameObject/ThemeContainer
                 for (int i = 0; i < profileList.arraySize; i++)
@@ -143,8 +144,6 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                             }
                         }
 
-                        EditorGUILayout.Space();
-
                         SerializedProperty themes = profileItem.FindPropertyRelative("Themes");
                         ValidateThemesForDimensions(dimensions, themes);
 
@@ -160,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                                 using (new EditorGUILayout.HorizontalScope())
                                 {
                                     string prefKey = themeItem.objectReferenceValue.name + "Profiles" + i + "_Theme" + t + "_Edit";
-                                    showThemeSettings = InspectorUIUtility.DrawSectionFoldoutWithKey(themeLabel, prefKey);
+                                    showThemeSettings = InspectorUIUtility.DrawSectionFoldoutWithKey(themeLabel, prefKey, null, false);
                                     EditorGUILayout.PropertyField(themeItem, new GUIContent(string.Empty, "Theme properties for interaction feedback"));
                                 }
 
@@ -210,30 +209,33 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
 
         private void RenderEventSettings()
         {
-            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Events", ShowEventsPrefKey, MixedRealityStylesUtility.TitleFoldoutStyle))
+            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Events", ShowEventsPrefKey, MixedRealityStylesUtility.BoldTitleFoldoutStyle))
             {
-                EditorGUILayout.Space();
-
-                SerializedProperty onClick = serializedObject.FindProperty("OnClick");
-                EditorGUILayout.PropertyField(onClick, new GUIContent("OnClick"));
-
-                SerializedProperty events = serializedObject.FindProperty("Events");
-                for (int i = 0; i < events.arraySize; i++)
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
                 {
-                    SerializedProperty eventItem = events.GetArrayElementAtIndex(i);
-                    if (InteractableEventInspector.RenderEvent(eventItem))
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("OnClick"), OnClickEventLabel);
+
+                    if (InspectorUIUtility.DrawSectionFoldoutWithKey("Receivers", ShowEventReceiversPrefKey, MixedRealityStylesUtility.TitleFoldoutStyle, false))
                     {
-                        events.DeleteArrayElementAtIndex(i);
-                        // If removed, skip rendering rest of list till next redraw
-                        break;
+                        SerializedProperty events = serializedObject.FindProperty("Events");
+                        for (int i = 0; i < events.arraySize; i++)
+                        {
+                            SerializedProperty eventItem = events.GetArrayElementAtIndex(i);
+                            if (InteractableEventInspector.RenderEvent(eventItem))
+                            {
+                                events.DeleteArrayElementAtIndex(i);
+                                // If removed, skip rendering rest of list till next redraw
+                                break;
+                            }
+
+                            EditorGUILayout.Space();
+                        }
+
+                        if (GUILayout.Button(AddEventReceiverLabel))
+                        {
+                            AddEvent(events.arraySize);
+                        }
                     }
-
-                    EditorGUILayout.Space();
-                }
-
-                if (GUILayout.Button(new GUIContent("Add Event")))
-                {
-                    AddEvent(events.arraySize);
                 }
             }
         }

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -474,7 +474,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Draws a section start (initiated by the Header attribute)
         /// </summary>
-        public static bool DrawSectionFoldout(string headerName, bool open = true, GUIStyle style = null, int size = 0)
+        public static bool DrawSectionFoldout(string headerName, bool open = true, GUIStyle style = null)
         {
             if (style == null)
             {
@@ -489,10 +489,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Draws a section start with header name and save open/close state to given preference key in SessionState
         /// </summary>
-        public static bool DrawSectionFoldoutWithKey(string headerName, string preferenceKey = null, GUIStyle style = null, int size = 0)
+        public static bool DrawSectionFoldoutWithKey(string headerName, string preferenceKey = null, GUIStyle style = null, bool defaultOpen = true)
         {
-            bool showPref = SessionState.GetBool(preferenceKey, true);
-            bool show = DrawSectionFoldout(headerName, showPref, style, size);
+            bool showPref = SessionState.GetBool(preferenceKey, defaultOpen);
+            bool show = DrawSectionFoldout(headerName, showPref, style);
             if (show != showPref)
             {
                 SessionState.SetBool(preferenceKey, show);

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -20,10 +20,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Default style for foldouts with bold large font size title
         /// </summary>
-        public static readonly GUIStyle TitleFoldoutStyle =
+        public static readonly GUIStyle BoldTitleFoldoutStyle =
           new GUIStyle(EditorStyles.foldout)
           {
               fontStyle = FontStyle.Bold,
+              fontSize = InspectorUIUtility.TitleFontSize,
+          };
+
+        /// <summary>
+        /// Default style for foldouts with large font size title
+        /// </summary>
+        public static readonly GUIStyle TitleFoldoutStyle =
+          new GUIStyle(EditorStyles.foldout)
+          {
+              //fontStyle = FontStyle.,
               fontSize = InspectorUIUtility.TitleFontSize,
           };
 


### PR DESCRIPTION
## Overview
This change is a polish pass on Interactable inspector. Primarily event receivers and themes details of an interactable would render everything by default. Especially for complex Interactable prefabs, this could be a bit overwhelming and annoying to scroll/navigate. 


- Made theme details and event receiver foldouts hidden by default. 
- Removed unused size parameter in inspectoruiutility draw foldouts
- Added helpbox style around events section

After:
![image](https://user-images.githubusercontent.com/25975362/68821518-6c6ed600-0643-11ea-8aad-3a69a74bf889.png)

Before:
![image](https://user-images.githubusercontent.com/25975362/68821623-b1930800-0643-11ea-872b-9bf68dcdd8aa.png)
![image](https://user-images.githubusercontent.com/25975362/68821641-bb1c7000-0643-11ea-83ea-d51da5d1ac86.png)


## Changes
- Fixes: # .

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
