### PR TITLE
fully apply extension service attribute to hand physics service

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsService.cs
@@ -11,7 +11,12 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     /// <summary>
     /// A simple service that creates KinematicRigidbodies on fingertips for physics interactions.
     /// </summary>
-    [MixedRealityExtensionService(SupportedPlatforms.WindowsUniversal)]
+    [MixedRealityExtensionService(
+        SupportedPlatforms.WindowsUniversal,
+        "Hand Physics Service",
+        "HandPhysicsService/Profiles/DefaultHandPhysicsServiceProfile.asset",
+        "MixedRealityToolkit.Extensions",
+        true)]
     public class HandPhysicsService : BaseExtensionService, IHandPhysicsService, IMixedRealityExtensionService
     {
         private HandPhysicsServiceProfile handPhysicsServiceProfile;

--- a/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs.meta
+++ b/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 4f9f54f9478441228dea18a2c828cfc6, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Fixes #6999

The hand physics extension service was not fully utilizing the extension service attribute. Notably, it was missing:
- Friendly name
- Default profile
- Profile folder root

Additionally, #6988 / #6133 introduced a new property to the attribute that informs the inspector as to whether or not the service requires a profile to properly function. This has been set to true for hand physics.

Verified:
- When selecting the service type, the profile and friendly name values are properly set
- When manually setting the profile to null, the appropriate warning message appears in the inspector