### PR TITLE
Material theme should not active/deactivate host gameobject

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableMaterialTheme.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableMaterialTheme.cs
@@ -58,18 +58,23 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             ThemePropertyValue start = new ThemePropertyValue();
 
-            material = renderer.material;
-            start.Material = material;
+            if (renderer != null)
+            {
+                material = renderer.material;
+                start.Material = material;
+            }
+
             return start;
         }
 
         /// <inheritdoc />
         public override void SetValue(ThemeStateProperty property, int index, float percentage)
         {
-            Host.SetActive(property.Values[index].Bool);
-
-            material = property.Values[index].Material;
-            renderer.material = material;
+            if (renderer != null)
+            {
+                material = property.Values[index].Material;
+                renderer.material = material;
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview
Material Theme had invalid line of code controlling whether gameobject host was active or not...but the property for the theme engine was of type material, not bool

## Changes
- Fixes: #6707 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
