### PR TITLE
Fix for FileNotFoundException on Mac - Issue 6643

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 !string.IsNullOrEmpty(bufferView.Buffer.uri))
             {
                 var parentDirectory = Directory.GetParent(gltfObject.Uri).FullName;
-                bufferView.Buffer.BufferData = File.ReadAllBytes($"{parentDirectory}\\{bufferView.Buffer.uri}");
+                bufferView.Buffer.BufferData = File.ReadAllBytes(Path.Combine(parentDirectory, bufferView.Buffer.uri));
             }
         }
 


### PR DESCRIPTION
## Overview
Fix for FileNotFoundException that appeared on import of the Examples package on a Mac.

## Changes
- Fixes: #6643 


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
