### PR TITLE
Fix spelling errors and dead links in the coding guidelines.

### DIFF
--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -32,7 +32,7 @@ Every time you add a public method, field, property, it becomes part of MRTK’s
 
 New public members should be carefully examined. Any public field will need to be maintained in the future. Remember that if the type of a public field (or serialized private field) changes or gets removed from a MonoBehaviour, that could break other people. The field will need to first be deprecated for a release, and code to migrate changes for people that have taken dependencies would need to be provided.
 
-### Prioritize Writing Tests 
+### Prioritize writing tests 
 MRTK is a community project, modified by a diverse range of contributors. These contributors may not know the details of your bug fix / feature, and accidentally break your feature. [MRTK runs continuous integration tests](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build?definitionId=16) before completing every pull request. Changes that break tests cannot be checked in. Therefore, tests are the best way to ensure that other people do not break your feature.
 
 When you fix a bug, write a test to ensure it does not regress in the future. If adding a feature, write tests that verify your feature works. This is required for all UX features except experimental features.

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -1,4 +1,4 @@
-# Coding Guidelines
+# Coding guidelines
 This document outlines coding principles and conventions to follow when contributing to MRTK.
 
 ---

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -1,11 +1,11 @@
 # Coding Guidelines
-This document outlines coding principles and convetions to follow when contributing to MRTK.
+This document outlines coding principles and conventions to follow when contributing to MRTK.
 
 ---
 
 ## Philosophy
 
-### Be consise and strive for simplicity
+### Be concise and strive for simplicity
 The simplest solution is often the best. This is an overriding aim of these guidelines and should be the goal of all coding activity. Part of being simple is being concise, and consistent with existing code. Try to keep your code simple.
 
 Readers should only encounter artifacts that provide useful information. For example, comments that restate what is obvious provide no extra information and increase the noise to signal ratio.
@@ -33,7 +33,7 @@ Every time you add a public method, field, property, it becomes part of MRTK’s
 New public members should be carefully examined. Any public field will need to be maintained in the future. Remember that if the type of a public field (or serialized private field) changes or gets removed from a MonoBehaviour, that could break other people. The field will need to first be deprecated for a release, and code to migrate changes for people that have taken dependencies would need to be provided.
 
 ### Prioritize Writing Tests 
-MRTK is a community project, modified by a diverse range of contributors. These contributors may not know the details of your bug fix / feature, and accidentally break your feature. [MRTK runs continuous integration tests](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=5428) before completing every pull request. Changes that break tests cannot be checked in. Therefore, tests are the best way to ensure that other people do not break your feature.
+MRTK is a community project, modified by a diverse range of contributors. These contributors may not know the details of your bug fix / feature, and accidentally break your feature. [MRTK runs continuous integration tests](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build?definitionId=16) before completing every pull request. Changes that break tests cannot be checked in. Therefore, tests are the best way to ensure that other people do not break your feature.
 
 When you fix a bug, write a test to ensure it does not regress in the future. If adding a feature, write tests that verify your feature works. This is required for all UX features except experimental features.
 
@@ -265,7 +265,7 @@ MyClass.cs
 ```c#
 public class MyClass
 {
-    private MyStruct myStructreference;
+    private MyStruct myStructReference;
     private MyEnumType myEnumReference;
 }
  ```
@@ -481,7 +481,7 @@ public class MyClass
 }
 ```
 
-#### Do:
+#### Do
 
  ```c#
  // Private references for use inside the class only
@@ -529,7 +529,7 @@ This chart can help you decide which `#if` to use, depending on your use cases a
 
 DateTime.UtcNow is faster than DateTime.Now. In previous performance investigations we've found that using DateTime.Now adds significant overhead especially when used in the Update() loop. [Others have hit the same issue](https://stackoverflow.com/questions/1561791/optimizing-alternatives-to-datetime-now).
 
-Prefer using DateTime.UtcNow unless you actually need the localized times (a legitmate reason may be you wanting to show the current time in the user's time zone). If you are dealing with relative times (i.e. the delta between some last update and now), it's best to use DateTime.UtcNow to avoid the overhead of doing timezone conversions.
+Prefer using DateTime.UtcNow unless you actually need the localized times (a legitimate reason may be you wanting to show the current time in the user's time zone). If you are dealing with relative times (i.e. the delta between some last update and now), it's best to use DateTime.UtcNow to avoid the overhead of doing timezone conversions.
 
 
 ## See also


### PR DESCRIPTION
I was reading this as part of reviewing another change, and noticed some immediate spelling errors really early on in the doc, which can reduce confidence on the quality of the rest of it (i.e. if the first thing you see is a spelling mistake in a long document, it can make you go like... huh...)

There was also a broken link (to CI) that was referencing a specific build from ages ago - that build information has long been cleared, so it was a dead link. I've updated that link to point the mrtk_pr build (which I believe is the most relevant given the other context in that area)