### PR TITLE
Change version number from 2.4 to 2.3 - NuGet Test Utilities package

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scripts/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scripts/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scripts/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scripts/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Utilities/InspectorFields/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Examples/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Examples")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Examples/Version.txt
+++ b/Assets/MixedRealityToolkit.Examples/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Extensions")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Extensions")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Extensions")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Extensions/Version.txt
+++ b/Assets/MixedRealityToolkit.Extensions/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/UnityAR/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/UnityAR/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/UnityAR/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/UnityAR/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/Version.txt
+++ b/Assets/MixedRealityToolkit.Providers/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsVoiceInput/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Providers")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.SDK/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit SDK")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit SDK")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit SDK")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.SDK/Version.txt
+++ b/Assets/MixedRealityToolkit.SDK/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Services/BoundarySystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/BoundarySystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/CameraSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/CameraSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputAnimation/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputAnimation/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/InputSystem/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/SceneSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/SceneSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/SpatialAwarenessSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/TeleportSystem/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Services/TeleportSystem/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Services/Version.txt
+++ b/Assets/MixedRealityToolkit.Services/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Tests/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tests/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tests")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Build.Editor
                      xmlns:mobile='http://schemas.microsoft.com/appx/manifest/mobile/windows10'
                      IgnorableNamespaces='uap uap2 uap3 uap4 mp mobile iot'
                      xmlns='http://schemas.microsoft.com/appx/manifest/foundation/windows10'>
-              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.4.0.0' />
+              <Identity Name='Microsoft.MixedReality.Toolkit' Publisher='CN=Microsoft' Version='2.3.0.0' />
               <mp:PhoneIdentity PhoneProductId='85c8bcd4-fbac-44ed-adf6-bfc01242a27f' PhonePublisherId='00000000-0000-0000-0000-000000000000' />
               <Properties>
                 <DisplayName>MixedRealityToolkit</DisplayName>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Services")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tests/Version.txt
+++ b/Assets/MixedRealityToolkit.Tests/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit.Tools/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tools")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tools/MSBuild/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tools")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tools/RuntimeTools/Tools/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit.Tools/RuntimeTools/Tools/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit Tools")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit.Tools/Version.txt
+++ b/Assets/MixedRealityToolkit.Tools/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/Assets/MixedRealityToolkit/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Extensions/EditorClassExtensions/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Inspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Async/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Async/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Editor/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/AssemblyInfo.cs
@@ -4,8 +4,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyProduct("Microsoft® Mixed Reality Toolkit")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]

--- a/Assets/MixedRealityToolkit/Version.txt
+++ b/Assets/MixedRealityToolkit/Version.txt
@@ -1,1 +1,1 @@
-Microsoft Mixed Reality Toolkit 2.4.0
+Microsoft Mixed Reality Toolkit 2.3.0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -668,9 +668,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   scriptingDefineSymbols:
     1: 
-    4: ARFOUNDATION_PRESENT
-    7: ARFOUNDATION_PRESENT
-    14: DOTNETWINRT_PRESENT
+    14: 
   platformArchitecture:
     iOS: 1
   scriptingBackend:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.4.0
+  bundleVersion: 2.3.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -668,7 +668,9 @@ PlayerSettings:
   webGLThreadsSupport: 0
   scriptingDefineSymbols:
     1: 
-    14: 
+    4: ARFOUNDATION_PRESENT
+    7: ARFOUNDATION_PRESENT
+    14: DOTNETWINRT_PRESENT
   platformArchitecture:
     iOS: 1
   scriptingBackend:
@@ -687,7 +689,7 @@ PlayerSettings:
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: Microsoft.MixedReality.Toolkit
-  metroPackageVersion: 2.4.0.0
+  metroPackageVersion: 2.3.0.0
   metroCertificatePath: Assets/WSATestCertificate.pfx
   metroCertificatePassword: 
   metroCertificateSubject: Microsoft

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0
+  MRTKVersion: 2.3.0
   packagingEnabled: false
 
 jobs:

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0
+  MRTKVersion: 2.3.0
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.4.12f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0
+  MRTKVersion: 2.3.0
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.3.7f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0
+  MRTKVersion: 2.3.0
 
 jobs:
 - job: CIDeveloperValidation

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -6,7 +6,7 @@ name: $(Date:yyyyMMdd)v$(Rev:r)
 variables:
   Unity2018Version: Unity2018.4.12f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0  # Major.Minor.Patch
+  MRTKVersion: 2.3.0  # Major.Minor.Patch
   MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
 
 jobs:

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.3.7f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0
+  MRTKVersion: 2.3.0
   packagingEnabled: false
 
 jobs:

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -3,7 +3,7 @@
 variables:
   Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
-  MRTKVersion: 2.4.0
+  MRTKVersion: 2.3.0
 
 jobs:
 - job: PRValidation


### PR DESCRIPTION
## Overview
Changes version number from 2.4 to 2.3 for the NuGet Test Utilities PR: #7032 

## Changes
- Updates version number


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
