### PR TITLE
Fixed errors when highlighting constraints

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -157,8 +157,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
                     EditorGUILayout.LabelField(constraintName);
                     if (GUILayout.Button("Go to component"))
                     {
-                        Debug.Log($"Highlighting {ObjectNames.NicifyVariableName(constraintName)} (Script)");
                         Highlighter.Highlight("Inspector", $"{ObjectNames.NicifyVariableName(constraintName)} (Script)");
+                        EditorGUIUtility.ExitGUI();
                     }
                     EditorGUILayout.EndHorizontal();
                 }


### PR DESCRIPTION
Highlighting constraints in the ObjectManipulatorInspector was causing errors to be logged and the highlighter could end up highlighting random windows. I found this fix online.