### PR TITLE
Guidance for adding documentation to experimental features

### DIFF
--- a/Documentation/Contributing/ExperimentalFeatures.md
+++ b/Documentation/Contributing/ExperimentalFeatures.md
@@ -59,6 +59,13 @@ Adding a component menu:
 [AddComponentMenu("MRTK/Experimental/MyCommand")]
 ```
 
+## Documentation
+Follow these steps to add documentation for your experimental feature:
+
+1. Any documentation for an experimental feature should go in a `README.md` file in the experimental folder. For example, [`MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md`](../../Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md). 
+
+1. Under *Feature Overviews* Add a link in the *Experimental* section at [`Documentation/toc.yml`](../toc.yml).
+
 ### Minimize impact to MRTK code
 
 While your MRTK change might get your experiment to work, it could impact other people in ways you do not expect.

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -218,7 +218,7 @@
       href: README_HandInteractionExamples.md
     - name: Eye Tracking Interaction Example
       href: EyeTracking/EyeTracking_ExamplesOverview.md
-  - name: Experimental Features
+  - name: Experimental
     items:
     - name: Scrolling Object Collection
       href: ../Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/README.md


### PR DESCRIPTION
carried over changes from @julenka s PR #7056 
changed experimental features folder name
also added more information / highlighted menu entry for experimental features in guideline
