### PR TITLE
Fix poke pointer layer mask

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool IsNearObject
         {
-            get { return (closestProximityTouchable != null); }
+            get => closestProximityTouchable != null;
         }
 
         /// <inheritdoc />
@@ -203,12 +203,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             for (int i = 0; i < NearInteractionTouchableUnityUI.Instances.Count; i++)
             {
                 NearInteractionTouchableUnityUI touchable = NearInteractionTouchableUnityUI.Instances[i];
-                float distance = touchable.DistanceToTouchable(Position, out Vector3 normal);
-                if (distance <= touchableDistance && distance < closestDistance)
+                if (touchable.gameObject.IsInLayerMask(layerMask))
                 {
-                    closest = touchable;
-                    closestDistance = distance;
-                    closestNormal = normal;
+                    float distance = touchable.DistanceToTouchable(Position, out Vector3 normal);
+                    if (distance <= touchableDistance && distance < closestDistance)
+                    {
+                        closest = touchable;
+                        closestDistance = distance;
+                        closestNormal = normal;
+                    }
                 }
             }
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -14,7 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SceneQueryType raycastMode = SceneQueryType.SphereOverlap;
 
         /// <inheritdoc />
-        public override SceneQueryType SceneQueryType { get { return raycastMode; } set { raycastMode = value; } }
+        public override SceneQueryType SceneQueryType 
+        { 
+            get => raycastMode; 
+            set => raycastMode = value;
+        }
 
         [SerializeField]
         [Min(0.0f)]
@@ -90,10 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns>True if the pointer is near any collider that's both on a grabbable layer mask, and has a NearInteractionGrabbable.</returns>
         public bool IsNearObject
         {
-            get
-            {
-                return queryBufferNearObjectRadius.ContainsGrabbable();
-            }
+            get => queryBufferNearObjectRadius.ContainsGrabbable();
         }
 
         /// <summary>
@@ -304,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                 // Also to not turn off the hand ray if hand is near a grabbable that's not actually visible
                                 grabbable = null;
                             }
-                        }   
+                        }
                     }
 
                     if (grabbable != null)
@@ -360,7 +361,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 result = xMin <= cameraPos.x && cameraPos.x <= xMax 
                     && yMin <= cameraPos.y && cameraPos.y <= yMax
                     && zMin <= cameraPos.z && cameraPos.z <= zMax;
+
                 colliderCache.Add(myCollider, result);
+
                 return result;
             }
 
@@ -382,13 +385,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Camera mainCam = CameraCache.Main;
                 var cameraToPoint = point - mainCam.transform.position;
+
                 var pointCameraDist = Vector3.Dot(mainCam.transform.forward, cameraToPoint);
                 if (pointCameraDist < minDist || pointCameraDist > maxDist)
                 {
                     return false;
                 }
+
                 var verticalFOV = mainCam.fieldOfView + coneAngleBufferDegrees;
                 var degrees = Mathf.Acos(pointCameraDist / cameraToPoint.magnitude) * Mathf.Rad2Deg;
+
                 return degrees < verticalFOV * 0.5f;
             }
 


### PR DESCRIPTION
## Overview
Adds missing check to validate unity ui touchables are in valid layer mask

## Changes
- Fixes: #6967 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
