### PR TITLE
Add .EditMode to all edit mode test namespaces

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityHandTrackingProfileTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityHandTrackingProfileTests.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 
-namespace Microsoft.MixedReality.Toolkit.Input
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     class MixedRealityHandTrackingProfileTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Extensions/CameraExtensionTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Extensions/CameraExtensionTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Extensions
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Extensions
 {
     public class CameraExtensionTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
@@ -10,7 +10,7 @@ using System.IO;
 using System.Linq;
 using UnityEngine.TestTools;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Core
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
 {
     // Tests for the MixedRealityToolkitFiles utility class
     public class MixedRealityToolkitFilesTests

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Tests.Services;
+using Microsoft.MixedReality.Toolkit.Tests.EditMode.Services;
 using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Core
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
 {
     public class MixedRealityToolkitTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Physics;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Physics
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Physics
 {
     class InterpolationUtilitiesTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Physics;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Physics
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Physics
 {
     class InterpolatorTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using System.Xml.Linq;
 using System.Linq;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Build.Editor
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Build.Editor
 {
     class UwpAppxBuildToolsTest
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/ProjectPreferencesTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/ProjectPreferencesTest.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Core.Utilities.Editor
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
 {
     /// <summary>
     /// Test structure to test <see cref="Microsoft.MixedReality.Toolkit.Utilities.Editor.ProjectPreferences"/>

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/ScreenshotUtility/ScreenshotUtilityTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/ScreenshotUtility/ScreenshotUtilityTest.cs
@@ -8,7 +8,7 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Build.Editor
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Build.Editor
 {
     class ScreenshotUtilityTest
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderTest.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging;
 using NUnit.Framework;
 using System.Globalization;
 
-namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     class UserInputRecorderTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Experimental/BoundsControlTests.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
 {
     /// <summary>
     /// Tests for edit mode behavior of bounds control

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -5,7 +5,7 @@ using Microsoft.MixedReality.Toolkit.Input.UnityInput;
 using Microsoft.MixedReality.Toolkit.OpenVR.Input;
 using NUnit.Framework;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     public class ControllerMappingTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/DefaultPrimaryPointerSelectorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/DefaultPrimaryPointerSelectorTests.cs
@@ -4,7 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using NUnit.Framework;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     public class DefaultPrimaryPointerSelectorTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/GazePointerStateMachineTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/GazePointerStateMachineTests.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.TestTools;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     class GazePointerStateMachineTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Tests.Services;
+using Microsoft.MixedReality.Toolkit.Tests.EditMode.Services;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     public class InputSystemTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InteractionDefinitionTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InteractionDefinitionTests.cs
@@ -6,7 +6,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     public class InteractionDefinitionTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestPointer.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/TestPointer.cs
@@ -6,7 +6,7 @@ using Microsoft.MixedReality.Toolkit.Physics;
 using System;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     // Dummy pointer class used as a placeholder for a proper pointer in some unit test.
     // Only the interfaces required for the tests are implemented. Feel free to add implementations as needed.

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/UnityInputManagerHelperTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/UnityInputManagerHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.MixedReality.Toolkit.Input.Editor;
 using Microsoft.MixedReality.Toolkit.Input;
 using NUnit.Framework;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.InputSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     public class UnityInputManagerHelperTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/BaseTestExtensionService.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/BaseTestExtensionService.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     /// <summary>
     /// A base class for test extension services.

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestDataProvider1.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestDataProvider1.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal interface ITestDataProvider1 : IMixedRealityDataProvider, ITestService
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestExtensionService1.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestExtensionService1.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     /// <summary>
     /// An empty extension service used for testing.

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestExtensionService2.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestExtensionService2.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     /// <summary>
     /// An empty extension service used for testing.

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestExtensionService3.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestExtensionService3.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     /// <summary>
     /// An empty extension service used for testing.

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestFailService.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestFailService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal interface ITestFailService { }
 }

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestInputDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestInputDataProvider.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
 using Microsoft.MixedReality.Toolkit.Input;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal interface ITestInputDataProvider : IMixedRealityDataProvider, ITestService, IMixedRealityInputDeviceManager
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestService.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/ITestService.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal interface ITestService : IMixedRealityService
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestBaseDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestBaseDataProvider.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     /// <summary>
     /// Base class for test data providers

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestDataProvider1.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestDataProvider1.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal class TestDataProvider1 : TestBaseDataProvider, ITestDataProvider1
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestExtensionService1.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestExtensionService1.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal class TestExtensionService1 : BaseTestExtensionService, ITestExtensionService1
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestExtensionService2.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestExtensionService2.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal class TestExtensionService2 : BaseTestExtensionService, ITestExtensionService2
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestExtensionService3.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestExtensionService3.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal class TestExtensionService3 : BaseTestExtensionService, ITestExtensionService3
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestFailService.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestFailService.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal class TestFailService : BaseService, ITestFailService
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestInputDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestInputDataProvider.cs
@@ -4,7 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     /// <summary>
     /// Dummy test IMixedRealityInputDeviceManager implementation only used for testing

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   isCustomProfile: 0
   dataProviderConfigurations:
   - componentType:
-      reference: Microsoft.MixedReality.Toolkit.Tests.Services.TestInputDataProvider,
+      reference: Microsoft.MixedReality.Toolkit.Tests.EditMode.Services.TestInputDataProvider,
         Microsoft.MixedReality.Toolkit.Tests.EditModeTests
     componentName: Test Input Data Provider
     priority: 0
@@ -26,6 +26,7 @@ MonoBehaviour:
   raycastProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.DefaultRaycastProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   focusQueryBufferSize: 128
+  focusIndividualCompoundCollider: 0
   inputActionsProfile: {fileID: 11400000, guid: 723eb97b02944311b92861f473eee53e,
     type: 2}
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   isCustomProfile: 0
   observerConfigurations:
   - componentType:
-      reference: Microsoft.MixedReality.Toolkit.Tests.Services.TestSpatialAwarenessDataProvider,
+      reference: Microsoft.MixedReality.Toolkit.Tests.EditMode.Services.TestSpatialAwarenessDataProvider,
         Microsoft.MixedReality.Toolkit.Tests.EditModeTests
     componentName: Test Spatial Awareness Data Provider
     priority: 0

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestSpatialAwarenessDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestSpatialAwarenessDataProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.Services
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
 {
     internal interface ITestSpatialAwarenessDataProvider : IMixedRealityDataProvider, ITestService, IMixedRealitySpatialAwarenessObserver, IMixedRealitySpatialAwarenessMeshObserver
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
-using Microsoft.MixedReality.Toolkit.Tests.Services;
+using Microsoft.MixedReality.Toolkit.Tests.EditMode.Services;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Microsoft.MixedReality.Toolkit.Tests.SpatialAwarenessSystem
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
 {
     public class SpatialAwarenessSystemTests
     {

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
 {
     public class SpatialAwarenessSystemTests
     {
-        private const string TestSpatialAwarenessSysteProfilePath = "Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset";
+        private const string TestSpatialAwarenessSystemProfilePath = "Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset";
 
         [TearDown]
         public void TearDown()
@@ -62,10 +62,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
         }
 
         [Test]
-        public void TestDataProviderRegisteration()
+        public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(TestSpatialAwarenessSysteProfilePath);
+            MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(TestSpatialAwarenessSystemProfilePath);
 
             var spatialAwarenessSystem = new MixedRealitySpatialAwarenessSystem(MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile);
 


### PR DESCRIPTION
## Overview

Adds .EditMode to all edit mode test namespaces, in order to differentiate between the `BoundsControlTests` classes in both the EditModeTests assembly and the PlayModeTests assembly.

## Changes
- Fixes: the current asset retargeting break:
![image](https://user-images.githubusercontent.com/3580640/73099149-b4aa4000-3e9f-11ea-97f7-73e760148bac.png)