### PR TITLE
Add 2.2.0 to the documentation version list

### DIFF
--- a/web/version.js
+++ b/web/version.js
@@ -3,7 +3,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; 	// title in the dropdown for the root version of the docs
-	var versionArray = ["releases/2.0.0", "releases/2.1.0", "prerelease/2.2.0_stabilization"];	// list of all versions in the version folder
+	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0"];	// list of all versions in the version folder
 	
 	//--------------------------------------
 


### PR DESCRIPTION
This change removes prerelease/2.2.0_stabilization from the list of available documentation versions and replaces it with releases/2.2.0
