### PR TITLE
Add XR SDK settings files to repo

### DIFF
--- a/Assets/XR.meta
+++ b/Assets/XR.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3693bcfb4bb68ab479a8ae5eaaf21108
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Loaders.meta
+++ b/Assets/XR/Loaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0b00eda9c6678184a8c936ba154aa317
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Loaders/Windows MR Loader.asset
+++ b/Assets/XR/Loaders/Windows MR Loader.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a140b66429c96344083035352cb7c898, type: 3}
+  m_Name: Windows MR Loader
+  m_EditorClassIdentifier: 

--- a/Assets/XR/Loaders/Windows MR Loader.asset.meta
+++ b/Assets/XR/Loaders/Windows MR Loader.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f71156c4b70809f4a8542fa1ca99fe9f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Settings.meta
+++ b/Assets/XR/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f38d079aa23947449bcdbb11e4d7a9b9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Settings/Windows MR Package Settings.asset
+++ b/Assets/XR/Settings/Windows MR Package Settings.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e679265d16d650945812b915bb9d5cc3, type: 3}
+  m_Name: Windows MR Package Settings
+  m_EditorClassIdentifier: 
+  Keys: 
+  Values: []
+  BuildValues: []

--- a/Assets/XR/Settings/Windows MR Package Settings.asset
+++ b/Assets/XR/Settings/Windows MR Package Settings.asset
@@ -1,5 +1,32 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8196618691911559044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed912223f7b3af74d8e196b2a4e662b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DepthBufferFormat: 0
+  UseSharedDepthBuffer: 0
+--- !u!114 &-7462731363317155659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6c5bd16b42a1542ad52d1d47746bdb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UsePrimaryWindowForDisplay: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12,6 +39,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e679265d16d650945812b915bb9d5cc3, type: 3}
   m_Name: Windows MR Package Settings
   m_EditorClassIdentifier: 
-  Keys: 
-  Values: []
-  BuildValues: []
+  Keys: 0e00000001000000
+  Values:
+  - {fileID: 3397675408405997788}
+  - {fileID: -8196618691911559044}
+  BuildValues:
+  - {fileID: -7462731363317155659}
+--- !u!114 &3397675408405997788
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed912223f7b3af74d8e196b2a4e662b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DepthBufferFormat: 1
+  UseSharedDepthBuffer: 1

--- a/Assets/XR/Settings/Windows MR Package Settings.asset.meta
+++ b/Assets/XR/Settings/Windows MR Package Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b473d8d1ff820a242915cc3633363b8d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/XRGeneralSettings.asset
+++ b/Assets/XR/XRGeneralSettings.asset
@@ -1,0 +1,111 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5609432006805224515
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Android Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: -974958139742406341}
+  m_InitManagerOnStart: 1
+--- !u!114 &-3979523859960156722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: Metro Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders:
+  - {fileID: 11400000, guid: f71156c4b70809f4a8542fa1ca99fe9f, type: 2}
+--- !u!114 &-974958139742406341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: Android Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
+  m_Name: XRGeneralSettings
+  m_EditorClassIdentifier: 
+  Keys: 0e0000000100000007000000
+  Values:
+  - {fileID: 4268085174510186550}
+  - {fileID: 5555502764924699438}
+  - {fileID: -5609432006805224515}
+--- !u!114 &789108825542787325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: Standalone Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 1
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders:
+  - {fileID: 11400000, guid: f71156c4b70809f4a8542fa1ca99fe9f, type: 2}
+--- !u!114 &4268085174510186550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Metro Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: -3979523859960156722}
+  m_InitManagerOnStart: 1
+--- !u!114 &5555502764924699438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Standalone Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 789108825542787325}
+  m_InitManagerOnStart: 1

--- a/Assets/XR/XRGeneralSettings.asset.meta
+++ b/Assets/XR/XRGeneralSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68d3f4682465e9244a94c51343bb7c4c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,4 +8,8 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
     guid: 3dd4a396b5225f8469b9a1eb608bfa57
-  m_configObjects: {}
+  m_configObjects:
+    Unity.XR.WindowsMR.Settings: {fileID: 11400000, guid: b473d8d1ff820a242915cc3633363b8d,
+      type: 2}
+    com.unity.xr.management.loader_settings: {fileID: 11400000, guid: 68d3f4682465e9244a94c51343bb7c4c,
+      type: 2}

--- a/ProjectSettings/XRPackageSettings.asset
+++ b/ProjectSettings/XRPackageSettings.asset
@@ -1,0 +1,5 @@
+{
+    "m_Settings": [
+        "Windows MR Package Initialization"
+    ]
+}

--- a/ProjectSettings/XRSettings.asset
+++ b/ProjectSettings/XRSettings.asset
@@ -6,7 +6,7 @@
     ],
     "m_SettingValues": [
         "True",
-        "False",
-        ",Standalone,Android"
+        "True",
+        "Standalone,Android"
     ]
 }

--- a/ProjectSettings/XRSettings.asset
+++ b/ProjectSettings/XRSettings.asset
@@ -1,0 +1,12 @@
+{
+    "m_SettingKeys": [
+        "VR Device Disabled",
+        "VR Device User Alert",
+        "VR Device Transitioned Groups"
+    ],
+    "m_SettingValues": [
+        "True",
+        "False",
+        ",Standalone,Android"
+    ]
+}


### PR DESCRIPTION
## Overview

Adds several new scriptable assets from Unity for XR SDK.
These files are settings files specific to our repo's project, and won't need to be distributed as part of our packages. I'm including them to help with testing and validating the project on XR SDK.

I've verified that these files don't prevent building or running on previous Unity versions, even when their scripts don't exist: 

![image](https://user-images.githubusercontent.com/3580640/72191723-ffb05780-33b7-11ea-850f-e88dc8c05cf5.png)

and there's nothing in the console. PR validation and CI can double check :)

## Changes
- Part of #7003 