### PR TITLE
Add missing links, convert some crefs into xrefs, add alt text to images

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md
@@ -10,7 +10,7 @@ Simply drop these prefabs into a scene, add the desired objects, and press "Upda
 ### Prerequisites
 
 - All objects in collection must use the MRTK standard shader
-- Every object in the collection must have a collider with a <see cref="NearInteractionTouchable"/>. All collision testing is currently done using these collidables, ScrollingObjectCollection does not yet support a static/nonmoving backing collider.
+- Every object in the collection must have a collider with a [`NearInteractionTouchable`](xref:Microsoft.MixedReality.Toolkit.Input.NearInteractionTouchable). All collision testing is currently done using these collidables, ScrollingObjectCollection does not yet support a static/nonmoving backing collider.
 - All objects in collection need to be the same size currently, additionally you may get unexpected results if your objects aren't centered in a gameObject.
 - For a seamless touchable surface, the 'cell size' in the scrolling collection should match the size of every object in the collection.
  

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/README.md
@@ -14,7 +14,7 @@ The framework is flexible enough to allow you to provide offsets to rotate and r
 
 Using the visualizer is extremely simple, just add it to an existing GameObject in your scene and provided you have configured your controller correctly, they will simply be instantiated into the scene at runtime when controllers are detected.
 
-![](../../../../../../Documentation/Images/ControllerVisualizer/ControllerVisualizerInspector.png)
+![Controller visualizer inspector](../../../../../../Documentation/Images/ControllerVisualizer/ControllerVisualizerInspector.png)
 
 Check the documentation on configuring Controller Profiles for more details:
 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
@@ -90,7 +90,7 @@ These are different for each controller type, as shown below:
 
 The Action each input can perform, is completely up to you.
 
-> See the [Input Action]() configuration profile for more information.
+> See the [Input Action configuration profile](..\..\..\Documentation\Input\InputActions.md) for more information.
 
 ## Example Models
 ---

--- a/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
@@ -2,15 +2,15 @@
 
 When you need to use input controllers for your Mixed Reality project, they are registered and configured centrally within the Controller configuration profile as you can see here:
 
-![](../../../Documentation/Images/ControllerConfigurationProfile/01-MixedRealityControllerConfigurationProfileInspector.png)
+![Configuration profile inspector](../../../Documentation/Images/ControllerConfigurationProfile/01-MixedRealityControllerConfigurationProfileInspector.png)
 
 This enables you to very quickly define which SDK's / controllers you want to support in your project and configure how each are intended to work.
 
 The configuration is broken down in to several key components, as detailed below:
 
 ## Main Controller Template definition
----
-![](../../../Documentation/Images/ControllerConfigurationProfile/02-ControllerTemplateDefinition.png)
+
+![Controller model definition](../../../Documentation/Images/ControllerConfigurationProfile/02-ControllerTemplateDefinition.png)
 
 In the first section of the configuration, the options are detailed as follows:
 
@@ -33,10 +33,10 @@ To alter the position and rotation of the displayed model in relation to the Con
 This enables you to add a new controller definition (detailed below) to the profile to add another supported SDK.
 
 ## Controller Template
----
-![](../../../Documentation/Images/ControllerConfigurationProfile/03-ControllerTemplate.png)
 
-Each controller template allows you to configure any of the supported controllers for the various SDK's that have been enabled through the Mixed Reality Toolkit.
+![Controller template](../../../Documentation/Images/ControllerConfigurationProfile/03-ControllerTemplate.png)
+
+Each controller template allows you to configure any of the supported controllers for the various SDKs that have been enabled through the Mixed Reality Toolkit.
 Each controller is added by SDK and the prevailing hand.
 
 > Any SDK Controller types or hands NOT configured will not be detected or used in a running project.
@@ -84,7 +84,7 @@ These are different for each controller type, as shown below:
 
 | Motion Controller | Oculus Touch | Vive Wand |
 |---|---|---|
-|![](../../../Documentation/Images/ControllerConfigurationProfile/04-WMRInteractions.png)|![](../../../Documentation/Images/ControllerConfigurationProfile/05-OculusTouchInteractions.png)|![](../../../Documentation/Images/ControllerConfigurationProfile/06-ViveWandInteractions.png)|
+|![Windows Mixed Reality interactions](../../../Documentation/Images/ControllerConfigurationProfile/04-WMRInteractions.png)|![Oculus Touch interactions](../../../Documentation/Images/ControllerConfigurationProfile/05-OculusTouchInteractions.png)|![Vive Wand interactions](../../../Documentation/Images/ControllerConfigurationProfile/06-ViveWandInteractions.png)|
 
 > In the future custom mappings may become available, for now they are defined per the devices own specification according to the input definitions set out by Unity
 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
@@ -90,7 +90,7 @@ These are different for each controller type, as shown below:
 
 The Action each input can perform, is completely up to you.
 
-> See the [Input Action configuration profile](..\..\..\Documentation\Input\InputActions.md) for more information.
+> See the [Input Action configuration profile](../../../Documentation/Input/InputActions.md) for more information.
 
 ## Example Models
 ---

--- a/Assets/MixedRealityToolkit.SDK/Profiles/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/README.md
@@ -5,11 +5,11 @@ This folder contains example MRTK profiles used to configure your solution.
 
 This includes:
 
-## [MixedRealityConfigurationProfile]()
+## [MixedRealityConfigurationProfile](..\..\..\Documentation\MixedRealityConfigurationGuide.md)
 
 The main configuration profile for the Mixed Reality Toolkit, hosting the start up and manager initialization options for the framework.
 
-## [MixedRealityInputActionsProfile]()
+## [MixedRealityInputActionsProfile](..\..\..\Documentation\Input\InputActions.md)
 
 Input Actions catalogue for your project, defining the logical actions your project will perform for any given input / axis type
 
@@ -19,14 +19,14 @@ Central configuration file for controllers to be used in your project. Allows th
 
 Additionally, allows you to set the models to be used for those controllers, whether they are the SDK's default, a single generic model per hand or specific models for each controller type.
 
-## [MixedRealityCameraProfile]()
+## [MixedRealityCameraProfile](..\..\..\Documentation\CameraSystem\CameraSystemOverview.md)
 
 Camera profile options for the project, including clipping and skybox settings.
 
-## [MixedRealitySpeechCommandsProfile]()
+## [MixedRealitySpeechCommandsProfile](..\..\..\Documentation\Input\Speech.md)
 
 Similar to the Input Actions, allows you to define a set of recognised keywords and assign them to logical Input actions in your project.
 
-## [MixedRealityDiagnosticsProfile]()
+## [MixedRealityDiagnosticsProfile](..\..\..\Documentation\Diagnostics\ConfiguringDiagnostics.md)
 
 Configuration for showing diagnostic data while using your project.

--- a/Assets/MixedRealityToolkit.SDK/Profiles/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/README.md
@@ -5,11 +5,11 @@ This folder contains example MRTK profiles used to configure your solution.
 
 This includes:
 
-## [MixedRealityConfigurationProfile](..\..\..\Documentation\MixedRealityConfigurationGuide.md)
+## [MixedRealityConfigurationProfile](../../../Documentation/MixedRealityConfigurationGuide.md)
 
 The main configuration profile for the Mixed Reality Toolkit, hosting the start up and manager initialization options for the framework.
 
-## [MixedRealityInputActionsProfile](..\..\..\Documentation\Input\InputActions.md)
+## [MixedRealityInputActionsProfile](../../../Documentation/Input/InputActions.md)
 
 Input Actions catalogue for your project, defining the logical actions your project will perform for any given input / axis type
 
@@ -19,14 +19,14 @@ Central configuration file for controllers to be used in your project. Allows th
 
 Additionally, allows you to set the models to be used for those controllers, whether they are the SDK's default, a single generic model per hand or specific models for each controller type.
 
-## [MixedRealityCameraProfile](..\..\..\Documentation\CameraSystem\CameraSystemOverview.md)
+## [MixedRealityCameraProfile](../../../Documentation/CameraSystem/CameraSystemOverview.md)
 
 Camera profile options for the project, including clipping and skybox settings.
 
-## [MixedRealitySpeechCommandsProfile](..\..\..\Documentation\Input\Speech.md)
+## [MixedRealitySpeechCommandsProfile](../../../Documentation/Input/Speech.md)
 
 Similar to the Input Actions, allows you to define a set of recognised keywords and assign them to logical Input actions in your project.
 
-## [MixedRealityDiagnosticsProfile](..\..\..\Documentation\Diagnostics\ConfiguringDiagnostics.md)
+## [MixedRealityDiagnosticsProfile](../../../Documentation/Diagnostics/ConfiguringDiagnostics.md)
 
 Configuration for showing diagnostic data while using your project.

--- a/Documentation/Architecture/SystemsExtensionsProviders.md
+++ b/Documentation/Architecture/SystemsExtensionsProviders.md
@@ -9,7 +9,7 @@ Systems are services that provide the core functionality of the Mixed Reality To
 [`IMixedRealityService`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityService) interface.
 
 - [BoundarySystem](../Boundary/BoundarySystemGettingStarted.md)
-- CameraSystem
+- [CameraSystem](../CameraSystem/CameraSystemOverview.md)
 - [DiagnosticsSystem](../Diagnostics/DiagnosticsSystemGettingStarted.md)
 - [InputSystem](../Input/Overview.md)
 - [SceneSystem](../SceneSystem/SceneSystemGettingStarted.md)

--- a/Documentation/BuildAndDeploy.md
+++ b/Documentation/BuildAndDeploy.md
@@ -7,7 +7,7 @@ Instructions on how to build and deploy for Hololens 1 and Hololens 2 (UWP) can 
 **Tip:** When building for WMR, HoloLens 1, or HoloLens 2, it is recommended that the build settings "Target SDK Version"
 and "Minimum Platform Version" look like they do in the picture below:
 
-![](../Documentation/Images/getting_started/BuildWindow.png)
+![Build window](../Documentation/Images/getting_started/BuildWindow.png)
 
 The other settings can be different (for example, Build Configuration/Architecture/Build Type and others can always
 be changed inside the Visual Studio solution).

--- a/Documentation/Contributing/DevDocGuide.md
+++ b/Documentation/Contributing/DevDocGuide.md
@@ -42,7 +42,7 @@ Examples:
 
 ```c#
 /// Links to MRTK internal class SystemType
-///<see cref="Microsoft.MixedReality.Toolkit.Utilities.SystemType"/>
+/// <see cref="Microsoft.MixedReality.Toolkit.Utilities.SystemType"/>
 
 /// Links to external API - link provided by xref service
 /// <see cref="System.Collections.Generic.ICollection{Type}.Contains"/>

--- a/Documentation/DownloadingTheMRTK.md
+++ b/Documentation/DownloadingTheMRTK.md
@@ -1,6 +1,6 @@
 # How to download the Mixed Reality Toolkit
 
-![](../Documentation/Images/MRTK_Logo_Rev.png)
+![MRTK logo](../Documentation/Images/MRTK_Logo_Rev.png)
 
 The MRTK is available via the following methods. For feedback on these methods, or to request an additional distribution method, please [file an issue on Github](https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/new/choose)
 

--- a/Documentation/Input/InputState.md
+++ b/Documentation/Input/InputState.md
@@ -2,11 +2,11 @@
 
 It's possible to directly query the state of all inputs in MRTK by iterating over the controllers attached to the input sources. MRTK also provides convenience methods for accessing the position and rotation of the eyes, hands, head, and motion controller.
 
-See the InputDataExample scene for an example of querying input both via iterating over controllers, and by using the [`InputRayUtils`](cref:Microsoft.MixedReality.Toolkit.Input.InputRayUtils) class.
+See the InputDataExample scene for an example of querying input both via iterating over controllers, and by using the [`InputRayUtils`](xref:Microsoft.MixedReality.Toolkit.Input.InputRayUtils) class.
 
 ## Example: Access position, rotation of head, hands, eyes in MRTK
 
-MRTK's [`InputRayUtils`](cref:Microsoft.MixedReality.Toolkit.Input.InputRayUtils) class provides convenience methods for accessing the hand ray, head ray, eye gaze ray, and motion controller rays.
+MRTK's [`InputRayUtils`](xref:Microsoft.MixedReality.Toolkit.Input.InputRayUtils) class provides convenience methods for accessing the hand ray, head ray, eye gaze ray, and motion controller rays.
 
 ```c#
 // Get the head ray

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -1,6 +1,6 @@
 # Mixed Reality Toolkit Profile configuration guide
 
-![](../Documentation/Images/MRTK_Logo_Rev.png)
+![MRTK logo](../Documentation/Images/MRTK_Logo_Rev.png)
 
 The Mixed Reality Toolkit centralizes as much of the configuration required to manage the toolkit as possible (except for true runtime "things").
 
@@ -13,7 +13,7 @@ The main configuration profile, which is attached to the *MixedRealityToolkit* G
 > [!NOTE]
 > The Mixed Reality Toolkit "locks" the default configuration screens to ensure you always have a common start point for your project and it is encouraged to start defining your own settings as your project evolves. The MRTK configuration is not editable during playmode.
 
-![](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ActiveConfiguration.png)
+![MRTK configuration profile](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ActiveConfiguration.png)
 
 All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets\MixedRealityToolkit.SDK\Profiles
 
@@ -210,7 +210,7 @@ This could also be done in your own code. However, seeing as this was a very com
 
 Input action Rules can be configured for any of the available input axis. However, input actions from one axis type can be translated to another input action of the same axis type. You can map a dual axis action to another dual axis action, but not to a digital or none action.
 
-![](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_InputActionRulesProfile.png)
+![Input action rules profile](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_InputActionRulesProfile.png)
 
 ---
 <a name="pointer"></a>

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -324,7 +324,7 @@ You can enable service inspectors by checking *Use Service Inspectors* under *Ed
 
 Sharing the depth buffer with some mixed reality platforms can improve [hologram stabilization](hologram-stabilization.md). For example, the Windows Mixed Reality platform can modify the rendered scene per-pixel to account for subtle head movements during the time it took to render a frame. However, these techniques require depth buffers with accurate data to know where and how far geometry is from the user. 
 
-To ensure a scene renders all necessary data to the depth buffer, developers can toggle the *Render Depth Buffer* feature under *Editor Settings* in the Configuration Profile. This will take the current depth buffer and render it as color to the scene view by applying a post-processing effect, [`DepthBufferRenderer `](xref:Microsoft.MixedReality.Toolkit.Rendering.DepthBufferRenderer ), to the main camera. 
+To ensure a scene renders all necessary data to the depth buffer, developers can toggle the *Render Depth Buffer* feature under *Editor Settings* in the Configuration Profile. This will take the current depth buffer and render it as color to the scene view by applying a post-processing effect, [`DepthBufferRenderer`](xref:Microsoft.MixedReality.Toolkit.Rendering.DepthBufferRenderer), to the main camera.
 
 ![Render Depth Buffer Utility](Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_DepthBufferExample.gif)
 <sup>The blue cylinder in the scene has a material with ZWrite off so no depth data is written</sup>

--- a/Documentation/README_BoundingBox.md
+++ b/Documentation/README_BoundingBox.md
@@ -69,7 +69,8 @@ bbox.RotateHandleColliderPadding = 0.016f;
 ```
 
 ### Example: Set minimum, maximum bounding box scale using TransformScaleHandler
-To set the minimum and maximum scale, use the [`TransformScaleHandler`](cref:Microsoft.MixedReality.Toolkit.UI.TransformScaleHander). You can also use TransformScaleHandler to set minimum and maximum scale for [`ManipulationHandler`](cref:Microsoft.MixedReality.Toolkit.UI.ManipulationHandler).
+
+To set the minimum and maximum scale, use the [`TransformScaleHandler`](xref:Microsoft.MixedReality.Toolkit.UI.TransformScaleHandler). You can also use TransformScaleHandler to set minimum and maximum scale for [`ManipulationHandler`](xref:Microsoft.MixedReality.Toolkit.UI.ManipulationHandler).
 
 ```c#
 GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/Documentation/README_HandJointChaser.md
+++ b/Documentation/README_HandJointChaser.md
@@ -1,15 +1,15 @@
 # Hand Joint Chaser Example
-![](../Documentation/Images/HandJointChaser/MRTK_HandJointChaser_Main.jpg)
-This example scene demonstrates how to use Solver to attach objects to the hand joints. 
+
+![Hand joint chasers](../Documentation/Images/HandJointChaser/MRTK_HandJointChaser_Main.jpg)
+This example scene demonstrates how to use Solver to attach objects to the hand joints.
 
 ## Example scene
-You can find the example scene **HandJointChaserExample** scene under:
-[MixedRealityToolkit.Examples/Demos/Input/Scenes/](/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes)
+
+You can find the example scene **HandJointChaserExample** scene in the MixedRealityToolkit.Examples package under `Demos/Input/Scenes/`.
 
 ## Solver Handler
+
 Click **Tracked Object To Reference** and select **Hand Joint Left** or **Hand Joint Right**. You will be able to see **Tracked Hand Joint** drop down. From the drop down list, you can select specific joint to track.
-This example scene uses Radial View Solver to make an object follow the target object. See [Solver](README_Solver.md) page for more details. 
+This example scene uses Radial View Solver to make an object follow the target object. See [Solver](README_Solver.md) page for more details.
 
-
-![](../Documentation/Images/HandJointChaser/MRTK_Solver_HandJoint.jpg)
-
+![Hand joint solver](../Documentation/Images/HandJointChaser/MRTK_Solver_HandJoint.jpg)

--- a/Documentation/README_Sliders.md
+++ b/Documentation/README_Sliders.md
@@ -1,5 +1,6 @@
 # Sliders
-![](../Documentation/Images/Slider/MRTK_UX_Slider_Main.jpg)
+
+![Slider example](../Documentation/Images/Slider/MRTK_UX_Slider_Main.jpg)
 
 Sliders are UI components that allow you to continuously change a value by moving a slider on a track. Currently the Pinch Slider can be moved by directly grabbing the slider, either directly or at a distance. Sliders work on AR and VR, using motion controllers, hands, or Gesture + Voice.
 

--- a/Documentation/SceneSystem/SceneSystemGettingStarted.md
+++ b/Documentation/SceneSystem/SceneSystemGettingStarted.md
@@ -27,4 +27,4 @@ By default, the Scene System enforces several behaviors in the Unity editor. If 
 
 - `Editor Enforce Lighting Scene Types:` If true, the service will ensure that only the lighting-related components defined in `PermittedLightingSceneComponentTypes` are allowed in lighting scenes. Disable if you want total control over the content of lighting scenes.
 
-![](../Images/SceneSystem/MRTK_SceneSystemProfileEditorSettings.PNG)
+![Scene system editor settings](../Images/SceneSystem/MRTK_SceneSystemProfileEditorSettings.PNG)

--- a/Documentation/SceneSystem/SceneSystemSceneTypes.md
+++ b/Documentation/SceneSystem/SceneSystemSceneTypes.md
@@ -2,7 +2,7 @@
 
 Scenes have been divided into three types, and each type has a different function.
 
-![](../Images/SceneSystem/MRTK_SceneSystemEditorSceneHierarchy.png)
+![Scene system in the hierarchy](../Images/SceneSystem/MRTK_SceneSystemEditorSceneHierarchy.png)
 
 ## Content Scenes
 These are the scenes you're used to dealing with. Any kind of content can be stored in them, and they can be loaded or unloaded in any combination.
@@ -23,7 +23,7 @@ A set of scenes which store lighting information and lighting objects. Only one 
 
 Unity's lighting settings - ambient light, skyboxes, etc - can be tricky to manage when using additive loading because they're tied to individual scenes and override behavior is not straightforward. In practice this can cause confusion when assets are authored in lighting conditions that don't obtain at runtime.
 
-![](../Images/SceneSystem/MRTK_SceneSystemLightingSettings.png)
+![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemLightingSettings.png)
 
 The Scene System uses lighting scenes to ensure that these settings remain consistent regardless of what scenes are loaded or active, both in edit mode and in play mode.
 
@@ -32,13 +32,13 @@ To enable this feature, check `Use Lighting Scene` in your profile and populate 
 ### Cached Lighting Settings
 Your profile stores cached copies of the lighting settings kept in your lighting scenes. If those settings change in your lighting scenes, you will need to update your cache to ensure lighting appears as expected in play mode. Your profile will display a warning when it suspects your cached settings are out of date. Clicking `Update Cached Lighting Settings` will load each of your lighting scenes, extract their settings, then store them in your profile.
 
-![](../Images/SceneSystem/MRTK_SceneSystemCachedLightingSettings.png)
+![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemCachedLightingSettings.png)
 
 ### Editor Behavior
 One benefit of using lighting scenes is knowing your content is lit correctly while editing. To this end, the Scene Service will keep a lighting scene loaded at all times, and will copy that scene's lighting settings to the current active scene.\*
 
 You can change which lighting scene is loaded by opening the Scene System's [service inspector.](../MixedRealityConfigurationGuide.md#editor-utilities) In edit mode you can instantaneously transition between lighting scenes. In play mode, you can preview transitions.
 
-![](../Images/SceneSystem/MRTK_SceneSystemServiceInspector.png)
+![Scene system inspector](../Images/SceneSystem/MRTK_SceneSystemServiceInspector.png)
 
 \**Note: Typically the active scene determines your lighting settings in editor. However we choose not to use this feature to enforce lighting settings, because the active scene is also where newly created objects are placed by default, and lighting scenes are only permitted to contain lighting components. Instead, the current lighting scene's settings are automatically copied to the active scene's settings instead. Keep in mind that this will result in your content scene's lighting settings being over-written.*

--- a/Documentation/Tools/DependencyWindow.md
+++ b/Documentation/Tools/DependencyWindow.md
@@ -10,13 +10,13 @@ The Dependency Window displays how assets reference and depend on each other. De
 
 To open the window select *Mixed Reality Toolkit->Utilities->Dependency Window* this will open the window and automatically begin building your project's dependency graph. Once the dependency graph is built you can select assets in the project tab to inspect their dependencies.
 
-![](../../Documentation/Images/DependencyWindow/MRTK_Dependency_Window.png)
+![Dependency window](../../Documentation/Images/DependencyWindow/MRTK_Dependency_Window.png)
 
 The window displays a list of assets the currently select asset depends on, and a hierarchical list of assets that depend on it. If nothing depends on the currently selected asset you can consider deleting it from your project (note some assets are loaded programmatically via APIs like Shader.Find() and may not be caught by the dependency tracker).
 
 The window can also display just a list of all assets which are not referenced by any other assets and could be considered for deletion:
 
-![](../../Documentation/Images/DependencyWindow/MRTK_Dependency_Window_Unreferenced.png)
+![Dependency window showing unreferenced assets](../../Documentation/Images/DependencyWindow/MRTK_Dependency_Window_Unreferenced.png)
 
 > [!NOTE]
 > If assets are modified, added, or removed while the dependency window is in use it is advised to refresh the dependency graph for the most "up to date" results.

--- a/Documentation/Tools/ScreenshotUtility.md
+++ b/Documentation/Tools/ScreenshotUtility.md
@@ -10,10 +10,10 @@ Screenshots can be easily capture while in the editor by selecting *Mixed Realit
 
 By default, all screenshots are saved to your [temporary cache path](https://docs.unity3d.com/ScriptReference/Application-temporaryCachePath.html), the path to the screenshot will be displayed in the Unity console.
 
-![](../../Documentation/Images/ScreenshotUtility/MRTK_ScreenshotUtility_Menu_Item.png)
+![Screenshot utility menu item](../../Documentation/Images/ScreenshotUtility/MRTK_ScreenshotUtility_Menu_Item.png)
 
 ### Example Screenshot Capture
 
 The below screenshot was captured with the *"4x Resolution (Transparent Background)"* option. This outputs a high-resolution image with whatever pixels normally represented by the clear color saved as transparent pixels. This technique helps developers showcase their application for the store, or other media outlets, by overlaying this image on top of other imagery.
 
-![](../../Documentation/Images/ScreenshotUtility/MRTK_ScreenshotUtility_Example_Capture.png)
+![Screenshot utility capture example](../../Documentation/Images/ScreenshotUtility/MRTK_ScreenshotUtility_Example_Capture.png)


### PR DESCRIPTION
## Overview

Some links were empty, possibly awaiting the existence of their corresponding docs. Now that those docs exist, I've updated the empty links I found.
I also converted a few crefs into xrefs, since it didn't appear that crefs work in our markdown.
I also added alt text to all our images that were missing them. This is important for the accessibility of our docs to ensure images have alt text for screen readers.