### PR TITLE
Add nuget docs to TOC and polish

### DIFF
--- a/Documentation/MRTKNuGetPackage.md
+++ b/Documentation/MRTKNuGetPackage.md
@@ -1,20 +1,21 @@
 # Mixed Reality Toolkit NuGet package
 
-Mixed Reality Toolkit (MRTK) is now available as a NuGet package on NuGet.org. There are some differences when it comes to consuming NuGet version of MRTK as opposed to a .unitypackage, read **NuGet Package Considerations** below. If any issues are encountered, file an issue using this [template](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/new?assignees=&labels=Bug,Package%20Management%20-%20NuGet&template=bug-report.md&title=).
+Mixed Reality Toolkit (MRTK) is now available as a NuGet package on NuGet.org. There are some differences when it comes to consuming NuGet version of MRTK as opposed to a .unitypackage, read [NuGet Package Considerations](#nuget-package-considerations) below. If any issues are encountered, file an issue using this [template](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/new?assignees=&labels=Bug,Package%20Management%20-%20NuGet&template=bug-report.md&title=).
 
-**Note:** Migration of existing projects to consume MRTK as a NuGet package is not yet supported, use MRTK via NuGet only for new projects.
+> [!NOTE]
+> Migration of existing projects to consume MRTK as a NuGet package is not yet supported, use MRTK via NuGet only for new projects.
 
 ## Installing the NuGet package
 
 Follow these instructions to add the Mixed Reality Toolkit as a NuGet package to your project.
 
 1. Download the latest [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity/releases/latest) .unitypackage.
-    1. If you already have NuGetForUnity installed, please ensure you're using version 2.0.0 or newer.
-1. Import the package into your Unity project, [instructions](https://docs.unity3d.com/Manual/AssetPackages.html).
-1. In the Unity menu bar, click on **NuGet > Manage NuGet Packages**.
+    1. If *NuGetForUnity* is already installed, please ensure it is version **2.0.0 or newer**.
+1. Import the package into the Unity project, [instructions](https://docs.unity3d.com/Manual/AssetPackages.html).
+1. In the Unity menu bar, click on **NuGet** > **Manage NuGet Packages**.
 
     ![Manage NuGet Packages](Images/NuGet/ManageNuGetPackages.png)
-1. In the Search box, enter `Microsoft.MixedReality.Toolkit`.
+1. In the Search box, enter **Microsoft.MixedReality.Toolkit**.
 
     ![Manage NuGet Packages](Images/NuGet/SearchBox.png)
 1. Choose the MRTK core package:
@@ -26,9 +27,9 @@ Follow these instructions to add the Mixed Reality Toolkit as a NuGet package to
 
 ### Updating MRTK NuGet packages
 
-Steps 1-2 above will only need to be done once for your project, and the update is a much simpler step. Once newer packages available on NuGet.org (including prerelease), follow these steps:
+Steps 1-2 above will only need to be done once for the project, and the update is a much simpler step. Once newer packages are available on NuGet.org (including prerelease), follow these steps:
 
-1. In the Unity menu bar, click on NuGet > Manage NuGet Packages.
+1. In the Unity menu bar, click on **NuGet** > **Manage NuGet Packages**
 1. Switch to the **Updates** tab.
     - Check the **Show prerelease** box if you want to get latest prerelease version.
 1. Update the packages desired.
@@ -41,7 +42,8 @@ The release of MRTK as NuGet package is a new delivery mechanism being explored 
 
 NuGet package consists of compiled binaries as opposed to loose script files, and the C# script asset identifiers are different. As such, the assets like prefabs in the MRTK package have been updated to reference the appropriate compiled script. A project using the .unitypackage or source version of MRTK will have to re-target its assets as well, and although there is code for it this is not a supported scenario, yet.
 
-*Thereby, there is no currently supported way of migrating to NuGet from .unitypackage or source. This will change as we continue development on this delivery mechanism.*
+> [!IMPORTANT]
+> There is no currently supported way of migrating to NuGet from .unitypackage or source. This will change as we continue development on this delivery mechanism.
 
 ### Compiled binaries (NuGet) vs source files (.unitypackage)
 
@@ -62,9 +64,9 @@ With the latest source from MRTK, you can build the NuGet package locally and co
 1. Execute the `scripts\packaging\createnugetpackages.ps1` powershell script.
     - Specify the `-UnityDirectory` flag by passing the Editor folder of your Unity installation
     - Specify the `-Version` of the package to create, in x.x.x format. **Make sure the version is higher than available on NuGet.org**
-    - **Example:** `.\createnugetpackages.ps1 -UnityDirectory "C:\Program Files\Unity\Hub\Editor\2018.3\Editor" -Version 2.0.2`
+    - **Example:** `.\createnugetpackages.ps1 -UnityDirectory "C:\Program Files\Unity\Hub\Editor\2018.4.14f1\Editor" -Version 2.3.2`
 1. After the build succeeds, open the destination project with NuGet packages.
-    - Click on the menu **Edit > Preferences...**
+    - Click on the menu **Edit** > **Preferences...**
 
         ![Edit Preferences Menu Item](Images/NuGet/ProjectPreferences.png)
     - On the left, find **NuGet for Unity** tab.
@@ -77,7 +79,7 @@ With the latest source from MRTK, you can build the NuGet package locally and co
 
         ![Edit Preferences Menu Item](Images/NuGet/SaveNewSource.png)
 1. If this your first time building, or the version was incremented, follow the update process:
-    1. In the Unity menu bar, click on **NuGet > Manage NuGet Packages**.
+    1. In the Unity menu bar, click on **NuGet** > **Manage NuGet Packages**.
 
         ![Manage NuGet Packages](Images/NuGet/ManageNuGetPackages.png)
     1. Switch to the **Updates** tab.
@@ -85,3 +87,8 @@ With the latest source from MRTK, you can build the NuGet package locally and co
         ![Manage NuGet Packages](Images/NuGet/UpdatesTab.png)
     1. Update the packages to the version you just built desired.
 1. Otherwise, just delete the `Assets\Packages` folder and let NuGetForUnity restore the packages.
+
+## See also
+
+- [Building and Deploying MRTK](BuildAndDeploy.md)
+- [MRTK Package Contents](MRTK_PackageContents.md)

--- a/Documentation/MRTK_PackageContents.md
+++ b/Documentation/MRTK_PackageContents.md
@@ -96,4 +96,5 @@ The optional Microsoft.MixedRealityToolkit.Unity.Examples package includes demon
 
 ## See also
 
-[Getting Started with the MRTK](GettingStartedWithTheMRTK.md)
+- [Getting Started with the MRTK](GettingStartedWithTheMRTK.md)
+- [NuGet Packaging](MRTKNuGetPackage.md)

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -26,9 +26,9 @@ The following software is required.
 - [Windows 10 SDK](https://developer.microsoft.com/windows/downloads/windows-10-sdk) 18362 or later (installed by the Visual Studio Installer)
 - [Unity](https://unity3d.com/get-unity/download) 2018.4 LTS or 2019 (2019.3 recommended)
 
-NuGet requirements
+**NuGet requirements**
 
-If importing the Mixed Reality Toolkit NuGet packages, the following software is recommended.
+If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), the following software is recommended.
 
 - [NuGet for Unity 2.0.0 or newer](https://github.com/GlitchEnzo/NuGetForUnity/releases/latest)
 
@@ -62,9 +62,9 @@ The following software is required.
 - [Windows 10 SDK](https://developer.microsoft.com/windows/downloads/windows-10-sdk) 18362 or later (installed by the Visual Studio Installer)
 - [Unity](https://unity3d.com/get-unity/download) 2018.4 LTS, 2019.1 or 2019.2
 
-NuGet requirements
+**NuGet requirements**
 
-If importing the Mixed Reality Toolkit NuGet packages, the following software is recommended.
+If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), the following software is recommended.
 
 - [NuGet for Unity 2.0.0 or newer](https://github.com/GlitchEnzo/NuGetForUnity/releases/latest)
 
@@ -108,7 +108,7 @@ For the smoothest upgrade path, please use the following steps.
 
 **Updating from NuGet**
 
-If your project was created using the Mixed Reality Toolkit NuGet packages, please use the following steps.
+If your project was created using the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), please use the following steps.
 
 1. Select **NuGet > Manage NuGet Packages**
 1. Select the **Online** tab and click **Refresh**
@@ -359,9 +359,9 @@ The following software is required.
 - Windows 10 SDK 18362 or later (installed by the Visual Studio Installer)
 - Unity 2018.4, 2019.1 or 2019.2
 
-NuGet requirements
+**NuGet requirements**
 
-If importing the Mixed Reality Toolkit's NuGet packages, the following software is recommended.
+If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), the following software is recommended..
 
 - [NuGet for Unity](https://github.com/GlitchEnzo/NuGetForUnity)
 

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -11,6 +11,8 @@
     href: HTKToMRTKPortingGuide.md
   - name: Building and Deploying MRTK
     href: BuildAndDeploy.md
+  - name: NuGet Packages
+    href: MRTKNuGetPackage.md
   - name: Performance
     href: Performance/PerfGettingStarted.md
   - name: Hologram Stabilization


### PR DESCRIPTION
## Overview
The documentation page for nuget packaging with MRTK is not in the TOC and thus makes it more difficult to find.

[MRTK Nuget packages](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MRTKNuGetPackage.html)

This change also cleans up some polish for the MRTK nuget doc page. Furthermore, add some see also links to related articles in the "Getting started with MRTK" section.

## Changes
- Fixes: #7129 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
