### PR TITLE
Added setting of default configuration profile in case there's none set for adding the mrtk gameobject to the scene

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -87,7 +87,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 MixedRealityToolkit.SetActiveInstance(newInstance);
                 Selection.activeObject = newInstance;
 
-                if (configProfile != null)
+                if (configProfile == null)
+                {
+                    // if we don't have a profile set we get the default profile
+                    newInstance.ActiveProfile = GetDefaultConfigProfile();
+                }
+                else
                 {
                     newInstance.ActiveProfile = configProfile;
                 }

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -97,17 +97,8 @@ To create a **HoloLens application**, switch to Universal Windows Platform:
 
 ![Configure to scene](../Documentation/Images/MRTK_ConfigureScene.png)
 
-4. In the Inspector, you will see a prompt like this:
-
-![MRTK Configure Dialog](../Documentation/Images/MRTK_NoProfileMessage.png)
-
-Click "OK".
-
-5. Select "DefaultMixedRealityToolkitConfigurationProfile" from the list.
-
-![MRTK Select Configure Dialog](../Documentation/Images/MRTK_SelectConfigurationProfile.png)
-
-For more information on profiles, please see the [profiles](Profiles/Profiles.md) article.
+The inspector will now show the currently active MRTK configuration profile and the profile selection dropdown, where the default profile is already preselected. 
+Profiles configure the behavior of MRTK core components and are described in more detail in the [profiles](Profiles/Profiles.md) article.
 
 > [!NOTE] 
 > If you are getting started on the HoloLens or HoloLens 2, you should choose the "DefaultHoloLens1ConfigurationProfile" or DefaultHoloLens2ConfigurationProfile" instead.


### PR DESCRIPTION
## Overview
the default profile is now automatically set in the mrtk gameobject on configuring the scene.
the documentation reflects the new change

## Changes
- default profile is selected in case there's nothing selected when adding the mrtk gameobject to the scene
documentation explains to the user that they can chance the profile but we preselect the default profile for them
didn't add any pictures/screenshots on purpose as the text description should be enough and we shouldn't screenshot inspector properties 

## Verification
tested adding the MRTK gameobject to a new scene and checked if default config profile is set
