### PR TITLE
Update WMR scripts with DotNetWinRT support for Holographic Remoting

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -21,8 +21,8 @@ using Microsoft.Windows.Perception;
 using Microsoft.Windows.Perception.People;
 using Microsoft.Windows.UI.Input.Spatial;
 #endif
-#endif
-#endif
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
+#endif // UNITY_WSA
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -5,17 +5,23 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 
 #if UNITY_WSA
-using UnityEngine;
 using UnityEngine.XR.WSA.Input;
-#endif
-
-#if WINDOWS_UWP
-using Microsoft.MixedReality.Toolkit.Windows.Utilities;
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
 using System;
 using System.Collections.Generic;
+using UnityEngine;
+#if WINDOWS_UWP
+using Windows.Foundation.Metadata;
 using Windows.Perception;
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
+#elif DOTNETWINRT_PRESENT
+using Microsoft.Windows.Foundation.Metadata;
+using Microsoft.Windows.Perception;
+using Microsoft.Windows.Perception.People;
+using Microsoft.Windows.UI.Input.Spatial;
+#endif
+#endif
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
@@ -34,6 +40,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public WindowsMixedRealityArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
+#if WINDOWS_UWP
+            articulatedHandApiAvailable = ApiInformation.IsMethodPresent("SpatialInteractionSourceState", "TryGetHandPose");
+#elif UNITY_WSA && DOTNETWINRT_PRESENT
+            articulatedHandApiAvailable = typeof(SpatialInteractionSourceState).GetMethod("TryGetHandPose") != null;
+#endif
         }
 
         /// <summary>
@@ -54,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <inheritdoc/>
         public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
         {
-#if WINDOWS_UWP
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             return unityJointPoses.TryGetValue(joint, out pose);
 #else
             pose = MixedRealityPose.ZeroIdentity;
@@ -69,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             get
             {
                 bool valid = true;
-#if WINDOWS_UWP
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 Vector3 palmNormal = unityJointOrientations[(int)HandJointKind.Palm] * (-1 * Vector3.up);
                 if (CursorBeamBackwardTolerance >= 0)
                 {
@@ -86,17 +97,16 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                         valid = false;
                     }
                 }
-#endif // WINDOWS_UWP
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 return valid;
             }
         }
 
 #if UNITY_WSA
+#if DOTNETWINRT_PRESENT || WINDOWS_UWP
         private MixedRealityPose currentIndexPose = MixedRealityPose.ZeroIdentity;
 
-        private readonly HandRay handRay = new HandRay();
-
-#if WINDOWS_UWP
+        private SpatialInteractionManager spatialInteractionManager = null;
         private SpatialInteractionManager SpatialInteractionManager
         {
             get
@@ -113,15 +123,18 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
         }
 
-        private SpatialInteractionManager spatialInteractionManager = null;
+#if WINDOWS_UWP
         private HandMeshObserver handMeshObserver = null;
         private int[] handMeshTriangleIndices = null;
         private bool hasRequestedHandMeshObserver = false;
         private Vector2[] handMeshUVs;
+#endif // WINDOWS_UWP
 
         private readonly float CursorBeamBackwardTolerance = 0.5f;
         private readonly float CursorBeamUpTolerance = 0.8f;
-#endif // WINDOWS_UWP
+
+        private readonly bool articulatedHandApiAvailable = false;
+#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
 
         #region Update data functions
 
@@ -194,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         {
             handMeshObserver = await sourceState.Source.TryCreateHandMeshObserverAsync();
         }
-#endif
+#endif // WINDOWS_UWP
 
         /// <summary>
         /// Update the hand data from the device.
@@ -202,11 +215,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateHandData(InteractionSourceState interactionSourceState)
         {
-#if WINDOWS_UWP
+#if DOTNETWINRT_PRESENT || WINDOWS_UWP
             // Articulated hand support is only present in the 18362 version and beyond Windows
             // SDK (which contains the V8 drop of the Universal API Contract). In particular,
             // the HandPose related APIs are only present on this version and above.
-            if (!WindowsApiChecker.UniversalApiContractV8_IsAvailable)
+            if (!articulatedHandApiAvailable)
             {
                 return;
             }
@@ -219,6 +232,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 {
                     HandPose handPose = sourceState.TryGetHandPose();
 
+#if WINDOWS_UWP
                     if (CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.EnableHandMeshVisualization)
                     {
                         // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
@@ -301,6 +315,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                             handMeshObserver = null;
                         }
                     }
+#endif // WINDOWS_UWP
 
                     if (handPose != null && handPose.TryGetJoints(WindowsMixedRealityUtilities.SpatialCoordinateSystem, jointIndices, jointPoses))
                     {
@@ -334,12 +349,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                 }
             }
-#endif // WINDOWS_UWP
+#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
         }
 
         private void UpdateIndexFingerData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-#if WINDOWS_UWP
+#if DOTNETWINRT_PRESENT || WINDOWS_UWP
             UpdateCurrentIndexPose();
 
             // Update the interaction data source
@@ -351,12 +366,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 // Raise input system event if it's enabled
                 CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentIndexPose);
             }
-#endif // WINDOWS_UWP
+#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
         }
 
         #endregion Update data functions
 
-#if WINDOWS_UWP
+#if DOTNETWINRT_PRESENT || WINDOWS_UWP
         private static readonly HandJointKind[] jointIndices = new HandJointKind[]
         {
             HandJointKind.Palm,
@@ -446,7 +461,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #endregion Private InputSource Helpers
 
-#endif // WINDOWS_UWP
+#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
 #endif // UNITY_WSA
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityArticulatedHand.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         }
 
 #if UNITY_WSA
-#if DOTNETWINRT_PRESENT || WINDOWS_UWP
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
         private MixedRealityPose currentIndexPose = MixedRealityPose.ZeroIdentity;
 
         private SpatialInteractionManager spatialInteractionManager = null;
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private readonly float CursorBeamUpTolerance = 0.8f;
 
         private readonly bool articulatedHandApiAvailable = false;
-#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 
         #region Update data functions
 
@@ -215,7 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateHandData(InteractionSourceState interactionSourceState)
         {
-#if DOTNETWINRT_PRESENT || WINDOWS_UWP
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
             // Articulated hand support is only present in the 18362 version and beyond Windows
             // SDK (which contains the V8 drop of the Universal API Contract). In particular,
             // the HandPose related APIs are only present on this version and above.
@@ -349,12 +349,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                 }
             }
-#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
 
         private void UpdateIndexFingerData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-#if DOTNETWINRT_PRESENT || WINDOWS_UWP
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
             UpdateCurrentIndexPose();
 
             // Update the interaction data source
@@ -366,12 +366,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 // Raise input system event if it's enabled
                 CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentIndexPose);
             }
-#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
 
         #endregion Update data functions
 
-#if DOTNETWINRT_PRESENT || WINDOWS_UWP
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
         private static readonly HandJointKind[] jointIndices = new HandJointKind[]
         {
             HandJointKind.Palm,
@@ -461,7 +461,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #endregion Private InputSource Helpers
 
-#endif // DOTNETWINRT_PRESENT || WINDOWS_UWP
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 #endif // UNITY_WSA
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -9,9 +9,15 @@ using System.Collections.Generic;
 using UnityEngine;
 
 #if WINDOWS_UWP
+using Windows.Foundation.Metadata;
 using Windows.Perception;
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
+#elif UNITY_WSA && DOTNETWINRT_PRESENT
+using Microsoft.Windows.Foundation.Metadata;
+using Microsoft.Windows.Perception;
+using Microsoft.Windows.Perception.People;
+using Microsoft.Windows.UI.Input.Spatial;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
@@ -37,9 +43,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             IMixedRealityInputSystem inputSystem,
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : this(inputSystem, name, priority, profile) 
+            BaseMixedRealityProfile profile) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
+
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+            eyesApiAvailable = ApiInformation.IsPropertyPresent("SpatialPointerPose", "Eyes");
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 
         /// <summary>
@@ -71,23 +81,22 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public event Action OnSaccade;
         public event Action OnSaccadeX;
         public event Action OnSaccadeY;
+        private readonly bool eyesApiAvailable = false;
 
-#if WINDOWS_UWP
-
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         private static bool askedForETAccessAlready = false; // To make sure that this is only triggered once.
-
-#endif // WINDOWS_UWP
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
         #region IMixedRealityCapabilityCheck Implementation
-        
+
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
             if (WindowsApiChecker.UniversalApiContractV8_IsAvailable)
             {
-#if WINDOWS_UWP
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 return (capability == MixedRealityCapability.EyeTracking) && EyesPose.IsSupported();
-#endif // WINDOWS_UWP
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             }
 
             return false;
@@ -104,9 +113,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     this.GetType());
 #endif
 
-            if (Application.isPlaying && WindowsApiChecker.UniversalApiContractV8_IsAvailable)
+            if (Application.isPlaying && eyesApiAvailable)
             {
-#if WINDOWS_UWP
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 AskForETPermission();
 #endif
                 ReadProfile();
@@ -116,8 +125,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <inheritdoc />
         public override void Update()
         {
-#if WINDOWS_UWP
-            if (WindowsMixedRealityUtilities.SpatialCoordinateSystem == null || !WindowsApiChecker.UniversalApiContractV8_IsAvailable)
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+            if (WindowsMixedRealityUtilities.SpatialCoordinateSystem == null || !eyesApiAvailable)
             {
                 return;
             }
@@ -130,7 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 {
                     InputSystem?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
 
-                    if(eyes.Gaze.HasValue)
+                    if (eyes.Gaze.HasValue)
                     {
                         Ray newGaze = new Ray(WindowsMixedRealityUtilities.SystemVector3ToUnity(eyes.Gaze.Value.Origin), WindowsMixedRealityUtilities.SystemVector3ToUnity(eyes.Gaze.Value.Direction));
 
@@ -143,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                 }
             }
-#endif // WINDOWS_UWP
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 
         private void ReadProfile()
@@ -164,7 +173,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             SmoothEyeTracking = profile.SmoothEyeTracking;
         }
 
-#if WINDOWS_UWP
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         /// <summary>
         /// Triggers a prompt to let the user decide whether to permit using eye tracking 
         /// </summary>
@@ -176,7 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 await EyesPose.RequestAccessAsync();
             }
         }
-#endif // WINDOWS_UWP
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
         private Ray SmoothGaze(Ray? newGaze)
         {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
@@ -1,21 +1,25 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if WINDOWS_UWP
-#if ENABLE_DOTNET
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+#if NETFX_CORE
 using System;
-#endif // ENABLE_DOTNET
-using System.Runtime.InteropServices;
+#endif // NETFX_CORE
 using UnityEngine.XR.WSA;
+#if WINDOWS_UWP
+using System.Runtime.InteropServices;
 using Windows.Perception.Spatial;
-#endif // WINDOWS_UWP
+#elif DOTNETWINRT_PRESENT
+using Microsoft.Windows.Perception.Spatial;
+#endif
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 {
     public static class WindowsMixedRealityUtilities
     {
-#if WINDOWS_UWP
-#if ENABLE_DOTNET
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+#if NETFX_CORE
         [DllImport("DotNetNativeWorkaround.dll", EntryPoint = "MarshalIInspectable")]
         private static extern void GetSpatialCoordinateSystem(IntPtr nativePtr, out SpatialCoordinateSystem coordinateSystem);
 
@@ -43,11 +47,24 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 return Marshal.GetObjectForIUnknown(nativePtr) as SpatialCoordinateSystem;
             }
         }
-#else
+#elif WINDOWS_UWP
         public static SpatialCoordinateSystem SpatialCoordinateSystem => spatialCoordinateSystem ?? (spatialCoordinateSystem = Marshal.GetObjectForIUnknown(WorldManager.GetNativeISpatialCoordinateSystemPtr()) as SpatialCoordinateSystem);
+#elif DOTNETWINRT_PRESENT
+        public static SpatialCoordinateSystem SpatialCoordinateSystem
+        {
+            get
+            {
+                var spatialCoordinateSystemPtr = WorldManager.GetNativeISpatialCoordinateSystemPtr();
+                if (spatialCoordinateSystem == null && spatialCoordinateSystemPtr != System.IntPtr.Zero)
+                {
+                    spatialCoordinateSystem = SpatialCoordinateSystem.FromNativePtr(WorldManager.GetNativeISpatialCoordinateSystemPtr());
+                }
+                return spatialCoordinateSystem;
+            }
+        }
 #endif
         private static SpatialCoordinateSystem spatialCoordinateSystem = null;
-#endif // WINDOWS_UWP
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
         public static UnityEngine.Vector3 SystemVector3ToUnity(System.Numerics.Vector3 vector)
         {


### PR DESCRIPTION
## Overview
Adds the namespaces from the DotNetWinRT adapter, currently blocked behind `#if DOTNETWINRT_PRESENT`.

This is part 1 of bringing in remoting support. With this change, HL2 remoting can be used by manually setting the define in the Unity player settings and manually importing https://www.nuget.org/packages/Microsoft.Windows.MixedReality.DotNetWinRT.

This flow will be improved in upcoming PRs.

## Changes
- Part 1 of #6244