### PR TITLE
Update version of MSBuild for Unity

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private static string[] MSBuildRegistryScopes = new string[] { "com.microsoft" };
 
         private static string MSBuildPackageName = "com.microsoft.msbuildforunity";
-        private static string MSBuildPackageVersion = "0.8.2";
+        private static string MSBuildPackageVersion = "0.8.3";
 
         /// <summary>
         /// Ensures the required settings exist in the package manager to allow for


### PR DESCRIPTION
MSBuild for Unity is taking some changes that address issues discovered while using it with MRTK. This PR increases the version number that will be written to the manifest.

Please note this should NOT be merged until the new MSBuild update has been published.