### PR TITLE
Remove the 'alpha' tag from Release CI

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -7,7 +7,7 @@ variables:
   Unity2018Version: Unity2018.3.7f1
   Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.2.0  # Major.Minor.Patch
-  MRTKReleaseTag: 'alpha'  # final version component, e.g. 'RC2.1' or empty string
+  MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
 
 jobs:
 - job: CIReleaseValidation


### PR DESCRIPTION
NuGetForUnity doesn't support SemVer2.0, so we can't make use of prerelease packages that have alpha prepended.
