### PR TITLE
Update some asset menu paths

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
+++ b/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     /// Configuration profile for <see cref="HandPhysicsService"/> extension service.
     /// </summary>
 	[MixedRealityServiceProfile(typeof(IHandPhysicsService))]
-	[CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "MixedRealityToolkit/Hand Physics Service Configuration Profile")]
+	[CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality Toolkit/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
 	public class HandPhysicsServiceProfile : BaseMixedRealityProfile
 	{
         /// <summary>

--- a/Assets/MixedRealityToolkit.Extensions/LostTrackingService/LostTrackingServiceProfile.cs
+++ b/Assets/MixedRealityToolkit.Extensions/LostTrackingService/LostTrackingServiceProfile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
     /// The profile definition for an <see cref="ILostTrackingService"/>.
     /// </summary>
     [MixedRealityServiceProfile(typeof(ILostTrackingService))]
-    [CreateAssetMenu(fileName = "LostTrackingServiceProfile", menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Lost Tracking Service Profile")]
+    [CreateAssetMenu(fileName = "LostTrackingServiceProfile", menuName = "Mixed Reality Toolkit/Extensions/Lost Tracking Service/Mixed Reality Lost Tracking Service Profile")]
     public class LostTrackingServiceProfile : BaseMixedRealityProfile
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
+++ b/Assets/MixedRealityToolkit.Extensions/SceneTransitionService/SceneTransitionServiceProfile.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
 {
     [MixedRealityServiceProfile(typeof(ISceneTransitionService))]
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Extensions/Scene Transition Service/Scene Transition Service Profile", fileName = "SceneTransitionServiceProfile", order = 100)]
     public class SceneTransitionServiceProfile : BaseMixedRealityProfile
     {
         public bool UseDefaultProgressIndicator => useDefaultProgressIndicator;

--- a/Assets/MixedRealityToolkit.Providers/UnityAR/UnityARCameraSettingsProfile.cs
+++ b/Assets/MixedRealityToolkit.Providers/UnityAR/UnityARCameraSettingsProfile.cs
@@ -7,9 +7,9 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 {
     /// <summary>
-    /// Configuration profile for the XR Camera settings provider.
+    /// Configuration profile for the XR camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Unity AR Foundation Camera Settings Profile", fileName = "DefaultUnityARCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Providers/Unity AR/Unity AR Foundation Camera Settings Profile", fileName = "DefaultUnityARCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(UnityARCameraSettings))]
     public class UnityARCameraSettingsProfile : BaseCameraSettingsProfile
     {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
@@ -7,9 +7,9 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 {
     /// <summary>
-    /// Configuration profile for the Windows Mixed Reality Camera settings provider.
+    /// Configuration profile for the Windows Mixed Reality camera settings provider.
     /// </summary>
-    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
+    [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Providers/Windows Mixed Reality/Windows Mixed Reality Camera Settings Profile", fileName = "WindowsMixedRealityCameraSettingsProfile", order = 100)]
     [MixedRealityServiceProfile(typeof(BaseWindowsMixedRealityCameraSettings))]
     public class WindowsMixedRealityCameraSettingsProfile : BaseCameraSettingsProfile
     {

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -97,13 +97,26 @@ Omitting the namespace for an interface, class or data type will cause your chan
 
 ### Adding new MonoBehaviour scripts
 
-When adding new MonoBehaviour scripts with a pull-request, ensure the [`AddComponentMenu`](https://docs.unity3d.com/ScriptReference/AddComponentMenu.html) attribute is applied to all applicable files. This ensures the component is easily discoverable in the editor under the *Add Component* button. The attribute flag is not necessary if the component cannot show up in editor such as an abstract class.
+When adding new MonoBehaviour scripts with a pull request, ensure the [`AddComponentMenu`](https://docs.unity3d.com/ScriptReference/AddComponentMenu.html) attribute is applied to all applicable files. This ensures the component is easily discoverable in the editor under the *Add Component* button. The attribute flag is not necessary if the component cannot show up in editor such as an abstract class.
 
 In the example below, the *Package here* should be filled with the package location of the component. If placing an item in *MixedRealityToolkit.SDK* folder, then the package will be *SDK*. If placing an item in the *MixedRealityToolkit* folder, then use *Core* as the string to insert.
 
 ```c#
 [AddComponentMenu("Scripts/MRTK/{Package here}/MyNewComponent")]
 public class MyNewComponent : MonoBehaviour
+```
+
+### Adding new ScriptableObjects
+
+When adding new ScriptableObject scripts, ensure the [`CreateAssetMenu`](https://docs.unity3d.com/ScriptReference/CreateAssetMenu.html) attribute is applied to all applicable files. This ensures the component is easily discoverable in the editor via the asset creation menus. The attribute flag is not necessary if the component cannot show up in editor such as an abstract class.
+
+In the example below, the *Subfolder* should be filled with the MRTK subfolder, if applicable. If placing an item in *MixedRealityToolkit.Providers* folder, then the package will be *Providers*. If placing an item in the *MixedRealityToolkit* folder, set this to "Profiles".
+
+In the example below, the *MyNewService | MyNewProvider* should be filled with the your new class' name, if applicable. If placing an item in the *MixedRealityToolkit* folder, leave this string out.
+
+```c#
+[CreateAssetMenu(fileName = "MyNewProfile", menuName = "Mixed Reality Toolkit/{Subfolder}/{MyNewService | MyNewProvider}/MyNewProfile")]
+public class MyNewProfile : ScriptableObject
 ```
 
 ### Spaces vs tabs


### PR DESCRIPTION
## Overview

Started by noticing one was in its own path of `MixedRealityToolkit` vs `Mixed Reality Toolkit`, then started partitioning out some paths like our folder structure, to help structure the menus a bit more:

![image](https://user-images.githubusercontent.com/3580640/72465948-e1b66e80-378c-11ea-9c9e-03faaca9ec19.png)
