### PR TITLE
update DotNetWinRT min version

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -13,7 +13,7 @@
     <releaseNotes>$releaseNotes$</releaseNotes>
     <tags>Unity MixedReality</tags>
     <dependencies>
-      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1034" />
+      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1037" />
     </dependencies>
     <contentFiles>
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />


### PR DESCRIPTION
This change updates the nuspec file to specify an updated minimum version of the Microsoft.Windows.MixedReality.DotNetWinRT package.