### PR TITLE
Compilation Validator for 2019.2+

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/CompilationValidator.meta
+++ b/Assets/MixedRealityToolkit.SDK/CompilationValidator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e4b696e7b05c1aa4fa43aba125aef116
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.asmdef
+++ b/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "CompilationValidator",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.asmdef.meta
+++ b/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4aabc2b15b28826468320948920782c6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.cs
+++ b/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Diagnostics;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
+{
+    [InitializeOnLoad]
+    public class CompilationValidator
+    {
+        private const string warningTitle = "Assembly reference missing";
+        private const string warningMessage = "Unity 2019.2 and later requires that your UnityAR assembly definition be configured differently. We can attempt to do this automatically. Proceed?";
+        private const string unityArAsmdefPath = "Assets/MixedRealityToolkit.Staging/UnityAR/Microsoft.MixedReality.Toolkit.Providers.UnityAR.asmdef";
+        private const string spatialTrackingReference = "UnityEngine.SpatialTracking";
+        private const string powershellScriptPath = "scripts/support2019/setup_for_2019.ps1";
+
+        static CompilationValidator()
+        {
+#if UNITY_2019_2_OR_NEWER
+            TextAsset unityArAsmdef = AssetDatabase.LoadAssetAtPath<TextAsset>(unityArAsmdefPath);
+
+            if (!unityArAsmdef.text.Contains(spatialTrackingReference))
+            {
+                if (EditorUtility.DisplayDialog(warningTitle, warningMessage, "OK", "Cancel"))
+                {
+                    string path = Application.dataPath.Replace("Assets", powershellScriptPath);
+                    UnityEngine.Debug.Log("Running script " + path);
+
+                    try
+                    {
+                        var processInfo = new ProcessStartInfo("Powershell.exe", "-executionpolicy bypass -file " + path);
+                        processInfo.UseShellExecute = false;
+                        processInfo.CreateNoWindow = false;
+                        processInfo.WindowStyle = ProcessWindowStyle.Normal;
+
+                        var process = Process.Start(processInfo);
+
+                        process.WaitForExit();
+                        process.Close();
+                    }
+                    catch (Exception e)
+                    {
+                        UnityEngine.Debug.LogError("Unable to run script " + powershellScriptPath + ": " + e);
+                        EditorGUIUtility.PingObject(unityArAsmdef);
+                    }
+                }
+                else
+                {
+                    EditorGUIUtility.PingObject(unityArAsmdef);
+                }
+            }
+#endif
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.cs
+++ b/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using System;
 using System.Diagnostics;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/CompilationValidator/CompilationValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c5919b2bc07d9d47948eee0a0630e37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

Adds a script that loads on startup and checks for asmdef configuration in Unity 2019.2 & later. If asmdef files are not configured correctly a dialog is launched:

![Dialog](https://user-images.githubusercontent.com/9789716/69987063-8473a000-14f3-11ea-9585-16c651d57b0e.PNG)

Clicking OK executes our `setup_for_2019.ps1` powershell script.

## Changes
- Fixes: #6555

## Verification
This should be tested with fresh installs from github on a variety of systems.

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
