### PR TITLE
Fix FacadeHandler throwing exception

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             MixedRealityToolkit.Instance.ActiveProfile = null;
 
             // Tests
-            LogAssert.Expect(LogType.Error, "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit");
+            LogAssert.Expect(LogType.Warning, "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit");
             Assert.IsFalse(MixedRealityToolkit.Instance.HasActiveProfile);
             Assert.IsNull(MixedRealityToolkit.Instance.ActiveProfile);
         }

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -186,8 +186,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 
         private static void DestroyFacades()
         {
-            foreach (var facade in ServiceFacade.ActiveFacadeObjects)
+            for (int i = ServiceFacade.ActiveFacadeObjects.Count - 1; i >= 0; i--)
             {
+                var facade = ServiceFacade.ActiveFacadeObjects[i];
                 if (facade != null)
                 {
                     GameObjectExtensions.DestroyGameObject(facade.gameObject);

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit
         private static bool isInitializing = false;
         private static bool isApplicationQuitting = false;
         private static bool internalShutdown = false;
-
+        private const string NoMRTKProfileErrorMessage = "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
         #region Mixed Reality Toolkit Profile configuration
 
         /// <summary>
@@ -323,7 +323,11 @@ namespace Microsoft.MixedReality.Toolkit
             //If the Mixed Reality Toolkit is not configured, stop.
             if (ActiveProfile == null)
             {
-                Debug.LogError("No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit");
+                #if UNITY_EDITOR
+                    Debug.LogWarning(NoMRTKProfileErrorMessage);
+                #else
+                    Debug.LogError(NoMRTKProfileErrorMessage);
+                #endif
                 return;
             }
 
@@ -344,7 +348,7 @@ namespace Microsoft.MixedReality.Toolkit
             CoreServices.ResetCacheReferences();
             EnsureMixedRealityRequirements();
 
-            #region Services Registration
+#region Services Registration
 
             // If the Input system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.IsInputSystemEnabled)
@@ -452,7 +456,7 @@ namespace Microsoft.MixedReality.Toolkit
                 }
             }
 
-            #endregion Service Registration
+#endregion Service Registration
 
             InitializeAllServices();
 
@@ -513,7 +517,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-        #region MonoBehaviour Implementation
+#region MonoBehaviour Implementation
 
         private static MixedRealityToolkit activeInstance;
         private static bool newInstanceBeingInitialized = false;
@@ -640,9 +644,9 @@ namespace Microsoft.MixedReality.Toolkit
             UnregisterInstance(this);
         }
 
-        #endregion MonoBehaviour Implementation
+#endregion MonoBehaviour Implementation
 
-        #region Instance Registration
+#region Instance Registration
 
         private const string activeInstanceGameObjectName = "MixedRealityToolkit";
         private const string inactiveInstanceGameObjectName = "MixedRealityToolkit (Inactive)";
@@ -781,11 +785,11 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-        #endregion Instance Registration
+#endregion Instance Registration
 
-        #region Service Container Management
+#region Service Container Management
 
-        #region Registration
+#region Registration
         // NOTE: This method intentionally does not add to the registry. This is actually mostly a helper function for RegisterServiceInternal<T>.
         private bool RegisterServiceInternal(Type interfaceType, IMixedRealityService serviceInstance)
         {
@@ -844,9 +848,9 @@ namespace Microsoft.MixedReality.Toolkit
             return false;
         }
 
-        #endregion Registration
+#endregion Registration
 
-        #region Multiple Service Management
+#region Multiple Service Management
 
         /// <summary>
         /// Enable all services in the Mixed Reality Toolkit active service registry for a given type
@@ -1016,9 +1020,9 @@ namespace Microsoft.MixedReality.Toolkit
             return true;
         }
 
-        #endregion Multiple Service Management
+#endregion Multiple Service Management
 
-        #region Service Utilities
+#region Service Utilities
 
         /// <summary>
         /// Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core system.
@@ -1179,11 +1183,11 @@ namespace Microsoft.MixedReality.Toolkit
             return true;
         }
 
-        #endregion Service Utilities
+#endregion Service Utilities
 
-        #endregion Service Container Management
+#endregion Service Container Management
 
-        #region Core System Accessors
+#region Core System Accessors
 
         /// <summary>
         /// The current Input System registered with the Mixed Reality Toolkit.
@@ -1314,9 +1318,9 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-        #endregion Core System Accessors
+#endregion Core System Accessors
 
-        #region Application Event Listeners
+#region Application Event Listeners
         /// <summary>
         /// Registers once on startup and sets isApplicationQuitting to true when quit event is detected.
         /// </summary>
@@ -1429,6 +1433,6 @@ namespace Microsoft.MixedReality.Toolkit
         }
 #endif // UNITY_EDITOR
 
-        #endregion
+#endregion
     }
 }

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit
         private static bool internalShutdown = false;
         private const string NoMRTKProfileErrorMessage = "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
 
-#region Mixed Reality Toolkit Profile configuration
+        #region Mixed Reality Toolkit Profile configuration
 
         /// <summary>
         /// Checks if there is a valid instance of the MixedRealityToolkit, then checks if there is there a valid Active Profile.
@@ -124,9 +124,9 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#endregion Mixed Reality Toolkit Profile configuration
+        #endregion Mixed Reality Toolkit Profile configuration
 
-#region Mixed Reality runtime service registry
+        #region Mixed Reality runtime service registry
 
         private static readonly Dictionary<Type, IMixedRealityService> activeSystems = new Dictionary<Type, IMixedRealityService>();
 
@@ -147,9 +147,9 @@ namespace Microsoft.MixedReality.Toolkit
         [Obsolete("Use GetDataProvider<T> of MixedRealityService registering the desired IMixedRealityDataProvider")]
         public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices => new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices) as IReadOnlyList<Tuple<Type, IMixedRealityService>>;
 
-#endregion Mixed Reality runtime service registry
+        #endregion Mixed Reality runtime service registry
 
-#region IMixedRealityServiceRegistrar implementation
+        #region IMixedRealityServiceRegistrar implementation
 
         /// <inheritdoc />
         public bool RegisterService<T>(T serviceInstance) where T : IMixedRealityService
@@ -311,7 +311,7 @@ namespace Microsoft.MixedReality.Toolkit
             return GetAllServicesByNameInternal<T>(typeof(T), name);
         }
 
-#endregion IMixedRealityServiceRegistrar implementation
+        #endregion IMixedRealityServiceRegistrar implementation
 
         /// <summary>
         /// Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active services.
@@ -354,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit
             CoreServices.ResetCacheReferences();
             EnsureMixedRealityRequirements();
 
-#region Services Registration
+        #region Services Registration
 
             // If the Input system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.IsInputSystemEnabled)
@@ -462,7 +462,7 @@ namespace Microsoft.MixedReality.Toolkit
                 }
             }
 
-#endregion Service Registration
+        #endregion Service Registration
 
             InitializeAllServices();
 
@@ -523,7 +523,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#region MonoBehaviour Implementation
+        #region MonoBehaviour Implementation
 
         private static MixedRealityToolkit activeInstance;
         private static bool newInstanceBeingInitialized = false;
@@ -650,9 +650,9 @@ namespace Microsoft.MixedReality.Toolkit
             UnregisterInstance(this);
         }
 
-#endregion MonoBehaviour Implementation
+        #endregion MonoBehaviour Implementation
 
-#region Instance Registration
+        #region Instance Registration
 
         private const string activeInstanceGameObjectName = "MixedRealityToolkit";
         private const string inactiveInstanceGameObjectName = "MixedRealityToolkit (Inactive)";
@@ -791,11 +791,11 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#endregion Instance Registration
+        #endregion Instance Registration
 
-#region Service Container Management
+        #region Service Container Management
 
-#region Registration
+        #region Registration
         // NOTE: This method intentionally does not add to the registry. This is actually mostly a helper function for RegisterServiceInternal<T>.
         private bool RegisterServiceInternal(Type interfaceType, IMixedRealityService serviceInstance)
         {
@@ -854,9 +854,9 @@ namespace Microsoft.MixedReality.Toolkit
             return false;
         }
 
-#endregion Registration
+        #endregion Registration
 
-#region Multiple Service Management
+        #region Multiple Service Management
 
         /// <summary>
         /// Enable all services in the Mixed Reality Toolkit active service registry for a given type
@@ -1026,9 +1026,9 @@ namespace Microsoft.MixedReality.Toolkit
             return true;
         }
 
-#endregion Multiple Service Management
+        #endregion Multiple Service Management
 
-#region Service Utilities
+        #region Service Utilities
 
         /// <summary>
         /// Generic function used to interrogate the Mixed Reality Toolkit active system registry for the existence of a core system.
@@ -1189,11 +1189,11 @@ namespace Microsoft.MixedReality.Toolkit
             return true;
         }
 
-#endregion Service Utilities
+        #endregion Service Utilities
 
-#endregion Service Container Management
+        #endregion Service Container Management
 
-#region Core System Accessors
+        #region Core System Accessors
 
         /// <summary>
         /// The current Input System registered with the Mixed Reality Toolkit.
@@ -1324,9 +1324,9 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-#endregion Core System Accessors
+        #endregion Core System Accessors
 
-#region Application Event Listeners
+        #region Application Event Listeners
         /// <summary>
         /// Registers once on startup and sets isApplicationQuitting to true when quit event is detected.
         /// </summary>
@@ -1439,6 +1439,6 @@ namespace Microsoft.MixedReality.Toolkit
         }
 #endif // UNITY_EDITOR
 
-#endregion
+        #endregion
     }
 }

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -35,7 +35,8 @@ namespace Microsoft.MixedReality.Toolkit
         private static bool isApplicationQuitting = false;
         private static bool internalShutdown = false;
         private const string NoMRTKProfileErrorMessage = "No Mixed Reality Configuration Profile found, cannot initialize the Mixed Reality Toolkit";
-        #region Mixed Reality Toolkit Profile configuration
+
+#region Mixed Reality Toolkit Profile configuration
 
         /// <summary>
         /// Checks if there is a valid instance of the MixedRealityToolkit, then checks if there is there a valid Active Profile.
@@ -123,9 +124,9 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-        #endregion Mixed Reality Toolkit Profile configuration
+#endregion Mixed Reality Toolkit Profile configuration
 
-        #region Mixed Reality runtime service registry
+#region Mixed Reality runtime service registry
 
         private static readonly Dictionary<Type, IMixedRealityService> activeSystems = new Dictionary<Type, IMixedRealityService>();
 
@@ -146,9 +147,9 @@ namespace Microsoft.MixedReality.Toolkit
         [Obsolete("Use GetDataProvider<T> of MixedRealityService registering the desired IMixedRealityDataProvider")]
         public IReadOnlyList<Tuple<Type, IMixedRealityService>> RegisteredMixedRealityServices => new List<Tuple<Type, IMixedRealityService>>(registeredMixedRealityServices) as IReadOnlyList<Tuple<Type, IMixedRealityService>>;
 
-        #endregion Mixed Reality runtime service registry
+#endregion Mixed Reality runtime service registry
 
-        #region IMixedRealityServiceRegistrar implementation
+#region IMixedRealityServiceRegistrar implementation
 
         /// <inheritdoc />
         public bool RegisterService<T>(T serviceInstance) where T : IMixedRealityService
@@ -310,7 +311,7 @@ namespace Microsoft.MixedReality.Toolkit
             return GetAllServicesByNameInternal<T>(typeof(T), name);
         }
 
-        #endregion IMixedRealityServiceRegistrar implementation
+#endregion IMixedRealityServiceRegistrar implementation
 
         /// <summary>
         /// Once all services are registered and properties updated, the Mixed Reality Toolkit will initialize all active services.
@@ -323,11 +324,16 @@ namespace Microsoft.MixedReality.Toolkit
             //If the Mixed Reality Toolkit is not configured, stop.
             if (ActiveProfile == null)
             {
-                #if UNITY_EDITOR
+                if (!Application.isPlaying)
+                {
+                    // Log as warning if in edit mode. Likely user is making changes etc.
                     Debug.LogWarning(NoMRTKProfileErrorMessage);
-                #else
+                }
+                else
+                {
                     Debug.LogError(NoMRTKProfileErrorMessage);
-                #endif
+                }
+
                 return;
             }
 

--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -354,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit
             CoreServices.ResetCacheReferences();
             EnsureMixedRealityRequirements();
 
-        #region Services Registration
+            #region Services Registration
 
             // If the Input system has been selected for initialization in the Active profile, enable it in the project
             if (ActiveProfile.IsInputSystemEnabled)
@@ -462,7 +462,7 @@ namespace Microsoft.MixedReality.Toolkit
                 }
             }
 
-        #endregion Service Registration
+            #endregion Service Registration
 
             InitializeAllServices();
 


### PR DESCRIPTION
## Overview

Minor fix for Facade handler and MRTK initialize.

- Facade Handler was destroying objects as it enumerated through the list but destruction cause an invalid enumerator. Change uses for loop instead of foreach and deletes in reverse

- When there is no active profile, MRTK initializes and logs error. In Unity Editor, it is more appropriate as a warning while it will be an error on device/runtime. This is because MRTK runs in edit mode.

![profile-error](https://user-images.githubusercontent.com/25975362/70178623-9a779100-16aa-11ea-8912-5a18434a59a7.gif)

## Changes
- Fixes: #6794 6794

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch

