### PR TITLE
Update boundary system to use MRTK type instead of Unity type

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Boundary/Scripts/BoundaryVisualizationDemo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Boundary/Scripts/BoundaryVisualizationDemo.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Boundary;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityBoundary = UnityEngine.Experimental.XR.Boundary;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 {
@@ -144,12 +143,12 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 
                     Material material = null;
                     // Check inscribed rectangle first
-                    if (CoreServices.BoundarySystem.Contains(position, UnityBoundary.Type.PlayArea))
+                    if (CoreServices.BoundarySystem.Contains(position, BoundaryType.PlayArea))
                     {
                         material = playAreaMaterial;
                     }
                     // Then check geometry
-                    else if (CoreServices.BoundarySystem.Contains(position, UnityBoundary.Type.TrackedArea))
+                    else if (CoreServices.BoundarySystem.Contains(position, BoundaryType.TrackedArea))
                     {
                         material = trackedAreaMaterial;
                     }

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/MixedRealityBoundarySystem.cs
@@ -595,7 +595,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         public float? FloorHeight { get; private set; } = null;
 
         /// <inheritdoc/>
-        public bool Contains(Vector3 location, UnityBoundary.Type boundaryType = UnityBoundary.Type.TrackedArea)
+        public bool Contains(Vector3 location, BoundaryType boundaryType = BoundaryType.TrackedArea)
         {
             if (!EdgeUtilities.IsValidPoint(location))
             {
@@ -622,7 +622,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             // Boundary coordinates are always "on the floor"
             Vector2 point = new Vector2(location.x, location.z);
 
-            if (boundaryType == UnityBoundary.Type.PlayArea)
+            if (boundaryType == BoundaryType.PlayArea)
             {
                 // Check the inscribed rectangle.
                 if (rectangularBounds != null)
@@ -630,7 +630,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                     return rectangularBounds.IsInsideBoundary(point);
                 }
             }
-            else if (boundaryType == UnityBoundary.Type.TrackedArea)
+            else if (boundaryType == BoundaryType.TrackedArea)
             {
                 // Check the geometry
                 return EdgeUtilities.IsInsideBoundary(Bounds, point);

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/BoundaryType.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/BoundaryType.cs
@@ -1,11 +1,20 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.MixedReality.Toolkit.Boundary
 {
+    /// <summary>
+    /// Defines different types of boundaries that can be requested.
+    /// </summary>
     public enum BoundaryType
     {
+        /// <summary>
+        /// A rectangular area calculated as the largest rectangle within the tracked area, good for placing content near the user.
+        /// </summary>
         PlayArea,
+        /// <summary>
+        /// The full tracked boundary, typically manually drawn by a user while setting up their device.
+        /// </summary>
         TrackedArea
     }
 }

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/BoundaryType.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/BoundaryType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.MixedReality.Toolkit.Boundary
+{
+    public enum BoundaryType
+    {
+        PlayArea,
+        TrackedArea
+    }
+}

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/BoundaryType.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/BoundaryType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14f00db1440205648911737e3720c79f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/BoundarySystem/IMixedRealityBoundarySystem.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
-using UnityBoundary = UnityEngine.Experimental.XR.Boundary;
 
 namespace Microsoft.MixedReality.Toolkit.Boundary
 {
@@ -110,10 +109,10 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <returns>True if the location is within the specified area of the boundary space.</returns>
         /// <remarks>
         /// Use:
-        /// Boundary.Type.PlayArea for the inscribed volume
-        /// Boundary.Type.TrackedArea for the area defined by the boundary edges.
+        /// BoundaryType.PlayArea for the inscribed volume
+        /// BoundaryType.TrackedArea for the area defined by the boundary edges.
         /// </remarks>
-        bool Contains(Vector3 location, UnityBoundary.Type boundaryType = UnityBoundary.Type.TrackedArea);
+        bool Contains(Vector3 location, BoundaryType boundaryType = BoundaryType.TrackedArea);
 
         /// <summary>
         /// Returns the description of the inscribed rectangular bounds.

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -1,7 +1,18 @@
 # Updating the Microsoft Mixed Reality Toolkit
 
+- [2.1.0 to 2.2.0](#updating-210-to-220)
 - [2.0.0 to 2.1.0](#updating-200-to-210)
 - [RC2 to 2.0.0](#updating-rc2-to-200)
+
+## Updating 2.1.0 to 2.2.0
+
+- [API changes](#api-changes-in-220)
+
+### API changes in 2.2.0
+
+#### IMixedRealityBoundarySystem.Contains
+
+This method previously took in a specific, Unity-defined experimental enum. It now takes in an MRTK-defined enum that's identical to the Unity enum. This change helps prepare the MRTK for Unity's future boundary APIs.
 
 ## Updating 2.0.0 to 2.1.0
 


### PR DESCRIPTION
## Overview
In preparation for Unity's future boundary types, this PR looks to remove dependencies on Unity types.