### PR TITLE
Always enable View Asset and Documentation buttons in profile inspectors

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/InspectorUIUtility.cs
@@ -169,10 +169,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     tooltip = docURL,
                 };
 
-                if (GUILayout.Button(buttonContent, EditorStyles.miniButton, GUILayout.MaxWidth(DocLinkWidth)))
+                // The documentation button should always be enabled.
+                using (new GUIEnabledWrapper(true, true))
                 {
-                    Application.OpenURL(docURL);
-                    return true;
+                    if (GUILayout.Button(buttonContent, EditorStyles.miniButton, GUILayout.MaxWidth(DocLinkWidth)))
+                    {
+                        Application.OpenURL(docURL);
+                        return true;
+                    }
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -556,10 +556,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     // The view asset button should always be enabled.
                     using (new GUIEnabledWrapper(true, true))
                     { 
-                    if (GUILayout.Button("View Asset", EditorStyles.miniButton, GUILayout.Width(80)))
-                    {
-                        EditorGUIUtility.PingObject(property.objectReferenceValue);
-                    }
+                        if (GUILayout.Button("View Asset", EditorStyles.miniButton, GUILayout.Width(80)))
+                        {
+                            EditorGUIUtility.PingObject(property.objectReferenceValue);
+                        }
                     }
                 }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -553,9 +553,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // Draw a button that finds the profile in the project window
                 if (property.objectReferenceValue != null)
                 {
+                    // The view asset button should always be enabled.
+                    using (new GUIEnabledWrapper(true, true))
+                    { 
                     if (GUILayout.Button("View Asset", EditorStyles.miniButton, GUILayout.Width(80)))
                     {
                         EditorGUIUtility.PingObject(property.objectReferenceValue);
+                    }
                     }
                 }
 


### PR DESCRIPTION
#6597 identified an issue where non-destructive / informational controls were disabled in the profile inspector when showing sub-profile views.

This change renders View Asset and Documentation buttons enabled _always_.