### PR TITLE
add support for dotnetwinrt adapter in asset retargeter

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -376,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                                 }
                                 else if ((type.Namespace == null) || 
                                         !type.Namespace.Contains("Microsoft.MixedReality.Toolkit") ||
-                                        !type.Namespace.Contains."Microsoft.Windows.MixedReality")) // DotNetWinRT adapter
+                                        !type.Namespace.Contains("Microsoft.Windows.MixedReality")) // DotNetWinRT adapter
                                 {
                                     throw new InvalidDataException($"Type {type.Name} is not a member of an approved (typically, 'Microsoft.MixedReality.Toolkit') namespace");
                                 }

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -374,9 +374,11 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                                 {
                                     Debug.LogError($"Encountered a MonoScript we get a null Type from: '{monoScript.name}'");
                                 }
-                                else if (type.Namespace == null || !type.Namespace.Contains("Microsoft.MixedReality.Toolkit"))
+                                else if ((type.Namespace == null) || 
+                                        !type.Namespace.Contains("Microsoft.MixedReality.Toolkit") ||
+                                        !type.Namespace.Contains."Microsoft.Windows.MixedReality")) // DotNetWinRT adapter
                                 {
-                                    throw new InvalidDataException($"Type {type.Name} is not a member of the Microsoft.MixedReality.Toolkit namespace");
+                                    throw new InvalidDataException($"Type {type.Name} is not a member of an approved (typically, 'Microsoft.MixedReality.Toolkit') namespace");
                                 }
                                 else
                                 {


### PR DESCRIPTION
This change resolves a CI issue introduced by #6720 where the DotNetWinRT.dll was being scanned for asset retargeting and its namespace was not expected.
