### PR TITLE
fix auto-population of default profile

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/LostTrackingService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
     [MixedRealityExtensionService(
         SupportedPlatforms.WindowsUniversal,
         "Tracking Lost Service",
-        "LostTrackingService/DefaultLostTrackingServiceProfile.asset",
+        "LostTrackingService/Profiles/DefaultLostTrackingServiceProfile.asset",
         "MixedRealityToolkit.Extensions")]
     public class LostTrackingService : BaseExtensionService, ILostTrackingService, IMixedRealityExtensionService
     {

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         SupportedPlatforms.WindowsStandalone | SupportedPlatforms.MacStandalone |
         SupportedPlatforms.LinuxStandalone | SupportedPlatforms.WindowsUniversal,
         "Scene Transition Service",
-        "SceneTransitionService/DefaultSceneTransitionServiceProfile.asset",
+        "SceneTransitionService/Profiles/DefaultSceneTransitionServiceProfile.asset",
         "MixedRealityToolkit.Extensions")]
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.html")]
     public class SceneTransitionService : BaseExtensionService, ISceneTransitionService, IMixedRealityExtensionService


### PR DESCRIPTION
A recent change to the extension services moved the location of the default profiles. This rendered automatic population of the default profile non-functional.

This change fixes the pathing issue.