### PR TITLE
Added code to handle different mapping sizes

### DIFF
--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMapping.cs
@@ -140,43 +140,79 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         internal bool UpdateInteractionSettingsFromDefault()
         {
+            if (interactions == null || interactions.Length == 0) { return false; }
+
+            MixedRealityInteractionMapping[] newDefaultInteractions = GetDefaultInteractionMappings();
+
+            if (newDefaultInteractions == null)
+            {
+                return false;
+            }
+
+            if (interactions.Length != newDefaultInteractions.Length)
+            {
+                interactions = CreateNewMatchedMapping(interactions, newDefaultInteractions);
+                return true;
+            }
+
             bool updatedMappings = false;
 
-            if (interactions?.Length > 0)
+            for (int i = 0; i < newDefaultInteractions.Length; i++)
             {
-                MixedRealityInteractionMapping[] newDefaultInteractions = GetDefaultInteractionMappings();
+                MixedRealityInteractionMapping currentMapping = interactions[i];
+                MixedRealityInteractionMapping currentDefaultMapping = newDefaultInteractions[i];
 
-                if (newDefaultInteractions == null)
+                if (Equals(currentMapping, currentDefaultMapping))
                 {
-                    return updatedMappings;
-                }
-
-                for (int i = 0; i < newDefaultInteractions.Length; i++)
-                {
-                    MixedRealityInteractionMapping currentMapping = interactions[i];
-                    MixedRealityInteractionMapping currentDefaultMapping = newDefaultInteractions[i];
-
-                    if (currentMapping.Id != currentDefaultMapping.Id ||
-                        currentMapping.Description != currentDefaultMapping.Description ||
-                        currentMapping.AxisType != currentDefaultMapping.AxisType ||
-                        currentMapping.InputType != currentDefaultMapping.InputType ||
-                        currentMapping.KeyCode != currentDefaultMapping.KeyCode ||
-                        currentMapping.AxisCodeX != currentDefaultMapping.AxisCodeX ||
-                        currentMapping.AxisCodeY != currentDefaultMapping.AxisCodeY ||
-                        currentMapping.InvertXAxis != currentDefaultMapping.InvertXAxis ||
-                        currentMapping.InvertYAxis != currentDefaultMapping.InvertYAxis)
+                    interactions[i] = new MixedRealityInteractionMapping(currentDefaultMapping)
                     {
-                        interactions[i] = new MixedRealityInteractionMapping(currentDefaultMapping)
-                        {
-                            MixedRealityInputAction = currentMapping.MixedRealityInputAction
-                        };
+                        MixedRealityInputAction = currentMapping.MixedRealityInputAction
+                    };
 
-                        updatedMappings = true;
-                    }
+                    updatedMappings = true;
                 }
             }
 
             return updatedMappings;
+        }
+
+        private MixedRealityInteractionMapping[] CreateNewMatchedMapping(MixedRealityInteractionMapping[] interactions, MixedRealityInteractionMapping[] newDefaultInteractions)
+        {
+            MixedRealityInteractionMapping[] newDefaultMapping = new MixedRealityInteractionMapping[newDefaultInteractions.Length];
+
+            for (int i = 0; i < newDefaultInteractions.Length; i++)
+            {
+                for (int j = 0; j < interactions.Length; j++)
+                {
+                    if (Equals(interactions[j], newDefaultInteractions[i]))
+                    {
+                        newDefaultMapping[i] = new MixedRealityInteractionMapping(newDefaultInteractions[i])
+                        {
+                            MixedRealityInputAction = interactions[j].MixedRealityInputAction
+                        };
+                        break;
+                    }
+                }
+
+                if (newDefaultMapping[i] == null)
+                {
+                    newDefaultMapping[i] = new MixedRealityInteractionMapping(newDefaultInteractions[i]);
+                }
+            }
+
+            return newDefaultMapping;
+        }
+
+        private bool Equals(MixedRealityInteractionMapping a, MixedRealityInteractionMapping b)
+        {
+            return !(a.Description != b.Description ||
+                        a.AxisType != b.AxisType ||
+                        a.InputType != b.InputType ||
+                        a.KeyCode != b.KeyCode ||
+                        a.AxisCodeX != b.AxisCodeX ||
+                        a.AxisCodeY != b.AxisCodeY ||
+                        a.InvertXAxis != b.InvertXAxis ||
+                        a.InvertYAxis != b.InvertYAxis);
         }
 
         private MixedRealityInteractionMapping[] GetDefaultInteractionMappings()


### PR DESCRIPTION
## Overview
The current implementation for updating the controller mappings expects the currently active and newly aquired maps to be of the exact same size.
This PR handles size differences and tries to keep mapped actions active. Besides all the info a mapping can have, it ignores the ID because it's pretty much the index in the array, in order, which means inserting mappings breaks action transfer.

## Changes
- Fixes: #6991