### PR TITLE
Refactor out shared WMR articulated hand definition

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+#if WINDOWS_UWP
+using Windows.Perception.People;
+using Windows.UI.Input.Spatial;
+#endif // WINDOWS_UWP
+
+namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
+{
+    public class WindowsMixedRealityArticulatedHandDefinition
+    {
+        public WindowsMixedRealityArticulatedHandDefinition(IMixedRealityInputSource source, Handedness handedness)
+        {
+            inputSource = source;
+            this.handedness = handedness;
+        }
+
+        private readonly IMixedRealityInputSource inputSource;
+        private readonly Handedness handedness;
+        private readonly float cursorBeamBackwardTolerance = 0.5f;
+        private readonly float cursorBeamUpTolerance = 0.8f;
+
+        private Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
+        private MixedRealityPose currentIndexPose = MixedRealityPose.ZeroIdentity;
+
+        /// <summary>
+        /// The Windows Mixed Reality articulated hands default interactions.
+        /// </summary>
+        /// <remarks>A single interaction mapping works for both left and right articulated hands.</remarks>
+        public MixedRealityInteractionMapping[] DefaultInteractions => new[]
+        {
+            new MixedRealityInteractionMapping(0, "Spatial Pointer", AxisType.SixDof, DeviceInputType.SpatialPointer),
+            new MixedRealityInteractionMapping(1, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip),
+            new MixedRealityInteractionMapping(2, "Select", AxisType.Digital, DeviceInputType.Select),
+            new MixedRealityInteractionMapping(3, "Grab", AxisType.SingleAxis, DeviceInputType.TriggerPress),
+            new MixedRealityInteractionMapping(4, "Index Finger Pose", AxisType.SixDof, DeviceInputType.IndexFinger)
+        };
+
+        /// <summary>
+        /// Calculates whether the current pose allows for pointing/distant interactions.
+        /// </summary>
+        public bool IsInPointingPose
+        {
+            get
+            {
+                MixedRealityPose palmJoint;
+                if (unityJointPoses.TryGetValue(TrackedHandJoint.Palm, out palmJoint))
+                {
+                    Vector3 palmNormal = palmJoint.Rotation * (-1 * Vector3.up);
+                    if (cursorBeamBackwardTolerance >= 0)
+                    {
+                        Vector3 cameraBackward = -CameraCache.Main.transform.forward;
+                        if (Vector3.Dot(palmNormal.normalized, cameraBackward) > cursorBeamBackwardTolerance)
+                        {
+                            return false;
+                        }
+                    }
+                    if (cursorBeamUpTolerance >= 0)
+                    {
+                        if (Vector3.Dot(palmNormal, Vector3.up) > cursorBeamUpTolerance)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+        public void UpdateHandJoints(Dictionary<TrackedHandJoint, MixedRealityPose> jointPoses)
+        {
+            unityJointPoses = jointPoses;
+            CoreServices.InputSystem?.RaiseHandJointsUpdated(inputSource, handedness, unityJointPoses);
+        }
+
+        public void UpdateCurrentIndexPose(MixedRealityInteractionMapping interactionMapping)
+        {
+            if (unityJointPoses.TryGetValue(TrackedHandJoint.IndexTip, out currentIndexPose))
+            {
+                // Update the interaction data source
+                interactionMapping.PoseData = currentIndexPose;
+
+                // If our value changed raise it
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    CoreServices.InputSystem?.RaisePoseInputChanged(inputSource, handedness, interactionMapping.MixedRealityInputAction, currentIndexPose);
+                }
+            }
+        }
+
+#if WINDOWS_UWP
+        private Vector2[] handMeshUVs = null;
+        private HandMeshObserver handMeshObserver = null;
+        private int[] handMeshTriangleIndices = null;
+        private bool hasRequestedHandMeshObserver = false;
+
+        private async void SetHandMeshObserver(SpatialInteractionSourceState sourceState)
+        {
+            handMeshObserver = await sourceState.Source.TryCreateHandMeshObserverAsync();
+        }
+
+        private void InitializeUVs(Vector3[] neutralPoseVertices)
+        {
+            if (neutralPoseVertices.Length == 0)
+            {
+                Debug.LogError("Loaded 0 verts for neutralPoseVertices");
+            }
+
+            float minY = neutralPoseVertices[0].y;
+            float maxY = minY;
+
+            for (int ix = 1; ix < neutralPoseVertices.Length; ix++)
+            {
+                Vector3 p = neutralPoseVertices[ix];
+
+                if (p.y < minY)
+                {
+                    minY = p.y;
+                }
+                else if (p.y > maxY)
+                {
+                    maxY = p.y;
+                }
+            }
+
+            float scale = 1.0f / (maxY - minY);
+
+            handMeshUVs = new Vector2[neutralPoseVertices.Length];
+
+            for (int ix = 0; ix < neutralPoseVertices.Length; ix++)
+            {
+                Vector3 p = neutralPoseVertices[ix];
+
+                handMeshUVs[ix] = new Vector2(p.x * scale + 0.5f, (p.y - minY) * scale);
+            }
+        }
+
+        public void UpdateHandMesh(SpatialInteractionSourceState sourceState)
+        {
+            MixedRealityHandTrackingProfile handTrackingProfile = null;
+            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+            if (inputSystemProfile != null)
+            {
+                handTrackingProfile = inputSystemProfile.HandTrackingProfile;
+            }
+
+            if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
+            {
+                // If hand mesh visualization is disabled make sure to destroy our hand mesh observer if it has already been created
+                if (handMeshObserver != null)
+                {
+                    // Notify that hand mesh has been updated (cleared)
+                    HandMeshInfo handMeshInfo = new HandMeshInfo();
+                    CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                    hasRequestedHandMeshObserver = false;
+                    handMeshObserver = null;
+                }
+                return;
+            }
+
+            HandPose handPose = sourceState.TryGetHandPose();
+
+            // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
+            if (handMeshObserver == null && !hasRequestedHandMeshObserver)
+            {
+                SetHandMeshObserver(sourceState);
+                hasRequestedHandMeshObserver = true;
+            }
+
+            if (handMeshObserver != null && handMeshTriangleIndices == null)
+            {
+                uint indexCount = handMeshObserver.TriangleIndexCount;
+                ushort[] indices = new ushort[indexCount];
+                handMeshObserver.GetTriangleIndices(indices);
+                handMeshTriangleIndices = new int[indexCount];
+                Array.Copy(indices, handMeshTriangleIndices, (int)handMeshObserver.TriangleIndexCount);
+
+                // Compute neutral pose
+                Vector3[] neutralPoseVertices = new Vector3[handMeshObserver.VertexCount];
+                HandPose neutralPose = handMeshObserver.NeutralPose;
+                var vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
+                HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
+                handMeshVertexState.GetVertices(vertexAndNormals);
+
+                for (int i = 0; i < handMeshObserver.VertexCount; i++)
+                {
+                    neutralPoseVertices[i] = vertexAndNormals[i].Position.ToUnityVector3();
+                }
+
+                // Compute UV mapping
+                InitializeUVs(neutralPoseVertices);
+            }
+
+            if (handPose != null && handMeshObserver != null && handMeshTriangleIndices != null)
+            {
+                var vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
+                var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
+                handMeshVertexState.GetVertices(vertexAndNormals);
+
+                var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);
+                if (meshTransform.HasValue)
+                {
+                    System.Numerics.Vector3 scale;
+                    System.Numerics.Quaternion rotation;
+                    System.Numerics.Vector3 translation;
+                    System.Numerics.Matrix4x4.Decompose(meshTransform.Value, out scale, out rotation, out translation);
+
+                    var handMeshVertices = new Vector3[handMeshObserver.VertexCount];
+                    var handMeshNormals = new Vector3[handMeshObserver.VertexCount];
+
+                    for (int i = 0; i < handMeshObserver.VertexCount; i++)
+                    {
+                        handMeshVertices[i] = vertexAndNormals[i].Position.ToUnityVector3();
+                        handMeshNormals[i] = vertexAndNormals[i].Normal.ToUnityVector3();
+                    }
+
+                    HandMeshInfo handMeshInfo = new HandMeshInfo
+                    {
+                        vertices = handMeshVertices,
+                        normals = handMeshNormals,
+                        triangles = handMeshTriangleIndices,
+                        uvs = handMeshUVs,
+                        position = translation.ToUnityVector3(),
+                        rotation = rotation.ToUnityQuaternion()
+                    };
+
+                    CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                }
+            }
+        }
+#endif // WINDOWS_UWP
+    }
+}

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs.meta
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ed31dfb20949274d9033b9ca0a7bb3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityArticulatedHand.cs
@@ -40,6 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public WindowsMixedRealityArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
+            handDefinition = new WindowsMixedRealityArticulatedHandDefinition(inputSource, controllerHandedness);
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             articulatedHandApiAvailable = ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.SpatialInteractionSourceState", "TryGetHandPose");
 #endif
@@ -49,62 +50,23 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// The Windows Mixed Reality articulated hands default interactions.
         /// </summary>
         /// <remarks>A single interaction mapping works for both left and right articulated hands.</remarks>
-        public override MixedRealityInteractionMapping[] DefaultInteractions => new[]
-        {
-            new MixedRealityInteractionMapping(0, "Spatial Pointer", AxisType.SixDof, DeviceInputType.SpatialPointer),
-            new MixedRealityInteractionMapping(1, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip),
-            new MixedRealityInteractionMapping(2, "Select", AxisType.Digital, DeviceInputType.Select),
-            new MixedRealityInteractionMapping(3, "Grab", AxisType.SingleAxis, DeviceInputType.TriggerPress),
-            new MixedRealityInteractionMapping(4, "Index Finger Pose", AxisType.SixDof, DeviceInputType.IndexFinger)
-        };
+        public override MixedRealityInteractionMapping[] DefaultInteractions => handDefinition?.DefaultInteractions;
+
+        private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
+        private readonly WindowsMixedRealityArticulatedHandDefinition handDefinition;
 
         #region IMixedRealityHand Implementation
 
         /// <inheritdoc/>
-        public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose)
-        {
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-            return unityJointPoses.TryGetValue(joint, out pose);
-#else
-            pose = MixedRealityPose.ZeroIdentity;
-            return false;
-#endif
-        }
+        public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => unityJointPoses.TryGetValue(joint, out pose);
 
         #endregion IMixedRealityHand Implementation
 
         /// <inheritdoc/>
-        public override bool IsInPointingPose
-        {
-            get
-            {
-                bool valid = true;
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-                Vector3 palmNormal = unityJointOrientations[(int)HandJointKind.Palm] * (-1 * Vector3.up);
-                if (CursorBeamBackwardTolerance >= 0)
-                {
-                    Vector3 cameraBackward = -CameraCache.Main.transform.forward;
-                    if (Vector3.Dot(palmNormal.normalized, cameraBackward) > CursorBeamBackwardTolerance)
-                    {
-                        valid = false;
-                    }
-                }
-                if (valid && CursorBeamUpTolerance >= 0)
-                {
-                    if (Vector3.Dot(palmNormal, Vector3.up) > CursorBeamUpTolerance)
-                    {
-                        valid = false;
-                    }
-                }
-#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-                return valid;
-            }
-        }
+        public override bool IsInPointingPose => handDefinition.IsInPointingPose;
 
 #if UNITY_WSA
 #if WINDOWS_UWP || DOTNETWINRT_PRESENT
-        private MixedRealityPose currentIndexPose = MixedRealityPose.ZeroIdentity;
-
         private SpatialInteractionManager spatialInteractionManager = null;
         private SpatialInteractionManager SpatialInteractionManager
         {
@@ -122,25 +84,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
         }
 
-#if WINDOWS_UWP
-        private HandMeshObserver handMeshObserver = null;
-        private int[] handMeshTriangleIndices = null;
-        private bool hasRequestedHandMeshObserver = false;
-        private Vector2[] handMeshUVs;
-#endif // WINDOWS_UWP
-
-        private readonly float CursorBeamBackwardTolerance = 0.5f;
-        private readonly float CursorBeamUpTolerance = 0.8f;
-
         private readonly bool articulatedHandApiAvailable = false;
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 
         #region Update data functions
 
-        /// <summary>
-        /// Update the controller data from the provided platform state
-        /// </summary>
-        /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform</param>
+        /// <inheritdoc />
         public override void UpdateController(InteractionSourceState interactionSourceState)
         {
             if (!Enabled) { return; }
@@ -154,54 +103,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 switch (Interactions[i].InputType)
                 {
                     case DeviceInputType.IndexFinger:
-                        UpdateIndexFingerData(interactionSourceState, Interactions[i]);
+                        handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
                         break;
                 }
             }
         }
-
-#if WINDOWS_UWP
-        protected void InitializeUVs(Vector3[] neutralPoseVertices)
-        {
-            if (neutralPoseVertices.Length == 0)
-            {
-                Debug.LogError("Loaded 0 verts for neutralPoseVertices");
-            }
-
-            float minY = neutralPoseVertices[0].y;
-            float maxY = minY;
-
-            for (int ix = 1; ix < neutralPoseVertices.Length; ix++)
-            {
-                Vector3 p = neutralPoseVertices[ix];
-
-                if (p.y < minY)
-                {
-                    minY = p.y;
-                }
-                else if (p.y > maxY)
-                {
-                    maxY = p.y;
-                }
-            }
-
-            float scale = 1.0f / (maxY - minY);
-
-            handMeshUVs = new Vector2[neutralPoseVertices.Length];
-
-            for (int ix = 0; ix < neutralPoseVertices.Length; ix++)
-            {
-                Vector3 p = neutralPoseVertices[ix];
-
-                handMeshUVs[ix] = new Vector2(p.x * scale + 0.5f, (p.y - minY) * scale);
-            }
-        }
-
-        private async void SetHandMeshObserver(SpatialInteractionSourceState sourceState)
-        {
-            handMeshObserver = await sourceState.Source.TryCreateHandMeshObserverAsync();
-        }
-#endif // WINDOWS_UWP
 
         /// <summary>
         /// Update the hand data from the device.
@@ -224,148 +130,38 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 if (sourceState.Source.Id.Equals(interactionSourceState.source.id))
                 {
-                    HandPose handPose = sourceState.TryGetHandPose();
-
 #if WINDOWS_UWP
-                    MixedRealityHandTrackingProfile handTrackingProfile = null;
-                    MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
-                    if (inputSystemProfile != null)
-                    {
-                        handTrackingProfile = inputSystemProfile.HandTrackingProfile;
-                    }
-
-                    if (handTrackingProfile != null && handTrackingProfile.EnableHandMeshVisualization)
-                    {
-                        // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
-                        if (handMeshObserver == null && !hasRequestedHandMeshObserver)
-                        {
-                            SetHandMeshObserver(sourceState);
-                            hasRequestedHandMeshObserver = true;
-                        }
-
-                        if (handMeshObserver != null && handMeshTriangleIndices == null)
-                        {
-                            uint indexCount = handMeshObserver.TriangleIndexCount;
-                            ushort[] indices = new ushort[indexCount];
-                            handMeshObserver.GetTriangleIndices(indices);
-                            handMeshTriangleIndices = new int[indexCount];
-                            Array.Copy(indices, handMeshTriangleIndices, (int)handMeshObserver.TriangleIndexCount);
-
-                            // Compute neutral pose
-                            Vector3[] neutralPoseVertices = new Vector3[handMeshObserver.VertexCount];
-                            HandPose neutralPose = handMeshObserver.NeutralPose;
-                            var vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
-                            HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
-                            handMeshVertexState.GetVertices(vertexAndNormals);
-
-                            for (int i = 0; i < handMeshObserver.VertexCount; i++)
-                            {
-                                neutralPoseVertices[i] = vertexAndNormals[i].Position.ToUnityVector3();
-                            }
-
-                            // Compute UV mapping
-                            InitializeUVs(neutralPoseVertices);
-                        }
-
-                        if (handPose != null && handMeshObserver != null && handMeshTriangleIndices != null)
-                        {
-                            var vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
-                            var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
-                            handMeshVertexState.GetVertices(vertexAndNormals);
-
-                            var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);
-                            if (meshTransform.HasValue)
-                            {
-                                System.Numerics.Vector3 scale;
-                                System.Numerics.Quaternion rotation;
-                                System.Numerics.Vector3 translation;
-                                System.Numerics.Matrix4x4.Decompose(meshTransform.Value, out scale, out rotation, out translation);
-
-                                var handMeshVertices = new Vector3[handMeshObserver.VertexCount];
-                                var handMeshNormals = new Vector3[handMeshObserver.VertexCount];
-
-                                for (int i = 0; i < handMeshObserver.VertexCount; i++)
-                                {
-                                    handMeshVertices[i] = vertexAndNormals[i].Position.ToUnityVector3();
-                                    handMeshNormals[i] = vertexAndNormals[i].Normal.ToUnityVector3();
-                                }
-
-                                HandMeshInfo handMeshInfo = new HandMeshInfo
-                                {
-                                    vertices = handMeshVertices,
-                                    normals = handMeshNormals,
-                                    triangles = handMeshTriangleIndices,
-                                    uvs = handMeshUVs,
-                                    position = translation.ToUnityVector3(),
-                                    rotation = rotation.ToUnityQuaternion()
-                                };
-
-                                CoreServices.InputSystem?.RaiseHandMeshUpdated(InputSource, ControllerHandedness, handMeshInfo);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // if hand mesh visualization is disabled make sure to destroy our hand mesh observer if it has already been created
-                        if (handMeshObserver != null)
-                        {
-                            // notify that hand mesh has been updated (cleared)
-                            HandMeshInfo handMeshInfo = new HandMeshInfo();
-                            CoreServices.InputSystem?.RaiseHandMeshUpdated(InputSource, ControllerHandedness, handMeshInfo);
-                            hasRequestedHandMeshObserver = false;
-                            handMeshObserver = null;
-                        }
-                    }
+                    handDefinition?.UpdateHandMesh(sourceState);
 #endif // WINDOWS_UWP
+
+                    HandPose handPose = sourceState.TryGetHandPose();
 
                     if (handPose != null && handPose.TryGetJoints(WindowsMixedRealityUtilities.SpatialCoordinateSystem, jointIndices, jointPoses))
                     {
                         for (int i = 0; i < jointPoses.Length; i++)
                         {
-                            unityJointOrientations[i] = jointPoses[i].Orientation.ToUnityQuaternion();
-                            unityJointPositions[i] = jointPoses[i].Position.ToUnityVector3();
+                            Vector3 jointPosition = jointPoses[i].Position.ToUnityVector3();
+                            Quaternion jointOrientation = jointPoses[i].Orientation.ToUnityQuaternion();
 
-                            // We want the controller to follow the Playspace, so fold in the playspace transform here to 
-                            // put the controller pose into world space.
-                            unityJointPositions[i] = MixedRealityPlayspace.TransformPoint(unityJointPositions[i]);
-                            unityJointOrientations[i] = MixedRealityPlayspace.Rotation * unityJointOrientations[i];
+                            // We want the joints to follow the playspace, so fold in the playspace transform here to 
+                            // put the joint pose into world space.
+                            jointPosition = MixedRealityPlayspace.TransformPoint(jointPosition);
+                            jointOrientation = MixedRealityPlayspace.Rotation * jointOrientation;
 
-                            if (jointIndices[i] == HandJointKind.IndexTip)
+                            TrackedHandJoint handJoint = ConvertHandJointKindToTrackedHandJoint(jointIndices[i]);
+
+                            if (handJoint == TrackedHandJoint.IndexTip)
                             {
                                 lastIndexTipRadius = jointPoses[i].Radius;
                             }
 
-                            TrackedHandJoint handJoint = ConvertHandJointKindToTrackedHandJoint(jointIndices[i]);
-
-                            if (!unityJointPoses.ContainsKey(handJoint))
-                            {
-                                unityJointPoses.Add(handJoint, new MixedRealityPose(unityJointPositions[i], unityJointOrientations[i]));
-                            }
-                            else
-                            {
-                                unityJointPoses[handJoint] = new MixedRealityPose(unityJointPositions[i], unityJointOrientations[i]);
-                            }
+                            unityJointPoses[handJoint] = new MixedRealityPose(jointPosition, jointOrientation);
                         }
-                        CoreServices.InputSystem?.RaiseHandJointsUpdated(InputSource, ControllerHandedness, unityJointPoses);
+
+                        handDefinition?.UpdateHandJoints(unityJointPoses);
                     }
+                    break;
                 }
-            }
-#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
-        }
-
-        private void UpdateIndexFingerData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
-        {
-#if WINDOWS_UWP || DOTNETWINRT_PRESENT
-            UpdateCurrentIndexPose();
-
-            // Update the interaction data source
-            interactionMapping.PoseData = currentIndexPose;
-
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
-            {
-                // Raise input system event if it's enabled
-                CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentIndexPose);
             }
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
@@ -404,9 +200,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         };
 
         private readonly JointPose[] jointPoses = new JointPose[jointIndices.Length];
-        private readonly Vector3[] unityJointPositions = new Vector3[jointIndices.Length];
-        private readonly Quaternion[] unityJointOrientations = new Quaternion[jointIndices.Length];
-        private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
         private float lastIndexTipRadius = 0;
 
         private TrackedHandJoint ConvertHandJointKindToTrackedHandJoint(HandJointKind handJointKind)
@@ -449,18 +242,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 default: return TrackedHandJoint.None;
             }
         }
-
-        #region Protected InputSource Helpers
-
-        protected void UpdateCurrentIndexPose()
-        {
-            currentIndexPose.Rotation = unityJointOrientations[(int)HandJointKind.IndexTip];
-
-            var skinOffsetFromBone = (currentIndexPose.Rotation * Vector3.forward * lastIndexTipRadius);
-            currentIndexPose.Position = (unityJointPositions[(int)HandJointKind.IndexTip] + skinOffsetFromBone);
-        }
-
-        #endregion Private InputSource Helpers
 
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 #endif // UNITY_WSA

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityArticulatedHand.cs
@@ -3,12 +3,12 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
+using System.Collections.Generic;
 
 #if UNITY_WSA
 using UnityEngine.XR.WSA.Input;
 #if WINDOWS_UWP || DOTNETWINRT_PRESENT
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 #if WINDOWS_UWP
 using Windows.Foundation.Metadata;

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -40,10 +40,13 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
         private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
         private readonly WindowsMixedRealityArticulatedHandDefinition handDefinition;
-        
+
         private static readonly HandFinger[] handFingers = Enum.GetValues(typeof(HandFinger)) as HandFinger[];
         private readonly List<Bone> fingerBones = new List<Bone>();
+
+#if WINDOWS_UWP && WMR_ENABLED
         private readonly List<object> states = new List<object>();
+#endif // WINDOWS_UWP && WMR_ENABLED
 
         #region IMixedRealityHand Implementation
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -3,17 +3,16 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
 
 #if WINDOWS_UWP
-using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 #if WMR_ENABLED
 using UnityEngine.XR.WindowsMR;
 #endif // WMR_ENABLED
-using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
 #endif // WINDOWS_UWP
 
@@ -31,70 +30,30 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// Constructor.
         /// </summary>
         public WindowsMixedRealityXRSDKArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
-            : base(trackingState, controllerHandedness, inputSource, interactions) { }
+            : base(trackingState, controllerHandedness, inputSource, interactions)
+        {
+            handDefinition = new WindowsMixedRealityArticulatedHandDefinition(inputSource, controllerHandedness);
+        }
 
         /// <inheritdoc />
-        public override MixedRealityInteractionMapping[] DefaultInteractions => new[]
-        {
-            new MixedRealityInteractionMapping(0, "Spatial Pointer", AxisType.SixDof, DeviceInputType.SpatialPointer),
-            new MixedRealityInteractionMapping(1, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip),
-            new MixedRealityInteractionMapping(2, "Select", AxisType.Digital, DeviceInputType.Select),
-            new MixedRealityInteractionMapping(3, "Grab", AxisType.SingleAxis, DeviceInputType.TriggerPress),
-            new MixedRealityInteractionMapping(4, "Index Finger Pose", AxisType.SixDof, DeviceInputType.IndexFinger)
-        };
+        public override MixedRealityInteractionMapping[] DefaultInteractions => handDefinition?.DefaultInteractions;
 
+        private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
+        private readonly WindowsMixedRealityArticulatedHandDefinition handDefinition;
+        
         private static readonly HandFinger[] handFingers = Enum.GetValues(typeof(HandFinger)) as HandFinger[];
         private readonly List<Bone> fingerBones = new List<Bone>();
-        private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
-
-#if WINDOWS_UWP
-        private HandMeshObserver handMeshObserver = null;
-        private int[] handMeshTriangleIndices = null;
-        private bool hasRequestedHandMeshObserver = false;
-        private Vector2[] handMeshUVs;
         private readonly List<object> states = new List<object>();
 
-        protected void InitializeUVs(Vector3[] neutralPoseVertices)
-        {
-            if (neutralPoseVertices.Length == 0)
-            {
-                Debug.LogError("Loaded 0 verts for neutralPoseVertices");
-            }
+        #region IMixedRealityHand Implementation
 
-            float minY = neutralPoseVertices[0].y;
-            float maxY = minY;
+        /// <inheritdoc/>
+        public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => unityJointPoses.TryGetValue(joint, out pose);
 
-            for (int ix = 1; ix < neutralPoseVertices.Length; ix++)
-            {
-                Vector3 p = neutralPoseVertices[ix];
+        #endregion IMixedRealityHand Implementation
 
-                if (p.y < minY)
-                {
-                    minY = p.y;
-                }
-                else if (p.y > maxY)
-                {
-                    maxY = p.y;
-                }
-            }
-
-            float scale = 1.0f / (maxY - minY);
-
-            handMeshUVs = new Vector2[neutralPoseVertices.Length];
-
-            for (int ix = 0; ix < neutralPoseVertices.Length; ix++)
-            {
-                Vector3 p = neutralPoseVertices[ix];
-
-                handMeshUVs[ix] = new Vector2(p.x * scale + 0.5f, (p.y - minY) * scale);
-            }
-        }
-
-        private async void SetHandMeshObserver(SpatialInteractionSourceState sourceState)
-        {
-            handMeshObserver = await sourceState.Source.TryCreateHandMeshObserverAsync();
-        }
-#endif // WINDOWS_UWP
+        /// <inheritdoc/>
+        public override bool IsInPointingPose => handDefinition.IsInPointingPose;
 
         #region Update data functions
 
@@ -112,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 switch (Interactions[i].InputType)
                 {
                     case DeviceInputType.IndexFinger:
-                        UpdateIndexFingerData(Interactions[i]);
+                        handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
                         break;
                 }
             }
@@ -124,6 +83,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateHandData(InputDevice inputDevice)
         {
+#if WINDOWS_UWP && WMR_ENABLED
+            XRSDKSubsystemHelpers.InputSubsystem?.GetCurrentSourceStates(states);
+
+            foreach (SpatialInteractionSourceState sourceState in states)
+            {
+                if (sourceState.Source.Handedness.ToMRTKHandedness() == ControllerHandedness)
+                {
+                    handDefinition?.UpdateHandMesh(sourceState);
+                    break;
+                }
+            }
+#endif // WINDOWS_UWP && WMR_ENABLED
+
             Hand hand;
             if (inputDevice.TryGetFeatureValue(CommonUsages.handData, out hand))
             {
@@ -141,7 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
                             if (bone.TryGetPosition(out position) || bone.TryGetRotation(out rotation))
                             {
-                                // We want input sources to follow the Playspace, so fold in the playspace transform here to
+                                // We want input sources to follow the playspace, so fold in the playspace transform here to
                                 // put the controller pose into world space.
                                 position = MixedRealityPlayspace.TransformPoint(position);
                                 rotation = MixedRealityPlayspace.Rotation * rotation;
@@ -155,123 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                     }
                 }
 
-                CoreServices.InputSystem?.RaiseHandJointsUpdated(InputSource, ControllerHandedness, unityJointPoses);
-            }
-
-#if WINDOWS_UWP
-            MixedRealityHandTrackingProfile handTrackingProfile = null;
-            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
-            if (inputSystemProfile != null)
-            {
-                handTrackingProfile = inputSystemProfile.HandTrackingProfile;
-            }
-
-            if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
-            {
-                // if hand mesh visualization is disabled make sure to destroy our hand mesh observer if it has already been created
-                if (handMeshObserver != null)
-                {
-                    // Notify that hand mesh has been updated (cleared)
-                    HandMeshInfo handMeshInfo = new HandMeshInfo();
-                    CoreServices.InputSystem?.RaiseHandMeshUpdated(InputSource, ControllerHandedness, handMeshInfo);
-                    hasRequestedHandMeshObserver = false;
-                    handMeshObserver = null;
-                }
-                return;
-            }
-
-#if WMR_ENABLED
-            XRSDKSubsystemHelpers.InputSubsystem?.GetCurrentSourceStates(states);
-#endif // WMR_ENABLED
-
-            foreach (SpatialInteractionSourceState sourceState in states)
-            {
-                if (sourceState.Source.Handedness.ToMRTKHandedness() == ControllerHandedness)
-                {
-                    HandPose handPose = sourceState.TryGetHandPose();
-
-                    // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
-                    if (handMeshObserver == null && !hasRequestedHandMeshObserver)
-                    {
-                        SetHandMeshObserver(sourceState);
-                        hasRequestedHandMeshObserver = true;
-                    }
-
-                    if (handMeshObserver != null && handMeshTriangleIndices == null)
-                    {
-                        uint indexCount = handMeshObserver.TriangleIndexCount;
-                        ushort[] indices = new ushort[indexCount];
-                        handMeshObserver.GetTriangleIndices(indices);
-                        handMeshTriangleIndices = new int[indexCount];
-                        Array.Copy(indices, handMeshTriangleIndices, (int)handMeshObserver.TriangleIndexCount);
-
-                        // Compute neutral pose
-                        Vector3[] neutralPoseVertices = new Vector3[handMeshObserver.VertexCount];
-                        HandPose neutralPose = handMeshObserver.NeutralPose;
-                        var vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
-                        HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
-                        handMeshVertexState.GetVertices(vertexAndNormals);
-
-                        for (int i = 0; i < handMeshObserver.VertexCount; i++)
-                        {
-                            neutralPoseVertices[i] = vertexAndNormals[i].Position.ToUnityVector3();
-                        }
-
-                        // Compute UV mapping
-                        InitializeUVs(neutralPoseVertices);
-                    }
-
-                    if (handPose != null && handMeshObserver != null && handMeshTriangleIndices != null)
-                    {
-                        var vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
-                        var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
-                        handMeshVertexState.GetVertices(vertexAndNormals);
-
-                        var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);
-                        if (meshTransform.HasValue)
-                        {
-                            System.Numerics.Vector3 scale;
-                            System.Numerics.Quaternion rotation;
-                            System.Numerics.Vector3 translation;
-                            System.Numerics.Matrix4x4.Decompose(meshTransform.Value, out scale, out rotation, out translation);
-
-                            var handMeshVertices = new Vector3[handMeshObserver.VertexCount];
-                            var handMeshNormals = new Vector3[handMeshObserver.VertexCount];
-
-                            for (int i = 0; i < handMeshObserver.VertexCount; i++)
-                            {
-                                handMeshVertices[i] = vertexAndNormals[i].Position.ToUnityVector3();
-                                handMeshNormals[i] = vertexAndNormals[i].Normal.ToUnityVector3();
-                            }
-
-                            HandMeshInfo handMeshInfo = new HandMeshInfo
-                            {
-                                vertices = handMeshVertices,
-                                normals = handMeshNormals,
-                                triangles = handMeshTriangleIndices,
-                                uvs = handMeshUVs,
-                                position = translation.ToUnityVector3(),
-                                rotation = rotation.ToUnityQuaternion()
-                            };
-
-                            CoreServices.InputSystem?.RaiseHandMeshUpdated(InputSource, ControllerHandedness, handMeshInfo);
-                        }
-                    }
-                }
-            }
-#endif // WINDOWS_UWP
-        }
-
-        private void UpdateIndexFingerData(MixedRealityInteractionMapping interactionMapping)
-        {
-            // Update the interaction data source
-            interactionMapping.PoseData = unityJointPoses[TrackedHandJoint.IndexTip];
-
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
-            {
-                // Raise input system event if it's enabled
-                CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.PoseData);
+                handDefinition?.UpdateHandJoints(unityJointPoses);
             }
         }
 
@@ -295,46 +151,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 case HandFinger.Ring: return TrackedHandJoint.RingMetacarpal + index;
                 case HandFinger.Pinky: return TrackedHandJoint.PinkyMetacarpal + index;
                 default: return TrackedHandJoint.None;
-            }
-        }
-
-        #region IMixedRealityHand Implementation
-
-        /// <inheritdoc/>
-        public bool TryGetJoint(TrackedHandJoint joint, out MixedRealityPose pose) => unityJointPoses.TryGetValue(joint, out pose);
-
-        #endregion IMixedRealityHand Implementation
-
-        private readonly float CursorBeamBackwardTolerance = 0.5f;
-        private readonly float CursorBeamUpTolerance = 0.8f;
-
-        /// <inheritdoc/>
-        public override bool IsInPointingPose
-        {
-            get
-            {
-                bool valid = true;
-                MixedRealityPose palmJoint;
-                if (unityJointPoses.TryGetValue(TrackedHandJoint.Palm, out palmJoint))
-                {
-                    Vector3 palmNormal = palmJoint.Rotation * (-1 * Vector3.up);
-                    if (CursorBeamBackwardTolerance >= 0)
-                    {
-                        Vector3 cameraBackward = -CameraCache.Main.transform.forward;
-                        if (Vector3.Dot(palmNormal.normalized, cameraBackward) > CursorBeamBackwardTolerance)
-                        {
-                            valid = false;
-                        }
-                    }
-                    if (valid && CursorBeamUpTolerance >= 0)
-                    {
-                        if (Vector3.Dot(palmNormal, Vector3.up) > CursorBeamUpTolerance)
-                        {
-                            valid = false;
-                        }
-                    }
-                }
-                return valid;
             }
         }
 


### PR DESCRIPTION
## Overview

Initial hand / controller rework, by separating out some of the WMR articulated hand definitions from any specific Unity API set.
This is a first step toward separating hand / controller definitions from the APIs that supply their data, which will also help unblock bringing new features like https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6973 to HL2 and beyond.

## Changes
- Part of #7003, 