### PR TITLE
added possibility to set target of bounds control / bounding box in code

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -44,6 +44,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                 return targetObject;
             }
+
+            set
+            {
+                if (targetObject != value)
+                {
+                    targetObject = value;
+                    CreateRig();
+                }
+            }
         }
 
         [Tooltip("For complex objects, automatic bounds calculation may not behave as expected. Use an existing Box Collider (even on a child object) to manually determine bounds of bounds control.")]
@@ -880,7 +889,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             var rigRootObj = new GameObject(rigRootName);
             rigRoot = rigRootObj.transform;
-            rigRoot.parent = transform;
+            rigRoot.parent = Target.transform;
 
             var pH = rigRootObj.AddComponent<PointerHandler>();
             pH.OnPointerDown.AddListener(OnPointerDown);
@@ -1170,7 +1179,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 // move rig into position and rotation
                 rigRoot.position = TargetBounds.bounds.center;
                 rigRoot.rotation = Target.transform.rotation;
-                rigRoot.parent = transform;
+                rigRoot.parent = Target.transform;
             }
         }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -173,6 +173,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 return targetObject;
             }
+
+            set
+            {
+                if (targetObject != value)
+                {
+                    targetObject = value;
+                    CreateRig();
+                }
+            }
         }
 
         [Tooltip("For complex objects, automatic bounds calculation may not behave as expected. Use an existing Box Collider (even on a child object) to manually determine bounds of Bounding Box.")]

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -358,11 +358,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             bbox.Target = cube;
             bbox.Active = true;
 
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-
             // front right corner is corner 3
             var frontRightCornerPos = cube.transform.Find("rigRoot/corner_3").position;
 
+            // grab corner and scale object
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
             int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BoundingBoxTests.cs
@@ -37,6 +37,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             PlayModeTestUtilities.TearDown();
         }
 
+        private readonly Vector3 boundingBoxStartCenter = Vector3.forward * 1.5f;
+        private readonly Vector3 boundingBoxStartScale = Vector3.one * 0.5f;
+
         /// <summary>
         /// Instantiates a bounding box at 0, 0, -1.5f
         /// box is at scale .5, .5, .5
@@ -44,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private BoundingBox InstantiateSceneAndDefaultBbox()
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            cube.transform.position = Vector3.forward * 1.5f;
+            cube.transform.position = boundingBoxStartCenter;
             BoundingBox bbox = cube.AddComponent<BoundingBox>();
 
             MixedRealityPlayspace.PerformTransformation(
@@ -54,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 p.LookAt(cube.transform.position);
             });
 
-            bbox.transform.localScale *= 0.5f;
+            bbox.transform.localScale = boundingBoxStartScale;
             bbox.Active = true;
 
             return bbox;
@@ -325,6 +328,62 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             bbox.gameObject.SetActive(true);
             yield return hand.Move(Vector3.right * 0.2f, numHandSteps);
             Assert.AreEqual(afterTransformScale, bbox.transform.localScale);
+        }
+
+
+        /// <summary>
+        /// Tests setting a target in code that is a different gameobject than the gameobject the boundingbox component is attached to
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SetTarget()
+        {
+            // create cube without control
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = boundingBoxStartCenter;
+
+            MixedRealityPlayspace.PerformTransformation(
+            p =>
+            {
+                p.position = Vector3.zero;
+                p.LookAt(cube.transform.position);
+            });
+
+            cube.transform.localScale = boundingBoxStartScale;
+
+            // create another gameobject with boundscontrol attached 
+            var emptyGameObject = new GameObject("empty");
+            BoundingBox bbox = emptyGameObject.AddComponent<BoundingBox>();
+
+            // set target to cube
+            bbox.Target = cube;
+            bbox.Active = true;
+
+            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+
+            // front right corner is corner 3
+            var frontRightCornerPos = cube.transform.Find("rigRoot/corner_3").position;
+
+            Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
+            int numSteps = 30;
+            var delta = new Vector3(0.1f, 0.1f, 0f);
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialHandPosition);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            yield return hand.MoveTo(frontRightCornerPos, numSteps);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.MoveTo(frontRightCornerPos + delta, numSteps);
+
+            var endBounds = cube.GetComponent<BoxCollider>().bounds;
+            Vector3 expectedCenter = new Vector3(0.033f, 0.033f, 1.467f);
+            Vector3 expectedSize = Vector3.one * .567f;
+            TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");
+
+            Object.Destroy(emptyGameObject);
+            Object.Destroy(cube);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -334,6 +334,62 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
+        /// Tests setting a target in code that is a different gameobject than the gameobject the bounds control component is attached to
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SetTarget()
+        {
+            // create cube without control
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = boundsControlStartCenter;
+
+            MixedRealityPlayspace.PerformTransformation(
+            p =>
+            {
+                p.position = Vector3.zero;
+                p.LookAt(cube.transform.position);
+            });
+
+            cube.transform.localScale = boundsControlStartScale;
+
+            // create another gameobject with boundscontrol attached 
+            var emptyGameObject = new GameObject("empty");
+            BoundsControl bbox = emptyGameObject.AddComponent<BoundsControl>();
+
+            // set target to cube
+            bbox.Target = cube;
+            bbox.Active = true;
+
+            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+
+            // front right corner is corner 3
+            var frontRightCornerPos = cube.transform.Find("rigRoot/corner_3").position;
+
+            Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
+            int numSteps = 30;
+            var delta = new Vector3(0.1f, 0.1f, 0f);
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialHandPosition);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            yield return hand.MoveTo(frontRightCornerPos, numSteps);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return hand.MoveTo(frontRightCornerPos + delta, numSteps);
+
+
+            var endBounds = cube.GetComponent<BoxCollider>().bounds;
+            Vector3 expectedCenter = new Vector3(0.033f, 0.033f, 1.467f);
+            Vector3 expectedSize = Vector3.one * .567f;
+            TestUtilities.AssertAboutEqual(endBounds.center, expectedCenter, "endBounds incorrect center");
+            TestUtilities.AssertAboutEqual(endBounds.size, expectedSize, "endBounds incorrect size");
+
+            Object.Destroy(emptyGameObject);
+            Object.Destroy(cube);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+
+        }
+
+        /// <summary>
         /// Returns the AABB of the bounds control rig (corners, edges)
         /// that make up the bounds control by using the positions of the corners
         /// </summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -360,11 +360,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             bbox.Target = cube;
             bbox.Active = true;
 
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
-
             // front right corner is corner 3
             var frontRightCornerPos = cube.transform.Find("rigRoot/corner_3").position;
 
+            // grab corner and scale object
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
             int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
@@ -374,7 +373,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(frontRightCornerPos, numSteps);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return hand.MoveTo(frontRightCornerPos + delta, numSteps);
-
 
             var endBounds = cube.GetComponent<BoxCollider>().bounds;
             Vector3 expectedCenter = new Vector3(0.033f, 0.033f, 1.467f);


### PR DESCRIPTION
## Overview
- added possibility to set target of bounding box / bounds control in code
- added tests to verify target setting works - test will create cube without bounding box / bounds control and create another empty gameobject unrelated to the cube that has bounding box / bounds control attached - target of bounding box / bounds control is set to cube gameobject and correct behavior is verified through near interaction scaling
- fixed bug where rigroot was attached to bounds control gameobject instead of target gameobject 



## Changes
- Fixes: #5992 
