### PR TITLE
Fix Interactable default input action

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -44,10 +44,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         [FormerlySerializedAs("States")]
         [SerializeField]
+        [Tooltip("ScriptableObject to reference for basic state logic to follow when interacting and transitioning between states. Should generally be \"DefaultInteractableStates\" object")]
         private States states;
 
         /// <summary>
-        /// A collection of states and basic state logic
+        /// ScriptableObject to reference for basic state logic to follow when interacting and transitioning between states. Should generally be "DefaultInteractableStates" object
         /// </summary>
         public States States
         {
@@ -65,7 +66,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public InteractableStates StateManager { get; protected set; }
 
         /// <summary>
-        /// Which action is this interactable listening for
+        /// The Interactable will only respond to input down events fired with the corresponding assigned Input Action.
+        /// Available input actions are populated via the Input Actions Profile under the MRTK Input System Profile assigned in the current scene
         /// </summary>
         public MixedRealityInputAction InputAction { get; set; }
 
@@ -74,13 +76,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         [HideInInspector]
         [SerializeField]
+        [Tooltip("The Interactable will only respond to input down events fired with the corresponding assigned Input Action." +
+        "Available input actions are populated via the Input Actions Profile under the MRTK Input System Profile assigned in the current scene.")]
         private int InputActionId = 0;
 
         [FormerlySerializedAs("IsGlobal")]
         [SerializeField]
+        [Tooltip("If true, this Interactable will listen globally for any IMixedRealityInputHandler input events. These include general input up/down and clicks." +
+        "If false, this Interactable will only respond to general input click events if the pointer target is this GameObject's, or one of it's children's, collider.")]
         protected bool isGlobal = false;
         /// <summary>
-        /// Is the interactable listening to global events (input only)
+        /// If true, this Interactable will listen globally for any IMixedRealityInputHandler input events. These include general input up/down and clicks.
+        /// If false, this Interactable will only respond to general input click events if the pointer target is this GameObject's, or one of it's children's, collider.
         /// </summary>
         public bool IsGlobal
         {
@@ -216,8 +223,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public bool CanDeselect = true;
 
         /// <summary>
-        /// A voice command to fire a click event
+        /// This string keyword is the voice command that will fire a click on this Interactable.
         /// </summary>
+        [Tooltip("This string keyword is the voice command that will fire a click on this Interactable.")]
         public string VoiceCommand = "";
 
         [FormerlySerializedAs("RequiresFocus")]
@@ -312,6 +320,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         // Field just used for serialization to save if the Interactable should start enabled or disabled
         [FormerlySerializedAs("Enabled")]
         [SerializeField]
+        [Tooltip("Defines whether the Interactable is enabled or not internally." +
+        "This is different than the Enabled property at the GameObject/Component level." +
+        "When false, Interactable will continue to run in Unity but not respond to Input." +
+        "\n\nProperty is useful for disabling UX, such as greying out a button, until a user completes some pre-mandatory step such as fill out their name, etc")]
         private bool enabledOnStart = true;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -322,7 +322,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [FormerlySerializedAs("Enabled")]
         [SerializeField]
         [Tooltip("Defines whether the Interactable is enabled or not internally." +
-        "This is different than the Enabled property at the GameObject/Component level." +
+        "This is different than the enabled property at the GameObject/Component level." +
         "When false, Interactable will continue to run in Unity but not respond to Input." +
         "\n\nProperty is useful for disabling UX, such as greying out a button, until a user completes some pre-mandatory step such as fill out their name, etc")]
         private bool enabledOnStart = true;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -230,6 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         [FormerlySerializedAs("RequiresFocus")]
         [SerializeField]
+        [Tooltip("If true, then the voice command will only respond to voice commands while this Interactable has focus.")]
         public bool voiceRequiresFocus = true;
         /// <summary>
         /// Does the voice command require this to have focus?

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         [HideInInspector]
         [SerializeField]
-        private int InputActionId = -1;
+        private int InputActionId = 0;
 
         [FormerlySerializedAs("IsGlobal")]
         [SerializeField]
@@ -1062,8 +1062,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public static MixedRealityInputAction ResolveInputAction(int index)
         {
             MixedRealityInputAction[] actions = CoreServices.InputSystem.InputSystemProfile.InputActionsProfile.InputActions;
-            index = Mathf.Clamp(index, 0, actions.Length - 1);
-            return actions[index];
+            if (actions?.Length > 0)
+            {
+                index = Mathf.Clamp(index, 0, actions.Length - 1);
+                return actions[index];
+            }
+
+            return default;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         protected string[] speechKeywordOptions = null;
 
         private static readonly GUIContent InputActionsLabel = new GUIContent("Input Actions");
-        private static readonly GUIContent selectionModeLabel = new GUIContent("Selection Mode", "The selection mode of the Interactable is based on the number of Dimensions available.");
+        private static readonly GUIContent selectionModeLabel = new GUIContent("Selection Mode", "The selection mode of the Interactable is based on the number of dimensions available.");
         private static readonly GUIContent dimensionsLabel = new GUIContent("Dimensions", "The amount of theme layers for sequence button functionality (3-9)");
         private static readonly GUIContent startDimensionLabel = new GUIContent("Start Dimension Index", "The dimensionIndex value to set on start.");
         private static readonly GUIContent isToggledLabel = new GUIContent("Is Toggled", "Should this Interactable be toggled on or off by default on start.");

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -35,14 +35,12 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         protected string[] inputActionOptions = null;
         protected string[] speechKeywordOptions = null;
 
-        private static readonly GUIContent InputActionsLabel = new GUIContent("Input Actions", "The input action filter");
-        private static readonly GUIContent selectionModeLabel = new GUIContent("Selection Mode", "How the Interactable should react to input");
+        private static readonly GUIContent InputActionsLabel = new GUIContent("Input Actions");
+        private static readonly GUIContent selectionModeLabel = new GUIContent("Selection Mode", "The selection mode of the Interactable is based on the number of Dimensions available.");
         private static readonly GUIContent dimensionsLabel = new GUIContent("Dimensions", "The amount of theme layers for sequence button functionality (3-9)");
         private static readonly GUIContent startDimensionLabel = new GUIContent("Start Dimension Index", "The dimensionIndex value to set on start.");
-        private static readonly GUIContent CurrentDimensionLabel = new GUIContent("Dimension Index", "The dimensionIndex value at runtime.");
-        private static readonly GUIContent isToggledLabel = new GUIContent("Is Toggled", "The toggled value to set on start.");
+        private static readonly GUIContent isToggledLabel = new GUIContent("Is Toggled", "Should this Interactable be toggled on or off by default on start.");
         private static readonly GUIContent CreateThemeLabel = new GUIContent("Create and Assign New Theme", "Create a new theme");
-        private static readonly GUIContent AddThemePropertyLabel = new GUIContent("+ Add Theme Property", "Add Theme Property");
         private static readonly GUIContent SpeechComamndsLabel = new GUIContent("Speech Command", "Speech Commands to use with Interactable, pulled from MRTK/Input/Speech Commands Profile");
         private static readonly GUIContent OnClickEventLabel = new GUIContent("OnClick", "Fired when this Interactable is triggered by a click.");
         private static readonly GUIContent AddEventReceiverLabel = new GUIContent("Add Event", "Add event receiver to this Interactable for special event handling.");
@@ -265,7 +263,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                     statesProperty.objectReferenceValue = GetDefaultInteractableStatesFile();
                 }
 
-                EditorGUILayout.PropertyField(statesProperty, new GUIContent("States", "The States this Interactable is based on"));
+                EditorGUILayout.PropertyField(statesProperty, new GUIContent("States"));
 
                 if (statesProperty.objectReferenceValue == null)
                 {
@@ -274,7 +272,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                     return;
                 }
 
-                EditorGUILayout.PropertyField(enabledProperty, new GUIContent("Enabled", "Is this Interactable Enabled?"));
+                EditorGUILayout.PropertyField(enabledProperty, new GUIContent("Enabled"));
 
                 // Input Actions
                 bool validActionOptions = inputActionOptions != null;
@@ -286,7 +284,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
 
                 using (new EditorGUI.IndentLevelScope())
                 {
-                    EditorGUILayout.PropertyField(isGlobal, new GUIContent("Is Global", "Like a modal, does not require focus"));
+                    EditorGUILayout.PropertyField(isGlobal, new GUIContent("Is Global"));
                 }
 
                 // Speech keywords
@@ -314,7 +312,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                     using (new EditorGUI.IndentLevelScope())
                     {
                         SerializedProperty requireGaze = serializedObject.FindProperty("voiceRequiresFocus");
-                        EditorGUILayout.PropertyField(requireGaze, new GUIContent("Requires Focus", "Does the voice command require gazing at this interactable?"));
+                        EditorGUILayout.PropertyField(requireGaze, new GUIContent("Requires Focus", "If true, then the voice command will only respond to voice commands while this Interactable has focus."));
                     }
                 }
 

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -44,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         private static readonly GUIContent SpeechComamndsLabel = new GUIContent("Speech Command", "Speech Commands to use with Interactable, pulled from MRTK/Input/Speech Commands Profile");
         private static readonly GUIContent OnClickEventLabel = new GUIContent("OnClick", "Fired when this Interactable is triggered by a click.");
         private static readonly GUIContent AddEventReceiverLabel = new GUIContent("Add Event", "Add event receiver to this Interactable for special event handling.");
+        private static readonly GUIContent VoiceRequiresFocusLabel = new GUIContent("Requires Focus");
 
         protected virtual void OnEnable()
         {
@@ -312,7 +313,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                     using (new EditorGUI.IndentLevelScope())
                     {
                         SerializedProperty requireGaze = serializedObject.FindProperty("voiceRequiresFocus");
-                        EditorGUILayout.PropertyField(requireGaze, new GUIContent("Requires Focus", "If true, then the voice command will only respond to voice commands while this Interactable has focus."));
+                        EditorGUILayout.PropertyField(requireGaze, VoiceRequiresFocusLabel);
                     }
                 }
 


### PR DESCRIPTION
## Overview

When creating a new Interactable, the inputactionid was set to -1. This is actually kind of silly because on awake, the id is clamped to available values of the input actions profile list. This defaults it back to 0 so at least in the editor it appears correct

**Before:**
![image](https://user-images.githubusercontent.com/25975362/69198112-7f245780-0ae8-11ea-84e0-d3138bd22105.png)

**After:**
![image](https://user-images.githubusercontent.com/25975362/69198046-42f0f700-0ae8-11ea-948f-bf1ba3c7a935.png)

## Changes
- Fixes: #

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
