### PR TITLE
Use variable instead of explicit Unity version in pipelines

### DIFF
--- a/pipelines/templates/tasks/unitypackages.yml
+++ b/pipelines/templates/tasks/unitypackages.yml
@@ -9,7 +9,7 @@ steps:
     targetType: filePath
     filePath: ./scripts/packaging/unitypackage.ps1
     arguments: >
-      -UnityDirectory ${Env:Unity2018.3.7f1}
+      -UnityDirectory ${Env:$(Unity2018Version)}
       -OutputDirectory $(Build.ArtifactStagingDirectory)\build\unitypackages\output
       -RepoDirectory $(Get-Location)
       -LogDirectory $(Build.ArtifactStagingDirectory)\build\unitypackages\logs


### PR DESCRIPTION
## Overview

#7038 introduced an issue with the unitypackage phase of CI. The unitypackage step used an explicit Unity version, so this updates it to use the defined variable instead.

## Changes
- Fixes: https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=8445&view=logs&j=ae5f814d-d003-5afd-2125-fa0189ea8658&t=4f395fa6-3ac2-5732-7a27-84aace4a750b