### PR TITLE
SpatialMeshObserver refactor

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
-using UnityEngine.EventSystems;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
 {
@@ -19,9 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         "ObjectMeshObserver/Profiles/DefaultObjectMeshObserverProfile.asset",
         "MixedRealityToolkit.Providers")]
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.html")]
-    public class SpatialObjectMeshObserver : 
-        BaseSpatialObserver, 
-        IMixedRealitySpatialAwarenessMeshObserver, 
+    public class SpatialObjectMeshObserver :
+        BaseSpatialMeshObserver,
         IMixedRealityCapabilityCheck
     {
         /// <summary>
@@ -59,35 +56,23 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
 
         private GameObject spatialMeshObject = null;
 
-        private MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> meshEventData = null;
+        #region BaseSpatialMeshObserver Implementation
 
         /// <summary>
         /// Reads the settings from the configuration profile.
         /// </summary>
-        private void ReadProfile()
+        protected override void ReadProfile()
         {
+            base.ReadProfile();
+
             SpatialObjectMeshObserverProfile profile = ConfigurationProfile as SpatialObjectMeshObserverProfile;
             if (profile == null) { return; }
 
             // SpatialObjectMeshObserver settings
             spatialMeshObject = profile.SpatialMeshObject;
-
-            // IMixedRealitySpatialAwarenessObserver settings
-            StartupBehavior = profile.StartupBehavior;
-            IsStationaryObserver = profile.IsStationaryObserver;
-            ObservationExtents = profile.ObservationExtents;
-            ObserverVolumeType = profile.ObserverVolumeType;
-            UpdateInterval = profile.UpdateInterval;
-
-            // IMixedRealitySpatialAwarenessMeshObserver settings
-            DisplayOption = profile.DisplayOption;
-            LevelOfDetail = profile.LevelOfDetail;
-            MeshPhysicsLayer = profile.MeshPhysicsLayer;
-            OcclusionMaterial = profile.OcclusionMaterial;
-            RecalculateNormals = profile.RecalculateNormals;
-            TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter;
-            VisibleMaterial = profile.VisibleMaterial;
         }
+
+        #endregion BaseSpatialMeshObserver Implementation
 
         #region IMixedRealityCapabilityCheck Implementation
 
@@ -102,16 +87,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         #region IMixedRealityDataProvider Implementation
 
         /// <inheritdoc />
-        public override void Initialize()
-        {
-            meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
-
-            ReadProfile();
-
-            base.Initialize();
-        }
-
-        /// <inheritdoc />
         public override void Update()
         {
             if (!IsRunning) 
@@ -123,13 +98,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         }
 
         #endregion IMixedRealityDataProvider Implementation
-
-        #region IMixedRealitySpatialAwarenessObserver Implementation
-
-        private GameObject observedObjectParent = null;
-
-        /// <inheritdoc />
-        protected virtual GameObject ObservedObjectParent => observedObjectParent != null ? observedObjectParent : (observedObjectParent = SpatialAwarenessSystem?.CreateSpatialAwarenessObservationParent(Name));
 
         #region BaseSpatialObserver Implementation
 
@@ -150,6 +118,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
                 Suspend();
             }
         }
+
+        #endregion BaseSpatialObserver Implementation
+
+        #region IMixedRealitySpatialAwarenessObserver Implementation
 
         /// <inheritdoc />
         public override void ClearObservations()
@@ -183,19 +155,11 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
             IsRunning = false;
         }
 
-        #endregion BaseSpatialObserver Implementation
+        #endregion IMixedRealitySpatialAwarenessObserver Implementation
+
+        #region Helpers
         
         private int currentMeshId = 0;
-
-        /// <summary>
-        /// Event sent whenever a mesh is added.
-        /// </summary>
-        private static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshAdded =
-            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
-            {
-                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
-                handler.OnObservationAdded(spatialEventData);
-            };
 
         /// <summary>
         /// Sends the observations using the mesh data contained within the configured 3D model.
@@ -238,9 +202,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         /// </summary>
         private void RemoveMeshObject(int meshId)
         {
-            SpatialAwarenessMeshObject meshObject = null;
-
-            if (meshes.TryGetValue(meshId, out meshObject))
+            if (meshes.TryGetValue(meshId, out SpatialAwarenessMeshObject meshObject))
             {
                 // Remove the mesh object from the collection.
                 meshes.Remove(meshId);
@@ -252,115 +214,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
                 // Send the mesh removed event
                 meshEventData.Initialize(this, meshId, null);
                 SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshRemoved);
-            }
-        }
-
-        /// <summary>
-        /// Event sent whenever a mesh is discarded.
-        /// </summary>
-        private static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshRemoved =
-            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
-            {
-                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
-                handler.OnObservationRemoved(spatialEventData);
-            };
-
-        #endregion IMixedRealitySpatialAwarenessObserver Implementation
-
-        #region IMixedRealitySpatialAwarenessMeshObserver Implementation
-
-        private SpatialAwarenessMeshDisplayOptions displayOption = SpatialAwarenessMeshDisplayOptions.Visible;
-        
-        /// <inheritdoc />
-        public SpatialAwarenessMeshDisplayOptions DisplayOption
-        {
-            get => displayOption;
-
-            set
-            {
-                displayOption = value;
-                ApplyUpdatedMeshDisplayOption(displayOption);
-            }
-        }
-
-        /// <inheritdoc />
-        public SpatialAwarenessMeshLevelOfDetail LevelOfDetail { get; set; } = SpatialAwarenessMeshLevelOfDetail.Coarse;
-
-        private Dictionary<int, SpatialAwarenessMeshObject> meshes = new Dictionary<int, SpatialAwarenessMeshObject>();
-
-        /// <inheritdoc />
-        public IReadOnlyDictionary<int, SpatialAwarenessMeshObject> Meshes => new Dictionary<int, SpatialAwarenessMeshObject>(meshes);
-
-        private int meshPhysicsLayer = 31;
-
-        /// <inheritdoc />
-        public int MeshPhysicsLayer
-        {
-            get => meshPhysicsLayer;
-
-            set
-            {
-                if ((value < 0) || (value > 31))
-                {
-                    Debug.LogError("Specified MeshPhysicsLayer is out of bounds. Please set a value between 0 and 31, inclusive.");
-                    return;
-                }
-                
-                meshPhysicsLayer = value;
-
-                ApplyUpdatedPhysicsLayer();
-            }
-        }
-
-        /// <inheritdoc />
-        public int MeshPhysicsLayerMask => (1 << MeshPhysicsLayer);
-
-        /// <inheritdoc />
-        public bool RecalculateNormals { get; set; } = true;
-
-        /// <inheritdoc />
-        public int TrianglesPerCubicMeter { get; set; } = 0;
-
-        private Material occlusionMaterial = null;
-
-        /// <inheritdoc />
-        public Material OcclusionMaterial
-        {
-            get => occlusionMaterial;
-
-            set
-            {
-                if (value != occlusionMaterial)
-                {
-                    occlusionMaterial = value;
-
-                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion)
-                    {
-                        ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Occlusion);
-                    }
-                }
-            }
-        }
-
-
-        private Material visibleMaterial = null;
-
-        /// <inheritdoc />
-        public Material VisibleMaterial
-        {
-            get => visibleMaterial;
-
-            set
-            {
-                if (value != visibleMaterial)
-                {
-                    visibleMaterial = value;
-
-                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible)
-                    {
-                        ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Visible);
-                    }
-                }
             }
         }
 
@@ -384,45 +237,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
             meshObject.Renderer.enabled = enable;
         }
 
-        /// <summary>
-        /// Updates the material for each observed mesh,.
-        /// </summary>
-        /// <param name="option">
-        /// The <see cref="SpatialAwarenessMeshDisplayOptions"/> value to be used to determine the appropriate material.
-        /// </param>
-        private void ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions option)
-        {
-            bool enable = (option != SpatialAwarenessMeshDisplayOptions.None);
-
-            foreach (SpatialAwarenessMeshObject meshObject in Meshes.Values)
-            {
-                if ((meshObject?.Renderer == null)) { continue; }
-
-                if (enable)
-                {
-                    meshObject.Renderer.sharedMaterial = (option == SpatialAwarenessMeshDisplayOptions.Visible) ?
-                        VisibleMaterial :
-                        OcclusionMaterial;
-                }
-
-                meshObject.Renderer.enabled = enable;
-            }
-        }
-
-        /// <summary>
-        /// Updates the mesh physics layer for current mesh observations.
-        /// </summary>
-        private void ApplyUpdatedPhysicsLayer()
-        {
-            foreach (SpatialAwarenessMeshObject meshObject in Meshes.Values)
-            {
-                if (meshObject?.GameObject == null) { continue; }
-
-                meshObject.GameObject.layer = MeshPhysicsLayer;
-
-            }
-        }
-
-        #endregion IMixedRealitySpatialAwarenessMeshObserver Implementation
+        #endregion Helpers
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -277,6 +277,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 outstandingMeshObject = null;
             }
 
+            // Cleanup the spare mesh object	
+            if (spareMeshObject != null)	
+            {	
+                // Destroy the game object, destroy the meshes.	
+                SpatialAwarenessMeshObject.Cleanup(spareMeshObject);	
+                spareMeshObject = null;	
+            }
+
             if (wasRunning)
             {
                 Resume();

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -6,7 +6,6 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.EventSystems;
 
 #if UNITY_WSA
 using UnityEngine.XR;
@@ -27,8 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         "MixedRealityToolkit.SDK")]
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.html")]
     public class WindowsMixedRealitySpatialMeshObserver :
-        BaseSpatialObserver,
-        IMixedRealitySpatialAwarenessMeshObserver,
+        BaseSpatialMeshObserver,
         IMixedRealityCapabilityCheck
     {
         /// <summary>
@@ -62,41 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
             string name = null,
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
-        {
-            ReadProfile();
-        }
-
-        private void ReadProfile()
-        {
-            if (ConfigurationProfile == null)
-            {
-                Debug.LogError("Windows Mixed Reality Spatial Mesh Observer requires a configuration profile to run properly.");
-                return;
-            }
-
-            MixedRealitySpatialAwarenessMeshObserverProfile profile = ConfigurationProfile as MixedRealitySpatialAwarenessMeshObserverProfile;
-            if (profile == null)
-            {
-                Debug.LogError("Windows Mixed Reality Spatial Mesh Observer's configuration profile must be a MixedRealitySpatialAwarenessMeshObserverProfile.");
-                return;
-            }
-
-            // IMixedRealitySpatialAwarenessObserver settings
-            StartupBehavior = profile.StartupBehavior;
-            IsStationaryObserver = profile.IsStationaryObserver;
-            ObservationExtents = profile.ObservationExtents;
-            ObserverVolumeType = profile.ObserverVolumeType;
-            UpdateInterval = profile.UpdateInterval;
-
-            // IMixedRealitySpatialAwarenessMeshObserver settings
-            DisplayOption = profile.DisplayOption;
-            LevelOfDetail = profile.LevelOfDetail;
-            MeshPhysicsLayer = profile.MeshPhysicsLayer;
-            OcclusionMaterial = profile.OcclusionMaterial;
-            RecalculateNormals = profile.RecalculateNormals;
-            TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter;
-            VisibleMaterial = profile.VisibleMaterial;
-        }
+        { }
 
         #region BaseSpatialObserver Implementation
 
@@ -142,6 +106,37 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
 
         #endregion BaseSpatialObserver Implementation
 
+        #region BaseSpatialMeshObserver Implementation
+
+        /// <inheritdoc />
+        protected override int LookupTriangleDensity(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        {
+            int triangleDensity;
+            switch (levelOfDetail)
+            {
+                case SpatialAwarenessMeshLevelOfDetail.Coarse:
+                    triangleDensity = 0;
+                    break;
+
+                case SpatialAwarenessMeshLevelOfDetail.Medium:
+                    triangleDensity = 400;
+                    break;
+
+                case SpatialAwarenessMeshLevelOfDetail.Fine:
+                    triangleDensity = 2000;
+                    break;
+
+                default:
+                    Debug.LogWarning($"There is no triangle density lookup for {levelOfDetail}, defaulting to Coarse");
+                    triangleDensity = 0;
+                    break;
+            }
+
+            return triangleDensity;
+        }
+
+        #endregion BaseSpatialMeshObserver Implementation
+
         #region IMixedRealityCapabilityCheck Implementation
 
         /// <inheritdoc />
@@ -168,8 +163,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// </summary>
         public override void Initialize()
         {
-            meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
-
             base.Initialize();
 
 #if UNITY_EDITOR && UNITY_WSA
@@ -189,13 +182,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         #endregion IMixedRealityDataProvider Implementation
 
         #region IMixedRealitySpatialAwarenessObserver Implementation
-
-        private GameObject observedObjectParent = null;
-
-        /// <summary>
-        /// The <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see> to which observed objects are parented.
-        /// </summary>
-        private GameObject ObservedObjectParent => observedObjectParent != null ? observedObjectParent : (observedObjectParent = SpatialAwarenessSystem?.CreateSpatialAwarenessObservationParent("WindowsMixedRealitySpatialMeshObserver"));
 
 #if UNITY_WSA
         /// <summary>
@@ -228,150 +214,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         private float lastUpdated = 0;
 #endif // UNITY_WSA
 
-        public SpatialAwarenessMeshDisplayOptions displayOption = SpatialAwarenessMeshDisplayOptions.Visible;
-        /// <inheritdoc />
-        public SpatialAwarenessMeshDisplayOptions DisplayOption
-        {
-            get
-            {
-                return displayOption;
-            }
-
-            set
-            {
-                displayOption = value;
-                ApplyUpdatedMeshDisplayOption(displayOption);
-            }
-        }
-
-        public SpatialAwarenessMeshLevelOfDetail levelOfDetail = SpatialAwarenessMeshLevelOfDetail.Coarse;
-
-        /// <inheritdoc />
-        public SpatialAwarenessMeshLevelOfDetail LevelOfDetail
-        {
-            get { return levelOfDetail; }
-
-            set
-            {
-                if (value != SpatialAwarenessMeshLevelOfDetail.Custom)
-                {
-                    TrianglesPerCubicMeter = LookupTriangleDensity(value);
-                }
-
-                levelOfDetail = value;
-            }
-        }
-
-        /// <summary>
-        /// Maps <see cref="SpatialAwarenessMeshLevelOfDetail"/> to <see cref="TrianglesPerCubicMeter"/>.
-        /// </summary>
-        /// <param name="levelOfDetail">The desired level of density for the spatial mesh.</param>
-        /// <returns>
-        /// The number of triangles per cubic meter that will result in the desired level of density.
-        /// </returns>
-        private int LookupTriangleDensity(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
-        {
-            int triangleDensity = 0;
-
-            switch (levelOfDetail)
-            {
-                case SpatialAwarenessMeshLevelOfDetail.Coarse:
-                    triangleDensity = 0;
-                    break;
-
-                case SpatialAwarenessMeshLevelOfDetail.Medium:
-                    triangleDensity = 400;
-                    break;
-
-                case SpatialAwarenessMeshLevelOfDetail.Fine:
-                    triangleDensity = 2000;
-                    break;
-
-                default:
-                    Debug.LogWarning($"There is no triangle density lookup for {levelOfDetail}, defaulting to Coarse");
-                    triangleDensity = 0;
-                    break;
-            }
-
-            return triangleDensity;
-        }
-
-        private Dictionary<int, SpatialAwarenessMeshObject> meshes = new Dictionary<int, SpatialAwarenessMeshObject>();
-
-        /// <inheritdoc />
-        public IReadOnlyDictionary<int, SpatialAwarenessMeshObject> Meshes => new Dictionary<int, SpatialAwarenessMeshObject>(meshes) as IReadOnlyDictionary<int, SpatialAwarenessMeshObject>;
-
-        private int meshPhysicsLayer = 31;
-
-        /// <inheritdoc />
-        public int MeshPhysicsLayer
-        {
-            get => meshPhysicsLayer;
-
-            set
-            {
-                if ((value < 0) || (value > 31))
-                {
-                    Debug.LogError("Specified MeshPhysicsLayer is out of bounds. Please set a value between 0 and 31, inclusive.");
-                    return;
-                }
-
-                meshPhysicsLayer = value;
-                ApplyUpdatedPhysicsLayer();
-            }
-        }
-
-        /// <inheritdoc />
-        public int MeshPhysicsLayerMask => (1 << MeshPhysicsLayer);
-
-        private Material occlusionMaterial = null;
-
-        /// <inheritdoc />
-        public Material OcclusionMaterial
-        {
-            get => occlusionMaterial;
-
-            set
-            {
-                if (value != occlusionMaterial)
-                {
-                    occlusionMaterial = value;
-
-                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion)
-                    {
-                        ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Occlusion);
-                    }
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        public bool RecalculateNormals { get; set; } = true;
-
-        /// <inheritdoc />
-        public int TrianglesPerCubicMeter { get; set; } = 0;
-
-        private Material visibleMaterial = null;
-
-        /// <inheritdoc />
-        public Material VisibleMaterial
-        {
-            get => visibleMaterial;
-
-            set
-            {
-                if (value != visibleMaterial)
-                {
-                    visibleMaterial = value;
-
-                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible)
-                    {
-                        ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Visible);
-                    }
-                }
-            }
-        }
-
         /// <inheritdoc/>
         public override void Resume()
         {
@@ -387,7 +229,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
 
             // UpdateObserver keys off of this value to start observing.
             IsRunning = true;
-
 #endif // UNITY_WSA
         }
 
@@ -410,8 +251,44 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         }
 
 #if UNITY_WSA
-        private MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> meshEventData = null;
+        /// <inheritdoc />
+        public override void ClearObservations()
+        {
+            bool wasRunning = false;
 
+            if (IsRunning)
+            {
+                wasRunning = true;
+                Debug.Log("Cannot clear observations while the observer is running. Suspending this observer.");
+                Suspend();
+            }
+
+            IReadOnlyList<int> observations = new List<int>(Meshes.Keys);
+            foreach (int meshId in observations)
+            {
+                RemoveMeshObject(meshId);
+            }
+
+            // Cleanup the outstanding mesh object.
+            if (outstandingMeshObject != null)
+            {
+                // Destroy the game object, destroy the meshes.
+                SpatialAwarenessMeshObject.Cleanup(outstandingMeshObject);
+                outstandingMeshObject = null;
+            }
+
+            if (wasRunning)
+            {
+                Resume();
+            }
+        }
+#endif // UNITY_WSA
+
+        #endregion IMixedRealitySpatialAwarenessObserver Implementation
+
+        #region Helpers
+
+#if UNITY_WSA
         /// <summary>
         /// Requests updates from the surface observer.
         /// </summary>
@@ -448,6 +325,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                     ConfigureObserverVolume();
 
                     observer.Update(SurfaceObserver_OnSurfaceChanged);
+
                     lastUpdated = Time.time;
                 }
             }
@@ -559,7 +437,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         protected void RemoveMeshObject(int id)
         {
             SpatialAwarenessMeshObject mesh;
-
             if (meshes.TryGetValue(id, out mesh))
             {
                 // Remove the mesh object from the collection.
@@ -573,16 +450,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshRemoved);
             }
         }
-
-        /// <summary>
-        /// Event sent whenever a mesh is discarded.
-        /// </summary>
-        private static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshRemoved =
-            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
-            {
-                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
-                handler.OnObservationRemoved(spatialEventData);
-            };
 
         /// <summary>
         /// Reclaims the <see cref="SpatialAwarenessMeshObject"/> to allow for later reuse.
@@ -745,96 +612,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshAdded);
             }
         }
-
-        /// <summary>
-        /// Event sent whenever a mesh is added.
-        /// </summary>
-        private static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshAdded =
-            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
-            {
-                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
-                handler.OnObservationAdded(spatialEventData);
-            };
-
-        /// <summary>
-        /// Event sent whenever a mesh is updated.
-        /// </summary>
-        private static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshUpdated =
-            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
-            {
-                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
-                handler.OnObservationUpdated(spatialEventData);
-            };
-
-        /// <inheritdoc />
-        public override void ClearObservations()
-        {
-            bool wasRunning = false;
-
-            if (IsRunning)
-            {
-                wasRunning = true;
-                Debug.Log("Cannot clear observations while the observer is running. Suspending this observer.");
-                Suspend();
-            }
-
-            IReadOnlyList<int> observations = new List<int>(Meshes.Keys);
-            foreach (int meshId in observations)
-            {
-                RemoveMeshObject(meshId);
-            }
-
-            // Cleanup the outstanding mesh object.
-            if (outstandingMeshObject != null)
-            {
-                // Destroy the game object, destroy the meshes.
-                SpatialAwarenessMeshObject.Cleanup(outstandingMeshObject);
-                outstandingMeshObject = null;
-            }
-
-            if (wasRunning)
-            {
-                Resume();
-            }
-        }
 #endif // UNITY_WSA
 
-        /// <summary>
-        /// Applies the mesh display option to existing meshes when modified at runtime.
-        /// </summary>
-        /// <param name="option">The <see cref="SpatialAwarenessMeshDisplayOptions"/> to apply to the meshes.</param>
-        private void ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions option)
-        {
-            bool enable = (option != SpatialAwarenessMeshDisplayOptions.None);
-
-            foreach (SpatialAwarenessMeshObject meshObject in Meshes.Values)
-            {
-                if ((meshObject == null) || (meshObject.Renderer == null)) { continue; }
-
-                if (enable)
-                {
-                    meshObject.Renderer.sharedMaterial = (option == SpatialAwarenessMeshDisplayOptions.Visible) ?
-                        VisibleMaterial :
-                        OcclusionMaterial;
-                }
-
-                meshObject.Renderer.enabled = enable;
-            }
-        }
-
-        /// <summary>
-        /// Updates the mesh physics layer for current mesh observations.
-        /// </summary>
-        private void ApplyUpdatedPhysicsLayer()
-        {
-            foreach (SpatialAwarenessMeshObject meshObject in Meshes.Values)
-            {
-                if (meshObject?.GameObject == null) { continue; }
-
-                meshObject.GameObject.layer = MeshPhysicsLayer;
-            }
-        }
-
-        #endregion IMixedRealitySpatialAwarenessObserver Implementation
+        #endregion Helpers
     }
 }

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/BaseSpatialAwarenessObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/BaseSpatialAwarenessObject.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 {
-
     public partial class BaseSpatialAwarenessObject : IMixedRealitySpatialAwarenessObject
     {
         /// <inheritdoc />
@@ -17,18 +16,19 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc />
         public MeshRenderer Renderer { get; set; }
 
+        /// <summary>
+        /// The MeshFilter associated with this spatial object's renderer.
+        /// </summary>
         public MeshFilter Filter { get; set; }
 
-        /// <summary>
-        /// 
-        /// </summary>
+        /// <inheritdoc />
         public virtual void CleanObject()
         {
             // todo: consider if this should be virtual, and what params it should contain
         }
 
         /// <summary>
-        /// constructor
+        /// Constructor.
         /// </summary>
         protected BaseSpatialAwarenessObject()
         {

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessMeshObject.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         public MeshCollider Collider { get; set; }
 
         /// <summary>
-        /// Constructor
+        /// Constructor.
         /// </summary>
         private SpatialAwarenessMeshObject() : base() { }
 

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessPlanarObject.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/SpatialAwarenessPlanarObject.cs
@@ -7,16 +7,15 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 {
     public partial class SpatialAwarenessPlanarObject : BaseSpatialAwarenessObject
     {
-        // todo
-        public BoxCollider Collider { get; set;  }
+        /// <summary>
+        /// The BoxCollider associated with this plane's GameObject.
+        /// </summary>
+        public BoxCollider Collider { get; set; }
 
         /// <summary>
-        /// constructor
+        /// Constructor.
         /// </summary>
-        public SpatialAwarenessPlanarObject()
-        {
-            //empty for now
-        }
+        public SpatialAwarenessPlanarObject() : base() { }
 
         /// <summary>
         /// Creates a <see cref="SpatialAwarenessPlanarObject"/>.

--- a/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessObject.cs
+++ b/Assets/MixedRealityToolkit/Interfaces/SpatialAwareness/IMixedRealitySpatialAwarenessObject.cs
@@ -7,27 +7,24 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
 {
     public interface IMixedRealitySpatialAwarenessObject
     {
-        //todo
         /// <summary>
-        /// 
+        /// A unique ID identifying this spatial object.
         /// </summary>
         int Id { get; set; }
 
         /// <summary>
-        /// 
+        /// The GameObject representing this spatial object in the scene.
         /// </summary>
         GameObject GameObject { get; set; }
 
         /// <summary>
-        /// 
+        /// The MeshRenderer of this spatial object.
         /// </summary>
         MeshRenderer Renderer { get; set; }
 
         ///<summary>
-        ///
+        /// Cleans up this spatial object.
         /// </summary>
         void CleanObject();
-
-
     }
 }

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
+{
+    /// <summary>
+    /// Class providing a base implementation of the <see cref="IMixedRealitySpatialAwarenessMeshObserver"/> interface.
+    /// </summary>
+    public abstract class BaseSpatialMeshObserver : BaseSpatialObserver, IMixedRealitySpatialAwarenessMeshObserver
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="spatialAwarenessSystem">The <see cref="SpatialAwareness.IMixedRealitySpatialAwarenessSystem"/> to which the observer is providing data.</param>
+        /// <param name="name">The friendly name of the data provider.</param>
+        /// <param name="priority">The registration priority of the data provider.</param>
+        /// <param name="profile">The configuration profile for the data provider.</param>
+        protected BaseSpatialMeshObserver(
+            IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
+        {
+            ReadProfile();
+        }
+
+        #region BaseSpatialMeshObserver Implementation
+
+        protected MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> meshEventData = null;
+
+        private GameObject observedObjectParent = null;
+
+        /// <summary>
+        /// The parent GameObject for all observed meshes to be placed under.
+        /// </summary>
+        protected virtual GameObject ObservedObjectParent => observedObjectParent != null ? observedObjectParent : (observedObjectParent = SpatialAwarenessSystem?.CreateSpatialAwarenessObservationParent(Name));
+
+        protected virtual void ReadProfile()
+        {
+            if (ConfigurationProfile == null)
+            {
+                Debug.LogError($"{Name} requires a configuration profile to run properly.");
+                return;
+            }
+
+            MixedRealitySpatialAwarenessMeshObserverProfile profile = ConfigurationProfile as MixedRealitySpatialAwarenessMeshObserverProfile;
+            if (profile == null)
+            {
+                Debug.LogError($"{Name}'s configuration profile must be a MixedRealitySpatialAwarenessMeshObserverProfile.");
+                return;
+            }
+
+            // IMixedRealitySpatialAwarenessObserver settings
+            StartupBehavior = profile.StartupBehavior;
+            IsStationaryObserver = profile.IsStationaryObserver;
+            ObservationExtents = profile.ObservationExtents;
+            ObserverVolumeType = profile.ObserverVolumeType;
+            UpdateInterval = profile.UpdateInterval;
+
+            // IMixedRealitySpatialAwarenessMeshObserver settings
+            DisplayOption = profile.DisplayOption;
+            LevelOfDetail = profile.LevelOfDetail;
+            MeshPhysicsLayer = profile.MeshPhysicsLayer;
+            OcclusionMaterial = profile.OcclusionMaterial;
+            RecalculateNormals = profile.RecalculateNormals;
+            TrianglesPerCubicMeter = profile.TrianglesPerCubicMeter;
+            VisibleMaterial = profile.VisibleMaterial;
+        }
+
+        /// <summary>
+        /// Applies the mesh display option to existing meshes when modified at runtime.
+        /// </summary>
+        /// <param name="option">The <see cref="SpatialAwarenessMeshDisplayOptions"/> value to be used to determine the appropriate material.</param>
+        protected virtual void ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions option)
+        {
+            bool enable = (option != SpatialAwarenessMeshDisplayOptions.None);
+
+            foreach (SpatialAwarenessMeshObject meshObject in Meshes.Values)
+            {
+                if (meshObject?.Renderer == null) { continue; }
+
+                if (enable)
+                {
+                    meshObject.Renderer.sharedMaterial = (option == SpatialAwarenessMeshDisplayOptions.Visible) ?
+                        VisibleMaterial :
+                        OcclusionMaterial;
+                }
+
+                meshObject.Renderer.enabled = enable;
+            }
+        }
+
+        /// <summary>
+        /// Maps <see cref="SpatialAwarenessMeshLevelOfDetail"/> to <see cref="TrianglesPerCubicMeter"/>.
+        /// </summary>
+        /// <param name="levelOfDetail">The desired level of density for the spatial mesh.</param>
+        /// <returns>
+        /// The number of triangles per cubic meter that will result in the desired level of density.
+        /// </returns>
+        protected virtual int LookupTriangleDensity(SpatialAwarenessMeshLevelOfDetail levelOfDetail)
+        {
+            // By default, returns the existing value. This will be custom defined for each platform, if necessary.
+            return TrianglesPerCubicMeter;
+        }
+
+        /// <summary>
+        /// Updates the mesh physics layer for current mesh observations.
+        /// </summary>
+        protected virtual void ApplyUpdatedPhysicsLayer()
+        {
+            foreach (SpatialAwarenessMeshObject meshObject in Meshes.Values)
+            {
+                if (meshObject?.GameObject == null) { continue; }
+
+                meshObject.GameObject.layer = MeshPhysicsLayer;
+            }
+        }
+
+        /// <summary>
+        /// Event sent whenever a mesh is added.
+        /// </summary>
+        protected static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshAdded =
+            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
+            {
+                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
+                handler.OnObservationAdded(spatialEventData);
+            };
+
+        /// <summary>
+        /// Event sent whenever a mesh is updated.
+        /// </summary>
+        protected static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshUpdated =
+            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
+            {
+                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
+                handler.OnObservationUpdated(spatialEventData);
+            };
+
+        /// <summary>
+        /// Event sent whenever a mesh is discarded.
+        /// </summary>
+        protected static readonly ExecuteEvents.EventFunction<IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>> OnMeshRemoved =
+            delegate (IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject> handler, BaseEventData eventData)
+            {
+                MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject> spatialEventData = ExecuteEvents.ValidateEventData<MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>>(eventData);
+                handler.OnObservationRemoved(spatialEventData);
+            };
+
+        #endregion BaseSpatialMeshObserver Implementation
+
+        #region IMixedRealityDataProvider Implementation
+
+        /// <summary>
+        /// Initializes event data and creates the observer.
+        /// </summary>
+        public override void Initialize()
+        {
+            meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
+            
+            base.Initialize();
+        }
+
+        #endregion IMixedRealityDataProvider Implementation
+
+        #region IMixedRealitySpatialMeshObserver Implementation
+
+        private SpatialAwarenessMeshDisplayOptions displayOption = SpatialAwarenessMeshDisplayOptions.Visible;
+
+        /// <inheritdoc />
+        public SpatialAwarenessMeshDisplayOptions DisplayOption
+        {
+            get { return displayOption; }
+            set
+            {
+                displayOption = value;
+                ApplyUpdatedMeshDisplayOption(displayOption);
+            }
+        }
+
+        private SpatialAwarenessMeshLevelOfDetail levelOfDetail = SpatialAwarenessMeshLevelOfDetail.Coarse;
+
+        /// <inheritdoc />
+        public SpatialAwarenessMeshLevelOfDetail LevelOfDetail
+        {
+            get { return levelOfDetail; }
+            set
+            {
+                if (value != SpatialAwarenessMeshLevelOfDetail.Custom)
+                {
+                    TrianglesPerCubicMeter = LookupTriangleDensity(value);
+                }
+
+                levelOfDetail = value;
+            }
+        }
+
+        /// <summary>
+        /// The backing field for Meshes, to allow the mesh observer implementation to track its meshes.
+        /// </summary>
+        protected readonly Dictionary<int, SpatialAwarenessMeshObject> meshes = new Dictionary<int, SpatialAwarenessMeshObject>();
+
+        /// <inheritdoc />
+        public IReadOnlyDictionary<int, SpatialAwarenessMeshObject> Meshes => new Dictionary<int, SpatialAwarenessMeshObject>(meshes);
+
+        private int meshPhysicsLayer = 31;
+
+        /// <inheritdoc />
+        public int MeshPhysicsLayer
+        {
+            get { return meshPhysicsLayer; }
+            set
+            {
+                if ((value < 0) || (value > 31))
+                {
+                    Debug.LogError("Specified MeshPhysicsLayer is out of bounds. Please set a value between 0 and 31, inclusive.");
+                    return;
+                }
+
+                meshPhysicsLayer = value;
+                ApplyUpdatedPhysicsLayer();
+            }
+        }
+
+        /// <inheritdoc />
+        public int MeshPhysicsLayerMask => (1 << MeshPhysicsLayer);
+
+        /// <inheritdoc />
+        public bool RecalculateNormals { get; set; } = true;
+
+        /// <inheritdoc />
+        public int TrianglesPerCubicMeter { get; set; } = 0;
+
+        private Material occlusionMaterial = null;
+
+        /// <inheritdoc />
+        public Material OcclusionMaterial
+        {
+            get { return occlusionMaterial; }
+            set
+            {
+                if (value != occlusionMaterial)
+                {
+                    occlusionMaterial = value;
+
+                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Occlusion)
+                    {
+                        ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Occlusion);
+                    }
+                }
+            }
+        }
+
+        private Material visibleMaterial = null;
+
+        /// <inheritdoc />
+        public Material VisibleMaterial
+        {
+            get { return visibleMaterial; }
+            set
+            {
+                if (value != visibleMaterial)
+                {
+                    visibleMaterial = value;
+
+                    if (DisplayOption == SpatialAwarenessMeshDisplayOptions.Visible)
+                    {
+                        ApplyUpdatedMeshDisplayOption(SpatialAwarenessMeshDisplayOptions.Visible);
+                    }
+                }
+            }
+        }
+
+        #endregion IMixedRealitySpatialMeshObserver Implementation
+    }
+}

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs.meta
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb283f9fcabe1ff46a767f251c93f24d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
@@ -70,7 +70,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
-            if (disposed) { return; }
+            if (disposed)
+            {
+                return;
+            }
 
             base.Dispose(disposing);
 

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
@@ -55,6 +55,54 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </summary>
         protected IMixedRealitySpatialAwarenessSystem SpatialAwarenessSystem { get; private set; }
 
+        /// <summary>
+        /// Creates the spatial observer and handles the desired startup behavior.
+        /// </summary>
+        protected virtual void CreateObserver() { }
+
+        /// <summary>
+        /// Ensures that the spatial observer has been stopped and destroyed.
+        /// </summary>
+        protected virtual void CleanupObserver() { }
+
+        #region BaseService Implementation
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed) { return; }
+
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                CleanupObservationsAndObserver();
+            }
+
+            disposed = true;
+        }
+
+        #endregion BaseService Implementation
+
+        #region IMixedRealityDataProvider Implementation
+
+        /// <summary>
+        /// Creates the observer.
+        /// </summary>
+        public override void Initialize()
+        {
+            CreateObserver();
+        }
+
+        /// <summary>
+        /// Suspends the observer, clears observations, cleans up the observer, then re-initializes.
+        /// </summary>
+        public override void Reset()
+        {
+            Destroy();
+            Initialize();
+        }
+
         /// <inheritdoc />
         public override void Enable()
         {
@@ -67,12 +115,21 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc />
         public override void Disable()
         {
+            // If we are disabled while running...
             if (IsRunning)
             {
+                // Suspend the observer
                 Suspend();
             }
         }
 
+        /// <inheritdoc />
+        public override void Destroy()
+        {
+            CleanupObservationsAndObserver();
+        }
+
+        #endregion IMixedRealityDataProvider Implementation
 
         #region IMixedRealityEventSource Implementation
 
@@ -157,5 +214,21 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         public virtual void ClearObservations() { }
 
         #endregion IMixedRealitySpatialAwarenessObserver Implementation
+
+        #region Helpers
+
+        /// <summary>
+        /// Destroys all observed objects and the observer.
+        /// </summary>
+        private void CleanupObservationsAndObserver()
+        {
+            Disable();
+
+            // Destroys all observed objects and the observer.
+            ClearObservations();
+            CleanupObserver();
+        }
+
+        #endregion Helpers
     }
 }


### PR DESCRIPTION
## Overview

Part of XR SDK implementation, to reduce duplicated code. Also a bit of an extension of #6919 

 Moves some duplicated code down into `BaseSpatialObserver`, and also creates a new `BaseSpatialMeshObserver` to contain some duplicated mesh observer code.

Observer lifecycle can now be automatically handled by overriding `BaseSpatialObserver`'s `CreateObserver` and `CleanupObserver` methods.

Filled in a few missing docs along the way as well.

In-app behavior should be unchanged, other than `SpatialObjectMeshObserver`, where `CleanupObserver` no longer calls `ClearObservations`, to match the WMR implementation and separate the two cleanup methods.

The one outstanding thing I'll need to better address for the XR SDK implementation is `TrianglesPerCubicMeter`. Our native WMR implementation uses this value, but XR SDK takes in a 0.0 to 1.0 value instead. That will come in a follow-up PR, possibly at the same time as the XR SDK implementation.