### PR TITLE
Update recommended version for new MRC and header update

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/WindowsMixedRealityCameraSettingsProfileInspector.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/WindowsMixedRealityCameraSettingsProfileInspector.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Editor
                     InspectorUIUtility.RenderDocumentationButton(MRCDocURL);
                 }
 
-                EditorGUILayout.HelpBox("Render from PV Camera is supported on Unity 2018.4.12f1 or newer and 2019.3 or newer. Enabling the feature on other versions may result in incorrect capture behavior.", MessageType.Info);
+                EditorGUILayout.HelpBox("Render from PV Camera is supported on Unity 2018.4.13f1 or newer and 2019.3 or newer. Enabling the feature on other versions may result in incorrect capture behavior.", MessageType.Info);
 
                 EditorGUILayout.PropertyField(renderFromPVCameraForMixedRealityCapture, pvCameraRenderingTitle);
 

--- a/Documentation/Contributing/CONTRIBUTING.md
+++ b/Documentation/Contributing/CONTRIBUTING.md
@@ -6,6 +6,7 @@ If you have any questions, please reach out on the [mixed-reality-toolkit channe
  You can join the Slack community via the [automatic invitation sender](https://holodevelopersslack.azurewebsites.net/).
 
 ## Submission process
+
 We provide several paths to enable developers to contribute to the Mixed Reality Toolkit, all starting with [creating a new Issue](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose).
 
 <img src="../Images/Contributing/SelectIssueType.png" width="600">
@@ -17,6 +18,7 @@ From here you file:
 - **Feature request** - Proposal for a new Mixed Reality Toolkit feature
 
 ## Proposing Feature Requests
+
 When requesting a new Mixed Reality Toolkit feature, it is important to document the customer benefit / problem to be solved. Once submitted, a feature request will be reviewed and discussed on GitHub. We encourage open and constructive discussion of each feature proposal to ensure that the work is beneficial to a large segment of customers.
 
 To avoid needing to rework the feature, it is generally recommended that development of the feature does not begin during the review phase. Many times, the community review process uncovers one or more issues that may require significant changes in the proposed implementation.
@@ -42,4 +44,3 @@ When adding a bug fix or feature, follow these steps:
 1. Ensure the code and feature(s) are documented as described in the [Documentation Guidelines](DocumentationGuide.md).
 1. Ensure the code works as intended on all platforms. Please see [Release notes](../ReleaseNotes.md) for the list of supported platforms. For Windows UWP projects, code must be [WACK compliant](https://developer.microsoft.com/en-us/windows/develop/app-certification-kit). To do this, generate a Visual Studio solution, right click on project; **Store** > **Create App Packages**. Follow the prompts and run WACK tests. Make sure they all succeed.
 1. Follow the instructions at [Pull Requests](PullRequests.md) when making a pull request.
-

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -51,8 +51,8 @@ When you fix a bug, write a test to ensure it does not regress in the future. If
 All Microsoft employees contributing new files should add the following standard License header at the top of any new files, exactly as shown below:
 
 ```c#
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 ```
 
 ### Function / Method summary headers

--- a/Documentation/Contributing/UnitTests.md
+++ b/Documentation/Contributing/UnitTests.md
@@ -207,8 +207,8 @@ Edit mode tests are executed in Unity's edit mode and can be added under the **M
 To create a new test the following template can be used:
 
 ``` csharp
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using NUnit.Framework;
 


### PR DESCRIPTION
## Overview
Updates the recommended version from 2018.4.12 to 2018.4.13.
Also, updates the Microsoft contribution header to the currently recommended internal guidelines on https://docs.opensource.microsoft.com/content/releasing/copyright-headers.html