### PR TITLE
Mark MRC capture settings as experimental, disabled by default

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/WindowsMixedRealityCameraSettingsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/WindowsMixedRealityCameraSettingsProfileInspector.cs
@@ -37,13 +37,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Editor
                 serializedObject.Update();
 
                 EditorGUILayout.Space();
-                EditorGUILayout.LabelField("Mixed Reality Capture Settings", EditorStyles.boldLabel);
-
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.PropertyField(renderFromPVCameraForMixedRealityCapture, pvCameraRenderingTitle);
+                    EditorGUILayout.LabelField("Mixed Reality Capture Settings (Experimental)", EditorStyles.boldLabel);
                     InspectorUIUtility.RenderDocumentationButton(MRCDocURL);
                 }
+
+                EditorGUILayout.HelpBox("Render from PV Camera is supported on Unity 2018.4.12f1 or newer and 2019.3 or newer. Enabling the feature on other versions may result in incorrect capture behavior.", MessageType.Info);
+
+                EditorGUILayout.PropertyField(renderFromPVCameraForMixedRealityCapture, pvCameraRenderingTitle);
 
                 serializedObject.ApplyModifiedProperties();
             }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Profiles/DefaultWindowsMixedRealityCameraSettingsProfile.asset
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Profiles/DefaultWindowsMixedRealityCameraSettingsProfile.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: DefaultWindowsMixedRealityCameraSettingsProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  renderFromPVCameraForMixedRealityCapture: 1
+  renderFromPVCameraForMixedRealityCapture: 0

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityCameraSettingsProfile.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityCameraSettingsProfile.cs
@@ -9,13 +9,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     /// <summary>
     /// Configuration profile for the Windows Mixed Reality Camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Windows Mixed Reality Camera Settings Profile", fileName = "DefaultWindowsMixedRealityCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(WindowsMixedRealityCameraSettings))]
     public class WindowsMixedRealityCameraSettingsProfile : BaseCameraSettingsProfile
     {
         [SerializeField]
         [Tooltip("If enabled, will render scene from PV camera projection matrix while MRC is active. This will ensure that holograms, such as hand meshes, remain visibly aligned in the video output.")]
-        private bool renderFromPVCameraForMixedRealityCapture = true;
+        private bool renderFromPVCameraForMixedRealityCapture = false;
 
         /// <summary>
         /// Whether to use photo/video camera rendering for Mixed Reality Capture on Windows.


### PR DESCRIPTION
This change addresses #6732 by adding a message qualifying which versions of Unity support the MRC capture settings provided by the Windows Mixed Reality camera settings provider.

It also marks this feature as experimental as there have been some issues with hologram stability in MRC recordings.

The default profile ships with the setting disabled. Customers can enable by cloning and modifying the profile.