### PR TITLE
Add null check if no (or incorrect type) camera settings profile is set

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// </summary>
         private void InitializeReprojectionUpdater()
         {
-            if (reprojectionUpdater == null)
+            if (reprojectionUpdater == null && Profile != null)
             {
                 reprojectionUpdater = CameraCache.Main.EnsureComponent<WindowsMixedRealityReprojectionUpdater>();
                 reprojectionUpdater.ReprojectionMethod = Profile.ReprojectionMethod;


### PR DESCRIPTION
## Overview

Adds a null check before trying to access the profile. It's not required to add a profile (for example, these features don't exist on HL1).

## Changes
- Fixes: #7095 