### PR TITLE
Fix foundation unitypackage packaging: do not presume ar or xr plugins

### DIFF
--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -175,6 +175,9 @@ $OutputDirectory = Resolve-Path $OutputDirectory
 $LogDirectory = Resolve-Path $LogDirectory
 $RepoDirectory = Resolve-Path $RepoDirectory
 
+Write-Verbose "Cleaning package manifest (removing AR and XR references)"
+CleanPackageManifest
+
 foreach ($entry in $packages.GetEnumerator()) {
     $packageName = $entry.Name;
     $folders = $entry.Value

--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -105,6 +105,24 @@ function GetPackageVersion() {
         Select-Object -First 1
 }
 
+function CleanPackageManifest() {
+    <#
+    .SYNOPSIS
+        Ensures that the package manifest does not contain packages that trigger adding dependencies on
+        optional features by default.
+    #>
+
+    $fileName = $RepoDirectory + "\Packages\manifest.json"
+    (Get-Content $fileName) | ForEach-Object {
+        if ($_ -notmatch ("arfoundation|arsubsystems|xr.management|legacyinputhelpers")) {
+            $line = $_
+        }
+        else {
+            $line = ""
+        }
+    $line } | Set-Content $fileName  
+}
+
 # Beginning of the .unitypackage script main section
 # The overall structure of this script looks like:
 #


### PR DESCRIPTION
This change updates the MRTK CI unitypackage creation step to remove ar foundation and xr management related packages from the checked in manifest prior to package creation.

This was leading to #7192 due to the fact that, when creating unitypackage files, the project is opened into Unity and any methods decorated to run on project load (specifically the unityar configuration checker) are executed. Since MRTK has a checked in manifest containing arfoundation, this caused the unityar asmdf to incorrectly be modified during packaging.

Fixes: #7192

Special thanks to @keveleigh for his assistance (read: donation) with the powershell commands