### PR TITLE
Header capitalization phase 4

### DIFF
--- a/Documentation/README_NearMenu.md
+++ b/Documentation/README_NearMenu.md
@@ -1,4 +1,4 @@
-# Near Menu
+# Near menu
 
 ![Near Menu](../Documentation/Images/NearMenu/MRTK_UX_NearMenu.png)
 

--- a/Documentation/README_ObjectCollection.md
+++ b/Documentation/README_ObjectCollection.md
@@ -21,11 +21,11 @@ To create a collection, create an empty GameObject and assign one of the Object 
 
 ![Object collection](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionScript.png)
 
-## `GridObjectCollection` Content Alignment
+## `GridObjectCollection` content alignment
 
 The content in a GridObjectCollection can be aligned so that the parent object is anchored to the top/middle/bottom and left/center/right of the collection. Use the **anchor** property to specify content alignment.
 
-## `GridObjectCollection` Layout Order
+## `GridObjectCollection` layout order
 
 Use the **Layout** field to specify the row / column order that children are laid out:
 

--- a/Documentation/README_Slate.md
+++ b/Documentation/README_Slate.md
@@ -16,7 +16,7 @@ A slate control is composed of the following elements:
 
 <img src="../Documentation/Images/Slate/MRTK_Slate_Structure.png" width="650">
 
-## Bounding Box
+## Bounding box
 
 A slate control contains a bounding box script for scaling and rotating. For more information on bounding box, please see the [Bounding box](README_BoundingBox.md) page.
 

--- a/Documentation/README_Sliders.md
+++ b/Documentation/README_Sliders.md
@@ -9,7 +9,7 @@ Sliders are UI components that allow you to continuously change a value by movin
 You can find examples in the **SliderExample** scene under:
 [MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes/](/Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes)
 
-## How to use Sliders
+## How to use sliders
 
 Drag and drop the **PinchSlider** prefab into the scene hierarchy. If you want to modify or create your own slider, remember to do the following:
 
@@ -23,7 +23,7 @@ We also recommend using the following hierarchy
   - TrackVisuals - Containing the track and any other visuals
   - OtherVisuals - Containing any other visuals
 
-## Slider Events
+## Slider events
 
 Sliders expose the following events:
 
@@ -33,7 +33,7 @@ Sliders expose the following events:
 - OnHoverEntered - Called when the user's hand / controller hovers over the slider, using either near or far interaction.
 - OnHoverExited - Called when the user's hand / controller is no longer near the slider.
 
-## Configuring Slider Bound and Axis
+## Configuring slider bound and axis
 
 You can directly move the starting and end points of the slider by moving the handles in the Scene:
 

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -49,7 +49,7 @@ The *Tracked Target Type* property of the [`SolverHandler`](xref:Microsoft.Mixed
 ![Solver](Images/Solver/TrackedObjectType-Example.gif)  
 *Example of various properties associated with each TrackedTargetType*
 
-## How to chain Solvers
+## How to chain solvers
 
 It is possible to add multiple `Solver` components to the same GameObject thus chaining their algorithms. The `SolverHandler` components handles updating all solvers on the same GameObject. By default the `SolverHandler` calls `GetComponents<Solver>()` on Start which will return the Solvers in the order that they appear in the inspector.
 
@@ -58,7 +58,7 @@ Furthermore, setting the *Updated Linked Transform* property to true will instru
 > [!NOTE]
 > Developers can modify the order of execution of Solvers by setting the `SolverHandler.Solvers` property directly.
 
-## How to create a new Solver
+## How to create a new solver
 
 All solvers must inherit from the abstract base class, [`Solver`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.Solver). The primary requirements of a Solver extension involves overriding the `SolverUpdate` method. In this method, developers should update the inherited `GoalPosition`, `GoalRotation` and `GoalScale` properties to the desired values. Furthermore, it is generally valuable to leverage `SolverHandler.TransformTarget` as the frame of reference desired by the consumer.
 
@@ -85,7 +85,7 @@ public class InFront : Solver
 
 ## Solver implementation guides
 
-### Common Solver properties
+### Common solver properties
 
 Every Solver component has a core-set of identical properties that control the core Solver behavior.
 
@@ -159,7 +159,7 @@ Conversely, a [`SurfaceMagnetism`](xref:Microsoft.MixedReality.Toolkit.Utilities
 
 Finally, surfaces farther than the `MaxRaycastDistance` property setting will be ignored by the `SurfaceMagnetism` raycasts.
 
-### Hand Menu with HandConstraint and HandConstraintPalmUp
+### Hand menu with HandConstraint and HandConstraintPalmUp
 
 ![Hand Menu UX Example](Images/Solver/MRTK_UX_HandMenu.png)
 
@@ -180,11 +180,11 @@ Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.Mi
     * *OnFirstHandDetected*: occurs when the hand tracking state changes from no hands in view, to the first hand in view.
     * *OnLastHandLost*: occurs when the hand tracking state changes from at least one hand in view, to no hands in view.
 
-## Experimental Solvers
+## Experimental solvers
 
 These solvers are available in MRTK but are currently experimental. Their APIs and functionality are subject to change. Furthermore, their robustness and quality may be lower than standard features.
 
-### Directional Indicator
+### Directional indicator
 
 The [`DirectionalIndicator`](xref:Microsoft.MixedReality.Toolkit.Experimental.Utilities.DirectionalIndicator) class is a tag-along component that orients itself to the direction of a desired point in space.
 

--- a/Documentation/README_TextPrefab.md
+++ b/Documentation/README_TextPrefab.md
@@ -1,4 +1,4 @@
-# Text Prefab
+# Text prefab
 These prefabs are optimized for the rendering quality in Windows Mixed Reality. For more information, please read the guideline [Text in Unity](https://docs.microsoft.com/windows/mixed-reality/text-in-unity) on Microsoft Windows Dev Center.
 
 #### [3DTextPrefab.prefab](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text)

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -1,4 +1,4 @@
-# Microsoft Mixed Reality Toolkit Release Notes
+# Microsoft Mixed Reality Toolkit release notes
 
 - [Version 2.2.0](#version-220)
 - [Version 2.1.0](#version-210)

--- a/Documentation/Rendering/MaterialInstance.md
+++ b/Documentation/Rendering/MaterialInstance.md
@@ -1,4 +1,4 @@
-# Material Instance
+# Material instance
 
 The [`MaterialInstance`](xref:Microsoft.MixedReality.Toolkit.Rendering.MaterialInstance) behavior aides in tracking instance material lifetime and automatically destroys instanced materials for the user. This utility component can be used as a replacement to [Renderer.material]("https://docs.unity3d.com/ScriptReference/Renderer-material.html") or 
 [Renderer.materials]("https://docs.unity3d.com/ScriptReference/Renderer-materials.html").
@@ -92,6 +92,6 @@ public class MyBehaviour : MonoBehaviour,  IMaterialInstanceOwner
 
 For more information please see the example usage demonstrated within the [`ClippingPrimitive`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) behavior.
 
-## See Also
+## See also
 
 * [MRTK Standard Shader](../README_MRTKStandardShader.md)

--- a/Documentation/SceneSystem/SceneSystemContentLoading.md
+++ b/Documentation/SceneSystem/SceneSystemContentLoading.md
@@ -1,8 +1,8 @@
-# Content Scene Loading
+# Content scene loading
 
-All content load operations are asynchronous, and by default all content loading is additive. Manager and lighting scenes are never affected by content loading operations. For information about monitoring load progress and scene activation, see [Monitoring Content Loading.](SceneSystemLoadProgress.md)
+All content load operations are asynchronous, and by default all content loading is additive. Manager and lighting scenes are never affected by content loading operations. For information about monitoring load progress and scene activation, see [Monitoring Content Loading](SceneSystemLoadProgress.md).
 
-## Loading Content
+## Loading content
 
 To load content scenes use the `LoadContent` method:
 
@@ -16,7 +16,7 @@ await sceneSystem.LoadContent("MyContentScene");
 await sceneSystem.LoadContent(new string[] { "MyContentScene1", "MyContentScene2", "MyContentScene3" });
 ```
 
-## Single Scene Loading
+## Single scene loading
 
 The equivalent of a single scene load can be achieved via the optional `mode` argument. `LoadSceneMode.Single` will first unload all loaded content scenes before proceeding with the load.
 
@@ -33,7 +33,7 @@ await sceneSystem.LoadContent("ContentScene3");
 await sceneSystem.LoadContent("SingleContentScene", LoadSceneMode.Single);
 ```
 
-## Next / Previous Scene Loading
+## Next / previous scene loading
 
 Content can be singly loaded in order of build index. This is useful for showcase applications that take users through a set of demonstration scenes one-by-one.
 
@@ -73,7 +73,7 @@ if (prevSceneRequested)
 }
 ```
 
-## Loading by Tag
+## Loading by tag
 
 ![MRTK_SceneSystemLoadingByTag](../Images/SceneSystem/MRTK_SceneSystemLoadingByTag.png)
 
@@ -124,7 +124,7 @@ Trees | Vegetation | •
 
 ---
 
-## Editor Behavior
+## Editor behavior
 
 You can perform all these operations in editor and in play mode by using the Scene System's [service inspector.](../MixedRealityConfigurationGuide.md#editor-utilities) In edit mode scene loads will be instantaneous, while in play mode you can observe loading progress and use [activation tokens.](SceneSystemLoadProgress.md)
 

--- a/Documentation/SceneSystem/SceneSystemLightingScenes.md
+++ b/Documentation/SceneSystem/SceneSystemLightingScenes.md
@@ -1,4 +1,4 @@
-# Lighting Scene Operations
+# Lighting scene operations
 
 The default lighting scene defined in your profile is loaded on startup. That lighting scene remains loaded until `SetLightingScene` is called.
 
@@ -8,7 +8,7 @@ IMixedRealitySceneSystem sceneSystem = MixedRealityToolkit.Instance.GetService<I
 sceneSystem.SetLightingScene("MorningLighting");
 ```
 
-## Lighting Setting Transitions
+## Lighting setting transitions
 
 `transitionType` controls the style of the transition to new lighting scene.
 

--- a/Documentation/SceneSystem/SceneSystemLoadProgress.md
+++ b/Documentation/SceneSystem/SceneSystemLoadProgress.md
@@ -1,6 +1,6 @@
-# Monitoring Content Loading
+# Monitoring content loading
 
-## Scene Operation Progress
+## Scene operation progress
 
 When content is being loaded or unloaded, the `SceneOperationInProgress` property will return true. You can monitor the progress of this operation via the `SceneOperationProgress` property.
 
@@ -25,7 +25,7 @@ await sceneSystem.LoadContent("ContentScene1");
 sceneSystem.LoadContent("ContentScene2", LoadSceneMode.Single)
 ```
 
-### Progress Examples
+### Progress examples
 
 `SceneOperationInProgress` can be useful if activity should be suspended while content is being loaded:
 
@@ -73,7 +73,7 @@ public class ProgressDialog : MonoBehaviour
 
 ---
 
-## Monitoring With Actions
+## Monitoring with actions
 
 The Scene System provides several actions to let you know when scenes are being loaded or unloaded. Each action relays the name of the affected scene.
 
@@ -96,7 +96,7 @@ Action | When it's invoked | Content Scenes | Lighting Scenes | Manager Scenes
 `OnWillUnloadScene` | Just prior to a scene unload | • | • | •
 `OnSceneUnloaded` | After a scene is fully unloaded |  • | • | •
 
-### Action Examples
+### Action examples
 
 Another progress dialog example using actions and a coroutine instead of Update:
 
@@ -145,7 +145,7 @@ public class ProgressDialog : MonoBehaviour
 
 ---
 
-## Controlling Scene Activation
+## Controlling scene activation
 
 By default content scenes are set to activate when loaded. If you want to control scene activation manually, you can pass a `SceneActivationToken` to any content load method. If multiple content scenes are being loaded by a single operation, this activation token will apply to all scenes.
 

--- a/Documentation/SceneSystem/SceneSystemSceneTypes.md
+++ b/Documentation/SceneSystem/SceneSystemSceneTypes.md
@@ -1,10 +1,10 @@
-# Scene Types
+# Scene types
 
 Scenes have been divided into three types, and each type has a different function.
 
 ![Scene system in the hierarchy](../Images/SceneSystem/MRTK_SceneSystemEditorSceneHierarchy.png)
 
-## Content Scenes
+## Content scenes
 
 These are the scenes you're used to dealing with. Any kind of content can be stored in them, and they can be loaded or unloaded in any combination.
 
@@ -20,7 +20,7 @@ To enable this feature, check `Use Manager Scene` in your profile and drag a sce
 
 ___
 
-## Lighting Scenes
+## Lighting scenes
 
 A set of scenes which store lighting information and lighting objects. Only one can be loaded at a time, and their settings can be blended during loads for smooth lighting transitions.
 
@@ -32,13 +32,13 @@ The Scene System uses lighting scenes to ensure that these settings remain consi
 
 To enable this feature, check `Use Lighting Scene` in your profile and populate the `Lighting Scenes` array.
 
-### Cached Lighting Settings
+### Cached lighting settings
 
 Your profile stores cached copies of the lighting settings kept in your lighting scenes. If those settings change in your lighting scenes, you will need to update your cache to ensure lighting appears as expected in play mode. Your profile will display a warning when it suspects your cached settings are out of date. Clicking `Update Cached Lighting Settings` will load each of your lighting scenes, extract their settings, then store them in your profile.
 
 ![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemCachedLightingSettings.png)
 
-### Editor Behavior
+### Editor behavior
 
 One benefit of using lighting scenes is knowing your content is lit correctly while editing. To this end, the Scene Service will keep a lighting scene loaded at all times, and will copy that scene's lighting settings to the current active scene.\*
 

--- a/Documentation/SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.md
+++ b/Documentation/SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.md
@@ -1,8 +1,8 @@
-# Configuring Mesh Observers for Device
+# Configuring mesh observers for device
 
 This guide will walk through configuring the out-of-box Spatial Mesh Observer in MRTK which supports the Windows Mixed Reality platform (i.e HoloLens). The default implementation provided by the Mixed Reality Toolkit is the [WindowsMixedRealitySpatialMeshObserver](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness.WindowsMixedRealitySpatialMeshObserver) class. Many of the properties in this article though apply for other [custom Observer implementations](CreateDataProvider.md).
 
-## Profile Settings
+## Profile settings
 
 The following two items must be defined first when configuring a Spatial Mesh Observer profile for the [Spatial Awareness system](SpatialAwarenessGettingStarted.md).
 
@@ -14,7 +14,7 @@ The following two items must be defined first when configuring a Spatial Mesh Ob
 
 ![Mesh Observer General Settings](../../Documentation/Images/SpatialAwareness/SpatialAwarenessMeshObserverProfile_TypesPlatforms.png)
 
-### General Settings
+### General settings
 
 ![Mesh Observer General Settings](../../Documentation/Images/SpatialAwareness/MeshObserverGeneralSettings.png)
 
@@ -49,7 +49,7 @@ The observer shape defines the type of volume that the mesh observer will use wh
 
 The observation extents define the distance from the observation point that meshes will be observed.
 
-### Physics Settings
+### Physics settings
 
 ![Mesh Observer Physics Settings](../../Documentation/Images/SpatialAwareness/MeshObserverPhysicsSettings.png)
 
@@ -64,7 +64,7 @@ The physics layer on which spatial mesh objects will be placed in order to inter
 
 Specifies whether or not the mesh observer will recalculate the normals of the mesh following observation. This setting is available to ensure applications receive meshes that contain valid normals data on platforms that do not return them with meshes.
 
-### Level of Detail Settings
+### Level of detail settings
 
 ![Mesh Observer Level of Detail Settings](../../Documentation/Images/SpatialAwareness/MeshObserverLevelOfDetailSettings.png)
 
@@ -87,7 +87,7 @@ Specifies the level of detail (LOD) of the spatial mesh data. Currently defined 
 
 Valid when using the *Custom* setting for the **Level of Detail** property and specifies the triangle density for the spatial mesh.
 
-### Display Settings
+### Display settings
 
 ![Mesh Observer Display Settings](../../Documentation/Images/SpatialAwareness/MeshObserverDisplaySettings.png)
 
@@ -112,7 +112,7 @@ Indicates the material to be used when visualizing the spatial mesh.
 
 Indicates the material to be used to cause the spatial mesh to occlude holograms.
 
-## See Also
+## See also
 
 - [Spatial Awareness System](SpatialAwarenessGettingStarted.md)
 - [Configuring Spatial Awareness system via Code](UsageGuide.md)

--- a/Documentation/SpatialAwareness/CreateDataProvider.md
+++ b/Documentation/SpatialAwareness/CreateDataProvider.md
@@ -1,4 +1,4 @@
-# Creating a Spatial Awareness system data provider
+# Creating a spatial awareness system data provider
 
 The Spatial Awareness system is an extensible system for providing applications with data about real world environments. To add support for a new hardware platform or a new form of Spatial Awareness data, a custom data provider may be required.
 
@@ -16,7 +16,7 @@ Data providers can be distributed in one of two ways:
 
 The approval process for submissions of new data providers to the MRTK will vary on a case-by-case basis and will be communicated at the time of the initial proposal. Proposals can be submitted by creating a new [*Feature Request* type issue](https://github.com/microsoft/MixedRealityToolkit-Unity/issues).
 
-### Third Party add-on
+### Third party add-on
 
 **Namespace**
 

--- a/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.md
+++ b/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.md
@@ -1,4 +1,4 @@
-# Spatial Awareness
+# Spatial awareness
 
 ![Spatial Awareness](../../Documentation/Images/SpatialAwareness/MRTK_SpatialAwareness_Main.png)
 
@@ -7,7 +7,7 @@ The Spatial Awareness system provides real-world environmental awareness in mixe
 > [!NOTE]
 > At this time, the Mixed Reality Toolkit does not ship with Spatial Understanding algorithms as originally packaged in the HoloToolkit. Spatial Understanding generally involves transforming Spatial Mesh data to create simplified and/or grouped Mesh data such as planes, walls, floors, ceilings, etc.
 
-## Getting Started
+## Getting started
 
 Adding support for Spatial Awareness requires two key components of the Mixed Reality Toolkit: the Spatial Awareness system and a supported platform provider.
 
@@ -15,7 +15,7 @@ Adding support for Spatial Awareness requires two key components of the Mixed Re
 2. [Register](#register-observers) and [configure](ConfiguringSpatialAwarenessMeshObserver.md) one or more spatial observers to provide mesh data
 3. [Build and deploy](#build-and-deploy) to a platform that supports Spatial Awareness
 
-### Enable the Spatial Awareness system
+### Enable the spatial awareness system
 
 The Spatial Awareness system is managed by the MixedRealityToolkit object (or another [service registrar](xref:Microsoft.MixedReality.Toolkit.IMixedRealityServiceRegistrar) component). Follow the steps below to enable or disable the *Spatial Awareness system* in the *MixedRealityToolkit* profile.
 
@@ -60,7 +60,7 @@ The Spatial Awareness system is similar in that data providers supply the system
 > Users of the [DefaultMixedRealityToolkitConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset) will have the Spatial Awareness system pre-configured for the Windows Mixed Reality platform which uses
 the [`WindowsMixedRealitySpatialMeshObserver`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness.WindowsMixedRealitySpatialMeshObserver) class.
 
-### Build and Deploy
+### Build and deploy
 
 Once the Spatial Awareness system is configured with the desired observer(s), the project can be built and deployed to the target platform.
 
@@ -84,7 +84,7 @@ Information for controlling and extending observers via code:
 - [Configuring Observers via Code](UsageGuide.md)
 - [Creating a custom Observer](CreateDataProvider.md)
 
-## See Also
+## See also
 
 - [Spatial Awareness API documentation](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness)
 - [Spatial Mapping Overview WMR](https://docs.microsoft.com/windows/mixed-reality/spatial-mapping)

--- a/Documentation/SpatialAwareness/SpatialObjectMeshObserver.md
+++ b/Documentation/SpatialAwareness/SpatialObjectMeshObserver.md
@@ -1,4 +1,4 @@
-# Configuring Mesh Observers for Editor
+# Configuring mesh observers for the editor
 
 A convenient way to provide environment mesh data in the Unity editor is to use the [`SpatialObjectMeshObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.SpatialObjectMeshObserver) class. The *Spatial Object Mesh Observer* is an editor-only data provider for the [Spatial Awareness system](SpatialAwarenessGettingStarted.md) that enables importing 3D model data to represent a spatial mesh. One common use of the *Spatial Object Mesh Observer* is to import data scanned via a Microsoft HoloLens to test how an
 experience adapts to different environments from within Unity.
@@ -11,7 +11,7 @@ This guide will walk through setting up a *Spatial Object Mesh Observer*. There 
 1. Set the Environment Mesh Data object
 1. [Configure rest of the Mesh Observer profile properties](ConfiguringSpatialAwarenessMeshObserver.md)
 
-### Set up a *Spatial Object Mesh Observer* profile
+### Set up a *spatial object mesh observer* profile
 
 1. Select the desired *Mixed Reality Toolkit* configuration profile or select the *Mixed Reality Toolkit* object in scene
 1. Open or expand the *Spatial Awareness System* tab
@@ -28,7 +28,7 @@ This guide will walk through setting up a *Spatial Object Mesh Observer*. There 
 
     ![Select the Mesh Object](../../Documentation/Images/SpatialAwareness/ObjectObserverProfile.png)
 
-### Spatial Object Mesh Observer profile notes
+### Spatial object mesh observer profile notes
 
 Since the *Spatial Object Mesh Observer* loads data from a 3D model, it does not honor some of the standard mesh
 observer settings which are outlined below.

--- a/Documentation/SpatialAwareness/UsageGuide.md
+++ b/Documentation/SpatialAwareness/UsageGuide.md
@@ -1,8 +1,8 @@
-# Configuring Mesh Observers via code
+# Configuring mesh observers via code
 
 This article will discuss some of the key mechanisms and APIs to programmatically configure the [Spatial Awareness system](SpatialAwarenessGettingStarted.md) and related *Mesh Observer* data providers.
 
-## Accessing Mesh Observers
+## Accessing mesh observers
 
 Mesh Observer classes that implement the [`IMixedRealitySpatialAwarenessMeshObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialAwareness.IMixedRealitySpatialAwarenessMeshObserver) interface provide platform-specific mesh data to the Spatial Awareness system. Multiple Observers can be configured in the Spatial Awareness profile.
 
@@ -102,7 +102,7 @@ observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.None;
 observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.Occlusion;
 ```
 
-## Registering for Mesh Observation events
+## Registering for mesh observation events
 
 Components can implement the `IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>` and then register with the Spatial Awareness system to receive Mesh Observation events.
 
@@ -145,7 +145,7 @@ public class MyMeshObservationExample : MonoBehaviour, SpatialAwarenessHandler
 }
 ```
 
-## See Also
+## See also
 
 - [Spatial Awareness Getting Started](SpatialAwarenessGettingStarted.md)
 - [Configuring the Spatial Awareness Mesh Observer](ConfiguringSpatialAwarenessMeshObserver.md)

--- a/Documentation/TeleportSystem/Overview.md
+++ b/Documentation/TeleportSystem/Overview.md
@@ -1,4 +1,4 @@
-# Teleport System
+# Teleport system
 
 The teleport system is a sub-system of the MRTK that handles teleporting the user when the
 application is using an opaque display. For AR experiences (like HoloLens), the teleportation

--- a/Documentation/Tools/ControllerMappingTool.md
+++ b/Documentation/Tools/ControllerMappingTool.md
@@ -1,4 +1,4 @@
-# Controller Mapping Tool
+# Controller mapping tool
 
 The controller mapping tool is a runtime (on device or in the editor) tool that enables developers to quickly determine the Unity input axis and button mappings for a hardware controller (ex: motion controller).
 
@@ -8,7 +8,7 @@ This tool is very useful when developing support for a new hardware controller. 
 
 ## Using the controller mapping tool
 
-To get started with the controller mapping tool, navigate to **MixedRealityToolkit.Tools\RuntimeTools\Tools\ControllerMappingTool** and open the **ControllerMappingTool** scene. Once the scene has been loaded, the project can either be run in the editor, using play mode, or built and run on a device. 
+To get started with the controller mapping tool, navigate to **MixedRealityToolkit.Tools\RuntimeTools\Tools\ControllerMappingTool** and open the **ControllerMappingTool** scene. Once the scene has been loaded, the project can either be run in the editor, using play mode, or built and run on a device.
 
 To examine Unity's mappings for a controller:
 
@@ -17,8 +17,8 @@ To examine Unity's mappings for a controller:
 - Note the mappings in the display
 - Update the control mappings in the input system data provider for the controller
 
-> [!Note]
-> The controller mapping tool does not make use of Microsoft Mixed Reality Toolkit components. It directly communicates with Unity to determine and display the control mappings. 
+> [!NOTE]
+> The controller mapping tool does not make use of Microsoft Mixed Reality Toolkit components. It directly communicates with Unity to determine and display the control mappings.
 
 ### All controls display
 
@@ -28,7 +28,7 @@ The large display panel reports the state of all defined Unity input axes and bu
 
 ### Active controls display
 
-The smaller, narrow display panel shows the Unity input axed and buttons which are in an actice state (ex: a button is pressed). The active controls display provides an easy to read summary view of the state of the controller.
+The smaller, narrow display panel shows the Unity input axed and buttons which are in an active state (ex: a button is pressed). The active controls display provides an easy to read summary view of the state of the controller.
 
 ![Active controls display](../Images/ControllerMappingTool/ActiveControls.png)
 

--- a/Documentation/Tools/DependencyWindow.md
+++ b/Documentation/Tools/DependencyWindow.md
@@ -1,5 +1,5 @@
 
-# Dependency Window
+# Dependency window
 
 Often in Unity it is difficult to gleam which assets are being used, and what is referencing them. The "Find References in Scene" option works great when you are only concerned with the current scene, but what about your entire Unity project? This is where the [Dependency Window](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Tools/DependencyWindow) can be useful.
 

--- a/Documentation/Tools/ExtensionServiceCreationWizard.md
+++ b/Documentation/Tools/ExtensionServiceCreationWizard.md
@@ -1,12 +1,14 @@
 
-# Extension Service Creation Wizard
+# Extension service creation wizard
 
 Making the transition from singletons to services can be difficult. This wizard can supplement our other documentation and sample code by enabling devs to create new services with (roughly) the same ease as creating a new MonoBehaviour script. To learn about creating services from scratch, see our [Guide to building Registered Services](../MixedRealityConfigurationGuide.md) (Coming soon).
 
-### Launching the wizard
+## Launching the wizard
+
 Launch the wizard from the main menu: **MixedRealityToolkit/Utilities/Create Extension Service** - the wizard will then take you through the process of generating your service script, interface and profile class.
 
-### Editing your service script
+## Editing your service script
+
 By default, your new script assets will be generated in the MixedRealityToolkit.Extensions folder. Once you've completed the wizard, navigate here and open your new service script.
 
 Generated service scripts include some prompts similar to new MonoBehaviour scripts. They will let you know where to initialize and update your service.

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -1,4 +1,4 @@
-# Getting Started with Holographic Remoting
+# Getting started with Holographic Remoting
 
 Holographic remoting streams holographic content from a PC to your Microsoft HoloLens in real-time, using a Wi-Fi connection. This feature can significantly increase developer productivity when developing mixed reality applications.
 
@@ -57,7 +57,7 @@ When the session is complete, exit play mode.
 > [!Note]
 > There is a known issue with some versions of Unity where the editor may hang upon entering play mode during a remoting session. This issue may manifest if the Holographic window is open when the project is loaded. To ensure this issue does not occur, always close the Holographic dialog prior to exiting Unity.
 
-## See Also
+## See also
 
 - [Holographic Remoting troubleshooting and limitations](https://docs.microsoft.com/windows/mixed-reality/holographic-remoting-troubleshooting)
 - [Microsoft Holographic Remoting software license terms](https://docs.microsoft.com/legal/mixed-reality/microsoft-holographic-remoting-software-license-terms)

--- a/Documentation/Tools/OptimizeWindow.md
+++ b/Documentation/Tools/OptimizeWindow.md
@@ -1,4 +1,4 @@
-# Optimize Window
+# Optimize window
 
 The MRTK Optimize Window is a utility to help automate and inform in the process of configuring a mixed reality project for best [performance](../Performance/PerfGettingStarted.md) in Unity. This tool generally focuses on rendering configurations that when set to the correct preset can save milliseconds of processing.
 
@@ -20,7 +20,7 @@ A green check icon means that an optimal value has been configured in the projec
 
 ![MRTK Optimize Window Settings](../../Documentation/Images/Performance/OptimizeWindow_Settings.png)
 
-### Single Pass Instanced Rendering
+### Single Pass Instanced rendering
 
 [Single Pass instanced rendering](https://docs.unity3d.com/Manual/SinglePassInstancing.html) is the most efficient rendering path for mixed reality applications. This configuration ensures the render pipeline is executed only once for both eyes and that draw calls are instanced across both eyes.
 
@@ -70,7 +70,7 @@ The *Shader Analysis* tab scans the current project's Asset folder for materials
 
 ![MRTK Optimize Window Settings](../../Documentation/Images/Performance/OptimizeWindow_ShaderAnalysis.png)
 
-## See Also
+## See also
 
 - [Performance](../Performance/PerfGettingStarted.md)
 - [Hologram Stabilization](../hologram-stabilization.md)

--- a/Documentation/Tools/ScreenshotUtility.md
+++ b/Documentation/Tools/ScreenshotUtility.md
@@ -1,11 +1,11 @@
 
-# Screenshot Utility
+# Screenshot utility
 
 Often taking screenshots in Unity for documentation and promotional imagery can be burdensome and the output often looks less than desirable. This is where the [ScreenshotUtility](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Tools/ScreenshotUtility) class comes into play.
 
 The ScreenshotUtility class aides in taking screenshots via menu items and public APIs within the Unity editor. Screenshots can be captured at various resolutions and with transparent clear colors for use in easy post compositing of images. Taking screenshots from a standalone build is not supported by this tool.
 
-## Taking Screenshots
+## Taking screenshots
 
 Screenshots can be easily capture while in the editor by selecting *Mixed Reality Toolkit->Utilities->Take Screenshot* and then selecting your desired option. Make sure to have the game window tab visible if capturing while not playing, or a screenshot may not be saved.
 
@@ -13,7 +13,7 @@ By default, all screenshots are saved to your [temporary cache path](https://doc
 
 ![Screenshot utility menu item](../../Documentation/Images/ScreenshotUtility/MRTK_ScreenshotUtility_Menu_Item.png)
 
-## Example Screenshot Capture
+## Example screenshot capture
 
 The below screenshot was captured with the *"4x Resolution (Transparent Background)"* option. This outputs a high-resolution image with whatever pixels normally represented by the clear color saved as transparent pixels. This technique helps developers showcase their application for the store, or other media outlets, by overlaying this image on top of other imagery.
 

--- a/Documentation/VisualThemes.md
+++ b/Documentation/VisualThemes.md
@@ -1,5 +1,5 @@
 
-# Visual Themes
+# Visual themes
 
 Themes allow for flexible control of UX assets in response to various states transitions. This may involve changing a button's color, resizing an element in response to focus, etc. The Visual Themes framework is made up of two key pieces: 1) configuration and 2) runtime engines.
 
@@ -31,7 +31,7 @@ To create a new [`State`](xref:Microsoft.MixedReality.Toolkit.UI.States) asset:
 
 A [`State`](xref:Microsoft.MixedReality.Toolkit.UI.States) ScriptableObject defines both the list of states as well as the type of *StateModel* to create for these states. A *StateModel* is a class that extends [`BaseStateModel`](xref:Microsoft.MixedReality.Toolkit.UI.BaseStateModel) and implements the state machine logic to generate the current state at runtime. The current state from this class is generally used by Theme Engines at runtime to dictate what values to set against material properties, GameObject transforms, and more.
 
-### Theme Engine properties
+### Theme engine properties
 
 Outside of *States*, a [`Theme`](xref:Microsoft.MixedReality.Toolkit.UI.Theme) asset also defines a list of Theme Engines and the associated properties for these engines. A [Theme engine](#theme-engines) again defines the logic to set the correct values against a GameObject at runtime.
 
@@ -84,11 +84,11 @@ testTheme.States = defaultStates;
 testTheme.Definitions = new List<ThemeDefinition>() { newThemeType };
 ```
 
-## Theme Engines
+## Theme engines
 
 A [Theme Engine](#theme-engines) is a class that extends from the [`InteractableThemeBase`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableThemeBase) class. These classes are instantiated at runtime and configured with a [`ThemeDefinition`](xref:Microsoft.MixedReality.Toolkit.UI.ThemeDefinition) object as outlined earlier.
 
-### Default Theme Engines
+### Default theme engines
 
 MRTK ships with a default set of Theme Engines listed below:
 
@@ -109,7 +109,7 @@ MRTK ships with a default set of Theme Engines listed below:
 
 The default Theme Engines can be found under [MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines).
 
-### Custom Theme Engines
+### Custom theme engines
 
 As stated, a Theme Engine is defined as a class that extends from the [`InteractableThemeBase`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableThemeBase) class. Thus, new Theme Engine need only extend this class and implement the following:
 
@@ -154,7 +154,7 @@ If the custom Theme Engine can support targeting shader properties. It is recomm
 > - [`InteractableTextureTheme`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableTextureTheme)
 > - [`ScaleOffsetColorTheme`](xref:Microsoft.MixedReality.Toolkit.UI.ScaleOffsetColorTheme)
 
-### Custom Theme Engine example
+### Custom theme engine example
 
 The class below is an example of a custom new Theme Engine. This implementation will find a [MeshRenderer](https://docs.unity3d.com/ScriptReference/MeshRenderer.html) component on the initialized host object and control its visibility based on the current state.
 

--- a/README.md
+++ b/README.md
@@ -13,31 +13,31 @@ MRTK-Unity is a Microsoft-driven project that provides a set of components and f
   * Windows Mixed Reality headsets
   * OpenVR headsets (HTC Vive / Oculus Rift)
 
-# Getting Started with MRTK
+# Getting started with MRTK
 
 | [![Getting Started and Documentation](Documentation/Images/MRTK_Icon_GettingStarted.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)<br/>[Getting Started](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)| [![Getting Started](Documentation/Images/MRTK_Icon_ArchitectureOverview.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Architecture/Overview.html)<br/>[MRTK Overview](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Architecture/Overview.html)| [![Feature Guides](Documentation/Images/MRTK_Icon_FeatureGuides.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html)<br/>[Feature Guides](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html)| [![API Reference](Documentation/Images/MRTK_Icon_APIReference.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/api/Microsoft.MixedReality.Toolkit.html)<br/>[API Reference](https://microsoft.github.io/MixedRealityToolkit-Unity/api/Microsoft.MixedReality.Toolkit.html)|
 |:---|:---|:---|:---|
 
-# Build Status
+# Build status
 
 | Branch | CI Status | Docs Status |
 |---|---|---|
 | `mrtk_development` |[![CI Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_CI?branchName=mrtk_development)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=15)|[![Docs Status](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_apis/build/status/public/mrtk_docs?branchName=mrtk_development)](https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/latest?definitionId=7)
 
-# Required Software
+# Required software
 
  | [![Windows SDK 18362+](Documentation/Images/MRTK170802_Short_17.png)](https://developer.microsoft.com/windows/downloads/windows-10-sdk) [Windows SDK 18362+](https://developer.microsoft.com/windows/downloads/windows-10-sdk)| [![Unity](Documentation/Images/MRTK170802_Short_18.png)](https://unity3d.com/get-unity/download/archive) [Unity 2018.4.x](https://unity3d.com/get-unity/download/archive)| [![Visual Studio 2019](Documentation/Images/MRTK170802_Short_19.png)](http://dev.windows.com/downloads) [Visual Studio 2019](http://dev.windows.com/downloads)| [![Emulators (optional)](Documentation/Images/MRTK170802_Short_20.png)](https://docs.microsoft.com/windows/mixed-reality/using-the-hololens-emulator) [Emulators (optional)](https://docs.microsoft.com/windows/mixed-reality/using-the-hololens-emulator)|
 | :--- | :--- | :--- | :--- |
 | To build apps with MRTK v2, you need the Windows 10 May 2019 Update SDK. <br> To run apps for immersive headsets, you need the Windows 10 Fall Creators Update. | The Unity 3D engine provides support for building mixed reality projects in Windows 10 | Visual Studio is used for code editing, deploying and building UWP app packages | The Emulators allow you to test your app without the device in a simulated environment |
 
-# Feature Areas
+# Feature areas
 
 | ![Input System](Documentation/Images/MRTK_Icon_InputSystem.png) [Input System](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Overview.html)<br/>&nbsp;  | ![Hand Tracking<br/> (HoloLens 2)](Documentation/Images/MRTK_Icon_HandTracking.png) [Hand Tracking<br/> (HoloLens 2)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/InputSystem/HandTracking.html) | ![Eye Tracking<br/> (HoloLens 2)](Documentation/Images/MRTK_Icon_EyeTracking.png) [Eye Tracking<br/> (HoloLens 2)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/EyeTracking/EyeTracking_Main.html) | ![Profiles](Documentation/Images/MRTK_Icon_Profiles.png) [Profiles](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html)<br/>&nbsp; | ![Gaze + Gesture<br/> (HoloLens)](Documentation/Images/MRTK_Icon_GazeSelect.png) [Gaze + Gesture<br/> (HoloLens)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Gestures.html) |
 | :--- | :--- | :--- | :--- | :--- |
 | ![UI Controls](Documentation/Images/MRTK_Icon_UIControls.png) [UI Controls](https://microsoft.github.io/MixedRealityToolkit-Unity/README.html#ui-and-interaction-building-blocks)<br/>&nbsp; | ![Solvers](Documentation/Images/MRTK_Icon_Solver.png) [Solvers](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Solver.html)<br/>&nbsp; | ![Multi-Scene<br/> Manager](Documentation/Images/MRTK_Icon_SceneSystem.png) [Multi-Scene<br/> Manager](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SceneSystem/SceneSystemGettingStarted.html) | ![Spatial<br/> Awareness](Documentation/Images/MRTK_Icon_SpatialUnderstanding.png) [Spatial<br/> Awareness](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.html) | ![Diagnostic<br/> Tool](Documentation/Images/MRTK_Icon_Diagnostics.png) [Diagnostic<br/> Tool](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Diagnostics/DiagnosticsSystemGettingStarted.html) |
 | ![MRTK Standard Shader](Documentation/Images/MRTK_Icon_StandardShader.png) [MRTK Standard Shader](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_MRTKStandardShader.html?q=shader) | ![Speech & Dictation](Documentation/Images/MRTK_Icon_VoiceCommand.png) [Speech](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Speech.html)<br/> & [Dictation](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Dictation.html) | ![Boundary<br/>System](Documentation/Images/MRTK_Icon_Boundary.png) [Boundary<br/>System](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Boundary/BoundarySystemGettingStarted.html)| ![In-Editor<br/>Simulation](Documentation/Images/MRTK_Icon_InputSystem.png) [In-Editor<br/>Simulation](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/InputSimulation/InputSimulationService.html) | ![Experimental<br/>Features](Documentation/Images/MRTK_Icon_Experimental.png) [Experimental<br/>Features](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Contributing/ExperimentalFeatures.html)|
 
-# UI and Interaction Building blocks
+# UI and interaction building blocks
 
 |  [![Button](Documentation/Images/Button/MRTK_Button_Main.png)](Documentation/README_Button.md) [Button](Documentation/README_Button.md) | [![Bounding Box](Documentation/Images/BoundingBox/MRTK_BoundingBox_Main.png)](Documentation/README_BoundingBox.md) [Bounding Box](Documentation/README_BoundingBox.md) | [![Manipulation Handler](Documentation/Images/ManipulationHandler/MRTK_Manipulation_Main.png)](Documentation/README_ManipulationHandler.md) [Manipulation Handler](Documentation/README_ManipulationHandler.md) |
 |:--- | :--- | :--- |
@@ -61,7 +61,7 @@ MRTK-Unity is a Microsoft-driven project that provides a set of components and f
 |:--- | :--- | :--- | :--- |
 | Automate configuration of Mixed Reality projects for performance optimizations | Analyze dependencies between assets and identify unused assets |  Configure and execute an end-to-end build process for Mixed Reality applications | Record and playback head movement and hand tracking data in editor |
 
-# Example Scenes
+# Example scenes
 
 Explore MRTK's various types of interactions and UI controls in [this example scene](Documentation/README_HandInteractionExamples.md).
 
@@ -69,7 +69,7 @@ You can find  other example scenes under [**Assets/MixedRealityToolkit.Examples/
 
 [![Example Scene](Documentation/Images/MRTK_Examples.png)](Documentation/README_HandInteractionExamples.md)
 
-# MRTK Examples Hub
+# MRTK examples hub
 
 With the MRTK Examples Hub, you can try various example scenes in MRTK.
 You can find pre-built app packages for HoloLens(x86), HoloLens 2(ARM), and Windows Mixed Reality immersive headsets(x64) under [**Release Assets**](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v2.0.0) folder. [Use the Windows Device Portal to install apps on HoloLens](https://docs.microsoft.com/hololens/hololens-install-apps#use-the-windows-device-portal-to-install-apps-on-hololens).
@@ -78,14 +78,13 @@ See [Examples Hub README page](Documentation/README_ExampleHub.md) to learn abou
 
 [![Example Scene](Documentation/Images/MRTK_ExamplesHub.png)](Documentation/README_HandInteractionExamples.md)
 
-
 # Sample apps made with MRTK
+
 | [![Periodic Table of the Elements](Documentation/Images/MRDL_PeriodicTable.jpg)](https://medium.com/@dongyoonpark/bringing-the-periodic-table-of-the-elements-app-to-hololens-2-with-mrtk-v2-a6e3d8362158)| [![Galaxy Explorer](Documentation/Images/MRTK_GalaxyExplorer.jpg)](https://docs.microsoft.com/windows/mixed-reality/galaxy-explorer-update)|
 |:--- | :--- | 
 | [Periodic Table of the Elements](https://github.com/Microsoft/MRDL_Unity_PeriodicTable) is an open-source sample app which demonstrates how to use MRTK's input system and building blocks to create an app experience for HoloLens and Immersive headsets. Read the porting story: [Bringing the Periodic Table of the Elements app to HoloLens 2 with MRTK v2](https://medium.com/@dongyoonpark/bringing-the-periodic-table-of-the-elements-app-to-hololens-2-with-mrtk-v2-a6e3d8362158) |[Galaxy Explorer](https://github.com/Microsoft/GalaxyExplorer) is an open-source sample app that was originally developed in March 2016 as part of the HoloLens 'Share Your Idea' campaign. Galaxy Explorer has been updated with new features for HoloLens 2, using MRTK v2. Read the story: [The Making of Galaxy Explorer for HoloLens 2](https://docs.microsoft.com/windows/mixed-reality/galaxy-explorer-update)|
 
-
-# Engage with the Community
+# Engage with the community
 
 - Join the conversation around MRTK on [Slack](https://holodevelopers.slack.com/). You can join the Slack community via the [automatic invitation sender](https://holodevelopersslack.azurewebsites.net/).
 
@@ -110,11 +109,12 @@ For more information, see the [Code of Conduct FAQ](https://opensource.microsoft
 | :------------------------| :--------------------- | :---------------------- |
 | Spatial Anchors is a cross-platform service that allows you to create Mixed Reality experiences using objects that persist their location across devices over time.| Discover and integrate Azure powered speech capabilities like speech to text, speaker recognition or speech translation into your application.| Identify and analyze your image or video content using Vision Services like computer vision, face detection, emotion recognition or video indexer. |
 
-# Learn more about the MRTK Project
+# Learn more about the MRTK project
 
 You can find our planning material on [our wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki) under the Project Management Section. You can always see the items the team is actively working on in the Iteration Plan issue.
 
-# How to Contribute
+# How to contribute
+
 Learn how you can contribute to MRTK at [Contributing](Documentation/Contributing/CONTRIBUTING.md).
 
 **For details on the different branches used in the Mixed Reality Toolkit repositories, check this [Branch Guide here](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/Branch-Guide).**


### PR DESCRIPTION
## Overview

Our documentation guidelines recommend [using sentence case for headlines](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Contributing/DocumentationGuide.html#capitalization), something our docs currently do inconsistently. This is phase 4 of #6893, #6898, and #6899 (I broke them up so it isn't 100+ files all at once) to fix up our headers.

NOTE: These PRs are only intended to update headers. Some non-header casing changes may have made their way in, but I'm trying to split these changes into more reviewable chunks.