### PR TITLE
Fixes an issue on the InscribedRectangle algorithm to have a proper initial search space for candidates.

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/BoundarySystem.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/BoundarySystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 39fdd302c5e3d754b84adf86fe0155ae
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Boundary;
+using NUnit.Framework;
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Boundary
+{
+    public class InscribedRectangleTests
+    {
+        // When doing double/expected value comparison, we give a slightly larger
+        // than usual tolerance because of the nature of how the inscribed rectangle
+        // works. Note that the tolerance is percent based because there are larger
+        // errors that accumulate when the edges span a larger space.
+        private const double TolerancePercent = 0.02;
+
+        [Test]
+        public void TestSimpleSquare()
+        {
+            // A set of edges that represents a 10x10 square.
+            Edge[] edges = new Edge[]
+            {
+                new Edge(new Vector2(0, 0), new Vector2(0, 10)),
+                new Edge(new Vector2(0, 10), new Vector2(10, 10)),
+                new Edge(new Vector2(10, 10), new Vector2(10, 0)),
+                new Edge(new Vector2(10, 0), new Vector2(0, 0))
+            };
+
+            InscribedRectangle rectangle = new InscribedRectangle(edges, 0 /*randomSeed*/);
+
+            AssertWithinTolerance(10.0, rectangle.Height);
+            AssertWithinTolerance(10.0, rectangle.Width);
+        }
+
+        [Test]
+        public void TestSimpleRectangle()
+        {
+            // A set of edges that represents a 10x10 square.
+            Edge[] edges = new Edge[]
+            {
+                new Edge(new Vector2(0, 0), new Vector2(0, 10)),
+                new Edge(new Vector2(0, 10), new Vector2(100, 10)),
+                new Edge(new Vector2(100, 10), new Vector2(100, 0)),
+                new Edge(new Vector2(100, 0), new Vector2(0, 0))
+            };
+
+            InscribedRectangle rectangle = new InscribedRectangle(edges, 0 /*randomSeed*/);
+
+            AssertWithinTolerance(10.0, rectangle.Height);
+            AssertWithinTolerance(100.0, rectangle.Width);
+        }
+
+        /// <summary>
+        /// This test case exists to validate the fix for https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7171
+        /// </summary>
+        /// <remarks>
+        /// In particular, this issue used an incorrect Math.min where Math.max was needed, cutting
+        /// down the candidate search space for rectangles. This rough ASCII art shows how the issue comes about:
+        ///
+        /// #
+        /// ###
+        /// #####
+        /// #######
+        /// #########
+        /// ###########
+        /// #############
+        /// ###############
+        /// #################
+        /// ###################
+        /// #####################
+        /// #######################
+        /// #########################
+        /// ###########################
+        /// #############################
+        /// #
+        /// #############################
+        ///
+        /// In this 'room', notice that the largest inscribed rectangle is
+        /// actually the one on top. However, because of the issue in #7171, the candidate search space
+        /// was being reduced to only the bottom space. As a result, before the fix for that, we would
+        /// return the size of the bottom rectangle (which is incorrect - it's the one on top).
+        /// </remarks>
+        [Test]
+        public void TestDegenerateSailboat()
+        {
+            // A set of edges that represents the fancy art above. Note that in this test case
+            // the width/height is a bit lengtened to really ensure that the top rectangle is
+            // much bigger.
+            Edge[] edges = new Edge[]
+            {
+                new Edge(new Vector2(0, 0), new Vector2(100, 0)),
+                new Edge(new Vector2(100, 0), new Vector2(100, 1)),
+                new Edge(new Vector2(100, 1), new Vector2(1, 1)),
+                new Edge(new Vector2(1, 1), new Vector2(1, 2)),
+                new Edge(new Vector2(1, 2), new Vector2(100, 2)),
+                new Edge(new Vector2(100, 2), new Vector2(0, 100)),
+                new Edge(new Vector2(0, 100), new Vector2(0, 0)),
+            };
+
+            InscribedRectangle rectangle = new InscribedRectangle(edges, 0 /*randomSeed*/);
+
+            // The area should be greater than 100 because:
+            // 1) The area of the rectangle below would roughly be less than or equal to 100, and this
+            //    rectangle shouldn't get chosen by the algorithm because it's the smaller one.
+            Assert.GreaterOrEqual(rectangle.Height * rectangle.Width, 100);
+
+            // The center should be above y = 2 (i.e. we shouldn't be choosing the tiny sliver
+            // under the sailboat).
+            Assert.GreaterOrEqual(rectangle.Center.y, 2);
+        }
+
+        /// <summary>
+        /// Asserts that the expected and actual values are within 'tolernace' percent.
+        /// </summary>
+        /// <remarks>
+        /// Assumes that expected isn't zero (none of our test cases should lead to an empty sized
+        /// rectangle).
+        /// </remarks>
+        private static void AssertWithinTolerance(double expected, double actual)
+        {
+            Assert.IsTrue(Math.Abs((expected - actual)/expected) < TolerancePercent);
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c16dbfa815637124a89363702a6c6768
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Microsoft.MixedReality.Toolkit.Tests.EditModeTests.asmdef
@@ -12,7 +12,8 @@
         "Microsoft.MixedReality.Toolkit.Examples",
         "Microsoft.MixedReality.Toolkit.Tools",
         "Microsoft.MixedReality.Toolkit.Providers.OpenVR",
-        "Microsoft.MixedReality.Toolkit.Tests.Utilities"
+        "Microsoft.MixedReality.Toolkit.Tests.Utilities",
+        "Microsoft.MixedReality.Toolkit.Services.BoundarySystem"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Assets/MixedRealityToolkit/Definitions/BoundarySystem/InscribedRectangle.cs
+++ b/Assets/MixedRealityToolkit/Definitions/BoundarySystem/InscribedRectangle.cs
@@ -124,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
 
                 if ((edge.PointA.y > maxY) || (edge.PointB.y > maxY))
                 {
-                    maxY = Mathf.Min(edge.PointA.y, edge.PointB.y);
+                    maxY = Mathf.Max(edge.PointA.y, edge.PointB.y);
                 }
 
             }


### PR DESCRIPTION
## Overview
There's been a latent bug in the InscribedRectangle algorithm since it was checked in a few years ago (https://github.com/microsoft/MixedRealityToolkit-Unity/commit/e40334655740a7adfd6fae0389cef9b3e854ca44) - in particular, the code that figures out the candidate search space (i.e. the (minx, miny), (maxx, maxy) bounds). With the current code, generally things will work out because the set of edges passed to the algorithm will generally be okay and won't degenerate.

However, there are cases (where each pairwise point has at least one y coordinate that is super small) where the degenerancy ends up being really bad. In that case the incorrect usage of Math.min instead of Math.max causes us to flatten the search space substantially, in some cases dropping to the wrong location entirely.

The best case example (or worst case example) is in the included test case (i.e the degenerate sailboat) where the current code will trigger us to find a rectangle within the lower sliver, but the working algorithm will correctly find something within the sail.

## Changes
- Fixes: #7171
