### PR TITLE
Correct the api contract version for the spatial issupported check

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-            if (WindowsApiChecker.UniversalApiContractV8_IsAvailable)
+            if (WindowsApiChecker.UniversalApiContractV4_IsAvailable)
             {
 #if WINDOWS_UWP
                 return (capability == MixedRealityCapability.SpatialAwarenessMesh) && WindowsSpatialSurfaces.SpatialSurfaceObserver.IsSupported();


### PR DESCRIPTION
The capability checker uses api contract checks to ensure that functions are not called on platforms for which they are not supported.

The Windows Mixed Realtiy spatial mesh observer check was incorrectly using version 8 of the contract, which was preventing the code from correctly running on the first generation HoloLens.

This change updates the check to use version 4, which correctly maps to the introduction of SpatialSurfaceObserver.IsSupported

Fixes #6613