### PR TITLE
Remove duplicate build step

### DIFF
--- a/pipelines/templates/compilemsbuild.yml
+++ b/pipelines/templates/compilemsbuild.yml
@@ -50,18 +50,6 @@ steps:
   inputs:
     solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
     msbuildArchitecture: 'x64'
-    platform: 'WSA'
-    configuration: 'InEditor'
-    createLogFile: true
-    restoreNugetPackages: false
-    msbuildVersion: '15.0'
-    msbuildArguments: '/p:BuildProjectReferences=false'
-  displayName: 'Build InEditor WSA'
-
-- task: MSBuild@1
-  inputs:
-    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
-    msbuildArchitecture: 'x64'
     platform: 'Android'
     configuration: 'Player'
     createLogFile: true


### PR DESCRIPTION
## Overview
Removes a duplicate `Build InEditor WSA` step

## Changes
- Fixes:
![image](https://user-images.githubusercontent.com/3580640/68891641-1ac35b80-06d6-11ea-92b2-0335e9d587b1.png)