### PR TITLE
Clean up unnecessary GC allocation every frame

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -193,28 +193,28 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (pointerPreferences != null)
             {
-                Action<IMixedRealityPointer, PointerBehavior> setPointerState =
-                    (ptr, behavior) =>
-                    {
-                        if (behavior == PointerBehavior.Default)
-                        {
-                            return;
-                        }
-
-                        bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
-                        ptr.IsActive = isPointerOn;
-                        if (ptr is GenericPointer genericPtr)
-                        {
-                            genericPtr.IsInteractionEnabled = isPointerOn;
-                        }
-                        unassignedPointers.Remove(ptr);
-                    };
-
                 foreach (IMixedRealityPointer pointer in allPointers)
                 {
-                    setPointerState(pointer, pointerPreferences.GetPointerBehavior(pointer));
+                    ApplyPointerBehavior(pointer, pointerPreferences.GetPointerBehavior(pointer));
                 }
             }
+        }
+
+        private void ApplyPointerBehavior(IMixedRealityPointer pointer, PointerBehavior behavior)
+        {
+            if (behavior == PointerBehavior.Default)
+            {
+                return;
+            }
+
+            bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
+            pointer.IsActive = isPointerOn;
+            if (pointer is GenericPointer genericPtr)
+            {
+                genericPtr.IsInteractionEnabled = isPointerOn;
+            }
+
+            unassignedPointers.Remove(pointer);
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -16,8 +16,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Vector3 screenDelta = Vector3.zero;
         public Vector3 viewportDelta = Vector3.zero;
         public Vector3 worldDelta = Vector3.zero;
+
+        public void Reset()
+        {
+            screenDelta = Vector3.zero;
+            viewportDelta = Vector3.zero;
+            worldDelta = Vector3.zero;
+        }
     }
 
+    /// <summary>
+    /// Service that provides simulated mixed reality input information based on mouse and keyboard input in editor
+    /// </summary>
     [MixedRealityDataProvider(
         typeof(IMixedRealityInputSystem),
         SupportedPlatforms.WindowsEditor | SupportedPlatforms.MacEditor | SupportedPlatforms.LinuxEditor,
@@ -61,6 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return handDataProvider != null ? handDataProvider.IsAlwaysVisibleLeft : false; }
             set { if (handDataProvider != null) { handDataProvider.IsAlwaysVisibleLeft = value; } }
         }
+
         /// <inheritdoc />
         public bool IsAlwaysVisibleHandRight
         {
@@ -104,6 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 handDataProvider.ResetHand(Handedness.Left);
             }
         }
+
         /// <inheritdoc />
         public void ResetHandRight()
         {
@@ -127,6 +139,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Indicators to show input simulation state in the viewport.
         /// </summary>
         private GameObject indicators;
+
+        /// <summary>
+        /// Tracks mouse movement delta information in different coordinate system spaces between updates
+        /// </summary>
+        private MouseDelta mouseDelta = new MouseDelta();
+
+        private Vector3 lastMousePosition;
+        private bool wasFocused;
+        private bool wasCursorLocked;
 
         #region BaseInputDeviceManager Implementation
 
@@ -252,7 +273,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 DisableCameraControl();
             }
 
-            MouseDelta mouseDelta = UpdateMouseDelta();
+            UpdateMouseDelta();
+
             if (UserInputEnabled)
             {
                 if (handDataProvider != null)
@@ -363,32 +385,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private Vector3 lastMousePosition;
-        private bool wasFocused;
-        private bool wasCursorLocked;
-
         private void ResetMouseDelta()
         {
             lastMousePosition = UnityEngine.Input.mousePosition;
+
+            mouseDelta.Reset();
         }
 
-        private MouseDelta UpdateMouseDelta()
+        private void UpdateMouseDelta()
         {
             var profile = InputSimulationProfile;
 
             bool isFocused = Application.isFocused;
-            bool gainedFocus = (!wasFocused && isFocused);
+            bool gainedFocus = !wasFocused && isFocused;
             wasFocused = isFocused;
 
             bool isCursorLocked = UnityEngine.Cursor.lockState != CursorLockMode.None;
-            bool cursorLockChanged = (wasCursorLocked != isCursorLocked);
+            bool cursorLockChanged = wasCursorLocked != isCursorLocked;
             wasCursorLocked = isCursorLocked;
 
             // Reset in cases where mouse position is jumping
             if (gainedFocus || cursorLockChanged)
             {
                 ResetMouseDelta();
-                return new MouseDelta();
             }
             else
             {
@@ -414,53 +433,56 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // Interpret scroll values as world space delta
                 worldDelta.z *= profile.HandDepthMultiplier;
 
+                Vector2 worldDepthDelta = new Vector2(worldDelta.z, 0);
+
                 // Convert world space scroll delta into screen space pixels
-                screenDelta.z = WorldToScreen(new Vector2(worldDelta.z, 0)).x;
+                screenDelta.z = WorldToScreen(worldDepthDelta).x;
 
                 // Convert screen space x/y delta into world space
-                Vector2 worldDelta2D = ScreenToWorld(new Vector2(screenDelta.x, screenDelta.y));
+                Vector2 worldDelta2D = ScreenToWorld(screenDelta);
                 worldDelta.x = worldDelta2D.x;
                 worldDelta.y = worldDelta2D.y;
 
                 // Viewport delta x and y can be computed from screen x/y.
                 // Note that the conversion functions do not change Z, it is expected to always be in world space units.
                 Vector3 viewportDelta = CameraCache.Main.ScreenToViewportPoint(screenDelta);
+                
                 // Compute viewport-scale z delta
-                viewportDelta.z = WorldToViewport(new Vector2(worldDelta.z, 0)).x;
+                viewportDelta.z = WorldToViewport(worldDepthDelta).x;
 
                 lastMousePosition = UnityEngine.Input.mousePosition;
 
-                return new MouseDelta()
-                {
-                    screenDelta = screenDelta,
-                    worldDelta = worldDelta,
-                    viewportDelta = viewportDelta,
-                };
+                mouseDelta.screenDelta = screenDelta;
+                mouseDelta.worldDelta = worldDelta;
+                mouseDelta.viewportDelta = viewportDelta;
             }
         }
 
         // Default world-space distance for converting screen/viewport scroll offsets into world space depth offset.
         // The pixel-to-world-unit ratio changes with depth, so have to chose a fixed distance for conversion.
-        private const float mouseWorldDepth = 0.5f;
         // Center of the viewport is at (0.5, 0.5)
+        private const float mouseWorldDepth = 0.5f;
 
-        private Vector2 ScreenToWorld(Vector2 screenDelta)
+        private Vector2 ScreenToWorld(Vector3 screenDelta)
         {
             Vector3 deltaViewport3D = new Vector3(
                 screenDelta.x / (0.5f * CameraCache.Main.pixelWidth),
                 screenDelta.y / (0.5f * CameraCache.Main.pixelHeight),
                 1) * mouseWorldDepth;
+
             var invProjMat = Matrix4x4.Inverse(CameraCache.Main.projectionMatrix);
             Vector3 deltaWorld3D = invProjMat * deltaViewport3D;
+
             return new Vector2(deltaWorld3D.x, deltaWorld3D.y);
         }
 
         private Vector2 WorldToScreen(Vector2 deltaWorld)
         {
             Vector3 deltaWorld3D = new Vector3(deltaWorld.x, deltaWorld.y, mouseWorldDepth);
-            var projMat = CameraCache.Main.projectionMatrix;
-            Vector4 proj = projMat * deltaWorld3D;
+
+            Vector4 proj = CameraCache.Main.projectionMatrix * deltaWorld3D;
             Vector3 deltaViewport3D = -proj / proj.w;
+
             return new Vector2(
                 deltaViewport3D.x * CameraCache.Main.pixelWidth,
                 deltaViewport3D.y * CameraCache.Main.pixelHeight);
@@ -469,9 +491,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Vector2 WorldToViewport(Vector2 deltaWorld)
         {
             Vector3 deltaWorld3D = new Vector3(deltaWorld.x, deltaWorld.y, mouseWorldDepth);
-            var projMat = CameraCache.Main.projectionMatrix;
-            Vector4 proj = projMat * deltaWorld3D;
+
+            Vector4 proj = CameraCache.Main.projectionMatrix * deltaWorld3D;
             Vector3 deltaViewport3D = -proj / proj.w;
+
             return new Vector2(deltaViewport3D.x, deltaViewport3D.y);
         }
     }

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/InputSimulationService.cs
@@ -17,6 +17,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Vector3 viewportDelta = Vector3.zero;
         public Vector3 worldDelta = Vector3.zero;
 
+        /// <summary>
+        /// Resets all vector contents to zero vector values
+        /// </summary>
         public void Reset()
         {
             screenDelta = Vector3.zero;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -723,7 +723,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private void RegisterPointers(IMixedRealityInputSource inputSource)
         {
             // If our input source does not have any pointers, then skip.
-            if (inputSource.Pointers == null) { return; }
+            if (inputSource.Pointers == null)
+            {
+                return;
+            }
 
             IMixedRealityPointerMediator mediator = null;
 
@@ -733,15 +736,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 try
                 {
                     // First, try to use constructor used by DefaultPointerMediator (it takes a IPointePreferences)
-                    mediator = Activator.CreateInstance(
-                    CoreServices.InputSystem.InputSystemProfile.PointerProfile.PointerMediator.Type,
-                    this) as IMixedRealityPointerMediator;
+                    mediator = Activator.CreateInstance(mediatorType, this) as IMixedRealityPointerMediator;
                 }
                 catch (MissingMethodException)
                 {
                     // We are using custom mediator not provided by MRTK, instantiate with empty constructor
-                    mediator = Activator.CreateInstance(
-                        CoreServices.InputSystem.InputSystemProfile.PointerProfile.PointerMediator.Type) as IMixedRealityPointerMediator;
+                    mediator = Activator.CreateInstance(mediatorType) as IMixedRealityPointerMediator;
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -954,12 +954,11 @@ namespace Microsoft.MixedReality.Toolkit
             // Unregister core services (active systems)
             // We need to destroy services in backwards order as those which are initialized 
             // later may rely on those which are initialized first.
-            var orderedActiveSystems = activeSystems.OrderByDescending(m => m.Value.Priority).ToArray();
+            var orderedActiveSystems = activeSystems.OrderByDescending(m => m.Value.Priority);
 
-            int length = activeSystems.Count;
-            for (int i = 0; i < length; i++)
+            foreach (var service in orderedActiveSystems)
             {
-                Type type = orderedActiveSystems[i].Key;
+                Type type = service.Key;
 
                 if (typeof(IMixedRealityBoundarySystem).IsAssignableFrom(type))
                 {

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -955,10 +955,11 @@ namespace Microsoft.MixedReality.Toolkit
             // We need to destroy services in backwards order as those which are initialized 
             // later may rely on those which are initialized first.
             var orderedActiveSystems = activeSystems.OrderByDescending(m => m.Value.Priority);
+            int length = activeSystems.Count;
 
-            foreach (var system in orderedActiveSystems)
+            for (int i = 0; i < length; i++)
             {
-                Type type = system.Key;
+                Type type = orderedActiveSystems.ElementAt(i).Key;
 
                 if (typeof(IMixedRealityBoundarySystem).IsAssignableFrom(type))
                 {
@@ -997,23 +998,36 @@ namespace Microsoft.MixedReality.Toolkit
 
         private bool ExecuteOnAllServicesInOrder(Action<IMixedRealityService> execute)
         {
-            var orderedSystems = MixedRealityServiceRegistry.GetAllServices();
-            return ExecuteOnAllServices(orderedSystems, execute);
+            if (!HasProfileAndIsInitialized)
+            {
+                return false;
+            }
+
+            var services = MixedRealityServiceRegistry.GetAllServices();
+            int length = services.Count;
+            for (int i = 0; i < length; i++)
+            {
+                execute(services[i]);
+            }
+
+            return true;
         }
 
         private bool ExecuteOnAllServicesReverseOrder(Action<IMixedRealityService> execute)
         {
-            var orderedSystems = MixedRealityServiceRegistry.GetAllServices().Reverse();
-            return ExecuteOnAllServices(orderedSystems, execute);
-        }
-
-        private bool ExecuteOnAllServices(IEnumerable<IMixedRealityService> services, Action<IMixedRealityService> execute)
-        {
-            if (!HasProfileAndIsInitialized) { return false; }
-            foreach (var system in services)
+            if (!HasProfileAndIsInitialized)
             {
-                execute(system);
+                return false;
             }
+
+            var services = MixedRealityServiceRegistry.GetAllServices();
+            int length = services.Count;
+
+            for (int i = length - 1; i >= 0; i--)
+            {
+                execute(services[i]);
+            }
+
             return true;
         }
 
@@ -1107,9 +1121,13 @@ namespace Microsoft.MixedReality.Toolkit
 
             if (!CanGetService(interfaceType)) { return new List<T>() as IReadOnlyList<T>; }
 
-            foreach (var service in MixedRealityServiceRegistry.GetAllServices())
+            bool isNullServiceName = string.IsNullOrEmpty(serviceName);
+            var systems = MixedRealityServiceRegistry.GetAllServices();
+            int length = systems.Count;
+            for (int i = 0; i < length; i++)
             {
-                if (service is T && (string.IsNullOrEmpty(serviceName) || service.Name == serviceName))
+                IMixedRealityService service = systems[i];
+                if (service is T && (isNullServiceName || service.Name == serviceName))
                 {
                     services.Add((T)service);
                 }

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -954,12 +954,12 @@ namespace Microsoft.MixedReality.Toolkit
             // Unregister core services (active systems)
             // We need to destroy services in backwards order as those which are initialized 
             // later may rely on those which are initialized first.
-            var orderedActiveSystems = activeSystems.OrderByDescending(m => m.Value.Priority);
-            int length = activeSystems.Count;
+            var orderedActiveSystems = activeSystems.OrderByDescending(m => m.Value.Priority).ToArray();
 
+            int length = activeSystems.Count;
             for (int i = 0; i < length; i++)
             {
-                Type type = orderedActiveSystems.ElementAt(i).Key;
+                Type type = orderedActiveSystems[i].Key;
 
                 if (typeof(IMixedRealityBoundarySystem).IsAssignableFrom(type))
                 {

--- a/Assets/MixedRealityToolkit/Utilities/MixedRealityServiceRegistry.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MixedRealityServiceRegistry.cs
@@ -390,7 +390,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <remarks>
         /// The list is sorted in ascending priority order.
         /// </remarks>
-        public static IReadOnlyCollection<IMixedRealityService> GetAllServices()
+        public static IReadOnlyList<IMixedRealityService> GetAllServices()
         {
             return allServices;
         }


### PR DESCRIPTION
## Overview
This change cleans up some of the unnecessary GC allocation every frame. Although these are minor in size, they do add up over time and more importantly can be easily avoided without changing functionality. 

MRTK.ExecuteOnAllServicesInOrder - 40B
Due to foreach loop on IEnumerable

DefaultPointerMediator.ApplyCustomPointerBehaviours - 366B
Due to action allocation that can be a standalone function

InputSimulationService.UpdateMouseDelta - 92B
Re-used MouseDelta class instead of allocating every update

## Changes
- Fixes: #6772 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
