### PR TITLE
Mrtk profile requirements

### DIFF
--- a/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs
+++ b/Assets/MixedRealityToolkit/Attributes/MixedRealityServiceProfileAttribute.cs
@@ -8,12 +8,24 @@ namespace Microsoft.MixedReality.Toolkit
     /// <summary>
     /// Attribute that defines which service a profile is meant to be consumed by.
     /// Only applies to profiles that are consumed by types implementing IMixedRealityService.
+    /// A service must implement all required types and no excluded types to be considered compatible with the profile.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public class MixedRealityServiceProfileAttribute : Attribute
     {
-        public MixedRealityServiceProfileAttribute(Type serviceType) { ServiceType = serviceType; }
+        public MixedRealityServiceProfileAttribute(Type requiredType, Type excludedType = null)
+        {
+            RequiredTypes = new Type[] { requiredType };
+            ExcludedTypes = excludedType != null ? new Type[] { excludedType } : new Type[0];
+        }
 
-        public Type ServiceType { get; private set; }
+        public MixedRealityServiceProfileAttribute(Type[] requiredTypes, Type[] excludedTypes = null)
+        {
+            RequiredTypes = requiredTypes;
+            ExcludedTypes = excludedTypes != null ? excludedTypes : new Type[0];
+        }
+
+        public Type[] RequiredTypes { get; private set; }
+        public Type[] ExcludedTypes { get; private set; }
     }
 }

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityEyeTrackingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityEyeTrackingProfile.cs
@@ -3,12 +3,13 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Eye Tracking Profile", fileName = "MixedRealityEyeTrackingProfile", order = (int)CreateProfileMenuItemIndices.EyeTracking)]
-    [MixedRealityServiceProfile(typeof(IMixedRealityEyeGazeDataProvider))]
+    [MixedRealityServiceProfile(requiredTypes: new Type[] { typeof(IMixedRealityEyeGazeDataProvider), typeof(IMixedRealityEyeSaccadeProvider) })]
     public class MixedRealityEyeTrackingProfile : BaseMixedRealityProfile
     {
         [SerializeField]

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityProfileUtility.cs
@@ -79,10 +79,30 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             foreach (MixedRealityServiceProfileAttribute serviceProfileAttribute in profileType.GetCustomAttributes(typeof(MixedRealityServiceProfileAttribute), true))
             {
-                if (serviceProfileAttribute.ServiceType.IsAssignableFrom(serviceType))
+                bool requirementsMet = true;
+                foreach (Type requiredType in serviceProfileAttribute.RequiredTypes)
                 {
-                    return true;
+                    if (!requiredType.IsAssignableFrom(serviceType))
+                    {
+                        requirementsMet = false;
+                        break;
+                    }
                 }
+
+                if (requirementsMet)
+                {
+                    foreach (Type excludedType in serviceProfileAttribute.ExcludedTypes)
+                    {
+                        if (excludedType.IsAssignableFrom(serviceType))
+                        {
+                            requirementsMet = false;
+                            break;
+                        }
+
+                    }
+                }
+
+                return requirementsMet;
             }
             return false;
         }


### PR DESCRIPTION
## Overview
Updates the `MixedRealityServiceProfileAttribute` to support multiple required types and multiple excluded types.

The default constructor still accepts one required type and no excluded types, so this is a non-breaking change.

Also updates the eye tracking profile to require both `IMixedRealityEyeGazeDataProvider` and `IMixedRealityEyeSaccadeProvider.` This requirement excludes eye tracking profiles from the input simulation profiles list:

![FilteredList](https://user-images.githubusercontent.com/9789716/69993019-cdc9ec80-14ff-11ea-922b-fde42a34ec31.png)

## Changes
- Fixes: #6765

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
