### PR TITLE
Expose [SerializeField] private fields as properties

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -44,13 +44,146 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion
 
-        #region Public properties
+        #region Private Serialized Fields with Public Properties
+
+        [Header("Target Bounding Box")]
+        [SerializeField]
+        private BoundingBox boundingBox = null;
+
+        public BoundingBox TargetBoundingBox
+        {
+            get { return boundingBox; }
+            set { boundingBox = value; }
+        }
+
+        [SerializeField]
+        private GameObject baseRenderer = null;
+        public GameObject BaseRenderer
+        {
+            get => baseRenderer;
+            set => baseRenderer = value;
+        }
+
+        [SerializeField]
+        private Transform buttonParent = null;
+        public Transform ButtonParent
+        {
+            get => buttonParent;
+            set => buttonParent = value;
+        }
+
+        [SerializeField]
+        private GameObject backgroundBar = null;
+        public GameObject BackgroundBar
+        {
+            get => backgroundBar;
+            set => backgroundBar = value;
+        }
+        
+        [Header("States")]
+        [SerializeField]
+        private AppBarDisplayTypeEnum displayType = AppBarDisplayTypeEnum.Manipulation;
+        public AppBarDisplayTypeEnum DisplayType
+        {
+            get { return displayType; }
+            set { displayType = value; }
+        }
+
+        [SerializeField]
+        private AppBarStateEnum state = AppBarStateEnum.Default;
+        public AppBarStateEnum State
+        {
+            get { return state; }
+            set { state = value; }
+        }
+
+        [Header("Default Button Options")]
+        [SerializeField]
+        private bool useRemove = true;
+        public bool UseRemove
+        {
+            get { return useRemove; }
+            set { useRemove = value; }
+        }
+
+        [SerializeField]
+        private bool useAdjust = true;
+        public bool UseAdjust
+        {
+            get { return useAdjust; }
+            set { useAdjust = value; }
+        }
+
+        [SerializeField]
+        private bool useHide = true;
+        public bool UseHide
+        {
+            get { return useHide; }
+            set { useHide = value; }
+        }
+
+        [Header("Default Button Icons")]
+        [SerializeField]
+        private Texture adjustIcon = null;
+        public Texture AdjustIcon
+        {
+            get => adjustIcon;
+            set => adjustIcon = value;
+        }
+
+        [SerializeField]
+        private Texture doneIcon = null;
+        public Texture DoneIcon
+        {
+            get => doneIcon;
+            set => doneIcon = value;
+        }
+
+        [SerializeField]
+        private Texture hideIcon = null;
+        public Texture HideIcon
+        {
+            get => hideIcon;
+            set => hideIcon = value;
+        }
+
+        [SerializeField]
+        private Texture removeIcon = null;
+        public Texture RemoveIcon
+        {
+            get => removeIcon;
+            set => removeIcon = value;
+        }
+
+        [SerializeField]
+        private Texture showIcon = null;
+        public Texture ShowIcon
+        {
+            get => showIcon;
+            set => showIcon = value;
+        }
+
+        [Header("Scale & Position Options")]
+        /// <summary>
+        /// Uses an alternate follow style that works better for very oblong objects
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Uses an alternate follow style that works better for very oblong objects.")]
+        private bool useTightFollow = false;
+        public bool UseTightFollow
+        {
+            get { return useTightFollow; }
+            set { useTightFollow = value; }
+        }
 
         /// <summary>
         /// Where to display the app bar on the y axis
         /// This can be set to negative values
         /// to force the app bar to appear below the object
         /// </summary>
+        [SerializeField]
+        [Tooltip("Where to display the app bar on the y axis. This can be set to negative values to force the app bar to appear below the object.")]
+        private float hoverOffsetYScale = 0.25f;
         public float HoverOffsetYScale
         {
             get { return hoverOffsetYScale; }
@@ -60,119 +193,32 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Pushes the app bar away from the object
         /// </summary>
+        [SerializeField]
+        [Tooltip("Pushes the app bar away from the object.")]
+        private float hoverOffsetZ = 0f;
         public float HoverOffsetZ
         {
             get { return hoverOffsetZ; }
             set { hoverOffsetZ = value; }
         }
 
-        /// <summary>
-        /// Uses an alternate follow style that works better for very oblong objects
-        /// </summary>
-        public bool UseTightFollow
-        {
-            get { return useTightFollow; }
-            set { useTightFollow = value; }
-        }
-
-        public AppBarDisplayTypeEnum DisplayType
-        {
-            get { return displayType; }
-            set { displayType = value; }
-        }
-
-        public AppBarStateEnum State
-        {
-            get { return state; }
-            set { state = value; }
-        }
-
-        public bool UseRemove
-        {
-            get { return useRemove; }
-            set { useRemove = value; }
-        }
-
-        public bool UseAdjust
-        {
-            get { return useAdjust; }
-            set { useAdjust = value; }
-        }
-
-        public bool UseHide
-        {
-            get { return useHide; }
-            set { useHide = value; }
-        }
-
-        #endregion
-
-        #region Private Serialized Fields
-
-        [Header("Target Bounding Box")]
-        [SerializeField]
-        private BoundingBox boundingBox = null;
-
-        [SerializeField]
-        private GameObject baseRenderer = null;
-
-        [SerializeField]
-        private Transform buttonParent = null;
-
-        [SerializeField]
-        private GameObject backgroundBar = null;
-               
-        [Header("States")]
-        [SerializeField]
-        private AppBarDisplayTypeEnum displayType = AppBarDisplayTypeEnum.Manipulation;
-
-        [SerializeField]
-        private AppBarStateEnum state = AppBarStateEnum.Default;
-
-        [Header("Default Button Options")]
-        [SerializeField]
-        private bool useRemove = true;
-
-        [SerializeField]
-        private bool useAdjust = true;
-
-        [SerializeField]
-        private bool useHide = true;
-
-        [Header("Default Button Icons")]
-        [SerializeField]
-        private Texture adjustIcon = null;
-
-        [SerializeField]
-        private Texture doneIcon = null;
-
-        [SerializeField]
-        private Texture hideIcon = null;
-
-        [SerializeField]
-        private Texture removeIcon = null;
-
-        [SerializeField]
-        private Texture showIcon = null;
-
-        [Header("Scale & Position Options")]
-        [SerializeField]
-        [Tooltip("Uses an alternate follow style that works better for very oblong objects.")]
-        private bool useTightFollow = false;
-
-        [SerializeField]
-        [Tooltip("Where to display the app bar on the y axis. This can be set to negative values to force the app bar to appear below the object.")]
-        private float hoverOffsetYScale = 0.25f;
-
-        [SerializeField]
-        [Tooltip("Pushes the app bar away from the object.")]
-        private float hoverOffsetZ = 0f;
+        
 
         [SerializeField]
         private float buttonWidth = 0.032f;
-
+        public float ButtonWidth
+        {
+            get => buttonWidth;
+            set => buttonWidth = value;
+        }
+        
         [SerializeField]
         private float buttonDepth = 0.016f;
+        public float ButtonDepth
+        {
+            get => buttonDepth;
+            set => buttonDepth = value;
+        }
 
         #endregion
 
@@ -199,11 +245,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void Reset()
         {
-            state = AppBarStateEnum.Default;
+            State = AppBarStateEnum.Default;
             FollowBoundingBox(false);
             lastTimeTapped = Time.time + coolDownTime;
         }
-               
+
         public void OnButtonPressed(AppBarButton button)
         {
             if (Time.time < lastTimeTapped + coolDownTime)
@@ -218,19 +264,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     break;
 
                 case ButtonTypeEnum.Adjust:
-                    state = AppBarStateEnum.Manipulation;
+                    State = AppBarStateEnum.Manipulation;
                     break;
 
                 case ButtonTypeEnum.Hide:
-                    state = AppBarStateEnum.Hidden;
+                    State = AppBarStateEnum.Hidden;
                     break;
 
                 case ButtonTypeEnum.Show:
-                    state = AppBarStateEnum.Default;
+                    State = AppBarStateEnum.Default;
                     break;
 
                 case ButtonTypeEnum.Done:
-                    state = AppBarStateEnum.Default;
+                    State = AppBarStateEnum.Default;
                     break;
 
                 default:
@@ -241,8 +287,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         protected virtual void OnClickRemove()
         {
             // Set the app bar and bounding box to inactive
-            boundingBox.Target.SetActive(false);
-            boundingBox.gameObject.SetActive(false);
+            TargetBoundingBox.Target.SetActive(false);
+            TargetBoundingBox.gameObject.SetActive(false);
             gameObject.SetActive(false);
         }
 
@@ -250,12 +296,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             buttons.Clear();
 
-            foreach (Transform child in buttonParent)
+            foreach (Transform child in ButtonParent)
             {
                 AppBarButton appBarButton = child.GetComponent<AppBarButton>();
                 if (appBarButton == null)
                     throw new Exception("Found a transform without an AppBarButton component under buttonTransforms!");
-                
+
                 appBarButton.InitializeButtonContent(this);
                 // Set to invisible initially if not custom
                 switch (appBarButton.ButtonType)
@@ -309,8 +355,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             buttons.Sort(delegate (AppBarButton b1, AppBarButton b2) { return b2.DisplayOrder.CompareTo(b1.DisplayOrder); });
 
             // Use active button number to determine background size and offset
-            float backgroundBarSize = buttonWidth * activeButtonNum;
-            Vector3 positionOffset = Vector3.right * ((backgroundBarSize / 2) - (buttonWidth / 2));
+            float backgroundBarSize = ButtonWidth * activeButtonNum;
+            Vector3 positionOffset = Vector3.right * ((backgroundBarSize / 2) - (ButtonWidth / 2));
 
             // Go through them again, setting active as
             activeButtonNum = 0;
@@ -318,7 +364,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 // Set the sibling index and target position so the button will behave predictably when set visible
                 buttons[i].transform.SetSiblingIndex(i);
-                buttons[i].SetTargetPosition((Vector3.left * buttonWidth * activeButtonNum) + positionOffset);
+                buttons[i].SetTargetPosition((Vector3.left * ButtonWidth * activeButtonNum) + positionOffset);
 
                 if (!buttons[i].Visible)
                     continue;
@@ -327,22 +373,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             targetBarSize.x = backgroundBarSize;
-            backgroundBar.transform.localScale = Vector3.Lerp(backgroundBar.transform.localScale, targetBarSize, Time.deltaTime * backgroundBarMoveSpeed);
-            backgroundBar.transform.localPosition = Vector3.forward * buttonDepth / 2;
+            BackgroundBar.transform.localScale = Vector3.Lerp(BackgroundBar.transform.localScale, targetBarSize, Time.deltaTime * backgroundBarMoveSpeed);
+            BackgroundBar.transform.localPosition = Vector3.forward * ButtonDepth / 2;
         }
 
         private void UpdateBoundingBox()
         {
-            if (boundingBox == null || boundingBox.Target == null)
+            if (TargetBoundingBox == null || TargetBoundingBox.Target == null)
             {
-                if (displayType == AppBarDisplayTypeEnum.Manipulation)
+                if (DisplayType == AppBarDisplayTypeEnum.Manipulation)
                 {
                     // Hide our buttons
-                    baseRenderer.SetActive(false);
+                    BaseRenderer.SetActive(false);
                 }
                 else
                 {
-                    baseRenderer.SetActive(true);
+                    BaseRenderer.SetActive(true);
                 }
                 return;
             }
@@ -351,24 +397,24 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (!Application.isPlaying)
                 return;
 
-            if (boundingBox == null)
+            if (TargetBoundingBox == null)
                 return;
 
-            switch (state)
+            switch (State)
             {
                 case AppBarStateEnum.Manipulation:
-                    boundingBox.Active = true;
+                    TargetBoundingBox.Active = true;
                     break;
 
                 default:
-                    boundingBox.Active = false;
+                    TargetBoundingBox.Active = false;
                     break;
             }
         }
 
         private void FollowBoundingBox(bool smooth)
         {
-            if (boundingBox == null)
+            if (TargetBoundingBox == null)
                 return;
 
             //calculate best follow position for AppBar
@@ -376,7 +422,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             Vector3 headPosition = CameraCache.Main.transform.position;
             boundsPoints.Clear();
 
-            helper.UpdateNonAABoundingBoxCornerPositions(boundingBox, boundsPoints);
+            helper.UpdateNonAABoundingBoxCornerPositions(TargetBoundingBox, boundsPoints);
             int followingFaceIndex = helper.GetIndexOfForwardFace(headPosition);
             Vector3 faceNormal = helper.GetFaceNormal(followingFaceIndex);
 
@@ -387,7 +433,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             transform.position = smooth ? Vector3.Lerp(transform.position, finalPosition, Time.deltaTime * backgroundBarMoveSpeed) : finalPosition;
 
             // Rotate on the y axis
-            Vector3 direction = (boundingBox.TargetBounds.bounds.center - finalPosition).normalized;
+            Vector3 direction = (TargetBoundingBox.TargetBounds.bounds.center - finalPosition).normalized;
             if (direction != Vector3.zero)
             {
                 Vector3 eulerAngles = Quaternion.LookRotation(direction, Vector3.up).eulerAngles;
@@ -410,22 +456,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     break;
 
                 case ButtonTypeEnum.Remove:
-                    if (!useRemove)
+                    if (!UseRemove)
                         return false;
                     break;
 
                 case ButtonTypeEnum.Hide:
-                    if (!useHide)
+                    if (!UseHide)
                         return false;
                     break;
 
                 case ButtonTypeEnum.Adjust:
-                    if (!useAdjust)
+                    if (!UseAdjust)
                         return false;
                     break;
             }
 
-            switch (state)
+            switch (State)
             {
                 case AppBarStateEnum.Default:
                 default:
@@ -476,31 +522,31 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 case ButtonTypeEnum.Show:
                     buttonText = "Show";
-                    buttonIcon = showIcon;
+                    buttonIcon = ShowIcon;
                     displayOrder = 0;
                     break;
 
                 case ButtonTypeEnum.Hide:
                     buttonText = "Hide";
-                    buttonIcon = hideIcon;
+                    buttonIcon = HideIcon;
                     displayOrder = 1;
                     break;
 
                 case ButtonTypeEnum.Adjust:
                     buttonText = "Adjust";
-                    buttonIcon = adjustIcon;
+                    buttonIcon = AdjustIcon;
                     displayOrder = 2;
                     break;
 
                 case ButtonTypeEnum.Remove:
                     buttonText = "Remove";
-                    buttonIcon = removeIcon;
+                    buttonIcon = RemoveIcon;
                     displayOrder = 3;
                     break;
 
                 case ButtonTypeEnum.Done:
                     buttonText = "Done";
-                    buttonIcon = doneIcon;
+                    buttonIcon = DoneIcon;
                     displayOrder = 4;
                     break;
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -47,6 +47,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Private Serialized Fields with Public Properties
 
         [Header("Target Bounding Box")]
+        /// <summary>
+        /// The bounding box this AppBar will use for its placement and control for manipulation
+        /// </summary>
+        [Tooltip("The bounding box this AppBar will use for its placement and control for manipulation")]
         [SerializeField]
         private BoundingBox boundingBox = null;
 
@@ -56,6 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { boundingBox = value; }
         }
 
+        /// <summary>
+        /// The parent game object for the renderable objects in the AppBar
+        /// </summary>
+        [Tooltip("The parent game object for the renderable objects in the app bar")]
         [SerializeField]
         private GameObject baseRenderer = null;
         public GameObject BaseRenderer
@@ -64,6 +72,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => baseRenderer = value;
         }
 
+        /// <summary>
+        /// The parent transform for the button collection
+        /// </summary>
+        [Tooltip("The parent transform for the button collection")]
         [SerializeField]
         private Transform buttonParent = null;
         public Transform ButtonParent
@@ -72,6 +84,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => buttonParent = value;
         }
 
+        /// <summary>
+        /// The background gameobject, scales to fill area behind buttons
+        /// </summary>
+        [Tooltip("The background gameobject, scales to fill area behind buttons")]
         [SerializeField]
         private GameObject backgroundBar = null;
         public GameObject BackgroundBar
@@ -81,6 +97,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
         
         [Header("States")]
+        /// <summary>
+        /// The AppBar's display type, default is Manipulation
+        /// </summary>
+        [Tooltip("The AppBar's display type, default is Manipulation")]
         [SerializeField]
         private AppBarDisplayTypeEnum displayType = AppBarDisplayTypeEnum.Manipulation;
         public AppBarDisplayTypeEnum DisplayType
@@ -89,6 +109,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { displayType = value; }
         }
 
+        /// <summary>
+        /// The AppBar's current state
+        /// </summary>
+        [Tooltip("The AppBar's current state")]
         [SerializeField]
         private AppBarStateEnum state = AppBarStateEnum.Default;
         public AppBarStateEnum State
@@ -97,7 +121,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { state = value; }
         }
 
+
         [Header("Default Button Options")]
+        /// <summary>
+        /// Should the AppBar have a Remove button
+        /// </summary>
+        [Tooltip("Should the AppBar have a Remove button")]
         [SerializeField]
         private bool useRemove = true;
         public bool UseRemove
@@ -106,6 +135,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { useRemove = value; }
         }
 
+        /// <summary>
+        /// Should the AppBar have an Adjust button
+        /// </summary>
+        [Tooltip("Should the AppBar have an Adjust button")]
         [SerializeField]
         private bool useAdjust = true;
         public bool UseAdjust
@@ -114,6 +147,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { useAdjust = value; }
         }
 
+        /// <summary>
+        /// Should the AppBar have a Hide button
+        /// </summary>
+        [Tooltip("Should the AppBar have a Hide button")]
         [SerializeField]
         private bool useHide = true;
         public bool UseHide
@@ -123,6 +160,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [Header("Default Button Icons")]
+        /// <summary>
+        /// The Adjust button texture
+        /// </summary>
+        [Tooltip("The Adjust button texture")]
         [SerializeField]
         private Texture adjustIcon = null;
         public Texture AdjustIcon
@@ -131,6 +172,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => adjustIcon = value;
         }
 
+        /// <summary>
+        /// The Done button texture
+        /// </summary>
+        [Tooltip("The Done button texture")]
         [SerializeField]
         private Texture doneIcon = null;
         public Texture DoneIcon
@@ -139,6 +184,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => doneIcon = value;
         }
 
+        /// <summary>
+        /// The Hide button texture
+        /// </summary>
+        [Tooltip("The Hide button texture")]
         [SerializeField]
         private Texture hideIcon = null;
         public Texture HideIcon
@@ -147,6 +196,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => hideIcon = value;
         }
 
+        /// <summary>
+        /// The Remove button texture
+        /// </summary>
+        [Tooltip("The Remove button texture")]
         [SerializeField]
         private Texture removeIcon = null;
         public Texture RemoveIcon
@@ -155,6 +208,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set => removeIcon = value;
         }
 
+        /// <summary>
+        /// The Show button texture
+        /// </summary>
+        [Tooltip("The Show button texture")]
         [SerializeField]
         private Texture showIcon = null;
         public Texture ShowIcon
@@ -202,8 +259,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             set { hoverOffsetZ = value; }
         }
 
-        
 
+        /// <summary>
+        /// The button width for each button
+        /// </summary>
+        [Tooltip("The button width for each button")]
         [SerializeField]
         private float buttonWidth = 0.032f;
         public float ButtonWidth
@@ -211,7 +271,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get => buttonWidth;
             set => buttonWidth = value;
         }
-        
+
+        /// <summary>
+        /// The button depth for each button
+        /// </summary>
+        [Tooltip("The button depth for each button")]
         [SerializeField]
         private float buttonDepth = 0.016f;
         public float ButtonDepth


### PR DESCRIPTION
Expose `[SerializeField] private` fields as properties and update class to use property references instead of fields.

## Overview
This change allows for the runtime creation and modification of the AppBar script.