### PR TITLE
Harden MRTK Project Configurator

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -91,15 +91,30 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            RenderChoiceDialog();
-
-            EditorGUILayout.Space();
-
-            showConfigurations = EditorGUILayout.Foldout(showConfigurations, "Modify Configurations", true);
-            if (showConfigurations)
+            if (!MixedRealityProjectConfigurator.IsProjectConfigured())
             {
-                RenderConfigurations();
+                RenderChoiceDialog();
+
+                EditorGUILayout.Space();
+
+                showConfigurations = EditorGUILayout.Foldout(showConfigurations, "Modify Configurations", true);
+                if (showConfigurations)
+                {
+                    RenderConfigurations();
+                }
             }
+            else
+            {
+                RenderConfiguredConfirmation();
+            }
+        }
+
+        private void RenderConfiguredConfirmation()
+        {
+            const string dialogTitle = "Project Configuration Complete";
+            const string dialogContent = "This Unity project is properly configured for the Mixed Reality Toolkit.";
+            EditorGUILayout.LabelField(dialogTitle, EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(dialogContent);
         }
 
         private void RenderChoiceDialog()

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -76,6 +76,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 ValidTargets = targets;
             }
 
+            /// <summary>
+            /// Returns true if the active build target is contained in the ValidTargets list or the list contains a BuildTarget.NoTarget entry, false otherwise
+            /// </summary>
             public bool IsActiveBuildTargetValid()
             {
                 foreach (var buildTarget in ValidTargets)

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -52,42 +52,84 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             IOSCameraUsageDescription,
         };
 
-        // The check functions for each type of setting
-        private static readonly Dictionary<Configurations, Func<bool>> ConfigurationGetters = new Dictionary<Configurations, Func<bool>>()
+        private class ConfigGetter
         {
-            { Configurations.LatestScriptingRuntime,  () => { return IsLatestScriptingRuntime(); } },
-            { Configurations.ForceTextSerialization,  () => { return IsForceTextSerialization(); } },
-            { Configurations.VisibleMetaFiles,  () => { return IsVisibleMetaFiles(); } },
-            { Configurations.VirtualRealitySupported,  () => { return PlayerSettings.virtualRealitySupported; } },
-            { Configurations.SinglePassInstancing,  () => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); } },
-            { Configurations.SpatialAwarenessLayer,  () => { return HasSpatialAwarenessLayer(); } },
-            { Configurations.EnableMSBuildForUnity, () => { return IsMSBuildForUnityEnabled(); } },
+            /// <summary>
+            /// Array of build targets where the get action is valid
+            /// </summary>
+            public BuildTarget[] ValidTargets;
+
+            /// <summary>
+            /// Action to perform to determine if the current configuration is correctly enabled
+            /// </summary>
+            public Func<bool> GetAction;
+
+            public ConfigGetter(Func<bool> get, BuildTarget target = BuildTarget.NoTarget)
+            {
+                GetAction = get;
+                ValidTargets = new BuildTarget[] { target };
+            }
+
+            public ConfigGetter(Func<bool> get, BuildTarget[] targets)
+            {
+                GetAction = get;
+                ValidTargets = targets;
+            }
+
+            public bool IsActiveBuildTargetValid()
+            {
+                foreach (var buildTarget in ValidTargets)
+                {
+                    if (buildTarget == BuildTarget.NoTarget || buildTarget == EditorUserBuildSettings.activeBuildTarget)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        // The check functions for each type of setting
+        private static readonly Dictionary<Configurations, ConfigGetter> ConfigurationGetters = new Dictionary<Configurations, ConfigGetter>()
+        {
+            { Configurations.LatestScriptingRuntime, new ConfigGetter(() => { return IsLatestScriptingRuntime(); }) },
+            { Configurations.ForceTextSerialization, new ConfigGetter(() => { return IsForceTextSerialization(); }) },
+            { Configurations.VisibleMetaFiles, new ConfigGetter(() => { return IsVisibleMetaFiles(); }) },
+            { Configurations.VirtualRealitySupported, new ConfigGetter(() => { return PlayerSettings.virtualRealitySupported; }) },
+            { Configurations.SinglePassInstancing, new ConfigGetter(() => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); }) },
+            { Configurations.SpatialAwarenessLayer, new ConfigGetter(() => { return HasSpatialAwarenessLayer(); }) },
+            { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return IsMSBuildForUnityEnabled(); }) },
 
             // UWP Capabilities
-            { Configurations.SpatialPerceptionCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.SpatialPerception); } },
-            { Configurations.MicrophoneCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.Microphone); } },
-            { Configurations.InternetClientCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.InternetClient); } },
+            { Configurations.SpatialPerceptionCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.SpatialPerception); }, BuildTarget.WSAPlayer) },
+            { Configurations.MicrophoneCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.Microphone); }, BuildTarget.WSAPlayer) },
+            { Configurations.InternetClientCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.InternetClient); }, BuildTarget.WSAPlayer) },
 #if UNITY_2019_3_OR_NEWER
-            { Configurations.EyeTrackingCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.GazeInput); } },
+            { Configurations.EyeTrackingCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.GazeInput); }, BuildTarget.WSAPlayer) },
 #endif
 
             // Android Settings
-            { Configurations.AndroidMultiThreadedRendering, () => { return PlayerSettings.GetMobileMTRendering(BuildTargetGroup.Android) == false; } },
-            { Configurations.AndroidMinSdkVersion, () => { return PlayerSettings.Android.minSdkVersion >= MinAndroidSdk; } },
+            { Configurations.AndroidMultiThreadedRendering, 
+                new ConfigGetter(() => { return PlayerSettings.GetMobileMTRendering(BuildTargetGroup.Android) == false; }, BuildTarget.Android) },
+            { Configurations.AndroidMinSdkVersion,
+                new ConfigGetter(() => { return PlayerSettings.Android.minSdkVersion >= MinAndroidSdk; }, BuildTarget.Android) },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, () => {
+            { Configurations.IOSMinOSVersion, new ConfigGetter(() => {
                     float version;
                     if (!float.TryParse(PlayerSettings.iOS.targetOSVersionString, out version)) { return false; }
-                    return version >= iOSMinOsVersion; } },
-            { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture; } },
-            { Configurations.IOSCameraUsageDescription, () => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); } },
+                    return version >= iOSMinOsVersion; }, BuildTarget.iOS) },
+            { Configurations.IOSArchitecture, 
+                new ConfigGetter(() => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture; }, BuildTarget.iOS) },
+            { Configurations.IOSCameraUsageDescription, 
+                new ConfigGetter(() => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); }, BuildTarget.iOS) },
         };
 
         // The configure functions for each type of setting
         private static Dictionary<Configurations, Action> ConfigurationSetters = new Dictionary<Configurations, Action>()
         {
-            { Configurations.LatestScriptingRuntime,  () => { SetLatestScriptingRuntime(); } },
+            { Configurations.LatestScriptingRuntime, () => { SetLatestScriptingRuntime(); } },
             { Configurations.ForceTextSerialization,  () => { SetForceTextSerialization(); } },
             { Configurations.VisibleMetaFiles,  () => { SetVisibleMetaFiles(); } },
             { Configurations.VirtualRealitySupported,  () => { PlayerSettings.virtualRealitySupported = true; } },
@@ -122,7 +164,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             if (ConfigurationGetters.ContainsKey(config))
             {
-                return ConfigurationGetters[config].Invoke();
+                var configGetter = ConfigurationGetters[config];
+                if (configGetter.IsActiveBuildTargetValid())
+                {
+                    return configGetter.GetAction.Invoke();
+                }
             }
 
             return false;
@@ -146,9 +192,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <returns>true if entire project is configured as recommended, false otherwise</returns>
         public static bool IsProjectConfigured()
         {
-            foreach (var getter in ConfigurationGetters)
+            foreach (var configGetter in ConfigurationGetters)
             {
-                if (!getter.Value.Invoke())
+                if (configGetter.Value.IsActiveBuildTargetValid() && !configGetter.Value.GetAction.Invoke())
                 {
                     return false;
                 }
@@ -313,6 +359,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 PlayerSettings.SetVirtualRealitySDKs(targetGroup, targetSDKs.ToArray());
                 PlayerSettings.SetVirtualRealitySupported(targetGroup, true);
             }
+        }
+
+        private static bool GetCapability(PlayerSettings.WSACapability capability)
+        {
+            return MixedRealityOptimizeUtils.IsBuildTargetUWP() ? PlayerSettings.WSA.GetCapability(capability) : true;
         }
     }
 }


### PR DESCRIPTION
## Overview
The project configurator unfortunately did not take into account the current build target platform. Thus, some setting checks were not valid/necessary. Example: If targeting Standalone, we would still check if the recommended UWP capabilities were set. 

This change adds a buildtarget filter to the configuration getters.

Furthermore, if the project has been appropriately configured as recommended, the Configuration window now just displays a confirmation message instead of the "Hey we want to change stuff...but there is nothing to change"

**Users should no longer be able to see this**
![MRTK_Configurator](https://user-images.githubusercontent.com/25975362/73501598-4374fc00-437b-11ea-8f43-bca3802cd2c3.PNG)

## Changes
- Fixes: #7197 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
