### PR TITLE
Mac fix: Remove hardcoded '\' in GetPackageCache

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/FileUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/FileUtilities.cs
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </returns>
         public static DirectoryInfo GetPackageCache()
         {
-            const string packageCacheFolderName = @"Library\PackageCache";
+            string packageCacheFolderName = Path.Combine("Library", "PackageCache");
 
             DirectoryInfo projectRoot = new DirectoryInfo(Application.dataPath).Parent;
             return new DirectoryInfo(Path.Combine(projectRoot.FullName, packageCacheFolderName));


### PR DESCRIPTION
This change fixes a \ vs / path separator issue that was reported by @julenka when using MRTK on a Mac as part of #7109 

This is a companion change to #7122 
