### PR TITLE
[GLTF-Import] Files get ignored, when File ending is not lower case

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 
             if (useBackgroundThread) { await BackgroundThread; }
 
-            if (uri.ToLower().EndsWith(".gltf"))
+            if (uri.EndsWith(".gltf", StringComparison.OrdinalIgnoreCase))
             {
                 string gltfJson = File.ReadAllText(uri);
 
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                     return null;
                 }
             }
-            else if (uri.ToLower().EndsWith(".glb"))
+            else if (uri.EndsWith(".glb", StringComparison.OrdinalIgnoreCase))
             {
                 byte[] glbData;
 

--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 
             if (useBackgroundThread) { await BackgroundThread; }
 
-            if (uri.EndsWith(".gltf"))
+            if (uri.ToLower().EndsWith(".gltf"))
             {
                 string gltfJson = File.ReadAllText(uri);
 
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                     return null;
                 }
             }
-            else if (uri.EndsWith(".glb"))
+            else if (uri.ToLower().EndsWith(".glb"))
             {
                 byte[] glbData;
 


### PR DESCRIPTION
## Overview
When trying to import GLTF or GLB files with upper case File ending f.e. "Video camera.GLB" the GlbAssetImporter Script get's triggerd but inside GltfEditorImporter.OnImportGltfAsset the file get's ignored because the file ending is not lower case.