### PR TITLE
Header capitalization phase 3

### DIFF
--- a/Documentation/Input/HandTracking.md
+++ b/Documentation/Input/HandTracking.md
@@ -1,12 +1,12 @@
-# Hand Tracking
+# Hand tracking
 
-## Hand Tracking Profile
+## Hand tracking profile
 
 The _Hand Tracking profile_ is found under the _Input System profile_. It contains settings for customizing hand representation.
 
 <img src="../../Documentation/Images/Input/HandTrackingProfile.png" width="650px" style="display:block;">
 
-## Joint Prefabs
+## Joint prefabs
 
 Joint prefabs are visualized using simple prefabs. The _Palm_ and _Index Finger_ joints are of special importance and have their own prefab, while all other joints share the same prefab.
 
@@ -17,7 +17,7 @@ By default the hand joint prefabs are simple geometric primitives. These can be 
 
 <img src="../../Documentation/Images/InputSimulation/MRTK_Core_Input_Hands_JointVisualizerPrefabs.png" width="350px"  style="display:block;">
 
-## Hand Mesh Prefab
+## Hand mesh prefab
 
 The hand mesh is used if fully defined mesh data is provided by the hand tracking device. The mesh renderable in the prefab is replaced by data from the device, so a dummy mesh such as a cube is sufficient. The material of the prefab is used for the hand mesh.
 
@@ -47,11 +47,11 @@ Available joints are listed in the [`TrackedHandJoint`](xref:Microsoft.MixedReal
 > [!NOTE]
 > Joint object are destroyed when hand tracking is lost! Make sure that any scripts using the joint object handle the `null` case gracefully to avoid errors!
 
-### Accessing a given Hand Controller
+### Accessing a given hand controller
 
 A specific hand controller is often available, e.g. when handling input events. In this case the joint data can be requested directly from the device, using the [`IMixedRealityHand`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand) interface.
 
-#### Polling Joint Pose from Controller
+#### Polling joint pose from controller
 
 The [`TryGetJoint`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand.TryGetJoint*) function returns `false` if the requested joint is not available for some reason. In that case the resulting pose will be [`MixedRealityPose.ZeroIdentity`](xref:Microsoft.MixedReality.Toolkit.Utilities.MixedRealityPose.ZeroIdentity).
 
@@ -69,7 +69,7 @@ public void OnSourceDetected(SourceStateEventData eventData)
 }
 ```
 
-#### Joint Transform from Hand Visualizer
+#### Joint transform from hand visualizer
 
 Joint objects can be requested from the [controller visualizer](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityController.Visualizer).
 
@@ -91,7 +91,7 @@ public void OnSourceDetected(SourceStateEventData eventData)
 
 If no specific controller is given then utility classes are provided for convenient access to hand joint data. These functions request joint data from the first available hand device currently tracked.
 
-#### Polling Joint Pose from HandJointUtils
+#### Polling joint pose from HandJointUtils
 
 [`HandJointUtils`](xref:Microsoft.MixedReality.Toolkit.Input.HandJointUtils) is a static class that queries the first active hand device.
 
@@ -102,7 +102,7 @@ if (HandJointUtils.TryGetJointPose(TrackedHandJoint.IndexTip, Handedness.Right, 
 }
 ```
 
-#### Joint Transform from Hand Joint Service
+#### Joint transform from hand joint service
 
 [`IMixedRealityHandJointService`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandJointService) keeps a persistent set of [GameObjects](https://docs.unity3d.com/ScriptReference/GameObject.html) for tracking joints.
 
@@ -124,11 +124,11 @@ if (handJointService != null)
 }
 ```
 
-### Hand Tracking Events
+### Hand tracking events
 
 The input system provides events as well, if polling data from controllers directly is not desirable.
 
-#### Joint Events
+#### Joint events
 
 [`IMixedRealityHandJointHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandJointHandler) handles updates of joint positions.
 
@@ -150,7 +150,7 @@ public class MyHandJointEventHandler : IMixedRealityHandJointHandler
 }
 ```
 
-#### Mesh Events
+#### Mesh events
 
 [`IMixedRealityHandMeshHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHandMeshHandler) handles changes of the articulated hand mesh.
 
@@ -181,7 +181,7 @@ public class MyHandMeshEventHandler : IMixedRealityHandMeshHandler
 }
 ```
 
-## Known Issues
+## Known issues
 
 ### .NET Native
 

--- a/Documentation/Input/InputActions.md
+++ b/Documentation/Input/InputActions.md
@@ -1,8 +1,8 @@
-# Input Actions
+# Input actions
 
 [**Input Actions**](InputActions.md) are abstractions over raw inputs meant to help isolating application logic from the specific input sources producing an input. It can be useful, for example, to define a *Select* action and map it to the left mouse button, a button in a gamepad and a trigger in a 6 DOF controller. You can then have your application logic listen for *Select* input action events instead of having to be aware of all the different inputs that can produce it.
 
-## Creating An Input Action
+## Creating an input action
 
 Input actions are configured in the **Input Actions Profile**, inside the *Input System Profile* in the Mixed Reality Toolkit component, specifying a name for the action and the type of inputs (*Axis Constraint*) it can be mapped to:
 
@@ -19,11 +19,11 @@ Six Dof | 3D pose with translation and rotation like the one produced by 6 DOF c
 
 You can find the full list in [`AxisType`](xref:Microsoft.MixedReality.Toolkit.Utilities.AxisType).
 
-## Mapping Inputs To Actions
+## Mapping input to actions
 
 The way you map an input to and action depends on the type of the input source:
 
-### Controller Inputs
+### Controller input
 
 Go to the **Controller Input Mapping Profile**, under the *Input System Profile*. There you will find a list of all supported controllers:
 
@@ -33,22 +33,22 @@ Select the one you want to configure and a dialog window will appear with all th
 
 <img src="../../Documentation/Images/Input/InputActionAssignment.PNG" style="max-width:100%;">
 
-### Speech Inputs
+### Speech input
 
 In the **Speech Command Profile**, under the *Input System Profile*, you'll find the list of currently defined speech commands. To map one of them to an action, just select it in the *Action* drop down.
 
 <img src="../../Documentation/Images/Input/SpeechCommandsProfile.png" style="max-width:100%;">
 
-### Gesture Inputs
+### Gesture input
 
 The **Gestures Profile**, under the *Input System Profile*, contains all defined gestures. You can map each of them to an action by selecting it in the *Action* drop down.
 
 <img src="../../Documentation/Images/Input/GestureProfile.png" style="max-width:100%;">
 
-## Handling Input Actions
+## Handling input actions
 
 > [!WARNING]
-> Currently only input actions of *Digital* type can be handled using the methods described in this section. For other action types, you'll have to handle directly the events for the corresponding inputs instead. For example, to handle a 6 DOF  action mapped to controller inputs, you'll have to use [`IMixedRealityGestureHandler<T>`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityGestureHandler`1) with T = [`MixedRealityPose`](xref:Microsoft.MixedReality.Toolkit.Utilities.MixedRealityPose).
+> Currently only input actions of *Digital* type can be handled using the methods described in this section. For other action types, you'll have to handle directly the events for the corresponding inputs instead. For example, to handle a 6 DOF action mapped to controller inputs, you'll have to use [`IMixedRealityGestureHandler<T>`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityGestureHandler`1) with T = [`MixedRealityPose`](xref:Microsoft.MixedReality.Toolkit.Utilities.MixedRealityPose).
 
 The easiest way to handle input actions is to make use of the [`InputActionHandler`](xref:Microsoft.MixedReality.Toolkit.Input.InputActionHandler) script. This allows you to define the action you want to listen to and react to action started and ended events using Unity Events.
 

--- a/Documentation/Input/InputProviders.md
+++ b/Documentation/Input/InputProviders.md
@@ -1,4 +1,4 @@
-# Input Providers
+# Input providers
 
 Input providers are registered in the **Registered Service Providers Profile**, found in the Mixed Reality Toolkit component:
 

--- a/Documentation/Input/InputState.md
+++ b/Documentation/Input/InputState.md
@@ -1,4 +1,4 @@
-# Accessing Input State in MRTK
+# Accessing input state in MRTK
 
 It's possible to directly query the state of all inputs in MRTK by iterating over the controllers attached to the input sources. MRTK also provides convenience methods for accessing the position and rotation of the eyes, hands, head, and motion controller.
 
@@ -49,7 +49,7 @@ foreach(var controller in CoreServices.InputSystem.DetectedControllers)
 }
 ```
 
-## See Also
+## See also
 
 - [InputEvents](InputEvents.md)
 - [Pointers](Pointers.md)

--- a/Documentation/Input/Overview.md
+++ b/Documentation/Input/Overview.md
@@ -1,4 +1,4 @@
-# Input Overview
+# Input overview
 
 The Input System in MRTK allows you to:
 
@@ -22,4 +22,4 @@ Controllers can have [**Pointers**](Pointers.md) attached to them that query the
 
 While you can handle [input events directly in UI components](InputEvents.md), it is recommended to use [pointer events](pointers.md#pointer-event-interfaces) to keep the implementation device-independent.
 
-MRTK also provides several convenience methods to query input state directly in a device-independent way. See [Accessing Input State in MRTK](InputState.md) for more details.
+MRTK also provides several convenience methods to query input state directly in a device-independent way. See [Accessing input state in MRTK](InputState.md) for more details.

--- a/Documentation/Input/Pointers.md
+++ b/Documentation/Input/Pointers.md
@@ -114,7 +114,7 @@ Useful Sphere Pointer properties:
 
 <img src="../../Documentation/Images/Pointers/MRTK_Pointers_Parabolic.png" width="400">
 
-## Pointer support for Mixed Reality Platforms
+## Pointer support for mixed reality platforms
 
 The following table details the pointer types that are typically used for the common platforms in MRTK. NOTE:
 it's possible to add different pointer types to these platforms. For example, you could add a Poke pointer or Sphere pointer to VR. Additionally, VR devices with a gamepad could use the GGV pointer.
@@ -196,7 +196,7 @@ public class ColorTap : MonoBehaviour, IMixedRealityFocusHandler, IMixedRealityP
 }
 ```
 
-### Query Pointers
+### Query pointers
 
 It is possible to gather all pointers currently active by looping through the available input sources (i.e controllers and inputs available) to discover which pointers are attached to them.
 
@@ -216,7 +216,7 @@ foreach (var inputSource in CoreServices.InputSystem.DetectedInputSources)
 }
 ```
 
-#### Primary Pointer
+#### Primary pointer
 
 Developers can subscribe to the FocusProviders PrimaryPointerChanged event to be notified when the primary pointer in focus has changed. This can be extremely useful to identify if the user is currently interacting with a scene via gaze or a hand ray or other input source.
 
@@ -246,7 +246,7 @@ The [PrimaryPointerExample scene](https://github.com/microsoft/MixedRealityToolk
 
 <img src="../../Documentation/Images/Pointers/PrimaryPointerExample.png" style="max-width:100%;">
 
-### Pointer Result
+### Pointer result
 
 The pointer [`Result`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer.Result) property contains the current result for the scene query used to determine the object with focus. For a raycast pointer, like the ones created by default for motion controllers, gaze input and hand rays, it will contain the location and normal of the raycast hit.
 
@@ -264,7 +264,7 @@ The [PointerResultExample scene](https://github.com/microsoft/MixedRealityToolki
 
 <img src="../../Documentation/Images/Input/PointerResultExample.png" style="max-width:100%;">
 
-### Disable Pointers
+### Disable pointers
 
 To turn enable and disable pointers (for example, to disable the hand ray), set the [`PointerBehavior`](xref:Microsoft.MixedReality.Toolkit.Input.PointerBehavior) for a given pointer type via [`PointerUtils`](xref:Microsoft.MixedReality.Toolkit.Input.PointerUtils).
 
@@ -297,7 +297,7 @@ For pointer events handled by [`IMixedRealityPointerHandler`](xref:Microsoft.Mix
 
 <img src="../../Documentation/Images/Pointers/PointerHandler.png" style="max-width:100%;">
 
-## Pointer Extent
+## Pointer extent
 
 Far pointers have settings which limit how far they will raycast and interact with other objects in the scene.
 By default, this value is set to 10 meters. This value was chosen to remain consistent with the behavior
@@ -312,7 +312,7 @@ fields:
 *Default Pointer Extent* - This controls the length of the pointer ray/line that will
 render when the pointer is not interacting with anything.
 
-## See Also
+## See also
 
 - [Pointer Architecture](../Architecture/InputSystem/ControllersPointersAndFocus.md)
 - [Input Events](InputEvents.md)

--- a/Documentation/Input/Speech.md
+++ b/Documentation/Input/Speech.md
@@ -8,7 +8,7 @@ Speech input providers, like *Windows Speech Input*, don't create any controller
 
 <img src="../../Documentation/Images/Input/SpeechCommandsProfile.png" width="450px">
 
-## Handling Speech Input
+## Handling speech input
 
 The [**`Speech Input Handler`**](xref:Microsoft.MixedReality.Toolkit.Input.SpeechInputHandler) script can be added to a GameObject to handle speech commands using [**UnityEvents**](https://docs.unity3d.com/Manual/UnityEvents.html). It automatically shows the list of the defined keywords from the **Speech Commands Profile**.
 
@@ -20,7 +20,7 @@ Assign optional **SpeechConfirmationTooltip.prefab** to display animated confirm
 
 Alternatively, developers can implement the [`IMixedRealitySpeechHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealitySpeechHandler) interface in a custom script component to [handle speech input events](InputEvents.md#input-event-interface-example).
 
-## Example Scene
+## Example scene
 
 The **SpeechInputExample** scene, in `MixedRealityToolkit.Examples\Demos\Input\Scenes\Speech`, shows how to use speech. You can also listen to speech command events directly in your own script by implementing [`IMixedRealitySpeechHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealitySpeechHandler) (see table of [event handlers](InputEvents.md)).
 

--- a/Documentation/InputSimulation/InputAnimationFileFormat.md
+++ b/Documentation/InputSimulation/InputAnimationFileFormat.md
@@ -1,4 +1,4 @@
-# Input Animation Binary File Format Specification
+# Input animation binary file format specification
 
 ## Overall structure
 
@@ -29,7 +29,7 @@ The input animation data consists of a sequence of animation curves. The number 
 | Hand Joints Left | [Joint Pose Curves](#joint-pose-curves) |
 | Hand Joints Right | [Joint Pose Curves](#joint-pose-curves) |
 
-### Joint Pose Curves
+### Joint pose curves
 
 For each hand a sequence of joint animation curves is stored. The number of joints is fixed, and a set of pose curves is stored for each joint.
 
@@ -63,7 +63,7 @@ For each hand a sequence of joint animation curves is stored. The number of join
 | PinkyDistalJoint | [Pose Curves](#pose-curves) |
 | PinkyTip | [Pose Curves](#pose-curves) |
 
-### Pose Curves
+### Pose curves
 
 Pose curves are a sequence of 3 animation curves for the position vector, followed by 4 animation curves for the rotation quaternion.
 
@@ -77,7 +77,7 @@ Pose curves are a sequence of 3 animation curves for the position vector, follow
 | Rotation Z | [Float Curve](#float-curve) |
 | Rotation W | [Float Curve](#float-curve) |
 
-### Float Curve
+### Float curve
 
 Floating point curves are fully fledged Bézier curves with a variable number of keyframes. Each keyframe stores a time and a curve value, as well as tangents and weights on the left and right side of each keyframe.
 
@@ -88,7 +88,7 @@ Floating point curves are fully fledged Bézier curves with a variable number of
 | Number of keyframes | Int32 |
 | Keyframes | [Float Keyframe](#float-keyframe) |
 
-### Float Keyframe
+### Float keyframe
 
 A float keyframe stores tangent and weight values alongside the basic time and value.
 
@@ -102,7 +102,7 @@ A float keyframe stores tangent and weight values alongside the basic time and v
 | OutWeight | Float32 |
 | WeightedMode | Int32, [Weighted Mode](#weighted-mode) |
 
-### Boolean Curve
+### Boolean curve
 
 Boolean curves are simple sequences of on/off values. On every keyframe the value of the curve flips immediately.
 
@@ -113,7 +113,7 @@ Boolean curves are simple sequences of on/off values. On every keyframe the valu
 | Number of keyframes | Int32 |
 | Keyframes | [Boolean Keyframe](#boolean-keyframe) |
 
-### Boolean Keyframe
+### Boolean keyframe
 
 A boolean keyframe only stores a time and value.
 
@@ -122,7 +122,7 @@ A boolean keyframe only stores a time and value.
 | Time | Float32 |
 | Value | Float32 |
 
-### Wrap Mode
+### Wrap mode
 
 The semantics of Pre- and Post-Wrap modes follow the [Unity WrapMode](https://docs.unity3d.com/ScriptReference/WrapMode.html) definition. They are a combination of the following bits:
 
@@ -134,7 +134,7 @@ The semantics of Pre- and Post-Wrap modes follow the [Unity WrapMode](https://do
 | 4 | PingPong: When time reaches the end of the animation clip, time will ping pong back between beginning and end. |
 | 8 | ClampForever: Plays back the animation. When it reaches the end, it will keep playing the last frame and never stop playing. |
 
-### Weighted Mode
+### Weighted mode
 
 The semantics of the Weighted mode follow the [Unity WeightedMode](https://docs.unity3d.com/ScriptReference/WeightedMode.html) definition.
 

--- a/Documentation/InputSimulation/InputAnimationRecording.md
+++ b/Documentation/InputSimulation/InputAnimationRecording.md
@@ -1,4 +1,4 @@
-# Input Animation Recording
+# Input animation recording
 
 MRTK features an recording system by which head movement and hand tracking data can be stored in animation files. The recorded data can then be played back using the [input simulation system](InputSimulationService.md).
 
@@ -12,11 +12,11 @@ Recording input is a useful tool in a variety of situations:
   The recording system supports a "rolling buffer" concept that allows recording recent input in the background.
   See [Input Recording Service](#input-recording-service).
 
-## Recording and Playback services
+## Recording and playback services
 
 Two input system services are provided to record and play back input respectively.
 
-### Input Recording Service
+### Input recording service
 
 [`InputRecordingService`](xref:Microsoft.MixedReality.Toolkit.Input.InputRecordingService) takes data from the main camera transform and active hand controllers and stores it in an internal buffer. When requested this data is then serialized into binary files for storage and later replay.
 
@@ -32,7 +32,7 @@ The data in the recording buffer can be saved in a binary file using the [SaveIn
 
 For details on the binary file format see [Input Animation File Format Specification](InputAnimationFileFormat.md).
 
-### Input Playback Service
+### Input playback service
 
 [`InputPlaybackService`](xref:Microsoft.MixedReality.Toolkit.Input.InputPlaybackService) reads a binary file with input animation data and then applies this data through the [InputSimulationService](xref:Microsoft.MixedReality.Toolkit.Input.InputSimulationService) to recreate the recorded movements.
 

--- a/Documentation/InputSimulation/InputSimulationService.md
+++ b/Documentation/InputSimulation/InputSimulationService.md
@@ -1,4 +1,4 @@
-# Input Simulation Service
+# Input simulation service
 
 The Input Simulation Service emulates the behaviour of devices and platforms that may not be available in the Unity editor. Examples include:
 
@@ -12,7 +12,7 @@ Users can use a conventional keyboard and mouse combination to control simulated
 > [!WARNING]
 > This does not work when using Unity's XR Holographic Emulation > Emulation Mode = "Simulate in Editor". Unity's in-editor simulation will take control away from MRTK's input simulation. In order to use the MRTK input simulation service, you will need to set XR Holographic Emulation to Emulation Mode = *"None"*
 
-## Enabling the Input Simulation Service
+## Enabling the input simulation service
 
 Input simulation is enabled by default in MRTK.
 
@@ -25,7 +25,7 @@ Input simulation is an optional [Mixed Reality service](../MixedRealityServices.
 
 Enable the input simulation tools window from the  _Mixed Reality Toolkit > Utilities > Input Simulation_ menu. This window provides access to the state of input simulation during play mode.
 
-## Viewport Buttons
+## Viewport buttons
 
 A prefab for in-editor buttons to control basic hand placement can be specified in the input simulation profile under __Indicators Prefab__. This is an optional utility, the same features can be accessed in the [input simulation tools window](#input-simulation-tools-window).
 
@@ -39,7 +39,7 @@ Hand icons show the state of the simulated hands:
 * ![Controlled hand icon](../../Documentation/Images/InputSimulation/MRTK_InputSimulation_HandIndicator_Controlled.png "Controlled hand icon") The hand is tracked and controlled by the user. Click to hide the hand.
 * ![Reset hand icon](../../Documentation/Images/InputSimulation/MRTK_InputSimulation_HandIndicator_Reset.png "Reset hand icon") Click to reset the hand to default position.
 
-## Camera Control
+## Camera control
 
 Head movement can be emulated by the Input Simulation Service.
 
@@ -63,11 +63,11 @@ Camera position and rotation angles can be set explicitly in the tools window, a
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Z7L4I1ET7GU" class="center" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
 
-## Hand Simulation
+## Hand simulation
 
 The input simulation supports emulated hand devices. These virtual hands can interact with any object that supports regular hand devices, such as buttons or grabbable objects.
 
-### Hand Simulation Mode
+### Hand simulation mode
 
 In the [input simulation tools window](#input-simulation-tools-window) the __Hand Simulation Mode__ setting switches between two distinct input models. The default mode can also be set in the input simulation profile.
 
@@ -103,7 +103,7 @@ All hand placement can also changed in the [input simulation tools window](#inpu
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/uRYfwuqsjBQ" class="center" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
 
-### Hand Gestures
+### Hand gestures
 
 Hand gestures such as pinching, grabbing, poking, etc. can also be simulated.
 
@@ -118,7 +118,7 @@ Each of the mouse buttons can be mapped to transform the hand shape into a diffe
 > [!NOTE]
 > The _Pinch_ gesture is the only gesture that performs the "Select" action at this point.
 
-### One-Hand Manipulation
+### One-hand manipulation
 
 1. Press and  __Left/Right Hand Control Key__ (*Left Shift* or *Space*)
 2. Point at object
@@ -128,7 +128,7 @@ Each of the mouse buttons can be mapped to transform the hand shape into a diffe
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/rM0xaHam6wM" class="center" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
 
-### Two-Hand Manipulation
+### Two-hand manipulation
 
 For manipulating objects with two hands at the same time, the persistent hand mode is recommended.
 
@@ -142,7 +142,7 @@ For manipulating objects with two hands at the same time, the persistent hand mo
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Qol5OFNfN14" class="center" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
 
-### GGV Interaction
+### GGV interaction
 
 1. Enable GGV simulation by switching __Hand Simulation Mode__ to _Gestures_ in the [Input Simulation Profile](#enabling-the-input-simulation-service)
 1. Rotate the camera to point the gaze cursor at the interactable object (right mouse button)

--- a/Documentation/MRTK_PackageContents.md
+++ b/Documentation/MRTK_PackageContents.md
@@ -1,4 +1,4 @@
-# Mixed Reality Toolkit Packages
+# Mixed Reality Toolkit packages
 
 The Microsoft Mixed Reality Toolkit is provided as a collection of packages. The contents of these packages is described in the following sections.
 
@@ -94,6 +94,6 @@ The optional Microsoft.MixedRealityToolkit.Unity.Examples package includes demon
 | | Inspectors | Unity Editor inspectors used by demo scenes. |
 | | StandardAssets | Common assets shared by multiple demo scenes. |
 
-## See Also
+## See also
 
 [Getting Started with the MRTK](GettingStartedWithTheMRTK.md)

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -1,4 +1,4 @@
-# Mixed Reality Toolkit Profile configuration guide
+# Mixed Reality Toolkit profile configuration guide
 
 ![MRTK logo](../Documentation/Images/MRTK_Logo_Rev.png)
 
@@ -241,7 +241,7 @@ Gestures are a system specific implementation allowing you to assign input actio
 ---
 <a name="speech"></a>
 
-## Speech Commands
+## Speech commands
 
 Like gestures, some runtime platforms also provide intelligent "Speech to Text" functionality with the ability to generate commands that can be received by a Unity project. This configuration profile allows you to configure the following:
 
@@ -299,13 +299,13 @@ If your controller representation in the scene needs to be offset from the physi
 
 <a name="editor-utilities"></a>
 
-## Editor Utilities
+## Editor utilities
 
 The following utilities work only in the editor and are useful to improve development productivity.
 
 ![MRTK Editor Configuration Utilities](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_EditorConfiguration.png)
 
-### Service Inspectors
+### Service inspectors
 
 Service Inspectors are an editor-only feature that generates in-scene objects representing active services. Selecting these objects displays inspectors which offer documentation links, control over editor visualizations and insight into the state of the service.
 
@@ -313,7 +313,7 @@ Service Inspectors are an editor-only feature that generates in-scene objects re
 
 You can enable service inspectors by checking *Use Service Inspectors* under *Editor Settings* in the Configuration Profile.
 
-### Depth Buffer Renderer
+### Depth buffer renderer
 
 Sharing the depth buffer with some mixed reality platforms can improve [hologram stabilization](hologram-stabilization.md). For example, the Windows Mixed Reality platform can modify the rendered scene per-pixel to account for subtle head movements during the time it took to render a frame. However, these techniques require depth buffers with accurate data to know where and how far geometry is from the user.
 
@@ -322,6 +322,6 @@ To ensure a scene renders all necessary data to the depth buffer, developers can
 ![Render Depth Buffer Utility](Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_DepthBufferExample.gif)
 <sup>The blue cylinder in the scene has a material with ZWrite off so no depth data is written</sup>
 
-## See Also
+## See also
 
 * [Hologram Stabilization](hologram-stabilization.md)

--- a/Documentation/Packaging/MRTK_Modularization.md
+++ b/Documentation/Packaging/MRTK_Modularization.md
@@ -1,8 +1,8 @@
-# Mixed Reality Toolkit Componentization
+# Mixed Reality Toolkit componentization
 
 One of the great new features of Mixed Reality Toolkit v2 is improved componentization. Wherever possible, individual components are isolated from all but the core layer of the foundation.
 
-## Minimized Dependencies
+## Minimized dependencies
 
 MRTK v2 was intentionally developed to be modular and to minimize dependencies between system services 
 (ex: spatial awareness).
@@ -12,7 +12,7 @@ Due to the nature of some system services (ex: input and teleportation), a small
 While it is expected that services will need one or more data provider components, there are no direct links 
 between them. The same is true for SDK features (ex: User Interface components).
 
-## Component Communication
+## Component communication
 
 To ensure that there are no direct links between components, MRTK v2 utilizes interfaces to communicate between 
 services, data providers and application code. These interfaces are defined in and all communication is routed 
@@ -35,7 +35,7 @@ It is possible to uncheck arbitrary items during the import of the Foundation pa
 
 ## Upcoming features
 
-### Application Architecture
+### Application architecture
 
 The MRTK will have support to enable applications to be built with a variety of architectures, including:
 
@@ -46,14 +46,14 @@ The MRTK will have support to enable applications to be built with a variety of 
 
 When selecting an application architecture, it is important to consider design flexibility and application performance. The architectures described here are not expected to be suitable for every application.
 
-#### MixedRealityToolkit Service Locator
+#### MixedRealityToolkit service locator
 
 The MRTK enables (and automatically configures) application scenes to use the default [`MixedRealityToolkit`](xref:Microsoft.MixedReality.Toolkit.MixedRealityToolkit) service locator component. This component includes support for configuring MRTK systems and data providers via configuration inspectors and manages component lifespans and core behaviors (ex: when to update).
 
 All systems are represented in the core configuration inspector, regardless of whether or not they are present or enabled in the project. Please see the [Mixed Reality Configuration Guide](../MixedRealityConfigurationGuide.md) for more
 information.
 
-#### Individual Service Components
+#### Individual service components
 
 Some developers have expressed a desire to include individual service components into the application scene hierarchy. To enable this usage, services will either need to be encapsulated in a custom registrar or be self-registering / self-managing.
 
@@ -62,11 +62,11 @@ A self-registering service would implement the [`IMixedRealityServiceRegistrar`]
 A self-managing service could be implemented as a singleton object in the scene hierarchy. This object would provide
 and instance property which application code could use to directly access service functionality.
 
-#### Custom Service Locator
+#### Custom service locator
 
 Some developers have requested the ability to create a custom service locator component. Custom service locators would implement the [`IMixedRealityServiceRegistrar`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityServiceRegistrar) interface and manage the life cycle and core behaviors of active services.
 
-#### Hybrid Architecture
+#### Hybrid architecture
 
 The MRTK will support a hybrid architecture in which developers can combine the previous approaches as needed or desired. For example, a developer could start with the [`MixedRealityToolkit`](xref:Microsoft.MixedReality.Toolkit.MixedRealityToolkit) service locator and add a self-registering
 service.

--- a/Documentation/Packaging/MRTK_Packages.md
+++ b/Documentation/Packaging/MRTK_Packages.md
@@ -1,4 +1,4 @@
-# Mixed Reality Toolkit Packages
+# Mixed Reality Toolkit packages
 
 The Mixed Reality Toolkit (MRTK) is a collection of packages that enable cross platform Mixed Reality application development by providing support for Mixed Reality hardware and platforms.
 
@@ -11,7 +11,7 @@ The MRTK ships via the following Unity packages:
 
 These packages are released and supported by Microsoft from source code in the [mrtk_release](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/mrtk_release) branch on GitHub.
 
-## Foundation Package
+## Foundation package
 
 The Mixed Reality Toolkit Foundation is the set of code that enables your application to leverage common functionality across Mixed Reality Platforms.
 
@@ -50,13 +50,13 @@ The MRTK foundation includes the following system services:
 
 Feature Assets are collections of related functionality delivered as Unity assets and scripts including user interface controls, Standard assets, and more.
 
-## Extensions Package
+## Extensions package
 
 The extensions package contains additional services and components that extend the functionality of the foundation package.
 
 - [Scene Transition Service](../Extensions/SceneTransitionService/SceneTransitionServiceOverview.md)
 
-## Examples Package
+## Examples package
 
 The examples package contains demos, sample scripts, and sample scenes that exercise functionality in the foundation package. This package contains the [HandInteractionExample scene](../README_HandInteractionExamples.md) (pictured below) which contains sample objects
 that respond to various types of hand input (articulated and non-articulated).
@@ -68,7 +68,7 @@ This package also contains eye tracking demos, which are [documented here](../Ey
 More generally, any new feature in the MRTK should contain a corresponding example in the examples package, roughly following
 the same folder structure and location.
 
-## Tools Package
+## Tools package
 
 The tools package contains tools that are useful for creating mixed reality experiences whose code will ultimately not
 ship as part of an application.
@@ -78,7 +78,7 @@ ship as part of an application.
 - [Optimize Window](../Tools/OptimizeWindow.md)
 - [Screenshot Utility](../Tools/ScreenshotUtility.md)
 
-## See Also
+## See also
 
 - [Architecture Overview](../Architecture/Overview.md)
 - [Systems, Extension Services and Data Providers](../Architecture/SystemsExtensionsProviders.md)

--- a/Documentation/Performance/PerfGettingStarted.md
+++ b/Documentation/Performance/PerfGettingStarted.md
@@ -4,7 +4,7 @@
 
 The easiest way to rationalize performance is via framerate or how many times your application can render an image per second. It is important to meet the target framerate, as outlined by the platform being targeted (i.e [Windows Mixed Reality](https://docs.microsoft.com/windows/mixed-reality/understanding-performance-for-mixed-reality), [Oculus](https://developer.oculus.com/documentation/pcsdk/latest/concepts/dg-performance-guidelines/), etc). For example, on HoloLens, the target framerate is 60 FPS. Low framerate applications can result in deteriorated user experiences such as worsened [hologram stabilization](../hologram-Stabilization.md), world tracking, hand tracking, and more. To help developers track and achieve quality framerate, the Mixed Reality Toolkit provides a variety of tools and scripts.
 
-### Visual Profiler
+### Visual profiler
 
 To continuously track performance over the lifetime of development, it is highly recommended to always show a framerate visual while running & debugging an application. The Mixed Reality Toolkit provides the [Visual Profiler](../Diagnostics/UsingVisualProfiler.md) diagnostic tool which gives real-time information about the current FPS and memory usage in application view. The Visual Profiler can be configured via the [Diagnostics System Settings](../Diagnostics/DiagnosticsSystemGettingStarted.md) under the [MRTK Profiles Inspector](../MixedRealityConfigurationGuide.md).
 
@@ -15,7 +15,7 @@ Furthermore, it is particularly important to utilize the Visual Profiler to trac
 
 ![Visual Profiler Interface](../../Documentation/Images/Diagnostics/VisualProfiler.png)
 
-### Optimize Window
+### Optimize window
 
 The [MRTK Optimize Window](../Tools/OptimizeWindow.md) offers information and automation tools to help mixed reality developers set up their environment for the best performing results and identify potential bottlenecks in their scene & assets. Certain key configurations in Unity can help deliver substantially more optimized results for mixed reality projects.
 
@@ -92,7 +92,7 @@ If [z-fighting](https://en.wikipedia.org/wiki/Z-fighting) occurs due to the lowe
 > [!NOTE]
 > To quickly determine which objects in a scene do not write to the depth buffer visually, one can use the [*Render Depth Buffer* utility](../MixedRealityConfigurationGuide.md#editor-utilities) under the *Editor Settings* in the MRTK Configuration profile.
 
-## General Recommendations
+## General recommendations
 
 Performance can be an ambiguous and constantly changing challenge for mixed reality developers and the spectrum of knowledge to rationalize performance is vast. There are some general recommendations for understanding how to approach performance for an application though.
 

--- a/Documentation/Profiles/Profiles.md
+++ b/Documentation/Profiles/Profiles.md
@@ -10,14 +10,14 @@ For example, the Input system's behavior is governed by an [input system profile
 > [!NOTE]
 > While it is intended that profiles can be swapped out at runtime, this [currently does not work](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4289)
 
-## Default Profile
+## Default profile
 
 The MRTK provides a set of default profiles which cover most platforms and scenarios that the MRTK supports. For example, when you select the [DefaultMixedRealityToolkitConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset) you will be able to try out scenarios on VR (OpenVR, WMR) and HoloLens (1 and 2).
 
 Note that because this is a general use profile, it's not optimized for any particular use case. If you want to have
 more performant/specific settings that are better on other platforms, see the other profiles below, which are slightly tweaked to be better on their respective platforms.
 
-## HoloLens 2 Profile
+## HoloLens 2 profile
 
 The MRTK also provides a default profile that is optimized for deployment and testing on
 the HoloLens 2: [DefaultHoloLens2ConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset).

--- a/Documentation/README_BoundingBox.md
+++ b/Documentation/README_BoundingBox.md
@@ -96,15 +96,15 @@ private void PutABoxAroundIt(GameObject target)
 
 ## Inspector properties
 
-### Target Object
+### Target object
 
 This property specifies which object will get transformed by the bounding box manipulation. If no object is set, the bounding box defaults to the owner object.
 
-### Bounds Override
+### Bounds override
 
 Sets a box collider from the object for bounds computation.
 
-### Activation Behavior
+### Activation behavior
 
 There are several options to activate the bounding box interface.
 
@@ -113,15 +113,15 @@ There are several options to activate the bounding box interface.
 * *Activate By Pointer*: Bounding Box becomes visible when it is targeted by a hand-ray pointer.
 * *Activate Manually*: Bounding Box does not become visible automatically. You can manually activate it through a script by accessing the boundingBox.Active property.
 
-### Scale Minimum
+### Scale minimum
 
 The minimum allowed scale. This property is deprecated and it is preferable to add a [`TransformScaleHandler`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs) script. If this script is added, the minimum scale will be taken from it instead of from BoundingBox.
 
-### Scale Maximum
+### Scale maximum
 
 The maximum allowed scale. This property is deprecated and it is preferable to add a [`TransformScaleHandler`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs) script. If this script is added, the maximum scale will be taken from it instead of from BoundingBox.
 
-### Box Display
+### Box display
 
 Various bounding box visualization options.
 

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -59,7 +59,7 @@ To leverage specific articulated hand input state information, you can use press
 
 <img src="../Documentation/Images/Button/MRTK_Button_HowTo_PressableButton.png" width="450">
 
-## Interaction States
+## Interaction states
 
 In the idle state, the button's front plate is not visible. As a finger approaches or a cursor from gaze input targets the surface, the front plate's glowing border becomes visible. There is additional highlighting of the fingertip position on the front plate surface. When pushed with a finger, the front plate moves with the fingertip. When the fingertip touches the surface of the front plate, it shows a subtle pulse effect to give visual feedback of the touch point.
 
@@ -89,7 +89,7 @@ Unity audio source for the audio feedback clips.
 *NearInteractionTouchable.cs*
 Required to make any object touchable with articulated hand input.
 
-## Prefab Layout
+## Prefab layout
 
 The *ButtonContent* object contains front plate, text label and icon. The *FrontPlate* responds to the proximity of the index fingertip using the *Button_Box* shader. It shows glowing borders, proximity light, and a pulse effect on touch. The text label is made with TextMesh Pro. *SeeItSayItLabel*'s visibility is controlled by [Interactable](README_Interactable.md)'s theme.
 
@@ -115,7 +115,7 @@ Assign the material to the *UIButtonSquareIcon* object.
 
 <img src="../Documentation/Images/Button/MRTK_Button_IconUpdate4.png">
 
-## Voice command ('See-it, Say-it')
+## Voice command ('see-it, say-it')
 
 **Speech Input Handler**
 The [Interactable](README_Interactable.md) script in Pressable Button already implements `IMixedRealitySpeechHandler`. A voice command keyword can be set here.
@@ -138,7 +138,7 @@ You can find the examples of these buttons in the **PressableButtonExample** sce
 
 <img src="../Documentation/Images/Button/MRTK_PressableButtonCube0.png">
 
-### 1. Creating a Pressable Button with Cube (Near interaction only)
+### 1. Creating a pressable button with cube (near interaction only)
 
 1. Create a Unity Cube (GameObject > 3D Object > Cube)
 2. Add `PressableButton.cs` script
@@ -189,7 +189,7 @@ You will see the object responds to both far(hand ray or gaze cursor) and near(h
 <img src="../Documentation/Images/Button/MRTK_PressableButtonCubeRun3.jpg">
 <img src="../Documentation/Images/Button/MRTK_PressableButtonCubeRun4.jpg">
 
-## Custom Button Examples
+## Custom button examples
 
 In the [HandInteractionExample scene](README_HandInteractionExamples.md), you can take a look at the piano and round button examples which are both using `PressableButton`.
 

--- a/Documentation/README_ExampleHub.md
+++ b/Documentation/README_ExampleHub.md
@@ -10,7 +10,7 @@ MRTK Examples Hub is a Unity scene that makes it easy to experience multiple sce
 
 MRTK Examples Hub uses [Scene Transition Service](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.html) and related scripts. If you are using MRTK through Unity packages, please import **Microsoft.MixedReality.Toolkit.Unity.Extensions.x.x.x.unitypackage** which is part of the [release packages](https://github.com/microsoft/MixedRealityToolkit-Unity/releases). If you are using MRTK through the repository clone, you should already have **MixedRealityToolkit.Extensions** folder in your project.
 
-## MRTKExamplesHub Scene and the Scene System
+## MRTKExamplesHub scene and the scene system
 
 Open **MRTKExamplesHub.unity** which is located at `MixedRealityToolkit.Examples/Experimental/Demos/ExamplesHub/Scenes/` It is an empty scene with MixedRealityToolkit, MixedRealityPlayspace and LoadHubOnStartup. This scene is configured to use MRTK's Scene System. Click `MixedRealitySceneSystem` under MixedRealityToolkit. It will display the Scene System's information in the Inspector panel.
 

--- a/Documentation/README_HandJointChaser.md
+++ b/Documentation/README_HandJointChaser.md
@@ -1,4 +1,4 @@
-# Hand Joint Chaser Example
+# Hand joint chaser example
 
 ![Hand joint chasers](../Documentation/Images/HandJointChaser/MRTK_HandJointChaser_Main.jpg)
 This example scene demonstrates how to use Solver to attach objects to the hand joints.
@@ -7,7 +7,7 @@ This example scene demonstrates how to use Solver to attach objects to the hand 
 
 You can find the example scene **HandJointChaserExample** scene in the MixedRealityToolkit.Examples package under `Demos/Input/Scenes/`.
 
-## Solver Handler
+## Solver handler
 
 Click **Tracked Object To Reference** and select **Hand Joint Left** or **Hand Joint Right**. You will be able to see **Tracked Hand Joint** drop down. From the drop down list, you can select specific joint to track.
 This example scene uses Radial View Solver to make an object follow the target object. See [Solver](README_Solver.md) page for more details.

--- a/Documentation/README_Interactable.md
+++ b/Documentation/README_Interactable.md
@@ -92,7 +92,7 @@ The selection modes available are:
 
 The current Selection Mode can be queried at runtime via [`Interactable.ButtonMode`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable.ButtonMode). Updating the mode at runtime can be achieved by setting the  [`Interactable.Dimensions`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable.Dimensions) property to match the desired functionality. Furthermore, the current dimension, useful for *Toggle* and *Multi-Dimension* modes, can be accessed via [`Interactable.CurrentDimension`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable.CurrentDimension).
 
-### Interactable Profiles
+### Interactable profiles
 
 *Profiles* are items that create a relationship between a GameObject and a [Visual Theme](VisualThemes.md). The profile defines what content will be manipulated by a theme when a [state change occurs](#general-input-settings).
 
@@ -125,7 +125,7 @@ A custom receiver can be created by making a new class that extends [`ReceiverBa
 
 *Example of a Toggle Event Receiver*
 
-### Interactable Receivers
+### Interactable receivers
 
  The [`InteractableReceiver`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableReceiver) component allows for events to be defined outside of the source *Interactable* component. The *InteractableReceiver* will listen for a filtered event type fired by another *Interactable*. If the *Interactable* property is not directly assigned, then the *Search Scope* property defines the direction the *InteractableReceiver* listens for events which is either on itself, in a parent, or in a child GameObject.
 
@@ -183,7 +183,7 @@ public virtual void OnClick(InteractableStates state,
 }
 ```
 
-##### Displaying custom Event Receiver fields in the inspector
+##### Displaying custom event receiver fields in the inspector
 
 *ReceiverBase* scripts use [`InspectorField`](xref:Microsoft.MixedReality.Toolkit.Utilities.Editor.InspectorField) attributes to expose custom properties in the inspector. Here's an example of Vector3 a custom property with tooltip and label information. This property will show up as configurable in the inspector when an *Interactable* GameObject is selected and has the associated *Event Receiver* type added.
 
@@ -203,7 +203,7 @@ Take the button one step further, by creating a new profile, assigning the GameO
 > [!NOTE]
 > Making a [button pressable](README_Button.md) requires the`PressableButton` component. Additionally, the `PhysicalPressEventRouter` component is needed to funnel press events to the *Interactable* component.
 
-### Creating Toggle and Multi-Dimension buttons
+### Creating toggle and multi-dimension buttons
 
 #### Toggle button
 
@@ -243,7 +243,7 @@ To create a custom radial button group:
 
 <img src="../Documentation/Images/Interactable/InteractableToggleCollection.png" width="450">
 
-#### Multi-Dimensional button
+#### Multi-dimensional button
 
 Multi-Dimension selection mode is used to create sequential buttons, or a button that has more than two steps, like controlling speed with three values, Fast (1x), Faster (2x) or Fastest (3x).
 
@@ -304,7 +304,7 @@ interactable.Profiles = new List<InteractableProfileItem>()
 interactable.TriggerOnClick()
 ```
 
-### Interactable Events via code
+### Interactable events via code
 
 One can add an action to the base [`Interactable.OnClick`](xref:Microsoft.MixedReality.Toolkit.UI.Interactable.OnClick) event via code with the following example.
 

--- a/Documentation/README_LostTrackingService.md
+++ b/Documentation/README_LostTrackingService.md
@@ -1,10 +1,10 @@
-# Lost Tracking Visualization
+# Lost tracking visualization
 
 ![Lost Tracking](../Documentation/Images/LostTracking/LostTrackingVisualization.jpg)
 
 Lost Tracking Extension Service provides HoloLens shell style animated visual for the lost tracking state.
 
-## How to use Lost Tracking Extensions
+## How to use lost tracking extensions
 
 In MRTK Profile, add **Lost Tracking Service** to the Extensions. Assign **DefaultLostTrackingServiceProfile** which includes **LostTrackingVisualPrefab**.
 

--- a/Documentation/README_MRTKStandardShader.md
+++ b/Documentation/README_MRTKStandardShader.md
@@ -4,7 +4,7 @@
 
 MRTK Standard shading system utilizes a single, flexible shader that can achieve visuals similar to Unity's Standard Shader, implement [Fluent Design System](https://www.microsoft.com/design/fluent/) principles, and remain performant on mixed reality devices.
 
-## Example Scenes
+## Example scenes
 
 You can find the shader material examples in the **MaterialGallery** scene under:
 [MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes) All materials in this scene are using the MRTK/Standard shader.
@@ -19,7 +19,7 @@ You can find a comparison scene to compare and test the MRTK/Standard shader aga
 
 The MRTK/Standard shading system is an "uber shader" that uses [Unity's shader program variant feature](https://docs.unity3d.com/Manual/SL-MultipleProgramVariants.html) to auto-generate optimal shader code based on material properties. When a user selects material properties in the material inspector they only incur performance cost for features they have enabled.
 
-## Material Inspector
+## Material inspector
 
 A custom material inspector exists for the MRTK/Standard shader called [`MixedRealityStandardShaderGUI.cs`](xref:Microsoft.MixedReality.Toolkit.Editor.MixedRealityStandardShaderGUI). The inspector automatically enables/disables shader features based on user selection and aides in setting up render state. For more information about each feature **please hover over each property in the Unity Editor for a tooltip.**
 
@@ -63,11 +63,11 @@ MRTK Standard shader statistics example
 
 The MRTK/Standard uses a simple approximation for lighting. Because this shader does not calculate for physical correctness and energy conservation, it renders quickly and efficient. Blinn-Phong is the primary lighting technique which is blended with Fresnel and image based lighting to approximate physically based lighting. The shader supports the following lighting techniques:
 
-### Directional Light
+### Directional light
 
 The shader will respect the direction, color, and intensity of the first Unity Directional Light in the scene (if enabled). Dynamic point lights, spot lights, or any other Unity light will not be considered in real time lighting.
 
-### Spherical Harmonics
+### Spherical harmonics
 
 The shader will use Light Probes to approximate lights in the scene using [Spherical Harmonics](https://docs.unity3d.com/Manual/LightProbes-TechnicalInformation.html) if enabled. Spherical harmonics calculations are performed per vertex to reduce calculation cost.
 
@@ -75,15 +75,15 @@ The shader will use Light Probes to approximate lights in the scene using [Spher
 
 For static lighting the shader will respect lightmaps built by Unity's [Lightmapping system](https://docs.unity3d.com/Manual/Lightmapping.html) simply mark the renderer as static (or lightmap static) to use lightmaps.
 
-### Hover Light
+### Hover light
 
 A Hover Light is a Fluent Design System paradigm that mimics a "point light" hovering near the surface of an object. Often used for far away cursor lighting the application can control the properties of a Hover Light via the [`HoverLight.cs`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight). Up to 3 Hover Lights are supported at a time.
 
-### Proximity Light
+### Proximity light
 
 A Proximity Light is a Fluent Design System paradigm that mimics a "gradient inverse point light" hovering near the surface of an object. Often used for near cursor lighting the application can control the properties of a Proximity Light via the [`ProximityLight.cs`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight). Up to 2 Proximity Lights are supported at a time.
 
-## Lightweight Scriptable Render Pipeline Support
+## Lightweight Scriptable Render Pipeline support
 
 The MRTK contains an upgrade path to allow developers to utilize Unity's Lightweight Scriptable Render Pipeline (LWRP) with MRTK shaders. Tested in Unity 2019.1.1f1 and Lightweight RP 5.7.2 package. or instructions on getting started with the LWRP please see [this page](https://docs.unity3d.com/Packages/com.unity.render-pipelines.lightweight@5.10/manual/getting-started-with-lwrp.html).
 
@@ -93,7 +93,7 @@ To perform the MRTK upgrade select: **Mixed Reality Toolkit -> Utilities -> Upgr
 
 After the upgrade occurs the MRTK/Standard shader will be altered and any magenta (shader error) materials should be fixed. To verify the upgrade successfully occurred please check the console for: **Upgraded Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader for use with the Lightweight Render Pipeline.**
 
-## UGUI Support
+## UGUI support
 
 The MRTK Standard shading system works with Unity's built in [UI system](https://docs.unity3d.com/Manual/UISystem.html). On Unity UI components the unity_ObjectToWorld matrix is not the transformation matrix of the local transform the Graphic component lives on but that of its parent Canvas. Many MRTK/Standard shader effects require object scale to be known. To solve this issue the [`ScaleMeshEffect.cs`](xref:Microsoft.MixedReality.Toolkit.Input.Utilities.ScaleMeshEffect) will store scaling information into UV channel attributes during UI mesh construction.
 
@@ -103,7 +103,7 @@ A Canvas within the MRTK will prompt for the addition of a [`ScaleMeshEffect.cs`
 
 ![scale mesh effect](../Documentation/Images/MRTKStandardShader/MRTK_ScaleMeshEffect.jpg)
 
-## Texture Combiner
+## Texture combiner
 
 To improve parity with the Unity Standard shader per pixel metallic, smoothness, emissive, and occlusion values can all be controlled via [channel packing](http://wiki.polycount.com/wiki/ChannelPacking). For example:
 
@@ -124,11 +124,11 @@ Or, you can use the MRTK Texture Combiner Tool. To open the tool select: **Mixed
 
 This windows can be automatically filled out by selecting a Unity Standard shader and clicking "Autopopulate from Standard Material." Or, you can manually specify a texture (or constant value) per red, green, blue, or alpha channel. The texture combination is GPU accelerated and does not require the input texture to be CPU accessible.
 
-## Additional Feature Documentation
+## Additional feature documentation
 
 Below are extra details on a handful of features details available with the MRTK/Standard shader.
 
-### Primitive Clipping
+### Primitive clipping
 
 Performant plane, sphere, and box shape clipping with the ability to specify which side of the primitive to clip against (inside or outside). You can find a scene that demonstrates advanced usage of clipping primitives in the  **ClippingExamples** scene under: [MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes)
 
@@ -138,7 +138,7 @@ Performant plane, sphere, and box shape clipping with the ability to specify whi
 
 ![primitive clipping gizmos](../Documentation/Images/MRTKStandardShader/MRTK_PrimitiveClippingGizmos.gif)
 
-### Mesh Outlines
+### Mesh outlines
 
 Many mesh outline techniques are done using a [post processing](https://docs.unity3d.com/Manual/PostProcessingOverview.html) technique. Post processing provides great quality outlines, but can be prohibitively expensive on many Mixed Reality devices. You can find a scene that demonstrates usage of mesh outlines in the  **OutlineExamples** scene under: [MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes)
 
@@ -161,25 +161,25 @@ The outline behaviors are designed to be used in conjunction with the MRTK/Stand
 1. Smooth normals generated via [`MeshSmoother.cs`](xref:Microsoft.MixedReality.Toolkit.Utilities.MeshSmoother).
 2. Default normals used, notice the artifacts around the cube corners. 
 
-### Stencil Testing
+### Stencil testing
 
 Built in configurable stencil test support to achieve a wide array of effects. Such as portals:
 
 ![stencil test](../Documentation/Images/MRTKStandardShader/MRTK_StencilTest.gif)
 
-### Instanced Color Support
+### Instanced color support
 
 Instanced color support to give thousands of GPU instanced meshes unique material properties:
 
 ![instanced properties](../Documentation/Images/MRTKStandardShader/MRTK_InstancedProperties.gif)
 
-### Triplanar Mapping
+### Triplanar mapping
 
 Triplanar mapping is a technique to programmatically texture a mesh. Often used in terrain, meshes without UVs, or difficult to unwrap shapes. This implementation supports world or local space projection, the specification of blending smoothness, and normal map support. Note, each texture used requires 3 texture samples, so please use sparingly in performance critical situations.
 
 ![triplanar](../Documentation/Images/MRTKStandardShader/MRTK_TriplanarMapping.gif)
 
-### Vertex Extrusion
+### Vertex extrusion
 
 Vertex extrusion in world space. Useful for visualizing extruded bounding volumes or transitions in/out meshes.
 


### PR DESCRIPTION
## Overview

Our documentation guidelines recommend [using sentence case for headlines](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Contributing/DocumentationGuide.html#capitalization), something our docs currently do inconsistently. This is phase 3 of #6893 and #6898 (I broke them up so it isn't 100+ files all at once) to fix up our headers.

NOTE: These PRs are only intended to update headers. Some non-header casing changes may have made their way in, but I'm trying to split these changes into more reviewable chunks.