### PR TITLE
Update the extension service creator to work when the extension package isn't installed

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -352,7 +352,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Check to see whether editor prefs exist of our persistent state
             // If it does, load that now and clear the state
             string persistentState = SessionState.GetString(PersistentStateKey, string.Empty);
-            if (false && !string.IsNullOrEmpty(persistentState))
+            if (!string.IsNullOrEmpty(persistentState))
             {
                 state = JsonUtility.FromJson<PersistentState>(persistentState);
                 // If we got this far we know we were successful

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -255,7 +256,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region static
 
-        private static readonly string DefaultExtensionsFolderName = "MixedRealityToolkit.Extensions";
+        private static readonly string DefaultGeneratedFolderName = "MixedRealityToolkit.Generated";
+        private static readonly string DefaultExtensionsFolderName = "Extensions";
         private static readonly string DefaultExtensionNamespace = "Microsoft.MixedReality.Toolkit.Extensions";
         private static readonly string PersistentStateKey = "MRTK_ExtensionServiceWizard_State_Before_Recompilation";
         private static readonly string ScriptExtension = ".cs";
@@ -273,7 +275,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region paths
 
-        private string ExtensionsFolder => MixedRealityToolkitFiles.MapModulePath(MixedRealityToolkitModuleType.Extensions);
+        private string ExtensionsFolder => Path.Combine("Assets", DefaultGeneratedFolderName, DefaultExtensionsFolderName);
         private string ServiceTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt");
         private string InspectorTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionInspectorTemplate.txt");
         private string InterfaceTemplatePath => MixedRealityToolkitFiles.MapRelativeFilePath(MixedRealityToolkitModuleType.Tools, "ExtensionServiceCreator/Templates/ExtensionInterfaceTemplate.txt");
@@ -350,7 +352,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Check to see whether editor prefs exist of our persistent state
             // If it does, load that now and clear the state
             string persistentState = SessionState.GetString(PersistentStateKey, string.Empty);
-            if (!string.IsNullOrEmpty(persistentState))
+            if (false && !string.IsNullOrEmpty(persistentState))
             {
                 state = JsonUtility.FromJson<PersistentState>(persistentState);
                 // If we got this far we know we were successful
@@ -413,7 +415,13 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             if (!AssetDatabase.IsValidFolder(ExtensionsFolder))
             {
-                AssetDatabase.CreateFolder("Assets", DefaultExtensionsFolderName);
+                var generatedFolder = Path.Combine("Assets", DefaultGeneratedFolderName);
+                if (!AssetDatabase.IsValidFolder(generatedFolder))
+                {
+                    AssetDatabase.CreateFolder("Assets", DefaultGeneratedFolderName);
+                }
+                
+                AssetDatabase.CreateFolder(generatedFolder, DefaultExtensionsFolderName);
                 AssetDatabase.Refresh();
             }
 

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -320,11 +320,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         /// <param name="module">Module type to search for</param>
         /// <remarks>
-        /// Returns first valid module folder path (relative) found
+        /// Returns first valid module folder path (relative) found. Returns null otherwise.
         /// </remarks>
         public static string MapModulePath(MixedRealityToolkitModuleType module)
         {
-            return GetAssetDatabasePath(MapRelativeFolderPathToAbsolutePath(module, ""));
+            var path = MapRelativeFolderPathToAbsolutePath(module, "");
+            return path != null ? GetAssetDatabasePath(path) : null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
The extension service creator wizard today looks for the MixedRealityToolkit.Extensions folder in order to place its newly generated content. This fails when the default extensions package isn't installed, because the folder doesn't exist. Note that it's more than just the folder that needs to exist - each of the MRTK folders also require a 'sentinel' file to be placed in them, so that the MixedRealityToolkitFiles.cs code can find them even when they are placed in arbitrary folders/locations within the project (to support placing the MRTK at arbitrary locations). As a result, the code that tries to re-create the extensions folder doesn't work (i.e. it doesn't do the sentinel file creation).

In reality, because these are generated files, they should really go into the MixedRealityToolkit.Generated folder, so I've changed it to avoid the default/inbox Extensions folder. Now it shares the same general destination as other wizard generated assets.


## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7086