### PR TITLE
Add special WSA InEditor NuGet restore to CI

### DIFF
--- a/pipelines/templates/compilemsbuild.yml
+++ b/pipelines/templates/compilemsbuild.yml
@@ -31,6 +31,18 @@ steps:
     createLogFile: true
     restoreNugetPackages: false
     msbuildVersion: '15.0'
+    msbuildArguments: '/t:Restore /p:BuildProjectReferences=false'
+  displayName: 'NuGet Restore for InEditor WSA (Special)'
+
+- task: MSBuild@1
+  inputs:
+    solution: '$(Build.SourcesDirectory)\MSBuild\Projects\MixedRealityToolkit.sln'
+    msbuildArchitecture: 'x64'
+    platform: 'WSA'
+    configuration: 'InEditor'
+    createLogFile: true
+    restoreNugetPackages: false
+    msbuildVersion: '15.0'
     msbuildArguments: '/p:BuildProjectReferences=false'
   displayName: 'Build InEditor WSA'
   


### PR DESCRIPTION
## Overview
The new WSA InEditor build step needs its own NuGet restore, like the existing WSA Player build step. This is mostly copied and pasted from the existing one.