### PR TITLE
Fix UnityAR namespaces in Unity 2019.3

### DIFF
--- a/Assets/MixedRealityToolkit.Staging/UnityAR/UnityARCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/UnityARCameraSettings.cs
@@ -6,11 +6,11 @@ using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
-#if (UNITY_IOS || UNITY_ANDROID) && ARFOUNDATION_PRESENT
+#if ARFOUNDATION_PRESENT
 using UnityEngine.SpatialTracking;
 using UnityEngine.XR;
 using UnityEngine.XR.ARFoundation;
-#endif // (UNITY_IOS || UNITY_ANDROID) && ARFOUNDATION_PRESENT
+#endif // ARFOUNDATION_PRESENT
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 {
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         /// </summary>
         public UnityARCameraSettingsProfile SettingsProfile => ConfigurationProfile as UnityARCameraSettingsProfile;
 
-#if (UNITY_IOS || UNITY_ANDROID) && ARFOUNDATION_PRESENT
+#if ARFOUNDATION_PRESENT
         private bool isSupportedArConfiguration = true;
         private bool isInitialized = false;
 
@@ -214,6 +214,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 
             isInitialized = false;
         }
-#endif // (UNITY_IOS || UNITY_ANDROID) && ARFOUNDATION_PRESENT
+#endif // ARFOUNDATION_PRESENT
     }
 }

--- a/Assets/MixedRealityToolkit.Staging/UnityAR/UnityARCameraSettingsProfile.cs
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/UnityARCameraSettingsProfile.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using UnityEngine;
-using UnityEngine.SpatialTracking;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 {
@@ -14,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     [MixedRealityServiceProfile(typeof(UnityARCameraSettings))]
     public class UnityARCameraSettingsProfile : BaseCameraSettingsProfile
     {
-#region Tracked Pose Driver settings
+        #region Tracked Pose Driver settings
 
         [SerializeField]
         [Tooltip("The portion of the device (ex: color camera) from which to read the pose.")]
@@ -43,6 +42,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         /// </summary>
         public ArUpdateType UpdateType => updateType;
 
-#endregion Tracked Pose Driver settings
+        #endregion Tracked Pose Driver settings
     }
 }

--- a/Assets/MixedRealityToolkit.Staging/UnityAR/Utilities/ArEnumConversion.cs
+++ b/Assets/MixedRealityToolkit.Staging/UnityAR/Utilities/ArEnumConversion.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
+#if ARFOUNDATION_PRESENT
 using UnityEngine.SpatialTracking;
+#endif // ARFOUNDATION_PRESENT
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 {
@@ -11,8 +13,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
     /// </summary>
     public static class ArEnumConversion
     {
+#if ARFOUNDATION_PRESENT
         /// <summary>
-        /// Converts from a <see cref="ArTrackedPose"/> to a Unity tracked pose value.
+        /// Converts from an <see cref="ArTrackedPose"/> to a Unity tracked pose value.
         /// </summary>
         /// <param name="pose">Value to convert.</param>
         /// <returns>
@@ -43,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         }
 
         /// <summary>
-        /// Converts from a <see cref="ArTrackingType"/> to a Unity tracking type value.
+        /// Converts from an <see cref="ArTrackingType"/> to a Unity tracking type value.
         /// </summary>
         /// <param name="trackingType">Value to convert.</param>
         /// <returns>
@@ -66,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         }
 
         /// <summary>
-        /// Converts from a <see cref="ArUpdateType"/> to a Unity update type value.
+        /// Converts from an <see cref="ArUpdateType"/> to a Unity update type value.
         /// </summary>
         /// <param name="updateType">Value to convert.</param>
         /// <returns>
@@ -87,5 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
                     return (TrackedPoseDriver.UpdateType)((int)updateType);
             }
         }
+#endif // ARFOUNDATION_PRESENT
     }
 }


### PR DESCRIPTION
## Overview

In Unity 2019, some existing types no longer exist in-engine and are instead distributed via the package manager. The `UnityEngine.SpatialTracking` namespace is one of them.

Also, this simplifies `#if (UNITY_IOS || UNITY_ANDROID) && ARFOUNDATION_PRESENT` checks down to just `#if ARFOUNDATION_PRESENT`, since we only set that define for specific platforms to begin with.