### PR TITLE
NullCheck before accessing shader

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/GenericOpenVRController.cs
@@ -264,7 +264,12 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
                 }
 
                 OpenVRRenderModel openVRRenderModel = controllerModelGameObject.AddComponent<OpenVRRenderModel>();
-                openVRRenderModel.shader = visualizationProfile.GetDefaultControllerModelMaterialOverride(GetType(), ControllerHandedness).shader;
+                Material overrideMaterial = visualizationProfile.GetDefaultControllerModelMaterialOverride(GetType(), ControllerHandedness);
+                if (overrideMaterial != null)
+                {
+                    openVRRenderModel.shader = overrideMaterial.shader;
+                }
+
                 failedToObtainControllerModel = !openVRRenderModel.LoadModel(ControllerHandedness);
 
                 if (!failedToObtainControllerModel)


### PR DESCRIPTION
## Overview
The material accessed might not be assigned in the inspector. Furthermore, if the shader of the assignee is null, internally it will just be set to the MRKT Standard Shader so it's save to just check and not assign any if no material is found.

## Changes
- Fixes: #7102