### PR TITLE
Remove staging package from CI's packaging steps

### DIFF
--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -92,11 +92,6 @@ $packages = @{
     "Tools" = @(
         "Assets\MixedRealityToolkit.Tools"
     );
-    # NOTE: This is a temporary package to facilitate experimental Unity AR support while we
-    # invest in better packaging solution
-    "Providers.UnityAR" = @(
-        "Assets\MixedRealityToolkit.Staging"
-    );
 }
 
 function GetPackageVersion() {


### PR DESCRIPTION
#7017 moved the UnityAR provider into Providers and removed the staging folder. It neglected, however, to update the packaging portion of the CI pipeline.

This change addresses that issue.