### PR TITLE
Line pointer line fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -78,6 +78,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Debug.LogError($"No Mixed Reality Line Renderers found on {gameObject.name}. Did you forget to add a Mixed Reality Line Renderer?");
             }
+
+            for (int i = 0; i < lineRenderers.Length; i++)
+            {
+                lineRenderers[i].enabled = true;
+            }
         }
 
         #region MonoBehaviour Implementation


### PR DESCRIPTION
## Overview
#6863 and #6822 when merged together left an issue open with the managed MixedRealityLineRenderer component.

The pointer cache change made it such that pointers are re-used.
The line refactor change eliminated the redundant MRLineRenderer classes.

The LinePointer class had a bug in it whereby it disabled MRLineRenderers OnDisable() but did not re-enable on OnEnable(). Before these PRs, this was not evident to the user because there were redundant MRLineRenderers and not all were registered with the LinePointer class.

**Changes:**
This fix ensures correct lifecycle management by the LinePointer class

**BEFORE**
![linepointer-before](https://user-images.githubusercontent.com/25975362/72099278-2b0e4600-32d5-11ea-9d2b-8ba66d37d53f.gif)

**AFTER**
![linepointer-after](https://user-images.githubusercontent.com/25975362/72099288-2e093680-32d5-11ea-9ead-9fff9531aa10.gif)

## Changes
- Fixes: #7005 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
