### PR TITLE
Allow Windows extensions to properly use DotNetWinRT (and some compiler warning fixes)

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/Extensions/WindowsExtensions.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/Extensions/WindowsExtensions.cs
@@ -3,7 +3,11 @@
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 using Microsoft.MixedReality.Toolkit.Utilities;
+#if WINDOWS_UWP
 using Windows.UI.Input.Spatial;
+#elif DOTNETWINRT_PRESENT
+using Microsoft.Windows.UI.Input.Spatial;
+#endif
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -211,10 +211,14 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         /// <inheritdoc/>
         protected override IMixedRealityServiceConfiguration GetDataProviderConfiguration(int index)
         {
-            var configurations = (target as MixedRealityInputSystemProfile)?.DataProviderConfigurations;
-            if (configurations != null && index >= 0 && index < configurations.Length)
+            MixedRealityInputSystemProfile targetProfile = target as MixedRealityInputSystemProfile;
+            if (targetProfile != null)
             {
-                return configurations[index];
+                var configurations = targetProfile.DataProviderConfigurations;
+                if (configurations != null && index >= 0 && index < configurations.Length)
+                {
+                    return configurations[index];
+                }
             }
 
             return null;

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityInputSystemProfileInspector.cs
@@ -19,7 +19,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         private static bool showDataProviders = false;
         private const string ShowInputSystem_DataProviders_PreferenceKey = "ShowInputSystem_DataProviders_PreferenceKey";
-        private SerializedProperty dataProviderConfigurations;
 
         private SerializedProperty focusProviderType;
         private SerializedProperty focusQueryBufferSize;


### PR DESCRIPTION
## Overview

1. Adds the DotNetWinRT namespace when valid
2. Removes an unused field that was throwing a warning
3. Fixes an incorrect null propagation on a Unity object

## Changes
- Fixes: #7108, part of #7003 