### PR TITLE
Mac fix: remove another hardcoded '\' when creating mrtk auth-generated

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -421,13 +421,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             if (generatedDirs == null || !generatedDirs.Any())
             {
                 string parentFolderPath = Directory.GetParent(folderPath).FullName;
-                string generatedFolderPath = parentFolderPath + "\\" + "MixedRealityToolkit.Generated";
+                string generatedFolderPath = Path.Combine(parentFolderPath, "MixedRealityToolkit.Generated");
                 if (!Directory.Exists(generatedFolderPath))
                 {
                     Directory.CreateDirectory(generatedFolderPath);
                 }
 
-                string generatedSentinelFilePath = generatedFolderPath + "\\" + "MRTK.Generated.sentinel";
+                string generatedSentinelFilePath = Path.Combine(generatedFolderPath, "MRTK.Generated.sentinel");
                 if (!File.Exists(generatedSentinelFilePath))
                 {
                     // Make sure we create and dispose/close the filestream just created


### PR DESCRIPTION
## Overview
Removes another hardcoded "\\" in file path when creating the MRTK autogenerated "Generated" folder used in MRTK's project preferences.

## Changes
- Fixes: #7109

Needs to be tested on Windows, fix verified only on Mac.

## Notes
I found a list of other potential hard coded strings we may want to fix in a follow-up:

```
$ find . -name *.cs -exec grep --with-filename -F '"\\"' {} \;
./MixedRealityToolkit.Examples/Demos/EyeTracking/General/Scripts/Utils/Utils.cs:                    goName = g.parent.name + "\\" + goName;
./MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/BasicInputLogger.cs:                    string fullPath = logRootFolder.Path + "\\" + LogDirectory;
./MixedRealityToolkit.Examples/Demos/EyeTracking/DemoVisualizer/Scripts/BasicInputLogger.cs:                    string fullPath = logRootFolder.Path + "\\" + LogDirectory;
./MixedRealityToolkit.Examples/Demos/Gltf/Scripts/TestGltfLoading.cs:            path = path.Replace("/", "\\");
./MixedRealityToolkit.Examples/Demos/Gltf/Scripts/Editor/TestGltfLoadingEditor.cs:            path = path.Replace("/", "\\");
./MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs:            int nameStart = uri.Replace("\\", "/").LastIndexOf("/", StringComparison.Ordinal) + 1;
./MixedRealityToolkit/Utilities/Gltf/Serialization/Importers/GltfEditorImporter.cs:                        path = path.Replace("\\", "/").Replace(Application.dataPath, "Assets");
./MixedRealityToolkit/Utilities/Gltf/Serialization/ConstructGltf.cs:                    var projectPath = path.Replace("\\", "/");
./MixedRealityToolkit/Inspectors/PropertyDrawers/ScenePickPropertyDrawer.cs:                    Options[i + 1] = new GUIContent(scenes[i].path.Replace("/", "\\"));
./MixedRealityToolkit.Tools/MSBuild/Scripts/CSProjectInfo.cs:                    { "<!--UNITY_EDITOR_INSTALL_FOLDER-->", Path.GetDirectoryName(EditorApplication.applicationPath) + "\\"},
./MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs:            if (!thisAbsolute.EndsWith("\\"))
./MixedRealityToolkit.Tools/MSBuild/Scripts/Utilities.cs:                thisAbsolute = thisAbsolute + "\\";
./MixedRealityToolkit.Tools/BuildWindow/BuildDeployWindow.cs:                            int lastBackslashIndex = fullBuildLocation.LastIndexOf("\\", StringComparison.Ordinal);
```

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
