### PR TITLE
Execute borderlight width calculation only on scale changes

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/MaintainBorderLightWidth.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MaintainBorderLightWidth.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     {
         private Renderer targetRenderer = null;
         private MaterialPropertyBlock properties = null;
-        private int borderWidthID = 0;
+        private static int borderWidthID = Shader.PropertyToID("_BorderWidth");
         private float initialBorderWidth = 1.0f;
         private Vector3 initialScale = Vector3.one;
         private Vector3 prevScale;
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             // Cache the initial border width state.
             targetRenderer = GetComponent<Renderer>();
             properties = new MaterialPropertyBlock();
-            borderWidthID = Shader.PropertyToID("_BorderWidth");
+
             initialBorderWidth = targetRenderer.sharedMaterial.GetFloat(borderWidthID);
             initialScale = transform.lossyScale;
             prevScale = initialScale;

--- a/Assets/MixedRealityToolkit/Utilities/MaintainBorderLightWidth.cs
+++ b/Assets/MixedRealityToolkit/Utilities/MaintainBorderLightWidth.cs
@@ -19,6 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private int borderWidthID = 0;
         private float initialBorderWidth = 1.0f;
         private Vector3 initialScale = Vector3.one;
+        private Vector3 prevScale;
 
         private void Start()
         {
@@ -28,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             borderWidthID = Shader.PropertyToID("_BorderWidth");
             initialBorderWidth = targetRenderer.sharedMaterial.GetFloat(borderWidthID);
             initialScale = transform.lossyScale;
+            prevScale = initialScale;
 
             for (int i = 0; i < 3; ++i)
             {
@@ -40,8 +42,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private void LateUpdate()
         {
-            if (targetRenderer != null)
+            if (targetRenderer != null && prevScale != transform.lossyScale)
             {
+                prevScale = transform.lossyScale;
+
                 // Find the axis with the smallest scale.
                 var minAxis = 0;
                 var minScale = float.MaxValue;


### PR DESCRIPTION
## Overview
MaintainBorderLightWidth.cs component scales the correct border light width value based on scale changes of the gameobject at runtime. Originally though, this calculation would be performed every lateupdate(). Although not incredibly noteworthy and expensive, this component is on ever button which in for example the HandInteractionExampleScene adds up. 

This change caches the previous lossyscale value for the GameObject and only performs the border width light update if the GameObject's scale has changed. 

Furthermore, the shader property id has been switched to static since it'll be a constant value for every component. 

## Changes
- Fixes: # .

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
