### PR TITLE
added missing experimental entry for box display of bounds control

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
@@ -7,7 +7,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     /// Shareable configuration for the <see cref="BoxDisplay" /> of <see cref="BoundsControl"/>
     /// This class provides all data members needed to create a solid box display for bounds control
     /// </summary>
-    [CreateAssetMenu(fileName = "BoxDisplayConfiguration", menuName = "Mixed Reality Toolkit/Bounds Control/Box Display Configuration")]
+    [CreateAssetMenu(fileName = "BoxDisplayConfiguration", menuName = "Mixed Reality Toolkit/Experimental/Bounds Control/Box Display Configuration")]
     public class BoxDisplayConfiguration : ScriptableObject
     {
         [SerializeField]


### PR DESCRIPTION
## Overview
moved menu entry for box display of bounds control into experimental section - Must've forgotten to save that file when pushing my changes yesterday

