### PR TITLE
Overlapping pressable buttons fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -156,11 +156,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         ///</summary>
         public bool IsTouching
         {
-            get
-            {
-                return isTouching;
-            }
-
+            get => isTouching;
             private set
             {
                 if (value != isTouching)
@@ -189,18 +185,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public bool IsPressing { get; private set; }
 
-
         /// <summary>
         /// Transform for local to world space in the world direction of a press
         /// Multiply local scale positions by this value to convert to world space
         /// </summary>
-        public float LocalToWorldScale
-        {
-            get
-            {
-                return 1.0f / WorldToLocalScale;
-            }
-        }
+        public float LocalToWorldScale => 1.0f / WorldToLocalScale;
 
         /// <summary>
         /// The press direction of the button as defined by a NearInteractionTouchableSurface.
@@ -221,20 +210,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private Transform PushSpaceSourceTransform
         {
-            get { return movingButtonVisuals != null ? movingButtonVisuals.transform : transform; }
+            get => movingButtonVisuals != null ? movingButtonVisuals.transform : transform; 
         }
 
         /// <summary>
         /// Transform for world to local space in the world direction of press
         /// Multiply world scale positions by this value to convert to local space
         /// </summary>
-        private float WorldToLocalScale
-        {
-            get
-            {
-                return transform.InverseTransformVector(WorldSpacePressDirection).magnitude;
-            }
-        }
+        private float WorldToLocalScale => transform.InverseTransformVector(WorldSpacePressDirection).magnitude;
         
         /// <summary>
         /// Initial offset from moving visuals to button
@@ -421,7 +404,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (touchPoints.ContainsKey(eventData.Controller))
             {
-                // Giving a last chance to check if pressed ocurred before another Near interaction becomes the closest to pointer
+                // When focus is lost, before removing controller, update the respective touch point to give a last chance for checking if pressed occurred 
                 touchPoints[eventData.Controller] = eventData.InputData;
                 UpdateTouch();
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -82,15 +82,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </summary>
         private IEnumerator PressButtonWithHand()
         {
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
             Vector3 p1 = new Vector3(0, 0, 0.5f);
             Vector3 p2 = new Vector3(0, 0, 1.08f);
             Vector3 p3 = new Vector3(0.1f, 0, 1.08f);
 
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.Open, p1);
-            yield return PlayModeTestUtilities.MoveHand(p1, p2, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHand(p2, p3, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(p1);
+            yield return hand.MoveTo(p2);
+            yield return hand.MoveTo(p3);
         }
 
         #endregion
@@ -282,14 +281,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             });
 
             // move the hand quickly from very far distance into the button and check if it was pressed
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+            TestHand hand = new TestHand(Handedness.Right);
             int numSteps = 2;
             Vector3 p1 = new Vector3(0, 0, -20.0f);
             Vector3 p2 = new Vector3(0, 0, 0.02f);
 
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHand(p1, p2, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService, numSteps);
-            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
+            yield return hand.Show(p1);
+            yield return hand.MoveTo(p2, numSteps);
 
             Assert.IsTrue(buttonPressed, "Button did not get pressed when hand moved to press it.");
 
@@ -326,15 +324,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             });
 
             // Move the hand so the pointer passes through the two buttons 
-            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+            TestHand hand = new TestHand(Handedness.Right);
             float handReach = 0.1f;
             int numSteps = (int)Mathf.Ceil(handReach / (distance * 0.5f)); // Maximum hand speed in order to trigger touch started in the first button before the second button becomes the closest touchable to pointer
-            Vector3 p1 = new Vector3(0, 0, -handReach/2);
-            Vector3 p2 = new Vector3(0, 0, handReach/2);
 
-            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
-            yield return PlayModeTestUtilities.MoveHand(p1, p2, ArticulatedHandPose.GestureId.Open, Handedness.Right, inputSimulationService, numSteps);
-            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
+            yield return hand.Show(new Vector3(0, 0, -handReach / 2));
+            yield return hand.Move(new Vector3(0,0, handReach), numSteps);
 
             Assert.IsTrue(buttonPressed, "Button did not get pressed when a second button is nearby");
 
@@ -678,7 +673,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var method = typeof(PressableButton).GetMethod("UpdateMovingVisualsPosition", BindingFlags.NonPublic | BindingFlags.Instance);
             method.Invoke(button, System.Array.Empty<object>());
         }
-
 
         /// <summary>
         /// Tests if Interactable is internally disabled, then the PhysicalPressEventRouter


### PR DESCRIPTION
## Overview
PressableButton does not trigger the ButtonPressed event when OnTouchCompleted is triggered by pointer getting closer to another NearInteractionTouchable

## Expected Behavior
When a second pressable button is slightly overlapping with the back of a pressable button, ButtonPressed event trigger should be guaranteed if the following happens:

- Poke Pointer moves from the front of Button 1
- Poke Pointer touches Button 1 triggering OnTouchStarted
- Second button becomes the closest touchable to pointer in the same frame as pointer passes first button pressed plane or after
- ButtonPressed event is triggered

![pb_overlap_fix](https://user-images.githubusercontent.com/16922045/73000232-7443b700-3df8-11ea-8e4b-a7638ff596f9.png)

## Changes
Checking button state whenever OnTouchComplete is called to avoid missing a press when a second NearInteractionTouchable is closer to the pointer than the button
- Fixes: #6968


## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
