### PR TITLE
Update version 2.2 -> 2.3 in mrtk_dev

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scripts/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scripts/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scripts/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scripts/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Extensions")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Extensions")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Extensions")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.SDK/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit SDK")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit SDK")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit SDK")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/CameraSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/TeleportSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/TeleportSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Staging/UnityAR/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Staging/UnityAR/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Staging/Version.txt
+++ b/Assets/MixedRealityToolkit.Staging/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.2.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Tests/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tests/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tests")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tools/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tools")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tools")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tools/RuntimeTools/Tools/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/RuntimeTools/Tools/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tools")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Async/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Async/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/AssemblyInfo.cs
@@ -4,8 +4,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]


### PR DESCRIPTION
## Overview
A new version.txt and all the new AssemblyInfo.cs files were added in the stabilization branch, which is currently targeting the 2.2 release. mrtk_development has moved on to 2.3, so these files need to be updated.

Related: https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6518