### PR TITLE
Fix prioritized layer mask usage in FocusProvider.GetPrioritizedHitResult

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public IMixedRealityPointer PrimaryPointer
         {
-            get { return primaryPointer; }
+            get => primaryPointer;
             private set
             {
                 if (value != PrimaryPointer)
@@ -1033,7 +1033,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        PointerHitResult GetPrioritizedHitResult(PointerHitResult hit1, PointerHitResult hit2, LayerMask[] prioritizedLayerMasks)
+        private PointerHitResult GetPrioritizedHitResult(PointerHitResult hit1, PointerHitResult hit2, LayerMask[] prioritizedLayerMasks)
         {
             if (hit1.hitObject != null && hit2.hitObject != null)
             {
@@ -1041,12 +1041,23 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (prioritizedLayerMasks.Length > 1)
                 {
                     // Get the index in the prioritized layer masks
-                    int layerIndex1 = hit1.hitObject.layer.FindLayerListIndex(prioritizedLayerMasks);
-                    int layerIndex2 = hit2.hitObject.layer.FindLayerListIndex(prioritizedLayerMasks);
+                    int layerMaskIndex1 = hit1.hitObject.layer.FindLayerListIndex(prioritizedLayerMasks);
+                    int layerMaskIndex2 = hit2.hitObject.layer.FindLayerListIndex(prioritizedLayerMasks);
 
-                    if (layerIndex1 != layerIndex2)
+                    if (layerMaskIndex1 != layerMaskIndex2)
                     {
-                        return (layerIndex1 < layerIndex2) ? hit1 : hit2;
+                        if (layerMaskIndex1 == -1)
+                        {
+                            return hit2;
+                        }
+                        else if (layerMaskIndex2 == -1)
+                        {
+                            return hit1;
+                        }
+                        else
+                        {
+                            return (layerMaskIndex1 < layerMaskIndex2) ? hit1 : hit2;
+                        }
                     }
                 }
 

--- a/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         [PhysicsLayer]
         [SerializeField]
         [Tooltip("Physics layer on which to set observed meshes.")]
-        private int meshPhysicsLayer = 31;
+        private int meshPhysicsLayer = BaseSpatialObserver.DefaultSpatialAwarenessLayer;
 
         /// <summary>
         /// The Unity Physics Layer on which to set observed meshes.

--- a/Assets/MixedRealityToolkit/Extensions/LayerExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/LayerExtensions.cs
@@ -23,15 +23,12 @@ namespace Microsoft.MixedReality.Toolkit
         /// <returns>LayerMaskList index, or -1 for not found</returns>
         public static int FindLayerListIndex(this int layer, LayerMask[] layerMasks)
         {
-            var i = 0;
             for (int j = 0; j < layerMasks.Length; j++)
             {
-                if (layer.IsInLayerMask(layerMasks[i]))
+                if (layer.IsInLayerMask(layerMasks[j]))
                 {
-                    return i;
+                    return j;
                 }
-
-                i++;
             }
 
             return -1;

--- a/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseSpatialObserver.cs
@@ -13,23 +13,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     public abstract class BaseSpatialObserver : BaseDataProvider<IMixedRealitySpatialAwarenessSystem>, IMixedRealitySpatialAwarenessObserver
     {
         /// <summary>
-        /// Constructor.
+        /// Default dedicated layer for spatial awareness layer used by most components in MRTK
         /// </summary>
-        /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the observer.</param>
-        /// <param name="spatialAwarenessSystem">The <see cref="SpatialAwareness.IMixedRealitySpatialAwarenessSystem"/> to which the observer is providing data.</param>
-        /// <param name="name">The friendly name of the data provider.</param>
-        /// <param name="priority">The registration priority of the data provider.</param>
-        /// <param name="profile">The configuration profile for the data provider.</param>
-        [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
-        protected BaseSpatialObserver(
-            IMixedRealityServiceRegistrar registrar,
-            IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
-            string name = null,
-            uint priority = DefaultPriority, 
-            BaseMixedRealityProfile profile = null) : this(spatialAwarenessSystem, name, priority, profile)
-        {
-            Registrar = registrar;
-        }
+        public const int DefaultSpatialAwarenessLayer = 31;
 
         /// <summary>
         /// Constructor.
@@ -185,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         public AutoStartBehavior StartupBehavior { get; set; } = AutoStartBehavior.AutoStart;
 
         /// <inheritdoc />
-        public int DefaultPhysicsLayer { get; } = 31;
+        public int DefaultPhysicsLayer { get; } = DefaultSpatialAwarenessLayer;
 
         /// <inheritdoc />
         public bool IsRunning { get; protected set; } = false;
@@ -233,5 +219,28 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         }
 
         #endregion Helpers
+        
+        #region Obsolete
+        
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="registrar">The <see cref="IMixedRealityServiceRegistrar"/> instance that loaded the observer.</param>
+        /// <param name="spatialAwarenessSystem">The <see cref="SpatialAwareness.IMixedRealitySpatialAwarenessSystem"/> to which the observer is providing data.</param>
+        /// <param name="name">The friendly name of the data provider.</param>
+        /// <param name="priority">The registration priority of the data provider.</param>
+        /// <param name="profile">The configuration profile for the data provider.</param>
+        [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
+        protected BaseSpatialObserver(
+            IMixedRealityServiceRegistrar registrar,
+            IMixedRealitySpatialAwarenessSystem spatialAwarenessSystem,
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseMixedRealityProfile profile = null) : this(spatialAwarenessSystem, name, priority, profile)
+        {
+            Registrar = registrar;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Overview
This change fixes use of the `FocusProvider.GetPrioritizedHitResult` method. The layer extension FindLayerListIndex can return -1 which in `GetPrioritizedHitResult` will be selected as it's always the MIN value.

This change rewrites the comparison method to handle the -1 cases and adds a new test: TestPrioritizedLayerMask

Also add a const int for the default spatial awareness layer to track across project

## Changes
- Fixes: #6481 

## Verification
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
