### PR TITLE
Removes a stale portion of the CodingGuidelines that talks about unrolled foreach vs. for loops.

### DIFF
--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -442,13 +442,6 @@ Always use private fields and public properties if access to the field is needed
  }
  ```
 
-#### Do
-
- ```c#
-int length = items.length; // cache reference to list/array length
-for(int i=0; i < length; i++)
- ```
-
 ### Cache values and serialize them in the scene/prefab whenever possible
 
 With the HoloLens in mind, it's best to optimize for performance and cache references in the scene or prefab to limit runtime memory allocations.


### PR DESCRIPTION
This section of the coding guidelines survived some refactoring, but should have been deleted at some point in the past - it was part of a section that talks about using foreach vs for (mentioning to use for instead of foreach). This information is somewhat dated now (i.e. see https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4538#discussion_r295852607 - on newer version of Unity it's not really a thing based on those discussions)

See that this chunk of "do" code used to be in the foreach vs for section:

https://github.com/microsoft/MixedRealityToolkit-Unity/blame/22742fe3165cd062b4477cfbdaeaddd2d3734448/Documentation/Contributing/CodingGuidelines.md#L512
