### PR TITLE
Remove outdated remark

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -41,10 +41,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// This class works by looking for sentinel files (following the pattern MRTK.*.sentinel,
     /// for example, MRTK.Core.sentinel) in order to identify where the MRTK is located
     /// within the project.
-    ///
-    /// If the MRTK is being consumed as code that sits within the Assets folder, the "root"
-    /// MRTK folder must be at most three directories deep - this search code will only reason
-    /// over MRTK folders that sit in a depth range [0, 3].
     /// </remarks>
     [InitializeOnLoad]
     public static class MixedRealityToolkitFiles


### PR DESCRIPTION
No longer limited to search depth of 3, since it's using `SearchOption.AllDirectories`, modified in a45ece4f8a19d88411a095d286668d34b3c2b71b