### PR TITLE
Investigation into some failing CI steps

### DIFF
--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -17,5 +17,6 @@ jobs:
   steps:
   - template: templates/ci-common.yml
     parameters:
-      packagingEnabled: true
-      packagePublishing: true
+      performCommonStep: false
+      packagingEnabled: false
+      packagePublishing: false

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -1,12 +1,14 @@
 # CI build for developer builds.
 parameters:
+  performCommonStep: true
   packagingEnabled: true
   packagePublishing: true
 
 steps:
-- template: common.yml
-  parameters:
-    buildUWPDotNet: false
+- ${{ if eq(parameters.performCommonStep, true) }}:
+  - template: common.yml
+    parameters:
+      buildUWPDotNet: false
 - template: compilemsbuild.yml
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/unitypackages.yml


### PR DESCRIPTION
So in one of the CI builds, we're seeing a failure on a nuget restore step due to some corrupted version that is being passed in the .csprojs.

Looking at the various machines/failures, I'm currently pretty stumped because:
1) This started failing a long time ago, and even when I re-queue a commit from way before then, the build is still failing at the same step. However, all of our pipelines are configured in YAML (which means running an older build *should* take the corresponding older pipeline configuration as well)
2) There is a similar pipeline that is succeeding, that is running on the same agent pool and same build machine (and same Unity version and other parameters) but is not failing. What the effffff.

I'm trying this change (not actually submitting) to try to tease apart to find out if there's a specific step within here that is triggering some weirdness.

Don't merge this or look at this - setting up a PR so that my trials and tribulations are public and so that I have a commit I can try to build against.