### PR TITLE
Fixed bounds control runtime example

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scenes/BoundsControlRuntimeExample.unity
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scenes/BoundsControlRuntimeExample.unity
@@ -220,49 +220,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 264808312}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &328635476
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 328635477}
-  - component: {fileID: 328635478}
-  m_Layer: 0
-  m_Name: MixedRealityBoundarySystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &328635477
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 328635476}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &328635478
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 328635476}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &342624755
 GameObject:
   m_ObjectHideFlags: 0
@@ -294,49 +251,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &359810650
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 359810651}
-  - component: {fileID: 359810652}
-  m_Layer: 0
-  m_Name: FocusProvider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &359810651
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 359810650}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &359810652
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 359810650}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &442498765
 GameObject:
   m_ObjectHideFlags: 0
@@ -377,8 +291,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Status Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: afc8299d5d5bbd440a0616c8ecbc7217, type: 2}
@@ -416,7 +328,6 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_textAlignment: 4097
-  m_isAlignmentEnumConverted: 1
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 1
@@ -443,6 +354,7 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
@@ -457,12 +369,9 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 0
-  m_inputSource: 3
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 442498768}
   m_subTextObjects:
@@ -532,12 +441,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b55691ad5b034fe6966763a6e23818d2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handedness: 0
-  trackedObjectToReference: 0
+  trackedTargetType: 0
+  trackedHandness: 3
   trackedHandJoint: 2
+  transformOverride: {fileID: 0}
   additionalOffset: {x: 0, y: 0, z: 0}
   additionalRotation: {x: 0, y: 0, z: 0}
-  transformTarget: {fileID: 0}
   updateSolvers: 1
 --- !u!114 &442498770
 MonoBehaviour:
@@ -558,7 +467,6 @@ MonoBehaviour:
   maintainScale: 1
   smoothing: 0
   lifetime: 0
-  SolverHandler: {fileID: 442498769}
   orientationType: 0
   localOffset: {x: 0, y: 0, z: 1}
   worldOffset: {x: 0, y: 0, z: 0}
@@ -630,49 +538,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 1025, y: 648}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &513590250
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 513590251}
-  - component: {fileID: 513590252}
-  m_Layer: 0
-  m_Name: MixedRealitySpatialAwarenessSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &513590251
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513590250}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &513590252
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513590250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &652816306
 GameObject:
   m_ObjectHideFlags: 0
@@ -797,92 +662,6 @@ Transform:
   m_Father: {fileID: 1801423600}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &846383347
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 846383348}
-  - component: {fileID: 846383349}
-  m_Layer: 0
-  m_Name: MixedRealityDiagnosticsSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &846383348
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 846383347}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &846383349
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 846383347}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &864321461
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 864321462}
-  - component: {fileID: 864321463}
-  m_Layer: 0
-  m_Name: MixedRealityCameraSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &864321462
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 864321461}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &864321463
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 864321461}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &874614036
 GameObject:
   m_ObjectHideFlags: 0
@@ -1025,92 +804,6 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!1 &924376805
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 924376806}
-  - component: {fileID: 924376807}
-  m_Layer: 0
-  m_Name: MixedRealityTeleportSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &924376806
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 924376805}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &924376807
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 924376805}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &978728932
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 978728933}
-  - component: {fileID: 978728934}
-  m_Layer: 0
-  m_Name: DefaultRaycastProvider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &978728933
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 978728932}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &978728934
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 978728932}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1081672140
 GameObject:
   m_ObjectHideFlags: 0
@@ -1190,49 +883,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1356826827
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1356826828}
-  - component: {fileID: 1356826829}
-  m_Layer: 0
-  m_Name: MixedRealityInputSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1356826828
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1356826827}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2051637126}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1356826829
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1356826827}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1685224230
 GameObject:
   m_ObjectHideFlags: 0
@@ -1359,9 +1009,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: Bounding Box Runtime Tests
+  m_text: Bounds Control Runtime Tests
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 6a84f857bec7e7345843ae29404c57ce, type: 2}
   m_sharedMaterial: {fileID: 21202819797275496, guid: 6a84f857bec7e7345843ae29404c57ce,
@@ -1398,7 +1046,6 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_textAlignment: 257
-  m_isAlignmentEnumConverted: 1
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -1425,13 +1072,14 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: -40.90899, w: 0}
   m_textInfo:
     textComponent: {fileID: 1782114190}
-    characterCount: 26
+    characterCount: 28
     spriteCount: 0
     spaceCount: 3
     wordCount: 4
@@ -1439,12 +1087,9 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 0
-  m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1782114193}
   m_subTextObjects:
@@ -1630,10 +1275,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: 'This example demonstrates how to create a bounding box at runtime and modify
-    various bounding box properties.
+  m_text: 'This example demonstrates how to create a bounds control at runtime and
+    modify various bounds control properties.
 
 
     Say "select" or press ''1'' to advance to the next example'
@@ -1673,7 +1316,6 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_textAlignment: 257
-  m_isAlignmentEnumConverted: 1
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -1700,13 +1342,14 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
   m_firstVisibleCharacter: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: -40.90899, w: -7.350438}
   m_textInfo:
     textComponent: {fileID: 1825291915}
-    characterCount: 167
+    characterCount: 171
     spriteCount: 0
     spaceCount: 28
     wordCount: 28
@@ -1714,12 +1357,9 @@ MonoBehaviour:
     lineCount: 4
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 0
-  m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 1825291918}
   m_subTextObjects:
@@ -1796,7 +1436,7 @@ GameObject:
   - component: {fileID: 1993683264}
   - component: {fileID: 1993683265}
   m_Layer: 0
-  m_Name: Bounding Box Test
+  m_Name: Bounds Control Test
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1825,7 +1465,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1993683263}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a76745b0a647f444b850e879efd3576, type: 3}
+  m_Script: {fileID: 11500000, guid: 9c4729c09ee8e644fb457e1db1945d65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   statusText: {fileID: 442498766}
@@ -1873,15 +1513,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 978728933}
-  - {fileID: 359810651}
-  - {fileID: 328635477}
-  - {fileID: 864321462}
-  - {fileID: 846383348}
-  - {fileID: 1356826828}
-  - {fileID: 513590251}
-  - {fileID: 924376806}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -13,7 +13,6 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
 {
-    [AddComponentMenu("Scripts/MRTK/Experimental/Examples/BoundsControlRuntimeExample")]
     /// <summary>
     /// This example script demonstrates various bounds control runtime configurations
     /// </summary>

--- a/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl;
+using Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections;
 using System.Text;
@@ -12,9 +13,9 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
 {
+    [AddComponentMenu("Scripts/MRTK/Experimental/Examples/BoundsControlRuntimeExample")]
     /// <summary>
-    /// TODO: This demo probably needs to be adjusted
-    /// Currently it's just a copy of BoundingBoxExampleTest
+    /// This example script demonstrates various bounds control runtime configurations
     /// </summary>
     public class BoundsControlRuntimeExample : MonoBehaviour, IMixedRealitySpeechHandler
     {
@@ -67,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 SetStatus("Instantiate BoundsControl");
                 boundsControl = cube.AddComponent<BoundsControl>();
                 boundsControl.HideElementsInInspector = false;
-                boundsControl.BoundsControlActivation = Toolkit.Experimental.UI.BoundsControlTypes.BoundsControlActivationType.ActivateOnStart;
+                boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
                 var mh = cube.AddComponent<ManipulationHandler>();
                 yield return WaitForSpeechCommand();
 
@@ -98,15 +99,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 yield return WaitForSpeechCommand();
 
                 SetStatus("FlattenX");
-                boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenX;
+                boundsControl.FlattenAxis = FlattenModeType.FlattenX;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("FlattenY");
-                boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenY;
+                boundsControl.FlattenAxis = FlattenModeType.FlattenY;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("FlattenNone");
-                boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.DoNotFlatten;
+                boundsControl.FlattenAxis = FlattenModeType.DoNotFlatten;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("ShowWireframe false");
@@ -170,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Wireframe shape cylinder");
-                boundsControl.LinksConfiguration.WireframeShape = Toolkit.Experimental.UI.BoundsControlTypes.WireframeType.Cylindrical;
+                boundsControl.LinksConfiguration.WireframeShape = WireframeType.Cylindrical;
                 yield return WaitForSpeechCommand();
 
                 Destroy(cube);
@@ -199,7 +200,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 }
 
                 boundsControl = multiRoot.AddComponent<BoundsControl>();
-                boundsControl.BoundsControlActivation = Toolkit.Experimental.UI.BoundsControlTypes.BoundsControlActivationType.ActivateOnStart;
+                boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
                 boundsControl.HideElementsInInspector = false;
                 boundsControl.LinksConfiguration.WireframeEdgeRadius = .05f;
                 multiRoot.AddComponent<ManipulationHandler>();

--- a/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MixedRealityToolkit.Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
 
         private bool speechTriggeredFlag;
         private Vector3 cubePosition = new Vector3(0, 0, 2);
-        private BoundsControl bbox;
+        private BoundsControl boundsControl;
 
         protected virtual void OnEnable()
         {
@@ -65,9 +65,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 cube.transform.position = cubePosition;
 
                 SetStatus("Instantiate BoundsControl");
-                bbox = cube.AddComponent<BoundsControl>();
-                bbox.HideElementsInInspector = false;
-                bbox.BoundsControlActivation = Toolkit.Experimental.UI.BoundsControlTypes.BoundsControlActivationType.ActivateOnStart;
+                boundsControl = cube.AddComponent<BoundsControl>();
+                boundsControl.HideElementsInInspector = false;
+                boundsControl.BoundsControlActivation = Toolkit.Experimental.UI.BoundsControlTypes.BoundsControlActivationType.ActivateOnStart;
                 var mh = cube.AddComponent<ManipulationHandler>();
                 yield return WaitForSpeechCommand();
 
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 var bc = newObject.AddComponent<BoxCollider>();
                 bc.center = new Vector3(.25f, 0, 0);
                 bc.size = new Vector3(0.162f, 0.1f, 1);
-                bbox.BoundsOverride = bc;
+                boundsControl.BoundsOverride = bc;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Change target bounds override size");
@@ -84,93 +84,93 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Remove target bounds override");
-                bbox.BoundsOverride = null;
+                boundsControl.BoundsOverride = null;
                 Destroy(newObject);
                 newObject = null;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("HideElementsInInspector true");
-                bbox.HideElementsInInspector = true;
+                boundsControl.HideElementsInInspector = true;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("HideElementsInInspector false");
-                bbox.HideElementsInInspector = false;
+                boundsControl.HideElementsInInspector = false;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("FlattenX");
-                bbox.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenX;
+                boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenX;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("FlattenY");
-                bbox.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenY;
+                boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenY;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("FlattenNone");
-                bbox.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.DoNotFlatten;
+                boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.DoNotFlatten;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("ShowWireframe false");
-                bbox.LinksConfiguration.ShowWireFrame = false;
+                boundsControl.LinksConfiguration.ShowWireFrame = false;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("ShowWireframe true");
-                bbox.LinksConfiguration.ShowWireFrame = true;
+                boundsControl.LinksConfiguration.ShowWireFrame = true;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BoxPadding 0.2f");
-                bbox.BoxPadding = new Vector3(0.2f, 0.2f, 0.2f);
+                boundsControl.BoxPadding = new Vector3(0.2f, 0.2f, 0.2f);
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BoxPadding 0");
-                bbox.BoxPadding = Vector3.zero;
+                boundsControl.BoxPadding = Vector3.zero;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Set scale handle size 0.3");
-                bbox.ScaleHandlesConfiguration.HandleSize = 0.3f;
+                boundsControl.ScaleHandlesConfiguration.HandleSize = 0.3f;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Set scale handle widget prefab");
                 Debug.Assert(scaleWidget != null);
-                bbox.ScaleHandlesConfiguration.HandlePrefab = scaleWidget;
+                boundsControl.ScaleHandlesConfiguration.HandlePrefab = scaleWidget;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Handles red");
-                bbox.ScaleHandlesConfiguration.HandleMaterial = redMaterial;
-                bbox.RotationHandles.HandleMaterial = redMaterial;
+                boundsControl.ScaleHandlesConfiguration.HandleMaterial = redMaterial;
+                boundsControl.RotationHandles.HandleMaterial = redMaterial;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BBox material cyan");
                 Debug.Assert(cyanMaterial != null);
-                bbox.BoxDisplayConfiguration.BoxMaterial = cyanMaterial;
+                boundsControl.BoxDisplayConfiguration.BoxMaterial = cyanMaterial;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BBox grabbed material red");
-                bbox.BoxDisplayConfiguration.BoxGrabbedMaterial = redMaterial;
-                mh.OnManipulationStarted.AddListener((med) => bbox.HighlightWires());
-                mh.OnManipulationEnded.AddListener((med) => bbox.UnhighlightWires());
+                boundsControl.BoxDisplayConfiguration.BoxGrabbedMaterial = redMaterial;
+                mh.OnManipulationStarted.AddListener((med) => boundsControl.HighlightWires());
+                mh.OnManipulationEnded.AddListener((med) => boundsControl.UnhighlightWires());
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BBox material none");
-                bbox.BoxDisplayConfiguration.BoxMaterial = null;
+                boundsControl.BoxDisplayConfiguration.BoxMaterial = null;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Scale X and update rig");
                 cube.transform.localScale = new Vector3(2, 1, 1);
-                bbox.CreateRig();
+                boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Rotate 20 degrees and update rig");
                 cube.transform.localRotation = Quaternion.Euler(0, 20, 0);
-                bbox.RotationHandles.ShowRotationHandleForY = true;
-                bbox.CreateRig();
+                boundsControl.RotationHandles.ShowRotationHandleForY = true;
+                boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Wireframe radius 0.1");
-                bbox.LinksConfiguration.WireframeEdgeRadius = 0.1f;
+                boundsControl.LinksConfiguration.WireframeEdgeRadius = 0.1f;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Wireframe shape cylinder");
-                bbox.LinksConfiguration.WireframeShape = Toolkit.Experimental.UI.BoundsControlTypes.WireframeType.Cylindrical;
+                boundsControl.LinksConfiguration.WireframeShape = Toolkit.Experimental.UI.BoundsControlTypes.WireframeType.Cylindrical;
                 yield return WaitForSpeechCommand();
 
                 Destroy(cube);
@@ -198,10 +198,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                     lastParent = cubechild.transform;
                 }
 
-                bbox = multiRoot.AddComponent<BoundsControl>();
-                bbox.BoundsControlActivation = Toolkit.Experimental.UI.BoundsControlTypes.BoundsControlActivationType.ActivateOnStart;
-                bbox.HideElementsInInspector = false;
-                bbox.LinksConfiguration.WireframeEdgeRadius = .05f;
+                boundsControl = multiRoot.AddComponent<BoundsControl>();
+                boundsControl.BoundsControlActivation = Toolkit.Experimental.UI.BoundsControlTypes.BoundsControlActivationType.ActivateOnStart;
+                boundsControl.HideElementsInInspector = false;
+                boundsControl.LinksConfiguration.WireframeEdgeRadius = .05f;
                 multiRoot.AddComponent<ManipulationHandler>();
 
                 SetStatus("Randomize Child Scale for skewing");
@@ -217,8 +217,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                     childTransform.transform.localScale = new Vector3(baseScale * Random.Range(.5f, 2f), baseScale * Random.Range(.5f, 2f), baseScale * Random.Range(.5f, 2f));
                 }
 
-                bbox.LinksConfiguration.WireframeEdgeRadius = 1f;
-                bbox.CreateRig();
+                boundsControl.LinksConfiguration.WireframeEdgeRadius = 1f;
+                boundsControl.CreateRig();
                 SetStatus("Delete GameObject");
                 yield return WaitForSpeechCommand();
 

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -178,6 +178,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 flattenedHandles = new int[] { 9, 10, 8, 11 };
             }
+            else
+            {
+                flattenedHandles = null;
+            }
         }
 
         [SerializeField]

--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -26,7 +26,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         private List<Link> links = new List<Link>();
-        private List<Renderer> linkRenderers = new List<Renderer>();
 
         private LinksConfiguration config;
 
@@ -63,11 +62,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             if (links != null)
             {
-                for (int i = 0; i < linkRenderers.Count; ++i)
+                for (int i = 0; i < links.Count; ++i)
                 {
-                    if (linkRenderers[i] != null)
+                    Renderer linkRenderer = links[i].transform.gameObject.GetComponent<Renderer>();
+                    if (linkRenderer != null)
                     {
-                        linkRenderers[i].enabled = isVisible;
+                        linkRenderer.enabled = isVisible;
                     }
                 }
             }
@@ -122,11 +122,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void Flatten(ref int[] flattenedHandles)
         {
-            if (flattenedHandles != null && linkRenderers != null)
+            if (flattenedHandles != null)
             {
                 for (int i = 0; i < flattenedHandles.Length; ++i)
                 {
-                    linkRenderers[flattenedHandles[i]].enabled = false;
+                    Renderer linkRenderer = links[flattenedHandles[i]].transform.gameObject.GetComponent<Renderer>();
+                    if (linkRenderer)
+                    {
+                        linkRenderer.enabled = false;
+                    }
                 }
             }
         }
@@ -173,7 +177,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     link.transform.position = rotationHandles.GetEdgeCenter(i);
                     link.transform.parent = parent;
                     Renderer linkRenderer = link.GetComponent<Renderer>();
-                    linkRenderers.Add(linkRenderer);
 
                     if (config.WireframeMaterial != null)
                     {


### PR DESCRIPTION
## Overview
Runtime example demonstrates various runtime configurations / features of bounds control. This was carried over from BoundingBox but wasn't fully functional.

Change includes:
- Patching up scene to use the BoundsControl scripts
- Replacing all occurrences of BoundingBox with BoundsControl
- Fixed a bug when switching from a flattened state into a non flattened one
- Removed unnecessary caching of renderer components in BoundsControl links which introduces another possible source of error rather than bringing us a performance win (the renderers are just used for changing the visibility flag or when changing the flatten mode)


This change has to go in after #7096 has been merged

## Changes
- Fixes: #6926 

