### PR TITLE
disable packaging of source code in nupkg files

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -30,20 +30,21 @@
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.dll*" target="Plugins\" />
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.pdb*" target="Plugins\" />
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Gltf.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit" />
+    <!-- commenting source packaging for the 2.2.0 release -->
+    <!-- <file src="..\..\Assets\MixedRealityToolkit\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit" /> -->
 
     <!-- Assemblies and Sources that are built from the MixedRealityToolkit.Providers folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.Providers\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Providers" />
+    <!-- <file src="..\..\Assets\MixedRealityToolkit.Providers\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Providers" /> -->
 
     <!-- Assemblies and Sources that are built from the MixedRealityToolkit.SDK folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.SDK.*" target="Plugins\" />
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.SDK.Inspectors.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.SDK\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.SDK" />
+    <!-- <file src="..\..\Assets\MixedRealityToolkit.SDK\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.SDK" /> -->
 
     <!-- Assemblies and Sources that are built from the MixedRealityToolkit.Services folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.*" target="Plugins\" />
-    <file src="..\..\Assets\MixedRealityToolkit.Services\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Services" />
+    <!-- <file src="..\..\Assets\MixedRealityToolkit.Services\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Services" /> -->
 
     <!-- 
       link.xml is copied to the root location, so that it can catch IL2CPP

--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -27,6 +27,7 @@
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.*" target="Plugins\" />
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Demos.*" target="Plugins\" />
-    <file src="..\..\..\Assets\MixedRealityToolkit.Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Examples" />
+    <!-- commenting source packaging for the 2.2.0 release -->
+    <!-- <file src="..\..\..\Assets\MixedRealityToolkit.Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Examples" /> -->
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
+++ b/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
@@ -26,6 +26,7 @@
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Extensions.targets" />
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Extensions.*" target="Plugins\" />
-    <file src="..\..\..\Assets\MixedRealityToolkit.Extensions\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Extensions" />
+    <!-- commenting source packaging for the 2.2.0 release -->
+    <!-- <file src="..\..\..\Assets\MixedRealityToolkit.Extensions\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Extensions" /> -->
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Staging/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
@@ -26,6 +26,7 @@
     <file src="..\..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Providers.UnityAR.targets" />
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR.*" target="Plugins\" />
-    <file src="..\..\..\..\Assets\MixedRealityToolkit.Staging\UnityAR\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Staging\UnityAR" />
+    <!-- commenting source packaging for the 2.2.0 release -->
+    <!-- <file src="..\..\..\..\Assets\MixedRealityToolkit.Staging\UnityAR\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Staging\UnityAR" /> -->
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
+++ b/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
@@ -26,6 +26,7 @@
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tests.targets" />
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.*" target="Plugins\" />
-    <file src="..\..\..\Assets\MixedRealityToolkit.Tests\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tests" />
+    <!-- commenting source packaging for the 2.2.0 release -->
+    <!-- <file src="..\..\..\Assets\MixedRealityToolkit.Tests\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tests" /> -->
   </files>
 </package>

--- a/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
@@ -26,6 +26,7 @@
     <file src="..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tools.targets" />
 
     <file src="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tools.*" target="Plugins\" />
-    <file src="..\..\..\Assets\MixedRealityToolkit.Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tools" />
+    <!-- commenting source packaging for the 2.2.0 release -->
+    <!-- <file src="..\..\..\Assets\MixedRealityToolkit.Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Tools" /> -->
   </files>
 </package>


### PR DESCRIPTION
This change instructs the build pipeline to not include script source files in the nuget packages.

This is done because of an issue with NuGet for Unity and very long file names.