### PR TITLE
Fix building NuGet locally and add support for DotNetWinRT in NuGet packages

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -21,7 +21,7 @@
   </metadata>
   <files>
     <file src="MixedRealityToolkit\**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta;MixedRealityToolkit\toc.yml*" target="MRTK\" />
-    <file src="MixedRealityToolkit.Providers\**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta;MixedRealityToolkit.Providers\License.txt*;MixedRealityToolkit.Providers\Version.txt*" target="MRTK\" />
+    <file src="MixedRealityToolkit.Providers\**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta;MixedRealityToolkit.Providers\License.txt*;MixedRealityToolkit.Providers\Version.txt*;MixedRealityToolkit.Providers\WindowsMixedReality\DotNetAdapter*;MixedRealityToolkit.Providers\WindowsMixedReality\DotNetAdapter\**\*.*" target="MRTK\" />
     <file src="MixedRealityToolkit.SDK\**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta;MixedRealityToolkit.SDK\License.txt*;MixedRealityToolkit.SDK\Version.txt*;MixedRealityToolkit.SDK\toc.yml*;MixedRealityToolkit.SDK\StandardAssets.meta;MixedRealityToolkit.SDK\StandardAssets\Fonts.meta;MixedRealityToolkit.SDK\StandardAssets\Materials.meta;MixedRealityToolkit.SDK\StandardAssets\Shaders.meta;MixedRealityToolkit.SDK\StandardAssets\Textures.meta" target="MRTK\" />
     <file src="MixedRealityToolkit.Services\**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta;MixedRealityToolkit.Services\License.txt*;MixedRealityToolkit.Services\Version.txt*" target="MRTK\" />
 

--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -11,7 +11,7 @@
     <description>The Mixed Reality Toolkit is a collection of scripts and components intended to accelerate development of applications targeting Microsoft HoloLens and Windows Mixed Reality headsets.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <tags>Unity MixedReality</tags>
+    <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
       <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1037" />
     </dependencies>

--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -11,7 +11,7 @@
     <description>Examples of the Mixed Reality Toolkit</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <tags>Unity MixedReality</tags>
+    <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
       <dependency id="Microsoft.MixedReality.Toolkit.Foundation" version="$version$" />
     </dependencies>

--- a/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
+++ b/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
@@ -11,7 +11,7 @@
     <description>Extension services and components for the Mixed Reality Toolkit</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <tags>Unity MixedReality</tags>
+    <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
       <dependency id="Microsoft.MixedReality.Toolkit.Foundation" version="$version$" />
     </dependencies>

--- a/Assets/MixedRealityToolkit.Staging/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
@@ -11,7 +11,7 @@
     <description>Mixed Reality Toolkit provider adding support for mobile (phones and tablets) AR devices. NOTE: This package requires Unity's Package Manager AR Foundation as well as AR Core and/or AR Kit packages.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <tags>Unity MixedReality</tags>
+    <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
       <dependency id="Microsoft.MixedReality.Toolkit.Foundation" version="$version$" />
     </dependencies>

--- a/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
+++ b/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
@@ -11,7 +11,7 @@
     <description>Tests for the Mixed Reality Toolkit.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <tags>Unity MixedReality</tags>
+    <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
       <dependency id="Microsoft.MixedReality.Toolkit.Foundation" version="$version$" />
     </dependencies>

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.InEditor.Template.props.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.InEditor.Template.props.template
@@ -1,0 +1,23 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework><!--TARGET_FRAMEWORK_TOKEN--></TargetFramework>
+    <DefineConstants>$(DefineConstants);DOTNETWINRT_PRESENT;<!--PLATFORM_COMMON_DEFINE_CONSTANTS--></DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsEditorOnlyTarget)' == 'false' OR '$(IsEditorOnlyTarget)' == ''">
+    <AssemblySearchPaths>$(AssemblySearchPaths);<!--PLATFORM_COMMON_ASSEMBLY_SEARCH_PATHS_TOKEN--></AssemblySearchPaths>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsEditorOnlyTarget)' == 'false' OR '$(IsEditorOnlyTarget)' == ''">
+<!--PLATFORM_COMMON_REFERENCE_TEMPLATE_START-->
+    <Reference Include="##REFERENCE_TOKEN##">
+      <Private>false</Private>
+      <HintPath><!--HINT_PATH_TOKEN--></HintPath>
+    </Reference>
+<!--PLATFORM_COMMON_REFERENCE_TEMPLATE_END-->
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.*" />
+  </ItemGroup>
+</Project>

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.InEditor.Template.props.template.meta
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.InEditor.Template.props.template.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5f08374158e9e704f99c5333b74581af
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
@@ -11,7 +11,7 @@
     <description>Editor and utility tooling of the Mixed Reality Toolkit</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <tags>Unity MixedReality</tags>
+    <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
       <dependency id="Microsoft.MixedReality.Toolkit.Foundation" version="$version$" />
     </dependencies>

--- a/scripts/packaging/NuGetRestoreProject.csproj
+++ b/scripts/packaging/NuGetRestoreProject.csproj
@@ -15,7 +15,7 @@
 <Project Sdk="Microsoft.Build.Traversal/2.0.2">
 
   <PropertyGroup>
-    <RestoreSources>$(RestorePackageFeed)</RestoreSources>
+    <RestoreSources>$(RestorePackageFeed);https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Overview

1. Filters out the DotNetAdapter folder from being packaged in the NuGet package.
    1. This prevents the csproj from being packaged, which would cause MSBuildForUnity (if present) to resolve its dependency and a duplicate DotNetWinRT DLL.
1. Adds a custom WSA.InEditor.Template.props, to add the `DOTNETWINRT_PRESENT` define and add a package reference to DotNetWinRT.
1. Adds `https://api.nuget.org/v3/index.json` to the package restore csproj, used during local NuGet packaging, due to the new DotNetWinRT dependency.

## Changes
- Fixes: #6244 

## Known Issues

1. The WSA Player DLL still needs to be updated with the define and reference. @andreiborodin is helping with the investigation.