### PR TITLE
Update pipelines to run Unity 2018.4 instead of Unity 2018.3

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorProjectUtilities.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </remarks>
         public static void CheckMinimumEditorVersion()
         {
-#if !UNITY_2018_3_OR_NEWER
+#if !UNITY_2018_4_OR_NEWER
             DisplayIncorrectEditorVersionDialog();
 #endif
         }

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -233,7 +233,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return false;
             }
 
-            // Load the manfiest file.
+            // Load the manifest file.
             string manifestFileContents = File.ReadAllText(manifestPath);
             if (string.IsNullOrWhiteSpace(manifestFileContents))
             {

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,0 +1,23 @@
+# Pipelines
+
+## Each file and their use
+
+### ci-daily
+
+This runs on externally-facing machines daily. It validates the repo on both Unity 2018 and Unity 2019.
+
+### ci-packaging-dontpublish
+
+This runs on externally-facing machines whenever a PR is merged.
+
+### ci-packaging-internal
+
+This runs on internally-facing machines whenever a PR is merged.
+
+### ci-release
+
+This runs on internally-facing machines manually. It packages and signs the packages for public release.
+
+### pr
+
+This runs on externally-facing machines as part of PR validation.

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -1,7 +1,7 @@
 # CI build for developer builds.
 
 variables:
-  Unity2018Version: Unity2018.3.7f1
+  Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.3.0
   packagingEnabled: false
@@ -25,7 +25,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.3.7f1
+    - Unity2018.4.6f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -1,7 +1,7 @@
 # CI build producing developer packages.
 
 variables:
-  Unity2018Version: Unity2018.3.7f1
+  Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.3.0
 
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.3.7f1
+    - Unity2018.4.6f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -1,7 +1,7 @@
 # CI build producing developer packages.
 
 variables:
-  Unity2018Version: Unity2018.3.7f1
+  Unity2018Version: Unity2018.4.12f1
   Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.3.0
 
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: Analog On-Prem
     demands:
-    - Unity2018.3.7f1
+    - Unity2018.4.12f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -4,7 +4,7 @@
 name: $(Date:yyyyMMdd)v$(Rev:r)
 
 variables:
-  Unity2018Version: Unity2018.3.7f1
+  Unity2018Version: Unity2018.4.12f1
   Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.3.0  # Major.Minor.Patch
   MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
@@ -15,7 +15,7 @@ jobs:
   pool:
     name: Analog On-Prem
     demands:
-    - Unity2018.3.7f1  # variable expansion not allowed here
+    - Unity2018.4.12f1  # variable expansion not allowed here
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,7 +1,7 @@
 # Build for PR validation.
 
 variables:
-  Unity2018Version: Unity2018.3.7f1
+  Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
   MRTKVersion: 2.3.0
 
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.3.7f1
+    - Unity2018.4.6f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:


### PR DESCRIPTION
## Overview

This updates our pipelines to run on the installed Unity 2018.4 versions instead of 2018.3.

Internal machines have Unity 2018.4.12 and external machines have Unity 2018.4.6.

I also added a README to remind myself which pipelines were used where.