### PR TITLE
Fix invalid scene transition service profile

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubRegisteredServiceProvidersProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubRegisteredServiceProvidersProfile.asset
@@ -20,5 +20,5 @@ MonoBehaviour:
     componentName: Scene Transition Service
     priority: 10
     runtimePlatform: 15
-    configurationProfile: {fileID: 11400000, guid: 45c20fade71a3ec418860b757ff5a5ce,
+    configurationProfile: {fileID: 11400000, guid: 23872a85e06a8a54f9381e062152f891,
       type: 2}

--- a/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubRegisteredServiceProvidersProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubRegisteredServiceProvidersProfile.asset
@@ -16,9 +16,9 @@ MonoBehaviour:
   configurations:
   - componentType:
       reference: Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions.SceneTransitionService,
-        Assembly-CSharp
+        Microsoft.MixedReality.Toolkit.Extensions.SceneTransitionService
     componentName: Scene Transition Service
     priority: 10
     runtimePlatform: 15
-    configurationProfile: {fileID: 11400000, guid: 23872a85e06a8a54f9381e062152f891,
+    configurationProfile: {fileID: 11400000, guid: 45c20fade71a3ec418860b757ff5a5ce,
       type: 2}

--- a/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneSystemProfile.asset
@@ -34,91 +34,91 @@ MonoBehaviour:
   - Name: MRTKExamplesHubMainMenu
     Path: Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Scenes/MRTKExamplesHubMainMenu.unity
     Included: 1
-    BuildIndex: 1
+    BuildIndex: 2
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 63a00118e809c754f9c7911bb85d635f, type: 3}
   - Name: HandInteractionExamples
     Path: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
     Included: 1
-    BuildIndex: 0
+    BuildIndex: 1
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 3dd4a396b5225f8469b9a1eb608bfa57, type: 3}
   - Name: ClippingExamples
     Path: Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/ClippingExamples.unity
     Included: 1
-    BuildIndex: 2
+    BuildIndex: 3
     Tag: Untagged
     Asset: {fileID: 102900000, guid: e532091edada3e04aa706112e8d5f310, type: 3}
   - Name: TooltipExamples
     Path: Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity
     Included: 1
-    BuildIndex: 3
+    BuildIndex: 4
     Tag: Untagged
     Asset: {fileID: 102900000, guid: de90a43947eced441b4c426e11f35f28, type: 3}
   - Name: MaterialGallery
     Path: Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/MaterialGallery.unity
     Included: 1
-    BuildIndex: 4
+    BuildIndex: 5
     Tag: Untagged
     Asset: {fileID: 102900000, guid: c6b1477d31864dff836e9738518eae60, type: 3}
   - Name: BoundingBoxExamples
     Path: Assets/MixedRealityToolkit.Examples/Demos/UX/BoundingBox/Scenes/BoundingBoxExamples.unity
     Included: 1
-    BuildIndex: 5
+    BuildIndex: 6
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 9da574c0affd04d42a6b1e5db09e82b4, type: 3}
   - Name: PressableButtonExample
     Path: Assets/MixedRealityToolkit.Examples/Demos/UX/PressableButton/Scenes/PressableButtonExample.unity
     Included: 1
-    BuildIndex: 6
+    BuildIndex: 7
     Tag: Untagged
     Asset: {fileID: 102900000, guid: b2d06bb8d7f107d4783a56c796c5c120, type: 3}
   - Name: HandMenuExamples
     Path: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandMenuExamples.unity
     Included: 1
-    BuildIndex: 7
+    BuildIndex: 8
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 2792ec9767804e644906ab978f2eed23, type: 3}
   - Name: SlateExample
     Path: Assets/MixedRealityToolkit.Examples/Demos/UX/Slate/SlateExample.unity
     Included: 1
-    BuildIndex: 8
+    BuildIndex: 9
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 86e8b0c6246dbb74aa04ecd40a57d89c, type: 3}
   - Name: SliderExample
     Path: Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes/SliderExample.unity
     Included: 1
-    BuildIndex: 9
+    BuildIndex: 10
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 086aad2912678d04e968264b2398004b, type: 3}
   - Name: EyeTrackingDemo-02-TargetSelection
     Path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-02-TargetSelection.unity
     Included: 1
-    BuildIndex: 10
+    BuildIndex: 11
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 55643f7e4eceb734784192b162f565e0, type: 3}
   - Name: EyeTrackingDemo-03-Navigation
     Path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity
     Included: 1
-    BuildIndex: 11
+    BuildIndex: 12
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 5df475f0bf57b1f488d59e0e16040d9a, type: 3}
   - Name: EyeTrackingDemo-04-TargetPositioning
     Path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-04-TargetPositioning.unity
     Included: 1
-    BuildIndex: 12
+    BuildIndex: 13
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 91ded1f5ef2ae854ba4ac94eca7a2494, type: 3}
   - Name: EyeTrackingDemo-05-Visualizer
     Path: Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-05-Visualizer.unity
     Included: 1
-    BuildIndex: 13
+    BuildIndex: 14
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 2d6c43a82f3a88c4dbdc3b5e99a68d8a, type: 3}
   - Name: NearMenuExamples
     Path: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/NearMenuExamples.unity
     Included: 1
-    BuildIndex: 14
+    BuildIndex: 15
     Tag: Untagged
     Asset: {fileID: 102900000, guid: bf3eb3415bffceb41810526380c2c71c, type: 3}
   permittedLightingSceneComponentTypes:

--- a/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneTransitionServiceProfile.asset
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneTransitionServiceProfile.asset
@@ -23,5 +23,5 @@ MonoBehaviour:
   fadeTargets: 0
   cameraFaderType:
     reference: Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions.CameraFaderQuad,
-      Assembly-CSharp
+      Microsoft.MixedReality.Toolkit.Extensions.SceneTransitionService
   cameraFaderMaterial: {fileID: 2100000, guid: 625ee7fe9fc9cb549b4f5ee443687d00, type: 2}

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Profiles/DefaultSceneTransitionServiceProfile.asset
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/Profiles/DefaultSceneTransitionServiceProfile.asset
@@ -23,5 +23,5 @@ MonoBehaviour:
   fadeTargets: 0
   cameraFaderType:
     reference: Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions.CameraFaderQuad,
-      Assembly-CSharp
+      Microsoft.MixedReality.Toolkit.Extensions.SceneTransitionService
   cameraFaderMaterial: {fileID: 2100000, guid: 625ee7fe9fc9cb549b4f5ee443687d00, type: 2}

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -92,6 +92,24 @@ function CheckMainCamera(
     return $false;
 }
 
+function CheckAssemblyCSharp(
+    [string]$FileName,
+    [string[]]$FileContent,
+    [int]$LineNumber
+) {
+    <#
+    .SYNOPSIS
+        Checks if the given profile contains references to Assembly-CSharp, often indicative of invalid reference
+        Returns true if such a reference exists.
+    #>
+    if ($FileName -and $FileContent[$LineNumber] -match "Assembly-CSharp") {
+        Write-Host "An instance of 'Assembly-CSharp' was found in $FileName at line $LineNumber"
+        Write-Host "Please update this to reference the correct assembly."
+        return $true
+    }
+    return $false
+}
+
 function CheckCustomProfile(
     [string]$FileName,
     [string[]]$FileContent,
@@ -221,6 +239,9 @@ function CheckAsset(
     $fileContent = Get-Content $FileName
     for ($i = 0; $i -lt $fileContent.Length; $i++) {
         if (CheckCustomProfile $FileName $fileContent $i) {
+            $containsIssue = $true
+        }
+        if (CheckAssemblyCSharp $FileName $fileContent $i) {
             $containsIssue = $true
         }
     }

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -99,7 +99,7 @@ function CheckAssemblyCSharp(
 ) {
     <#
     .SYNOPSIS
-        Checks if the given profile contains references to Assembly-CSharp, often indicative of invalid reference
+        Checks if the given profile contains references to Assembly-CSharp, often indicative of invalid reference.
         Returns true if such a reference exists.
     #>
     if ($FileName -and $FileContent[$LineNumber] -match "Assembly-CSharp") {


### PR DESCRIPTION
## Overview
The scene transition service profile had some invalid types, fix this by clicking "repair" button and updating assets. 

Invalid assets, I clicked "repair" to the right to fix these

![image](https://user-images.githubusercontent.com/168492/69284806-5497d480-0ba4-11ea-831b-b8eef2828378.png)

Currently trying to see if I can write a CI script to detect all references to invalid types in assets.

## Changes
- Fixes: #6669
- Add script to ensure that CI catches any invalid references to assemblies in the profile assets

