### PR TITLE
Change default GridObjectCollection layout order to "RowThenColumn" to avoid asset upgrade when new assets created

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private LayoutOrder layout = LayoutOrder.RowThenColumn;
 
         /// <summary>
-        /// Whether to sort objects by row first or by column first
+        /// Specify direction in which children are laid out.
         /// </summary>
         public LayoutOrder Layout
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -41,9 +41,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { orientType = value; }
         }
 
-        [Tooltip("Whether to sort objects by row first or by column first")]
+        [Tooltip("Specify direction in which children are laid out.")]
         [SerializeField]
-        private LayoutOrder layout = LayoutOrder.ColumnThenRow;
+        private LayoutOrder layout = LayoutOrder.RowThenColumn;
 
         /// <summary>
         /// Whether to sort objects by row first or by column first
@@ -470,7 +470,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 string friendlyName = GetUserFriendlyName();
 
-                Debug.Log($"Upgrade GridObjectCollection on {friendlyName} from version 0 to version 1 for MRTK 2.2 release. Please save scene / prefab.");
                 // Migrate from version 0 to version 1
                 UpgradeAssetToVersion1();
                 assetVersion = 1;
@@ -490,7 +489,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 Layout = LayoutOrder.RowThenColumn;
                 var friendlyName = GetUserFriendlyName();
-                Debug.Log($"Changing LayoutOrder for {friendlyName} from ColumnThenRow to RowThenColumn. See https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6773#issuecomment-561918891 for details.");
+                Debug.Log($"[MRTK 2.2 asset upgrade] Changing LayoutOrder for {friendlyName} from ColumnThenRow to RowThenColumn. See https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6773#issuecomment-561918891 for details.");
             }
         }
 


### PR DESCRIPTION
Fixes #6814 by ensuring that newly created assets do not have ColumnThenRow layout, which is what triggers the asset upgrade in (asset version must be 0 and layout must be ColumnThenRow).

Additional changes:
- Update tooltip and logging

The bug is caused because newly created assets will have asset version 0, and also assets that actually are old and need to be upgraded will have asset version 0. This problem would happen in all cases when we are adding asset versions to assets that already exist.  It would be great to find another way to solve this problem, but for now this approach fixes #6814 and will prevent log messages from showing up whenever a grid object collection gets added in MRTK 2.2. See keveleigh's comments in #6814 for some more details. Until we find a better solution

## Verification
Created new assets and verified that error message did not get printed.
