### PR TITLE
UnityAR asmdef check: update #elif to include 2019_1

### DIFF
--- a/Assets/MixedRealityToolkit.Staging/UnityAR/Editor/ConfigurationChecker/UnityARConfigurationChecker.cs
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/Editor/ConfigurationChecker/UnityARConfigurationChecker.cs
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
             {
                 updateTo = "2018";
             }
-#elif UNITY_2019_2_OR_NEWER
+#elif UNITY_2019_1_OR_NEWER
             if (!fileContents.Contains(arFoundationReference) ||
                 !fileContents.Contains(spatialTrackingReference))
             {


### PR DESCRIPTION
This change includes Unity 2019.1 in the asmdef file check.

Fixes #6854