### PR TITLE
add scene query buffer size to sphere pointer inspector

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Pointers/SpherePointerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Pointers/SpherePointerInspector.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SerializedProperty nearObjectMargin;
         private SerializedProperty grabLayerMasks;
         private SerializedProperty triggerInteraction;
-
+        private SerializedProperty sceneQueryBufferSize;
 
         private bool spherePointerFoldout = true;
 
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             base.OnEnable();
 
             sphereCastRadius = serializedObject.FindProperty("sphereCastRadius");
+            sceneQueryBufferSize = serializedObject.FindProperty("sceneQueryBufferSize");
             nearObjectMargin = serializedObject.FindProperty("nearObjectMargin");
             grabLayerMasks = serializedObject.FindProperty("grabLayerMasks");
             triggerInteraction = serializedObject.FindProperty("triggerInteraction");
@@ -41,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 using (new EditorGUI.IndentLevelScope())
                 {
                     EditorGUILayout.PropertyField(sphereCastRadius);
+                    EditorGUILayout.PropertyField(sceneQueryBufferSize);
                     EditorGUILayout.PropertyField(nearObjectMargin);
                     EditorGUILayout.PropertyField(triggerInteraction);
                     EditorGUILayout.PropertyField(grabLayerMasks, true);


### PR DESCRIPTION
## Overview
There was no way to edit the scene query buffer size for grab pointer in editor. This adds that field to the inspector.

![image](https://user-images.githubusercontent.com/168492/70735529-4892c480-1cc3-11ea-8d22-bd0a038150aa.png)


## Changes
- Fixes: #6878


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
