### PR TITLE
Fix Pressable Button State Reset

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -479,7 +479,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <summary>
         /// State that corresponds to Gesture reaching max threshold or limits
-        /// Currently not controlled by Interactable directly
         /// </summary>
         public virtual bool HasGestureMax
         {
@@ -489,7 +488,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <summary>
         /// State that corresponds to Interactable is touching another object 
-        /// Currently not controlled by Interactable directly
         /// </summary>
         public virtual bool HasCollision
         {
@@ -654,6 +652,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (rollOffTimer >= rollOffTime)
                 {
                     HasPress = false;
+                    HasGesture = false;
                 }
             }
 


### PR DESCRIPTION
## Overview

Pressable Button get stuck in Gesture State if hand moves to out of focus position in between a pinch and open gestures.

Before:
![pb_reset_before](https://user-images.githubusercontent.com/16922045/70546606-7b27aa80-1b67-11ea-891f-c79bec288992.gif)

After:
![pb_reset_after](https://user-images.githubusercontent.com/16922045/70546617-81b62200-1b67-11ea-9429-9f9c0d0c952d.gif)


## Changes
Interactable.cs handles button states and timeout for reseting HasPress when Input Position goes out of threshold. HasGesture timeout is not being handled.

We assume the following desirable behaviour:

1. Hand focus on Button with far pointer
2. Hand performs Pinch gesture
3. Button enters visual Pressed state
4. Hand Moves pointer to outside of Button focus
5. Button goes back to Default state
6. Interactable does NOT triggers OnClick.

- Fixes: #6641.


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
