### PR TITLE
package android and ios players in foundation (#6441)

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Android.meta.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Android.meta.template
@@ -1,0 +1,103 @@
+fileFormatVersion: 2
+#PROJECT_GUID_TEMPLATE guid: <PROJECT_GUID_TOKEN>
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+#EXECUTION_ORDER_TEMPLATE   executionOrder: <EMPTY_TOKEN>
+#EXECUTION_ORDER_ENTRY_TEMPLATE     <SCRIPT_FULL_NAME_TOKEN>: <SCRIPT_EXECUTION_VALUE_TOKEN>
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 0
+  platformData:
+  - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 1
+        Exclude iOS: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: ARMv7
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Android.meta.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.Android.meta.template.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b2f7a1fddaec81548884e4b8d708550a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.iOS.meta.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.iOS.meta.template
@@ -1,0 +1,105 @@
+fileFormatVersion: 2
+#PROJECT_GUID_TEMPLATE guid: <PROJECT_GUID_TOKEN>
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+#EXECUTION_ORDER_TEMPLATE   executionOrder: <EMPTY_TOKEN>
+#EXECUTION_ORDER_ENTRY_TEMPLATE     <SCRIPT_FULL_NAME_TOKEN>: <SCRIPT_EXECUTION_VALUE_TOKEN>
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 0
+  platformData:
+  - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 1
+        Exclude iOS: 0
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.iOS.meta.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildTemplates/Plugin.iOS.meta.template.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 413b7539251f01943890f85a52db6510
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change completes the work specified in #6441 by updating the build tooling to package prebuilt players in the foundation package.

Verified this change by running the packaging commands locally and inspecting the contents of the nupkg file,