### PR TITLE
Fix Line Renderer editor error

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/EllipseLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/EllipseLineDataProvider.cs
@@ -13,21 +13,29 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     public class EllipseLineDataProvider : BaseMixedRealityLineDataProvider
     {
         [SerializeField]
-        [Range(0, 2048)]
+        [Tooltip("Resolution is the number of points used to define positions for points on the line. Equivalent to PointCount. Clamped at 2048 max")]
+        [Range(0, MaxResolution)]
         private int resolution = 36;
 
+        /// <summary>
+        /// Resolution is the number of points used to define positions for points on the line. Equivalent to PointCount. Clamped at 2048 max
+        /// </summary>
         public int Resolution
         {
-            get { return resolution; }
-            set { resolution = Mathf.Clamp(value, 0, 2048); }
+            get => resolution;
+            set => resolution = Mathf.Clamp(value, 0, MaxResolution);
         }
 
+        [Tooltip("Radius of ellipsis defined by Vector2 where x is half-width and y is half-height")]
         [SerializeField]
         private Vector2 radius = Vector2.one;
 
+        /// <summary>
+        /// Radius of ellipsis defined by Vector2 where x is half-width and y is half-height
+        /// </summary>
         public Vector2 Radius
         {
-            get { return radius; }
+            get => radius;
             set
             {
                 if (value.x < 0)
@@ -44,22 +52,25 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
+        private const int MaxResolution = 2048;
+
+
         #region BaseMixedRealityLineDataProvider Implementation
 
         /// <inheritdoc />
-        public override int PointCount => resolution;
+        public override int PointCount => Resolution;
 
         /// <inheritdoc />
         protected override Vector3 GetPointInternal(float normalizedDistance)
         {
-            return LineUtility.GetEllipsePoint(radius, normalizedDistance * 2f * Mathf.PI);
+            return LineUtility.GetEllipsePoint(Radius, normalizedDistance * 2f * Mathf.PI);
         }
 
         /// <inheritdoc />
         protected override Vector3 GetPointInternal(int pointIndex)
         {
-            float angle = ((float)pointIndex / resolution) * 2f * Mathf.PI;
-            return LineUtility.GetEllipsePoint(radius, angle);
+            float angle = ((float)pointIndex / Resolution) * 2f * Mathf.PI;
+            return LineUtility.GetEllipsePoint(Radius, angle);
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SimpleLineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SimpleLineDataProvider.cs
@@ -11,11 +11,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [AddComponentMenu("Scripts/MRTK/Core/SimpleLineDataProvider")]
     public class SimpleLineDataProvider : BaseMixedRealityLineDataProvider
     {
+        [Tooltip("The starting point of this line.")]
         [SerializeField]
         private MixedRealityPose startPoint = MixedRealityPose.ZeroIdentity;
 
         /// <summary>
-        /// The Starting point of this line.
+        /// The starting point of this line which is always located at the GameObject's transform position
         /// </summary>
         /// <remarks>Always located at this <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>'s <see href="https://docs.unity3d.com/ScriptReference/Transform-position.html">Transform.position</see></remarks>
         public MixedRealityPose StartPoint => startPoint;
@@ -29,8 +30,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// </summary>
         public MixedRealityPose EndPoint
         {
-            get { return endPoint; }
-            set { endPoint = value; }
+            get => endPoint;
+            set => endPoint = value;
         }
 
         #region Line Data Provider Implementation
@@ -44,9 +45,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             switch (pointIndex)
             {
                 case 0:
-                    return startPoint.Position;
+                    return StartPoint.Position;
                 case 1:
-                    return endPoint.Position;
+                    return EndPoint.Position;
                 default:
                     Debug.LogError("Invalid point index");
                     return Vector3.zero;
@@ -73,13 +74,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <inheritdoc />
         protected override Vector3 GetPointInternal(float normalizedDistance)
         {
-            return Vector3.Lerp(startPoint.Position, endPoint.Position, normalizedDistance);
+            return Vector3.Lerp(StartPoint.Position, EndPoint.Position, normalizedDistance);
         }
 
         /// <inheritdoc />
         protected override float GetUnClampedWorldLengthInternal()
         {
-            return Vector3.Distance(startPoint.Position, endPoint.Position);
+            return Vector3.Distance(StartPoint.Position, EndPoint.Position);
         }
 
         /// <inheritdoc />

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SplineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SplineDataProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         };
 
         /// <summary>
-        /// List of positions and orientations that define control points to generate spline
+        /// List of positions and orientations that define control points to generate the spline
         /// </summary>
         public MixedRealityPose[] ControlPoints => controlPoints;
 

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SplineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SplineDataProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [AddComponentMenu("Scripts/MRTK/Core/SplineDataProvider")]
     public class SplineDataProvider : BaseMixedRealityLineDataProvider
     {
-        [Tooltip("List of positions and orientations that define control points to generate spline")]
+        [Tooltip("List of positions and orientations that define control points to generate the spline")]
         [SerializeField]
         private MixedRealityPose[] controlPoints =
         {

--- a/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SplineDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/DataProviders/SplineDataProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [AddComponentMenu("Scripts/MRTK/Core/SplineDataProvider")]
     public class SplineDataProvider : BaseMixedRealityLineDataProvider
     {
+        [Tooltip("List of positions and orientations that define control points to generate spline")]
         [SerializeField]
         private MixedRealityPose[] controlPoints =
         {
@@ -20,6 +21,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             new MixedRealityPose(Vector3.right, Quaternion.identity),
         };
 
+        /// <summary>
+        /// List of positions and orientations that define control points to generate spline
+        /// </summary>
         public MixedRealityPose[] ControlPoints => controlPoints;
 
         [SerializeField]
@@ -27,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         public bool AlignAllControlPoints
         {
-            get { return alignAllControlPoints; }
+            get => alignAllControlPoints;
             set
             {
                 if (alignAllControlPoints != value)
@@ -43,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// </summary>
         public void ForceUpdateAlignment()
         {
-            if (alignAllControlPoints)
+            if (AlignAllControlPoints)
             {
                 for (int i = 0; i < PointCount; i++)
                 {
@@ -54,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         private void UpdatePointAlignment(int pointIndex)
         {
-            if (alignAllControlPoints)
+            if (AlignAllControlPoints)
             {
                 int prevControlPoint;
                 int changedControlPoint;
@@ -187,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 pointIndex = 0;
             }
 
-            if (alignAllControlPoints)
+            if (AlignAllControlPoints)
             {
                 if (pointIndex % 3 == 0)
                 {

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/BaseMixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/BaseMixedRealityLineRenderer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         protected BaseMixedRealityLineDataProvider lineDataSource;
 
         /// <summary>
-        /// The line data this component will render
+        /// The data provider component that provides the positioning source information for the LineRenderer.
         /// </summary>
         public BaseMixedRealityLineDataProvider LineDataSource
         {
@@ -192,6 +192,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return LineWidth.Evaluate(Mathf.Repeat(normalizedLength + widthOffset, 1f)) * widthMultiplier;
         }
 
+        /// <summary>
+        /// Gets the normalized distance along the line path (range 0 to 1) going the given number of steps provided
+        /// </summary>
+        /// <param name="stepNum">Number of steps to take "walking" along the curve </param>
         protected virtual float GetNormalizedPointAlongLine(int stepNum)
         {
             float normalizedDistance = 0;
@@ -225,9 +229,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             UpdateLine();
         }
 
+        /// <summary>
+        /// Executes every Unity LateUpdate(). Any property updates or frame updates should occur here to update the line data source.
+        /// </summary>
         protected abstract void UpdateLine();
 
-#if UNITY_EDITOR
+        #region Gizmos
+
+        #if UNITY_EDITOR
+
         protected virtual void OnDrawGizmos()
         {
             if (UnityEditor.Selection.activeGameObject == gameObject || Application.isPlaying) { return; }
@@ -321,6 +331,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 Gizmos.DrawLine(lastPos, firstPos);
             }
         }
-#endif
+
+        #endif
+        #endregion
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Lines/Renderers/MixedRealityLineRenderer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 enabled = false;
             }
 
-            if (FadeLineBrightnessOnEnable)
+            if (FadeLineBrightnessOnEnable && Application.isPlaying)
             {
                 fadeLine = StartCoroutine(FadeLine(FadeLinePercentage, FadeLineAnimationTime));
             }


### PR DESCRIPTION
## Overview
The `MixedRealityLineRenderer` class executes always and thus in edit mode. The control has the capability to fade in the line via a coroutine executed in OnEnable. The problem is the control directly modifies the gradient value and executes in edit mode. So the fade overwrites any defaults or changing of the gradient in edit mode

Also some clean up on related classes with comments etc

## Changes
- Fixes: # .

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
