### PR TITLE
Update GenericBaseEventData to not throw when selectedObject is invoked.

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/EventSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/EventSystemTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Diagnostics;
+using NUnit.Framework;
+using UnityEngine.EventSystems;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
+{
+    class EventSystemTests
+    {
+        /// <summary>
+        /// A basic test that validates that access to selectedObject doesn't throw a NullReferenceException
+        /// </summary>
+        [Test]
+        public void TestSelectedObjectAccess()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                DiagnosticsEventData eventData = new DiagnosticsEventData(EventSystem.current);
+                eventData.Initialize(null);
+                Assert.IsNull(eventData.selectedObject);
+            });
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/EventSystemTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/EventSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f1e8993fd929cf4d8b4d36a50631518
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/EventDatum/GenericBaseEventData.cs
+++ b/Assets/MixedRealityToolkit/EventDatum/GenericBaseEventData.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using UnityEngine;
 using UnityEngine.EventSystems;
 
 namespace Microsoft.MixedReality.Toolkit
@@ -22,10 +23,22 @@ namespace Microsoft.MixedReality.Toolkit
         public DateTime EventTime { get; private set; }
 
         /// <summary>
+        /// The BaseEventData.selectedObject is explicitly hidden because access to it
+        /// (either via get or set) throws a NullReferenceException in typical usage within
+        /// the MRTK. Prefer using the subclasses own fields to access information about
+        /// the event instead of fields on BaseEventData.
+        /// </summary>
+        /// <remarks>
+        /// BaseEventData is only used because it's part of Unity's EventSystem dispatching,
+        /// so this code must subclass it in order to leverage EventSystem.ExecuteEvents
+        /// </remarks>
+        public new GameObject selectedObject { get; protected set; }
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="eventSystem">Usually <see href="https://docs.unity3d.com/ScriptReference/EventSystems.EventSystem-current.html">EventSystems.EventSystem.current</see></param>
-        public GenericBaseEventData(EventSystem eventSystem) : base(eventSystem) { }
+        public GenericBaseEventData(EventSystem eventSystem) : base(eventSystem) {}
 
         /// <summary>
         /// Used to initialize/reset the event and populate the data.


### PR DESCRIPTION
## Overview
Accessing the selectedObject on any field within any of the MRTK's event data (for example, DiagnosticSystemEventData or MixedRealityPointerEventData) will throw a NullReferenceException, because the majority (I think all) of these eventData objects get instantiated with a null EventSystem in their constructor (i.e. this is due to another startup mismatch where EventSystem.current is null when the input system is starting up).

As it turns out, passing a valid EventSystem doesn't seem to matter for the usage of ExecuteEvents in the rest of our stuff, so the simplest/safest option here is just to make sure that we don't end up NullRef-ing on the access of a specific field within our code. 

It would have also been possible to change up our startup mechanics to wait for the camera's event system to initialize first, though this would be a scarier change.

I think the main principle behind this fix is that a simple field access shouldn't throw a NullRef.

Note that I considered exposing the selected pointer target here as well (see the issue linked) but I still have some qualms about attempting to squash more complex event data into base Unity concepts (i.e. we're really using BaseEventData only to work with ExecuteEvents).

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7187