### PR TITLE
Bugfix boundingbox rotationhandle #2

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1462,6 +1462,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 var cornerbounds = GetMaxBounds(cornerVisual);
                 float maxDim = Mathf.Max(Mathf.Max(cornerbounds.size.x, cornerbounds.size.y), cornerbounds.size.z);
                 cornerbounds.size = maxDim * Vector3.one;
+                cornerbounds.center = Vector3.zero;
 
                 // we need to multiply by this amount to get to desired scale handle size
                 var invScale = scaleHandleSize / cornerbounds.size.x;
@@ -1592,7 +1593,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 midpointVisual.transform.localPosition = Vector3.zero;
                 
                 Bounds bounds = new Bounds(midpointBounds.center * invScale, midpointBounds.size * invScale);
-                bounds.size = bounds.size.RotateAround(bounds.center, midpointVisual.transform.localRotation);
+                if (edgeAxes[i] == CardinalAxisType.X)
+                {
+                    bounds.size = new Vector3(bounds.size.y, bounds.size.x, bounds.size.z);
+                }
+                else if (edgeAxes[i] == CardinalAxisType.Z)
+                {
+                    bounds.size = new Vector3(bounds.size.x, bounds.size.z, bounds.size.y);
+                }
 
                 AddComponentsToAffordance(midpoint, bounds, rotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, rotateHandleColliderPadding);
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1462,7 +1462,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 var cornerbounds = GetMaxBounds(cornerVisual);
                 float maxDim = Mathf.Max(Mathf.Max(cornerbounds.size.x, cornerbounds.size.y), cornerbounds.size.z);
                 cornerbounds.size = maxDim * Vector3.one;
-                cornerbounds.center = Vector3.zero;
+
+                cornerbounds.center = new Vector3(
+                    (i & (1 << 0)) == 0 ? cornerbounds.center.x : -cornerbounds.center.x,
+                    (i & (1 << 1)) == 0 ? -cornerbounds.center.y : cornerbounds.center.y,
+                    (i & (1 << 2)) == 0 ? -cornerbounds.center.z : cornerbounds.center.z
+                    );
 
                 // we need to multiply by this amount to get to desired scale handle size
                 var invScale = scaleHandleSize / cornerbounds.size.x;


### PR DESCRIPTION
## Overview
Following #6528, which introduces bug #6582

- Now rotating depending on the handle edge orientation (and no the visual mesh itself)

- Also fixes for scale handles : this seems to work fines with the example scene, but it's hard to know if it will work in every situation.
this fix will use the center of the mesh as the center of the box collider and will rotate accordingly ot the corner, another option would be to center iton the exact corner position (that's the commit jsut before that sets the center at Vector3.zero

A unittest checking if the mesh isinside the handleboxcollider won't guarantee it either (box collider size does not depends sololy on the mesh, but mosty on 'size' and 'padding' properties)

## Changes
- Fixes: #6582 and #6507.


## Verification

- Double check my math :)
- Feel free to cherrypick what you want or do another PR if this can speed up the process for 2.2.0

> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
