### PR TITLE
Fix toggle colleciton inspector

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableToggleCollectionInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableToggleCollectionInspector.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -21,12 +15,14 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
         protected InteractableToggleCollection instance;
         protected SerializedProperty toggleListProperty;
         protected SerializedProperty currentIndexProperty;
+        protected SerializedProperty onSelectionEventsProperty;
 
         protected virtual void OnEnable()
         {
             instance = (InteractableToggleCollection)target;
             toggleListProperty = serializedObject.FindProperty("toggleList");
             currentIndexProperty = serializedObject.FindProperty("currentIndex");
+            onSelectionEventsProperty = serializedObject.FindProperty("OnSelectionEvents");
         }
 
         public override void OnInspectorGUI()
@@ -45,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                 else
                 {
                     instance.SetSelection(currentIndex, true, true);
-                }  
+                }
             }
         }
 
@@ -61,6 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             }
 
             EditorGUILayout.PropertyField(currentIndexProperty);
+            EditorGUILayout.PropertyField(onSelectionEventsProperty);
 
             serializedObject.ApplyModifiedProperties();
         }


### PR DESCRIPTION
## Overview
InteractableToggleCollectionInspector does not render public property OnSelectionEvents in a InteractableToggleCollection. Just adds serializedproperty field to inspector class

**BEFORE**
![image](https://user-images.githubusercontent.com/25975362/73224643-fc8aca80-411e-11ea-82c1-f85cbe120bb1.png)

**AFTER**
![image](https://user-images.githubusercontent.com/25975362/73224586-d36a3a00-411e-11ea-9480-f133dd8c1698.png)

## Changes
- Fixes: #7167 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
