### PR TITLE
How to add menu items for experimental features

### DIFF
--- a/Documentation/Contributing/ExperimentalFeatures.md
+++ b/Documentation/Contributing/ExperimentalFeatures.md
@@ -42,6 +42,22 @@ See [this PR](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4532) 
 
 Add an `[Experimental]` attribute above one of your fields to have a small dialog appear in the component editor that mentions your feature is experimental and subject to significant changes.
 
+### Menus for experimental features should go under "Experimental" sub-menu
+Ensure that experimental features are under "experimental" sub-menus when adding commands to menus in the editor. Here are a few examples:
+
+Adding a top-level menu command:
+
+```csharp
+[MenuItem("Mixed Reality Toolkit/Experimental/MyCommand")]
+public static void MyCommand()
+```
+
+Adding a component menu:
+
+```csharp
+[AddComponentMenu("MRTK/Experimental/MyCommand")]
+```
+
 ### Minimize impact to MRTK code
 
 While your MRTK change might get your experiment to work, it could impact other people in ways you do not expect.


### PR DESCRIPTION
## Overview
Following #6492 this pr provides guidance that menu items for experimental features should go under "experimental" sub-menu.

- Fixes: #6466
