### PR TITLE
Fix deploy issue after Unity assembly reload

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -279,7 +279,6 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 GUILayout.Label("Quick Options");
                 using (new EditorGUILayout.HorizontalScope())
                 {
-
                     EditorUserBuildSettings.wsaSubtarget = (WSASubtarget)EditorGUILayout.Popup((int)EditorUserBuildSettings.wsaSubtarget, deviceNames);
 
                     bool canInstall = CanInstall;
@@ -300,7 +299,6 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     GUI.enabled = true;
 
                     OpenPlayerSettingsGUI();
-
                 }
             }
             GUILayout.Space(10);

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -1131,6 +1131,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             }
         }
 
+        /// <summary>
+        /// Builds the open Unity project for
+        /// <see href="https://docs.unity3d.com/ScriptReference/BuildTarget.WSAPlayer.html">BuildTarget.WSAPlayer</see>.
+        /// </summary>
         public static async void BuildUnityProject()
         {
             Debug.Assert(!isBuilding);
@@ -1144,6 +1148,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             isBuilding = false;
         }
 
+        /// <summary>
+        /// Builds an AppX for the open Unity project for
+        /// <see href="https://docs.unity3d.com/ScriptReference/BuildTarget.WSAPlayer.html">BuildTarget.WSAPlayer</see>.
+        /// </summary>
         public static async void BuildAppx()
         {
             Debug.Assert(!isBuilding);
@@ -1171,7 +1179,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             isBuilding = false;
         }
 
-        public static async void BuildAll(bool install = true)
+        /// <summary>
+        /// Builds the open Unity project and its AppX for
+        /// <see href="https://docs.unity3d.com/ScriptReference/BuildTarget.WSAPlayer.html">BuildTarget.WSAPlayer</see>.
+        /// </summary>
+        public async void BuildAll(bool install = true)
         {
             Debug.Assert(!isBuilding);
             isBuilding = true;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// Builds the open Unity project and its AppX for
         /// <see href="https://docs.unity3d.com/ScriptReference/BuildTarget.WSAPlayer.html">BuildTarget.WSAPlayer</see>.
         /// </summary>
-        public async void BuildAll(bool install = true)
+        public static async void BuildAll(bool install = true)
         {
             Debug.Assert(!isBuilding);
             isBuilding = true;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -174,10 +174,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private const float HALF_WIDTH = 256f;
 
-        private static float timeLastUpdatedBuilds;
-
         private string[] targetIps;
-        private List<Version> windowsSdkVersions = new List<Version>();
+        private readonly List<Version> windowsSdkVersions = new List<Version>();
 
         private Vector2 scrollPosition;
 
@@ -1236,8 +1234,6 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             }
 
             UpdatePackageName();
-
-            timeLastUpdatedBuilds = Time.realtimeSinceStartup;
         }
 
         private static string CalcMostRecentBuild()

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -619,7 +619,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             public string pathSuffix;
         }
 
-        private static VSWhereFindOption[] VSWhereFindOptions =
+        private static readonly VSWhereFindOption[] VSWhereFindOptions =
         {
             // This find option corresponds to the version of vswhere that ships with VS2019.
             new VSWhereFindOption(

--- a/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -778,10 +778,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
                 if (success)
                 {
-                    targetDevice.CsrfToken = response.ResponseBody;
+                    // If null, authentication succeeded but we had no cookie token in the response.
+                    // This usually means Unity has a cached token, so it can be ignored.
+                    if (response.ResponseBody != null)
+                    {
+                        targetDevice.CsrfToken = response.ResponseBody;
 
-                    // Strip the beginning of the cookie header
-                    targetDevice.CsrfToken = targetDevice.CsrfToken.Replace("CSRF-Token=", string.Empty);
+                        // Strip the beginning of the cookie header
+                        targetDevice.CsrfToken = targetDevice.CsrfToken.Replace("CSRF-Token=", string.Empty);
+                    }
                 }
                 else
                 {

--- a/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -728,7 +728,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
         /// <summary>
         /// This Utility method finalizes the URL and formats the HTTPS string if needed.
         /// </summary>
-        /// <remarks>Local Machine will be changed to 127.0.1:10080 for HoloLens connections.</remarks>
+        /// <remarks>Local Machine will be changed to 127.0.0.1:10080 for HoloLens connections.</remarks>
         /// <param name="targetUrl">The target URL i.e. 128.128.128.128</param>
         /// <returns>The finalized URL with http/https prefix.</returns>
         public static string FinalizeUrl(string targetUrl)
@@ -745,7 +745,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
         }
 
         /// <summary>
-        /// Refreshes the CSRF Token in case the device or it's portal was restarted.
+        /// Refreshes the CSRF Token in case the device or its portal was restarted.
         /// </summary>
         /// <returns>True, if refresh was successful.</returns>
         public static async Task<bool> RefreshCsrfTokenAsync(DeviceInfo targetDevice)
@@ -767,16 +767,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
         /// <returns>True if Authentication is successful, otherwise false.</returns>
         public static async Task<bool> EnsureAuthenticationAsync(DeviceInfo targetDevice)
         {
-            string auth = Rest.GetBasicAuthentication(targetDevice.User, targetDevice.Password);
-
-            if (targetDevice.Authorization.ContainsKey("Authorization"))
-            {
-                targetDevice.Authorization["Authorization"] = auth;
-            }
-            else
-            {
-                targetDevice.Authorization.Add("Authorization", auth);
-            }
+            targetDevice.Authorization["Authorization"] = Rest.GetBasicAuthentication(targetDevice.User, targetDevice.Password);
 
             bool success;
 
@@ -828,7 +819,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
         private static async Task<Response> DevicePortalAuthorizationAsync(DeviceInfo targetDevice)
         {
-            var webRequest = UnityWebRequest.Get(FinalizeUrl(targetDevice.IP));
+            UnityWebRequest webRequest = UnityWebRequest.Get(FinalizeUrl(targetDevice.IP));
 
             webRequest.timeout = 5;
             webRequest.SetRequestHeader("Authorization", targetDevice.Authorization["Authorization"]);


### PR DESCRIPTION
## Overview
After Unity reloads assemblies (which it does after a script changes), the authorization token was being lost, since it doesn't get serialized when state is reloaded.
Unity's web request API caches the previous authorization cookie. This causes two things:

1. Our next attempt to authorize succeeds but doesn't return a response, since we're contacting the device with the previous cookie
2. Code that assumed we'd get a response throws a nullref

Now, if the request succeeds but nothing is returned, we ignore the result and move on like normal, since we know we've been properly authenticated via the cached cookie.

Also cleans up some unused fields and adds some documentation.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5697