### PR TITLE
Unbork the CI build

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/Scripts/MSBuildTools.cs
@@ -150,7 +150,8 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 ProcessReferences(buildTarget, references, out HashSet<string> platformAssemblySearchPaths, out HashSet<string> platformAssemblyReferencePaths, priorToCheck);
 
                 string targetUWPPlatform = uwpTargetPlatformVersion;
-                if (string.IsNullOrWhiteSpace(targetUWPPlatform))
+                // If the version string is not a valid one, default to the highest available SDK version on the machine.
+                if (string.IsNullOrWhiteSpace(targetUWPPlatform) || !Version.TryParse(targetUWPPlatform, out _))
                 {
                     targetUWPPlatform = Utilities.GetUWPSDKs().Max().ToString(4);
                 }


### PR DESCRIPTION
One of the CI builds (that builds both NuGet and Standalone/UWP/etc) is currently on the floor due to in invalid version that's being piped back from Unity's wsaUWPSDK:

Error MSB4086: A numeric comparison was attempted on "$(TargetPlatformVersion)" that evaluates to "winv6.3" instead of a number, in condition "'$(TargetPlatformVersion)' >= '10.0.11000.0'".

winv6.3 isn't actually an interesting (or valid) version number.

Here's where things get a bit weird -
This issue actually started happening quite a while back (i.e. mid november). It's not actually an issue in the pipeline/code itself, because when we re-queue a really old commit, the same issue occurs
It's also not an issue with some specific build machines or different pool configurations (i.e. there successful CIs run on the same machines as the non-successful ones).

I ended up narrowing it down to the UWP build step before the generation of SDK packages - i.e. if the UWP build step runs first, it looks like it (or something) is mutating the  wsaUWPSDK to 'winv6.3', which then borks the Generate SDK Packages step (i.e. it causes the generation to have that invalid string).

When I delete the UWP build step from the pipeline (as seen in the build/infrastructure branch), things work just fine.

The other thing here is I haven't been able to repro this locally (i.e. doing a UWP build followed by generation of SDK packages creates csproj files with correct target platform versions - I assume at this point that there is some specific configuration/SDK setup on the build machine that's leading to this situation (i.e. I've matched Unity version, VS version, etc).

I think that I'd like to keep the build order (i.e. we should be building the standalone + running tests before generating packages, as in general we should only package something if we know it's actually good).

To this end I'm updating this code to just be more resilient to this (i.e. not just an empty version, but also an invalid one in case someone set it to something incorrect).