### PR TITLE
Add new foundation package dependency

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -12,6 +12,9 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
     <tags>Unity MixedReality</tags>
+    <dependencies>
+      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1034" />
+    </dependencies>
     <contentFiles>
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />
     </contentFiles>


### PR DESCRIPTION
Portions of the MRTK foundation now require the Microsoft.Windows.MixedReality.DotNetWinRT package to make accessing some platform functionality significantly easier.

This change adds the dependency to the nuspec file and fixes #6631