### PR TITLE
Update BaseController.SetupConfiguration parameters to no longer take in a source type

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -614,7 +614,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 if (interactionSource.kind == InteractionSourceKind.Hand)
                 {
                     detectedController = new WindowsMixedRealityArticulatedHand(TrackingState.NotTracked, controllingHand, inputSource);
-                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityArticulatedHand), inputSourceType))
+                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityArticulatedHand)))
                     {
                         // Controller failed to be setup correctly.
                         // Return null so we don't raise the source detected.
@@ -624,7 +624,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 else if (interactionSource.kind == InteractionSourceKind.Controller)
                 {
                     detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
-                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityController), inputSourceType))
+                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityController)))
                     {
                         // Controller failed to be setup correctly.
                         // Return null so we don't raise the source detected.
@@ -640,7 +640,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             else
             {
                 detectedController = new WindowsMixedRealityGGVHand(TrackingState.NotTracked, controllingHand, inputSource);
-                if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityGGVHand), inputSourceType))
+                if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityGGVHand)))
                 {
                     // Controller failed to be setup correctly.
                     // Return null so we don't raise the source detected.

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/BaseInputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/BaseInputSimulationService.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return null;
             }
 
-            if (!controller.SetupConfiguration(controllerType, InputSourceType.Hand))
+            if (!controller.SetupConfiguration(controllerType))
             {
                 // Controller failed to be setup correctly.
                 Debug.LogError($"Failed to Setup {controllerType} controller");

--- a/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/Devices/IMixedRealityController.cs
@@ -72,6 +72,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Some controllers such as articulated should only be able 
         /// to invoke pointing/distant interactions in certain poses.
         /// </summary>
-        bool IsInPointingPose { get;  }
+        bool IsInPointingPose { get; }
     }
 }

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -76,12 +76,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public Vector3 Velocity { get; protected set; }
 
+        /// <inheritdoc />
         public virtual bool IsInPointingPose => true;
 
         #endregion IMixedRealityController Implementation
 
         /// <summary>
-        /// Setups up the configuration based on the Mixed Reality Controller Mapping Profile.
+        /// Sets up the configuration based on the Mixed Reality Controller Mapping Profile.
         /// </summary>
         [Obsolete("The second parameter is no longer used. This method now reads from the controller's input source.")]
         public bool SetupConfiguration(Type controllerType, InputSourceType inputSourceType = InputSourceType.Controller)
@@ -90,8 +91,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Setups up the configuration based on the Mixed Reality Controller Mapping Profile.
+        /// Sets up the configuration based on the Mixed Reality Controller Mapping Profile.
         /// </summary>
+        /// <param name="controllerType">The type this controller represents.</param>
         public bool SetupConfiguration(Type controllerType)
         {
             if (IsControllerMappingEnabled())

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -83,14 +83,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Setups up the configuration based on the Mixed Reality Controller Mapping Profile.
         /// </summary>
+        [Obsolete("The second parameter is no longer used. This method now reads from the controller's input source.")]
         public bool SetupConfiguration(Type controllerType, InputSourceType inputSourceType = InputSourceType.Controller)
+        {
+            return SetupConfiguration(controllerType);
+        }
+
+        /// <summary>
+        /// Setups up the configuration based on the Mixed Reality Controller Mapping Profile.
+        /// </summary>
+        public bool SetupConfiguration(Type controllerType)
         {
             if (IsControllerMappingEnabled())
             {
                 if (GetControllerVisualizationProfile() != null &&
                     GetControllerVisualizationProfile().RenderMotionControllers)
                 {
-                    TryRenderControllerModel(controllerType, inputSourceType);
+                    TryRenderControllerModel(controllerType, InputSource.SourceType);
                 }
 
                 // We can only enable controller profiles if mappings exist.


### PR DESCRIPTION
## Overview
This method was taking in an `InputSourceType`, though one is already saved for this controller as part of its `InputSource`.

Instead of having this second parameter, it's been marked as `Obsolete` and the type is now read from the `InputSource`