### PR TITLE
Updating the coding guidelines to recommend PoshStyle as the PowerShell coding guidelines

### DIFF
--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -561,9 +561,7 @@ Prefer using DateTime.UtcNow unless you actually need the localized times (a leg
 
 ## PowerShell coding conventions
 
-A subset of the MRTK codebase uses PowerShell for pipeline infrastructure and various scripts and utilities. New PowerShell code should follow the PoshCode style:
-
-https://poshcode.gitbooks.io/powershell-practice-and-style/
+A subset of the MRTK codebase uses PowerShell for pipeline infrastructure and various scripts and utilities. New PowerShell code should follow the PoshCode style.
 
 ## See also
 

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -44,7 +44,7 @@ MRTK is a community project, modified by a diverse range of contributors. These 
 
 When you fix a bug, write a test to ensure it does not regress in the future. If adding a feature, write tests that verify your feature works. This is required for all UX features except experimental features.
 
-## Coding conventions
+## C# Coding conventions
 
 ### Script license information headers
 
@@ -558,6 +558,12 @@ This chart can help you decide which `#if` to use, depending on your use cases a
 DateTime.UtcNow is faster than DateTime.Now. In previous performance investigations we've found that using DateTime.Now adds significant overhead especially when used in the Update() loop. [Others have hit the same issue](https://stackoverflow.com/questions/1561791/optimizing-alternatives-to-datetime-now).
 
 Prefer using DateTime.UtcNow unless you actually need the localized times (a legitimate reason may be you wanting to show the current time in the user's time zone). If you are dealing with relative times (i.e. the delta between some last update and now), it's best to use DateTime.UtcNow to avoid the overhead of doing timezone conversions.
+
+## PowerShell coding conventions
+
+A subset of the MRTK codebase uses PowerShell for pipeline infrastructure and various scripts and utilities. New PowerShell code should follow the PoshCode style:
+
+https://poshcode.gitbooks.io/powershell-practice-and-style/
 
 ## See also
 


### PR DESCRIPTION
Our PowerShell code is currently using some random style (which is somewhat consistent within the files themselves, but are not necessarily consistent across files). This change updates our coding guidelines to recommend/reference the PoshCode style.

I've looked at some other resources both internal to Microsoft and externally visible as well (i.e. https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines?view=powershell-6, and https://docs.microsoft.com/en-us/contribute/powershell/powershell-style-code) however none were as extensive as PoshCode.