### PR TITLE
Remove if UNITY_EDITOR check

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -458,7 +458,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         #region asset version migration
-#if UNITY_EDITOR
         private const int CurrentAssetVersion = 1;
 
         [SerializeField]
@@ -504,7 +503,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             return objectName;
         }
-#endif
         #endregion
 
     }


### PR DESCRIPTION
## Overview
GridObjectCollection was throwing errors on device because assets were being loaded without the asset version in runtime but saved with the asset version. See comment from @gilbdev  in #6938. Thank you for the help!

## Changes
- Fixes: #6938
