### PR TITLE
Reclaim outstandingMeshObject on suspend

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs
@@ -397,6 +397,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
             // UpdateObserver keys off of this value to stop observing.
             IsRunning = false;
 
+            // Halt any outstanding work.
+            if (outstandingMeshObject != null)
+            {
+                ReclaimMeshObject(outstandingMeshObject);
+                outstandingMeshObject = null;
+            }
+
             // Clear any pending work.
             meshWorkQueue.Clear();
 #endif // UNITY_WSA


### PR DESCRIPTION
## Overview
As was pointed out by @darax in #6809, the Windows Mixed Reality spatial observer was not properly handling cases where there was an outstandingMeshObject at the time Suspend is called.

This change reclaims and nulls the outstandingMeshObject in Suspend().

Tested on a HoloLens using the SpatialAwareness demo scene and was successfully able to resume from over 20 suspends.

## Changes
- Fixes: #6809, fixes #6425,
