### PR TITLE
Filter out the ProjectSettings .asset files, which don't have a meta file

### DIFF
--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -331,7 +331,8 @@ function CheckAsset {
             }
         }
 
-        if (CheckForMetaFile $FileName) {
+        # Filter out the ProjectSettings .asset files, which don't have a meta file and don't need one.
+        if ((-not $FileName.Contains("\ProjectSettings\")) -and (CheckForMetaFile $FileName)) {
             $containsIssue = $true
         }
 


### PR DESCRIPTION
## Overview

Removes a false positive when a ProjectSettings .asset file is updated. These files don't need meta files, so the meta file checker doesn't need to run.

## Fixes
https://dev.azure.com/aipmr/MixedRealityToolkit-Unity-CI/_build/results?buildId=8449&view=logs&j=c1841906-0df4-5516-e3c5-68840a78c082&t=b0b212c9-e072-56eb-4467-a1e6a0002cf3