### PR TITLE
Added support for Unity UI when setting a gaze target in FocusProvider

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -559,22 +559,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // another raycast if it's not populated
             if (gazeHitResult == null)
             {
+                // get 3d hit
                 hitResult3d.Clear();
                 var raycastProvider = CoreServices.InputSystem.RaycastProvider;
                 LayerMask[] prioritizedLayerMasks = (gazeProviderPointingData.Pointer.PrioritizedLayerMasksOverride ?? FocusLayerMasks);
                 QueryScene(gazeProviderPointingData.Pointer, raycastProvider, prioritizedLayerMasks,
                     hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
-                //gazeHitResult = hitResult3d;
 
+                // get ui hit
                 hitResultUi.Clear();
                 RaycastGraphics(gazeProviderPointingData.Pointer, gazeProviderPointingData.GraphicEventData, prioritizedLayerMasks, hitResultUi);
 
+                // set gaze hit according to distance and priorization layer mask
                 gazeHitResult = GetPrioritizedHitResult(hitResult3d, hitResultUi, prioritizedLayerMasks);
-                TruncatePointerRayToHit(gazeProviderPointingData.Pointer, gazeHitResult);
             }
 
             CoreServices.InputSystem.GazeProvider.UpdateGazeInfoFromHit(gazeHitResult.raycastHit);
-            Debug.LogWarning((gazeHitResult.raycastHit.transform != null) ? gazeHitResult.raycastHit.transform.name : "nothing");
 
             // Zero out value after every use to ensure the hit result is updated every frame.
             gazeHitResult = null;

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -259,7 +259,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 raycastHit.normal = hitNormalOnObject;
                 raycastHit.distance = rayDistance;
                 raycastHit.transform = result.gameObject.transform;
-                raycastHit.raycastValid = false; //we can't populate all fields of MixedRealityRaycastHit in case of a GraphicsRaycast so we flag the hit data as invalid 
+                raycastHit.raycastValid = true;
 
                 graphicsRaycastResult = result;
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -259,7 +259,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 raycastHit.normal = hitNormalOnObject;
                 raycastHit.distance = rayDistance;
                 raycastHit.transform = result.gameObject.transform;
-                raycastHit.raycastValid = false;
+                raycastHit.raycastValid = false; //we can't populate all fields of MixedRealityRaycastHit in case of a GraphicsRaycast so we flag the hit data as invalid 
 
                 graphicsRaycastResult = result;
 

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -270,7 +270,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 this.ray = ray;
                 this.rayStepIndex = rayStepIndex;
                 this.rayDistance = rayDistance;
-                
             }
         }
 
@@ -990,8 +989,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                         hit = GetPrioritizedHitResult(hit, hitResultUi, prioritizedLayerMasks);
                     }
-
-                   
 
                     if (hit != hitResult3d || hitResult3dLayer > 0)
                     {

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -18,7 +18,6 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Linq;
 using Microsoft.MixedReality.Toolkit.UI;
-using Microsoft.MixedReality.Toolkit.Input.Utilities;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -18,6 +18,7 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Linq;
 using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Input.Utilities;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
@@ -90,6 +91,41 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             Assert.NotNull(CoreServices.InputSystem.GazeProvider.GazeTarget, "GazeProvider target is null when looking at an object with hand raised");
+        }
+
+        [UnityTest]
+        public IEnumerator TestGazeProviderTargetUnityUi()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // spawn 3d object 
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = Vector3.forward;
+            cube.transform.localScale = Vector3.one * 0.5f;
+            yield return null;
+            yield return null;
+
+            // make sure we get the 3d object as a gaze target
+            Assert.AreEqual(CoreServices.InputSystem.GazeProvider.GazeTarget, cube, "GazeProvider target is not set to 3d object (cube)");
+
+           // yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // spawn 2d unity ui
+            var canvas = UnityUiUtilities.CreateCanvas(0.002f);
+            var toggle = UnityUiUtilities.CreateToggle(Color.gray, Color.blue, Color.green);
+            toggle.transform.SetParent(canvas.transform, false);
+            canvas.transform.position = Vector3.forward * 0.5f;
+
+            yield return null;
+            yield return null;
+
+
+            //yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // check if gaze target has changed to unity ui
+            Assert.AreEqual(CoreServices.InputSystem.GazeProvider.GazeTarget, toggle.gameObject, "GazeProvider target is not set to toggle unity ui");
+
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -103,27 +103,26 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             cube.transform.position = Vector3.forward;
             cube.transform.localScale = Vector3.one * 0.5f;
             yield return null;
-            yield return null;
 
             // make sure we get the 3d object as a gaze target
             Assert.AreEqual(CoreServices.InputSystem.GazeProvider.GazeTarget, cube, "GazeProvider target is not set to 3d object (cube)");
-
-           // yield return PlayModeTestUtilities.WaitForEnterKey();
 
             // spawn 2d unity ui
             var canvas = UnityUiUtilities.CreateCanvas(0.002f);
             var toggle = UnityUiUtilities.CreateToggle(Color.gray, Color.blue, Color.green);
             toggle.transform.SetParent(canvas.transform, false);
             canvas.transform.position = Vector3.forward * 0.5f;
-
             yield return null;
-            yield return null;
-
-
-            //yield return PlayModeTestUtilities.WaitForEnterKey();
 
             // check if gaze target has changed to unity ui
             Assert.AreEqual(CoreServices.InputSystem.GazeProvider.GazeTarget, toggle.gameObject, "GazeProvider target is not set to toggle unity ui");
+
+            // destroy unity ui
+            Object.DestroyImmediate(canvas.gameObject);
+            yield return null;
+
+            // make sure gaze is back at 3d object
+            Assert.AreEqual(CoreServices.InputSystem.GazeProvider.GazeTarget, cube, "GazeProvider target is not set to 3d object (cube)");
 
             yield return null;
         }


### PR DESCRIPTION
## Overview
Fixed gazetarget not properly set in focusprovider:
Previously the gaze target only took physics raycast into account which will only cover 3d meshes.
After this change we will also take graphics raycast into account which includes Unity UI.

There's a test to verify that FocusProvider sets the gaze target correctly to a Unity UI element if it is in focus..

## Changes
- Fixes: #6343 


## Verification
FocusProvider test that checked that 3d objects as well as unity ui gameobjects can be focused / set as gazetargets.