### PR TITLE
Remove migration warning and button

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
@@ -74,15 +74,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         public override void OnInspectorGUI()
         {
-            EditorGUILayout.HelpBox("Manipulation Handler will soon be removed, please upgrade to Object Manipulator", MessageType.Warning);
-            if (GUILayout.Button("Upgrade to Object Manipulator"))
-            {
-                var migrationHandler = new ObjectManipulatorMigrationHandler();
-                var manipulationHandler = target as ManipulationHandler;
-                migrationHandler.Migrate(manipulationHandler.gameObject);
-                return;
-            }
-
             EditorGUILayout.PropertyField(hostTransform);
             EditorGUILayout.PropertyField(manipulationType);
             EditorGUILayout.PropertyField(allowFarManipulation);


### PR DESCRIPTION
## Overview
Removing migration warning and button for `ManipulationHandler` as we don't yet want to advise people to make the switch.
