### PR TITLE
fix mouse provider not auto selecting profile

### DIFF
--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -12,7 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         typeof(IMixedRealityInputSystem),
         (SupportedPlatforms)(-1), // All platforms supported by Unity
         "Unity Mouse Device Manager",
-        "Profiles/DefaultMixedRealityMouseInputProfile.asset")]  
+        "Profiles/DefaultMixedRealityMouseInputProfile.asset",
+        "MixedRealityToolkit.SDK")]  
     public class MouseDeviceManager : BaseInputDeviceManager, IMixedRealityMouseDeviceManager
     {
         /// <summary>


### PR DESCRIPTION
While investigating #6765, it was found that the mouse device manager does not automatically set its default profile when selected.

Added "MixedRealityToolkit.SDK" to the data provider attribute to inform the system the location of the file.