### PR TITLE
Fix slate zooming for GGV Pointer

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -642,7 +642,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else//is far
             {
-                if (TryGetHandRayPoint(controller, out Vector3 handRayPt) == true)
+                if (data.currentPointer is GGVPointer)
+                {
+                    data.touchingInitialPt = SnapFingerToQuad(data.currentPointer.Position);
+                    data.touchingPoint = data.touchingInitialPt;
+                    data.touchingPointSmoothed = data.touchingInitialPt;
+                }
+                else if (TryGetHandRayPoint(controller, out Vector3 handRayPt) == true)
                 {
                     data.touchingInitialPt = SnapFingerToQuad(handRayPt);
                     data.touchingPoint = data.touchingInitialPt;
@@ -651,15 +657,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     {
                         data.touchingRayOffset = handRayPt - SnapFingerToQuad(touchPosition);
                     }
-                }
-               
-                if (data.currentPointer is GGVPointer)
-                {
-                    data.touchingInitialPt = SnapFingerToQuad(data.currentPointer.Position);
-                    data.touchingPoint = data.touchingInitialPt;
-                    data.touchingPointSmoothed = data.touchingInitialPt;
-                    data.touchingRayOffset = Vector3.zero;
-                }
+                }              
             }
 
             //store value in case of MRController

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -652,6 +652,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         data.touchingRayOffset = handRayPt - SnapFingerToQuad(touchPosition);
                     }
                 }
+               
+                if (data.currentPointer is GGVPointer)
+                {
+                    data.touchingInitialPt = SnapFingerToQuad(data.currentPointer.Position);
+                    data.touchingPoint = data.touchingInitialPt;
+                    data.touchingPointSmoothed = data.touchingInitialPt;
+                    data.touchingRayOffset = Vector3.zero;
+                }
             }
 
             //store value in case of MRController

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
@@ -56,13 +56,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
-            TestHand h = new TestHand(Handedness.Right); ;
-            yield return h.MoveTo(panObject.transform.position);
-            yield return h.Move(new Vector3(0, -0.05f, 0), 10);
+            TestHand handRight = new TestHand(Handedness.Right); ;
+            yield return handRight.MoveTo(panObject.transform.position);
+            yield return handRight.Move(new Vector3(0, -0.05f, 0), 10);
 
             Assert.AreEqual(0.1, totalPanDelta.y, 0.05, "pan delta is not correct");
 
-            yield return h.Hide();
+            yield return handRight.Hide();
         }
 
         /// <summary>
@@ -75,23 +75,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
-            TestHand h = new TestHand(Handedness.Right);
+            TestHand handRight = new TestHand(Handedness.Right);
             Vector3 screenPoint = CameraCache.Main.ViewportToScreenPoint(new Vector3(0.5f, 0.25f, 0.5f));
-            yield return h.Show(CameraCache.Main.ScreenToWorldPoint(screenPoint));
+            yield return handRight.Show(CameraCache.Main.ScreenToWorldPoint(screenPoint));
 
             Assert.True(PointerUtils.TryGetHandRayEndPoint(Handedness.Right, out Vector3 hitPointStart));
 
-            yield return h.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return h.Move(new Vector3(0, -0.05f, 0), 10);
+            yield return handRight.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return handRight.Move(new Vector3(0, -0.05f, 0), 10);
+
             Assert.True(PointerUtils.TryGetHandRayEndPoint(Handedness.Right, out Vector3 hitPointEnd));
-            yield return h.SetGesture(ArticulatedHandPose.GestureId.Open);
+
+            yield return handRight.SetGesture(ArticulatedHandPose.GestureId.Open);
 
             TestUtilities.AssertNotAboutEqual(hitPointStart, hitPointEnd, "ray should not stick on slate scrolling");
             Assert.AreEqual(0.1, totalPanDelta.y, 0.05, "pan delta is not correct");
 
-
-
-            yield return h.Hide();
+            yield return handRight.Hide();
         }
 
         /// <summary>
@@ -102,20 +102,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             InstantiateFromPrefab(Vector3.forward);
 
-            TestHand h = new TestHand(Handedness.Right);
-            yield return h.Show(Vector3.zero);
+            TestHand handRight = new TestHand(Handedness.Right);
+            yield return handRight.Show(Vector3.zero);
+            yield return handRight.MoveTo(panZoom.transform.position, 10);
 
-            yield return h.MoveTo(panZoom.transform.position, 10);
+            TestHand handLeft = new TestHand(Handedness.Left);
+            yield return handLeft.Show(Vector3.zero);
 
-            TestHand h2 = new TestHand(Handedness.Left);
-            yield return h2.Show(Vector3.zero);
-            yield return h2.MoveTo(panZoom.transform.position + Vector3.right * -0.01f, 10);
+            yield return handLeft.MoveTo(panZoom.transform.position + Vector3.right * -0.01f, 10);
+            yield return handRight.Move(new Vector3(0.01f, 0f, 0f));
+            yield return handLeft.Move(new Vector3(-0.01f, 0f, 0f));
 
-            yield return h.Move(new Vector3(0.01f, 0f, 0f));
-            yield return h2.Move(new Vector3(-0.01f, 0f, 0f));
             Assert.AreEqual(0.4, panZoom.CurrentScale, 0.1, "slate did not zoom in using two finger touch");
 
-            yield return h.Hide();
+            yield return handRight.Hide();
+            yield return handLeft.Hide();
         }
 
         /// <summary>
@@ -128,21 +129,22 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
-            TestHand h = new TestHand(Handedness.Right);
-            yield return h.Show(new Vector3(0.0f, 0.0f, 0.6f));
+            TestHand handRight = new TestHand(Handedness.Right);
+            yield return handRight.Show(new Vector3(0.0f, 0.0f, 0.6f));
 
-            TestHand h2 = new TestHand(Handedness.Left);
-            yield return h2.Show(new Vector3(-0.1f, 0.0f, 0.6f));
+            TestHand handLeft = new TestHand(Handedness.Left);
+            yield return handLeft.Show(new Vector3(-0.1f, 0.0f, 0.6f));
 
-            yield return h.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return h2.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return handRight.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return handLeft.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
-            yield return h.Move(new Vector3(0.005f, 0.0f, 0.0f), 10);
-            yield return h2.Move(new Vector3(-0.005f, 0.0f, 0.0f), 10);
+            yield return handRight.Move(new Vector3(0.005f, 0.0f, 0.0f), 10);
+            yield return handLeft.Move(new Vector3(-0.005f, 0.0f, 0.0f), 10);
 
             Assert.AreEqual(0.5, panZoom.CurrentScale, 0.1, "slate did not zoom in using two ggv hands");
 
-            yield return h.Hide();
+            yield return handRight.Hide();
+            yield return handLeft.Hide();
         }
         /// <summary>
         /// Test ggv scroll instantiated from prefab
@@ -151,7 +153,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator Prefab_GGVScroll()
         {
             InstantiateFromPrefab(Vector3.forward);
-            yield return RunGGVScrollTest(0.2f);
+            yield return RunGGVScrollTest(0.25f);
         }
 
         /// <summary>
@@ -176,14 +178,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
-            TestHand h = new TestHand(Handedness.Right);
-            yield return h.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return h.Show(Vector3.zero);
-            yield return h.Move(new Vector3(0.0f, -0.1f, 0f));
+            TestHand handRight = new TestHand(Handedness.Right);
+            yield return handRight.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return handRight.Show(Vector3.zero);
+            yield return handRight.Move(new Vector3(0.0f, -0.1f, 0f));
 
             Assert.AreEqual(expectedScroll, totalPanDelta.y, 0.1, "pan delta is not correct");
 
-            yield return h.Hide();
+            yield return handRight.Hide();
         }
 
         private void InstantiateFromCode(Vector3 pos)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
@@ -119,6 +119,32 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test ggv zooming instantiated from prefab
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Prefab_GGVZoom()
+        {
+            InstantiateFromPrefab(Vector3.forward);
+
+            PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
+
+            TestHand h = new TestHand(Handedness.Right);
+            yield return h.Show(new Vector3(0.0f, 0.0f, 0.6f));
+
+            TestHand h2 = new TestHand(Handedness.Left);
+            yield return h2.Show(new Vector3(-0.1f, 0.0f, 0.6f));
+
+            yield return h.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return h2.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            yield return h.Move(new Vector3(0.005f, 0.0f, 0.0f), 10);
+            yield return h2.Move(new Vector3(-0.005f, 0.0f, 0.0f), 10);
+
+            Assert.AreEqual(0.5, panZoom.CurrentScale, 0.1, "slate did not zoom in using two ggv hands");
+
+            yield return h.Hide();
+        }
+        /// <summary>
         /// Test ggv scroll instantiated from prefab
         /// </summary>
         [UnityTest]
@@ -155,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return h.Show(Vector3.zero);
             yield return h.Move(new Vector3(0.0f, -0.1f, 0f));
 
-            Assert.AreEqual(expectedScroll, totalPanDelta.y, 0.05, "pan delta is not correct");
+            Assert.AreEqual(expectedScroll, totalPanDelta.y, 0.1, "pan delta is not correct");
 
             yield return h.Hide();
         }


### PR DESCRIPTION
## Overview
Slate Zooming in/out not working properly on Hololens 1. Issue can be replicated on the Editor. 

Before:
![slate_zoom_before](https://user-images.githubusercontent.com/16922045/71083774-b63f6480-218b-11ea-9d4a-5682a6329a30.gif)

After:
![slate_zoom_after](https://user-images.githubusercontent.com/16922045/71083805-cbb48e80-218b-11ea-957d-f42c1c74b0a9.gif)



## Changes
- Touching point logic was modified on HandInteractionPanZoom.cs to account for both Right Hand and Left Hand controllers having same pointer/slate touch position on GGV.

- Fixes: #6371  .



## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
