### PR TITLE
BaseSpatialMeshObserver and MixedRealityOptimizeUtils updates for XR SDK

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset
@@ -52,3 +52,4 @@ MonoBehaviour:
   registeredServiceProvidersProfile: {fileID: 11400000, guid: efbaf6ea540c69f4fb75415a5d145a53,
     type: 2}
   useServiceInspectors: 1
+  renderDepthBuffer: 0

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpatialObserverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpatialObserverTests.cs
@@ -25,8 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </summary>
     public class SpatialObserverTests
     {
-        private const string TestSpatialAwarenessSysteProfilePath = "Assets/MixedRealityToolkit.Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset";
-        private const string TestSpatialAwarenessSysteProfilePath_ManualStart = "Assets/MixedRealityToolkit.Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile_ManualStart.asset";
+        private const string TestSpatialAwarenessSystemProfilePath = "Assets/MixedRealityToolkit.Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset";
+        private const string TestSpatialAwarenessSystemProfilePath_ManualStart = "Assets/MixedRealityToolkit.Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile_ManualStart.asset";
 
         /// <summary>
         /// Test default case of Auto-Start SpatialObjectMeshObserver observer type and SpatialAwarenessSystem in editor
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestAutoStartObserver()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSysteProfilePath);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestManualStartObserver()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSysteProfilePath_ManualStart);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath_ManualStart);
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestDisableSpatialAwarenessSystem()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSysteProfilePath);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
 
             mrtkProfile.IsSpatialAwarenessSystemEnabled = false;
 

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                 if (!AudioSettings.GetSpatializerPluginName().Equals(MSFT_AudioSpatializerPlugin))
                 {
-                    // If using UWP, developers should use the Microsoft Audio Spatilizer plugin
+                    // If using UWP, developers should use the Microsoft Audio Spatializer plugin
                     Debug.LogWarning("<b>Audio Spatializer Plugin</b> not currently set to <i>" + MSFT_AudioSpatializerPlugin + "</i>. Switch to <i>" + MSFT_AudioSpatializerPlugin + "</i> under <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i>");
                 }
             }

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs
@@ -25,7 +25,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         {
-            ReadProfile();
         }
 
         #region BaseSpatialMeshObserver Implementation
@@ -162,6 +161,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
             
             base.Initialize();
+
+            ReadProfile();
         }
 
         #endregion IMixedRealityDataProvider Implementation

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialMeshObserver.cs
@@ -159,10 +159,10 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         public override void Initialize()
         {
             meshEventData = new MixedRealitySpatialAwarenessEventData<SpatialAwarenessMeshObject>(EventSystem.current);
-            
-            base.Initialize();
 
             ReadProfile();
+
+            base.Initialize();
         }
 
         #endregion IMixedRealityDataProvider Implementation

--- a/Assets/MixedRealityToolkit/Utilities/Editor/InputMappingAxisUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/InputMappingAxisUtility.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System.Collections.Generic;
 using UnityEditor;
@@ -40,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         /// <param name="axisMappings">Optional array of Axis Mappings, to configure your own custom set</param>
         public static void CheckUnityInputManagerMappings(InputManagerAxis[] axisMappings)
         {
-            AssureInputManagerReference();
+            EnsureInputManagerReference();
 
             if (axisMappings != null)
             {
@@ -65,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         /// <param name="axisMappings">Optional array of Axis Mappings, to configure your own custom set</param>
         public static void RemoveMappings(InputManagerAxis[] axisMappings)
         {
-            AssureInputManagerReference();
+            EnsureInputManagerReference();
 
             if (axisMappings != null)
             {
@@ -83,7 +84,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         private static void AddAxis(InputManagerAxis axis)
         {
-            AssureInputManagerReference();
+            EnsureInputManagerReference();
 
             SerializedProperty axesProperty = inputManagerAsset.FindProperty("m_Axes");
 
@@ -149,7 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         private static void RemoveAxis(string axis)
         {
-            AssureInputManagerReference();
+            EnsureInputManagerReference();
 
             SerializedProperty axesProperty = inputManagerAsset.FindProperty("m_Axes");
 
@@ -169,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         /// </summary>
         public static bool DoesAxisNameExist(string axisName)
         {
-            AssureInputManagerReference();
+            EnsureInputManagerReference();
 
             if (AxisNames.Count == 0 || inputManagerAsset.UpdateIfRequiredOrScript())
             {
@@ -184,7 +185,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         /// </summary>
         private static void RefreshLocalAxesList()
         {
-            AssureInputManagerReference();
+            EnsureInputManagerReference();
 
             AxisNames.Clear();
 
@@ -196,12 +197,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
             }
         }
 
-        private static void AssureInputManagerReference()
+        private static void EnsureInputManagerReference()
         {
             if (inputManagerAsset == null)
             {
                 // Grabs the actual asset file into a SerializedObject, so we can iterate through it and edit it.
-                inputManagerAsset = new SerializedObject(AssetDatabase.LoadAssetAtPath("ProjectSettings/InputManager.asset", typeof(UnityEngine.Object)));
+                inputManagerAsset = MixedRealityOptimizeUtils.GetSettingsObject("InputManager");
             }
         }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityOptimizeUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityOptimizeUtils.cs
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             PlayerSettings.VRDaydream.depthFormat = depthFormat;
 
             var playerSettings = GetSettingsObject("PlayerSettings");
-#if UNITY_2019
+#if UNITY_2019_1_OR_NEWER
             PlayerSettings.VRWindowsMixedReality.depthBufferFormat = set16BitDepthBuffer ?
                 PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat16Bit :
                 PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat24Bit;

--- a/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityOptimizeUtils.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/MixedRealityOptimizeUtils.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
             else if (IsBuildTargetUWP())
             {
-#if UNITY_2019
+#if UNITY_2019_1_OR_NEWER
                 PlayerSettings.VRWindowsMixedReality.depthBufferSharingEnabled = enableDepthBuffer;
 #else
                 var playerSettings = GetSettingsObject("PlayerSettings");
@@ -92,12 +92,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             var playerSettings = GetSettingsObject("PlayerSettings");
 #if UNITY_2019
-        PlayerSettings.VRWindowsMixedReality.depthBufferFormat = set16BitDepthBuffer ? 
-            PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat16Bit :
-            PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat24Bit;
+            PlayerSettings.VRWindowsMixedReality.depthBufferFormat = set16BitDepthBuffer ?
+                PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat16Bit :
+                PlayerSettings.VRWindowsMixedReality.DepthBufferFormat.DepthBufferFormat24Bit;
 
-        ChangeProperty(playerSettings, 
-                "vrSettings.lumin.depthFormat", 
+            ChangeProperty(playerSettings,
+                "vrSettings.lumin.depthFormat",
                 property => property.intValue = depthFormat);
 #else
             ChangeProperty(playerSettings,
@@ -108,27 +108,27 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         public static bool IsRealtimeGlobalIlluminationEnabled()
         {
-            var lightmapSettings = GetLighmapSettings();
+            var lightmapSettings = GetLightmapSettings();
             var property = lightmapSettings?.FindProperty("m_GISettings.m_EnableRealtimeLightmaps");
             return property != null && property.boolValue;
         }
 
         public static void SetRealtimeGlobalIlluminationEnabled(bool enabled)
         {
-            var lightmapSettings = GetLighmapSettings();
+            var lightmapSettings = GetLightmapSettings();
             ChangeProperty(lightmapSettings, "m_GISettings.m_EnableRealtimeLightmaps", property => property.boolValue = enabled);
         }
 
         public static bool IsBakedGlobalIlluminationEnabled()
         {
-            var lightmapSettings = GetLighmapSettings();
+            var lightmapSettings = GetLightmapSettings();
             var property = lightmapSettings?.FindProperty("m_GISettings.m_EnableBakedLightmaps");
             return property != null && property.boolValue;
         }
 
         public static void SetBakedGlobalIlluminationEnabled(bool enabled)
         {
-            var lightmapSettings = GetLighmapSettings();
+            var lightmapSettings = GetLightmapSettings();
             ChangeProperty(lightmapSettings, "m_GISettings.m_EnableBakedLightmaps", property => property.boolValue = enabled);
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return new SerializedObject(settings);
         }
 
-        public static SerializedObject GetLighmapSettings()
+        public static SerializedObject GetLightmapSettings()
         {
             var getLightmapSettingsMethod = typeof(LightmapEditorSettings).GetMethod("GetLightmapSettings", BindingFlags.Static | BindingFlags.NonPublic);
             var lightmapSettings = getLightmapSettingsMethod.Invoke(null, null) as UnityEngine.Object;


### PR DESCRIPTION
## Overview

1. Moves `BaseSpatialMeshObserver`'s `ReadProfile()` from constructor to `Initialize` to better support profile resetting.
1. Update `MixedRealityOptimizeUtils` typo and `#ifdef` to support versions past 2019.
1. Update `InputMappingAxisUtility` to use a static method in `MixedRealityOptimizeUtils` for loading the input settings asset.