### PR TITLE
Improvements to Hand Constraint juicyness

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -303,7 +303,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 handBounds.Bounds.TryGetValue(trackedController.ControllerHandedness, out trackedHandBounds))
             {
                 float distance;
-                Ray ray = CalculateProjectedSafeZoneRay(goalPosition, trackedController, safeZone);
+                Ray ray = CalculateProjectedSafeZoneRay(goalPosition, SolverHandler.TransformTarget, trackedController, safeZone, RotationBehavior);
                 trackedHandBounds.Expand(safeZoneBuffer);
 
                 if (trackedHandBounds.IntersectRay(ray, out distance))
@@ -407,7 +407,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             return false;
         }
 
-        private static Ray CalculateProjectedSafeZoneRay(Vector3 origin, IMixedRealityController hand, SolverSafeZone handSafeZone)
+        private static Ray CalculateProjectedSafeZoneRay(Vector3 origin, Transform targetTransform, IMixedRealityController hand, SolverSafeZone handSafeZone, SolverRotationBehavior rotationBehavior)
         {
             Vector3 direction;
 
@@ -416,8 +416,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 default:
                 case SolverSafeZone.UlnarSide:
                     {
-                        direction = Vector3.Cross(CameraCache.Main.transform.forward, Vector3.up);
-                        direction = IsPalmFacingCamera(hand) ? direction : -direction;
+                        if (rotationBehavior == SolverRotationBehavior.LookAtTrackedObject)
+                        {
+                            direction = targetTransform.right;
+                        }
+                        else
+                        {
+                            direction = Vector3.Cross(CameraCache.Main.transform.forward, Vector3.up);
+                            direction = IsPalmFacingCamera(hand) ? direction : -direction;
+                        }
 
                         if (hand.ControllerHandedness.IsLeft())
                         {
@@ -428,8 +435,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
                 case SolverSafeZone.RadialSide:
                     {
-                        direction = Vector3.Cross(CameraCache.Main.transform.forward, Vector3.up);
-                        direction = IsPalmFacingCamera(hand) ? direction : -direction;
+
+                        if (rotationBehavior == SolverRotationBehavior.LookAtTrackedObject)
+                        {
+                            direction = -targetTransform.right;
+                        }
+                        else
+                        {
+                            direction = Vector3.Cross(CameraCache.Main.transform.forward, Vector3.up);
+                            direction = IsPalmFacingCamera(hand) ? direction : -direction;
+                        }
 
                         if (hand.ControllerHandedness == Handedness.Right)
                         {

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraint.cs
@@ -51,8 +51,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public SolverSafeZone SafeZone
         {
-            get { return safeZone; }
-            set { safeZone = value; }
+            get => safeZone;
+            set => safeZone = value;
         }
 
         [SerializeField]
@@ -64,8 +64,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public float SafeZoneBuffer
         {
-            get { return safeZoneBuffer; }
-            set { safeZoneBuffer = value; }
+            get => safeZoneBuffer;
+            set => safeZoneBuffer = value;
         }
 
         [SerializeField]
@@ -77,8 +77,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public bool UpdateWhenOppositeHandNear
         {
-            get { return updateWhenOppositeHandNear; }
-            set { updateWhenOppositeHandNear = value; }
+            get => updateWhenOppositeHandNear;
+            set => updateWhenOppositeHandNear = value;
         }
 
         [SerializeField]
@@ -90,8 +90,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public bool HideHandCursorsOnActivate
         {
-            get { return hideHandCursorsOnActivate; }
-            set { hideHandCursorsOnActivate = value; }
+            get => hideHandCursorsOnActivate;
+            set => hideHandCursorsOnActivate = value;
         }
 
         /// <summary>
@@ -123,8 +123,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public SolverRotationBehavior RotationBehavior
         {
-            get { return rotationBehavior; }
-            set { rotationBehavior = value; }
+            get => rotationBehavior;
+            set => rotationBehavior = value;
         }
 
         /// <summary>
@@ -151,8 +151,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public SolverOffsetBehavior OffsetBehavior
         {
-            get { return offsetBehavior; }
-            set { offsetBehavior = value; }
+            get => offsetBehavior;
+            set => offsetBehavior = value;
         }
 
         [SerializeField]
@@ -164,8 +164,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public UnityEvent OnHandActivate
         {
-            get { return onHandActivate; }
-            set { onHandActivate = value; }
+            get => onHandActivate;
+            set => onHandActivate = value;
         }
 
         [SerializeField]
@@ -177,8 +177,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public UnityEvent OnHandDeactivate
         {
-            get { return onHandDeactivate; }
-            set { onHandDeactivate = value; }
+            get => onHandDeactivate;
+            set => onHandDeactivate = value;
         }
 
         [SerializeField]
@@ -190,8 +190,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public UnityEvent OnFirstHandDetected
         {
-            get { return onFirstHandDetected; }
-            set { onFirstHandDetected = value; }
+            get => onFirstHandDetected;
+            set => onFirstHandDetected = value;
         }
 
         [SerializeField]
@@ -203,8 +203,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public UnityEvent OnLastHandLost
         {
-            get { return onLastHandLost; }
-            set { onLastHandLost = value; }
+            get => onLastHandLost;
+            set => onLastHandLost = value;
         }
 
         private Handedness previousHandedness = Handedness.None;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -79,14 +79,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             MixedRealityPose palmPose;
             var jointedHand = controller as IMixedRealityHand;
 
-            float palmCameraAngle = 360f;
             bool palmFacingThresholdMet = false;
 
             if (jointedHand != null)
             {
                 if (jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
                 {
-                    palmCameraAngle = Vector3.Angle(palmPose.Up, CameraCache.Main.transform.forward);
+                    float palmCameraAngle = Vector3.Angle(palmPose.Up, CameraCache.Main.transform.forward);
 
                     if (requireFlatHand)
                     {

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         private bool followHandUntilFacingCamera = false;
 
         [SerializeField]
-        [Tooltip("Angle between hand up and camera forward, below which the hand menu follows the gaze, if followHandUntilFacingCamera is active.")]
+        [Tooltip("Angle (in degrees) between hand up and camera forward, below which the hand menu follows the gaze, if followHandUntilFacingCamera is active.")]
         private float followHandCameraFacingThresholdAngle = 60f;
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -26,8 +26,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public float FacingCameraTrackingThreshold
         {
-            get { return facingCameraTrackingThreshold; }
-            set { facingCameraTrackingThreshold = value; }
+            get => facingCameraTrackingThreshold;
+            set => facingCameraTrackingThreshold = value;
         }
 
         [SerializeField]
@@ -39,8 +39,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public bool RequireFlatHand
         {
-            get { return requireFlatHand; }
-            set { requireFlatHand = value; }
+            get => requireFlatHand;
+            set => requireFlatHand = value;
         }
 
         [SerializeField]
@@ -53,8 +53,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public float FlatHandThreshold
         {
-            get { return flatHandThreshold; }
-            set { flatHandThreshold = value; }
+            get => flatHandThreshold;
+            set => flatHandThreshold = value;
         }
 
         [SerializeField]
@@ -66,8 +66,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public bool FollowHandUntilFacingCamera
         {
-            get { return followHandUntilFacingCamera; }
-            set { followHandUntilFacingCamera = value; }
+            get => followHandUntilFacingCamera;
+            set => followHandUntilFacingCamera = value;
         }
 
         [SerializeField]
@@ -79,8 +79,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// </summary>
         public float FollowHandCameraFacingThresholdAngle
         {
-            get { return followHandCameraFacingThresholdAngle; }
-            set { followHandCameraFacingThresholdAngle = value; }
+            get => followHandCameraFacingThresholdAngle;
+            set => followHandCameraFacingThresholdAngle = value;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -30,6 +30,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             set => facingCameraTrackingThreshold = value;
         }
 
+        [System.Obsolete("Use FacingCameraTrackingThreshold property instead")]
+        public float FacingThreshold
+        {
+            get => FacingCameraTrackingThreshold;
+            set => FacingCameraTrackingThreshold = value;
+        }
+
         [SerializeField]
         [Tooltip("Do the fingers on the hand need to be straightened, rather than curled, to form a flat hand shape. Only supported by IMixedRealityHand controllers.")]
         private bool requireFlatHand = false;

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -61,9 +61,27 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         [Tooltip("With this active, solver will follow hand rotation until the menu is sufficiently aligned with the gaze, at which point it faces the camera.")]
         private bool followHandUntilFacingCamera = false;
 
+        /// <summary>
+        /// With this active, solver will follow hand rotation until the menu is sufficiently aligned with the gaze, at which point it faces the camera.
+        /// </summary>
+        public bool FollowHandUntilFacingCamera
+        {
+            get { return followHandUntilFacingCamera; }
+            set { followHandUntilFacingCamera = value; }
+        }
+
         [SerializeField]
         [Tooltip("Angle (in degrees) between hand up and camera forward, below which the hand menu follows the gaze, if followHandUntilFacingCamera is active.")]
         private float followHandCameraFacingThresholdAngle = 60f;
+
+        /// <summary>
+        /// Angle (in degrees) between hand up and camera forward, below which the hand menu follows the gaze, if followHandUntilFacingCamera is active.
+        /// </summary>
+        public float FollowHandCameraFacingThresholdAngle
+        {
+            get { return followHandCameraFacingThresholdAngle; }
+            set { followHandCameraFacingThresholdAngle = value; }
+        }
 
         /// <summary>
         /// Determines if a controller meets the requirements for use with constraining the tracked object and determines if the 
@@ -118,11 +136,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                         if (palmCameraAngle > followHandCameraFacingThresholdAngle)
                         {
                             RotationBehavior = SolverRotationBehavior.LookAtTrackedObject;
+                            OffsetBehavior = SolverOffsetBehavior.TrackedObjectRotation;
                         }
                         // If we are within the threshold angle, we snap to follow the camera
                         else
                         {
                             RotationBehavior = SolverRotationBehavior.LookAtMainCamera;
+                            OffsetBehavior = SolverOffsetBehavior.LookAtCameraRotation;
                         }
                     }
                 }

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 {
@@ -15,17 +16,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
     {
         [Header("Palm Up")]
         [SerializeField]
+        [FormerlySerializedAs("facingThreshold")]
         [Tooltip("The angle (in degrees) of the cone between the palm's up and camera's forward have to match. Only supported by IMixedRealityHand controllers.")]
         [Range(0.0f, 90.0f)]
-        private float facingThreshold = 80.0f;
+        private float facingCameraTrackingThreshold = 80.0f;
 
         /// <summary>
         /// The angle (in degrees) of the cone between the palm's up and camera's forward have to match. Only supported by <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand"/> controllers.
         /// </summary>
-        public float FacingThreshold
+        public float FacingCameraTrackingThreshold
         {
-            get { return facingThreshold; }
-            set { facingThreshold = value; }
+            get { return facingCameraTrackingThreshold; }
+            set { facingCameraTrackingThreshold = value; }
         }
 
         [SerializeField]
@@ -56,12 +58,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         [SerializeField]
-        [Tooltip("When using hybrid hand rotation, solver hand rotation until the menu is aligned with the gaze sufficiently")]
-        private bool useHybridHandRotation = false;
+        [Tooltip("With this active, solver will follow hand rotation until the menu is sufficiently aligned with the gaze, at which point it faces the camera.")]
+        private bool followHandUntilFacingCamera = false;
 
         [SerializeField]
-        [Tooltip("Angle between hand up and camera forward, below which the hand menu follows the gaze, if useHybridHandRotation is active.")]
-        private float hybridHandRotationThresholdAngle = 60f;
+        [Tooltip("Angle between hand up and camera forward, below which the hand menu follows the gaze, if followHandUntilFacingCamera is active.")]
+        private float followHandCameraFacingThresholdAngle = 60f;
 
         /// <summary>
         /// Determines if a controller meets the requirements for use with constraining the tracked object and determines if the 
@@ -107,13 +109,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                     }
 
                     // Check if the palm angle meets the prescribed threshold
-                    palmFacingThresholdMet = palmCameraAngle < facingThreshold;
+                    palmFacingThresholdMet = palmCameraAngle < facingCameraTrackingThreshold;
 
                     // If using hybrid hand rotation, we proceed with additional checks
-                    if (useHybridHandRotation && palmFacingThresholdMet)
+                    if (followHandUntilFacingCamera && palmFacingThresholdMet)
                     {
                         // If we are above the threshold angle, keep the menu mapped to the tracked object
-                        if (palmCameraAngle > hybridHandRotationThresholdAngle)
+                        if (palmCameraAngle > followHandCameraFacingThresholdAngle)
                         {
                             RotationBehavior = SolverRotationBehavior.LookAtTrackedObject;
                         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -285,6 +285,63 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test the HandConstraintPalm up to make sure the FollowHandUntilFacingCamera behavior works as expected
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestHandConstraintPalmUpSolverPlacement()
+        {
+            // Instantiate our test GameObject with solver.
+            var testObjects = InstantiateTestSolver<HandConstraintPalmUp>();
+            testObjects.handler.TrackedTargetType = TrackedObjectType.HandJoint;
+            testObjects.handler.TrackedHandness = Handedness.Both;
+
+            var handConstraintSolver = (HandConstraintPalmUp) testObjects.solver;
+            handConstraintSolver.FollowHandUntilFacingCamera = true;
+
+            // Ensure that FacingCameraTrackingThreshold is greater than FollowHandCameraFacingThresholdAngle
+            Assert.AreEqual(handConstraintSolver.FacingCameraTrackingThreshold - handConstraintSolver.FollowHandCameraFacingThresholdAngle > 0, true);
+
+            yield return new WaitForSeconds(SolverUpdateWaitTime);
+
+            TestUtilities.AssertAboutEqual(testObjects.target.transform.position, Vector3.zero, "HandConstraintPalmUp solver did not start at the origin");
+
+            var cameraTransform = CameraCache.Main.transform;
+
+            // Place hand 1 meter in front of user, 50 cm below eye level
+            var handTestPos = cameraTransform.position + cameraTransform.forward - (Vector3.up * 0.5f);
+            
+            var cameraLookVector = (handTestPos - cameraTransform.position).normalized;
+
+            // Generate hand rotation with hand palm facing camera
+            var handRoation = Quaternion.LookRotation(cameraTransform.up, cameraLookVector);
+
+            // Add a right hand.
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(handTestPos);
+            yield return rightHand.SetRotation(handRoation);
+
+            yield return new WaitForSeconds(SolverUpdateWaitTime);
+
+            // Ensure Rotation and offset behavior are following camera
+            Assert.AreEqual(handConstraintSolver.RotationBehavior, HandConstraint.SolverRotationBehavior.LookAtMainCamera);
+            Assert.AreEqual(handConstraintSolver.OffsetBehavior, HandConstraint.SolverOffsetBehavior.LookAtCameraRotation);
+
+            // Rotate hand so palm is no longer within the FollowHandCameraFacingThresholdAngle
+            var newHandRot = handRoation * Quaternion.Euler(-(handConstraintSolver.FollowHandCameraFacingThresholdAngle + 1), 0f, 0f);
+            yield return rightHand.SetRotation(newHandRot);
+
+            yield return new WaitForSeconds(SolverUpdateWaitTime);
+
+            // Ensure Rotation and offset behavior are following camera
+            Assert.AreEqual(handConstraintSolver.RotationBehavior, HandConstraint.SolverRotationBehavior.LookAtTrackedObject);
+            Assert.AreEqual(handConstraintSolver.OffsetBehavior, HandConstraint.SolverOffsetBehavior.TrackedObjectRotation);
+
+            yield return rightHand.Hide();
+
+            yield return new WaitForSeconds(SolverUpdateWaitTime);
+        }
+
+        /// <summary>
         /// Test the Overlap solver and make sure it tracks the left simulated hand exactly
         /// </summary>
         [UnityTest]

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -171,6 +171,8 @@ Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.Mi
 
 * **Safe Zone**: The safe zone specifies where on the hand to constrain content. It is recommended that content be placed on the Ulnar Side to avoid overlap with the hand and improved interaction quality. Safe zones are calculated by taking the hands orientation projected into a plane orthogonal to the camera's view and raycasting against a bounding box around the hands. Safe zones are defined to work with [`IMixedRealityHand`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand) but also works with other controller types. It is recommended to explore what each safe zone represents on different controller types.
 
+* **Follow Hand Until Facing Camera** With this active, solver will follow hand rotation until the menu is sufficiently aligned with the gaze, at which point it faces the camera. This works by changing the SolverRotationBehavior in the HandConstraintSolver, from LookAtTrackedObject to LookAtMainCamera as the GazeAlignment angle with the solver varies.
+
 <img src="Images/Solver/MRTK_Solver_HandConstraintSafeZones.png" width="450">
 
 * **Activation Events**: Currently the [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) triggers four activation events. These events can be used in many different combinations to create unique [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behaviors, please see the HandBasedMenuExample scene under: [MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes) for examples of these behaviors.


### PR DESCRIPTION
# Overview

Addition of useHybridHandRotation for HandConstraintPalmUp.
- This adds an additional check in HandConstraintPalmUp's hand validation function, which changes the Rotation behavior if useHybridHandRotation is enabled.

Added better behavior for LookAtTrackedObject.
- This introduces a branch in CalculateProjectedSafeZoneRay of the HandConstraint base class, which computes the SafeZone Direction ray according to the rotation of the SolverHandler.TargetTransform, rather than exclusively from the head gaze.

The end result can be seen [here](https://twitter.com/prvncher/status/1211795961510584327)

With useHybridHandRotation enabled:
The menu matches your hand rotation until your palm and head gaze reach a threshold angle, which activates a different rotation behavior that makes the menu look at the camera instead.

In other words, it flips open and closed 
![gUBsKIae9V](https://user-images.githubusercontent.com/7420990/71605193-198aa880-2b35-11ea-92be-3d208075ffca.gif)
