### PR TITLE
Add ARM64 support to build window for Unity 2019 and support multiple VS versions side-by-side

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/BuildDeployWindow.cs
@@ -39,6 +39,9 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             x86 = 0,
             x64 = 1,
             ARM = 2,
+#if UNITY_2019_1_OR_NEWER
+            ARM64 = 3
+#endif // UNITY_2019_1_OR_NEWER
         }
 
         private enum PlatformToolset
@@ -584,6 +587,12 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             {
                 buildArchitecture = Architecture.ARM;
             }
+#if UNITY_2019_1_OR_NEWER
+            else if (currentArchitectureString.ToLower().Equals("arm64"))
+            {
+                buildArchitecture = Architecture.ARM64;
+            }
+#endif // UNITY_2019_1_OR_NEWER
 
             buildArchitecture = (Architecture)EditorGUILayout.EnumPopup("Build Platform", buildArchitecture, GUILayout.Width(HALF_WIDTH));
 

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -174,15 +174,15 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             // have VS2017 or VS2019 installed.
             foreach (VSWhereFindOption findOption in VSWhereFindOptions)
             {
-                string version = "";
+                string arguments = findOption.arguments;
                 if (string.IsNullOrWhiteSpace(EditorUserBuildSettings.wsaUWPVisualStudioVersion))
                 {
-                    version = " -latest";
+                    arguments += " -latest";
                 }
                 else
                 {
                     // Add version number with brackets to find only the specified version
-                    version = $" -version [{EditorUserBuildSettings.wsaUWPVisualStudioVersion}]";
+                    arguments += $" -version [{EditorUserBuildSettings.wsaUWPVisualStudioVersion}]";
                 }
 
                 var result = await new Process().StartProcessAsync(
@@ -193,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
-                    Arguments = $"{findOption.arguments}{version}",
+                    Arguments = arguments,
                     WorkingDirectory = @"C:\Program Files (x86)\Microsoft Visual Studio\Installer"
                 });
 

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -174,6 +174,16 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             // have VS2017 or VS2019 installed.
             foreach (VSWhereFindOption findOption in VSWhereFindOptions)
             {
+                string version = "";
+                if (string.IsNullOrWhiteSpace(EditorUserBuildSettings.wsaUWPVisualStudioVersion))
+                {
+                    version = "-latest";
+                }
+                else
+                {
+                    version = $"-version {EditorUserBuildSettings.wsaUWPVisualStudioVersion}";
+                }
+
                 var result = await new Process().StartProcessAsync(
                 new ProcessStartInfo
                 {
@@ -182,7 +192,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
-                    Arguments = findOption.arguments,
+                    Arguments = string.Format(findOption.arguments, version),
                     WorkingDirectory = @"C:\Program Files (x86)\Microsoft Visual Studio\Installer"
                 });
 
@@ -623,12 +633,12 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             // This find option corresponds to the version of vswhere that ships with VS2019.
             new VSWhereFindOption(
-                $@"/C vswhere -all -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe",
+                @"/C vswhere -all -products * {0} -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe",
                 ""),
             // This find option corresponds to the version of vswhere that ships with VS2017 - this doesn't have
             // support for the -find command switch.
             new VSWhereFindOption(
-                $@"/C vswhere -all -products * -requires Microsoft.Component.MSBuild -property installationPath",
+                @"/C vswhere -all -products * -requires Microsoft.Component.MSBuild -property installationPath",
                 "\\MSBuild\\15.0\\Bin\\MSBuild.exe"),
         };
     }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -177,11 +177,12 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 string version = "";
                 if (string.IsNullOrWhiteSpace(EditorUserBuildSettings.wsaUWPVisualStudioVersion))
                 {
-                    version = "-latest";
+                    version = " -latest";
                 }
                 else
                 {
-                    version = $"-version {EditorUserBuildSettings.wsaUWPVisualStudioVersion}";
+                    // Add version number with brackets to find only the specified version
+                    version = $" -version [{EditorUserBuildSettings.wsaUWPVisualStudioVersion}]";
                 }
 
                 var result = await new Process().StartProcessAsync(
@@ -192,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
-                    Arguments = string.Format(findOption.arguments, version),
+                    Arguments = $"{findOption.arguments}{version}",
                     WorkingDirectory = @"C:\Program Files (x86)\Microsoft Visual Studio\Installer"
                 });
 
@@ -633,7 +634,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             // This find option corresponds to the version of vswhere that ships with VS2019.
             new VSWhereFindOption(
-                @"/C vswhere -all -products * {0} -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe",
+                @"/C vswhere -all -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe",
                 ""),
             // This find option corresponds to the version of vswhere that ships with VS2017 - this doesn't have
             // support for the -find command switch.


### PR DESCRIPTION
## Overview

1. Adds `ARM64` as a valid build architecture when building in Unity 2019.
1. Fixes an issue with multiple VS versions installed side-by-side.
    1. Now, it keys `vswhere` off the setting in the Unity build window, which is already the setting the VS solution in the previous step would have been built with.

## Changes
- Fixes: #4349, #6532 