### PR TITLE
Add missing namespace to IMixedRealityMouseDeviceManager

### DIFF
--- a/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
@@ -1,27 +1,29 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using System;
 
-/// <summary>
-/// Interface defining a mouse input device manager.
-/// </summary>
-public interface IMixedRealityMouseDeviceManager : IMixedRealityInputDeviceManager
+namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Typed representation of the ConfigurationProfile property.
+    /// Interface defining a mouse input device manager.
     /// </summary>
-    [ObsoleteAttribute("The MouseInputProfile property has been deprecated and will be removed in a future version of MRTK.")]
-    MixedRealityMouseInputProfile MouseInputProfile { get; }
-    
-    /// <summary>
-    /// Gets or sets a multiplier value used to adjust the speed of the mouse cursor.
-    /// </summary>
-    float CursorSpeed { get; set; }
+    public interface IMixedRealityMouseDeviceManager : IMixedRealityInputDeviceManager
+    {
+        /// <summary>
+        /// Typed representation of the ConfigurationProfile property.
+        /// </summary>
+        [ObsoleteAttribute("The MouseInputProfile property has been deprecated and will be removed in a future version of MRTK.")]
+        MixedRealityMouseInputProfile MouseInputProfile { get; }
+        
+        /// <summary>
+        /// Gets or sets a multiplier value used to adjust the speed of the mouse cursor.
+        /// </summary>
+        float CursorSpeed { get; set; }
 
-    /// <summary>
-    /// Gets or sets a multiplier value used to adjust the speed of the mouse wheel.
-    /// </summary>
-    float WheelSpeed { get; set; }
+        /// <summary>
+        /// Gets or sets a multiplier value used to adjust the speed of the mouse wheel.
+        /// </summary>
+        float WheelSpeed { get; set; }
+    }
 }


### PR DESCRIPTION
## Overview
This file is missing its namespace. Adds `namespace Microsoft.MixedReality.Toolkit.Input`.