### PR TITLE
Progress Indicator State Field Fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorObjectDisplay.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorObjectDisplay.cs
@@ -66,12 +66,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private TextMeshPro messageText = null;
 
         [SerializeField]
-        private ProgressIndicatorState state = ProgressIndicatorState.Closed;
-
-        [SerializeField]
         [Range(0f, 1f)]
         private float progress;
 
+        private ProgressIndicatorState state = ProgressIndicatorState.Closed;
         private float currentScale;
 
         /// <inheritdoc/>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
@@ -30,8 +30,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         private TextMeshPro messageText = null;
         [SerializeField]
-        private ProgressIndicatorState state = ProgressIndicatorState.Closed;
-        [SerializeField]
         public float rotationSpeedRawDegrees = -200f;
         [SerializeField]
         public float spacingDegrees = 22f;
@@ -53,6 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private bool stopRequested;
         private float rotationWhenStopped;
         private MaterialPropertyBlock[] propertyBlocks = null;
+        private ProgressIndicatorState state = ProgressIndicatorState.Closed;
 
         /// <inheritdoc/>
         public async Task OpenAsync()


### PR DESCRIPTION
## Overview

Two of our progress indicators serialized their state field. This gave the impression that the progress indicator's state could be set manually. The fields are now private to prevent unintended usage.

## Changes

Fixes: #6593