### PR TITLE
Add [HideInInspector] to isCustomProfile

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/BaseMixedRealityProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BaseMixedRealityProfile.cs
@@ -8,6 +8,7 @@ namespace Microsoft.MixedReality.Toolkit
     public abstract class BaseMixedRealityProfile : ScriptableObject
     {
         [SerializeField]
+        [HideInInspector]
         private bool isCustomProfile = true;
 
         internal bool IsCustomProfile => isCustomProfile;


### PR DESCRIPTION
## Overview
Adds `[HideInInspector]` to BaseMixedRealityProfile, to clean up any profiles that inherit from this class but don't provide their own custom inspector.

## Changes
- Fixes:
![image](https://user-images.githubusercontent.com/3580640/70173234-4b6c3480-1687-11ea-8e99-1fd0dd876dab.png)
to this
![image](https://user-images.githubusercontent.com/3580640/70173244-4f985200-1687-11ea-82c2-9a2f0dffba89.png)