### PR TITLE
double check interface for null

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs
@@ -686,10 +686,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                 }
 
-                if (controller.Visualizer != null &&
-                    controller.Visualizer.GameObjectProxy != null)
+                var visualizer = controller.Visualizer;
+
+                if (visualizer != null && !visualizer.Equals(null) &&
+                    visualizer.GameObjectProxy != null)
                 {
-                    controller.Visualizer.GameObjectProxy.SetActive(false);
+                    visualizer.GameObjectProxy.SetActive(false);
                 }
             }
 


### PR DESCRIPTION
## Overview
This is a band-aid because the bug is annoying.
As mentioned in the the issue this fixes, checking interfaces for null is not sufficient in the case they were implemented by a UnityEngine.Object. This needs a more profound solution (maybe #5981) though.

## Changes
- Fixes: #6587.