### PR TITLE
Move RotateInOneHand options to constraint components

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Input/Handlers/ObjectManipulator.cs
@@ -25,8 +25,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         #region Public Enums
         public enum RotateInOneHandType
         {
-            FaceUser,
-            FaceAwayFromUser,
             MaintainOriginalRotation,
             RotateAboutObjectCenter,
             RotateAboutGrabPoint
@@ -283,15 +281,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         private Dictionary<uint, PointerData> pointerIdToPointerMap = new Dictionary<uint, PointerData>();
-        private Quaternion objectToHandRotation;
         private Quaternion objectToGripRotation;
         private bool isNearManipulation;
         private bool isManipulationStarted;
 
         private Rigidbody rigidBody;
         private bool wasKinematic = false;
-        
-        private Quaternion hostWorldRotationOnManipulationStart;
 
         private ConstraintManager constraints;
 
@@ -573,15 +568,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             PointerData pointerData = GetFirstPointer();
             IMixedRealityPointer pointer = pointerData.pointer;
 
-            // cache objects rotation on start to have a reference for constraint calculations
-            // if we don't cache this on manipulation start the near rotation might drift off the hand
-            // over time
-            hostWorldRotationOnManipulationStart = HostTransform.rotation;
-
-            // Calculate relative transform from object to hand.
-            Quaternion worldToPalmRotation = Quaternion.Inverse(pointer.Rotation);
-            objectToHandRotation = worldToPalmRotation * HostTransform.rotation;
-
             // Calculate relative transform from object to grip.
             Quaternion gripRotation;
             TryGetGripRotation(pointer, out gripRotation);
@@ -609,19 +595,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 case RotateInOneHandType.MaintainOriginalRotation:
                     targetTransform.Rotation = HostTransform.rotation;
                     break;
-                case RotateInOneHandType.FaceUser:
-                {
-                    Vector3 directionToTarget = pointerData.GrabPoint - CameraCache.Main.transform.position;
-                    // Vector3 directionToTarget = HostTransform.position - CameraCache.Main.transform.position;
-                    targetTransform.Rotation = Quaternion.LookRotation(-directionToTarget);
-                    break;
-                }
-                case RotateInOneHandType.FaceAwayFromUser:
-                {
-                    Vector3 directionToTarget = pointerData.GrabPoint - CameraCache.Main.transform.position;
-                    targetTransform.Rotation = Quaternion.LookRotation(directionToTarget);
-                    break;
-                }
                 case RotateInOneHandType.RotateAboutObjectCenter:
                 case RotateInOneHandType.RotateAboutGrabPoint:
                     Quaternion gripRotation;

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Input/Handlers/ObjectManipulator.cs
@@ -25,7 +25,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         #region Public Enums
         public enum RotateInOneHandType
         {
-            MaintainOriginalRotation,
             RotateAboutObjectCenter,
             RotateAboutGrabPoint
         };
@@ -589,23 +588,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             constraints.ApplyScaleConstraints(ref targetTransform, true, IsNearManipulation());
 
-            RotateInOneHandType rotateInOneHandType = isNearManipulation ? oneHandRotationModeNear : oneHandRotationModeFar;
-            switch (rotateInOneHandType)
-            {
-                case RotateInOneHandType.MaintainOriginalRotation:
-                    targetTransform.Rotation = HostTransform.rotation;
-                    break;
-                case RotateInOneHandType.RotateAboutObjectCenter:
-                case RotateInOneHandType.RotateAboutGrabPoint:
-                    Quaternion gripRotation;
-                    TryGetGripRotation(pointer, out gripRotation);
-                    targetTransform.Rotation = gripRotation * objectToGripRotation;
-                    break;
-            }
+            Quaternion gripRotation;
+            TryGetGripRotation(pointer, out gripRotation);
+            targetTransform.Rotation = gripRotation * objectToGripRotation;
+
             constraints.ApplyRotationConstraints(ref targetTransform, true, IsNearManipulation());
 
+            RotateInOneHandType rotateInOneHandType = isNearManipulation ? oneHandRotationModeNear : oneHandRotationModeFar;
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
             targetTransform.Position = moveLogic.Update(pointerPose, targetTransform.Rotation, targetTransform.Scale, rotateInOneHandType != RotateInOneHandType.RotateAboutObjectCenter);
+
             constraints.ApplyTranslationConstraints(ref targetTransform, true, IsNearManipulation());
 
             ApplyTargetTransform(targetTransform);
@@ -779,7 +771,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private bool TryGetGripRotation(IMixedRealityPointer pointer, out Quaternion rotation)
         {
-
             for (int i = 0; i < pointer.Controller.Interactions.Length; i++)
             {
                 if (pointer.Controller.Interactions[i].InputType == DeviceInputType.SpatialGrip)

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Input/Handlers/ObjectManipulator.cs
@@ -23,6 +23,19 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     public class ObjectManipulator : MonoBehaviour, IMixedRealityPointerHandler, IMixedRealityFocusChangedHandler
     {
         #region Public Enums
+
+        /// <summary>
+        /// Describes what pivot the manipulated object will rotate about when
+        /// you rotate your hand. This is not a description of any limits or 
+        /// additional rotation logic. If no other factors (such as constraints)
+        /// are involved, rotating your hand by an amount should rotate the object
+        /// by the same amount.
+        /// For example a possible future value here is RotateAboutUserDefinedPoint
+        /// where the user could specify a pivot that the object is to rotate
+        /// around.
+        /// An example of a value that should not be found here is MaintainRotationToUser
+        /// as this restricts rotation of the object when we rotate the hand.
+        /// </summary>
         public enum RotateInOneHandType
         {
             RotateAboutObjectCenter,

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
@@ -164,8 +164,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                         break;
                     }
                 case ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation:
-                    newMode = ObjectManipulator.RotateInOneHandType.MaintainOriginalRotation;
-                    break;
+                    {
+                        newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
+
+                        var rotConstraint = objManip.EnsureComponent<FixedRotationToWorldConstraint>();
+                        rotConstraint.TargetTransform = objManip.HostTransform;
+                        rotConstraint.HandType = ManipulationHandFlags.OneHanded;
+                        rotConstraint.ProximityType = proximity;
+                        break;
+                    }
                 case ManipulationHandler.RotateInOneHandType.RotateAboutObjectCenter:
                     newMode = ObjectManipulator.RotateInOneHandType.RotateAboutObjectCenter;
                     break;

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
@@ -142,11 +142,27 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                         break;
                     }
                 case ManipulationHandler.RotateInOneHandType.FaceUser:
-                    newMode = ObjectManipulator.RotateInOneHandType.FaceUser;
-                    break;
+                    {
+                        newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
+
+                        var rotConstraint = objManip.EnsureComponent<FaceUserConstraint>();
+                        rotConstraint.TargetTransform = objManip.HostTransform;
+                        rotConstraint.HandType = ManipulationHandFlags.OneHanded;
+                        rotConstraint.ProximityType = proximity;
+                        rotConstraint.FaceAway = false;
+                        break;
+                    }
                 case ManipulationHandler.RotateInOneHandType.FaceAwayFromUser:
-                    newMode = ObjectManipulator.RotateInOneHandType.FaceAwayFromUser;
-                    break;
+                    {
+                        newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
+
+                        var rotConstraint = objManip.EnsureComponent<FaceUserConstraint>();
+                        rotConstraint.TargetTransform = objManip.HostTransform;
+                        rotConstraint.HandType = ManipulationHandFlags.OneHanded;
+                        rotConstraint.ProximityType = proximity;
+                        rotConstraint.FaceAway = true;
+                        break;
+                    }
                 case ManipulationHandler.RotateInOneHandType.MaintainOriginalRotation:
                     newMode = ObjectManipulator.RotateInOneHandType.MaintainOriginalRotation;
                     break;

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
@@ -109,11 +109,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             Object.DestroyImmediate(manipHandler);
         }
 
-        private void MigrateOneHandRotationModes(ref ObjectManipulator objManip, ManipulationHandler.RotateInOneHandType mode, ManipulationProximityFlags proximity)
+        private void MigrateOneHandRotationModes(ref ObjectManipulator objManip, ManipulationHandler.RotateInOneHandType oldMode, ManipulationProximityFlags proximity)
         {
             ObjectManipulator.RotateInOneHandType newMode = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
 
-            switch (mode)
+            switch (oldMode)
             {
                 case ManipulationHandler.RotateInOneHandType.MaintainRotationToUser:
                     {

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
@@ -21,33 +21,48 @@ namespace Microsoft.MixedReality.Toolkit.UI
             constraints = gameObject.GetComponents<TransformConstraint>().ToList();
         }
 
-        public void ApplyScaleConstraints(ref MixedRealityTransform transform)
+        public void ApplyScaleConstraints(ref MixedRealityTransform transform, bool isOneHanded, bool isNear)
         {
+            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
+            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
+            
             foreach (var constraint in constraints)
             {
-                if (constraint.ConstraintType == Utilities.TransformFlags.Scale)
+                if (constraint.ConstraintType == Utilities.TransformFlags.Scale &&
+                    constraint.HandType.HasFlag(handMode) &&
+                    constraint.ProximityType.HasFlag(proximityMode))
                 {
                     constraint.ApplyConstraint(ref transform);
                 }
             }
         }
 
-        public void ApplyRotationConstraints(ref MixedRealityTransform transform)
+        public void ApplyRotationConstraints(ref MixedRealityTransform transform, bool isOneHanded, bool isNear)
         {
+            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
+            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
+            
             foreach (var constraint in constraints)
             {
-                if (constraint.ConstraintType == Utilities.TransformFlags.Rotate)
+                if (constraint.ConstraintType == Utilities.TransformFlags.Rotate &&
+                    constraint.HandType.HasFlag(handMode) &&
+                    constraint.ProximityType.HasFlag(proximityMode))
                 {
                     constraint.ApplyConstraint(ref transform);
                 }
             }
         }
 
-        public void ApplyTranslationConstraints(ref MixedRealityTransform transform)
+        public void ApplyTranslationConstraints(ref MixedRealityTransform transform, bool isOneHanded, bool isNear)
         {
+            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
+            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
+            
             foreach (var constraint in constraints)
             {
-                if (constraint.ConstraintType == Utilities.TransformFlags.Move)
+                if (constraint.ConstraintType == Utilities.TransformFlags.Move &&
+                    constraint.HandType.HasFlag(handMode) &&
+                    constraint.ProximityType.HasFlag(proximityMode))
                 {
                     constraint.ApplyConstraint(ref transform);
                 }

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/ConstraintManager.cs
@@ -23,50 +23,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void ApplyScaleConstraints(ref MixedRealityTransform transform, bool isOneHanded, bool isNear)
         {
-            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
-            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
-            
-            foreach (var constraint in constraints)
-            {
-                if (constraint.ConstraintType == Utilities.TransformFlags.Scale &&
-                    constraint.HandType.HasFlag(handMode) &&
-                    constraint.ProximityType.HasFlag(proximityMode))
-                {
-                    constraint.ApplyConstraint(ref transform);
-                }
-            }
+            ApplyConstraintsForType(ref transform, isOneHanded, isNear, TransformFlags.Scale);
         }
 
         public void ApplyRotationConstraints(ref MixedRealityTransform transform, bool isOneHanded, bool isNear)
         {
-            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
-            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
-            
-            foreach (var constraint in constraints)
-            {
-                if (constraint.ConstraintType == Utilities.TransformFlags.Rotate &&
-                    constraint.HandType.HasFlag(handMode) &&
-                    constraint.ProximityType.HasFlag(proximityMode))
-                {
-                    constraint.ApplyConstraint(ref transform);
-                }
-            }
+            ApplyConstraintsForType(ref transform, isOneHanded, isNear, TransformFlags.Rotate);
         }
 
         public void ApplyTranslationConstraints(ref MixedRealityTransform transform, bool isOneHanded, bool isNear)
         {
-            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
-            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
-            
-            foreach (var constraint in constraints)
-            {
-                if (constraint.ConstraintType == Utilities.TransformFlags.Move &&
-                    constraint.HandType.HasFlag(handMode) &&
-                    constraint.ProximityType.HasFlag(proximityMode))
-                {
-                    constraint.ApplyConstraint(ref transform);
-                }
-            }
+            ApplyConstraintsForType(ref transform, isOneHanded, isNear, TransformFlags.Move);
         }
 
         public void Initialize(MixedRealityPose worldPose)
@@ -74,6 +41,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
             foreach (var constraint in constraints)
             {
                 constraint.Initialize(worldPose);
+            }
+        }
+
+        private void ApplyConstraintsForType(ref MixedRealityTransform transform, bool isOneHanded, bool isNear, TransformFlags transformType)
+        {
+            ManipulationHandFlags handMode = isOneHanded ? ManipulationHandFlags.OneHanded : ManipulationHandFlags.TwoHanded;
+            ManipulationProximityFlags proximityMode = isNear ? ManipulationProximityFlags.Near : ManipulationProximityFlags.Far;
+
+            foreach (var constraint in constraints)
+            {
+                if (constraint.ConstraintType == transformType &&
+                    constraint.HandType.HasFlag(handMode) &&
+                    constraint.ProximityType.HasFlag(proximityMode))
+                {
+                    constraint.ApplyConstraint(ref transform);
+                }
             }
         }
     }

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FaceUserConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FaceUserConstraint.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    /// Component for fixing the rotation of a manipulated object such that
+    /// it always faces or faces away from the user
+    /// </summary>
+    public class FaceUserConstraint : TransformConstraint
+    {
+        #region Properties
+
+        [SerializeField]
+        [Tooltip("Option to use this constraint to face away from the user")]
+        private bool faceAway = false;
+
+        /// <summary>
+        /// If true, this will constrain rotation to face away from the user
+        /// </summary>
+        public bool FaceAway
+        {
+            get => faceAway;
+            set => faceAway = value;
+        }
+
+        public override TransformFlags ConstraintType => TransformFlags.Rotate;
+
+        #endregion Properties
+
+        #region Public Methods
+
+        /// <summary>
+        /// Updates an rotation so that its facing the camera
+        /// </summary>
+        public override void ApplyConstraint(ref MixedRealityTransform transform)
+        {
+            Vector3 directionToTarget = transform.Position - CameraCache.Main.transform.position;
+            transform.Rotation = Quaternion.LookRotation(faceAway ? -directionToTarget : directionToTarget);
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FaceUserConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FaceUserConstraint.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public override void ApplyConstraint(ref MixedRealityTransform transform)
         {
             Vector3 directionToTarget = transform.Position - CameraCache.Main.transform.position;
-            transform.Rotation = Quaternion.LookRotation(faceAway ? -directionToTarget : directionToTarget);
+            transform.Rotation = Quaternion.LookRotation(faceAway ? directionToTarget : -directionToTarget);
         }
 
         #endregion Public Methods

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FaceUserConstraint.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FaceUserConstraint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea5f249786382754b8635a1375f7b76c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs
@@ -7,8 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
-    /// Component for limiting the rotation of a manipulated object relative to the user
-    /// or BoundingBox
+    /// Component for fixing the rotation of a manipulated object relative to the user
     /// </summary>
     public class FixedRotationToUserConstraint : TransformConstraint
     {
@@ -31,8 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Removes rotation about given axis if its flag is found
-        /// in ConstraintOnRotation
+        /// Updates the objects rotation so that the rotation relative to the user
+        /// is fixed
         /// </summary>
         public override void ApplyConstraint(ref MixedRealityTransform transform)
         {

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    /// Component for limiting the rotation of a manipulated object relative to the user
+    /// or BoundingBox
+    /// </summary>
+    public class FixedRotationToUserConstraint : TransformConstraint
+    {
+        #region Properties
+
+        public override TransformFlags ConstraintType => TransformFlags.Rotate;
+
+        private Quaternion startObjectRotationCameraSpace;
+
+        #endregion Properties
+
+        #region Public Methods
+
+        /// <inheritdoc />
+        public override void Initialize(MixedRealityPose worldPose)
+        {
+            base.Initialize(worldPose);
+
+            startObjectRotationCameraSpace = Quaternion.Inverse(CameraCache.Main.transform.rotation) * worldPose.Rotation;
+        }
+
+        /// <summary>
+        /// Removes rotation about given axis if its flag is found
+        /// in ConstraintOnRotation
+        /// </summary>
+        public override void ApplyConstraint(ref MixedRealityTransform transform)
+        {
+            Vector3 euler = CameraCache.Main.transform.rotation.eulerAngles;
+            // don't use roll (feels awkward) - just maintain yaw / pitch angle
+            transform.Rotation = Quaternion.Euler(euler.x, euler.y, 0) * startObjectRotationCameraSpace;
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToUserConstraint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dac28f8bfe57b7f4182539cec9c0b40d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToWorldConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToWorldConstraint.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    /// Component for fixing the rotation of a manipulated object relative to the world
+    /// </summary>
+    public class FixedRotationToWorldConstraint : TransformConstraint
+    {
+        #region Properties
+
+        public override TransformFlags ConstraintType => TransformFlags.Rotate;
+
+        #endregion Properties
+
+        #region Public Methods
+
+        /// <summary>
+        /// Fix rotation to the rotation from manipulation start
+        /// </summary>
+        public override void ApplyConstraint(ref MixedRealityTransform transform)
+        {
+            transform.Rotation = this.worldPoseOnManipulationStart.Rotation;
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToWorldConstraint.cs.meta
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/FixedRotationToWorldConstraint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff5df7a2c3b5b4843bdc23997f95edc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs
@@ -26,6 +26,34 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => targetTransform = value;
         }
 
+        [SerializeField]
+        [EnumFlags]
+        [Tooltip("What type of manipulation this constraint applies to. Defaults to One Handed and Two Handed.")]
+        private ManipulationHandFlags handType = ManipulationHandFlags.OneHanded | ManipulationHandFlags.TwoHanded;
+
+        /// <summary>
+        /// Whether this constraint applies to one hand manipulation, two hand manipulation or both
+        /// </summary>
+        public ManipulationHandFlags HandType
+        {
+            get => handType;
+            set => handType = value;
+        }
+
+        [SerializeField]
+        [EnumFlags]
+        [Tooltip("What type of manipulation this constraint applies to. Defaults to Near and Far.")]
+        private ManipulationProximityFlags proximityType = ManipulationProximityFlags.Near | ManipulationProximityFlags.Far;
+
+        /// <summary>
+        /// Whether this constraint applies to near manipulation, far manipulation or both
+        /// </summary>
+        public ManipulationProximityFlags ProximityType
+        {
+            get => proximityType;
+            set => proximityType = value;
+        }
+
         protected MixedRealityPose worldPoseOnManipulationStart;
 
         public abstract TransformFlags ConstraintType { get; }

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Manipulation/ManipulationMoveLogic.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Manipulation/ManipulationMoveLogic.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             }
             else
             {
-                return pointerCentroidPose.Position + pointerCentroidPose.Rotation * (pointerLocalGrabPoint + grabToObject) * distanceRatio;
+                return pointerCentroidPose.Position + (pointerCentroidPose.Rotation * pointerLocalGrabPoint + grabToObject) * distanceRatio;
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Manipulation/ManipulationMoveLogic.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Manipulation/ManipulationMoveLogic.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             }
             else
             {
-                return pointerCentroidPose.Position + pointerCentroidPose.Rotation * pointerLocalGrabPoint + grabToObject * distanceRatio;
+                return pointerCentroidPose.Position + pointerCentroidPose.Rotation * (pointerLocalGrabPoint + grabToObject) * distanceRatio;
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// Component for setting the min/max scale values for ManipulationHandler
     /// or BoundingBox
     /// </summary>
-    [AddComponentMenu("Scripts/MRTK/SDK/TransformScaleHandler")]
+    [AddComponentMenu("Scripts/MRTK/SDK/MinMaxScaleConstraint")]
     public class MinMaxScaleConstraint : TransformConstraint
     {
         #region Properties

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.MixedReality.Toolkit.Experimental.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEditor;
 using UnityEngine;
 
@@ -80,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
             EditorGUILayout.PropertyField(manipulationType);
             EditorGUILayout.PropertyField(allowFarManipulation);
 
-            var handedness = (ObjectManipulator.HandMovementType)manipulationType.intValue;
+            var handedness = (ManipulationHandFlags)manipulationType.intValue;
 
             EditorGUILayout.Space();
             GUIStyle style = EditorStyles.foldout;
@@ -90,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 
             if (oneHandedFoldout)
             {
-                if (handedness.HasFlag(ObjectManipulator.HandMovementType.OneHanded))
+                if (handedness.HasFlag(ManipulationHandFlags.OneHanded))
                 {
                     EditorGUILayout.PropertyField(oneHandRotationModeNear);
                     EditorGUILayout.PropertyField(oneHandRotationModeFar);
@@ -106,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 
             if (twoHandedFoldout)
             {
-                if (handedness.HasFlag(ObjectManipulator.HandMovementType.TwoHanded))
+                if (handedness.HasFlag(ManipulationHandFlags.TwoHanded))
                 {
                     EditorGUILayout.PropertyField(twoHandedManipulationType);
                 }

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -4,9 +4,13 @@
 //
 
 using Microsoft.MixedReality.Toolkit.Experimental.UI;
+using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 {
@@ -41,6 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 
         bool oneHandedFoldout = true;
         bool twoHandedFoldout = true;
+        bool constraintsFoldout = true;
         bool physicsFoldout = true;
         bool smoothingFoldout = true;
         bool eventsFoldout = true;
@@ -119,6 +124,45 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 
             var mh = (ObjectManipulator)target;
             var rb = mh.HostTransform.GetComponent<Rigidbody>();
+
+            EditorGUILayout.Space();
+            constraintsFoldout = EditorGUILayout.Foldout(constraintsFoldout, "Constraints", true);
+
+            if (constraintsFoldout)
+            {
+                if (EditorGUILayout.DropdownButton(new GUIContent("Add Constraint"), FocusType.Keyboard))
+                {
+                    // create the menu and add items to it
+                    GenericMenu menu = new GenericMenu();
+
+                    var type = typeof(TransformConstraint);
+                    var types = AppDomain.CurrentDomain.GetAssemblies()
+                        .SelectMany(s => s.GetTypes())
+                        .Where(p => type.IsAssignableFrom(p));
+
+                    foreach (var derivedType in types)
+                    {
+                        menu.AddItem(new GUIContent(derivedType.Name), false, t => mh.gameObject.AddComponent((Type)t), derivedType);
+                    }
+
+                    menu.ShowAsContext();
+                }
+
+                var constraints = mh.GetComponents<TransformConstraint>();
+
+                foreach (var constraint in constraints)
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    string constraintName = constraint.GetType().Name;
+                    EditorGUILayout.LabelField(constraintName);
+                    if (GUILayout.Button("Go to component"))
+                    {
+                        Debug.Log($"Highlighting {ObjectNames.NicifyVariableName(constraintName)} (Script)");
+                        Highlighter.Highlight("Inspector", $"{ObjectNames.NicifyVariableName(constraintName)} (Script)");
+                    }
+                    EditorGUILayout.EndHorizontal();
+                }
+            }
 
             EditorGUILayout.Space();
             physicsFoldout = EditorGUILayout.Foldout(physicsFoldout, "Physics", true);

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 
                     var type = typeof(TransformConstraint);
                     var types = AppDomain.CurrentDomain.GetAssemblies()
-                        .SelectMany(s => s.GetTypes())
+                        .SelectMany(s => s.GetLoadableTypes())
                         .Where(p => type.IsAssignableFrom(p));
 
                     foreach (var derivedType in types)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ConstraintTests.cs
@@ -682,7 +682,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Tests that different constraints can apply for near and far manipulation
         /// </summary>
         [UnityTest]
-        public IEnumerator ConstrainByProximity()
+        public IEnumerator CombinedConstraintFarNear()
         {
             TestUtilities.PlayspaceToOriginLookingForward();
             

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ConstraintTests.cs
@@ -787,7 +787,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             float checkNegative() => Vector3.Dot(testObject.transform.forward, cameraToObject());
 
             TestUtilities.AssertAboutEqual(checkCollinear(), Vector3.zero, "Object not facing camera", 0.002f);
-            Assert.Greater(checkNegative(), 0, "Object facing away");
+            Assert.Less(checkNegative(), 0, "Object facing away");
 
             // Move the hand
             yield return hand.Move(new Vector3(0.2f, 0.2f, 0), numHandSteps);
@@ -795,7 +795,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.AreNotEqual(Vector3.forward, testObject.transform.position); // ensure the object moved
             TestUtilities.AssertAboutEqual(checkCollinear(), Vector3.zero, "Object not facing camera", 0.002f);
-            Assert.Greater(checkNegative(), 0, "Object facing away");
+            Assert.Less(checkNegative(), 0, "Object facing away");
 
             // Face away from user
             rotConstraint.FaceAway = true;
@@ -803,7 +803,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             TestUtilities.AssertAboutEqual(checkCollinear(), Vector3.zero, "Object not facing camera", 0.002f);
-            Assert.Less(checkNegative(), 0, "Object facing away");
+            Assert.Greater(checkNegative(), 0, "Object facing away");
 
             // Move the hand
             yield return hand.Move(new Vector3(0.2f, 0.2f, 0), numHandSteps);
@@ -811,7 +811,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.AreNotEqual(Vector3.forward, testObject.transform.position); // ensure the object moved
             TestUtilities.AssertAboutEqual(checkCollinear(), Vector3.zero, "Object not facing camera", 0.002f);
-            Assert.Less(checkNegative(), 0, "Object facing away");
+            Assert.Greater(checkNegative(), 0, "Object facing away");
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/ObjectManipulatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/ObjectManipulatorTests.cs
@@ -357,9 +357,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             foreach (ObjectManipulator.RotateInOneHandType type in Enum.GetValues(typeof(ObjectManipulator.RotateInOneHandType)))
             {
                 // Some rotation modes move the object on grab, don't test those
-                if (type == ObjectManipulator.RotateInOneHandType.MaintainOriginalRotation ||
-                    type == ObjectManipulator.RotateInOneHandType.FaceAwayFromUser ||
-                    type == ObjectManipulator.RotateInOneHandType.FaceUser)
+                if (type == ObjectManipulator.RotateInOneHandType.MaintainOriginalRotation)
                 {
                     continue;
                 }         

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/ObjectManipulatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/ObjectManipulatorTests.cs
@@ -356,12 +356,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // do this test for every one hand rotation mode
             foreach (ObjectManipulator.RotateInOneHandType type in Enum.GetValues(typeof(ObjectManipulator.RotateInOneHandType)))
             {
-                // Some rotation modes move the object on grab, don't test those
-                if (type == ObjectManipulator.RotateInOneHandType.MaintainOriginalRotation)
-                {
-                    continue;
-                }         
-
                 manipHandler.OneHandRotationModeFar = type;
 
                 TestUtilities.PlayspaceToOriginLookingForward();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/ObjectManipulatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/ObjectManipulatorTests.cs
@@ -173,71 +173,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Tests MaintainRotationToUser mode of ObjectManipulator (OneHandedOnly)
-        /// MaintainRotationToUser should only align with user / camera on x / y and not apply rotations in z
-        /// </summary>
-        [UnityTest]
-        public IEnumerator ObjectManipulatorRotateWithUser()
-        {
-            // set up cube with manipulation handler
-            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            testObject.transform.localScale = Vector3.one * 0.2f;
-            Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
-            testObject.transform.position = initialObjectPosition;
-            var manipHandler = testObject.AddComponent<ObjectManipulator>();
-            manipHandler.HostTransform = testObject.transform;
-            manipHandler.SmoothingActive = false;
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded;
-            manipHandler.OneHandRotationModeNear = ObjectManipulator.RotateInOneHandType.MaintainRotationToUser;
-
-            // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
-            testObject.AddComponent<NearInteractionGrabbable>();
-            yield return new WaitForFixedUpdate();
-            yield return null;
-
-
-            Vector3 initialGrabPosition = new Vector3(-0.1f, -0.1f, 1f); // grab the left bottom corner of the cube 
-            TestHand hand = new TestHand(Handedness.Right);
-            TestUtilities.PlayspaceToOriginLookingForward();
-
-            yield return hand.Show(initialGrabPosition);
-            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-
-            Quaternion originalObjRotation = testObject.transform.rotation;
-
-            CameraCache.Main.transform.Rotate(new Vector3(10, 0, 0));
-            yield return new WaitForFixedUpdate();
-            yield return null;
-
-            Quaternion rotatedOriginal = originalObjRotation * Quaternion.Euler(10, 0, 0);
-            // check if x rotation was applied to object
-            TestUtilities.AssertAboutEqual(testObject.transform.rotation.eulerAngles, rotatedOriginal.eulerAngles, "Object wasn't rotated with camera");
-
-            CameraCache.Main.transform.Rotate(new Vector3(-10, 0, 0));
-            CameraCache.Main.transform.Rotate(new Vector3(0, 10, 0));
-
-            yield return new WaitForFixedUpdate();
-            yield return null;
-
-            // check if y rotation was applied to object
-            rotatedOriginal = originalObjRotation * Quaternion.Euler(0, 10, 0);
-            TestUtilities.AssertAboutEqual(testObject.transform.rotation.eulerAngles, rotatedOriginal.eulerAngles, "Object wasn't rotated with camera");
-
-            CameraCache.Main.transform.Rotate(new Vector3(0, -10, 0));
-            CameraCache.Main.transform.Rotate(new Vector3(0, 0, 10));
-            yield return new WaitForFixedUpdate();
-            yield return null;
-
-            // check if z rotation wasn't applied to object
-            rotatedOriginal = originalObjRotation * Quaternion.Euler(0, 0, 10);
-            TestUtilities.AssertNotAboutEqual(testObject.transform.rotation.eulerAngles, rotatedOriginal.eulerAngles, "Object rolled with camera");
-
-            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
-            yield return hand.Hide();
-
-        }
-
-        /// <summary>
         /// Test validates throw behavior on manipulation handler. Box with disabled gravity should travel a 
         /// certain distance when being released from grab during hand movement
         /// </summary>
@@ -308,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var manipHandler = testObject.AddComponent<ObjectManipulator>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
 
             // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
             testObject.AddComponent<NearInteractionGrabbable>();
@@ -403,7 +338,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var manipHandler = testObject.AddComponent<ObjectManipulator>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
 
             // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
             testObject.AddComponent<NearInteractionGrabbable>();
@@ -511,7 +446,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var manipHandler = testObject.AddComponent<ObjectManipulator>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
             manipHandler.OneHandRotationModeFar = ObjectManipulator.RotateInOneHandType.RotateAboutGrabPoint;
             manipHandler.ReleaseBehavior = 0;
             manipHandler.AllowFarManipulation = false;
@@ -745,7 +680,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var manipHandler = testObject.AddComponent<ObjectManipulator>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded | ObjectManipulator.HandMovementType.TwoHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded | ManipulationHandFlags.TwoHanded;
 
             // add near interaction grabbable to be able to grab the cube with the simulated articulated hand
             testObject.AddComponent<NearInteractionGrabbable>();
@@ -1056,7 +991,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return null;
 
             // One Handed
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded;
 
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             Assert.AreEqual(1, manipulationStartedCount);
@@ -1108,7 +1043,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return null;
 
             // Two Handed
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.TwoHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.TwoHanded;
 
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             Assert.AreEqual(0, manipulationStartedCount);
@@ -1160,7 +1095,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return null;
 
             // One + Two Handed
-            manipHandler.ManipulationType = ObjectManipulator.HandMovementType.OneHanded | ObjectManipulator.HandMovementType.TwoHanded;
+            manipHandler.ManipulationType = ManipulationHandFlags.OneHanded | ManipulationHandFlags.TwoHanded;
 
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             Assert.AreEqual(1, manipulationStartedCount);

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationHandFlags.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationHandFlags.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Flags used to represent the number of hands that can be used in manipulation
+    /// </summary>
+    [System.Flags]
+    public enum ManipulationHandFlags
+    {
+        OneHanded = 1 << 0,
+        TwoHanded = 1 << 1,
+    }
+}

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationHandFlags.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationHandFlags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 331dc46d2942d1947964376312ddc59c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationProximityFlags.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationProximityFlags.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Flags used to represent whether manipulation can be far, near or both
+    /// </summary>
+    [System.Flags]
+    public enum ManipulationProximityFlags
+    {
+        Near = 1 << 0,
+        Far = 1 << 1,
+    }
+}

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationProximityFlags.cs.meta
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ManipulationProximityFlags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3cf8def1e3e5484c86b3dc60576feba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
In #6321 the way that manipulation constraint options work was changed, so that they are individual components that the user can add to a manipulation object, tidying the `ObjectManipulator` inspector options and decoupling the manipulation logic from the constraint logic. 
 
However, the options in the `RotateInOneHandType` enum, also constrain rotation in some way. It feels strange to me that we have a unique set of constraints only for one handed rotation, when these constraints could easily be applied to two hand rotation as well. 

I believe that this will reduce confusion and clutter with the `ObjectManipulator` inspector options. I also think that it will bring potentially useful functionality to two hand manipulation that before only existed for one handed. It will also further reduce coupling between manipulation logic and optional constraint logic.

## Changes
- Add `FixedRotationToUserConstraint` which replaces `MaintainRotationToUser` and `GravityAlignedMaintainRotationToUser` (gravity aligned can be achieved by also adding a `RotationAxisConstraint`).
- Add `FaceUserConstraint` which replaces `FaceUser` and `FaceAwayFromUser` (face away can be achieved by flipping a bool in the `FaceUserConstraint` component).
- Add `FixedRotationToWorldConstraint` which replaces `MaintainOriginalRotation`.
- Add options for all constraints so you can configure which manipulation types (one handed/two handed, near/far) they constrain for.
- Improved constraint discoverability. Constraints now show in the `ObjectManipulator` inspector with an option to create them from here.
- Added tests for new constraints.