### PR TITLE
Standardize C# codeblock syntax in docs

### DIFF
--- a/Documentation/Architecture/InputSystem/ControllersPointersAndFocus.md
+++ b/Documentation/Architecture/InputSystem/ControllersPointersAndFocus.md
@@ -53,7 +53,7 @@ Because the pointer mediator runs every frame, it ends up controlling the active
 #### Example: Disable hand rays in MRTK
 The following code will turn off the hand rays in MRTK:
 
-```csharp
+```c#
 // Turn off all hand rays
 PointerUtils.SetHandRayPointerBehavior(PointerBehavior.AlwaysOff);
 
@@ -63,13 +63,13 @@ PointerUtils.SetHandRayPointerBehavior(PointerBehavior.AlwaysOff, Handedness.Rig
 
 The following code will return hand rays to their default behavior in MRTK:
 
-```csharp
+```c#
 PointerUtils.SetHandRayPointerBehavior(PointerBehavior.Default);
 ```
 
 The following code will force hand rays to be on, regardless if near a grabbable:
 
-```csharp
+```c#
 // Turn off all hand rays
 PointerUtils.SetHandRayPointerBehavior(PointerBehavior.AlwaysOn);
 ```

--- a/Documentation/Architecture/InputSystem/Terminology.md
+++ b/Documentation/Architecture/InputSystem/Terminology.md
@@ -31,7 +31,7 @@ The input system has some of its own terminology that are worth defining:
     longer than arms-length from the user.
 
     Pointers are created by the device manager and then attached to an input source. To get all of the
-    pointers for a controller, do: ```controller.InputSource.Pointers```
+    pointers for a controller, do: `controller.InputSource.Pointers`
 
     Note that a controller can be associated with many different pointers at the same time. In order
     to ensure that this doesn’t devolve into chaos, there is a pointer mediator which controls which

--- a/Documentation/Architecture/SystemsExtensionsProviders.md
+++ b/Documentation/Architecture/SystemsExtensionsProviders.md
@@ -56,7 +56,7 @@ The MRTK input system utilizes only data providers that implement the [`IMixedRe
 
 The following example demonstrates accessing the input simulation provider and toggle the SmoothEyeTracking property.
 
-``` c#
+```c#
 if (CoreServices.InputSystem != null)
 {
     IMixedRealityDataProviderAccess dataProviderAccess = CoreServices.InputSystem as IMixedRealityDataProviderAccess;
@@ -88,7 +88,7 @@ The MRTK spatial awareness system utilizes only data providers that implement th
 
 The following example demonstrates accessing the registered spatial mesh data providers and changing the visibility of the meshes.
 
-``` c#
+```c#
 if (CoreServices.SpatialAwarenessSystem != null)
 {
     IMixedRealityDataProviderAccess dataProviderAccess =

--- a/Documentation/CameraSystem/CreateSettingsProvider.md
+++ b/Documentation/CameraSystem/CreateSettingsProvider.md
@@ -60,7 +60,7 @@ All camera settings providers must implement the [`IMixedRealityCameraSettingsPr
 interface, which specifies the minimum functionality required by the camera system. The MRTK foundation includes the [`BaseCameraSettingsProvider`](xref:Microsoft.MixedReality.Toolkit.CameraSystem.BaseCameraSettingsProvider)
 class which provides a default implementation of the required functionality.
 
-``` c#
+```c#
 namespace namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 {
     public class UnityARCameraSettings : BaseCameraSettingsProvider
@@ -73,7 +73,7 @@ namespace namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 A key step in creating a camera settings provider is to apply the [`MixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.MixedRealityDataProviderAttribute)
 attribute to the class. This step enables setting the default profile and platform(s) for the data provider, when selected in the Camera System profile as well as name, folder path, and more.
 
-``` c#
+```c#
     [MixedRealityDataProvider(
         typeof(IMixedRealityCameraSystem),
         SupportedPlatforms.Android | SupportedPlatforms.IOS,
@@ -115,7 +115,7 @@ In the Mixed Reality Toolkit, data providers are configured using [profiles](../
 
 Profile contents should mirror the developer selectable configuration options. Any user configurable properties defined in each interface should also be contained with the profile.
 
-```csharp
+```c#
 using UnityEngine.SpatialTracking;
 
 namespace namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
@@ -164,7 +164,7 @@ Profile inspectors are the user interface for configuring and viewing profile co
 
 The `CustomEditor` attribute informs Unity the type of asset to which the inspector applies.
 
-```csharp
+```c#
 namespace namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 {
     [CustomEditor(typeof(UnityARCameraSettingsProfile))]

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -495,8 +495,8 @@ public class MyClass
 
 #### Do
 
- ```c#
- // Private references for use inside the class only
+```c#
+// Private references for use inside the class only
 public class MyClass
 {
     private Material cachedMaterial;
@@ -516,7 +516,7 @@ public class MyClass
         Destroy(cachedMaterial);
     }
 }
- ```
+```
 
 > [!NOTE]
 > Alternatively, use Unity's "SharedMaterial" property which does not create a new material each time it is referenced.

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -335,33 +335,33 @@ public enum SDKType
 #### Do
 
  ```c#
+/// <summary>
+/// The SDKType lists the VR SDKs that are supported by the MRTK
+/// Initially, this lists proposed SDKs, not all may be implemented at this time (please see ReleaseNotes for more details)
+/// </summary>
+public enum SDKType
+{
     /// <summary>
-    /// The SDKType lists the VR SDKs that are supported by the MRTK
-    /// Initially, this lists proposed SDKs, not all may be implemented at this time (please see ReleaseNotes for more details)
+    /// No specified type or Standalone / non-VR type
     /// </summary>
-    public enum SDKType
-    {
-        /// <summary>
-        /// No specified type or Standalone / non-VR type
-        /// </summary>
-        None = 0,
-        /// <summary>
-        /// Undefined SDK.
-        /// </summary>
-        Other,
-        /// <summary>
-        /// The Windows 10 Mixed reality SDK provided by the Universal Windows Platform (UWP), for Immersive MR headsets and HoloLens.
-        /// </summary>
-        WindowsMR,
-        /// <summary>
-        /// The OpenVR platform provided by Unity (does not support the downloadable SteamVR SDK).
-        /// </summary>
-        OpenVR,
-        /// <summary>
-        /// The OpenXR platform. SDK to be determined once released.
-        /// </summary>
-        OpenXR
-    }
+    None = 0,
+    /// <summary>
+    /// Undefined SDK.
+    /// </summary>
+    Other,
+    /// <summary>
+    /// The Windows 10 Mixed reality SDK provided by the Universal Windows Platform (UWP), for Immersive MR headsets and HoloLens.
+    /// </summary>
+    WindowsMR,
+    /// <summary>
+    /// The OpenVR platform provided by Unity (does not support the downloadable SteamVR SDK).
+    /// </summary>
+    OpenVR,
+    /// <summary>
+    /// The OpenXR platform. SDK to be determined once released.
+    /// </summary>
+    OpenXR
+}
 ```
 
 ### Review Enum use for Bitfields

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -60,16 +60,16 @@ All Microsoft employees contributing new files should add the following standard
 All public classes, structs, enums, functions, properties, fields posted to the MRTK should be described as to it's purpose and use, exactly as shown below:
 
 ```c#
+/// <summary>
+/// The Controller definition defines the Controller as defined by the SDK / Unity.
+/// </summary>
+public struct Controller
+{
     /// <summary>
-    /// The Controller definition defines the Controller as defined by the SDK / Unity.
+    /// The ID assigned to the Controller
     /// </summary>
-    public struct Controller
-    {
-        /// <summary>
-        /// The ID assigned to the Controller
-        /// </summary>
-        public string ID;
-    }
+    public string ID;
+}
 ```
 
 This ensures documentation is properly generated and disseminated for all all classes, methods, and properties.
@@ -101,7 +101,7 @@ When adding new MonoBehaviour scripts with a pull-request, ensure the [`AddCompo
 
 In the example below, the *Package here* should be filled with the package location of the component. If placing an item in *MixedRealityToolkit.SDK* folder, then the package will be *SDK*. If placing an item in the *MixedRealityToolkit* folder, then use *Core* as the string to insert.
 
-```csharp
+```c#
 [AddComponentMenu("Scripts/MRTK/{Package here}/MyNewComponent")]
 public class MyNewComponent : MonoBehaviour
 ```
@@ -148,11 +148,11 @@ private string MyProperty; // <- Starts with an uppercase case letter
 
 #### Do
 
- ```c#
+```c#
 public string MyProperty;
 protected string MyProperty;
 private string myProperty;
- ```
+```
 
 ### Access Modifiers
 
@@ -180,13 +180,13 @@ void Bar() { }
 
 #### Do
 
- ```c#
+```c#
 public int MyVariable { get; protected set; } = 0;
 
 private void Foo() { }
 public void Bar() { }
 protected virtual void FooBar() { }
- ```
+```
 
 ### Use Braces
 
@@ -246,7 +246,7 @@ public class MyClass
 
 #### Do
 
- ```c#
+```c#
  // Private references for use inside the class only
 public class MyClass
 {
@@ -254,14 +254,14 @@ public class MyClass
     private enum MyEnumType() { }
     private class MyNestedClass() { }
 }
- ```
+```
 
 #### Do
 
- MyStruct.cs
+MyStruct.cs
 
- ```c#
- // Public Struct / Enum definitions for use in your class.  Try to make them generic for reuse.
+```c#
+// Public Struct / Enum definitions for use in your class.  Try to make them generic for reuse.
 public struct MyStruct
 {
     public string Var1;
@@ -287,7 +287,7 @@ public class MyClass
     private MyStruct myStructReference;
     private MyEnumType myEnumReference;
 }
- ```
+```
 
 ### Initialize Enums
 
@@ -306,14 +306,14 @@ public enum Value
 
 #### Do
 
- ```c#
+```c#
 public enum ValueType
 {
     Value1 = 0,
     Value2,
     Value3
 }
- ```
+```
 
 ### Order Enums for appropriate extension
 
@@ -334,7 +334,7 @@ public enum SDKType
 
 #### Do
 
- ```c#
+```c#
 /// <summary>
 /// The SDKType lists the VR SDKs that are supported by the MRTK
 /// Initially, this lists proposed SDKs, not all may be implemented at this time (please see ReleaseNotes for more details)
@@ -383,8 +383,8 @@ public enum Handedness
 
 ### Do
 
- ```c#
- [flags]
+```c#
+[Flags]
 public enum Handedness
 {
     None = 0 << 0,
@@ -392,7 +392,7 @@ public enum Handedness
     Right = 1 << 1,
     Both = Left | Right
 }
- ```
+```
 
 ## Best Practices, including Unity recommendations
 
@@ -407,40 +407,40 @@ Always use private fields and public properties if access to the field is needed
 
 #### Don't
 
- ```c#
- private float myValue1;
- private float myValue2;
+```c#
+private float myValue1;
+private float myValue2;
 
- public float MyValue1
- {
-     get{ return myValue1; }
-     set{ myValue1 = value }
- }
+public float MyValue1
+{
+    get{ return myValue1; }
+    set{ myValue1 = value }
+}
 
- public float MyValue2
- {
-     get{ return myValue2; }
-     set{ myValue2 = value }
- }
+public float MyValue2
+{
+    get{ return myValue2; }
+    set{ myValue2 = value }
+}
 ```
 
 #### Do
 
- ```c#
- // Enable field to be configurable in the editor and available externally to other scripts (field is correctly serialized in Unity)
- [SerializeField]
- [ToolTip("If using a tooltip, the text should match the public property's summary documentation, if appropriate.")]
- private float myValue; // <- Notice we co-located the backing field above our corresponding property.
+```c#
+// Enable field to be configurable in the editor and available externally to other scripts (field is correctly serialized in Unity)
+[SerializeField]
+[ToolTip("If using a tooltip, the text should match the public property's summary documentation, if appropriate.")]
+private float myValue; // <- Notice we co-located the backing field above our corresponding property.
 
- /// <summary>
- /// If using a tooltip, the text should match the public property's summary documentation, if appropriate.
- /// </summary>
- public float MyValue
- {
-     get{ return myValue; }
-     set{ myValue = value }
- }
- ```
+/// <summary>
+/// If using a tooltip, the text should match the public property's summary documentation, if appropriate.
+/// </summary>
+public float MyValue
+{
+    get{ return myValue; }
+    set{ myValue = value }
+}
+```
 
 ### Cache values and serialize them in the scene/prefab whenever possible
 
@@ -474,7 +474,7 @@ private void Update()
 {
     myRenderer.Foo(Bar);
 }
- ```
+```
 
 ### Cache references to materials, do not call the ".material" each time
 

--- a/Documentation/Contributing/DevDocGuide.md
+++ b/Documentation/Contributing/DevDocGuide.md
@@ -40,7 +40,7 @@ For external apis that don't provide an xref service hrefs to the documentation 
 
 Examples:
 
-```csharp
+```c#
 /// Links to MRTK internal class SystemType
 ///<see cref="Microsoft.MixedReality.Toolkit.Utilities.SystemType"/>
 

--- a/Documentation/Contributing/DevDocGuide.md
+++ b/Documentation/Contributing/DevDocGuide.md
@@ -122,10 +122,10 @@ Multiple versions of developer docs are supported and can be switched by the ver
 Depending on whether you want to have the "Improve this doc" to point to a specific version of the github repo you will have to add the following entry to the globalMetaData section in the docfx.json file before calling the docfx command:
 
 ```json
- "_gitContribute": {
-        "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity.git",
-        "branch": "mrtk_development"
-      }
+"_gitContribute": {
+    "repo": "https://github.com/Microsoft/MixedRealityToolkit-Unity.git",
+    "branch": "mrtk_development"
+}
 ```
 
 If you don't set this up docfx will default to the branch and repo of the current folder you're calling docfx from.

--- a/Documentation/Contributing/DocumentationGuide.md
+++ b/Documentation/Contributing/DocumentationGuide.md
@@ -34,7 +34,7 @@ This section describes frequently needed features. To see how they work, look at
 
 For code samples we use the blocks with three backticks \`\`\` and specify *csharp* as the language for syntax highlighting:
 
-``` csharp
+```c#
 int SampleFunction(int i)
 {
    return i + 42;
@@ -45,7 +45,7 @@ When mentioning code within a sentence `use a single backtick`.
 
 ### TODOs
 
-Avoid using TODOS in docs, as over time these TODOs (like code TODOs) tend to accumulate
+Avoid using TODOs in docs, as over time these TODOs (like code TODOs) tend to accumulate
 and information about how they should be updated and why gets lost.
 
 If it is absolutely necessary to add a TODO, follow these steps:

--- a/Documentation/Contributing/UnitTests.md
+++ b/Documentation/Contributing/UnitTests.md
@@ -116,7 +116,7 @@ To create a new play mode test:
 - Right click, Create > Testing > C# Test Script
 - Replace the default template with the skeleton below
 
-``` csharp
+```c#
 #if !WINDOWS_UWP
 // When the .NET scripting backend is enabled and C# projects are built
 // The assembly that this file is part of is still built for the player,
@@ -206,7 +206,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 Edit mode tests are executed in Unity's edit mode and can be added under the **MixedRealityToolkit.Tests** > **EditModeTests** folder in the Mixed Reality Toolkit repo.
 To create a new test the following template can be used:
 
-``` csharp
+```c#
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -231,7 +231,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 Tests should generally be named based on the class they are testing, or the scenario that they are testing.
 For example, given a to-be-tested class:
 
-```csharp
+```c#
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     class InterestingInputClass
@@ -242,7 +242,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
 Consider naming the test
 
-```csharp
+```c#
 namespace Microsoft.MixedReality.Toolkit.Tests.Input
 {
     class InterestingInputClassTest
@@ -285,7 +285,7 @@ There are two Utility classes that help with setting up MRTK and testing interac
 
 TestUtilities provide the following methods to set up your MRTK scene and GameObjects:
 
-``` csharp
+```c#
 /// creates the mrtk GameObject and sets the default profile if passed param is true
 TestUtilities.InitializeMixedRealityToolkit()
 

--- a/Documentation/DetectingPlatformCapabilities.md
+++ b/Documentation/DetectingPlatformCapabilities.md
@@ -24,7 +24,7 @@ The default MRTK Input System supports querying the following capabilities:
 
 The example code below checks to see if the input system has loaded a data provider with support for articulated hands.
 
-``` C#
+```c#
 bool supportsArticulatedHands = false;
 
 IMixedRealityCapabilityCheck capabilityCheck = CoreServices.InputSystem as IMixedRealityCapabilityCheck;
@@ -46,7 +46,7 @@ The default MRTK Spatial Awareness system supports querying the following capabi
 
 This example checks to see if the spatial awareness system has loaded a data provider with support for spatial meshes.
 
-``` C#
+```c#
 bool supportsSpatialMesh = false;
 
 IMixedRealityCapabilityCheck capabilityCheck = CoreServices.SpatialAwarenessSystem as IMixedRealityCapabilityCheck;

--- a/Documentation/Diagnostics/ConfiguringDiagnostics.md
+++ b/Documentation/Diagnostics/ConfiguringDiagnostics.md
@@ -42,7 +42,7 @@ The speed at which to move the profiler window to maintain visibility within the
 
 It's also possible to toggle the visibility of the diagnostics system and the profiler at runtime. For example, the code below will hide the diagnostics system and profiler.
 
-```C#
+```c#
 CoreServices.DiagnosticsSystem.ShowDiagnostics = false;
 
 CoreServices.DiagnosticsSystem.ShowProfiler = false;

--- a/Documentation/Extensions/ExtensionServices.md
+++ b/Documentation/Extensions/ExtensionServices.md
@@ -43,7 +43,7 @@ The component name and priority can also be adjusted.
 Extension services are accessed, in code, using the [`MixedRealityServiceRegistry`](xref:Microsoft.MixedReality.Toolkit.MixedRealityServiceRegistry)
 as shown in the example below.
 
-``` c#
+```c#
 INewService service = null;
 if (MixedRealityServiceRegistry.TryGetService<INewService>(out service))
 {

--- a/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.md
+++ b/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.md
@@ -49,7 +49,7 @@ You use the transition service by passing Tasks that are run while the camera is
 
 In most cases you will be using Tasks supplied by the SceneSystem service:
 
-```csharp
+```c#
 private async void TransitionToScene()
 {
     IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
@@ -68,7 +68,7 @@ private async void TransitionToScene()
 
 In other cases you may want to perform a transition without actually loading a scene:
 
-```csharp
+```c#
 private async void TransitionToScene()
 {
     ISceneTransitionService transition = MixedRealityToolkit.Instance.GetService<ISceneTransitionService>();
@@ -89,7 +89,7 @@ private async Task ResetScene()
 
 Or you may want to load a scene without using the SceneSystem service:
 
-```csharp
+```c#
 private async void TransitionToScene()
 {
     ISceneTransitionService transition = MixedRealityToolkit.Instance.GetService<ISceneTransitionService>();
@@ -116,7 +116,7 @@ private async Task LoadScene(string sceneName)
 
 You can also supply multiple tasks, which will be executed in order:
 
-```csharp
+```c#
 private async void TransitionToScene()
 {
     IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
@@ -163,7 +163,7 @@ A progress indicator is anything that implements the `IProgressIndicator` interf
 
 If `UseDefaultProgressIndicator` is checked in the SceneTransitionService profile, a progress indicator will be instantiated when a transition begins. For the duration of the transition this indicator's `Progress` and `Message` properties can be accessed via that service's `SetProgressValue` and `SetProgressMessage` methods.
 
-```csharp
+```c#
 private async void TransitionToScene()
 {
     IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();

--- a/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
+++ b/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
@@ -38,14 +38,14 @@ Here is an example from the [FollowEyeGaze.cs](xref:Microsoft.MixedReality.Toolk
 
 - Get the point of a hologram that the user is looking at:
 
-```csharp
+```c#
 // Show the object at the hit position of the user's eye gaze ray with the target.
 gameObject.transform.position = MixedRealityToolkit.InputSystem.EyeGazeProvider.HitPosition;
 ```
 
 - Showing a visual asset at a fixed distance from where the user is currently looking:
 
-```csharp
+```c#
 // If no target is hit, show the object at a default distance along the gaze ray.
 gameObject.transform.position =
 MixedRealityToolkit.InputSystem.EyeGazeProvider.GazeOrigin +

--- a/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
+++ b/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
@@ -16,7 +16,7 @@ This page covers the following:
 
 ### How to detect the eye calibration state
 
-The [MixedRealityToolkit.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a ```bool?``` property called ```IsEyeGazeValid```.
+The [MixedRealityToolkit.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a `bool?` property called `IsEyeGazeValid`.
 It returns null if no information from the eye tracker is available yet.
 Once data has been received, it will either return true or false to indicate that the user's eye tracking calibration is valid or invalid.
 
@@ -40,9 +40,9 @@ Once the notification is dismissed, it will slowly decrease its size and fade ou
       - The app gets restarted
       - A valid user has been detected and then a new uncalibrated user has put the device on
 
-   - For testing whether the animations and events are triggered correctly, the EyeCalibrationChecker script possesses a ```bool editorTestUserIsCalibrated``` flag. For example, when the app is running in the Unity Editor you can test, whether the notification automatically pops up once the calibration status changes from true to false and whether it automatically dismisses the notification again once the status changes from false to true.
+   - For testing whether the animations and events are triggered correctly, the EyeCalibrationChecker script possesses a `bool editorTestUserIsCalibrated` flag. For example, when the app is running in the Unity Editor you can test, whether the notification automatically pops up once the calibration status changes from true to false and whether it automatically dismisses the notification again once the status changes from false to true.
 
-```csharp
+```c#
     private bool? prevCalibrationStatus = null;
     ...
 

--- a/Documentation/EyeTracking/EyeTracking_TargetSelection.md
+++ b/Documentation/EyeTracking/EyeTracking_TargetSelection.md
@@ -51,7 +51,7 @@ To detect when a hologram is focused, use the _'IMixedRealityFocusHandler'_ inte
 
 Here is a simple example from [ColorTap.cs](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.ColorTap) to change a hologram's color when being looked at.
 
-```csharp
+```c#
 public class ColorTap : MonoBehaviour, IMixedRealityFocusHandler
 {
     void IMixedRealityFocusHandler.OnFocusEnter(FocusEventData eventData)
@@ -77,7 +77,7 @@ _OnPointerUp_, _OnPointerDown_, and _OnPointerClicked_.
 In the example below, we change the color of a hologram by looking at it and pinching or saying "select".
 The required action to trigger the event is defined by `eventData.MixedRealityInputAction == selectAction` whereby we can set the type of `selectAction` in the Unity Editor - by default it's the "Select" action. The types of available [MixedRealityInputActions](../Input/InputActions.md) can be configured in the MRTK Profile via _MRTK Configuration Profile_ -> _Input_ -> _Input Actions_.
 
-```csharp
+```c#
 public class ColorTap : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityPointerHandler
 {
     // Allow for editing the type of select action in the Unity Editor.
@@ -120,7 +120,7 @@ This is a behavior that you may not want to have active at all times and also so
 Having the [`OnLookAtRotateByEyeGaze`](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.OnLookAtRotateByEyeGaze)
 attached, a GameObject will rotate while being looked at.
 
-```csharp
+```c#
 public class OnLookAtRotateByEyeGaze : BaseEyeFocusHandler
 {
     ...
@@ -217,34 +217,34 @@ Similar to Example #1, we can easily create a hover feedback for our holographic
 
 1. Create a generic script that includes a public function to rotate the GameObject it is attached to. Below is an example from _RotateWithConstSpeedDir.cs_ where we can tweak the rotation direction and speed from the Unity Editor.
 
-```csharp
-using UnityEngine;
+    ```c#
+    using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
-{
-    /// <summary>
-    /// The associated GameObject will rotate when RotateTarget() is called based on a given direction and speed.
-    /// </summary>
-    public class RotateWithConstSpeedDir : MonoBehaviour
+    namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
     {
-        [Tooltip("Euler angles by which the object should be rotated by.")]
-        [SerializeField]
-        private Vector3 RotateByEulerAngles = Vector3.zero;
-
-        [Tooltip("Rotation speed factor.")]
-        [SerializeField]
-        private float speed = 1f;
-
         /// <summary>
-        /// Rotate game object based on specified rotation speed and Euler angles.
+        /// The associated GameObject will rotate when RotateTarget() is called based on a given direction and speed.
         /// </summary>
-        public void RotateTarget()
+        public class RotateWithConstSpeedDir : MonoBehaviour
         {
-            transform.eulerAngles = transform.eulerAngles + RotateByEulerAngles * speed;
+            [Tooltip("Euler angles by which the object should be rotated by.")]
+            [SerializeField]
+            private Vector3 RotateByEulerAngles = Vector3.zero;
+
+            [Tooltip("Rotation speed factor.")]
+            [SerializeField]
+            private float speed = 1f;
+
+            /// <summary>
+            /// Rotate game object based on specified rotation speed and Euler angles.
+            /// </summary>
+            public void RotateTarget()
+            {
+                transform.eulerAngles = transform.eulerAngles + RotateByEulerAngles * speed;
+            }
         }
     }
-}
-```
+    ```
 
 2. Add the [`EyeTrackingTarget`](xref:Microsoft.MixedReality.Toolkit.Input.EyeTrackingTarget) script to your target GameObject and reference the _RotateTarget()_ function in the UnityEvent trigger as shown the screenshot below:
 
@@ -281,7 +281,7 @@ You could simply link the script that is attached to each of our gem templates t
 If you don't want to drag and drop GameObjects around, you can also simply add a event listener directly to your script.  
 Here's an example from how we did it in the [`HitBehaviorDestroyOnSelect`](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.HitBehaviorDestroyOnSelect) script:
 
-```csharp
+```c#
 /// <summary>
 /// Destroys the game object when selected and optionally plays a sound or animation when destroyed.
 /// </summary>

--- a/Documentation/Input/CreateDataProvider.md
+++ b/Documentation/Input/CreateDataProvider.md
@@ -51,7 +51,7 @@ class can be used as a base class.
 > [!Note]
 > The `BaseInputDeviceManager` and `UnityJoystickManager` classes provide the required `IMixedRealityInputDeviceManager` implementation.
 
-``` c#
+```c#
 public class WindowsMixedRealityDeviceManager :
     BaseInputDeviceManager,
     IMixedRealityCapabilityCheck
@@ -66,7 +66,7 @@ gaze-gesture-voice hands and motion controllers.
 A key step of creating an input system data provider is to apply the [`MixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.MixedRealityDataProviderAttribute)
 attribute to the class. This step enables setting the default profile and platform(s) for the provider, when selected in the input system profile.
 
-``` c#
+```c#
 [MixedRealityDataProvider(
     typeof(IMixedRealityInputSystem),
     SupportedPlatforms.WindowsUniversal,
@@ -116,7 +116,7 @@ The next step is to add the logic for managing the input devices, including any 
 Next, apply the [`MixedRealityController`](xref:Microsoft.MixedReality.Toolkit.Input.MixedRealityControllerAttribute) attribute to the class. This attribute specifies the type of controller
 (ex: articulated hand), the handedness (ex: left or right) and an optional controller image.
 
-``` c#
+```c#
 [MixedRealityController(
     SupportedControllerType.WindowsMixedReality,
     new[] { Handedness.Left, Handedness.Right },
@@ -152,7 +152,7 @@ the [`IMixedRealityInputHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMix
 
 For digital (button) type controls, raise the OnInputDown and OnInputUp events.
 
-``` c#
+```c#
 // inputAction is the input event that is to be raised.
 if (interactionSourceState.touchpadPressed)
 {
@@ -166,7 +166,7 @@ else
 
 For analog controls (ex: touchpad position) the InputChanged event should be raised.
 
-``` c#
+```c#
 InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.touchpadPosition);
 ```
 
@@ -184,7 +184,7 @@ customers to modify the behavior to best suit the needs of the application.
 Profile contents should mirror the accessible properties of the observer (ex: update interval). All of the user configurable properties defined in each
 interface should be contained with the profile.
 
-``` c#
+```c#
 [CreateAssetMenu(
     menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Simulated Input Profile",
     fileName = "MixedRealityInputSimulationProfile",
@@ -201,7 +201,7 @@ The `CreateAssetMenu` attribute can be applied to the profile class to enable cu
 Profile inspectors are the user interface for configuring and viewing profile contents. Each profile inspector should extend the
 [`BaseMixedRealityToolkitConfigurationProfileInspector](xref:Microsoft.MixedReality.Toolkit.Editor.BaseMixedRealityToolkitConfigurationProfileInspector) class.
 
-``` c#
+```c#
 [CustomEditor(typeof(MixedRealityInputSimulationProfile))]
 public class MixedRealityInputSimulationProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
 { }

--- a/Documentation/Input/Gaze.md
+++ b/Documentation/Input/Gaze.md
@@ -46,7 +46,7 @@ bugs) as re-implementing the GazeProvider is non-trivial.
 
 This sample shows how to get the current game object that is targeted by the user gaze.
 
-```csharp
+```c#
 void LogCurrentGazeTarget()
 {
     if (CoreServices.InputSystem.GazeProvider.GazeTarget)
@@ -62,7 +62,7 @@ void LogCurrentGazeTarget()
 This sample shows how to get the Vector3 representing the direction of the user gaze
 and the origin (the point from which the direction is going).
 
-```csharp
+```c#
 void LogGazeDirectionOrigin()
 {
     Debug.Log("Gaze is looking in direction: "

--- a/Documentation/Input/HandTracking.md
+++ b/Documentation/Input/HandTracking.md
@@ -55,7 +55,7 @@ A specific hand controller is often available, e.g. when handling input events. 
 
 The [`TryGetJoint`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand.TryGetJoint*) function returns `false` if the requested joint is not available for some reason. In that case the resulting pose will be [`MixedRealityPose.ZeroIdentity`](xref:Microsoft.MixedReality.Toolkit.Utilities.MixedRealityPose.ZeroIdentity).
 
-```csharp
+```c#
 public void OnSourceDetected(SourceStateEventData eventData)
 {
   var hand = eventData.Controller as IMixedRealityHand;
@@ -73,7 +73,7 @@ public void OnSourceDetected(SourceStateEventData eventData)
 
 Joint objects can be requested from the [controller visualizer](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityController.Visualizer).
 
-```csharp
+```c#
 public void OnSourceDetected(SourceStateEventData eventData)
 {
   var handVisualizer = eventData.Controller.Visualizer as IMixedRealityHandVisualizer;
@@ -95,24 +95,23 @@ If no specific controller is given then utility classes are provided for conveni
 
 [`HandJointUtils`](xref:Microsoft.MixedReality.Toolkit.Input.HandJointUtils) is a static class that queries the first active hand device.
 
-```csharp
-  if (HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, Handedness.Right, out MixedRealityPose pose))
-  {
+```c#
+if (HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, Handedness.Right, out MixedRealityPose pose))
+{
     // ...
-  }
+}
 ```
 
 #### Joint Transform from Hand Joint Service
 
 [`IMixedRealityHandJointService`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandJointService) keeps a persistent set of [GameObjects](https://docs.unity3d.com/ScriptReference/GameObject.html) for tracking joints.
 
-```csharp
-  var handJointService = MixedRealityToolkit.Instance.GetService<IMixedRealityHandJointService>();
-  if (handJointService != null)
-  {
+```c#
+var handJointService = MixedRealityToolkit.Instance.GetService<IMixedRealityHandJointService>();
+if (handJointService != null)
+{
     Transform jointTransform = handJointService.RequestJointTransform(TrackedHandJoint.IndexTip, Handedness.Right);
     // ...
-  }
 }
 ```
 
@@ -124,21 +123,21 @@ The input system provides events as well, if polling data from controllers direc
 
 [`IMixedRealityHandJointHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandJointHandler) handles updates of joint positions.
 
-```csharp
+```c#
 public class MyHandJointEventHandler : IMixedRealityHandJointHandler
 {
-  public Handedness myHandedness;
+    public Handedness myHandedness;
 
-  void IMixedRealityHandJointHandler.OnHandJointsUpdated(InputEventData<IDictionary<TrackedHandJoint, MixedRealityPose>> eventData)
-  {
-    if (eventData.Handedness == myHandedness)
+    void IMixedRealityHandJointHandler.OnHandJointsUpdated(InputEventData<IDictionary<TrackedHandJoint, MixedRealityPose>> eventData)
     {
-      if (eventData.InputData.TryGetValue(TrackedHandJoint.IndexTip, out MixedRealityPose pose))
-      {
-        // ...
-      }
+        if (eventData.Handedness == myHandedness)
+        {
+            if (eventData.InputData.TryGetValue(TrackedHandJoint.IndexTip, out MixedRealityPose pose))
+            {
+                // ...
+            }
+        }
     }
-  }
 }
 ```
 
@@ -148,28 +147,28 @@ public class MyHandJointEventHandler : IMixedRealityHandJointHandler
 
 Note that hand meshes are not enabled by default.
 
-```csharp
+```c#
 public class MyHandMeshEventHandler : IMixedRealityHandMeshHandler
 {
-  public Handedness myHandedness;
-  public Mesh myMesh;
+    public Handedness myHandedness;
+    public Mesh myMesh;
 
-  public void OnHandMeshUpdated(InputEventData<HandMeshInfo> eventData)
-  {
-    if (eventData.Handedness == myHandedness)
+    public void OnHandMeshUpdated(InputEventData<HandMeshInfo> eventData)
     {
-      myMesh.vertices = eventData.InputData.vertices;
-      myMesh.normals = eventData.InputData.normals;
-      myMesh.triangles = eventData.InputData.triangles;
+        if (eventData.Handedness == myHandedness)
+        {
+            myMesh.vertices = eventData.InputData.vertices;
+            myMesh.normals = eventData.InputData.normals;
+            myMesh.triangles = eventData.InputData.triangles;
 
-      if (eventData.InputData.uvs != null && eventData.InputData.uvs.Length > 0)
-      {
-          myMesh.uv = eventData.InputData.uvs;
-      }
+            if (eventData.InputData.uvs != null && eventData.InputData.uvs.Length > 0)
+            {
+                myMesh.uv = eventData.InputData.uvs;
+            }
 
-      // ...
+            // ...
+        }
     }
-  }
 }
 ```
 

--- a/Documentation/Input/HowToAddNearInteractivity.md
+++ b/Documentation/Input/HowToAddNearInteractivity.md
@@ -26,7 +26,7 @@ Three key steps are required to listen for touch and/or grab input events on a p
 
 Below is a script that will print if an event is a touch or grab. In the relevant *IMixedRealityPointerHandler* interface function, one can look at the type of pointer that triggers that event via the [`MixedRealityPointerEventData`](xref:Microsoft.MixedReality.Toolkit.Input.MixedRealityPointerEventData). If the pointer is a *SpherePointer*, the interaction is a grab.
 
-```csharp
+```c#
 public class PrintPointerEvents : MonoBehaviour, IMixedRealityPointerHandler
 {
     public void OnPointerDown(MixedRealityPointerEventData eventData)
@@ -90,7 +90,7 @@ The default MRTK profile and the default HoloLens 2 profile already contain a *P
 
 The code below demonstrates a MonoBehavior that can be attached to a GameObject with a [`NearInteractionTouchable`](xref:Microsoft.MixedReality.Toolkit.Input.NearInteractionTouchable) variant component and respond to touch input events.
 
-```csharp
+```c#
 public class TouchEventsExample : MonoBehaviour, IMixedRealityTouchHandler
 {
     public void OnTouchStarted(HandTrackingInputEventData eventData)
@@ -109,7 +109,7 @@ public class TouchEventsExample : MonoBehaviour, IMixedRealityTouchHandler
 
 This example creates a cube, makes it touchable, and changes color on touch.
 
-```csharp
+```c#
 public static void MakeChangeColorOnTouch(GameObject target)
 {
     // Add and configure the touchable
@@ -128,7 +128,7 @@ public static void MakeChangeColorOnTouch(GameObject target)
 
 The below example shows how to make a GameObject draggable. Assumes that the game object has a collider on it.
 
-```csharp
+```c#
 public static void MakeNearDraggable(GameObject target)
 {
     // Instantiate and add grabbable

--- a/Documentation/Input/InputEvents.md
+++ b/Documentation/Input/InputEvents.md
@@ -40,7 +40,7 @@ At the script level, input events can be consumed by implementing one of the eve
 
 The code below demonstrates use of the [`IMixedRealitySpeechHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealitySpeechHandler) interface. When the user says the words "smaller" or "bigger" while focusing on a GameObject with this `ShowHideSpeechHandler` class, the GameObject will scale itself by half or twice as much.
 
-```csharp
+```c#
 public class ShowHideSpeechHandler : MonoBehavior, IMixedRealitySpeechHandler
 {
     ...
@@ -70,7 +70,7 @@ If an input event has been [marked as used](#how-to-stop-input-events), global r
 
 ### Global input registration example
 
-```csharp
+```c#
 public class GlobalHandListenerExample : MonoBehaviour,
     IMixedRealitySourceStateHandler, // Handle source detected and lost
     IMixedRealityHandJointHandler // handle joint position updates for hands
@@ -132,7 +132,7 @@ Fallback input handlers are similar to registered global input handlers but are 
 
 ### Fallback input handler example
 
-```csharp
+```c#
 public class GlobalHandListenerExample : MonoBehaviour,
     IMixedRealitySourceStateHandler // Handle source detected and lost
 {

--- a/Documentation/Input/InputState.md
+++ b/Documentation/Input/InputState.md
@@ -8,7 +8,7 @@ See the InputDataExample scene for an example of querying input both via iterati
 
 MRTK's [`InputRayUtils`](cref:Microsoft.MixedReality.Toolkit.Input.InputRayUtils) class provides convenience methods for accessing the hand ray, head ray, eye gaze ray, and motion controller rays.
 
-```csharp
+```c#
 // Get the head ray
 var headRay = InputRayUtils.GetHeadGazeRay();
 
@@ -26,7 +26,7 @@ else
 
 ## Example: Access position, rotation of all 6DOF controllers active in scene
 
-```csharp
+```c#
 foreach(var controller in CoreServices.InputSystem.DetectedControllers)
 {
     // Interactions for a controller is the list of inputs that this controller exposes

--- a/Documentation/Input/Pointers.md
+++ b/Documentation/Input/Pointers.md
@@ -161,7 +161,7 @@ Pointer input events are recognized and handled by the MRTK input system in a si
 
 Below is an example script that changes the color of the attached renderer when a pointer takes or leaves focus or when a pointer selects the object.
 
-```csharp
+```c#
 public class ColorTap : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityPointerHandler
 {
     private Color color_IdleState = Color.cyan;
@@ -201,7 +201,7 @@ public class ColorTap : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityP
 
 It is possible to gather all pointers currently active by looping through the available input sources (i.e controllers and inputs available) to discover which pointers are attached to them.
 
-```csharp
+```c#
 var pointers = new HashSet<IMixedRealityPointer>();
 
 // Find all valid pointers
@@ -221,7 +221,7 @@ foreach (var inputSource in CoreServices.InputSystem.DetectedInputSources)
 
 Developers can subscribe to the FocusProviders PrimaryPointerChanged event to be notified when the primary pointer in focus has changed. This can be extremely useful to identify if the user is currently interacting with a scene via gaze or a hand ray or other input source.
 
-```csharp
+```c#
 private void OnEnable()
 {
     var focusProvider = CoreServices.InputSystem?.FocusProvider;
@@ -251,7 +251,7 @@ The [PrimaryPointerExample scene](https://github.com/microsoft/MixedRealityToolk
 
 The pointer [`Result`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer.Result) property contains the current result for the scene query used to determine the object with focus. For a raycast pointer, like the ones created by default for motion controllers, gaze input and hand rays, it will contain the location and normal of the raycast hit.
 
-```csharp
+```c#
 private void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
 {
     var result = eventData.Pointer.Result;
@@ -268,7 +268,7 @@ The [PointerResultExample scene](https://github.com/microsoft/MixedRealityToolki
 ### Disable Pointers
 To turn enable and disable pointers (for example, to disable the hand ray), set the [`PointerBehavior`](xref:Microsoft.MixedReality.Toolkit.Input.PointerBehavior) for a given pointer type via [`PointerUtils`](xref:Microsoft.MixedReality.Toolkit.Input.PointerUtils).
 
-```csharp
+```c#
 // Disable the hand rays
 PointerUtils.SetHandRayPointerBehavior(PointerBehavior.AlwaysOff);
 

--- a/Documentation/Performance/PerfGettingStarted.md
+++ b/Documentation/Performance/PerfGettingStarted.md
@@ -132,7 +132,7 @@ For example, if there are a 100 cubes in a scene, a developer may want to assign
 
 To overcome this obstacle and still assign a unique color per cube, developers should leverage [MaterialPropertyBlock](https://docs.unity3d.com/ScriptReference/MaterialPropertyBlock.html).
 
-```csharp
+```c#
 private PropertyBlock m_PropertyBlock ;
 private Renderer myRenderer;
 

--- a/Documentation/README_BoundingBox.md
+++ b/Documentation/README_BoundingBox.md
@@ -24,61 +24,67 @@ You can find examples of Bounding Box configurations in the `BoundingBoxExamples
 ![Bounding Box](../Documentation/Images/BoundingBox/MRTK_BoundingBox_Assign.png)
 
 ## How to add and configure a bounding box in the code
-1. Instantiate cube gameobject
-```csharp
-   GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-```
-1. Assign `BoundingBox` script to an object with collider, using AddComponent<>()
-```csharp
-   private BoundingBox bbox;
-   bbox = cube.AddComponent<BoundingBox>();
-```
-1. Configure options (see [Inspector properties](#inspector-properties) section below)
-```csharp
-   // Make the scale handles large
-   bbox.ScaleHandleSize = 0.1f;
-   // Hide rotation handles
-   bbox.ShowRotationHandleForX = false;
-   bbox.ShowRotationHandleForY = false;
-   bbox.ShowRotationHandleForZ = false;
-```
 
-1. (Optional) Assign prefabs and materials for HoloLens 2 style Bounding Box. This still requires assignments through the inspector since the materials and prefabs should be dynamically loaded. 
+1. Instantiate cube GameObject
+
+    ```c#
+    GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+    ```
+
+1. Assign `BoundingBox` script to an object with collider, using AddComponent<>()
+
+    ```c#
+    private BoundingBox bbox;
+    bbox = cube.AddComponent<BoundingBox>();
+    ```
+
+1. Configure options (see [Inspector properties](#inspector-properties) section below)
+
+    ```c#
+    // Make the scale handles large
+    bbox.ScaleHandleSize = 0.1f;
+    // Hide rotation handles
+    bbox.ShowRotationHandleForX = false;
+    bbox.ShowRotationHandleForY = false;
+    bbox.ShowRotationHandleForZ = false;
+    ```
+
+1. (Optional) Assign prefabs and materials for HoloLens 2 style Bounding Box. This still requires assignments through the inspector since the materials and prefabs should be dynamically loaded.
 
 > [!NOTE]
 > Using Unity's 'Resources' folder or [Shader.Find]( https://docs.unity3d.com/ScriptReference/Shader.Find.html) for dynamically loading shaders is not recommended since shader permutations may be missing at runtime.
 
-```csharp
-   bbox.BoxMaterial = [Assign BoundingBox.mat]
-   bbox.BoxGrabbedMaterial = [Assign BoundingBoxGrabbed.mat]
-   bbox.HandleMaterial = [Assign BoundingBoxHandleWhite.mat]
-   bbox.HandleGrabbedMaterial = [Assign BoundingBoxHandleBlueGrabbed.mat]
-   bbox.ScaleHandlePrefab = [Assign MRTK_BoundingBox_ScaleHandle.prefab]
-   bbox.ScaleHandleSlatePrefab = [Assign MRTK_BoundingBox_ScaleHandle_Slate.prefab]
-   bbox.ScaleHandleSize = 0.016f;
-   bbox.ScaleHandleColliderPadding = 0.016f;
-   bbox.RotationHandleSlatePrefab = [Assign MRTK_BoundingBox_RotateHandle.prefab]
-   bbox.RotationHandleSize = 0.016f;
-   bbox.RotateHandleColliderPadding = 0.016f;
+```c#
+bbox.BoxMaterial = [Assign BoundingBox.mat]
+bbox.BoxGrabbedMaterial = [Assign BoundingBoxGrabbed.mat]
+bbox.HandleMaterial = [Assign BoundingBoxHandleWhite.mat]
+bbox.HandleGrabbedMaterial = [Assign BoundingBoxHandleBlueGrabbed.mat]
+bbox.ScaleHandlePrefab = [Assign MRTK_BoundingBox_ScaleHandle.prefab]
+bbox.ScaleHandleSlatePrefab = [Assign MRTK_BoundingBox_ScaleHandle_Slate.prefab]
+bbox.ScaleHandleSize = 0.016f;
+bbox.ScaleHandleColliderPadding = 0.016f;
+bbox.RotationHandleSlatePrefab = [Assign MRTK_BoundingBox_RotateHandle.prefab]
+bbox.RotationHandleSize = 0.016f;
+bbox.RotateHandleColliderPadding = 0.016f;
 ```
 
 ### Example: Set minimum, maximum bounding box scale using TransformScaleHandler
 To set the minimum and maximum scale, use the [`TransformScaleHandler`](cref:Microsoft.MixedReality.Toolkit.UI.TransformScaleHander). You can also use TransformScaleHandler to set minimum and maximum scale for [`ManipulationHandler`](cref:Microsoft.MixedReality.Toolkit.UI.ManipulationHandler).
 
-```csharp
-   GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-   bbox = cube.AddComponent<BoundingBox>();
-   // Important: BoundingBox creates a scale handler on start if one does not exist
-   // do not use AddComponent, as that will create a  duplicate handler that will not be used 
-   TransformScaleHandler scaleHandler = bbox.gameObject.GetComponent<TransformScaleHandler>();
-   scaleHandler.ScaleMinimum = 1f;
-   scaleHandler.ScaleMaximum = 2f;
+```c#
+GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+bbox = cube.AddComponent<BoundingBox>();
+// Important: BoundingBox creates a scale handler on start if one does not exist
+// do not use AddComponent, as that will create a  duplicate handler that will not be used
+TransformScaleHandler scaleHandler = bbox.gameObject.GetComponent<TransformScaleHandler>();
+scaleHandler.ScaleMinimum = 1f;
+scaleHandler.ScaleMaximum = 2f;
 ```
 
 ## Example: Add bounding box around a game object
 To add a bounding box around an object, just add a bounding box component to it:
 
-```csharp
+```c#
 private void PutABoxAroundIt(GameObject target)
 {
    target.AddComponent<BoundingBox>();

--- a/Documentation/README_ExampleHub.md
+++ b/Documentation/README_ExampleHub.md
@@ -37,7 +37,8 @@ In the **LoadContentScene** script's Inspector, you can define the scene name to
 
 The script uses the Scene System's LoadContent() function to load the scene. 
 Please refer to the [Scene System](SceneSystem/SceneSystemGettingStarted.md) page for more details.
-```csharp
+
+```c#
 MixedRealityToolkit.SceneSystem.LoadContent(contentName, loadSceneMode);
 ```
  

--- a/Documentation/README_Interactable.md
+++ b/Documentation/README_Interactable.md
@@ -147,7 +147,7 @@ Custom events can be created in two main ways:
 
 The [`CustomInteractablesReceiver`](xref:Microsoft.MixedReality.Toolkit.UI) class under `MixedRealityToolkit.Examples` displays status information about an *Interactable* and is an example how to create a custom Event Receiver.
 
-``` csharp
+```c#
 public CustomInteractablesReceiver(UnityEvent ev) : base(ev, "CustomEvent")
 {
     HideUnityEvents = true; // hides Unity events in the receiver - meant to be code only
@@ -156,7 +156,7 @@ public CustomInteractablesReceiver(UnityEvent ev) : base(ev, "CustomEvent")
 
 The following methods are useful to override/implement when creating a custom Event Receiver. [`ReceiverBase.OnUpdate()`](xref:Microsoft.MixedReality.Toolkit.UI.ReceiverBase) is an abstract method that can be used to detect state patterns/transitions. Furthermore, the [`ReceiverBase.OnVoiceCommand()`](xref:Microsoft.MixedReality.Toolkit.UI.ReceiverBase) and [`ReceiverBase.OnClick()`](xref:Microsoft.MixedReality.Toolkit.UI.ReceiverBase) methods are useful for creating custom event logic when the *Interactable* is selected.
 
-``` csharp
+```c#
 public override void OnUpdate(InteractableStates state, Interactable source)
 {
     if (state.CurrentState() != lastState)
@@ -187,7 +187,7 @@ public virtual void OnClick(InteractableStates state,
 
 *ReceiverBase* scripts use [`InspectorField`](xref:Microsoft.MixedReality.Toolkit.Utilities.Editor.InspectorField) attributes to expose custom properties in the inspector. Here's an example of Vector3 a custom property with tooltip and label information. This property will show up as configurable in the inspector when an *Interactable* GameObject is selected and has the associated *Event Receiver* type added.
 
-```csharp
+```c#
 [InspectorField(Label = "<Property label>",Tooltip = "<Insert tooltip info>",Type = InspectorField.FieldTypes.Vector3)]
 public Vector3 EffectOffset = Vector3.zero;
 ```
@@ -217,7 +217,7 @@ While the [`SelectionMode`](xref:Microsoft.MixedReality.Toolkit.UI.SelectionMode
 
 Developers can utilize the [`SetToggled`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable) and [`IsToggled`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable) interfaces to get/set the toggle state of an *Interactable* via code.
 
-```csharp
+```c#
 // If using SelectionMode = Toggle (i.e Dimensions == 2)
 
 // Make the Interactable selected and toggled on
@@ -255,7 +255,7 @@ Every click event will advance the `DimensionIndex` by 1 at runtime until the `D
 
 Developers can assess the [`DimensionIndex`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable) to determine which dimension is currently active.
 
-```csharp
+```c#
 // If using SelectionMode = Multi-dimension (i.e Dimensions >= 3)
 
 //Access the current DimensionIndex
@@ -272,7 +272,7 @@ myInteractable.IncreaseDimension();
 
 *Interactable* can be easily added to any GameObject at runtime. The following example demonstrates how to assign a profile with a [visual theme](visualthemes.md).
 
-```csharp
+```c#
 var interactableObject = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
 var interactable = interactableObject.AddComponent<Interactable>();
 
@@ -308,7 +308,7 @@ interactable.TriggerOnClick()
 
 One can add an action to the base [`Interactable.OnClick`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable.OnClick) event via code with the following example.
 
-```csharp
+```c#
 public static void AddOnClick(Interactable interactable)
 {
     interactable.OnClick.AddListener(() => Debug.Log("Interactable clicked"));
@@ -319,7 +319,7 @@ Use the [`Interactable.AddReceiver<T>()`](xref:Microsoft.MixedReality.Toolkit.UI
 
 The example code below demonstrates how to add an [InteractableOnFocusReceiver](xref:Microsoft.MixedReality.Toolkit.UI.InteractableOnFocusReceiver), which listens for focus enter/exit, and furthermore define action code to perform when the event instances fire.
 
-```csharp
+```c#
 public static void AddFocusEvents(Interactable interactable)
 {
     var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
@@ -331,7 +331,7 @@ public static void AddFocusEvents(Interactable interactable)
 
 The example code below demonstrates how to add an [InteractableOnToggleReceiver](xref:Microsoft.MixedReality.Toolkit.UI.InteractableOnFocusReceiver), which listens for selected/deselected state transitions on toggle-able *Interactables*, and furthermore define action code to perform when the event instances fire.
 
-```csharp
+```c#
 public static void AddToggleEvents(Interactable interactable)
 {
     var toggleReceiver = interactable.AddReceiver<InteractableOnToggleReceiver>();

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -65,7 +65,7 @@ All solvers must inherit from the abstract base class, [`Solver`](xref:Microsoft
 
 The code provided below gives an example of a new Solver component called `InFront` that places the attached object 2m in front of the `SolverHandler.TransformTarget`. If the `SolverHandler.TrackedTargetType` is set by the consumer as [`Head`](xref:Microsoft.MixedReality.Toolkit.Utilities.TrackedObjectType.Head), then the `SolverHandler.TransformTarget` will be the camera transform and thus this Solver will place the attached GameObject 2m in front of the users' gaze every frame.
 
-```csharp
+```c#
 /// <summary>
 /// InFront solver positions an object 2m in front of the tracked transform target
 /// </summary>

--- a/Documentation/README_SystemKeyboard.md
+++ b/Documentation/README_SystemKeyboard.md
@@ -6,33 +6,32 @@ A Unity application can invoke the system keyboard at any time. Note that the sy
 
 ## How to invoke the system keyboard ##
 
-``` csharp
-    public TouchScreenKeyboard keyboard;
+```c#
+public TouchScreenKeyboard keyboard;
 
-    ...
+...
 
-    public void OpenSystemKeyboard()
-    {
-        keyboard = TouchScreenKeyboard.Open("", TouchScreenKeyboardType.Default, false, false, false, false);
-    }
+public void OpenSystemKeyboard()
+{
+    keyboard = TouchScreenKeyboard.Open("", TouchScreenKeyboardType.Default, false, false, false, false);
+}
 ```
 
 ## How to read the input ##
 
-``` csharp
+```c#
+public TouchScreenKeyboard keyboard;
 
-    public TouchScreenKeyboard keyboard;
+...
 
-    ...
-
-    private void Update()
+private void Update()
+{
+    if (keyboard != null)
     {
-        if (keyboard != null)
-        {
-            keyboardText = keyboard.text;
-            // Do stuff with keyboardText
-        }
+        keyboardText = keyboard.text;
+        // Do stuff with keyboardText
     }
+}
 ```
 
 ## System keyboard example ##

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -447,7 +447,7 @@ See [change 5562](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/55
 
 We have had many requests for how to disable the far interaction (line pointer, hand rays, etc) at runtime. We now provide a one-line command to turn pointers on and off.
 
-```csharp
+```c#
 // Turn off all hand rays
 PointerUtils.SetHandRayPointerBehavior(PointerBehavior.AlwaysOff);
 
@@ -469,7 +469,7 @@ We had feedback that it's difficult to find out where the hand is pointing, or w
 
 Please see [change 5944](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5944) for details.
 
-```csharp
+```c#
 // Get the head ray
 var headRay = InputRayUtils.GetHeadGazeRay();
 
@@ -489,7 +489,7 @@ It's now possible to instantiate and configure interactable from code. See [chan
 
 It's now easier to add event listeners from code. Here's an example of how to add focus enter/exit events:
 
-```csharp
+```c#
 public static void AddFocusEvents(Interactable interactable)
 {
     var onFocusReceiver = interactable.AddReceiver<InteractableOnFocusReceiver>();
@@ -543,7 +543,7 @@ The `CollierNearInteractionTouchable` class is now obsolete. Replace all usages 
 
 Interactable has been upgraded to be configurable from code. The following methods in `Interactable` are now marked Obsolete:
 
-```csharp
+```c#
 public void ResetBaseStates()
 public int GetDimensionIndex()
 public void SetDimensionIndex(int index)

--- a/Documentation/Rendering/MaterialInstance.md
+++ b/Documentation/Rendering/MaterialInstance.md
@@ -8,7 +8,7 @@ The [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialI
 
 Why can using [Renderer.material]("https://docs.unity3d.com/ScriptReference/Renderer-material.html") be an issue? If you add the below code to a Unity scene and hit play memory usage will continue to climb and climb:
 
-```csharp
+```c#
 public class Leak : MonoBehaviour
 {
     private void Update()
@@ -27,7 +27,7 @@ public class Leak : MonoBehaviour
 
 As an alternative try using the [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) behavior:
 
-```csharp
+```c#
 public class NoLeak : MonoBehaviour
 {
     private void Update()
@@ -47,7 +47,7 @@ When invoking Unity's [Renderer.material]("https://docs.unity3d.com/ScriptRefere
 
 When a [MaterialPropertyBlock](https://docs.unity3d.com/ScriptReference/MaterialPropertyBlock.html) can not be used and a material must be instanced, [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) can be used as follows:
 
-```csharp
+```c#
 public class MyBehaviour : MonoBehaviour
 {
     // Assigned via the inspector. 
@@ -63,7 +63,7 @@ public class MyBehaviour : MonoBehaviour
 ```
 If multiple objects need ownership of the material instance it's best to take explicit ownership for reference tracking. (An optional interface called [`IMaterialInstanceOwner`](xref:Microsoft.MixedReality.Toolkit.Rendering.IMaterialInstanceOwner) exists to aide with ownership.) Below is example usage:
 
-```csharp
+```c#
 public class MyBehaviour : MonoBehaviour,  IMaterialInstanceOwner
 {
     // Assigned via the inspector. 

--- a/Documentation/SceneSystem/SceneSystemContentLoading.md
+++ b/Documentation/SceneSystem/SceneSystemContentLoading.md
@@ -5,7 +5,7 @@ All content load operations are asynchronous, and by default all content loading
 
 To load content scenes use the `LoadContent` method:
 
-```
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
 // Additively load a single content scene
@@ -18,7 +18,7 @@ await sceneSystem.LoadContent(new string[] { "MyContentScene1", "MyContentScene2
 ## Single Scene Loading
 The equivalent of a single scene load can be achieved via the optional `mode` argument. `LoadSceneMode.Single` will first unload all loaded content scenes before proceeding with the load.
 
-```
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
 // ContentScene1, ContentScene2 and ContentScene3 will be loaded additively
@@ -37,10 +37,11 @@ Content can be singly loaded in order of build index. This is useful for showcas
 ![MRTK_SceneSystemBuildSettings](../Images/SceneSystem/MRTK_SceneSystemBuildSettings.png)
 
 Note that next / prev content loading uses LoadSceneMode.Single by default to ensure that the previous content is unloaded.
-```
+
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
-if (nextSceneRequested && sceneSystem.NextContentExists) 
+if (nextSceneRequested && sceneSystem.NextContentExists)
 {
     await sceneSystem.LoadNextContent();
 }
@@ -53,10 +54,11 @@ if (prevSceneRequested && sceneSystem.PrevContentExists)
 `PrevContentExists` will return true if there is at least one content scene that has a lower build index than the lowest build index currently loaded. `NextContentExists` will return true if there is at least one content scene that has a higher build index than the highest build index currently loaded.
 
 If the `wrap` argument is true, content will loop back to the first / last build index. This removes the need to check for next / previous content:
-```
+
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
-if (nextSceneRequested) 
+if (nextSceneRequested)
 {
     await sceneSystem.LoadNextContent(true);
 }
@@ -72,7 +74,7 @@ if (prevSceneRequested)
 
 It's sometimes desirable to load content scenes in groups. Eg, a stage of an experience may be composed of multiple scenes, all of which must be loaded simultaneously to function. To facilitate this, you can tag your scenes and then load them or unload them with that tag.
 
-```
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
 await LoadContentByTag("Stage1");
@@ -84,7 +86,8 @@ await LoadContentByTag("Stage2);
 ```
 
 Loading by tag can also be useful if artists want to incorporate / remove elements from an experience without having to modify scripts. For instance, running this script with the following two sets of tags produces different results:
-```
+
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
 await LoadContentByTag("Terrain");

--- a/Documentation/SceneSystem/SceneSystemLightingScenes.md
+++ b/Documentation/SceneSystem/SceneSystemLightingScenes.md
@@ -1,14 +1,15 @@
 # Lighting Scene Operations
 The default lighting scene defined in your profile is loaded on startup. That lighting scene remains loaded until `SetLightingScene` is called.
 
-```
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
 sceneSystem.SetLightingScene("MorningLighting");
 ```
 ## Lighting Setting Transitions
 `transitionType` controls the style of the transition to new lighting scene.
-```
+
+```c#
 IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<IMixedRealitySceneSystem>();
 
 sceneSystem.SetLightingScene("MiddayLighting", LightingSceneTransitionType.CrossFade);

--- a/Documentation/ServiceUtilities/MixedRealityServiceRegistryAndIMixedRealityServiceRegistrar.md
+++ b/Documentation/ServiceUtilities/MixedRealityServiceRegistryAndIMixedRealityServiceRegistrar.md
@@ -19,7 +19,7 @@ use to acquire service instances in application code.
 
 The following snippet demonstrates acquiring an IMixedRealityInputSystem instance.
 
-```
+```c#
 IMixedRealityInputSystem inputSystem = null;
 
 if (!MixedRealityServiceRegistry.TryGetService<IMixedRealityInputSystem>(out inputSystem))

--- a/Documentation/SpatialAwareness/CreateDataProvider.md
+++ b/Documentation/SpatialAwareness/CreateDataProvider.md
@@ -68,7 +68,7 @@ All Spatial Awareness data providers must implement the [`IMixedRealitySpatialAw
 interface, which specifies the minimium functionality required by the Spatial Awareness system. The MRTK foundation includes the [`BaseSpatialObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.BaseSpatialObserver)
 class which provides a default implementation of this required functionality.
 
-``` c#
+```c#
 public class SpatialObjectMeshObserver :
     BaseSpatialObserver,
     IMixedRealitySpatialAwarenessMeshObserver,
@@ -84,7 +84,7 @@ public class SpatialObjectMeshObserver :
 A key step in creating a Spatial Awareness data provider is to apply the [`MixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.MixedRealityDataProviderAttribute)
 attribute to the class. This step enables setting the default profile and platform(s) for the data provider, when selected in the Spatial Awareness profile as well as Name, folder path, and more.
 
-``` c#
+```c#
 [MixedRealityDataProvider(
     typeof(IMixedRealitySpatialAwarenessSystem),
     SupportedPlatforms.WindowsEditor | SupportedPlatforms.MacEditor | SupportedPlatforms.LinuxEditor,
@@ -129,7 +129,7 @@ To allow applications to respond to changes in the device's understanding of the
 
  The following code from the [`SpatialObjectMeshObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.SpatialObjectMeshObserver) examples demonstrates raising and event when mesh data is added.
 
-```csharp
+```c#
 // The data to be sent when mesh observation events occur.
 // This member variable is initialized as part of the Initialize() method.
 private MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> meshEventData = null;
@@ -186,7 +186,7 @@ Profile contents should mirror the accessible properties of the data provider (e
 
 Base classes are encouraged if a new data provider extends an existing provider. For example, the [`SpatialObjectMeshObserverProfile`](xref:Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.SpatialObjectMeshObserverProfile) extends the [`MixedRealitySpatialAwarenessMeshObserverProfile`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.MixedRealitySpatialAwarenessMeshObserverProfile) to enable customers to provide a 3D model to be used as the environment data.
 
-```csharp
+```c#
 [CreateAssetMenu(
     menuName = "Mixed Reality Toolkit/Profiles/Spatial Object Mesh Observer Profile",
     fileName = "SpatialObjectMeshObserverProfile",
@@ -212,7 +212,7 @@ Profile inspectors are the user interface for configuring and viewing profile co
 
 The `CustomEditor` attribute informs Unity the type of asset to which the inspector applies.
 
-```csharp
+```c#
 [CustomEditor(typeof(SpatialObjectMeshObserverProfile))]
 public class SpatialObjectMeshObserverProfileInspector : BaseMixedRealityToolkitConfigurationProfileInspector
 { }

--- a/Documentation/SpatialAwareness/UsageGuide.md
+++ b/Documentation/SpatialAwareness/UsageGuide.md
@@ -8,7 +8,7 @@ Mesh Observer classes that implement the [`IMixedRealitySpatialAwarenessMeshObse
 
 Accessing the data providers of the Spatial Awareness system is mostly the same as for any other Mixed Reality Toolkit service. The Spatial Awareness service must be casted to the [`IMixedRealityDataProviderAccess`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityDataProviderAccess) interface to access via the `GetDataProvider<T>` APIs, which can then be utilized to access the Mesh Observer objects directly at runtime.
 
-```csharp
+```c#
 // Use CoreServices to quickly get access to the IMixedRealitySpatialAwarenessSystem
 var spatialAwarenessService = CoreServices.SpatialAwarenessSystem;
 
@@ -27,7 +27,7 @@ var spatialObjectMeshObserver = dataProviderAccess.GetDataProvider<IMixedReality
 
 One of the most common tasks when dealing with the Spatial Awareness system is turning the feature off/on dynamically at runtime. This is done per Observer via the [`IMixedRealitySpatialAwarenessObserver.Resume`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.IMixedRealitySpatialAwarenessObserver.Resume) and [`IMixedRealitySpatialAwarenessObserver.Suspend`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.IMixedRealitySpatialAwarenessObserver.Suspend) APIs.
 
-```csharp
+```c#
 // Cast the Spatial Awareness system to IMixedRealityDataProviderAccess to get an Observer
 var access = CoreServices.SpatialAwarenessSystem as IMixedRealityDataProviderAccess;
 
@@ -43,7 +43,7 @@ observer.Resume();
 
 This code functionality can also be simplified via access through the Spatial Awareness system directly.
 
-```csharp
+```c#
 var meshObserverName = "Spatial Object Mesh Observer";
 CoreServices.SpatialAwarenessSystem.ResumeObserver<IMixedRealitySpatialAwarenessMeshObserver>(meshObserverName);
 ```
@@ -52,7 +52,7 @@ CoreServices.SpatialAwarenessSystem.ResumeObserver<IMixedRealitySpatialAwareness
 
 It is generally convenient to start/stop all mesh observation in the application. This can be achieved through the helpful Spatial Awareness system APIs, [`ResumeObservers()`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.IMixedRealitySpatialAwarenessSystem.ResumeObservers) and [`SuspendObservers()`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.IMixedRealitySpatialAwarenessSystem.SuspendObservers).
 
-```csharp
+```c#
 // Resume Mesh Observation from all Observers
 CoreServices.SpatialAwarenessSystem.ResumeObservers();
 
@@ -69,7 +69,7 @@ If running in editor, one can use the [`AssetDatabase.CreateAsset()`](https://do
 
 If running on device, there are many community and store plugins available to serialize the `MeshFilter` data into a model file type([OBJ Example](http://wiki.unity3d.com/index.php/ObjExporter)).
 
-```csharp
+```c#
 // Cast the Spatial Awareness system to IMixedRealityDataProviderAccess to get an Observer
 var access = CoreServices.SpatialAwarenessSystem as IMixedRealityDataProviderAccess;
 
@@ -88,7 +88,7 @@ foreach (SpatialAwarenessMeshObject meshObject in observer.Meshes.Values)
 
 It's possible to programmatically hide/show meshes using the sample code below:
 
-```csharp
+```c#
 // Cast the Spatial Awareness system to IMixedRealityDataProviderAccess to get an Observer
 var access = CoreServices.SpatialAwarenessSystem as IMixedRealityDataProviderAccess;
 
@@ -110,7 +110,7 @@ The [DemoSpatialMeshHandler](https://github.com/microsoft/MixedRealityToolkit-Un
 
 This is a simplified example of *DemoSpatialMeshHandler* script and Mesh Observation event listening.
 
-```csharp
+```c#
 // Simplify type
 using SpatialAwarenessHandler = IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>;
 

--- a/Documentation/TeleportSystem/Overview.md
+++ b/Documentation/TeleportSystem/Overview.md
@@ -13,7 +13,7 @@ This can be done by selecting the MixedRealityToolkit object in the scene, click
 
 This can also be done at runtime:
 
-```csharp
+```c#
 void DisableTeleportSystem()
 {
     CoreServices.TeleportSystem.Disable();
@@ -39,7 +39,7 @@ and their associated payload.
 The code below shows how to create a MonoBehaviour that will listen for teleportation
 events. This code assumes that the teleport system is enabled.
 
-```csharp
+```c#
 using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Teleport;
 using UnityEngine;

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -211,7 +211,7 @@ New API `RegisterHandler` and `UnregisterHandler`:
 
 **_Examples of migration_**
 
-```csharp
+```c#
 // Old
 class SampleHandler : MonoBehaviour, IMixedRealitySourceStateHandler, IMixedRealityHandJointHandler
 {
@@ -243,7 +243,7 @@ class SampleHandler : MonoBehaviour, IMixedRealitySourceStateHandler, IMixedReal
 }
 ```
 
-```csharp
+```c#
 // Old
 class SampleHandler2 : InputSystemGlobalListener, IMixedRealitySpeechHandler
 {

--- a/Documentation/VisualThemes.md
+++ b/Documentation/VisualThemes.md
@@ -59,7 +59,7 @@ To help expedite development, the following helper methods are useful for simpli
 
 [`ThemeDefinition.GetDefaultThemeDefinition<T>()`](xref:Microsoft.MixedReality.Toolkit.UI.ThemeDefinition) - Every Theme Engine defines a default configuration with the correct properties needed for that Theme runtime type. This helper creates a definition for the given Theme Engine type.
 
-```csharp
+```c#
 // This code example builds a Theme ScriptableObject that can be used with an Interactable component.
 // A random color is selected for the on pressed state every time this code is executed.
 
@@ -158,7 +158,7 @@ If the custom Theme Engine can support targeting shader properties. It is recomm
 
 The class below is an example of a custom new Theme Engine. This implementation will find a [MeshRenderer](https://docs.unity3d.com/ScriptReference/MeshRenderer.html) component on the initialized host object and control it's visibility based on the current state.
 
-```csharp
+```c#
 using Microsoft.MixedReality.Toolkit.UI;
 using System;
 using System.Collections.Generic;
@@ -236,7 +236,7 @@ Extending off of the custom Theme Engine defined in the earlier section, the cod
 > [!NOTE]
 > `theme.OnUpdate(state,force)` should generally be called in the Update() method to support Theme Engines that utilize easing/lerping between values.
 
-```csharp
+```c#
 using Microsoft.MixedReality.Toolkit.UI;
 using System;
 using System.Collections.Generic;

--- a/Documentation/hologram-stabilization.md
+++ b/Documentation/hologram-stabilization.md
@@ -102,7 +102,7 @@ Devices such as HoloLens are constantly scanning and learning about the environm
 > [!NOTE]
 > Once a WorldAnchor component has been added to a GameObject, it is not possible to modify that GameObject's transform (i.e transform.position = x). A developer must remove the WorldAnchor to edit the transform.
 
-```csharp
+```c#
 WorldAnchor m_anchor;
 
 public void AddAnchor()


### PR DESCRIPTION
## Overview

Updates all examples of the MarkDown ` ```c#`, ` ```csharp`, and ` ```cs` syntax to ` ```c#`, for consistency.