### PR TITLE
Update casing in docs headers (phase 1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -28,12 +28,12 @@ A clear and concise description of what you expected to happen.
 
 If applicable, add screenshots to help explain your problem.
 
-## Your Setup (please complete the following information)
+## Your setup (please complete the following information)
 
 - Unity Version [e.g. 2018.3.11f1]
 - MRTK Version [e.g. v2.0]
 
-## Target Platform (please complete the following information)
+## Target platform (please complete the following information)
 
 - HoloLens
 - HoloLens 2

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-## Describe the Issue
+## Describe the issue
 A clear and concise what the issue
 
-## Feature Area
+## Feature area
 What's incorrect? What's missing?
 
-## Existing Doc Link
-If this is about something in an existing document, please provide link 
+## Existing doc link
+If this is about something in an existing document, please provide link
 
 ## Additional context
 Add any other context about the problem here.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,12 +1,12 @@
 ## Overview
 
-## Expected Behavior
+## Expected behavior
 
-## Actual Behavior
+## Actual behavior
 
 ## Steps to reproduce
 _(Links to sample github project preferred)_
 
-## Unity Editor Version
+## Unity editor version
 
-## Mixed Reality Toolkit Release Version
+## Mixed Reality Toolkit release version

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Models/Avocado/README.md
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Models/Avocado/README.md
@@ -4,7 +4,7 @@
 
 ![screenshot](../../../../../../Documentation/Images/gltf/avocado_screenshot.jpg)
 
-## License Information
+## License information
 
 [![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)  
 To the extent possible under law, Microsoft has waived all copyright and related or neighboring rights to this asset.

--- a/Assets/MixedRealityToolkit.Examples/Demos/README.md
+++ b/Assets/MixedRealityToolkit.Examples/Demos/README.md
@@ -23,7 +23,7 @@ Solvers also allow objects to be aware of their surroundings and moved with / ag
 
 This folder contains a simple demonstration scene showing several of the solver options and how they can be applied in a scene.
 
-## Standard Shader
+## Standard shader
 
 The MRTK standard shader is specifically customized for use in Mixed Reality environments and enabling several advanced effects "out of the box".
 

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/README.md
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/README.md
@@ -1,10 +1,10 @@
-# What is the "MixedRealityToolkit/Standard" shader?
+# MixedRealityToolkit/Standard shader
 
 The MixedRealityToolkit/Standard shader is a collection of shading techniques for mimicking [**Microsoft's Fluent Design System**](https://fluent.microsoft.com/) within Unity 3D.
 
 The goal of this shader is to have a single, flexible shader that can achieve visuals similar to Unity's Standard Shader, implement Fluent Design System principles, and remain performant on mixed reality devices.
 
-## Example Scenes
+## Example scenes
 
 To explore a Unity scene demonstrating materials which use many of the MixedRealityToolkit/Standard's features open **Scenes\MaterialGallery.unity** within Unity's editor, or deploy to a mixed reality device.
 To compare the Unity Standard shader to the MRTK Standard shader open **Scenes\StandardMaterialComparison.unity** within Unity's editor, or deploy to a mixed reality device.

--- a/Assets/MixedRealityToolkit.SDK/Experimental/PulseShader/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/PulseShader/README.md
@@ -1,4 +1,4 @@
-# Pulse Shader
+# Pulse shader
 
 ![MRTK_SpatialMesh_Pulse](https://user-images.githubusercontent.com/13754172/68261851-3489e200-fff6-11e9-9f6c-5574a7dd8db7.gif)
 

--- a/Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md
@@ -1,8 +1,8 @@
-# Scrolling Object Collection
+# Scrolling object collection
 
 The ScrollingObjectCollection is an Object Collection that natively scrolls 3D objects. It supports scrolling pressable buttons and Interactables as well as non-interactive objects. This collection supports both near and far input. In order to use ScrollingObjectCollection, objects must use the MRTK Standard Shader in order for the clipping effect to work properly.
 
-## Getting started with Scrolling Object Collection
+## Getting started with scrolling object collection
 
 For convenience, there are two ScrollingObjectCollection Prefabs available to use. One is configured to work with 32x92mm PressableButton prefabs, and the other is for any object in a 32x32x32mm container.
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Controllers/README.md
@@ -4,13 +4,13 @@ As part of the Mixed Reality Toolkit SDK, we provide scripts / controls for mana
 
 Currently we provide components for:
 
-## Controller Visualizer
+## Controller visualizer
 
 Provides a singular function for rendering controller models in a scene, whether it's a generic model for all controller, or controller specific models.
 The framework is flexible enough to allow you to provide offsets to rotate and reposition the model as it's drawn
 > Scaling isn't affected, it's up to you to pre-scale models appropriate to use in your Mixed Reality Scene
 
-### Controller Visualizer usage
+### Controller visualizer usage
 
 Using the visualizer is extremely simple, just add it to an existing GameObject in your scene and provided you have configured your controller correctly, they will simply be instantiated into the scene at runtime when controllers are detected.
 
@@ -20,10 +20,10 @@ Check the documentation on configuring Controller Profiles for more details:
 
 * [MixedReality Controller Configuration Profile configuration](../../../../Profiles/MixedRealityControllerConfigurationProfile.md)
 
-### Controller Visualizer notes
+### Controller visualizer notes
 
 The controller visualizer is still in active development, new features that will be added in the future include:
 
 * Ability to interrogate a given model to extract attachment nodes
-* Ability to use Animation configuration for a given model
+* Ability to use animation configuration for a given model
 * Configuration to be able to animate models from actions by animation or change in pose

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/README.md
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/README.md
@@ -2,14 +2,14 @@
 
 This folder contains the scripts necessary for making Interactable buttons that support Speech, Far Interaction and Near Interaction (Physical hand pressing)
 
-## High Level Description
+## High level description
 
 PhysicalButtonMovement is similar to HandInteractionPress.
 It uses External Object Targeting (EOT) to move an Interactable element along a press direction vector.
 PhysicalButtonMovement needs a large BoxCollider on the Ignore Raycast layer (which it sets automatically)
 It tracks the position of both index tip fingers and uses this to move the button as needed.
 
-## States and Events
+## States and events
 
 It then calls into a PhysicalPressEventRouter and calls events related to Touch, Press, Unpress (Default Click), and Untouch.
 
@@ -23,7 +23,7 @@ It also calls OnPointerClicked events, allowing for the PhysicalButtonMovement s
 
 If PhysicalPressEventRouter does not satisfy your use case, you can write your own and utilize it instead.
 
-## Touch Button & Button Cage
+## Touch button & button cage
 
 Pressable buttons feature a normally invisible mesh called a 'Button Cage' or a 'Button Box'
 This mesh has one direction as the button face (Negative Z).
@@ -34,7 +34,7 @@ TouchButton triggers the glow splash when the joint positions enter into a colli
 
 A Prefab is provide in MRTK.Examples/Demos/HandTracking/Prefabs/PressableButtons.
 
-## PhysicalButtonMovement Customization
+## PhysicalButtonMovement customization
 
 You can customize variables within the PressableButtons, such as the dimensions of the detection box collider.
 

--- a/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/MixedRealityControllerConfigurationProfile.md
@@ -1,4 +1,4 @@
-# Mixed Reality Controller Configuration Profile
+# Mixed reality controller configuration profile
 
 When you need to use input controllers for your Mixed Reality project, they are registered and configured centrally within the Controller configuration profile as you can see here:
 
@@ -8,34 +8,34 @@ This enables you to very quickly define which SDKs / controllers you want to sup
 
 The configuration is broken down in to several key components, as detailed below:
 
-## Main Controller Template definition
+## Main controller template definition
 
 ![Controller model definition](../../../Documentation/Images/ControllerConfigurationProfile/02-ControllerTemplateDefinition.png)
 
 In the first section of the configuration, the options are detailed as follows:
 
-### Render Motion Controllers
+### Render motion controllers
 
 This defines whether or not controllers should be rendered or not.  By not adding a ControllerVisualizer in to the scene also has the same effect.
 > This also disabled the Global Model options below.
 
-### Use Default Models (for future implementation)
+### Use default models
 
 This option will use the models for the controller direct from the SDK (where available), so that you don't have to configure a custom model.
 
-### Global Left / Right hand models
+### Global left / right hand models
 
 These allow you at the top level to define the default model that will be drawn for each controlling hand.  If no hand is available, the Left most model will be used by default.
 
-To alter the position and rotation of the displayed model in relation to the Controller pose, then update the controllers Model Prefab transform values.
+To alter the position and rotation of the displayed model in relation to the controller pose, then update the controller's ModelPrefab transform values.
 
 > See the "Example Models" section below for the controller models and their recommended transform settings provided in the SDK's "**Standard Assets**" folder.
 
-### Add a New Controller Template
+### Add a new controller template
 
 This enables you to add a new controller definition (detailed below) to the profile to add another supported SDK.
 
-## Controller Template
+## Controller template
 
 ![Controller template](../../../Documentation/Images/ControllerConfigurationProfile/03-ControllerTemplate.png)
 
@@ -50,7 +50,7 @@ The options for configuring a template are detailed as follows:
 
 Your custom name for the controller, just for easy reference
 
-### Controller Type (Work in progress, see list for enabled devices)
+### Controller type
 
 A drop down list of supported controllers by the Mixed Reality Toolkit, namely:
 
@@ -72,18 +72,18 @@ A drop down list of supported controllers by the Mixed Reality Toolkit, namely:
 Which hand is configured for this controller definition
 > Both does not configure all controllers at this time.
 
-### Use Default model
+### Use default model
 
 For this controller only, use the model for the controller direct from the SDK (where available), so that you don't have to configure a custom model. This overrides the Global Model setting.
 
 > [!NOTE]
 > This is currently supported on both Windows Mixed Reality and OpenVR, loading any controller models provided by the platform API.
 
-### Override Model
+### Override model
 
 Like the Global Model options, allows you to provide a model to be drawn for this specific controller. This overrides the Global Model setting.
 
-### Interaction Mappings
+### Interaction mappings
 
 The interaction mappings allow you to map logical input actions for use in your project to the various controller inputs available from the physical device.  
 
@@ -99,13 +99,13 @@ The Action each input can perform, is completely up to you.
 
 > See the [Input Action configuration profile](../../../Documentation/Input/InputActions.md) for more information.
 
-## Example Models
+## Example models
 
 The models provided in the Mixed Reality Toolkit "Standard Assets" folder are as follows:
 
 > These can be found in "Mixed Reality Toolkit SDK / Standard Assets / Controllers"
 
-### Debug Controllers
+### Debug controllers
 
 The Mixed Reality Toolkit provides a set of basic Gizmo style controllers, used to help align your models to the controller position output by the SDK, to help with offset settings.
 > Note, the ability to display BOTH the Gizmo and the controller models isn't supported as yet. This will be included in a future release.

--- a/Assets/MixedRealityToolkit/Providers/Hands/README.md
+++ b/Assets/MixedRealityToolkit/Providers/Hands/README.md
@@ -1,8 +1,8 @@
-# Hand Devices
+# Hand devices
 
 Base class for all hand devices, to act be implemented by all backends that want to provide hand input in MRTK. Simulated hands can be used if no hand tracking device is available.
 
-## Simulated Hands
+## Simulated hands
 
 Hand input can be simulated in Unity using the "In-Editor Input Simulation" service. This service is enabled by default.
 

--- a/Documentation/Architecture/InputSystem/ControllersPointersAndFocus.md
+++ b/Documentation/Architecture/InputSystem/ControllersPointersAndFocus.md
@@ -1,4 +1,4 @@
-# Controllers, Pointers, and Focus
+# Controllers, pointers, and focus
 
 Controllers, pointers, and focus are higher-level concepts that build upon the foundation established by the core input system. Together, they provide a large portion of the mechanism for interacting with objects in the scene.
 
@@ -36,7 +36,7 @@ Pointers generally fall into one of the following categories:
 
   These types of pointers plug into the teleportation system to handle moving the user to the location targeted by the pointer.
 
-## Pointer Mediation
+## Pointer mediation
 
 Because a single controller can have multiple pointers (for example, the articulated hand can have both near and far interaction pointers), there exists a component that is responsible for mediating which pointer should be active.
 

--- a/Documentation/Architecture/InputSystem/CoreSystem.md
+++ b/Documentation/Architecture/InputSystem/CoreSystem.md
@@ -1,4 +1,4 @@
-# Core System
+# Core system
 
 At the heart of the input system is the [MixedRealityInputSystem](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs),
 which is a service that is responsible for initializing and operating all of the input related
@@ -64,7 +64,7 @@ the event dispatch process stops.
 3. Event is sent to the focused object.
 4. Event is sent to fallback listeners.
 
-## Device Managers / Data Providers
+## Device managers and data providers
 
 These entities are responsible for interfacing with lower-level APIs (such as Windows Mixed Reality APIs,
 or OpenVR APIs) and translating data from those systems into ones that fit the MRTK's higher

--- a/Documentation/Architecture/InputSystem/Terminology.md
+++ b/Documentation/Architecture/InputSystem/Terminology.md
@@ -1,4 +1,4 @@
-# Input System
+# Input system
 
 The input system is one of the largest systems out of all features offered by the MRTK.
 So many things within the toolkit build on top of it (pointers, focus, prefabs). The code within the input

--- a/Documentation/Architecture/SpatialAwareness.md
+++ b/Documentation/Architecture/SpatialAwareness.md
@@ -1,3 +1,3 @@
-# Spatial Awareness
+# Spatial awareness
 
 Read [Spatial Awareness Getting Started](../SpatialAwareness/SpatialAwarenessGettingStarted.md)

--- a/Documentation/Architecture/SystemsExtensionsProviders.md
+++ b/Documentation/Architecture/SystemsExtensionsProviders.md
@@ -1,4 +1,4 @@
-# Systems, Extension Services and Data Providers
+# Systems, extension services and data providers
 
 In the Mixed Reality Toolkit, many of the features are delivered in the form of services. Services are grouped into three
 primary categories: systems, extension services and data providers.
@@ -30,7 +30,7 @@ component's configuration profile.
 
 ![Configuring an extension service](../Images/Profiles/ConfiguredExtensionService.png)
 
-## Data Providers
+## Data providers
 
 Data providers are components that, per their name, provide data to a Mixed Reality Toolkit service. All data providers must specify that
 they implement the [`IMixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityDataProvider) interface.
@@ -80,7 +80,7 @@ application is running.
 
 For information on writing a data provider for the MRTK input system, please see [creating an input system data provider](../Input/CreateDataProvider.md).
 
-### Spatial Awareness
+### Spatial awareness
 
 The MRTK spatial awareness system utilizes only data providers that implement the [`IMixedRealitySpatialAwarenessObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.IMixedRealitySpatialAwarenessObserver) interface.
 
@@ -113,7 +113,7 @@ if (CoreServices.SpatialAwarenessSystem != null)
 
 For information on writing a data provider for the MRTK spatial awareness system, please see [creating a spatial awareness system data provider](../SpatialAwareness/CreateDataProvider.md).
 
-## See Also
+## See also
 
 - [What makes a mixed reality feature](../MixedRealityServices.md)
 - [Extension services](../Extensions/ExtensionServices.md)

--- a/Documentation/Boundary/BoundarySystemGettingStarted.md
+++ b/Documentation/Boundary/BoundarySystemGettingStarted.md
@@ -1,10 +1,10 @@
-# Boundary System
+# Boundary system
 
 The Boundary system provides support for visualizing Virtual Reality boundary components in mixed reality applications. Boundaries define the area in which users can safely move around while wearing a VR headset. Boundaries are an important component of a mixed reality experience to help users avoid unseen obstacles while wearing a VR headset.
 
 Many Virtual Reality platforms provide an automatic display, for example a white outline superimposed on the virtual world as the user or their controller nears the boundary. The Mixed Reality Toolkit's Boundary System extends this feature to enable the display of an outline of the tracked area, a floor plane and other features that can be used to provide additional information to users.
 
-## Getting Started
+## Getting started
 
 Adding support for boundaries requires two key components of the Mixed Reality Toolkit: the Boundary System and a Virtual Reality platform configured with a boundary.
 
@@ -12,7 +12,7 @@ Adding support for boundaries requires two key components of the Mixed Reality T
 2. [Configure](#configure-boundary-visualization) the boundary visualization
 3. [Build and deploy](#build-and-deploy) to a VR platform with a configured boundary
 
-## Enable Boundary System
+## Enable boundary system
 
 The Boundary System is managed by the MixedRealityToolkit object (or another [service registrar](xref:Microsoft.MixedReality.Toolkit.IMixedRealityServiceRegistrar) component).
 
@@ -33,7 +33,7 @@ The following steps presume use of the MixedRealityToolkit object. Steps require
 > [!NOTE]
 > All Boundary System implementation must extend the [`IMixedRealityBoundarySystem`](xref:Microsoft.MixedReality.Toolkit.Boundary.IMixedRealityBoundarySystem)
 
-## Configure Boundary Visualization
+## Configure boundary visualization
 
 The [Boundary System uses a configuration profile](ConfiguringBoundaryVisualization.md) to specify which boundary components are to be displayed and to configure their appearance.
 
@@ -42,14 +42,14 @@ The [Boundary System uses a configuration profile](ConfiguringBoundaryVisualizat
 > [!NOTE]
 > Users of the default profile ([DefaultMixedRealityBoundaryVisualizationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityBoundaryVisualizationProfile.asset)) will have the boundary system pre-configured to display a floor plane, the play area and the tracked area.
 
-## Build and Deploy
+## Build and deploy
 
 Once the boundary system is configured with the desired visualization options, the project can be built deployed to the target platform.
 
 > [!NOTE]
 > Unity Play Mode enables in-editor visualization of the configured boundary. This feature enables rapid development and testing without requiring the build and deploy step. Be sure to do final acceptance testing using an built and deployed version of the application, running on the target hardware and platform.
 
-## Accessing Boundary System via code
+## Accessing boundary system via code
 
 If enabled and configured, the Boundary System can be accessed via the CoreServices static helper class. The reference can then be used to dynamically change the Boundary parameters and access related GameObjects managed by the system.
 
@@ -61,7 +61,7 @@ CoreServices.BoundarySystem.ShowBoundaryWalls = false;
 GameObject floorVisual = CoreServices.BoundarySystem.GetFloorVisualization();
 ```
 
-## See Also
+## See also
 
 - [Boundary API documentation](xref:Microsoft.MixedReality.Toolkit.Boundary)
 - [Configuring the Boundary Visualization](ConfiguringBoundaryVisualization.md)

--- a/Documentation/Boundary/ConfiguringBoundaryVisualization.md
+++ b/Documentation/Boundary/ConfiguringBoundaryVisualization.md
@@ -1,16 +1,16 @@
-# Configuring the Boundary Visualization
+# Configuring the boundary visualization
 
 The *Boundary Visualization Profile* provides options for configuring the visual aesthetics and other related parameters for the Boundary system. Boundary visualizations are attached to the Mixed Reality Playspace object in the scene and teleport with the user.
 
-## General Settings
+## General settings
 
 ![Boundary Visualization General Settings](../../Documentation/Images/Boundary/BoundaryVisualizationGeneralSettings.png)
 
-### Boundary Height
+### Boundary height
 
 The boundary height indicates the distance above the floor plane at which the boundary ceiling should be rendered. The default value is 3 meters.
 
-## Floor Settings
+## Floor settings
 
 ![Boundary Visualization Floor Settings](../../Documentation/Images/Boundary/BoundaryVisualizationFloorSettings.png)
 
@@ -30,7 +30,7 @@ Indicates the size, in meters, of the floor plane to be created. The default sca
 
 The layer on which the floor plane should be set. The default value is the *Default* layer.
 
-## Play Area Settings
+## Play area settings
 
 ![Boundary Visualization Play Area Settings](../../Documentation/Images/Boundary/BoundaryVisualizationPlayAreaSettings.png)
 
@@ -46,7 +46,7 @@ Indicates the material that should be used when creating the play area object.
 
 The layer on which the play area should be set. The default value is the *Ignore Raycast* layer.
 
-## Tracked Area Settings
+## Tracked area settings
 
 ![Boundary Visualization Tracked Area Settings](../../Documentation/Images/Boundary/BoundaryVisualizationTrackedAreaSettings.png)
 
@@ -62,7 +62,7 @@ Indicates the material that should be used when creating the tracked area outlin
 
 The layer on which the tracked area should be sets. The default value is the *Ignore Raycast* layer.
 
-## Boundary Wall Settings
+## Boundary wall settings
 
 ![Boundary Visualization Boundary Wall Settings](../../Documentation/Images/Boundary/BoundaryVisualizationWallSettings.png)
 
@@ -81,7 +81,7 @@ The layer on which the boundary walls should be set. The default value is the *I
 > [!NOTE]
 > Setting the boundary wall component to a physics layer other than *Ignore Raycast* may prevent users from interacting with objects within the scene.
 
-## Boundary Ceiling Settings
+## Boundary ceiling settings
 
 ![Boundary Visualization Boundary Ceiling Settings](../../Documentation/Images/Boundary/BoundaryVisualizationCeilingSettings.png)
 
@@ -100,7 +100,7 @@ The layer on which the boundary walls should be set. The default value is the *I
 > [!NOTE]
 > Setting the boundary ceiling component to a physics layer other than *Ignore Raycast* may prevent users from interacting with objects within the scene.
 
-## See Also
+## See also
 
 - [Boundary API documentation](xref:Microsoft.MixedReality.Toolkit.Boundary)
 - [Boundary System](BoundarySystemGettingStarted.md)

--- a/Documentation/CameraSystem/CameraSystemOverview.md
+++ b/Documentation/CameraSystem/CameraSystemOverview.md
@@ -1,4 +1,4 @@
-# Camera System
+# Camera system
 
 The camera system enables the Microsoft Mixed Reality Toolkit to configure and optimize the application's camera for use in mixed reality applications. Using the camera system, applications can be written to support both opaque (ex: virtual reality) and transparent (ex: Microsoft HoloLens) devices without needing to write code to distinguish between, and accommodate for, each type of display.
 

--- a/Documentation/CameraSystem/CreateSettingsProvider.md
+++ b/Documentation/CameraSystem/CreateSettingsProvider.md
@@ -1,4 +1,4 @@
-# Creating a Camera Settings Provider
+# Creating a camera settings provider
 
 The Camera system is an extensible system for providing support for platform specific camera configurations. To add support for a new camera configuration, a custom settings provider may be required.
 
@@ -14,7 +14,7 @@ Data providers can be distributed in one of two ways:
 
 The approval process for submissions of new data providers to the MRTK will vary on a case-by-case basis and will be communicated at the time of the initial proposal. Proposals can be submitted by creating a new [*Feature Request* type issue](https://github.com/microsoft/MixedRealityToolkit-Unity/issues).
 
-### Third Party add-on
+### Third party add-ons
 
 **Namespace**
 

--- a/Documentation/CameraSystem/UnityArCameraSettings.md
+++ b/Documentation/CameraSystem/UnityArCameraSettings.md
@@ -58,7 +58,7 @@ The available options are described in the following table.
 
 The default value for tracking type is **Update And Before Render**, to enable the lowest tracking latency.
 
-## See Also
+## See also
 
 - [Camera System Overview](CameraSystemOverview.md)
 - [Creating a Camera Settings Provider](CreateSettingsProvider.md)

--- a/Documentation/CameraSystem/WindowsMixedRealityCameraSettings.md
+++ b/Documentation/CameraSystem/WindowsMixedRealityCameraSettings.md
@@ -31,11 +31,11 @@ The Windows Mixed Reality Camera Settings also supports a profile. This profile 
 
 ![Windows Mixed Reality camera settings configuration](../Images/CameraSystem/WMRCameraSettingsProfile.png)
 
-### Render Mixed Reality Capture from the photo/video camera
+### Render mixed reality capture from the photo/video camera
 
 With this setting on HoloLens 2, you can enable hologram alignment in your mixed reality captures. If enabled, the platform will provide an additional HolographicCamera to the app when a mixed reality capture photo or video is taken. This HolographicCamera provides view matrices corresponding to the photo/video camera location, and it provides projection matrices using the photo/video camera field of view. This will ensure that holograms, such as hand meshes, remain visibly aligned in the video output.
 
-## See Also
+## See also
 
 - [Camera System Overview](CameraSystemOverview.md)
 - [Creating a Camera Settings Provider](CreateSettingsProvider.md)

--- a/Documentation/Contributing/BreakingChanges.md
+++ b/Documentation/Contributing/BreakingChanges.md
@@ -1,4 +1,4 @@
-# Breaking Changes
+# Breaking changes
 
 Consumers of the MRTK depend on having a stable release-to-release API surface, so that they can take updates to the MRTK without having large breaking changes each time.
 


### PR DESCRIPTION
## Overview

Our documentation guidelines recommend [using sentence case for headlines](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Contributing/DocumentationGuide.html#capitalization), something our docs currently do inconsistently. This is phase 1 of a few (I broke them up so it isn't 100+ files all at once) to fix up our headers.

NOTE: These PRs are only intended to update headers. Some non-header casing changes may have made their way in, but I'm trying to split these changes into more reviewable chunks.