### PR TITLE
Add TrackedPoseDriver for XR SDK at runtime

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/UnityAR/UnityARCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Providers/UnityAR/UnityARCameraSettings.cs
@@ -173,9 +173,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
 
             trackedPoseDriver.SetPoseSource(
                 TrackedPoseDriver.DeviceType.GenericXRDevice,
-                ArEnumConversion.ToUnityTrackedPose(SettingsProfile.PoseSource));
-            trackedPoseDriver.trackingType = ArEnumConversion.ToUnityTrackingType(SettingsProfile.TrackingType);
-            trackedPoseDriver.updateType = ArEnumConversion.ToUnityUpdateType(SettingsProfile.UpdateType);
+                ArEnumConversion.ToUnityTrackedPose(poseSource));
+            trackedPoseDriver.trackingType = ArEnumConversion.ToUnityTrackingType(trackingType);
+            trackedPoseDriver.updateType = ArEnumConversion.ToUnityUpdateType(updateType);
             trackedPoseDriver.UseRelativeTransform = false;
 
             isInitialized = true;

--- a/Assets/MixedRealityToolkit.Providers/XRSDK/Editor/ConfigurationChecker/XRSDKConfigurationChecker.cs
+++ b/Assets/MixedRealityToolkit.Providers/XRSDK/Editor/ConfigurationChecker/XRSDKConfigurationChecker.cs
@@ -18,10 +18,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         private const string AsmDefFileName = "Microsoft.MixedReality.Toolkit.Providers.XRSDK.asmdef";
         private const string XRManagementReference = "Unity.XR.Management";
         private const string ARSubsystemsReference = "Unity.XR.ARSubsystems";
+        private const string SpatialTrackingReference = "UnityEngine.SpatialTracking";
 
 #if UNITY_2019_3_OR_NEWER
         private static readonly VersionDefine XRManagementDefine = new VersionDefine("com.unity.xr.management", "", "XR_MANAGEMENT_ENABLED");
         private static readonly VersionDefine ARSubsystemsDefine = new VersionDefine("com.unity.xr.arsubsystems", "", "ARSUBSYSTEMS_ENABLED");
+        private static readonly VersionDefine SpatialTrackingDefine = new VersionDefine("com.unity.xr.legacyinputhelpers", "", "SPATIALTRACKING_ENABLED");
 #endif // UNITY_2019_3_OR_NEWER
 
         static XRSDKConfigurationChecker()
@@ -86,8 +88,14 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             }
             if (!references.Contains(ARSubsystemsReference))
             {
-                // Add a reference to the spatial tracking assembly
+                // Add a reference to the ARSubsystems assembly
                 references.Add(ARSubsystemsReference);
+                changed = true;
+            }
+            if (!references.Contains(SpatialTrackingReference))
+            {
+                // Add a reference to the spatial tracking assembly
+                references.Add(SpatialTrackingReference);
                 changed = true;
             }
 
@@ -103,17 +111,29 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 versionDefines.Add(ARSubsystemsDefine);
                 changed = true;
             }
+            if (!versionDefines.Contains(SpatialTrackingDefine))
+            {
+                // Add the spatial tracking #define
+                versionDefines.Add(SpatialTrackingDefine);
+                changed = true;
+            }
 #else
             if (references.Contains(XRManagementReference))
             {
-                // Remove the reference to the spatial tracking assembly
+                // Remove the reference to the XRManagement assembly
                 references.Remove(XRManagementReference);
                 changed = true;
             }
             if (references.Contains(ARSubsystemsReference))
             {
-                // Add a reference to the spatial tracking assembly
+                // Remove the reference to the ARSubsystems assembly
                 references.Remove(ARSubsystemsReference);
+                changed = true;
+            }
+            if (references.Contains(SpatialTrackingReference))
+            {
+                // Remove the reference to the spatial tracking assembly
+                references.Remove(SpatialTrackingReference);
                 changed = true;
             }
 #endif

--- a/Assets/MixedRealityToolkit.Providers/XRSDK/GenericXRSDKCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Providers/XRSDK/GenericXRSDKCameraSettings.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using UnityEngine;
+using UnityEngine.SpatialTracking;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK
 {
@@ -29,10 +31,37 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
             BaseCameraSettingsProfile profile = null) : base(cameraSystem, name, priority, profile)
         { }
 
+        private TrackedPoseDriver trackedPoseDriver = null;
+
         #region IMixedRealityCameraSettings
 
         /// <inheritdoc/>
         public override bool IsOpaque => XRSDKSubsystemHelpers.DisplaySubsystem?.displayOpaque ?? true;
+
+        /// <inheritdoc/>
+        public override void Enable()
+        {
+            base.Enable();
+
+            // Only track the TrackedPoseDriver if we added it ourselves.
+            // There may be a pre-configured TrackedPoseDriver on the camera.
+            if (!CameraCache.Main.GetComponent<TrackedPoseDriver>())
+            {
+                trackedPoseDriver = CameraCache.Main.gameObject.AddComponent<TrackedPoseDriver>();
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Disable()
+        {
+            if (trackedPoseDriver != null)
+            {
+                Object.Destroy(trackedPoseDriver);
+                trackedPoseDriver = null;
+            }
+
+            base.Disable();
+        }
 
         #endregion IMixedRealityCameraSettings
     }

--- a/Assets/MixedRealityToolkit.Providers/XRSDK/Profiles/DefaultXRSDKToolkitConfigurationProfile.asset
+++ b/Assets/MixedRealityToolkit.Providers/XRSDK/Profiles/DefaultXRSDKToolkitConfigurationProfile.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   isCustomProfile: 0
   targetExperienceScale: 3
   enableCameraSystem: 1
-  cameraProfile: {fileID: 0}
+  cameraProfile: {fileID: 11400000, guid: 6a6ea8e8cca71344ba773e4317537580, type: 2}
   cameraSystemType:
     reference: Microsoft.MixedReality.Toolkit.CameraSystem.MixedRealityCameraSystem,
       Microsoft.MixedReality.Toolkit.Services.CameraSystem


### PR DESCRIPTION
## Overview

1. Add `TrackedPoseDriver` for XR SDK at runtime
1. Fix camera settings that didn't have a profile set
1. Update `UnityARCameraSettings` to read from its cached data instead of the profile again

## Changes
- Part of #7003 