### PR TITLE
Only scale manipulation for xz distance

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -1016,14 +1016,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestHand hand = new TestHand(Handedness.Right);
             const int numHandSteps = 1;
 
-            float xPos, yPos;
+            float xPos, yPosUp, yPosDown;
 
             // Grab the object
             yield return hand.Show(new Vector3(0, 0, 0.5f));
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return null;
 
-            // Move the hand in a way that does not change the xz distance from the body
+            // Move the hand in a way that does not change the distance from the body ray
             float root2Over2 = Mathf.Cos(Mathf.PI / 4);
             Vector3 moveX = new Vector3(root2Over2, 0, root2Over2) * 0.5f;
             yield return hand.MoveTo(moveX, numHandSteps);
@@ -1031,13 +1031,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             xPos = testObject.transform.position.x - moveX.x;
 
-            Vector3 moveY = new Vector3(0, 0.5f, 0.5f);
-            yield return hand.MoveTo(moveY, numHandSteps);
+            Vector3 moveYUp = new Vector3(0, root2Over2, root2Over2) * 0.5f;
+            yield return hand.MoveTo(moveYUp, numHandSteps);
             yield return null;
 
-            yPos = testObject.transform.position.y - moveY.y;
+            yPosUp = testObject.transform.position.y - moveYUp.y;
 
-            Assert.AreEqual(xPos, yPos, 0.01f);
+            Vector3 moveYDown = new Vector3(0, -0.5f, 0.5f);
+            yield return hand.MoveTo(moveYDown, numHandSteps);
+            yield return null;
+
+            yPosDown = testObject.transform.position.y - moveYDown.y;
+
+            Assert.AreEqual(xPos, yPosUp, 0.02f);
+            Assert.AreEqual(xPos, Mathf.Abs(yPosDown), 0.02f);
 
             // Restore the input simulation profile
             iss.HandSimulationMode = oldHandSimMode;

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -31,9 +31,16 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// </summary>
         public void Setup(MixedRealityPose pointerCentroidPose, Vector3 grabCentroid, MixedRealityPose objectPose, Vector3 objectScale)
         {
-            Vector2 headPosXZ = new Vector2(CameraCache.Main.transform.position.x, CameraCache.Main.transform.position.z);
-            Vector2 pointerPosXZ = new Vector2(pointerCentroidPose.Position.x, pointerCentroidPose.Position.z);
-            pointerRefDistance = Vector2.Distance(pointerPosXZ, headPosXZ);
+            if (pointerCentroidPose.Position.y > CameraCache.Main.transform.position.y)
+            {
+                pointerRefDistance = Vector3.Distance(pointerCentroidPose.Position, CameraCache.Main.transform.position);
+            }
+            else
+            {
+                Vector2 headPosXZ = new Vector2(CameraCache.Main.transform.position.x, CameraCache.Main.transform.position.z);
+                Vector2 pointerPosXZ = new Vector2(pointerCentroidPose.Position.x, pointerCentroidPose.Position.z);
+                pointerRefDistance = Vector2.Distance(pointerPosXZ, headPosXZ);
+            }
             pointerPosIndependentOfHead = pointerRefDistance != 0;
             
             Quaternion worldToPointerRotation = Quaternion.Inverse(pointerCentroidPose.Rotation);
@@ -56,10 +63,19 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             if (pointerPosIndependentOfHead && movementConstraint != MovementConstraintType.FixDistanceFromHead)
             {
                 // Compute how far away the object should be based on the ratio of the current to original hand distance
-                Vector2 headPosXZ = new Vector2(CameraCache.Main.transform.position.x, CameraCache.Main.transform.position.z);
-                Vector2 pointerPosXZ = new Vector2(pointerCentroidPose.Position.x, pointerCentroidPose.Position.z);
+                float currentHandDistance = 0;
 
-                var currentHandDistance = Vector2.Distance(pointerPosXZ, headPosXZ);
+                if (pointerCentroidPose.Position.y > CameraCache.Main.transform.position.y)
+                {
+                    currentHandDistance = Vector3.Distance(pointerCentroidPose.Position, CameraCache.Main.transform.position);
+                }
+                else
+                {
+                    Vector2 headPosXZ = new Vector2(CameraCache.Main.transform.position.x, CameraCache.Main.transform.position.z);
+                    Vector2 pointerPosXZ = new Vector2(pointerCentroidPose.Position.x, pointerCentroidPose.Position.z);
+
+                    currentHandDistance = Vector2.Distance(pointerPosXZ, headPosXZ);
+                }
                 distanceRatio = currentHandDistance / pointerRefDistance;
             }
 

--- a/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Physics/TwoHandMoveLogic.cs
@@ -31,8 +31,9 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// </summary>
         public void Setup(MixedRealityPose pointerCentroidPose, Vector3 grabCentroid, MixedRealityPose objectPose, Vector3 objectScale)
         {
-            Vector3 headPosition = CameraCache.Main.transform.position;            
-            pointerRefDistance = Vector3.Distance(pointerCentroidPose.Position, headPosition);
+            Vector2 headPosXZ = new Vector2(CameraCache.Main.transform.position.x, CameraCache.Main.transform.position.z);
+            Vector2 pointerPosXZ = new Vector2(pointerCentroidPose.Position.x, pointerCentroidPose.Position.z);
+            pointerRefDistance = Vector2.Distance(pointerPosXZ, headPosXZ);
             pointerPosIndependentOfHead = pointerRefDistance != 0;
             
             Quaternion worldToPointerRotation = Quaternion.Inverse(pointerCentroidPose.Rotation);
@@ -50,13 +51,15 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>A Vector3 describing the desired position</returns>
         public Vector3 Update(MixedRealityPose pointerCentroidPose, Quaternion objectRotation, Vector3 objectScale, bool usePointerRotation, MovementConstraintType movementConstraint)
         {
-            Vector3 headPosition = CameraCache.Main.transform.position;
             float distanceRatio = 1.0f;
 
             if (pointerPosIndependentOfHead && movementConstraint != MovementConstraintType.FixDistanceFromHead)
             {
                 // Compute how far away the object should be based on the ratio of the current to original hand distance
-                var currentHandDistance = Vector3.Magnitude(pointerCentroidPose.Position - headPosition);
+                Vector2 headPosXZ = new Vector2(CameraCache.Main.transform.position.x, CameraCache.Main.transform.position.z);
+                Vector2 pointerPosXZ = new Vector2(pointerCentroidPose.Position.x, pointerCentroidPose.Position.z);
+
+                var currentHandDistance = Vector2.Distance(pointerPosXZ, headPosXZ);
                 distanceRatio = currentHandDistance / pointerRefDistance;
             }
 


### PR DESCRIPTION
## Overview
Previously, moving your hand down while you were manipulating an object moved the object further away. This was because the distance from the head was used to scale the manipulation distance. Now, we ignore y in this distance calculation, meaning you have to move your hand further from your body in order to scale the manipulation distance.

See .gifs below for comparison. The .gifs in #6589 demonstrate the problem very well.

### Before
![pre_depth_fix](https://user-images.githubusercontent.com/47415945/69559354-b63fb080-0fa1-11ea-9c9e-08c005335819.gif)

### After
![depth_fix](https://user-images.githubusercontent.com/47415945/69559004-16822280-0fa1-11ea-8538-c2c039539e83.gif)

## Changes
- Fixes: #6589.