### PR TITLE
Don't crash on global listeners

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Components/TestInputGlobalListener.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Components/TestInputGlobalListener.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -93,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             pointerUpCount++;
         }
 
-        public void OnPointerClicked(MixedRealityPointerEventData eventData)
+        public virtual void OnPointerClicked(MixedRealityPointerEventData eventData)
         {
             pointerClickedCount++;
         }
@@ -101,6 +102,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public void OnSpeechKeywordRecognized(SpeechEventData eventData)
         {
             speechCount++;
+        }
+    }
+
+    internal class TestInputGlobalListenerException : TestInputGlobalListener
+    {
+        public const string ExceptionMessage = "Test exception thrown during event fired for global listener";
+        public override void OnPointerClicked(MixedRealityPointerEventData eventData)
+        {
+            throw new Exception(ExceptionMessage);
         }
     }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputEventSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InputEventSystemTests.cs
@@ -344,6 +344,30 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Object.Destroy(object1);
             yield return null;
         }
+
+        /// <summary>
+        /// Test input system catches exception thrown in global listener responding to input event and that
+        /// the input system does not crash accordingly as well
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestGlobalListenerExceptionThrown()
+        {
+            var inputSystem = CoreServices.InputSystem;
+
+            var object1 = new GameObject("Object");
+            var listener = object1.AddComponent<TestInputGlobalListenerException>();
+
+            yield return null;
+
+            // Emit pointer event, which should be received by global handler
+            inputSystem.RaisePointerClicked(inputSystem.GazeProvider.GazePointer, MixedRealityInputAction.None, 1);
+
+            LogAssert.Expect(LogType.Exception, $"Exception: {TestInputGlobalListenerException.ExceptionMessage}");
+
+            Object.Destroy(object1);
+
+            yield return null;
+        }
     }
 }
 #endif

--- a/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseEventSystem.cs
@@ -94,7 +94,15 @@ namespace Microsoft.MixedReality.Toolkit
                         continue;
                     }
 
-                    eventHandler.Invoke((T)handlerEntry.handler, eventData);
+                    try
+                    {
+                        // Ensure client code does not crash our input system
+                        eventHandler.Invoke((T)handlerEntry.handler, eventData);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Overview
When firing regular events, Unity's event system is utilized. If the calling object throws an exception, Unity handles that and it does not crash the input system for the current frame. For global listeners, we are invoking the event handler's directly. Thus, any exceptions thrown in client code by consumers could crash our system. This change wraps the call in a try-catch to ensure the input system resumes running

Example class that can crash the input system from continuing execution
```c#
using Microsoft.MixedReality.Toolkit;
using Microsoft.MixedReality.Toolkit.Input;
using UnityEngine;

public class TestGlobal : MonoBehaviour, IMixedRealityFocusHandler
{
    public void OnFocusEnter(FocusEventData eventData)
    {
        GameObject c = null;
        c.transform.position = Vector3.zero;
    }

    public void OnFocusExit(FocusEventData eventData) { }
    void Start()
    {
        CoreServices.InputSystem?.RegisterHandler<IMixedRealityFocusHandler>(this);
    }
}
```

## Changes
- Fixes: # .

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
