### PR TITLE
Add component menu to obsolete

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/GrabReleaseDetector.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/GrabReleaseDetector.cs
@@ -8,7 +8,7 @@ using UnityEngine.Events;
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 {
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/GrabReleaseDetector")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/GrabReleaseDetector")]
     public class GrabReleaseDetector : MonoBehaviour, IMixedRealityPointerHandler
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/OnSelectVisualizerInputController.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/OnSelectVisualizerInputController.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
     /// </summary>
     [RequireComponent(typeof(EyeTrackingTarget))]
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/OnSelectVisualizerInputController")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/OnSelectVisualizerInputController")]
     public class OnSelectVisualizerInputController : BaseEyeFocusHandler, IMixedRealityPointerHandler
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/KeepFacingCamera.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/KeepFacingCamera.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
     /// This script continuously updates the orientation of the associated game object to keep facing the camera/user.
     /// </summary>
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/KeepFacingCamera")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/KeepFacingCamera")]
     public class KeepFacingCamera : MonoBehaviour
     {
         private Vector3 origForwardVector;

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/KeepThisAlive.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/KeepThisAlive.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
     /// Enforces to keep this GameObject alive across different scenes.
     /// </summary>
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/KeepThisAlive")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/KeepThisAlive")]
     public class KeepThisAlive : MonoBehaviour
     {
         public static KeepThisAlive Instance { get; private set; }

--- a/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/StatusText.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/StatusText.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 {
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/StatusText")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/StatusText")]
     public class StatusText : MonoBehaviour
     {
         #region Singleton

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/DemoTouchButton.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/DemoTouchButton.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 {
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/DemoTouchButton")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/DemoTouchButton")]
     public class DemoTouchButton : MonoBehaviour, IMixedRealityPointerHandler
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GrabTouchExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GrabTouchExample.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Examples
 {
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/GrabTouchExample")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/GrabTouchExample")]
     public class GrabTouchExample : MonoBehaviour, IMixedRealityTouchHandler, IMixedRealityInputHandler
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleBoundingBox.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/ToggleBoundingBox.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 {
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/Examples/ToggleBoundingBox")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/ToggleBoundingBox")]
     public class ToggleBoundingBox : MonoBehaviour
     {
         public BoundingBox boundingBox;

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/PointerClickHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/PointerClickHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// i.e. a primary mouse button click, motion controller selection press, or hand tap.
     /// </summary>
     [System.Obsolete("Use PointerHandler instead of PointerClickHandler", true)]
-    [AddComponentMenu("Scripts/MRTK/SDK/PointerClickHandler")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/PointerClickHandler")]
     public class PointerClickHandler : BaseInputHandler, IMixedRealityPointerHandler
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSize.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSize.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     [ExecuteInEditMode]
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/SDK/ButtonBackgroundSize")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/ButtonBackgroundSize")]
     public class ButtonBackgroundSize : MonoBehaviour
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSizeOffset.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSizeOffset.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     [ExecuteInEditMode]
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/SDK/ButtonBackgroundSizeOffset")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/ButtonBackgroundSizeOffset")]
     public class ButtonBackgroundSizeOffset : MonoBehaviour
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/InteractableHighlight.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Utilities/InteractableHighlight.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// </summary>
     /// <remarks>Useful with focusable <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>s</remarks>
     [System.Obsolete("This component is no longer supported", true)]
-    [AddComponentMenu("Scripts/MRTK/SDK/InteractableHighlight")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/InteractableHighlight")]
     public class InteractableHighlight : BaseFocusHandler
     {
         [Flags]

--- a/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/InputSystemGlobalListener.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     [Obsolete("InputSystemGlobalListener uses obsolete global input event registration API. " +
         "Use RegisterHandler/UnregisterHandler API directly (preferred) or InputSystemGlobalHandlerListener instead.")]
-    [AddComponentMenu("Scripts/MRTK/Services/InputSystemGlobalListener")]
+    [AddComponentMenu("Scripts/MRTK/Obsolete/InputSystemGlobalListener")]
     public class InputSystemGlobalListener : MonoBehaviour
     {
         private bool lateInitialize = true;


### PR DESCRIPTION
## Overview
Update AddComponentMenus to move obsolete monobehaviours to dedicated "folder" path so users know not to use them

## Changes
- Fixes: #6567


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
