### PR TITLE
Update WSA.Player.Template.props.template to reference the DotNetWinRT adapter

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.Player.Template.props.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.Player.Template.props.template
@@ -3,7 +3,7 @@
     <AssemblySearchPaths>$(AssemblySearchPaths);<!--PLATFORM_COMMON_ASSEMBLY_SEARCH_PATHS_TOKEN-->;C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5;$(UnityEditorInstallFolder)Data\PlaybackEngines\MetroSupport\Managed\UAP\</AssemblySearchPaths>
     <TargetFramework>uap10.0</TargetFramework>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <DefineConstants>$(DefineConstants);<!--PLATFORM_COMMON_DEFINE_CONSTANTS-->;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>$(DefineConstants);<!--PLATFORM_COMMON_DEFINE_CONSTANTS-->;NETFX_CORE;WINDOWS_UWP;DOTNETWINRT_PRESENT</DefineConstants>
     <NugetTargetMoniker>UAP,Version=v10.0</NugetTargetMoniker>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion><!--UWP_TARGET_PLATFORM_VERSION_TOKEN--></TargetPlatformVersion>
@@ -48,5 +48,15 @@
       <HintPath><!--HINT_PATH_TOKEN--></HintPath>
     </Reference>
 <!--PLATFORM_COMMON_REFERENCE_TEMPLATE_END-->
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DotNetWinRTVersion>0.5.1037</DotNetWinRTVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="$(DotNetWinRTVersion)" ExcludeAssets="Compile" />
+    <Reference Include="Microsoft.Windows.MixedReality.DotNetWinRT">
+      <HintPath>$(NuGetPackageRoot)\microsoft.windows.mixedreality.dotnetwinrt\$(DotNetWinRTVersion)\lib\uap10.0.18362\Microsoft.Windows.MixedReality.DotNetWinRT.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6827, fixing the known issue referenced there.

Adds the `#define` and adapter reference to the WSA player DLL to support https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6731

Part of https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6244