### PR TITLE
Include the MRTK.Generated meta file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,15 +59,13 @@ obj/
 # Project Specific List #
 # ===================== #
 artifacts/
-Assets/ThirdParty/
-Assets/ThirdParty.meta
-Assets/TextMesh Pro.meta
-Assets/TextMesh Pro/
+Assets/ThirdParty*
+Assets/TextMesh Pro*
 --Version/
 Assets/StreamingAssets/GltfModels/
 Assets/StreamingAssets/GltfModels.meta
 Assets/StreamingAssets.meta
-Assets/MixedRealityToolkit.Generated/*
+Assets/MixedRealityToolkit.Generated*
 
 /mrtk_log_mostRecentET.csv
 


### PR DESCRIPTION
## Overview
#6315 added a new project preferences object in the `.Generated` folder, but didn't also ignore its meta.
This adds that.