### PR TITLE
Update the .gitignore to ignore the MSBuildForUnity generated csproj and sln files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ doc/
 Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/Plugins*
 MSBuildForUnity.Common.props
 .obj
+/*.msb4u.csproj.meta
+*.msb4u.csproj.meta
+/*.msb4u.sln.meta
+*.msb4u.sln.meta


### PR DESCRIPTION
If you clone the MRTK repo and follow the default steps (i.e. configurator -> accept default changes) you'll start getting msb4u csproj and meta files being built and showing up in your status/workspace. This heavily clutters things and makes command line git tricky to use (and other forms of git as well).