### PR TITLE
Standardize docs headers syntax

### DIFF
--- a/Documentation/Boundary/ConfiguringBoundaryVisualization.md
+++ b/Documentation/Boundary/ConfiguringBoundaryVisualization.md
@@ -6,7 +6,7 @@ The *Boundary Visualization Profile* provides options for configuring the visual
 
 ![Boundary Visualization General Settings](../../Documentation/Images/Boundary/BoundaryVisualizationGeneralSettings.png)
 
-**Boundary Height**
+### Boundary Height
 
 The boundary height indicates the distance above the floor plane at which the boundary ceiling should be rendered. The default value is 3 meters.
 

--- a/Documentation/Diagnostics/ConfiguringDiagnostics.md
+++ b/Documentation/Diagnostics/ConfiguringDiagnostics.md
@@ -4,7 +4,7 @@
 
 ![Diagnostics General Settings](../../Documentation/Images/Diagnostics/DiagnosticsGeneralSettings.png)
 
-**Show Diagnostics**
+### Show Diagnostics
 
 Indicates whether or not the diagnostics system is to display the configured diagnostic options.
 
@@ -14,27 +14,27 @@ When disabled, all configured diagnostic options will be hidden.
 
 ![Diagnostics Profiler Settings](../../Documentation/Images/Diagnostics/DiagnosticsProfilerSettings.png)
 
-**Show Profiler**
+### Show Profiler
 
 Indicates whether or not the Visual Profiler is to be displayed.
 
-**Frame Sample Rate**
+### Frame Sample Rate
 
 The amount of time, in seconds to collect frames for frame rate calculation. The range is 0 to 5 seconds.
 
-**Window Anchor**
+### Window Anchor
 
 To what portion of the view port should the profiler window be anchored. The default value is Lower Center.
 
-**Window Offset**
+### Window Offset
 
 The offset, from the center of the view port, to place the Visual Profiler. The offset will be in the direction of the *Window Anchor* property.
 
-**Window Scale**
+### Window Scale
 
 Size multiplier applied to the profiler window. For example, setting the value to 2 will double the window size.
 
-**Window Follow Speed**
+### Window Follow Speed
 
 The speed at which to move the profiler window to maintain visibility within the view port.
 

--- a/Documentation/EyeTracking/EyeTracking_TargetSelection.md
+++ b/Documentation/EyeTracking/EyeTracking_TargetSelection.md
@@ -315,7 +315,7 @@ public class HitBehaviorDestroyOnSelect : MonoBehaviour
 }
 ```
 
-### Example #4: Use hand rays and eye gaze input together!
+### Example #4: Use hand rays and eye gaze input together
 
 Hand rays take priority over head and eye gaze targeting. This means, if hand rays are enabled, the moment the hands come into view, the hand ray will act as the primary pointer.
 However, there might be situations in which you want to use hand rays while still detecting whether a user is looking at a certain hologram. Easy! Essentially you require two steps:

--- a/Documentation/README_AppBar.md
+++ b/Documentation/README_AppBar.md
@@ -1,10 +1,10 @@
-# App bar #
+# App bar
 
 ![App bar](../Documentation/Images/AppBar/MRTK_AppBar_Main.png)
 
 App bar is a UI component that is used together with the [bounding box](README_BoundingBox.md) script. It adds button controls to an object with the intent to manipulate it. Using the 'Adjust' button, the bounding box interface for an object can be de- / activated. The "Remove" button should remove the object from the scene.
 
-## How to use app bar ##
+## How to use app bar
 
 Drag and drop [AppBar.prefab](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/AppBar/AppBar.prefab) into the scene hierarchy. In the inspector panel of the component, assign any object with a bounding box as the *Target Bounding Box* to add the app bar to it.
 

--- a/Documentation/README_BoundingBox.md
+++ b/Documentation/README_BoundingBox.md
@@ -94,17 +94,17 @@ private void PutABoxAroundIt(GameObject target)
 }
 ```
 
-## Inspector properties ##
+## Inspector properties
 
-**Target Object**
+### Target Object
 
 This property specifies which object will get transformed by the bounding box manipulation. If no object is set, the bounding box defaults to the owner object.
 
-**Bounds Override**
+### Bounds Override
 
 Sets a box collider from the object for bounds computation.
 
-**Activation Behavior**
+### Activation Behavior
 
 There are several options to activate the bounding box interface.
 
@@ -113,25 +113,25 @@ There are several options to activate the bounding box interface.
 * *Activate By Pointer*: Bounding Box becomes visible when it is targeted by a hand-ray pointer.
 * *Activate Manually*: Bounding Box does not become visible automatically. You can manually activate it through a script by accessing the boundingBox.Active property.
 
-**Scale Minimum**
+### Scale Minimum
 
 The minimum allowed scale. This property is deprecated and it is preferable to add a [`TransformScaleHandler`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs) script. If this script is added, the minimum scale will be taken from it instead of from BoundingBox.
 
-**Scale Maximum**
+### Scale Maximum
 
 The maximum allowed scale. This property is deprecated and it is preferable to add a [`TransformScaleHandler`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs) script. If this script is added, the maximum scale will be taken from it instead of from BoundingBox.
 
-**Box Display**
+### Box Display
 
 Various bounding box visualization options.
 
 If Flatten Axis is set to *Flatten Auto*, the script will disallow manipulation along the axis with the smallest extent. This results in a 2D bounding box, which is usually used for thin objects.
 
-**Handles**
+### Handles
 
 You can assign the material and prefab to override the handle style. If no handles are assigned, they will be displayed in the default style.
 
-## Events ##
+## Events
 
 Bounding box provides the following events. The example uses these events to play audio feedback.
 
@@ -177,7 +177,7 @@ Show and hide the handles with animation based on the distance to the hands. It 
 * **Medium Scale**: Scale value of the handle asset when the hands are within the range of the Bounding Box interaction(distance defined above by 'Handle Close Proximity'. Use 1 to show normal size)
 * **Close Scale**: Scale value of the handle asset when the hands are within the grab interaction(distance defined above by 'Handle Close Proximity'. Use 1.x to show bigger size)
 
-## Making an object movable with manipulation handler ##
+## Making an object movable with manipulation handler
 
 A bounding box can be combined with [`ManipulationHandler.cs`](README_ManipulationHandler.md) to make the object movable using far interaction. The manipulation handler supports both one and two-handed interactions. [Hand tracking](Input/HandTracking.md) can be used to interact with an object up close.
 

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -189,7 +189,7 @@ You will see the object responds to both far(hand ray or gaze cursor) and near(h
 <img src="../Documentation/Images/Button/MRTK_PressableButtonCubeRun3.jpg">
 <img src="../Documentation/Images/Button/MRTK_PressableButtonCubeRun4.jpg">
 
-## Custom Button Examples ##
+## Custom Button Examples
 
 In the [HandInteractionExample scene](README_HandInteractionExamples.md), you can take a look at the piano and round button examples which are both using `PressableButton`.
 

--- a/Documentation/README_ExampleHub.md
+++ b/Documentation/README_ExampleHub.md
@@ -1,4 +1,4 @@
-# MRTK Examples Hub #
+# MRTK Examples Hub
 
 ![MRTK Examples Hub](../Documentation/Images/ExamplesHub/MRTK_ExamplesHub.png)
 
@@ -6,12 +6,14 @@ MRTK Examples Hub is a Unity scene that makes it easy to experience multiple sce
 
 **MRTKExamplesHub.unity** is the container scene that has shared components including ``MixedRealityToolkit`` and ``MixedRealityPlayspace``. **MRTKExamplesHubMainMenu.unity** scene has the cube buttons.
 
-## Prerequisite ##
+## Prerequisite
 
 MRTK Examples Hub uses [Scene Transition Service](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.html) and related scripts. If you are using MRTK through Unity packages, please import **Microsoft.MixedReality.Toolkit.Unity.Extensions.x.x.x.unitypackage** which is part of the [release packages](https://github.com/microsoft/MixedRealityToolkit-Unity/releases). If you are using MRTK through the repository clone, you should already have **MixedRealityToolkit.Extensions** folder in your project.
 
-## MRTKExamplesHub Scene and the Scene System ##
-Open **MRTKExamplesHub.unity** which is located at ``MixedRealityToolkit.Examples/Experimental/Demos/ExamplesHub/Scenes/`` It is an empty scene with MixedRealityToolkit, MixedRealityPlayspace and LoadHubOnStartup. This scene is configured to use MRTK's Scene System. Click ``MixedRealitySceneSystem`` under MixedRealityToolkit. It will display the Scene System's information in the Inspector panel.
+## MRTKExamplesHub Scene and the Scene System
+
+Open **MRTKExamplesHub.unity** which is located at `MixedRealityToolkit.Examples/Experimental/Demos/ExamplesHub/Scenes/` It is an empty scene with MixedRealityToolkit, MixedRealityPlayspace and LoadHubOnStartup. This scene is configured to use MRTK's Scene System. Click `MixedRealitySceneSystem` under MixedRealityToolkit. It will display the Scene System's information in the Inspector panel.
+
 <br/><br/><img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHub_Hierarchy.png" width="300">
 <br/><br/><img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHub_Inspector1.png" width="450">
 
@@ -23,13 +25,13 @@ On the bottom of the Inspector, it displays the list of the scenes defined in th
 <br/><br/><img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHub_SceneSystem5.png">
 Example of loading multiple scenes.
 
-## Running the scene ##
+## Running the scene
 
 The scene works in both Unity's game mode and on device. Run the **MRTKExamplesHub** scene in the Unity editor and use MRTK's input simulation to interact with the scene contents. To build and deploy, simply build **MRTKExamplesHub** scene with other scenes that are included in the Scene System's list. The inspector also makes it easy to add scenes to the Build Settings. In the Building Settings, make sure **MRTKExamplesHub** scene is on the top of the list at index 0.
 
 <img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHub_BuildSettings.png" width="450">
 
-## How MRTKExamplesHub loads a scene ##
+## How MRTKExamplesHub loads a scene
 
 In the **MRTKExamplesHub** scene, you can find the ``ExamplesHubButton`` prefab.
 There is a **FrontPlate** object in the prefab which contains ``Interactable``.
@@ -46,8 +48,8 @@ Please refer to the [Scene System](SceneSystem/SceneSystemGettingStarted.md) pag
 ```c#
 MixedRealityToolkit.SceneSystem.LoadContent(contentName, loadSceneMode);
 ```
- 
-## Returning to the main menu scene ##
+
+## Returning to the main menu scene
 
 To return to the main menu scene (MRTKExamplesHubMainMenu scene), you can use the same Scene System `LoadContent()` method. The **ToggleFeaturesPanelExamplesHub.prefab** provides the 'Home' button which contains the **LoadContentScene** script. Use this prefab or provide a custom home button in each scene to allow the user to return to the main scene. One can put the **ToggleFeaturesPanelExamplesHub.prefab** in the **MRTKExamplesHub** scene to make it always visible since **MRTKExamplesHub** is a shared container scene. Make sure to hide/deactivate **ToggleFeaturesPanel.prefab** in each example scene.
 
@@ -55,9 +57,8 @@ To return to the main menu scene (MRTKExamplesHubMainMenu scene), you can use th
 
 <img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHubHomeButton.png" width="450">
 
+## Adding additional buttons
 
-
-## Adding additional buttons ##
 In the **CubeCollection** object, duplicate (or add) _ExampleHubButton_ prefabs and click **Update Collection** in the `GridObjectCollection`.
 This will update the cylinder layout based on the new total number of buttons.
 Please refer to the [Object Collection](README_ObjectCollection.md) page for more details.

--- a/Documentation/README_FingertipVisualization.md
+++ b/Documentation/README_FingertipVisualization.md
@@ -1,10 +1,10 @@
-# Fingertip visualization #
+# Fingertip visualization
 
 ![Fingertip visualization](../Documentation/Images/Fingertip/MRTK_FingertipVisualization_Main.png)
 
 The fingertip affordance helps the user recognize the distance from the target object. The ring shape visual adjusts its size based on the distance from the fingertip to the object. The fingertip visualization is primarily controlled by the [FingerCursor.prefab](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/FingerCursor.prefab) (and script) which is spawned as the cursor prefab of the *PokePointer*. Other components of the visualization include the *ProximityLight* script, and *MixedRealityStandard* shader.
 
-## How to use the fingertip visualization ##
+## How to use the fingertip visualization
 
 By default the fingertip visualization will work in any Unity scene that is configured to spawn a FingerCursor. Spawning of the FingerCursor occurs in the *DefaultMixedRealityToolkitConfigurationProfile* under:
 
@@ -12,13 +12,13 @@ By default the fingertip visualization will work in any Unity scene that is conf
 
 At a high level the fingertip visualization works by using a proximity light to project a colored gradient on any nearby surfaces that accept proximity lights. The finger cursor then looks for any nearby interactable surfaces, which are determined by parent `IMixedRealityNearPointer(s)`, to align the finger ring with a surface as the finger moves towards a surface. As a finger approaches a surface the finger ring is also dynamically animated using the round corner properties of the MixedRealityStandard shader.
 
-## Example scene ##
+## Example scene
 
 You can find fingertip visualization examples in almost any scene that works with articulated hands, but is prominent in the [HandInteractionExample scene](README_HandInteractionExamples.md).
 
 ![Fingertip visualization](../Documentation/Images/Fingertip/MRTK_FingertipVisualization_States.png)
 
-## Inspector properties ##
+## Inspector properties
 
 **FingerCursor**
 Many of the finger cursor properties are inherited from the base cursor class. Important properties include the far / near surface margins and widths which drive the finger ring animation in the MixedRealityStandard shader. For other properties please hover over the inspector tool tips.

--- a/Documentation/README_HandInteractionExamples.md
+++ b/Documentation/README_HandInteractionExamples.md
@@ -1,4 +1,4 @@
-# Hand interaction examples scene #
+# Hand interaction examples scene
 
 ![Hand Interaction Examples](../Documentation/Images/MRTK_Examples.png)
 
@@ -13,27 +13,27 @@ If you see large text after the TextMesh Pro import, open another Unity scene an
 
 <img src="../Documentation/Images/HandInteractionExamples/MRTK_Examples_TMP1.png" width="350">
 
-## Pressable button ##
+## Pressable button
 
 See [button](README_Button.md) page for the details.
 ![Hand Interaction Examples](../Documentation/Images/HandInteractionExamples/MRTK_Examples_PressTouch.png)
 
-## Bounding box ##
+## Bounding box
 
 See [bounding box](README_BoundingBox.md) page for the details.
 ![Hand Interaction Examples](../Documentation/Images/HandInteractionExamples/MRTK_Examples_BoundingBox.png)
 
-## Manipulation handler ##
+## Manipulation handler
 
 See [manipulation handler](README_ManipulationHandler.md) page for the details.
 ![Hand Interaction Examples](../Documentation/Images/HandInteractionExamples/MRTK_Examples_Manipulation.png)
 
-## Slate ##
+## Slate
 
 See [slate](README_Slate.md) page for the details.
 ![Hand Interaction Examples](../Documentation/Images/HandInteractionExamples/MRTK_Examples_Slate.png)
 
-## System keyboard ##
+## System keyboard
 
 See [system keyboard](README_SystemKeyboard.md) page for the details.
 ![Hand Interaction Examples](../Documentation/Images/HandInteractionExamples/MRTK_Examples_Keyboard.png)

--- a/Documentation/README_LostTrackingService.md
+++ b/Documentation/README_LostTrackingService.md
@@ -4,7 +4,8 @@
 
 Lost Tracking Extension Service provides HoloLens shell style animated visual for the lost tracking state.
 
-## How to use Lost Tracking Extensions ##
-In MRTK Profile, add **Lost Tracking Service** to the Extensions. Assign **DefaultLostTrackingServiceProfile** which includes **LostTrackingVisualPrefab**. 
+## How to use Lost Tracking Extensions
+
+In MRTK Profile, add **Lost Tracking Service** to the Extensions. Assign **DefaultLostTrackingServiceProfile** which includes **LostTrackingVisualPrefab**.
 
 <img src="../Documentation/Images/LostTracking/LostTracking_Extensions.png" width="550">

--- a/Documentation/README_ManipulationHandler.md
+++ b/Documentation/README_ManipulationHandler.md
@@ -1,10 +1,10 @@
-# Manipulation handler #
+# Manipulation handler
 
 ![Manipulation handler](../Documentation/Images/ManipulationHandler/MRTK_Manipulation_Main.png)
 
 The *ManipulationHandler* script allows for an object to be made movable, scalable, and rotatable using one or two hands. Manipulation can be restricted so that it only allows certain kinds of transformation. The script works with various types of inputs including HoloLens 2 articulated hand input, hand-rays, HoloLens (1st gen) gesture input, and immersive headset motion controller input.
 
-## How to use the manipulation handler ##
+## How to use the manipulation handler
 
 Add the [`ManipulationHandler.cs`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/ManipulationHandler.cs) component to a GameObject.
 
@@ -14,7 +14,7 @@ If you wish to set minimum or maximum values for the object's scale, you can add
 
 ![Manipulation Handler](../Documentation/Images/ManipulationHandler/MRTK_ManipulationHandler_Howto.png)
 
-## Inspector properties ##
+## Inspector properties
 
 <img src="../Documentation/Images/ManipulationHandler/MRTK_ManipulationHandler_Structure.png" width="450">
 
@@ -89,7 +89,7 @@ Specifies whether smoothing is active.
 **Smoothing Amount One Hand**
 Amount of smoothing to apply to the movement, scale, rotation. Smoothing of 0 means no smoothing. Max value means no change to value.
 
-## Events ##
+## Events
 
 Manipulation handler provides the following events:
 

--- a/Documentation/README_NearMenu.md
+++ b/Documentation/README_NearMenu.md
@@ -1,17 +1,18 @@
-# Near Menu #
+# Near Menu
 
 ![Near Menu](../Documentation/Images/NearMenu/MRTK_UX_NearMenu.png)
 
 Near Menu is a UX control which provides a collection of buttons or other UI components. It is floating around the user's body and easily accessible anytime. Since it is loosely coupled with the user, it does not disturb the user's interaction with the target content. The user can use the 'Pin' button to world-lock/unlock the menu. The menu can be grabbed and placed at a specific position.
 
-## Interaction behavior ##
-- **Tag-along**: The menu follows you and stays within 30-60cm range from the user for the near interactions. 
-- **Pin**: Using the 'Pin' button, the menu can be world-locked and released. 
+## Interaction behavior
+
+- **Tag-along**: The menu follows you and stays within 30-60cm range from the user for the near interactions.
+- **Pin**: Using the 'Pin' button, the menu can be world-locked and released.
 - **Grab and move**: The menu is always grabbable and movable. Regardless of the previous state, the menu will be pinned(world-locked) when grabbed and released. There are visual cues for the grabbable area. They are revealed on hand proximity.
 
 <img src="../Documentation/Images/NearMenu/MRTK_UX_NearMenu_Grab.png">
 
-## Prefabs ##
+## Prefabs
 
 Near Menu prefabs are designed to demonstrate how to use MRTK's various components to build menus for near interactions.
 
@@ -21,14 +22,14 @@ Near Menu prefabs are designed to demonstrate how to use MRTK's various componen
 - **NearMenuExample4x1.prefab**
 - **NearMenuExample4x2.prefab**
 
-## Example scene ##
+## Example scene
 
 You can find examples of Near Menu prefabs in the `NearMenuExamples` scene.
 
 <img src="../Documentation/Images/NearMenu/MRTK_UX_NearMenu_Examples.png">
 
-## Structure ##
 ## Structure
+
 Near Menu prefabs are made with following MRTK components.
 
 - [**PressableButtonHoloLens2**](README_Button.md) prefab
@@ -38,7 +39,7 @@ Near Menu prefabs are made with following MRTK components.
 
 ![Near Menu Prefab](../Documentation/Images/NearMenu/MRTK_UX_NearMenu_Structure.png)
 
-## How to customize ##
+## How to customize
 
 **1. Add/Remove Buttons**
 
@@ -60,8 +61,8 @@ Adjust the size of the `Quad` under `Backplate` object. The width and height of 
 
 *Default size of the HoloLens 2 button is 3.2x3.2 cm (0.032m)
 
+## See also
 
-## See also ##
 - [**Buttons**](README_Button.md)
 - [**Bounding Box**](README_BoundingBox.md)
 - [**Slider**](README_Sliders.md)

--- a/Documentation/README_ObjectCollection.md
+++ b/Documentation/README_ObjectCollection.md
@@ -1,10 +1,10 @@
-# Object collection #
+# Object collection
 
 ![Object collection](../Documentation/Images/ObjectCollection/MRTK_ObjectCollection_Main.jpg)
 
 Object collection is a script to help lay out an array of objects in predefined three-dimensional shapes. It supports various surface styles including plane, cylinder, sphere, and radial. Since it supports any object in Unity, it can be used to layout both 2D and 3D objects.
 
-# Object collection scripts #
+## Object collection scripts
 
 - [`GridObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs) supports Cylinder, Plane, Sphere, Radial surface types
 - [`ScatterObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/ScatterObjectCollection.cs) supports scattered style collection  
@@ -15,7 +15,7 @@ Object collection is a script to help lay out an array of objects in predefined 
 |![Grid Object Collection - Radial](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionRadial.png) Grid Object Collection - Radial | ![Grid Object Collection - Plane](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionPlane.png) Grid Object Collection - Plane |
 |![Scattered Object Collection](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionScattered.png) Scattered Object Collection | ![Tile Grid Object Collection](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionTileGrid.png) Tile Grid Object Collection |
 
-## How to use an object collection ##
+## How to use an object collection
 
 To create a collection, create an empty GameObject and assign one of the Object Collection scripts to it. Any object(s) can be added as a child of the GameObject. Once finished adding child objects, click the *Update Collection* button in the inspector panel to generate the object collection. The objects will be laid out in the scene according to the collection parameters. Update Collection can be accessed through the code too.
 
@@ -41,13 +41,13 @@ Use the **Layout** field to specify the row / column order that children are lai
 
 **Vertical** - Children are laid out in a single column using rows only.
 
-## Object collection examples ##
+## Object collection examples
 
 The [ObjectCollectionExamples.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/UX/Collections/Scenes/ObjectCollectionExamples.unity) example scene contains various examples of object collection types.
 
 [Periodic table of the elements](https://github.com/Microsoft/MRDesignLabs_Unity_PeriodicTable) is an example app that demonstrates how object collections work. It uses object collection to layout the 3D element boxes in different shapes.
 
-## Object collection types ##
+## Object collection types
 
 **3D objects**
 

--- a/Documentation/README_Slate.md
+++ b/Documentation/README_Slate.md
@@ -1,10 +1,10 @@
-# Slate #
+# Slate
 
 ![Slate](../Documentation/Images/Slate/MRTK_Slate_Main.png)
 
 The Slate prefab offers a thin window style control for displaying 2D content, for example plain text or articles including media. It offers a grabbable title bar as well as *Follow Me* and *Close* functionality. The content window can be scrolled via articulated hand input.
 
-## How to use a slate control ##
+## How to use a slate control
 
 A slate control is composed of the following elements:
 
@@ -16,7 +16,7 @@ A slate control is composed of the following elements:
 
 <img src="../Documentation/Images/Slate/MRTK_Slate_Structure.png" width="650">
 
-## Bounding Box ##
+## Bounding Box
 
 A slate control contains a bounding box script for scaling and rotating. For more information on bounding box, please see the [Bounding box](README_BoundingBox.md) page.
 
@@ -24,7 +24,7 @@ A slate control contains a bounding box script for scaling and rotating. For mor
 
 <img src="../Documentation/Images/Slate/MRTK_Slate_Scale.png" width="650">
 
-## Buttons ##
+## Buttons
 
 A standard slate offers two buttons as default on the top right of the title bar:
 
@@ -33,7 +33,7 @@ A standard slate offers two buttons as default on the top right of the title bar
 
 <img src="../Documentation/Images/Slate/MRTK_Slate_Buttons.png" width="650">
 
-## Scripts ##
+## Scripts
 
 In general, the `NearInteractionTouchable.cs` script must be attached to any object that is intended to receive touch events from the `IMixedRealityTouchHandler`.
 

--- a/Documentation/README_Sliders.md
+++ b/Documentation/README_Sliders.md
@@ -5,10 +5,12 @@
 Sliders are UI components that allow you to continuously change a value by moving a slider on a track. Currently the Pinch Slider can be moved by directly grabbing the slider, either directly or at a distance. Sliders work on AR and VR, using motion controllers, hands, or Gesture + Voice.
 
 ## Example scene
+
 You can find examples in the **SliderExample** scene under:
 [MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes/](/Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes)
 
 ## How to use Sliders
+
 Drag and drop the **PinchSlider** prefab into the scene hierarchy. If you want to modify or create your own slider, remember to do the following:
 
 - Make sure your that your thumb object has a collider on it. In the PinchSlider prefab, the collider is on `SliderThumb/Button_AnimationContainer/Slider_Button`
@@ -22,7 +24,9 @@ We also recommend using the following hierarchy
   - OtherVisuals - Containing any other visuals
 
 ## Slider Events
+
 Sliders expose the following events:
+
 - OnValueUpdated - Called whenever the slider value changes
 - OnInteractionStarted - Called when the user grabs the slider
 - OnInteractionEnded - Called when the user releases the slider
@@ -30,6 +34,7 @@ Sliders expose the following events:
 - OnHoverExited - Called when the user's hand / controller is no longer near the slider.
 
 ## Configuring Slider Bound and Axis
+
 You can directly move the starting and end points of the slider by moving the handles in the Scene:
 
 ![Sliders Config](../Documentation/Images/Sliders/MRTK_Sliders_Setup.png)
@@ -37,5 +42,3 @@ You can directly move the starting and end points of the slider by moving the ha
 You can also specify the axis (in local space) of the slider via the _Slider Axis_ field
 
 If you cannot use the handles, you can instead specify the start and end points of the slider via the _Slider Start Distance_ and _Slider End Distance_ fields. These specify start / end position of slider as a distance from the slider's center, in local coordinates. This means that once you set the slider start and end distances as you want them, you can scale the slider to be smaller or larger without needing to update the start and end distances.
-
-

--- a/Documentation/README_SystemKeyboard.md
+++ b/Documentation/README_SystemKeyboard.md
@@ -4,7 +4,7 @@
 
 A Unity application can invoke the system keyboard at any time. Note that the system keyboard will behave according to the target platform's capabilities, for example the keyboard on HoloLens 2 would support direct hand interactions, while the keyboard on HoloLens (1st gen) would support GGV<sup>[1](https://docs.microsoft.com/windows/mixed-reality/gaze)</sup>.
 
-## How to invoke the system keyboard ##
+## How to invoke the system keyboard
 
 ```c#
 public TouchScreenKeyboard keyboard;
@@ -17,7 +17,7 @@ public void OpenSystemKeyboard()
 }
 ```
 
-## How to read the input ##
+## How to read the input
 
 ```c#
 public TouchScreenKeyboard keyboard;
@@ -34,6 +34,6 @@ private void Update()
 }
 ```
 
-## System keyboard example ##
+## System keyboard example
 
 You can see a simple example of how to bring up system keyboard in [`MixedRealityKeyboard.cs`](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs)

--- a/Documentation/README_Tooltip.md
+++ b/Documentation/README_Tooltip.md
@@ -1,23 +1,24 @@
-# Tooltip #
+# Tooltip
 
 ![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Main.png)
 
 Tooltips are usually used to convey a hint or extra information upon closer inspection of an object. Tooltips can be used to annotate objects in the physical environment.
 
-## How to use a tooltip ##
+## How to use a tooltip
 
 A tooltip can be added directly to the hierarchy and targeted to an object.
 
 To use this method simply add a game object and one of the [tooltip prefabs](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips) to the scene hierarchy. In the prefab's inspector panel, expand the *Tool Tip* (script). Select a tip state and configure the tooltip.  Enter the respective text for the tool tip in the text field. Expand the *ToolTipConnector* (Script) and drag the object that is to have the tooltip from the hierarchy into the field labelled *Target*. This attaches the tooltip to the object.
 ![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Connector.png)
 
-
 This use assumes a tooltip that is always showing or that is shown / hidden via script by changing the tooltip state property of the tooltip component.
- 
-## Dynamically spawning tooltips ##
+
+## Dynamically spawning tooltips
+
 A tooltip can be dynamically added to an object at runtime as well as pre-set to show and hide on a tap or focus. Simply add the [`ToolTipSpawner`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs) script to any game object. Delays for appearing and disappearing can be set in the scripts inspector as well as a lifetime so that the tooltip will disappear after a set duration. Tooltips also feature style properties such as background visuals in the spawner script. By default the tooltip will be anchored to the object with the spawner script. This can be changed by assigning a GameObject to the anchor field.
 
-## Example scene ##
-In the [example scene files](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes), you will be able to find various examples of tooltips. 
+## Example scene
+
+In the [example scene files](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes), you will be able to find various examples of tooltips.
 
 ![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Examples.png)

--- a/Documentation/SceneSystem/SceneSystemGettingStarted.md
+++ b/Documentation/SceneSystem/SceneSystemGettingStarted.md
@@ -17,7 +17,7 @@ If your project consists of a single scene, the Scene System probably isn't nece
 - [Monitoring Content Loading](SceneSystemLoadProgress.md)
 - [Lighting Scene Loading](SceneSystemLightingScenes.md)
 
-# Editor settings
+## Editor settings
 
 By default, the Scene System enforces several behaviors in the Unity editor. If you find any of these behaviors heavy-handed, they can be disabled in the **Editor Settings** section of your Scene System profile.
 

--- a/Documentation/Tools/DependencyWindow.md
+++ b/Documentation/Tools/DependencyWindow.md
@@ -5,7 +5,7 @@ Often in Unity it is difficult to gleam which assets are being used, and what is
 
 The Dependency Window displays how assets reference and depend on each other. Dependencies are calculated by parsing guids within project YAML files (note, script to script dependencies are not considered).
 
-### Usage
+## Usage
 
 To open the window select *Mixed Reality Toolkit->Utilities->Dependency Window* this will open the window and automatically begin building your project's dependency graph. Once the dependency graph is built you can select assets in the project tab to inspect their dependencies.
 

--- a/Documentation/Tools/ScreenshotUtility.md
+++ b/Documentation/Tools/ScreenshotUtility.md
@@ -3,16 +3,17 @@
 
 Often taking screenshots in Unity for documentation and promotional imagery can be burdensome and the output often looks less than desirable. This is where the [ScreenshotUtility](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Tools/ScreenshotUtility) class comes into play.
 
-The ScreenshotUtility class aides in taking screenshots via menu items and public APIs within the Unity editor. Screenshots can be captured at various resolutions and with transparent clear colors for use in easy post compositing of images. Taking screenshots from a standalone build is not supported by this tool. 
+The ScreenshotUtility class aides in taking screenshots via menu items and public APIs within the Unity editor. Screenshots can be captured at various resolutions and with transparent clear colors for use in easy post compositing of images. Taking screenshots from a standalone build is not supported by this tool.
 
-### Taking Screenshots
+## Taking Screenshots
+
 Screenshots can be easily capture while in the editor by selecting *Mixed Reality Toolkit->Utilities->Take Screenshot* and then selecting your desired option. Make sure to have the game window tab visible if capturing while not playing, or a screenshot may not be saved.
 
 By default, all screenshots are saved to your [temporary cache path](https://docs.unity3d.com/ScriptReference/Application-temporaryCachePath.html), the path to the screenshot will be displayed in the Unity console.
 
 ![Screenshot utility menu item](../../Documentation/Images/ScreenshotUtility/MRTK_ScreenshotUtility_Menu_Item.png)
 
-### Example Screenshot Capture
+## Example Screenshot Capture
 
 The below screenshot was captured with the *"4x Resolution (Transparent Background)"* option. This outputs a high-resolution image with whatever pixels normally represented by the clear color saved as transparent pixels. This technique helps developers showcase their application for the store, or other media outlets, by overlaying this image on top of other imagery.
 


### PR DESCRIPTION
## Overview

1. Converts some third level lines that were bolded into headers
2. Removes the trailing `#` from any closed headers, as most of our docs use the unclosed style