### PR TITLE
Update dependency graph

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/DependencyWindow/DependencyWindow.cs
@@ -411,7 +411,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static bool IsGuidValid(string guid)
         {
-            return !string.IsNullOrEmpty(guid) && guid != nullGuid;
+            return !string.IsNullOrEmpty(guid) && guid != nullGuid
             && !string.IsNullOrEmpty(Path.GetExtension(AssetDatabase.GUIDToAssetPath(guid)));
         }
 

--- a/Assets/MixedRealityToolkit.Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/DependencyWindow/DependencyWindow.cs
@@ -50,6 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             ".mat",
             ".anim",
             ".controller",
+            ".playable",
         };
 
         private readonly string[] assetsWithMetaDependencies =
@@ -332,7 +333,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 }
 
                 string guid = GetGuidFromMeta(metaFile);
-
                 if (!IsGuidValid(guid))
                 {
                     continue;
@@ -412,6 +412,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private static bool IsGuidValid(string guid)
         {
             return !string.IsNullOrEmpty(guid) && guid != nullGuid;
+            && !string.IsNullOrEmpty(Path.GetExtension(AssetDatabase.GUIDToAssetPath(guid)));
         }
 
         private static string GetGuidFromMeta(string file)


### PR DESCRIPTION
## Overview
Adds .playable extension to assets to consider also fixed issue where folder-like assets were retrieved as dependencies, resulting in "empty" results being showed (actual values were like Resources/unity_builtin) etc.

![EmptyDependencies](https://user-images.githubusercontent.com/25975362/71839575-57755880-3070-11ea-9502-93e6d771fb8a.PNG)

## Changes
- Fixes: #6980 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
