### PR TITLE
Fix SR_Triangles and SR_Triangles_Object_Space shader warnings

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/Assets/SR_Triangles.shader
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/Assets/SR_Triangles.shader
@@ -122,7 +122,7 @@ Shader "SR_Triangles" {
             #endif
 
             FragmentInput vxOut[Geo_Max_Out_Vertices];
-            int stripVxCount[Geo_Max_Out_Vertices];
+            int stripVxCount;
             int vxOutCount;
             int stripCount;
 
@@ -181,7 +181,8 @@ Shader "SR_Triangles" {
                 HUX_GEO_SET_EXTRA1(Extra1);
                 HUX_GEO_SET_EXTRA2(Extra2);
                 HUX_GEO_SET_EXTRA3(Extra3);
-                vxOutCount += 1; stripVxCount[stripCount] += 1;
+                vxOutCount += 1;
+                stripVxCount += 1;
             }
 
             void Emit_Triangle_B25(
@@ -196,11 +197,13 @@ Shader "SR_Triangles" {
                 float Width,
                 out bool Next)
             {
-
+                // This function can be called at most once per geometry_main invocation.
+                // If this is called multiple times, stripVxCount must be augmented as an
+                // array (see https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6609
+                // for more details).
                 emitVertex_Bid25(P1,Extra1_1,Color,float4(1.0,0.0,0.0,Width));
                 emitVertex_Bid25(P2,Extra1_2,Color,float4(0.0,1.0,0.0,Width));
                 emitVertex_Bid25(P3,Extra1_3,Color,float4(0.0,0.0,1.0,Width));
-                stripCount += 1; stripVxCount[stripCount] = 0;
                 Next = Previous;
             }
 
@@ -425,8 +428,7 @@ Shader "SR_Triangles" {
             {
                 UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(vxIn[0]);
                 vxOutCount = 0;
-                stripCount = 0;
-                stripVxCount[0] = 0;
+                stripVxCount = 0;
 
                 float3 Reference_Q33;
                 float Distance_Q33;
@@ -473,17 +475,13 @@ Shader "SR_Triangles" {
                 bool Root = Next_Q25;
 
                 int vxix = 0;
-                int strip = 0;
-                while (strip < stripCount) {
-                    int i = 0;
-                    while (i < stripVxCount[strip]) {
-                        UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(vxIn[0],vxOut[vxix]);
-                        triStream.Append(vxOut[vxix]);
-                        i += 1; vxix += 1;
-                    }
-                    triStream.RestartStrip();
-                    strip += 1;
+                int i = 0;
+                while (i < stripVxCount) {
+                    UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(vxIn[0],vxOut[vxix]);
+                    triStream.Append(vxOut[vxix]);
+                    i += 1; vxix += 1;
                 }
+                triStream.RestartStrip();
             }
 
             //BLOCK_BEGIN Main_Fragment 38


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6609

The original change that added these shaders had a few warnings:
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5988

In particular, there was some code that added while loop that would always end up running once (i.e. it would be equivalent to just not having the loop). This gives a warning in Unity, and the MRTK should be warning-free. This work just unrolls the loop manually (i.e. recognizing that it is only ever run once, just getting rid of the loop)