### PR TITLE
Delay initialization of project configurator window

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -27,6 +27,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // Detect when we enter player mode so we can try checking for optimal configuration
             EditorApplication.playModeStateChanged += OnPlayStateModeChanged;
 
+            // Subscribe to editor application update which will call us once the editor is initialized and running
+            EditorApplication.update += OnInit;
+        }
+
+        private static void OnInit()
+        {
+            // We only want to execute once to initialize, unsubscribe from update event
+            EditorApplication.update -= OnInit;
+
             ShowProjectConfigurationDialog();
         }
 


### PR DESCRIPTION
## Overview
This change delays initialization of the MREditorSettings class till after the editor has been fully initialized. Before this change, the MREditorSettings class would start up once compiled (and thus it's static constructor executes. With this change, we wait till `EditorApplication.update` starts firing but only subscribe to this event for one event execution because we only need to init. 

Need to do further testing concerning #7109 with this PR

## Changes
- Fixes: #7109 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
