### PR TITLE
Fix some Unity object null propagation and other warnings

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
@@ -59,7 +59,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             initializedFromProfile = true;
 
-            var gestureProfile = CoreServices.InputSystem?.InputSystemProfile?.GesturesProfile;
+            MixedRealityGesturesProfile gestureProfile = null;
+            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+            if (inputSystemProfile != null)
+            {
+                gestureProfile = inputSystemProfile.GesturesProfile;
+            }
             if (gestureProfile != null)
             {
                 for (int i = 0; i < gestureProfile.Gestures.Length; i++)

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/SimulatedGestureHand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Vector3 cumulativeDelta = Vector3.zero;
         private MixedRealityPose currentGripPose = MixedRealityPose.ZeroIdentity;
 
-        private Vector3 navigationDelta => new Vector3(
+        private Vector3 NavigationDelta => new Vector3(
             Mathf.Clamp(cumulativeDelta.x, -1.0f, 1.0f) * currentRailsUsed.x,
             Mathf.Clamp(cumulativeDelta.y, -1.0f, 1.0f) * currentRailsUsed.y,
             Mathf.Clamp(cumulativeDelta.z, -1.0f, 1.0f) * currentRailsUsed.z);
@@ -293,7 +293,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (navigationInProgress)
             {
                 UpdateNavigationRails();
-                CoreServices.InputSystem?.RaiseGestureUpdated(this, navigationAction, navigationDelta);
+                CoreServices.InputSystem?.RaiseGestureUpdated(this, navigationAction, NavigationDelta);
             }
         }
 
@@ -301,7 +301,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (navigationInProgress)
             {
-                CoreServices.InputSystem?.RaiseGestureCompleted(this, navigationAction, navigationDelta);
+                CoreServices.InputSystem?.RaiseGestureCompleted(this, navigationAction, NavigationDelta);
                 navigationInProgress = false;
                 return true;
             }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -248,10 +248,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             MixedRealityInputSystemProfile profile = ConfigurationProfile as MixedRealityInputSystemProfile;
 
             // If the system gets disabled, the gaze provider is destroyed.
-            // Ensure that it gets recreated on when reenabled.
-            if (GazeProvider == null)
+            // Ensure that it gets recreated on when re-enabled.
+            if (GazeProvider == null && profile != null)
             {
-                InstantiateGazeProvider(profile?.PointerProfile);
+                InstantiateGazeProvider(profile.PointerProfile);
             }
 
             if ((GetDataProviders().Count == 0) && (profile != null))
@@ -272,7 +272,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void InstantiateGazeProvider(MixedRealityPointerProfile pointerProfile)
         {
-            if (pointerProfile?.GazeProviderType?.Type != null)
+            if (pointerProfile != null && pointerProfile.GazeProviderType?.Type != null)
             {
                 GazeProvider = CameraCache.Main.gameObject.EnsureComponent(pointerProfile.GazeProviderType.Type) as IMixedRealityGazeProvider;
                 GazeProvider.GazeCursorPrefab = pointerProfile.GazeCursorPrefab;
@@ -991,7 +991,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public void RaisePointerDown(IMixedRealityPointer pointer, MixedRealityInputAction inputAction, Handedness handedness = Handedness.None, IMixedRealityInputSource inputSource = null)
         {
             // Only lock the object if there is a grabbable above in the hierarchy
-            Transform currentObject = pointer.Result?.Details.Object?.transform;
+            Transform currentObject = null;
+            GameObject currentGameObject = pointer.Result?.Details.Object;
+            if (currentGameObject != null)
+            {
+                currentObject = currentGameObject.transform;
+            }
             IMixedRealityPointerHandler ancestorPointerHandler = null;
             while(currentObject != null && ancestorPointerHandler == null)
             {

--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -318,7 +318,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 GazeProvider = null;
             }
 
-            foreach(var provider in GetDataProviders<IMixedRealityInputDeviceManager>())
+            foreach (var provider in GetDataProviders<IMixedRealityInputDeviceManager>())
             {
                 if (provider != null)
                 {
@@ -998,13 +998,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 currentObject = currentGameObject.transform;
             }
             IMixedRealityPointerHandler ancestorPointerHandler = null;
-            while(currentObject != null && ancestorPointerHandler == null)
+            while (currentObject != null && ancestorPointerHandler == null)
             {
-                foreach(var component in currentObject.GetComponents<Component>())
+                foreach (var component in currentObject.GetComponents<Component>())
                 {
                     if (component is IMixedRealityPointerHandler)
                     {
-                        ancestorPointerHandler = (IMixedRealityPointerHandler) component;
+                        ancestorPointerHandler = (IMixedRealityPointerHandler)component;
                         break;
                     }
                 }

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                     if (Interactions[i].InputType == DeviceInputType.SpatialPointer)
                     {
                         // Spatial pointer raises Pose events
-                        MixedRealityPose controllerPose = MixedRealityPose.ZeroIdentity;
+                        controllerPose = MixedRealityPose.ZeroIdentity;
                         controllerPose.Rotation = Quaternion.Euler(mouseDelta);
                         Interactions[i].PoseData = controllerPose;
 


### PR DESCRIPTION
## Overview

Fixes some warnings:

1. Updates the capitalization convention of a private property to be PascalCase.
1. Fixes several incorrect cases of Unity object null propagation.
1. Fixes an unused field warning by updating the code to actually use it.