### PR TITLE
Add csproj and nuget for DotNetWinRT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ doc/
 /MSBuild/
 /PackagesCopy/
 !/scripts/Packaging/NuGetRestoreProject.csproj
+
+# ========================= #
+# MSBuildForUnity generated #
+# ========================= #
+Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/Plugins*
+MSBuildForUnity.Common.props
+.obj

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter.meta
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3817b39173905f4482a4a2c0ee34e39
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/DotNetAdapter.csproj
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/DotNetAdapter.csproj
@@ -1,0 +1,33 @@
+﻿<Project ToolsVersion="15.0">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
+
+  <PropertyGroup Condition="'$(UnityCurrentTargetFramework)' == ''">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UnityCurrentTargetFramework)' != ''">
+    <TargetFramework>$(UnityCurrentTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Make sure Unity ignores the contents of the intermediate output path. -->
+    <BaseIntermediateOutputPath>.obj</BaseIntermediateOutputPath>
+    <OutputPath>Plugins</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT">
+      <Version>0.5.1034</Version>
+    </PackageReference>
+    <PackageReference Include="MSBuildForUnity">
+      <Version>0.8.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Note that this is the special "NoTarget" SDK to prevent this project from producing a dll. -->
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" Version="1.0.80" />
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" Version="1.0.80" />
+</Project>

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/DotNetAdapter.csproj.meta
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/DotNetAdapter.csproj.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14c729fdf72b47f46bde418574656351
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400002: DotNetAdapter
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/NuGet.config
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources />
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/NuGet.config.meta
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/NuGet.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 75e631a6dc295704eb10f35f6023fc5c
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -92,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-            if (WindowsApiChecker.UniversalApiContractV8_IsAvailable)
+            if (eyesApiAvailable)
             {
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 return (capability == MixedRealityCapability.EyeTracking) && EyesPose.IsSupported();
@@ -117,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 AskForETPermission();
-#endif
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
                 ReadProfile();
             }
         }


### PR DESCRIPTION
## Overview
Along with @davidkline-ms's #6718, this will pull down the DotNetWinRT dependency.
Along with #6702, this will support full holographic remoting for HoloLens 2!

Also a slight update to the eye gaze data provider.

Docs will be incoming, but I want to unblock testing.

## Changes
- Part of #6244 