### PR TITLE
Move MSBuild for Unity enabling to MRTK Configurator

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -20,6 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {MRConfig.VirtualRealitySupported, true },
             {MRConfig.SinglePassInstancing, true },
             {MRConfig.SpatialAwarenessLayer, true },
+            {MRConfig.EnableMSBuildForUnity, true },
             // UWP Capabilities
             {MRConfig.MicrophoneCapability, true },
             {MRConfig.InternetClientCapability, true },
@@ -144,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
             RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path");
             RenderToggle(MRConfig.SpatialAwarenessLayer, "Set Default Spatial Awareness Layer");
-
+            RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
             EditorGUILayout.Space();
 
             if (MixedRealityOptimizeUtils.IsBuildTargetUWP())

--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
@@ -18,7 +18,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         static EditorProjectUtilities()
         {
             CheckMinimumEditorVersion();
-            PackageManifestUpdater.EnsureMSBuildForUnity();
             ApplyARFoundationUWPCompileFix();
         }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
@@ -23,12 +23,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             // Locate the full path to the package manifest.
             DirectoryInfo projectRoot = new DirectoryInfo(Application.dataPath).Parent;
-            string manifestPath = Path.Combine(projectRoot.FullName, PackageManifestRelativePath);
-            
+            string[] paths = { projectRoot.FullName, "Packages", "manifest.json" };
+            string manifestPath = Path.Combine(paths);
+
             // Verify that the package manifest file exists.
             if (!File.Exists(manifestPath))
             {
-                Debug.LogError("Unable to locate the package manifest file");
+                Debug.LogError($"Package manifest file ({manifestPath}) could not be found.");
                 return;
             }
 
@@ -58,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             if (manifest == null)
             {
-                Debug.LogError("Failed to load the package manifest");
+                Debug.LogError($"Failed to read the package manifest file ({manifestPath})");
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
@@ -13,8 +13,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </summary>
     internal static class PackageManifestUpdater
     {
-        private static string PackageManifestRelativePath = Path.Combine("Packages", "manifest.json");
-
         /// <summary>
         /// Ensures the required settings exist in the package manager to allow for
         /// installing MSBuild for Unity.

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -223,12 +223,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             // Locate the full path to the package manifest.
             DirectoryInfo projectRoot = new DirectoryInfo(Application.dataPath).Parent;
-            string manifestPath = Path.Combine(projectRoot.FullName, System.IO.Path.Combine("Packages", "manifest.json"));
+            string[] paths = { projectRoot.FullName, "Packages", "manifest.json" };
+            string manifestPath = Path.Combine(paths);
 
             // Verify that the package manifest file exists.
             if (!File.Exists(manifestPath))
             {
-                Debug.LogError("Unable to locate the package manifest file");
+                Debug.LogError($"Package manifest file ({manifestPath}) could not be found.");
                 return false;
             }
 
@@ -236,7 +237,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             string manifestFileContents = File.ReadAllText(manifestPath);
             if (string.IsNullOrWhiteSpace(manifestFileContents))
             {
-                Debug.LogError("Failed to load the package manifest file");
+                Debug.LogError($"Failed to read the package manifest file ({manifestPath})");
                 return false;
             }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.AndroidMinSdkVersion, () => { PlayerSettings.Android.minSdkVersion = MinAndroidSdk; } },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = iOSMinOsVersion.ToString(); } },
+            { Configurations.IOSMinOSVersion, () => { PlayerSettings.iOS.targetOSVersionString = iOSMinOsVersion.ToString("n1"); } },
             { Configurations.IOSArchitecture, () => { PlayerSettings.SetArchitecture(BuildTargetGroup.iOS, RequirediOSArchitecture); } },
             { Configurations.IOSCameraUsageDescription, () => { PlayerSettings.iOS.cameraUsageDescription = iOSCameraUsageDescription; } },
         };

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -32,6 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             VirtualRealitySupported,
             SinglePassInstancing,
             SpatialAwarenessLayer,
+            EnableMSBuildForUnity,
 
             // WSA Capabilities
             SpatialPerceptionCapability = 1000,
@@ -60,6 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.VirtualRealitySupported,  () => { return PlayerSettings.virtualRealitySupported; } },
             { Configurations.SinglePassInstancing,  () => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); } },
             { Configurations.SpatialAwarenessLayer,  () => { return HasSpatialAwarenessLayer(); } },
+            { Configurations.EnableMSBuildForUnity, () => { return IsMSBuildForUnityEnabled(); } },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.SpatialPerception); } },
@@ -91,6 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.VirtualRealitySupported,  () => { PlayerSettings.virtualRealitySupported = true; } },
             { Configurations.SinglePassInstancing,  () => { MixedRealityOptimizeUtils.SetSinglePassInstanced(); } },
             { Configurations.SpatialAwarenessLayer,  () => { SetSpatialAwarenessLayer(); } },
+            { Configurations.EnableMSBuildForUnity, () => { PackageManifestUpdater.EnsureMSBuildForUnity(); } },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true); } },
@@ -211,6 +214,35 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public static bool IsForceTextSerialization()
         {
             return EditorSettings.serializationMode == SerializationMode.ForceText;
+        }
+
+        /// <summary>
+        /// Checks package manifest to see if MSBuild for Unity is included in the dependencies.
+        /// </summary>
+        public static bool IsMSBuildForUnityEnabled()
+        {
+            // Locate the full path to the package manifest.
+            DirectoryInfo projectRoot = new DirectoryInfo(Application.dataPath).Parent;
+            string manifestPath = Path.Combine(projectRoot.FullName, System.IO.Path.Combine("Packages", "manifest.json"));
+
+            // Verify that the package manifest file exists.
+            if (!File.Exists(manifestPath))
+            {
+                Debug.LogError("Unable to locate the package manifest file");
+                return false;
+            }
+
+            // Load the manfiest file.
+            string manifestFileContents = File.ReadAllText(manifestPath);
+            if (string.IsNullOrWhiteSpace(manifestFileContents))
+            {
+                Debug.LogError("Failed to load the package manifest file");
+                return false;
+            }
+
+            // Attempt to find the MSBuild for Unity package name.
+            const string msBuildPackageName = "com.microsoft.msbuildforunity";
+            return manifestFileContents.Contains(msBuildPackageName);
         }
 
         /// <summary>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -179,7 +179,7 @@ PlayerSettings:
   StripUnusedMeshComponents: 0
   VertexChannelCompressionMask: 214
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 11
+  iOSTargetOSVersionString: 11.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 9.0


### PR DESCRIPTION
#6718 added automatic modification of the package manifest to add MSBuild for Unity on project load.

This change moves this to the MRTK Configuration dialog to allow customers to choose when / if they wish it to be installed.

Fixes #6723

A Getting Started documentation update describing MSBuild for Unity and its benefits will follow this PR shortly.

Also included in this change is an update to how the configurator writes out the required iOS version (was writing "11" needs to be writing "11.0").