### PR TITLE
Extension service wizard fixes

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -374,9 +374,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// Validate template assets
         /// </summary>
         /// <remarks>
-        /// Adds to items to errors log field if not valid
+        /// Adds items to errors log field if not valid
         /// </remarks>
-        /// <returns>true if errors encountered, false otherwise</returns>
+        /// <returns>true if no errors encountered, false otherwise</returns>
         public bool ValidateAssets(List<string> errors)
         {
             if (ServiceTemplate == null)
@@ -424,7 +424,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// Return true if configured Extension Service class name is valid. False otherwise
         /// </summary>
         /// <remarks>
-        /// Adds to items to errors log field if not valid
+        /// Adds items to errors log field if not valid
         /// </remarks>
         public bool ValidateName(List<string> errors)
         {
@@ -477,7 +477,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// Validate that SupportedPlatforms is not zero.
         /// </summary>
         /// <remarks>
-        /// Adds to items to errors log field if not valid
+        /// Adds items to errors log field if not valid
         /// </remarks>
         public bool ValidatePlatforms(List<string> errors)
         {
@@ -493,7 +493,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// Validate namespace property with each class/interface file to be created for new extension service
         /// </summary>
         /// <remarks>
-        /// Adds to items to errors log field if not valid
+        /// Adds items to errors log field if not valid
         /// </remarks>
         /// <returns>true if no errors, false otherwise</returns>
         public bool ValidateNamespace(List<string> errors)

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -268,8 +268,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public void ResetState()
         {
-            Debug.Log("Resetting state");
             SessionState.EraseString(PersistentStateKey);
+
+            CreateDefaultState();
+
+            StoreState();
         }
 
         public async void LoadStoredState()
@@ -489,7 +492,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             await Task.Delay(100);
             AssetDatabase.Refresh();
             AssetDatabase.SaveAssets();
-            await Task.Delay(100);
 
             // Subscribe to Unity's log output so we can detect compilation errors
             Application.logMessageReceived += LogMessageReceived;
@@ -504,6 +506,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             Application.logMessageReceived -= LogMessageReceived;
             // If we've gotten this far, it means that there was a compilation error
             // Otherwise this object would have been wiped from memory
+
+            Result = CreateResult.Error;
+            Stage = CreationStage.Finished;
         }
 
         public async Task ResumeAssetCreationProcessAfterReload()
@@ -681,11 +686,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 case LogType.Error:
                 case LogType.Exception:
-                    creationLog.Add("Encountered error while compiling");
+                    creationLog.Add("<color = red>Encountered error while compiling</color>");
                     creationLog.Add(condition);
                     Result = CreateResult.Error;
                     break;
-
                 default:
                     break;
             }

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -383,7 +383,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 if (!ReadTemplate(ServiceTemplatePath, ref ServiceTemplate))
                 {
-                    errors.Add("Script template not found in " + ServiceTemplatePath);
+                    errors.Add($"Script template not found in {ServiceTemplatePath}");
                 }
             }
 
@@ -391,7 +391,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 if (!ReadTemplate(InspectorTemplatePath, ref InspectorTemplate))
                 {
-                    errors.Add("Inspector template not found in " + InspectorTemplatePath);
+                    errors.Add($"Inspector template not found in {InspectorTemplatePath}");
                 }
             }
 
@@ -399,7 +399,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 if (!ReadTemplate(InterfaceTemplatePath, ref InterfaceTemplate))
                 {
-                    errors.Add("Interface template not found in " + InterfaceTemplatePath);
+                    errors.Add($"Interface template not found in {InterfaceTemplatePath}");
                 }
             }
 
@@ -407,7 +407,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 if (!ReadTemplate(ProfileTemplatePath, ref ProfileTemplate))
                 {
-                    errors.Add("Profile template not found in " + ProfileTemplatePath);
+                    errors.Add($"Profile template not found in {ProfileTemplatePath}");
                 }
             }
 

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -15,14 +15,14 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
     /// <summary>
-    /// Class used to generate service scripts and profile instances
+    /// Class used to generate service scripts and profile instances. Primarily designed for in-editor use
     /// </summary>
     public class ExtensionServiceCreator
     {
         #region enums and types
 
         /// <summary>
-        /// Result of create operation
+        /// Result of extension service file(s) create operation
         /// </summary>
         public enum CreateResult
         {
@@ -66,51 +66,93 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region public properties
 
+        /// <summary>
+        /// The name of the new extension service to build
+        /// </summary>
         public string ServiceName
         {
             get => state.ServiceName;
             set => state.ServiceName = value;
         }
 
+        /// <summary>
+        /// Should a ScriptableObject profile class be created for new extension service
+        /// </summary>
         public bool UsesProfile
         {
             get => state.UsesProfile;
             set => state.UsesProfile = value;
         }
 
+        /// <summary>
+        /// Should a custom editor inspector class be created for new extension service
+        /// </summary>
         public bool UsesInspector
         {
             get => state.UsesInspector;
             set => state.UsesInspector = value;
         }
 
+        /// <summary>
+        /// Supported platform flags for new extension service. Added to attribute on service class
+        /// </summary>
         public SupportedPlatforms Platforms
         {
             get => state.Platforms;
             set => state.Platforms = value;
         }
 
+        /// <summary>
+        /// Current stage in UI workflow for creation
+        /// </summary>
         public CreationStage Stage
         {
             get => state.Stage;
             set => state.Stage = value;
         }
 
+        /// <summary>
+        /// Namespace to utilize for all classes
+        /// </summary>
         public string Namespace
         {
             get => state.Namespace;
             set => state.Namespace = value;
         }
 
+        /// <summary>
+        /// Log of errors and updates thus far in the create operation of the new extension service classes
+        /// </summary>
         public string CreationLog { get => creationLog.ToString(); }
 
+        /// <summary>
+        /// Current result of extension service file(s) create operation
+        /// </summary>
         public CreateResult Result { get; private set; } = CreateResult.None;
 
+        /// <summary>
+        /// Name of interface to create for new extension service. Value is ServiceName with leading "I"
+        /// </summary>
         public string InterfaceName { get => "I" + ServiceName; }
+
+        /// <summary>
+        /// Name of ScriptableObject profile class to create. Value is ServiceName concatenated with "Profile"
+        /// </summary>
         public string ProfileName { get => ServiceName + "Profile"; }
+
+        /// <summary>
+        /// Name of Unity inspector class to create. Value is ServiceName concatenated with "Inspector"
+        /// </summary>
         public string InspectorName { get => ServiceName + "Inspector"; }
+
+        /// <summary>
+        /// Name of default ScriptableObject instance asset to create. Value is "Default" concatenated with ProfileName
+        /// </summary>
         public string ProfileAssetName { get => "Default" + ProfileName; }
 
+        /// <summary>
+        /// Unity object pointing to folder asset to place Service class file
+        /// </summary>
         public UnityEngine.Object ServiceFolderObject
         {
             get => state.ServiceFolder;
@@ -123,6 +165,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Unity object pointing to folder asset to place Inspector class file, if applicable
+        /// </summary>
         public UnityEngine.Object InspectorFolderObject
         {
             get => state.InspectorFolder;
@@ -135,6 +180,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Unity object pointing to folder asset to place interface file, if applicable
+        /// </summary>
         public UnityEngine.Object InterfaceFolderObject
         {
             get => state.InterfaceFolder;
@@ -147,6 +195,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Unity object pointing to folder asset to place ScriptableObject profile class file, if applicable
+        /// </summary>
         public UnityEngine.Object ProfileFolderObject
         {
             get => state.ProfileFolder;
@@ -159,6 +210,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Unity object pointing to folder asset to place ScriptableObject profile asset file, if applicable
+        /// </summary>
         public UnityEngine.Object ProfileAssetFolderObject
         {
             get => state.ProfileAssetFolder;
@@ -171,8 +225,29 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// System.Type of Extension Service created
+        /// </summary>
         public Type ServiceType { get; private set; }
+
+        /// <summary>
+        /// Object instance of ScriptableObject profile class for extension service created
+        /// </summary>
         public BaseMixedRealityProfile ProfileInstance { get; private set; }
+
+        /// <summary>
+        /// Sample code string demonstrating example usage for new Extension service created
+        /// </summary>
+        public string SampleCode
+        {
+            get
+            {
+                string sampleCode = SampleCodeTemplate;
+                sampleCode = sampleCode.Replace(InterfaceNameSearchString, InterfaceName);
+                sampleCode = sampleCode.Replace(ServiceNameSearchString, ServiceFieldName);
+                return sampleCode;
+            }
+        }
 
         #endregion
 
@@ -234,26 +309,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             get { return ProfileAssetFolderObject != null ? AssetDatabase.GetAssetPath(ProfileAssetFolderObject) : string.Empty; }
         }
 
-        public string SampleCode
-        {
-            get
-            {
-                string sampleCode = SampleCodeTemplate;
-                sampleCode = sampleCode.Replace(InterfaceNameSearchString, InterfaceName);
-                sampleCode = sampleCode.Replace(ServiceNameSearchString, ServiceFieldName);
-                return sampleCode;
-            }
-        }
-
         private string ServiceTemplate;
         private string InspectorTemplate;
         private string InterfaceTemplate;
         private string ProfileTemplate;
-
-        #endregion
-
-        #region private fields
-
         private StringBuilder creationLog = new StringBuilder();
         private PersistentState state;
 
@@ -261,12 +320,18 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region public methods
 
+        /// <summary>
+        /// Save current creator state to session registry in Unity
+        /// </summary>
         public void StoreState()
         {
             string stateString = JsonUtility.ToJson(state);
             SessionState.SetString(PersistentStateKey, stateString);
         }
 
+        /// <summary>
+        /// Reset current creator state to default and save
+        /// </summary>
         public void ResetState()
         {
             SessionState.EraseString(PersistentStateKey);
@@ -276,6 +341,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             StoreState();
         }
 
+        /// <summary>
+        /// Load creator state from unity SessionState
+        /// </summary>
         public async void LoadStoredState()
         {
             // (We can't call SessionState from inside a constructor)
@@ -302,10 +370,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
         }
 
+        /// <summary>
+        /// Validate template assets
+        /// </summary>
+        /// <remarks>
+        /// Adds to items to errors log field if not valid
+        /// </remarks>
+        /// <returns>true if errors encountered, false otherwise</returns>
         public bool ValidateAssets(List<string> errors)
         {
-            errors.Clear();
-
             if (ServiceTemplate == null)
             {
                 if (!ReadTemplate(ServiceTemplatePath, ref ServiceTemplate))
@@ -347,24 +420,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return errors.Count == 0;
         }
 
-        private bool ReadTemplate(string templatePath, ref string template)
-        {
-            string dataPath = Application.dataPath.Replace("/Assets", string.Empty);
-            string path = System.IO.Path.Combine(dataPath, templatePath);
-
-            try
-            {
-                template = System.IO.File.ReadAllText(path);
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning(e.ToString());
-                return false;
-            }
-
-            return !string.IsNullOrEmpty(template);
-        }
-
+        /// <summary>
+        /// Return true if configured Extension Service class name is valid. False otherwise
+        /// </summary>
+        /// <remarks>
+        /// Adds to items to errors log field if not valid
+        /// </remarks>
         public bool ValidateName(List<string> errors)
         {
             if (string.IsNullOrEmpty(ServiceName))
@@ -386,27 +447,40 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return errors.Count == 0;
         }
 
+        /// <summary>
+        /// Returns true if the asset supplied, via Folder object representing path and file name string (assumming .cs files only), does not exist. False otherwise
+        /// </summary>
         public bool CanBuildAsset(UnityEngine.Object folder, string fileName)
         {
             string folderPath = AssetDatabase.GetAssetPath(folder);
             return IsValidFolder(folderPath) && !AssetExists(folderPath, fileName, ScriptExtension);
         }
 
+        /// <summary>
+        /// Returns true if the folder path supplied by Folder object is a valid location in the Unity project, false otherwise
+        /// </summary>
         public bool IsValidFolder(UnityEngine.Object folder)
         {
             string folderPath = AssetDatabase.GetAssetPath(folder);
             return IsValidFolder(folderPath);
         }
 
+        /// <summary>
+        /// Returns true if the folder path string supplied is a valid location in the Unity project, false otherwise
+        /// </summary>
         public bool IsValidFolder(string folderPath)
         {
             return AssetDatabase.IsValidFolder(folderPath);
         }
 
+        /// <summary>
+        /// Validate that SupportedPlatforms is not zero.
+        /// </summary>
+        /// <remarks>
+        /// Adds to items to errors log field if not valid
+        /// </remarks>
         public bool ValidatePlatforms(List<string> errors)
         {
-            errors.Clear();
-
             if (Platforms == 0)
             {
                 errors.Add("Service must support at least one platform.");
@@ -415,6 +489,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return errors.Count == 0;
         }
 
+        /// <summary>
+        /// Validate namespace property with each class/interface file to be created for new extension service
+        /// </summary>
+        /// <remarks>
+        /// Adds to items to errors log field if not valid
+        /// </remarks>
+        /// <returns>true if no errors, false otherwise</returns>
         public bool ValidateNamespace(List<string> errors)
         {
             if (string.IsNullOrEmpty(Namespace))
@@ -422,34 +503,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 Namespace = DefaultExtensionNamespace;
             }
 
-            // Check if a class with this name already exists
-            Type serviceType = Type.GetType(Namespace + "." + ServiceName);
-            if (serviceType != null)
+            string[] assets = { ServiceName, InspectorName, InterfaceName, ProfileName };
+            for (int i = 0; i < assets.Length; i++)
             {
-                errors.Add("The type '" + ServiceName + "' already exists in this namespace.");
-            }
-
-            Type inspectorType = Type.GetType(Namespace + ".Editor." + InspectorName);
-            if (serviceType != null)
-            {
-                errors.Add("The type '" + InspectorName + "' already exists in this namespace.");
-            }
-
-            Type interfaceType = Type.GetType(Namespace + "." + InterfaceName);
-            if (interfaceType != null)
-            {
-                errors.Add("The type '" + InterfaceName + "' already exists in this namespace.");
-            }
-
-            Type profileType = Type.GetType(Namespace + "." + ProfileName);
-            if (profileType != null)
-            {
-                errors.Add("The type '" + ProfileName + "' already exists in this namespace.");
+                Type serviceType = Type.GetType($"{Namespace}.{assets[i]}");
+                if (serviceType != null)
+                {
+                    errors.Add($"The type '{assets[i]}' already exists in this namespace.");
+                }
             }
 
             return errors.Count == 0;
         }
 
+        /// <summary>
+        /// Start the creation process for all revelant extension service files based on current creator property settings
+        /// </summary>
         public async Task BeginAssetCreationProcess()
         {
             await Task.Yield();
@@ -514,7 +583,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             Stage = CreationStage.Finished;
         }
 
-        public async Task ResumeAssetCreationProcessAfterReload()
+        #endregion
+
+        #region private methods
+
+        private async Task ResumeAssetCreationProcessAfterReload()
         {
             await Task.Yield();
 
@@ -588,9 +661,23 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             Stage = CreationStage.Finished;
         }
 
-        #endregion
+        private bool ReadTemplate(string templatePath, ref string template)
+        {
+            string dataPath = Application.dataPath.Replace("/Assets", string.Empty);
+            string path = System.IO.Path.Combine(dataPath, templatePath);
 
-        #region private methods
+            try
+            {
+                template = System.IO.File.ReadAllText(path);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(e.ToString());
+                return false;
+            }
+
+            return !string.IsNullOrEmpty(template);
+        }
 
         private void CreateDefaultState()
         {

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -53,15 +53,129 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public bool UsesInspector;
             public SupportedPlatforms Platforms;
             public CreationStage Stage;
-            public string ServiceFolderPath;
-            public string InspectorFolderPath;
-            public string InterfaceFolderPath;
-            public string ProfileFolderPath;
-            public string ProfileAssetFolderPath;
+            public UnityEngine.Object ServiceFolder;
+            public UnityEngine.Object InspectorFolder;
+            public UnityEngine.Object InterfaceFolder;
+            public UnityEngine.Object ProfileFolder;
+            public UnityEngine.Object ProfileAssetFolder;
             public string Namespace;
         }
 
         #endregion
+
+        #region public properties
+
+        public string ServiceName
+        {
+            get => state.ServiceName;
+            set => state.ServiceName = value;
+        }
+
+        public bool UsesProfile
+        {
+            get => state.UsesProfile;
+            set => state.UsesProfile = value;
+        }
+
+        public bool UsesInspector
+        {
+            get => state.UsesInspector;
+            set => state.UsesInspector = value;
+        }
+
+        public SupportedPlatforms Platforms
+        {
+            get => state.Platforms;
+            set => state.Platforms = value;
+        }
+
+        public CreationStage Stage
+        {
+            get => state.Stage;
+            set => state.Stage = value;
+        }
+
+        public string Namespace
+        {
+            get => state.Namespace;
+            set => state.Namespace = value;
+        }
+
+        public IEnumerable<string> CreationLog { get => creationLog; }
+
+        public CreateResult Result { get; private set; } = CreateResult.None;
+
+        public string InterfaceName { get => "I" + ServiceName; }
+        public string ProfileName { get => ServiceName + "Profile"; }
+        public string InspectorName { get => ServiceName + "Inspector"; }
+        public string ProfileAssetName { get => "Default" + ProfileName; }
+
+        public UnityEngine.Object ServiceFolderObject
+        {
+            get => state.ServiceFolder;
+            set
+            {
+                if (IsValidFolder(value))
+                {
+                    state.ServiceFolder = value;
+                }
+            }
+        }
+
+        public UnityEngine.Object InspectorFolderObject
+        {
+            get => state.InspectorFolder;
+            set
+            {
+                if (IsValidFolder(value))
+                {
+                    state.InspectorFolder = value;
+                }
+            }
+        }
+
+        public UnityEngine.Object InterfaceFolderObject
+        {
+            get => state.InterfaceFolder;
+            set
+            {
+                if (IsValidFolder(value))
+                {
+                    state.InterfaceFolder = value;
+                }
+            }
+        }
+
+        public UnityEngine.Object ProfileFolderObject
+        {
+            get => state.ProfileFolder;
+            set
+            {
+                if (IsValidFolder(value))
+                {
+                    state.ProfileFolder = value;
+                }
+            }
+        }
+
+        public UnityEngine.Object ProfileAssetFolderObject
+        {
+            get => state.ProfileAssetFolder;
+            set
+            {
+                if (IsValidFolder(value))
+                {
+                    state.ProfileAssetFolder = value;
+                }
+            }
+        }
+
+        public Type ServiceType { get; private set; }
+        public BaseMixedRealityProfile ProfileInstance { get; private set; }
+
+        #endregion
+
+        #region private properties
 
         #region static
 
@@ -88,97 +202,35 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private string InspectorTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionInspectorTemplate.txt");
         private string InterfaceTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionInterfaceTemplate.txt");
         private string ProfileTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionProfileTemplate.txt");
-        
-        #endregion
-
-        #region public properties
-
-        public string ServiceName
-        {
-            get { return state.ServiceName; }
-            set { state.ServiceName = value; }
-        }
-
-        public bool UsesProfile
-        {
-            get { return state.UsesProfile; }
-            set { state.UsesProfile = value; }
-        }
-
-        public bool UsesInspector
-        {
-            get { return state.UsesInspector; }
-            set { state.UsesInspector = value; }
-        }
-
-        public SupportedPlatforms Platforms
-        {
-            get { return state.Platforms; }
-            set { state.Platforms = value; }
-        }
-
-        public CreationStage Stage
-        {
-            get { return state.Stage; }
-            set { state.Stage = value; }
-        }
-
-        public string Namespace
-        {
-            get { return state.Namespace; }
-            set { state.Namespace = value; }
-        }
-
-        public IEnumerable<string> CreationLog { get { return creationLog; } }
-        public CreateResult Result { get; private set; } = CreateResult.None;
-        public string InterfaceName { get { return "I" + ServiceName; } }
-        public string ProfileName { get { return ServiceName + "Profile"; } }
-        public string InspectorName { get { return ServiceName + "Inspector"; } }
-        public string ServiceFieldName { get { return Char.ToLowerInvariant(ServiceName[0]) + ServiceName.Substring(1); } }
-        public string ProfileFieldName { get { return Char.ToLowerInvariant(ProfileName[0]) + ProfileName.Substring(1); } }
-        public string ProfileAssetName { get { return "Default" + ProfileName; } }
-
-        public UnityEngine.Object ServiceFolderObject { get; set; }
-        public UnityEngine.Object InspectorFolderObject { get; set; }
-        public UnityEngine.Object InterfaceFolderObject { get; set; }
-        public UnityEngine.Object ProfileFolderObject { get; set; }
-        public UnityEngine.Object ProfileAssetFolderObject { get; set; }
-
-        public Type ServiceType { get; private set; }
-        public BaseMixedRealityProfile ProfileInstance { get; private set; }
 
         #endregion
 
-        #region private properties
+        private string ServiceFieldName { get { return Char.ToLowerInvariant(ServiceName[0]) + ServiceName.Substring(1); } }
+        private string ProfileFieldName { get { return Char.ToLowerInvariant(ProfileName[0]) + ProfileName.Substring(1); } }
 
         private string ServiceFolderPath
         {
-            get { return state.ServiceFolderPath; }
-            set { state.ServiceFolderPath = value; }
+            get { return ServiceFolderObject != null ? AssetDatabase.GetAssetPath(ServiceFolderObject) : string.Empty; }
         }
 
         private string InspectorFolderPath
         {
-            get { return state.InspectorFolderPath; }
-            set { state.InspectorFolderPath = value; }
+            get { return InspectorFolderObject != null ? AssetDatabase.GetAssetPath(InspectorFolderObject) : string.Empty; }
         }
 
         private string InterfaceFolderPath
         {
-            get { return state.InterfaceFolderPath; }
-            set { state.InterfaceFolderPath = value; }
+            get { return InterfaceFolderObject != null ? AssetDatabase.GetAssetPath(InterfaceFolderObject) : string.Empty; }
         }
 
         private string ProfileFolderPath
         {
-            get { return state.ProfileFolderPath; }
-            set { state.ProfileFolderPath = value; }
+            get { return ProfileFolderObject != null ? AssetDatabase.GetAssetPath(ProfileFolderObject) : string.Empty; }
         }
 
         private string ProfileAssetFolderPath
         {
-            get { return state.ProfileAssetFolderPath; }
-            set { state.ProfileAssetFolderPath = value; }
+            get { return ProfileAssetFolderObject != null ? AssetDatabase.GetAssetPath(ProfileAssetFolderObject) : string.Empty; }
         }
 
         public string SampleCode
@@ -311,8 +363,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public bool ValidateName(List<string> errors)
         {
-            errors.Clear();
-
             if (string.IsNullOrEmpty(ServiceName))
             {
                 errors.Add("Name cannot be empty.");
@@ -332,101 +382,28 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             return errors.Count == 0;
         }
 
-        public bool ValidateFolders(List<string> errors)
+        public bool CanBuildAsset(UnityEngine.Object folder, string fileName)
         {
-            errors.Clear();
+            string folderPath = AssetDatabase.GetAssetPath(folder);
+            return IsValidFolder(folderPath) && !AssetExists(folderPath, fileName, ScriptExtension);
+        }
 
-            if (ServiceFolderObject == null)
-            {
-                ServiceFolderObject = (UnityEngine.Object)AssetDatabase.LoadAssetAtPath(ExtensionsFolder, typeof(UnityEngine.Object));
-            }
+        public bool IsValidFolder(UnityEngine.Object folder)
+        {
+            string folderPath = AssetDatabase.GetAssetPath(folder);
+            return IsValidFolder(folderPath);
+        }
 
-            if (InspectorFolderObject == null && ServiceFolderObject != null)
-            {
-                InspectorFolderObject = ServiceFolderObject;
-            }
-
-            if (InterfaceFolderObject == null && ServiceFolderObject != null)
-            {
-                InterfaceFolderObject = ServiceFolderObject;
-            }
-
-            if (ProfileFolderObject == null && ServiceFolderObject != null)
-            {
-                ProfileFolderObject = ServiceFolderObject;
-            }
-
-            if (ProfileAssetFolderObject == null && ServiceFolderObject != null)
-            {
-                ProfileAssetFolderObject = ServiceFolderObject;
-            }
-
-            ServiceFolderPath = ServiceFolderObject != null ? AssetDatabase.GetAssetPath(ServiceFolderObject) : string.Empty;
-            InspectorFolderPath = InspectorFolderObject != null ? AssetDatabase.GetAssetPath(InspectorFolderObject) : string.Empty;
-            InterfaceFolderPath = InterfaceFolderObject != null ? AssetDatabase.GetAssetPath(InterfaceFolderObject) : string.Empty;
-            ProfileFolderPath = ProfileFolderObject != null ? AssetDatabase.GetAssetPath(ProfileFolderObject) : string.Empty;
-            ProfileAssetFolderPath = ProfileAssetFolderObject != null ? AssetDatabase.GetAssetPath(ProfileAssetFolderObject) : string.Empty;
-
-            // Make sure the folders exist and aren't other assets
-            if (!AssetDatabase.IsValidFolder(ServiceFolderPath))
-            {
-                errors.Add("Service folder is not valid.");
-            }
-
-            if (!AssetDatabase.IsValidFolder(InspectorFolderPath))
-            {
-                errors.Add("Inspector folder is not valid.");
-            }
-
-            if (!AssetDatabase.IsValidFolder(InterfaceFolderPath))
-            {
-                errors.Add("Interface folder is not valid.");
-            }
-
-            if (!AssetDatabase.IsValidFolder(ProfileFolderPath))
-            {
-                errors.Add("Profile folder is not valid.");
-            }
-
-            if (!AssetDatabase.IsValidFolder(ProfileAssetFolderPath))
-            {
-                errors.Add("Profile asset folder is not valid.");
-            }
-
-            // Make sure there aren't already assets with the same name
-            if (AssetExists(ServiceFolderPath, ServiceName, ScriptExtension))
-            {
-                errors.Add("Service script asset already exists. Delete it or choose a different service name to continue.");
-            }
-
-            if (AssetExists(InspectorFolderPath, InspectorName, ScriptExtension))
-            {
-                errors.Add("Inspector script asset already exists. Delete it or choose a different service name to continue.");
-            }
-
-            if (AssetExists(InterfaceFolderPath, InterfaceName, ScriptExtension))
-            {
-                errors.Add("Interface script asset already exists. Delete it or choose a different service name to continue.");
-            }
-
-            if (AssetExists(ProfileFolderPath, ProfileName, ScriptExtension))
-            {
-                errors.Add("Profile script asset already exists. Delete it or choose a different service name to continue.");
-            }
-
-            if (AssetExists(ProfileAssetFolderPath, ProfileAssetName, ProfileExtension))
-            {
-                errors.Add("Profile asset already exists. Delete it or choose a different service name to continue.");
-            }
-
-            return errors.Count == 0;
+        public bool IsValidFolder(string folderPath)
+        {
+            return AssetDatabase.IsValidFolder(folderPath);
         }
 
         public bool ValidatePlatforms(List<string> errors)
         {
             errors.Clear();
 
-            if ((int)Platforms == 0)
+            if (Platforms == 0)
             {
                 errors.Add("Service must support at least one platform.");
             }
@@ -436,8 +413,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public bool ValidateNamespace(List<string> errors)
         {
-            errors.Clear();
-
             if (string.IsNullOrEmpty(Namespace))
             {
                 Namespace = DefaultExtensionNamespace;
@@ -617,6 +592,26 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             state.UsesInspector = true;
             state.Stage = CreationStage.SelectNameAndPlatform;
             state.Platforms = SupportedPlatforms.LinuxStandalone | SupportedPlatforms.MacStandalone | SupportedPlatforms.WindowsStandalone | SupportedPlatforms.WindowsUniversal;
+
+            SetAllFolders(ExtensionsFolder);
+        }
+
+        public bool SetAllFolders(string path)
+        {
+            if (!AssetDatabase.IsValidFolder(path))
+            {
+                return false;
+            }
+
+            var newFolder = AssetDatabase.LoadAssetAtPath(path, typeof(UnityEngine.Object));
+
+            ServiceFolderObject = newFolder;
+            InterfaceFolderObject = newFolder;
+            InspectorFolderObject = newFolder;
+            ProfileFolderObject = newFolder;
+            ProfileAssetFolderObject = newFolder;
+
+            return true;
         }
 
         private bool AssetExists(string assetPath, string assetName, string extension)
@@ -636,15 +631,25 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             scriptContents = scriptContents.Replace(ProfileFieldNameSearchString, ProfileFieldName);
             scriptContents = scriptContents.Replace(ExtensionNamespaceSearchString, Namespace);
 
-            List<string> platformValues = new List<string>();
-            foreach (SupportedPlatforms platform in Enum.GetValues(typeof(SupportedPlatforms)))
+            const int SUPPORTED_PLATFORM_EVERYTHING = -1;
+            if ((int)Platforms == SUPPORTED_PLATFORM_EVERYTHING)
             {
-                if ((platform & Platforms) != 0)
-                {
-                    platformValues.Add("SupportedPlatforms." + platform.ToString());
-                }
+                scriptContents = scriptContents.Replace(SupportedPlatformsSearchString, "(SupportedPlatforms)(-1)");
             }
-            scriptContents = scriptContents.Replace(SupportedPlatformsSearchString, String.Join("|", platformValues.ToArray()));
+            else
+            {
+                List<string> platformValues = new List<string>();
+
+                foreach (SupportedPlatforms platform in Enum.GetValues(typeof(SupportedPlatforms)))
+                {
+                    if (Platforms.HasFlag(platform))
+                    {
+                        platformValues.Add("SupportedPlatforms." + platform.ToString());
+                    }
+                }
+
+                scriptContents = scriptContents.Replace(SupportedPlatformsSearchString, string.Join("|", platformValues.ToArray()));
+            }
 
             if (string.IsNullOrEmpty(scriptContents))
             {

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -686,7 +686,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 case LogType.Error:
                 case LogType.Exception:
-                    creationLog.Add("<color = red>Encountered error while compiling</color>");
+                    creationLog.Add("<color=red>Encountered error while compiling</color>");
                     creationLog.Add(condition);
                     Result = CreateResult.Error;
                     break;

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -15,9 +15,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     public class ExtensionServiceWizard : EditorWindow
     {
         private static ExtensionServiceWizard window;
-        private static readonly Color enabledColor = Color.white;
-        private static readonly Color disabledColor = Color.gray;
-        private static readonly Color readOnlyColor = Color.Lerp(enabledColor, Color.clear, 0.5f);
         private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Tools/ExtensionServiceCreationWizard.html";
         private static readonly Vector2 minWindowSize = new Vector2(500, 0);
         private const int docLinkWidth = 200;

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -2,12 +2,16 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Editor
 {
+    /// <summary>
+    /// Editor Window class that renders controls and logic for extension service creation walkthrough
+    /// </summary>
     public class ExtensionServiceWizard : EditorWindow
     {
         private static ExtensionServiceWizard window;
@@ -17,11 +21,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Tools/ExtensionServiceCreationWizard.html";
         private static readonly Vector2 minWindowSize = new Vector2(500, 0);
         private const int docLinkWidth = 200;
+        private const string TargetFolderLabel = "Target Folder";
 
         private ExtensionServiceCreator creator = new ExtensionServiceCreator();
         private List<string> errors = new List<string>();
         private bool registered = false;
-        private int numEllipses = 0;
+        private static float progrssBarTimer = 0.0f;
+
+        private Vector2 outputFoldersScrollPos;
+        private bool useUniversalFolder = true;
+        private UnityEngine.Object universalFolder;
 
         [MenuItem("Mixed Reality Toolkit/Utilities/Create Extension Service", false, 500)]
         private static void CreateExtensionServiceMenuItem()
@@ -29,15 +38,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (window != null)
             {
                 Debug.Log("Only one window allowed at a time");
-                // Only allow one window at a time
                 return;
             }
 
-            window = EditorWindow.CreateInstance<ExtensionServiceWizard>();
-            window.titleContent = new GUIContent("Create Extension Service");
+            // Dock it next to the Scene View.
+            window = GetWindow<ExtensionServiceWizard>(typeof(SceneView));
+            window.titleContent = new GUIContent("Extension Service Wizard", EditorGUIUtility.IconContent("d_DefaultSorting").image);
             window.minSize = minWindowSize;
             window.ResetCreator();
-            window.Show(true);
+            window.Show();
         }
 
         private void ResetCreator()
@@ -58,13 +67,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             creator.LoadStoredState();
+
         }
 
         private void OnGUI()
         {
+            MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
+
             if (!creator.ValidateAssets(errors))
             {
-                EditorGUILayout.LabelField("Validating assets...", EditorStyles.miniLabel);
+                EditorGUILayout.LabelField("Validating assets...");
                 foreach (string error in errors)
                 {
                     EditorGUILayout.HelpBox(error, MessageType.Error);
@@ -77,16 +89,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 case ExtensionServiceCreator.CreationStage.SelectNameAndPlatform:
                     DrawSelectNameAndPlatform();
                     break;
-
                 case ExtensionServiceCreator.CreationStage.ChooseOutputFolders:
                     DrawChooseOutputFolders();
                     break;
-
                 case ExtensionServiceCreator.CreationStage.CreatingExtensionService:
                 case ExtensionServiceCreator.CreationStage.CreatingProfileInstance:
                     DrawCreatingAssets();
                     break;
-
                 case ExtensionServiceCreator.CreationStage.Finished:
                     DrawFinished();
                     break;
@@ -98,164 +107,212 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.Space();
             EditorGUILayout.HelpBox("This wizard will help you set up and register a simple extension service. MRTK Services are similar to traditional MonoBehaviour singletons but with more robust access and lifecycle control. Scripts can access services through the MRTK's service provider interface. For more information about services, click the link below.", MessageType.Info);
 
-            GUIContent buttonContent = new GUIContent();
-            buttonContent.image = EditorGUIUtility.IconContent("_Help").image;
-            buttonContent.text = " Services Documentation";
-            buttonContent.tooltip = servicesDocumentationURL;
-
             using (new EditorGUILayout.HorizontalScope())
             {
                 GUILayout.FlexibleSpace();
-
-                if (GUILayout.Button(buttonContent, GUILayout.MaxWidth(docLinkWidth)))
-                {
-                    Application.OpenURL(servicesDocumentationURL);
-                }
-
+                InspectorUIUtility.RenderDocumentationButton(servicesDocumentationURL);
                 GUILayout.FlexibleSpace();
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.Space();
+
             EditorGUILayout.LabelField("Choose a name for your service.", EditorStyles.miniLabel);
-
             creator.ServiceName = EditorGUILayout.TextField("Service Name", creator.ServiceName);
-
-            bool readyToProgress = creator.ValidateName(errors);
-            foreach (string error in errors)
-            {
-                EditorGUILayout.HelpBox(error, MessageType.Error);
-            }
-
+            creator.ValidateName(errors);
             EditorGUILayout.Space();
+
             EditorGUILayout.LabelField("Choose which platforms your service will support.", EditorStyles.miniLabel);
-
             creator.Platforms = (SupportedPlatforms)EditorGUILayout.EnumFlagsField("Platforms", creator.Platforms);
-            readyToProgress &= creator.ValidatePlatforms(errors);
-            foreach (string error in errors)
-            {
-                EditorGUILayout.HelpBox(error, MessageType.Error);
-            }
-
+            creator.ValidatePlatforms(errors);
             EditorGUILayout.Space();
+
             EditorGUILayout.LabelField("Choose a namespace for your service.", EditorStyles.miniLabel);
-
             creator.Namespace = EditorGUILayout.TextField("Namespace", creator.Namespace);
-            readyToProgress &= creator.ValidateNamespace(errors);
-            foreach (string error in errors)
-            {
-                EditorGUILayout.HelpBox(error, MessageType.Error);
-            }
-
+            creator.ValidateNamespace(errors);
             EditorGUILayout.Space();
 
-            GUI.color = readyToProgress ? enabledColor : disabledColor;
-            if (GUILayout.Button("Next") && readyToProgress)
+            bool hasErrors = errors.Count > 0;
+            if (hasErrors)
             {
-                creator.Stage = ExtensionServiceCreator.CreationStage.ChooseOutputFolders;
-                creator.StoreState();
+                foreach (string error in errors)
+                {
+                    EditorGUILayout.HelpBox(error, MessageType.Error);
+                }
+            }
+
+            using (new EditorGUI.DisabledGroupScope(hasErrors))
+            {
+                if (GUILayout.Button("Next"))
+                {
+                    creator.Stage = ExtensionServiceCreator.CreationStage.ChooseOutputFolders;
+                    creator.StoreState();
+                }
             }
         }
 
         private void DrawChooseOutputFolders()
         {
-            GUI.color = enabledColor;
-
-            EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Below are the files you will be generating", EditorStyles.miniLabel);
-
-            EditorGUILayout.Space();
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-            EditorGUILayout.LabelField(creator.ServiceName + ".cs", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("This is the main script for your service. It functions similarly to a MonoBehaviour, with Enable, Disable and Update functions.", EditorStyles.wordWrappedMiniLabel);
-            creator.ServiceFolderObject = EditorGUILayout.ObjectField("Target Folder", creator.ServiceFolderObject, typeof(UnityEngine.Object), false);
-            EditorGUILayout.EndVertical();
-
-            EditorGUILayout.Space();
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-            EditorGUILayout.LabelField(creator.InterfaceName + ".cs", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("This is the interface that other scripts will use to interact with your service.", EditorStyles.wordWrappedMiniLabel);
-            creator.InterfaceFolderObject = EditorGUILayout.ObjectField("Target Folder", creator.InterfaceFolderObject, typeof(UnityEngine.Object), false);
-            EditorGUILayout.EndVertical();
-
-            EditorGUILayout.Space();
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-            EditorGUILayout.LabelField(creator.InspectorName + ".cs", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("An optional inspector for your service. This will be displayed in the editor when service inspectors are enabled.", EditorStyles.wordWrappedMiniLabel);
-            creator.UsesInspector = EditorGUILayout.Toggle("Generate Inspector", creator.UsesInspector);
-            if (creator.UsesInspector)
+            using (var scroll = new EditorGUILayout.ScrollViewScope(outputFoldersScrollPos))
             {
-                creator.InspectorFolderObject = EditorGUILayout.ObjectField("Target Folder", creator.InspectorFolderObject, typeof(UnityEngine.Object), false);
-            }
-            EditorGUILayout.EndVertical();
+                outputFoldersScrollPos = scroll.scrollPosition;
 
-            EditorGUILayout.Space();
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-            EditorGUILayout.LabelField(creator.ProfileName + ".cs", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("An optional profile script for your service. Profiles are scriptable objects that store permanent config data. If you're not sure whether your service will need a profile, it's best to create one. You can remove it later.", EditorStyles.wordWrappedMiniLabel);
-            creator.UsesProfile = EditorGUILayout.Toggle("Generate Profile", creator.UsesProfile);
-            if (creator.UsesProfile)
-            {
-                creator.ProfileFolderObject = EditorGUILayout.ObjectField("Target Folder", creator.ProfileFolderObject, typeof(UnityEngine.Object), false);
-            }
-            EditorGUILayout.EndVertical();
-
-            if (creator.UsesProfile)
-            {
-                EditorGUILayout.Space();
-                EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-                EditorGUILayout.LabelField(creator.ProfileAssetName + ".asset", EditorStyles.boldLabel);
-                EditorGUILayout.LabelField("A default instance of your profile.", EditorStyles.wordWrappedMiniLabel);
-                creator.ProfileAssetFolderObject = EditorGUILayout.ObjectField("Target Folder", creator.ProfileAssetFolderObject, typeof(UnityEngine.Object), false);
-                EditorGUILayout.EndVertical();
-            }
-
-            GUI.color = enabledColor;
-            EditorGUILayout.Space();
-
-            bool readyToProgress = creator.ValidateFolders(errors);
-            foreach (string error in errors)
-            {
-                EditorGUILayout.HelpBox(error, MessageType.Error);
-            }
-
-            EditorGUILayout.Space();
-
-            GUI.color = enabledColor;
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                if (GUILayout.Button("Back"))
+                useUniversalFolder = EditorGUILayout.ToggleLeft("Place all files in same folder", useUniversalFolder);
+                if (useUniversalFolder)
                 {
-                    creator.Stage = ExtensionServiceCreator.CreationStage.SelectNameAndPlatform;
-                    creator.StoreState();
+                    var newFolder = EditorGUILayout.ObjectField(TargetFolderLabel, creator.ServiceFolderObject, typeof(DefaultAsset), false);
+
+                    string path = AssetDatabase.GetAssetPath(newFolder);
+                    creator.SetAllFolders(path);
                 }
-                GUI.color = readyToProgress ? enabledColor : disabledColor;
-                if (GUILayout.Button("Next") && readyToProgress)
+
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Below are the files you will be generating", EditorStyles.miniLabel);
+
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
                 {
-                    // Start the async method that will wait for the service to be created
-                    CreateAssetsAsync();
+                    string svcFile = creator.ServiceName + ".cs";
+                    EditorGUILayout.LabelField(svcFile, EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField("This is the main script for your service. It functions similarly to a MonoBehaviour, with Enable, Disable and Update functions.", EditorStyles.wordWrappedMiniLabel);
+
+                    if (!useUniversalFolder)
+                    {
+                        creator.ServiceFolderObject = EditorGUILayout.ObjectField(TargetFolderLabel, creator.ServiceFolderObject, typeof(DefaultAsset), false);
+                    }
+
+                    if (!creator.CanBuildAsset(creator.ServiceFolderObject, creator.ServiceName))
+                    {
+                        errors.Add($"{svcFile} script cannot be created. Either invalid folder or asset already exists");
+                    }
+                }
+
+                EditorGUILayout.Space();
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                {
+                    string interfaceFile = creator.InterfaceName + ".cs";
+                    EditorGUILayout.LabelField(interfaceFile, EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField("This is the interface that other scripts will use to interact with your service.", EditorStyles.wordWrappedMiniLabel);
+
+                    if (!useUniversalFolder)
+                    {
+                        creator.InterfaceFolderObject = EditorGUILayout.ObjectField(TargetFolderLabel, creator.InterfaceFolderObject, typeof(DefaultAsset), false);
+                    }
+
+                    if (!creator.CanBuildAsset(creator.InterfaceFolderObject, creator.InterfaceName))
+                    {
+                        errors.Add($"{interfaceFile} script cannot be created. Either invalid folder or asset already exists");
+                    }
+                }
+
+                EditorGUILayout.Space();
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                {
+                    string inspectorFile = creator.InspectorName + ".cs";
+                    creator.UsesInspector = EditorGUILayout.ToggleLeft(inspectorFile + " (Optional)", creator.UsesInspector, EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField("An optional inspector for your service. This will be displayed in the editor when service inspectors are enabled.", EditorStyles.wordWrappedMiniLabel);
+
+                    if (creator.UsesInspector)
+                    {
+                        if (!useUniversalFolder)
+                        {
+                            creator.InspectorFolderObject = EditorGUILayout.ObjectField(TargetFolderLabel, creator.InspectorFolderObject, typeof(DefaultAsset), false);
+                        }
+
+                        if (!creator.CanBuildAsset(creator.InspectorFolderObject, creator.InspectorName))
+                        {
+                            errors.Add($"{inspectorFile} script cannot be created. Either invalid folder or asset already exists");
+                        }
+                    }
+                }
+
+                EditorGUILayout.Space();
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                {
+                    string profileFile = creator.ProfileName + ".cs";
+                    creator.UsesProfile = EditorGUILayout.ToggleLeft(profileFile + " (Optional)", creator.UsesProfile, EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField("An optional profile script for your service. Profiles are scriptable objects that store permanent config data. If you're not sure whether your service will need a profile, it's best to create one. You can remove it later.", EditorStyles.wordWrappedMiniLabel);
+
+                    if (creator.UsesProfile)
+                    {
+                        if (!useUniversalFolder)
+                        {
+                            creator.ProfileFolderObject = EditorGUILayout.ObjectField(TargetFolderLabel, creator.ProfileFolderObject, typeof(DefaultAsset), false);
+                        }
+
+                        if (!creator.CanBuildAsset(creator.ProfileFolderObject, creator.ProfileName))
+                        {
+                            errors.Add($"{profileFile} script cannot be created. Either invalid folder or asset already exists");
+                        }
+                    }
+                }
+
+                if (creator.UsesProfile)
+                {
+                    EditorGUILayout.Space();
+                    using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                    {
+                        string profileAssetFile = creator.ProfileAssetName + ".asset";
+                        EditorGUILayout.LabelField(profileAssetFile, EditorStyles.boldLabel);
+                        EditorGUILayout.LabelField("A default instance of your profile.", EditorStyles.wordWrappedMiniLabel);
+
+                        if (!useUniversalFolder)
+                        {
+                            creator.ProfileAssetFolderObject = EditorGUILayout.ObjectField(TargetFolderLabel, creator.ProfileAssetFolderObject, typeof(UnityEngine.Object), false);
+                        }
+
+                        if (!creator.CanBuildAsset(creator.ProfileAssetFolderObject, creator.ProfileAssetName))
+                        {
+                            errors.Add($"{profileAssetFile} script cannot be created. Either invalid folder or asset already exists");
+                        }
+                    }
+                }
+
+                EditorGUILayout.Space();
+
+                bool hasErrors = errors.Count > 0;
+                if (hasErrors)
+                {
+                    foreach (string error in errors)
+                    {
+                        EditorGUILayout.HelpBox(error, MessageType.Error);
+                    }
+                }
+
+                EditorGUILayout.Space();
+
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    if (GUILayout.Button("Back"))
+                    {
+                        creator.Stage = ExtensionServiceCreator.CreationStage.SelectNameAndPlatform;
+                        creator.StoreState();
+                    }
+
+                    using (new EditorGUI.DisabledGroupScope(hasErrors))
+                    {
+                        if (GUILayout.Button("Next"))
+                        {
+                            // Start the async method that will wait for the service to be created
+                            CreateAssetsAsync();
+                        }
+                    }
                 }
             }
         }
 
         private void DrawCreatingAssets()
         {
-            EditorGUILayout.LabelField("Creating assets...", EditorStyles.boldLabel);
+            //EditorGUILayout.LabelField("Creating assets...", EditorStyles.boldLabel);
 
-            // Draw crude working indicator so we know it hasn't frozen
-            numEllipses++;
-            if (numEllipses > 10)
+            using (var progressBarRect = new EditorGUILayout.VerticalScope())
             {
-                numEllipses = 0;
+                progrssBarTimer = Mathf.Clamp01(Time.realtimeSinceStartup % 1.0f);
+
+                EditorGUI.ProgressBar(progressBarRect.rect, progrssBarTimer, "Creating assets...");
+                GUILayout.Space(16);
             }
 
-            string workingIndicator = ".";
-            for (int i = 0; i < numEllipses; i++)
-            {
-                workingIndicator += ".";
-            }
-
-            EditorGUILayout.LabelField(workingIndicator, EditorStyles.boldLabel);
+            //EditorGUILayout.LabelField(workingIndicator, EditorStyles.boldLabel);
 
             switch (creator.Result)
             {
@@ -277,6 +334,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void DrawFinished()
         {
+            Debug.Log("FINISHED");
             EditorGUILayout.Space();
 
             switch (creator.Result)

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -71,13 +71,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
+            errors.Clear();
+
             if (!creator.ValidateAssets(errors))
             {
                 EditorGUILayout.LabelField("Validating assets...");
-                foreach (string error in errors)
-                {
-                    EditorGUILayout.HelpBox(error, MessageType.Error);
-                }
+                RenderErrorLog();
                 return;
             }
 
@@ -132,10 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             bool hasErrors = errors.Count > 0;
             if (hasErrors)
             {
-                foreach (string error in errors)
-                {
-                    EditorGUILayout.HelpBox(error, MessageType.Error);
-                }
+                RenderErrorLog();
             }
 
             using (new EditorGUI.DisabledGroupScope(hasErrors))
@@ -145,6 +141,14 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     creator.Stage = ExtensionServiceCreator.CreationStage.ChooseOutputFolders;
                     creator.StoreState();
                 }
+            }
+        }
+
+        private void RenderErrorLog()
+        {
+            for (int i = 0; i < errors.Count; i++)
+            {
+                EditorGUILayout.HelpBox(errors[i], MessageType.Error);
             }
         }
 
@@ -269,10 +273,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 bool hasErrors = errors.Count > 0;
                 if (hasErrors)
                 {
-                    foreach (string error in errors)
-                    {
-                        EditorGUILayout.HelpBox(error, MessageType.Error);
-                    }
+                    RenderErrorLog();
                 }
 
                 EditorGUILayout.Space();

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -395,12 +395,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void DrawCreationLog()
         {
-            foreach (string info in creator.CreationLog)
-            {
-                var style = new GUIStyle(EditorStyles.wordWrappedMiniLabel);
-                style.richText = true;
-                EditorGUILayout.LabelField(info, style);
-            }
+            var style = new GUIStyle(EditorStyles.wordWrappedMiniLabel);
+            style.richText = true;
+            EditorGUILayout.LabelField(creator.CreationLog, style);
         }
 
         private void RegisterServiceWithActiveMixedRealityProfile()

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// <summary>
     /// Editor Window class that renders controls and logic for extension service creation walkthrough
     /// </summary>
-    public class ExtensionServiceWizard : EditorWindow
+    internal class ExtensionServiceWizard : EditorWindow
     {
         private static ExtensionServiceWizard window;
         private static readonly string servicesDocumentationURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Tools/ExtensionServiceCreationWizard.html";

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -287,7 +287,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                     using (new EditorGUI.DisabledGroupScope(hasErrors))
                     {
-                        if (GUILayout.Button("Create files"))
+                        if (GUILayout.Button("Create Service"))
                         {
                             // Start the async method that will wait for the service to be created
                             CreateAssetsAsync();
@@ -395,7 +395,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void DrawCreationLog()
         {
-            var style = new GUIStyle(EditorStyles.wordWrappedMiniLabel);
+            var style = new GUIStyle(EditorStyles.wordWrappedLabel);
             style.richText = true;
             EditorGUILayout.LabelField(creator.CreationLog, style);
         }

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit;
 
@@ -9,7 +8,7 @@ namespace #NAMESPACE#
 	{
 		private #PROFILE_NAME# #PROFILE_FIELD_NAME#;
 
-		public #SERVICE_NAME#(IMixedRealityServiceRegistrar registrar,  string name,  uint priority,  BaseMixedRealityProfile profile) : base(registrar, name, priority, profile) 
+		public #SERVICE_NAME#(string name,  uint priority,  BaseMixedRealityProfile profile) : base(name, priority, profile) 
 		{
 			#PROFILE_FIELD_NAME# = (#PROFILE_NAME#)profile;
 		}


### PR DESCRIPTION
## Overview
This change cleans up the extension service wizard. In particular,

Allow one folder quick selection for all files to be created
Fix registrar constructor from obsolete to valid in template
Fix supported platforms to be -1 when everything
Added MRTK logo to window and tab icon
Added progress bar instead of ellipsis for async
General polish and code clean up (use scopes, better disables, rich text logging, use string building and string formatting instead of concatenation and more)

## Changes
- Fixes: #6776 , #6775 , #6774 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
