### PR TITLE
Fix CanInteract in Interactable

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private static readonly Quaternion DefaultRotationToggle = Quaternion.LookRotation(Vector3.forward);
 
         private static InputSimulationService inputSimulationService = null;
-        private const int MOVE_HAND_NUM_STEPS = 32;
+        private const int MoveHandNumSteps = 32;
 
         [SetUp]
         public override void Setup()
@@ -643,8 +643,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsFalse(secondRadialButton.IsToggled);
             Assert.IsFalse(thirdRadialButton.IsToggled);
 
-            yield return testHand.Show(Vector3.zero);
-
             var aBitBack = Vector3.forward * -0.2f;
             yield return testHand.MoveTo(secondRadialButton.transform.position);
             yield return testHand.Move(aBitBack);
@@ -919,7 +917,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move the hand towards
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, MOVE_HAND_NUM_STEPS, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, MoveHandNumSteps , ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
         }
 
         private IEnumerator MoveHandAwayFromButton()
@@ -928,7 +926,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 p3 = Vector3.zero;
 
             // Move the hand back
-            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, MOVE_HAND_NUM_STEPS, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, MoveHandNumSteps , ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
             yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -43,11 +43,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private static readonly Quaternion DefaultRotation = Quaternion.LookRotation(Vector3.up);
         private static readonly Quaternion DefaultRotationToggle = Quaternion.LookRotation(Vector3.forward);
 
+        private static InputSimulationService inputSimulationService = null;
+        private const int MOVE_HAND_NUM_STEPS = 32;
+
         [SetUp]
         public override void Setup()
         {
             base.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
+
+            inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
         }
 
         /// <summary>
@@ -118,22 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             touchHandler.OnTouchStarted.AddListener((HandTrackingInputEventData e) => interactable.SetInputDown());
             touchHandler.OnTouchCompleted.AddListener((HandTrackingInputEventData e) => interactable.SetInputUp());
 
-            // Move the hand forward to intersect the interactable
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 32;
-            Vector3 p1 = Vector3.zero;
-            Vector3 p2 = new Vector3(0.05f, 0f, 0.51f);
-            Vector3 p3 = Vector3.zero;
-
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
-
-            yield return CheckButtonTranslation(targetStartPosition, translateTargetObject);
-
-            // Move the hand back
-            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
-            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+            yield return TestClickPushButton(targetStartPosition, translateTargetObject);
 
             Assert.True(wasClicked, "Interactable was not clicked.");
 
@@ -142,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// Instantiates a push button prefab and uses simulated global input events to press it.
+        /// Instantiates a push button prefab and uses simulated global input events to press it. Test that global input behaves correctly when Interactable IsEnabled and not
         /// </summary>
         [UnityTest]
         public IEnumerator TestSelectGlobalInput()
@@ -162,51 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             bool wasClicked = false;
             interactable.OnClick.AddListener(() => { wasClicked = true; });
 
-            // Set interactable to global
-            interactable.IsGlobal = true;
-
-            // TODO: Troy - merge with TestSelectGlobalInputOnDisabled
-
-            Vector3 targetStartPosition = translateTargetObject.localPosition;
-
-            yield return null;
-
-            // Find an input source to associate with the input event (doesn't matter which one)
-            IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
-            Assert.NotNull(defaultInputSource, "At least one input source must be present for this test to work.");
-
-            yield return RunGlobalClick(defaultInputSource, interactable.InputAction, targetStartPosition, translateTargetObject);
-
-            Assert.True(wasClicked, "Interactable was not clicked.");
-            Assert.False(interactable.HasFocus, "Interactable had focus");
-            Assert.True(interactable.IsVisited, "Interactable was not visited");
-
-            // Remove as global listener and cleanup
-            GameObject.Destroy(interactable.gameObject);
-        }
-
-        /// <summary>
-        /// Instantiates a push button prefab and disable it but also enable global input. Ensure cannot interact because disabled
-        /// </summary>
-        [UnityTest]
-        public IEnumerator TestSelectGlobalInputOnDisabled()
-        {
-            // Load interactable prefab
-            Interactable interactable;
-            Transform translateTargetObject;
-
-            // Place out of the way of any pointers
-            InstantiatePressButtonPrefab(
-                new Vector3(10f, 0.0f, 0.5f),
-                DefaultRotation,
-                out interactable,
-                out translateTargetObject);
-
-            // Subscribe to interactable's on click so we know the click went through
-            bool wasClicked = false;
-            interactable.OnClick.AddListener(() => { wasClicked = true; });
-
-            // Set interactable disabled and receive global input
+            // Set interactable to global and disabled
             interactable.IsEnabled = false;
             interactable.IsGlobal = true;
 
@@ -220,9 +166,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return RunGlobalClick(defaultInputSource, interactable.InputAction, targetStartPosition, translateTargetObject, false);
 
-            Assert.False(wasClicked, "Interactable was clicked but is disabled.");
+            Assert.False(wasClicked, "Interactable was not clicked.");
             Assert.False(interactable.HasFocus, "Interactable had focus");
-            Assert.False(interactable.IsVisited, "Interactable was visited but is disabled");
+            Assert.False(interactable.IsVisited, "Interactable was not visited");
+
+            interactable.IsEnabled = true;
+
+            yield return RunGlobalClick(defaultInputSource, interactable.InputAction, targetStartPosition, translateTargetObject);
+
+            Assert.True(wasClicked, "Interactable was not clicked.");
+            Assert.False(interactable.HasFocus, "Interactable had focus");
+            Assert.True(interactable.IsVisited, "Interactable was not visited");
+
+            // Unregister global handlers
+            interactable.IsGlobal = false;
 
             // Remove as global listener and cleanup
             GameObject.Destroy(interactable.gameObject);
@@ -232,9 +189,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Assembles a push button from primitives and uses simulated input events to press it.
         /// </summary>
         [UnityTest]
-        public IEnumerator TestInputActionSelectInput()
+        public IEnumerator TestInputActions()
         {
-            // Load interactable
             Interactable interactable;
             Transform translateTargetObject;
 
@@ -245,49 +201,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             interactable.transform.position = new Vector3(0.0f, 0.0f, 0.5f);
             interactable.transform.eulerAngles = new Vector3(-90f, 0f, 0f);
 
-            // Subscribe to interactable's on click so we know the click went through
+            // Subscribe to interactable's on click and on press receiver so we know the click went through
             bool wasClicked = false;
             interactable.OnClick.AddListener(() => { wasClicked = true; });
-
-            Vector3 targetStartPosition = translateTargetObject.localPosition;
-
-            yield return null;
-
-            // Find an input source to associate with the input event (doesn't matter which one)
-            IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
-            Assert.NotNull(defaultInputSource, "At least one input source must be present for this test to work.");
-
-            yield return RunGlobalClick(defaultInputSource, interactable.InputAction, targetStartPosition, translateTargetObject);
-
-            Assert.True(wasClicked, "Interactable was not clicked.");
-            Assert.AreEqual(targetStartPosition, translateTargetObject.localPosition, "Transform target object was not translated back by action.");
-
-            // TODO: Troy - look at merging TestInputActionMenuInput?
-
-            //Cleanup
-            GameObject.Destroy(interactable.gameObject);
-        }
-
-        /// <summary>
-        /// Instantiates a push button prefab and uses simulated input events to press it.
-        /// </summary>
-        [UnityTest]
-        public IEnumerator TestInputActionMenuInput()
-        {
-            // Load interactable prefab
-            Interactable interactable;
-            Transform translateTargetObject;
-
-            InstantiatePressButtonPrefab(
-                new Vector3(0.0f, 0.0f, 0.5f),
-                DefaultRotation,
-                out interactable,
-                out translateTargetObject);
-
-            // Subscribe to interactable's on click so we know the click went through
-            bool wasClicked = false;
-            interactable.OnClick.AddListener(() => { wasClicked = true; });
-
             var pressReceiver = interactable.AddReceiver<InteractableOnPressReceiver>();
             bool wasPressed = false;
             pressReceiver.OnPress.AddListener(() => { wasPressed = true; Debug.Log("pressReciever wasPressed true"); });
@@ -296,7 +212,26 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Vector3 targetStartPosition = translateTargetObject.localPosition;
 
-            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            yield return null;
+
+            //
+            // Test Select Input Action
+            //
+
+            // Find an input source to associate with the input event (doesn't matter which one)
+            IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
+            Assert.NotNull(defaultInputSource, "At least one input source must be present for this test to work.");
+
+            yield return RunGlobalClick(defaultInputSource, interactable.InputAction, targetStartPosition, translateTargetObject);
+
+            Assert.True(wasClicked, "Interactable was not clicked.");
+            Assert.True(wasPressed, "interactable not pressed");
+            Assert.True(wasReleased, "interactable not released");
+            Assert.AreEqual(targetStartPosition, translateTargetObject.localPosition, "Transform target object was not translated back by action.");
+
+            //
+            // Test Menu Input Action
+            //
 
             // Find the menu action from the input system profile
             MixedRealityInputAction menuAction = CoreServices.InputSystem.InputSystemProfile.InputActionsProfile.InputActions.Where(m => m.Description == "Menu").FirstOrDefault();
@@ -304,17 +239,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Set the interactable to respond to a 'menu' input action
             interactable.InputAction = menuAction;
+            // Reset state tracking
+            wasClicked = wasPressed = wasReleased = false;
 
-            // Find an input source to associate with the input event (doesn't matter which one)
-            IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
-            Assert.NotNull(defaultInputSource, "At least one input source must be present for this test to work.");
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             yield return RunGlobalClick(defaultInputSource, menuAction, targetStartPosition, translateTargetObject);
 
+            Assert.True(wasClicked, "Interactable was not clicked.");
             Assert.True(wasPressed, "interactable not pressed");
             Assert.True(wasReleased, "interactable not released");
-            Assert.True(wasClicked, "Interactable was not clicked.");
+            Assert.AreEqual(targetStartPosition, translateTargetObject.localPosition, "Transform target object was not translated back by action.");
 
+            //Cleanup
             GameObject.Destroy(interactable.gameObject);
         }
 
@@ -363,6 +300,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(SelectionModes.Toggle, interactable.ButtonMode, "Interactable should be in Toggle selection mode");
             Assert.IsTrue(interactable.IsToggled, "Invalid Dimension should not change state");
 
+            // Test toggle off via code API
+            interactable.TriggerOnClick();
+            Assert.AreEqual(2, interactable.NumOfDimensions, "Interactable should be in Toggle selection mode");
+            Assert.AreEqual(0, interactable.CurrentDimension, "Interactable should be Toggled off");
+            Assert.AreEqual(SelectionModes.Toggle, interactable.ButtonMode, "Interactable should be in Toggle selection mode");
+            Assert.False(interactable.IsToggled, "Invalid Dimension should not change state");
+
             //Clean up
             GameObject.Destroy(interactable.gameObject);
 
@@ -370,7 +314,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// Instantiates a push button prefab and uses simulated voice input events to press it.
+        /// Instantiates a push button prefab and uses simulated voice input events to press it, both when IsEnabled and not
         /// </summary>
         [UnityTest]
         public IEnumerator TestVoiceInputOnPrefab()
@@ -388,41 +332,99 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Subscribe to interactable's on click so we know the click went through
             bool wasClicked = false;
             interactable.OnClick.AddListener(() => { wasClicked = true; });
-            
+
             Vector3 targetStartPosition = translateTargetObject.localPosition;
 
             // Set up its voice command
             interactable.VoiceCommand = "Select";
-
-            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            interactable.VoiceRequiresFocus = false;
 
             // Find an input source to associate with the input event (doesn't matter which one)
             IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
             Assert.NotNull(defaultInputSource, "At least one input source must be present for this test to work.");
 
-            // Raise a voice select input event, then wait for transition to take place
-            // Wait for at least one frame explicitly to ensure the input goes through
-            SpeechCommands commands = new SpeechCommands(interactable.VoiceCommand, KeyCode.None, interactable.InputAction);
-            CoreServices.InputSystem.RaiseSpeechCommandRecognized(defaultInputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(100), System.DateTime.Now, commands);
-            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            //
+            // Test speech when disabled
+            //
 
+            interactable.IsEnabled = false;
+
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            yield return FireSpeechCommand(interactable.VoiceCommand, interactable.InputAction, defaultInputSource);
+            yield return CheckButtonTranslation(targetStartPosition, translateTargetObject, false);
+
+            Assert.False(wasClicked, "Interactable was clicked.");
+            Assert.False(interactable.IsVisited, "Interactable was visited.");
+
+            //
+            // Test speech when enabled
+            //
+
+            interactable.IsEnabled = true;
+
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+            yield return FireSpeechCommand(interactable.VoiceCommand, interactable.InputAction, defaultInputSource);
             yield return CheckButtonTranslation(targetStartPosition, translateTargetObject);
 
             Assert.True(wasClicked, "Interactable was not clicked.");
-
-            // TODO: Troy - test when !isEnabled
+            Assert.True(interactable.IsVisited, "Interactable was not visited.");
 
             //Cleanup
             GameObject.Destroy(interactable.gameObject);
         }
 
+        /// <summary>
+        /// Test touch input on Interactable by looking at state changes, both for when IsEnabled and not
+        /// </summary>
         [UnityTest]
-        public IEnumerator TestTouch()
+        public IEnumerator TestTouchInput()
         {
-            // Test interactable with touch/press hand inside and away
-            yield return null;
+            Interactable interactable;
+            Transform translateTargetObject;
 
-            // test when !IsEnabled
+            InstantiatePressButtonPrefab(
+                new Vector3(0.0f, 0.0f, 0.5f),
+                DefaultRotation,
+                out interactable,
+                out translateTargetObject);
+
+            var touchableVolume = interactable.gameObject.AddComponent<NearInteractionTouchableVolume>();
+
+            //
+            // Test touch when disabled
+            //
+
+            interactable.IsEnabled = false;
+
+            yield return MoveHandToButton();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Assert.False(interactable.HasPhysicalTouch);
+            Assert.False(interactable.HasPress);
+
+            yield return MoveHandAwayFromButton();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            //
+            // Test touch when enabled
+            //
+
+            interactable.IsEnabled = true;
+
+            yield return MoveHandToButton();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Assert.True(interactable.HasPhysicalTouch);
+            Assert.True(interactable.HasPress);
+
+            yield return MoveHandAwayFromButton();
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            Assert.False(interactable.HasPhysicalTouch);
+            Assert.False(interactable.HasPress);
+
+            //Cleanup
+            GameObject.Destroy(interactable.gameObject);
         }
 
         /// <summary>
@@ -497,10 +499,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestDisableOnClick()
         {
-            var rightHand = new TestHand(Handedness.Right);
-            Vector3 p1 = Vector3.zero;
-            Vector3 p2 = new Vector3(0.05f, 0f, 0.51f);
-
             // Load the Model_PushButton interactable prefab
             Interactable interactable;
             Transform innerCylinderTransform;
@@ -513,36 +511,24 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.True(interactable.IsEnabled);
 
-            // OnClick, disable Interactable 
+            // OnClick, set Interactable IsEnabled false or aka disabled
             interactable.OnClick.AddListener(() => { interactable.IsEnabled = false; });
 
             // Get start position of the inner cylinder before button is pressed
             Vector3 innerCylinderStartPosition = innerCylinderTransform.localPosition;
 
-            // TODO: Troy -> Make same re-use function
+            yield return TestClickPushButton(innerCylinderStartPosition, innerCylinderTransform);
 
-            // Move the hand forward to press button
-            yield return rightHand.Show(p1);
-            yield return rightHand.MoveTo(p2);
-
-            // Ensure that the inner cylinder in the button has moved on press
-            yield return CheckButtonTranslation(innerCylinderStartPosition, innerCylinderTransform);
-
-            // Move the hand back
-            yield return rightHand.MoveTo(p1);
-            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
-
-            Assert.False(interactable.IsEnabled);
+            Assert.False(interactable.IsEnabled, "Interactable should be disabled");
 
             // Re-enable Interactable
             interactable.IsEnabled = true;
-            yield return null;
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
-            // Make sure the button depth is back at the starting position when re-enable the gameObject
+            // Make sure the button depth is back at the starting position when re-enable the gameObject and states have reset
             Assert.True(innerCylinderTransform.localPosition == innerCylinderStartPosition);
-
-            // Make sure the focus state is false after we re-enable Interactable
-            Assert.False(interactable.HasFocus);
+            Assert.False(interactable.HasFocus, "Interactable has focus");
+            Assert.True(interactable.IsVisited, "Interactable was not visited");
 
             GameObject.Destroy(interactable.gameObject);
         }
@@ -573,16 +559,69 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Vector3 targetStartPosition = pressButtonCylinder.localPosition;
 
+            //
+            // Test starting as disabled
+            //
             yield return TestClickPushButton(targetStartPosition, pressButtonCylinder, false);
 
             Assert.False(wasClicked, "Interactable was clicked.");
 
+            //
+            // Test when enabled
+            //
             interactable.IsEnabled = true;
 
             yield return TestClickPushButton(targetStartPosition, pressButtonCylinder, true);
 
             Assert.True(wasClicked, "Interactable was not clicked.");
 
+            // Cleanup
+            GameObject.Destroy(interactable.gameObject);
+        }
+
+        /// <summary>
+        /// Test the TriggerOnClick API for Interactable both when IsEnabled and not. Button should fire OnClick and move UI
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTriggerOnClick()
+        {
+            Interactable interactable;
+            Transform innerCylinderTransform;
+
+            InstantiatePressButtonPrefab(
+                new Vector3(0.0f, 0.0f, 0.5f),
+                DefaultRotation,
+                out interactable,
+                out innerCylinderTransform);
+
+            // Subscribe to interactable's on click so we know the click went through
+            bool wasClicked = false;
+            interactable.OnClick.AddListener(() => { wasClicked = true; });
+
+            Vector3 targetStartPosition = innerCylinderTransform.localPosition;
+
+            //
+            // Test TriggerOnClick when disabled
+            //
+            interactable.IsEnabled = false;
+
+            interactable.TriggerOnClick();
+
+            Assert.False(wasClicked, "Interactable was clicked.");
+            Assert.False(interactable.IsVisited, "Interactable was visited.");
+
+            //
+            // Test TriggerOnClick when enabled
+            //
+            interactable.IsEnabled = true;
+
+            interactable.TriggerOnClick();
+            yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+
+            Assert.True(wasClicked, "Interactable was not clicked.");
+            Assert.True(interactable.IsVisited, "Interactable was not visited.");
+
+            // Cleanup
             GameObject.Destroy(interactable.gameObject);
         }
 
@@ -594,40 +633,48 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator TestRadialSetPrefab()
         {
             var radialSet = InstantiateInteractableFromPath(Vector3.forward, Quaternion.identity, RadialSetPrefabAssetPath);
-            var firstRadialButton = radialSet.transform.Find("Radial (1)");
-            var secondRadialButton = radialSet.transform.Find("Radial (2)");
-            var thirdRadialButton = radialSet.transform.Find("Radial (3)");
+            var firstRadialButton = radialSet.transform.Find("Radial (1)").GetComponent<Interactable>();
+            var secondRadialButton = radialSet.transform.Find("Radial (2)").GetComponent<Interactable>();
+            var thirdRadialButton = radialSet.transform.Find("Radial (3)").GetComponent<Interactable>();
             var testHand = new TestHand(Handedness.Right);
             yield return testHand.Show(Vector3.zero);
 
-            Assert.IsTrue(firstRadialButton.GetComponent<Interactable>().IsToggled);
-            Assert.IsFalse(secondRadialButton.GetComponent<Interactable>().IsToggled);
-            Assert.IsFalse(thirdRadialButton.GetComponent<Interactable>().IsToggled);
+            Assert.IsTrue(firstRadialButton.IsToggled);
+            Assert.IsFalse(secondRadialButton.IsToggled);
+            Assert.IsFalse(thirdRadialButton.IsToggled);
 
             yield return testHand.Show(Vector3.zero);
 
             var aBitBack = Vector3.forward * -0.2f;
-            yield return testHand.MoveTo(firstRadialButton.position);
-            yield return testHand.Move(aBitBack);
-
             yield return testHand.MoveTo(secondRadialButton.transform.position);
             yield return testHand.Move(aBitBack);
 
-            Assert.IsFalse(firstRadialButton.GetComponent<Interactable>().IsToggled);
-            Assert.IsTrue(secondRadialButton.GetComponent<Interactable>().IsToggled);
-            Assert.IsFalse(thirdRadialButton.GetComponent<Interactable>().IsToggled);
+            Assert.IsFalse(firstRadialButton.IsToggled);
+            Assert.IsFalse(firstRadialButton.HasFocus);
+            Assert.IsTrue(secondRadialButton.IsToggled);
+            Assert.IsTrue(secondRadialButton.HasFocus);
+            Assert.IsFalse(thirdRadialButton.IsToggled);
+            Assert.IsFalse(thirdRadialButton.HasFocus);
 
-            // TODO: Troy - test focus here?
+            yield return testHand.MoveTo(thirdRadialButton.transform.position);
+            yield return testHand.Move(aBitBack);
+
+            Assert.IsFalse(firstRadialButton.IsToggled);
+            Assert.IsFalse(firstRadialButton.HasFocus);
+            Assert.IsFalse(secondRadialButton.IsToggled);
+            Assert.IsFalse(secondRadialButton.HasFocus);
+            Assert.IsTrue(thirdRadialButton.IsToggled);
+            Assert.IsTrue(thirdRadialButton.HasFocus);
 
             //Cleanup
             GameObject.Destroy(radialSet);
         }
 
-        [UnityTest]
         /// <summary>
         /// Tests that the toggle button states consistently return to original state
         /// after subsequent clicks (front plate does not move back after every click).
         /// </summary>
+        [UnityTest]
         public IEnumerator TestPressableToggleHoloLens2()
         {
             var rightHand = new TestHand(Handedness.Right);
@@ -865,23 +912,52 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(shouldTranslate, wasTranslated, "Transform target object did or did not translate properly by action.");
         }
 
-        private IEnumerator TestClickPushButton(Vector3 targetStartPosition, Transform translateTargetObject, bool shouldClick = true)
+        private IEnumerator MoveHandToButton()
         {
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-            int numSteps = 32;
             Vector3 p1 = Vector3.zero;
+            Vector3 p2 = new Vector3(0.05f, 0f, 0.51f);
+
+            // Move the hand towards
+            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, MOVE_HAND_NUM_STEPS, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+        }
+
+        private IEnumerator MoveHandAwayFromButton()
+        {
             Vector3 p2 = new Vector3(0.05f, 0f, 0.51f);
             Vector3 p3 = Vector3.zero;
 
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHandFromTo(p1, p2, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            // Move the hand back
+            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, MOVE_HAND_NUM_STEPS, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
+            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
+        }
+
+        private IEnumerator TestClickPushButton(Vector3 targetStartPosition, Transform translateTargetObject, bool shouldClick = true)
+        {
+            yield return MoveHandToButton();
 
             yield return CheckButtonTranslation(targetStartPosition, translateTargetObject, shouldClick);
 
-            // Move the hand back
-            yield return PlayModeTestUtilities.MoveHandFromTo(p2, p3, numSteps, ArticulatedHandPose.GestureId.Poke, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
+            yield return MoveHandAwayFromButton();
+
             yield return new WaitForSeconds(ButtonReleaseAnimationDelay);
+        }
+
+        private IEnumerator FireSpeechCommand(string voiceCommand, MixedRealityInputAction inputAction, IMixedRealityInputSource inputSource = null)
+        {
+            if (inputSource == null)
+            {
+                // Find an input source to associate with the input event (doesn't matter which one)
+                IMixedRealityInputSource defaultInputSource = CoreServices.InputSystem.DetectedInputSources.FirstOrDefault();
+                Assert.NotNull(defaultInputSource, "At least one input source must be present for this test to work.");
+                inputSource = defaultInputSource;
+            }
+
+            // Raise a voice select input event, then wait for transition to take place
+            // Wait for at least one frame explicitly to ensure the input goes through
+            SpeechCommands commands = new SpeechCommands(voiceCommand, KeyCode.None, inputAction);
+            CoreServices.InputSystem.RaiseSpeechCommandRecognized(inputSource, RecognitionConfidenceLevel.High, new System.TimeSpan(100), System.DateTime.Now, commands);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
         }
 
         private IEnumerator RunGlobalClick(IMixedRealityInputSource defaultInputSource, 


### PR DESCRIPTION
## Overview
CanInteract() in Interactable was used in some of the wrong input handler and other input handlers did not have any guard at all. This change remedies those missing guards.

Ensure Touch input is not responsive when !IsEnabled
Remove CanInteract guard on focus
Add IsEnabled guard on TriggerOnClick

Tests
-> Merge TestSelectGlobalInput and TestSelectGlobalInputOnDisabled
-> Merge TestSelectMenuInput and TestInputActionMenuInput
-> Add test for touch states (both enabled & disabled)
-> Add test for TriggerOnClick public API
-> Add HasFocus asserts on InteractableToggleCollection test (aka RadialSet)
-> Clean up helper methods and variables for re-use in InteractableTests class

![interactable-caninteract](https://user-images.githubusercontent.com/25975362/68975370-f041d300-07a7-11ea-975e-ab883fa467a2.gif)

## Changes
- Fixes: #6100 , #6489 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
