### PR TITLE
Fix Editor Hands with VR

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -425,7 +425,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             {
                 throw new InvalidOperationException("Failed to find the defineConstraints: [] when patching WSA dll.");
             }
-            File.WriteAllText(dllMetaPath, contents.Replace(searchString, "defineConstraints:\r\n    UNITY_WSA"));
+            File.WriteAllText(dllMetaPath, contents.Replace(searchString, "defineConstraints:\r\n  - UNITY_WSA"));
         }
 
         private static void CopyPluginContents(string outputPath)

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -405,7 +405,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             CopyPluginContents(Application.dataPath.Replace("Assets", "NuGet/Plugins"));
 
             // Special case the Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll for UNITY_WSA Editor
-            string dllPath = Utilities.GetFullPathFromAssetsRelative($"Assets/../MSBuild/Publish/InEditor/WindowsStandalone32/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll");
+            string dllPath = Utilities.GetFullPathFromAssetsRelative($"Assets/../MSBuild/Publish/InEditor/WSA/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll");
             string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
             string editorOutputDirectory = Application.dataPath.Replace("Assets", "NuGet/Plugins/EditorPlayer");
 

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -419,7 +419,13 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             // Patch the special cased library to have a define_constraint:
             string dllMetaPath = $"{dllOutputPath}.meta";
             Debug.Log($"Patching: {dllMetaPath}");
-            File.WriteAllText(dllMetaPath, File.ReadAllText(dllMetaPath).Replace("defineConstraints: []", "defineConstraints:\r\n    UNITY_WSA"));
+            string contents = File.ReadAllText(dllMetaPath);
+            string searchString = "defineConstraints: []";
+            if (!contents.Contains(searchString))
+            {
+                throw new InvalidOperationException("Failed to find the defineConstraints: [] when patching WSA dll.");
+            }
+            File.WriteAllText(dllMetaPath, contents.Replace(searchString, "defineConstraints:\r\n    UNITY_WSA"));
         }
 
         private static void CopyPluginContents(string outputPath)

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -403,7 +403,23 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             DirectoryInfo outputDirectory = new DirectoryInfo(outputPath);
             RecursiveFolderCleanup(outputDirectory);
             CopyPluginContents(Application.dataPath.Replace("Assets", "NuGet/Plugins"));
+
+            // Special case the Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll for UNITY_WSA Editor
+            string dllPath = Utilities.GetFullPathFromAssetsRelative($"Assets/../MSBuild/Publish/InEditor/WindowsStandalone32/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll");
+            string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+            string editorOutputDirectory = Application.dataPath.Replace("Assets", "NuGet/Plugins/EditorPlayer");
+
+            string dllOutputPath = Path.Combine(editorOutputDirectory, "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll");
+            File.Copy(dllPath, dllOutputPath, true);
+            File.Copy(pdbPath, Path.Combine(editorOutputDirectory, "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.pdb"), true);
+
+            // Update metas after copying in the special cased library
             UpdateMetaFiles(assemblyInformation);
+
+            // Patch the special cased library to have a define_constraint:
+            string dllMetaPath = $"{dllOutputPath}.meta";
+            Debug.Log($"Patching: {dllMetaPath}");
+            File.WriteAllText(dllMetaPath, File.ReadAllText(dllMetaPath).Replace("defineConstraints: []", "defineConstraints:\r\n    UNITY_WSA"));
         }
 
         private static void CopyPluginContents(string outputPath)


### PR DESCRIPTION
## Overview
This change swaps out the Editor DLL that is packaged as part of MRTK Foundation. Instead of using the Editor DLL build for standalone platform, it uses the Editor DLL built for WSA platform.

## Changes
- Fixes: #6391 