### PR TITLE
MixedRealityStandard shader - Manage round corners independently

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -89,9 +89,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent fluentLightIntensity = new GUIContent("Light Intensity", "Intensity Scaler for All Hover and Proximity Lights");
             public static GUIContent roundCorners = new GUIContent("Round Corners", "(Assumes UVs Specify Borders of Surface, Works Best on Unity Cube, Quad, and Plane)");
             public static GUIContent roundCornerRadius = new GUIContent("Unit Radius", "Rounded Rectangle Corner Unit Sphere Radius");
+            public static GUIContent roundCornersRadius = new GUIContent("Corners Radius", "UpLeft-UpRight-BottomRight-BottomLeft");
             public static GUIContent roundCornerMargin = new GUIContent("Margin %", "Distance From Geometry Edge");
             public static GUIContent independentCorners = new GUIContent("Independent Corners", "Manage each corner separately");
-            public static GUIContent roundCornerFactors = new GUIContent("Corner Factors", "UpLeft-UpRight-BottomRight-BottomLeft");
             public static GUIContent borderLight = new GUIContent("Border Light", "Enable Border Lighting (Assumes UVs Specify Borders of Surface, Works Best on Unity Cube, Quad, and Plane)");
             public static GUIContent borderLightUsesHoverColor = new GUIContent("Use Hover Color", "Border Color Comes From Hover Light Color Override");
             public static GUIContent borderLightReplacesAlbedo = new GUIContent("Replace Albedo", "Border Light Replaces Albedo (Replacement Rather Than Additive)");
@@ -176,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         protected MaterialProperty roundCornerRadius;
         protected MaterialProperty roundCornerMargin;
         protected MaterialProperty independentCorners;
-        protected MaterialProperty roundCornerFactors;
+        protected MaterialProperty roundCornersRadius;
         protected MaterialProperty borderLight;
         protected MaterialProperty borderLightUsesHoverColor;
         protected MaterialProperty borderLightReplacesAlbedo;
@@ -262,9 +262,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             fluentLightIntensity = FindProperty("_FluentLightIntensity", props);
             roundCorners = FindProperty("_RoundCorners", props);
             roundCornerRadius = FindProperty("_RoundCornerRadius", props);
+            roundCornersRadius = FindProperty("_RoundCornersRadius", props);
             roundCornerMargin = FindProperty("_RoundCornerMargin", props);
             independentCorners = FindProperty("_IndependentCorners", props);
-            roundCornerFactors = FindProperty("_RoundCornerFactors", props);
             borderLight = FindProperty("_BorderLight", props);
             borderLightUsesHoverColor = FindProperty("_BorderLightUsesHoverColor", props);
             borderLightReplacesAlbedo = FindProperty("_BorderLightReplacesAlbedo", props);
@@ -621,15 +621,17 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (PropertyEnabled(roundCorners))
             {
-                materialEditor.ShaderProperty(roundCornerRadius, Styles.roundCornerRadius, 2);
-                materialEditor.ShaderProperty(roundCornerMargin, Styles.roundCornerMargin, 2);
-
                 materialEditor.ShaderProperty(independentCorners, Styles.independentCorners,2);
-
                 if (PropertyEnabled(independentCorners))
                 {
-                    materialEditor.ShaderProperty(roundCornerFactors, Styles.roundCornerFactors, 3);
+                    materialEditor.ShaderProperty(roundCornersRadius, Styles.roundCornersRadius, 3);
                 }
+                else
+                {
+                    materialEditor.ShaderProperty(roundCornerRadius, Styles.roundCornerRadius, 2);
+                }
+
+                materialEditor.ShaderProperty(roundCornerMargin, Styles.roundCornerMargin, 2);
             }
 
             if (PropertyEnabled(roundCorners) || PropertyEnabled(borderLight))

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -621,10 +621,10 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (PropertyEnabled(roundCorners))
             {
-                materialEditor.ShaderProperty(independentCorners, Styles.independentCorners,2);
+                materialEditor.ShaderProperty(independentCorners, Styles.independentCorners, 2);
                 if (PropertyEnabled(independentCorners))
                 {
-                    materialEditor.ShaderProperty(roundCornersRadius, Styles.roundCornersRadius, 3);
+                    materialEditor.ShaderProperty(roundCornersRadius, Styles.roundCornersRadius, 2);
                 }
                 else
                 {

--- a/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -90,6 +90,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public static GUIContent roundCorners = new GUIContent("Round Corners", "(Assumes UVs Specify Borders of Surface, Works Best on Unity Cube, Quad, and Plane)");
             public static GUIContent roundCornerRadius = new GUIContent("Unit Radius", "Rounded Rectangle Corner Unit Sphere Radius");
             public static GUIContent roundCornerMargin = new GUIContent("Margin %", "Distance From Geometry Edge");
+            public static GUIContent independentCorners = new GUIContent("Independent Corners", "Manage each corner separately");
+            public static GUIContent roundCornerFactors = new GUIContent("Corner Factors", "UpLeft-UpRight-BottomRight-BottomLeft");
             public static GUIContent borderLight = new GUIContent("Border Light", "Enable Border Lighting (Assumes UVs Specify Borders of Surface, Works Best on Unity Cube, Quad, and Plane)");
             public static GUIContent borderLightUsesHoverColor = new GUIContent("Use Hover Color", "Border Color Comes From Hover Light Color Override");
             public static GUIContent borderLightReplacesAlbedo = new GUIContent("Replace Albedo", "Border Light Replaces Albedo (Replacement Rather Than Additive)");
@@ -173,6 +175,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         protected MaterialProperty roundCorners;
         protected MaterialProperty roundCornerRadius;
         protected MaterialProperty roundCornerMargin;
+        protected MaterialProperty independentCorners;
+        protected MaterialProperty roundCornerFactors;
         protected MaterialProperty borderLight;
         protected MaterialProperty borderLightUsesHoverColor;
         protected MaterialProperty borderLightReplacesAlbedo;
@@ -259,6 +263,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             roundCorners = FindProperty("_RoundCorners", props);
             roundCornerRadius = FindProperty("_RoundCornerRadius", props);
             roundCornerMargin = FindProperty("_RoundCornerMargin", props);
+            independentCorners = FindProperty("_IndependentCorners", props);
+            roundCornerFactors = FindProperty("_RoundCornerFactors", props);
             borderLight = FindProperty("_BorderLight", props);
             borderLightUsesHoverColor = FindProperty("_BorderLightUsesHoverColor", props);
             borderLightReplacesAlbedo = FindProperty("_BorderLightReplacesAlbedo", props);
@@ -617,6 +623,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 materialEditor.ShaderProperty(roundCornerRadius, Styles.roundCornerRadius, 2);
                 materialEditor.ShaderProperty(roundCornerMargin, Styles.roundCornerMargin, 2);
+
+                materialEditor.ShaderProperty(independentCorners, Styles.independentCorners,2);
+
+                if (PropertyEnabled(independentCorners))
+                {
+                    materialEditor.ShaderProperty(roundCornerFactors, Styles.roundCornerFactors, 3);
+                }
             }
 
             if (PropertyEnabled(roundCorners) || PropertyEnabled(borderLight))

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -940,25 +940,25 @@ Shader "Mixed Reality Toolkit/Standard"
 				{
 					if (i.uv.y > 0.5)
 					{
-						roundCornerFactor *= _RoundCornerFactors.x;
+						roundCornerFactor *= saturate(_RoundCornerFactors.x);
 					}
 					else
 					{
-						roundCornerFactor *= _RoundCornerFactors.w;
+						roundCornerFactor *= saturate(_RoundCornerFactors.w);
 					}
 				}
 				else
 				{
 					if (i.uv.y > 0.5)
 					{
-						roundCornerFactor *= _RoundCornerFactors.y;
+						roundCornerFactor *= saturate(_RoundCornerFactors.y);
 					}
 					else
 					{
-						roundCornerFactor *= _RoundCornerFactors.z;
+						roundCornerFactor *= saturate(_RoundCornerFactors.z);
 					}
 				}
-				float cornerCircleRadius = min(saturate(max(roundCornerFactor * (_RoundCornerRadius - _RoundCornerMargin), 0.01)), halfPI - _RoundCornerMargin) * i.scale.z;
+				float cornerCircleRadius = min(max(roundCornerFactor * (_RoundCornerRadius - _RoundCornerMargin), 0.01), halfPI - _RoundCornerMargin) * i.scale.z;
 #else 
                 float cornerCircleRadius = saturate(max(_RoundCornerRadius - _RoundCornerMargin, 0.01)) * i.scale.z;
 #endif
@@ -1073,7 +1073,7 @@ Shader "Mixed Reality Toolkit/Standard"
 #if defined(_ROUND_CORNERS)
                 fixed borderMargin = _RoundCornerMargin  + _BorderWidth * 0.5;
 #if defined(_INDEPENDENT_CORNERS)
-                cornerCircleRadius = min(saturate(max(roundCornerFactor * (_RoundCornerRadius - borderMargin), 0.01)), halfPI - borderMargin) * i.scale.z;
+                cornerCircleRadius = min(max(roundCornerFactor * (_RoundCornerRadius - borderMargin), 0.01), halfPI - borderMargin) * i.scale.z;
 #else
                 cornerCircleRadius = saturate(max(_RoundCornerRadius - borderMargin, 0.01)) * i.scale.z;
 #endif

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -932,8 +932,9 @@ Shader "Mixed Reality Toolkit/Standard"
                 float2 halfScale = i.scale.xy * 0.5;
                 float2 roundCornerPosition = distanceToEdge * halfScale;
 				
-#if defined(_INDEPENDENT_CORNERS)
 				fixed currentCornerRadius;
+
+#if defined(_INDEPENDENT_CORNERS)
 				
                 _RoundCornersRadius = clamp(_RoundCornersRadius, 0, 0.5);
 
@@ -959,10 +960,11 @@ Shader "Mixed Reality Toolkit/Standard"
 						currentCornerRadius = _RoundCornersRadius.z;
 					}
 				}
-				float cornerCircleRadius = saturate(max(currentCornerRadius - _RoundCornerMargin, 0.01)) * i.scale.z;
 #else 
-                float cornerCircleRadius = saturate(max(_RoundCornerRadius - _RoundCornerMargin, 0.01)) * i.scale.z;
+                currentCornerRadius = _RoundCornerRadius;
 #endif
+
+                float cornerCircleRadius = saturate(max(currentCornerRadius - _RoundCornerMargin, 0.01)) * i.scale.z;
 
                 float2 cornerCircleDistance = halfScale - (_RoundCornerMargin * i.scale.z) - cornerCircleRadius;
 
@@ -1073,11 +1075,9 @@ Shader "Mixed Reality Toolkit/Standard"
                 fixed borderValue;
 #if defined(_ROUND_CORNERS)
                 fixed borderMargin = _RoundCornerMargin  + _BorderWidth * 0.5;
-#if defined(_INDEPENDENT_CORNERS)
+
                 cornerCircleRadius = saturate(max(currentCornerRadius - borderMargin, 0.01)) * i.scale.z;
-#else
-                cornerCircleRadius = saturate(max(_RoundCornerRadius - borderMargin, 0.01)) * i.scale.z;
-#endif
+
                 cornerCircleDistance = halfScale - (borderMargin * i.scale.z) - cornerCircleRadius;
 
                 borderValue =  1.0 - RoundCornersSmooth(roundCornerPosition, cornerCircleDistance, cornerCircleRadius);

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -63,8 +63,8 @@ Shader "Mixed Reality Toolkit/Standard"
         [Toggle(_ROUND_CORNERS)] _RoundCorners("Round Corners", Float) = 0.0
         _RoundCornerRadius("Round Corner Radius", Range(0.0, 0.5)) = 0.25
         _RoundCornerMargin("Round Corner Margin", Range(0.0, 0.5)) = 0.01
-		[Toggle(_INDEPENDENT_CORNERS)] _IndependentCorners("Independent Corners", Float) = 0.0
-		_RoundCornersRadius("Round Corners Radius", Vector) = (0.5,0.5,0.5,0.5)
+        [Toggle(_INDEPENDENT_CORNERS)] _IndependentCorners("Independent Corners", Float) = 0.0
+        _RoundCornersRadius("Round Corners Radius", Vector) = (0.5,0.5,0.5,0.5)
         [Toggle(_BORDER_LIGHT)] _BorderLight("Border Light", Float) = 0.0
         [Toggle(_BORDER_LIGHT_USES_HOVER_COLOR)] _BorderLightUsesHoverColor("Border Light Uses Hover Color", Float) = 0.0
         [Toggle(_BORDER_LIGHT_REPLACES_ALBEDO)] _BorderLightReplacesAlbedo("Border Light Replaces Albedo", Float) = 0.0
@@ -513,7 +513,7 @@ Shader "Mixed Reality Toolkit/Standard"
 
 #if defined(_ROUND_CORNERS)
 #if defined(_INDEPENDENT_CORNERS)
-			float4 _RoundCornersRadius; 
+            float4 _RoundCornersRadius; 
 #else
             fixed _RoundCornerRadius;
 #endif
@@ -931,35 +931,35 @@ Shader "Mixed Reality Toolkit/Standard"
 #if defined(_ROUND_CORNERS)
                 float2 halfScale = i.scale.xy * 0.5;
                 float2 roundCornerPosition = distanceToEdge * halfScale;
-				
-				fixed currentCornerRadius;
+
+                fixed currentCornerRadius;
 
 #if defined(_INDEPENDENT_CORNERS)
-				
+
                 _RoundCornersRadius = clamp(_RoundCornersRadius, 0, 0.5);
 
-				if (i.uv.x < 0.5)
-				{
-					if (i.uv.y > 0.5)
-					{
-						currentCornerRadius = _RoundCornersRadius.x;
-					}
-					else
-					{
-						currentCornerRadius = _RoundCornersRadius.w;
-					}
-				}
-				else
-				{
-					if (i.uv.y > 0.5)
-					{
-						currentCornerRadius = _RoundCornersRadius.y;
-					}
-					else
-					{
-						currentCornerRadius = _RoundCornersRadius.z;
-					}
-				}
+                if (i.uv.x < 0.5)
+                {
+                    if (i.uv.y > 0.5)
+                    {
+                        currentCornerRadius = _RoundCornersRadius.x;
+                    }
+                    else
+                    {
+                        currentCornerRadius = _RoundCornersRadius.w;
+                    }
+                }
+                else
+                {
+                    if (i.uv.y > 0.5)
+                    {
+                        currentCornerRadius = _RoundCornersRadius.y;
+                    }
+                    else
+                    {
+                        currentCornerRadius = _RoundCornersRadius.z;
+                    }
+                }
 #else 
                 currentCornerRadius = _RoundCornerRadius;
 #endif

--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -64,7 +64,7 @@ Shader "Mixed Reality Toolkit/Standard"
         _RoundCornerRadius("Round Corner Radius", Range(0.0, 0.5)) = 0.25
         _RoundCornerMargin("Round Corner Margin", Range(0.0, 0.5)) = 0.01
         [Toggle(_INDEPENDENT_CORNERS)] _IndependentCorners("Independent Corners", Float) = 0.0
-        _RoundCornersRadius("Round Corners Radius", Vector) = (0.5,0.5,0.5,0.5)
+        _RoundCornersRadius("Round Corners Radius", Vector) = (0.5 ,0.5, 0.5, 0.5)
         [Toggle(_BORDER_LIGHT)] _BorderLight("Border Light", Float) = 0.0
         [Toggle(_BORDER_LIGHT_USES_HOVER_COLOR)] _BorderLightUsesHoverColor("Border Light Uses Hover Color", Float) = 0.0
         [Toggle(_BORDER_LIGHT_REPLACES_ALBEDO)] _BorderLightReplacesAlbedo("Border Light Replaces Albedo", Float) = 0.0


### PR DESCRIPTION
## Overview
The code attached to this pull request enhance the MixedRealityStandard shader and its custom GUI. 
It is simply adding to the 'Round Corners' feature the ability to manage each corner separately.

![Annotation 2020-01-06 164845](https://user-images.githubusercontent.com/49749106/71836044-66312f00-30b3-11ea-9498-573c95a08d43.png)

![Annotation 2020-01-06 164846](https://user-images.githubusercontent.com/49749106/71836049-6a5d4c80-30b3-11ea-8838-61974e4ed1ad.png)

![Annotation 2020-01-06 164716](https://user-images.githubusercontent.com/49749106/71829306-9cb37d80-30a4-11ea-9b42-d4ae833b664c.png)

## Know issues:
-  The editor tooltip over Corners Radius is not showing
- I would rather constrain anyhow the user to use values between 0 and 0.5 directly in the editor (One slider by corner? Custom editor?) instead of clamping the vectors values within the shader code. 

## Verification

You can easily review the feature by tweaking the material values in the MaterialGallery scene.

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
