### PR TITLE
Patch both the existing WMR DLL and the shared DLL when packaging NuGet

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -21,6 +21,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 {
     public static class WindowsMixedRealityUtilities
     {
+        /// <summary>
+        /// The provider that should be used for the corresponding utilities.
+        /// </summary>
+        /// <remarks>
+        /// This is intended to be used to support both XR SDK and Unity's legacy XR pipeline, which provide
+        /// different APIs to access these native objects.
+        /// </remarks>
+        public static IWindowsMixedRealityUtilitiesProvider UtilitiesProvider { get; set; } = null;
+
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 #if ENABLE_DOTNET
         [DllImport("DotNetNativeWorkaround.dll", EntryPoint = "MarshalIInspectable")]
@@ -50,8 +59,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
             }
         }
 #endif //ENABLE_DOTNET
-
-        public static IWindowsMixedRealityUtilitiesProvider UtilitiesProvider { get; set; } = null;
 
         /// <summary>
         /// Access the underlying native spatial coordinate system.

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -410,10 +410,13 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             // Update metas after copying in the special cased libraries
             UpdateMetaFiles(assemblyInformation);
+
+            PostProcessPatchDllConstraint("Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality");
+            PostProcessPatchDllConstraint("Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared");
         }
 
         /// <summary>
-        /// Patches the specified DLL to call into UWP APIs in the editor when set to the UNITY_WSA backend.
+        /// Patches the specified DLL to call into UWP APIs in the editor.
         /// </summary>
         /// <param name="dllName">The name, without file type, of the DLL to be patched.</param>
         private static void PostProcessPatchWsaDll(string dllName)
@@ -426,6 +429,16 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             string dllOutputPath = Path.Combine(editorOutputDirectory, $"{dllName}.dll");
             File.Copy(dllPath, dllOutputPath, true);
             File.Copy(pdbPath, Path.Combine(editorOutputDirectory, $"{dllName}.pdb"), true);
+        }
+
+        /// <summary>
+        /// Patches the specified DLL only run in the editor when set to the UNITY_WSA backend.
+        /// </summary>
+        /// <param name="dllName">The name, without file type, of the DLL to be patched.</param>
+        private static void PostProcessPatchDllConstraint(string dllName)
+        {
+            string editorOutputDirectory = Application.dataPath.Replace("Assets", "NuGet/Plugins/EditorPlayer");
+            string dllOutputPath = Path.Combine(editorOutputDirectory, $"{dllName}.dll");
 
             // Patch the special cased library to have a define_constraint:
             string dllMetaPath = $"{dllOutputPath}.meta";

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -405,17 +405,27 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             RecursiveFolderCleanup(outputDirectory);
             CopyPluginContents(Application.dataPath.Replace("Assets", "NuGet/Plugins"));
 
-            // Special case the Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll for UNITY_WSA Editor
-            string dllPath = Utilities.GetFullPathFromAssetsRelative($"Assets/../MSBuild/Publish/InEditor/WSA/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll");
+            PostProcessPatchWsaDll("Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality");
+            PostProcessPatchWsaDll("Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared");
+
+            // Update metas after copying in the special cased libraries
+            UpdateMetaFiles(assemblyInformation);
+        }
+
+        /// <summary>
+        /// Patches the specified DLL to call into UWP APIs in the editor when set to the UNITY_WSA backend.
+        /// </summary>
+        /// <param name="dllName">The name, without file type, of the DLL to be patched.</param>
+        private static void PostProcessPatchWsaDll(string dllName)
+        {
+            // Special case the DLL for UNITY_WSA Editor
+            string dllPath = Utilities.GetFullPathFromAssetsRelative($"Assets/../MSBuild/Publish/InEditor/WSA/{dllName}.dll");
             string pdbPath = Path.ChangeExtension(dllPath, ".pdb");
             string editorOutputDirectory = Application.dataPath.Replace("Assets", "NuGet/Plugins/EditorPlayer");
 
-            string dllOutputPath = Path.Combine(editorOutputDirectory, "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.dll");
+            string dllOutputPath = Path.Combine(editorOutputDirectory, $"{dllName}.dll");
             File.Copy(dllPath, dllOutputPath, true);
-            File.Copy(pdbPath, Path.Combine(editorOutputDirectory, "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.pdb"), true);
-
-            // Update metas after copying in the special cased library
-            UpdateMetaFiles(assemblyInformation);
+            File.Copy(pdbPath, Path.Combine(editorOutputDirectory, $"{dllName}.pdb"), true);
 
             // Patch the special cased library to have a define_constraint:
             string dllMetaPath = $"{dllOutputPath}.meta";
@@ -424,7 +434,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             string searchString = "defineConstraints: []";
             if (!contents.Contains(searchString))
             {
-                throw new InvalidOperationException("Failed to find the defineConstraints: [] when patching WSA dll.");
+                throw new InvalidOperationException("Failed to find the defineConstraints: [] when patching WSA DLL.");
             }
             File.WriteAllText(dllMetaPath, contents.Replace(searchString, "defineConstraints:\r\n  - UNITY_WSA"));
         }


### PR DESCRIPTION
## Overview

Fixes a MissingMethodException when running precompiled in the editor for WMR by patching in a correctly compiled WSA assembly instead of one compiled only for the editor.

```
MissingMethodException: Microsoft.MixedReality.Toolkit.WindowsMixedReality.IWindowsMixedRealityUtilitiesProvider Microsoft.MixedReality.Toolkit.WindowsMixedReality.WindowsMixedRealityUtilities.get_UtilitiesProvider()
Microsoft.MixedReality.Toolkit.BaseDataProviderAccessCoreSystem.Enable () (at <15332009bc6d452484cf8864bce900e4>:0)
Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem.Enable () (at <0a9cec65677742e088c48dc0b5b98b15>:0)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit+<>c.<EnableAllServices>b__62_0 (Microsoft.MixedReality.Toolkit.IMixedRealityService service) (at <15332009bc6d452484cf8864bce900e4>:0)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit.ExecuteOnAllServicesInOrder (System.Action`1[T] execute) (at <15332009bc6d452484cf8864bce900e4>:0)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit.EnableAllServices () (at <15332009bc6d452484cf8864bce900e4>:0)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit.OnEnable () (at <15332009bc6d452484cf8864bce900e4>:0)
```