### PR TITLE
Cherrypick #7199 and mark MSBuildForUnity as WSA-only

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -92,15 +92,30 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             MixedRealityInspectorUtility.RenderMixedRealityToolkitLogo();
 
-            RenderChoiceDialog();
-
-            EditorGUILayout.Space();
-
-            showConfigurations = EditorGUILayout.Foldout(showConfigurations, "Modify Configurations", true);
-            if (showConfigurations)
+            if (!MixedRealityProjectConfigurator.IsProjectConfigured())
             {
-                RenderConfigurations();
+                RenderChoiceDialog();
+
+                EditorGUILayout.Space();
+
+                showConfigurations = EditorGUILayout.Foldout(showConfigurations, "Modify Configurations", true);
+                if (showConfigurations)
+                {
+                    RenderConfigurations();
+                }
             }
+            else
+            {
+                RenderConfiguredConfirmation();
+            }
+        }
+
+        private void RenderConfiguredConfirmation()
+        {
+            const string dialogTitle = "Project Configuration Complete";
+            const string dialogContent = "This Unity project is properly configured for the Mixed Reality Toolkit.";
+            EditorGUILayout.LabelField(dialogTitle, EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(dialogContent);
         }
 
         private void RenderChoiceDialog()

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
             else
             {
-                var window = ScriptableObject.CreateInstance<MixedRealityProjectConfiguratorWindow>();
+                var window = CreateInstance<MixedRealityProjectConfiguratorWindow>();
                 window.titleContent = new GUIContent("MRTK Project Configurator", EditorGUIUtility.IconContent("_Popup").image);
                 window.position = new Rect(Screen.width / 2.0f, Screen.height / 2.0f, Default_Window_Height, Default_Window_Width);
                 window.ShowUtility();
@@ -147,69 +147,75 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
         }
 
+        private Vector2 scrollPosition = Vector2.zero;
+
         private void RenderConfigurations()
         {
             EditorGUILayout.LabelField("Enabled options will be applied to the project. Disabled items are already properly configured.");
             EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
-            RenderToggle(MRConfig.ForceTextSerialization, "Enable Force Text Serialization");
-            RenderToggle(MRConfig.VisibleMetaFiles, "Enable Visible meta files");
-            if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS())
+            using (var scrollView = new EditorGUILayout.ScrollViewScope(scrollPosition))
             {
+                scrollPosition = scrollView.scrollPosition;
+                EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
+                RenderToggle(MRConfig.ForceTextSerialization, "Enable Force Text Serialization");
+                RenderToggle(MRConfig.VisibleMetaFiles, "Enable Visible meta files");
+                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS())
+                {
 #if UNITY_2019_3_OR_NEWER
-                RenderToggle(MRConfig.VirtualRealitySupported, "Enable Legacy XR");
+                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable Legacy XR");
 #else
                 RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR Supported");
 #endif // UNITY_2019_3_OR_NEWER
-            }
+                }
 #if UNITY_2019_3_OR_NEWER
-            RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path (legacy XR API)");
+                RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path (legacy XR API)");
 #else
-            RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path");
+                RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path");
 #endif // UNITY_2019_3_OR_NEWER
-            RenderToggle(MRConfig.SpatialAwarenessLayer, "Set Default Spatial Awareness Layer");
-            EditorGUILayout.Space();
-
-            if (MixedRealityOptimizeUtils.IsBuildTargetUWP())
-            {
-                EditorGUILayout.LabelField("UWP Capabilities", EditorStyles.boldLabel);
-
-                RenderToggle(MRConfig.MicrophoneCapability, "Enable Microphone Capability");
-                RenderToggle(MRConfig.InternetClientCapability, "Enable Internet Client Capability");
-                RenderToggle(MRConfig.SpatialPerceptionCapability, "Enable Spatial Perception Capability");
-#if UNITY_2019_3_OR_NEWER
-                RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
-#endif
+                RenderToggle(MRConfig.SpatialAwarenessLayer, "Set default Spatial Awareness layer");
                 EditorGUILayout.Space();
 
-                EditorGUILayout.LabelField("MSBuild for Unity Support", EditorStyles.boldLabel);
-                EditorGUILayout.HelpBox("Enable this for additional HoloLens 2 features, like hand joint remoting and depth LSR mode.", MessageType.Info);
-                RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
-            }
-            else
-            {
-                trackToggles[MRConfig.MicrophoneCapability] = false;
-                trackToggles[MRConfig.InternetClientCapability] = false;
-                trackToggles[MRConfig.SpatialPerceptionCapability] = false;
+                if (MixedRealityOptimizeUtils.IsBuildTargetUWP())
+                {
+                    EditorGUILayout.LabelField("UWP Capabilities", EditorStyles.boldLabel);
+
+                    RenderToggle(MRConfig.MicrophoneCapability, "Enable Microphone Capability");
+                    RenderToggle(MRConfig.InternetClientCapability, "Enable Internet Client Capability");
+                    RenderToggle(MRConfig.SpatialPerceptionCapability, "Enable Spatial Perception Capability");
 #if UNITY_2019_3_OR_NEWER
-                trackToggles[MRConfig.EyeTrackingCapability] = false;
+                    RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
 #endif
-            }
+                    EditorGUILayout.Space();
 
-            if (MixedRealityOptimizeUtils.IsBuildTargetAndroid())
-            {
-                EditorGUILayout.LabelField("Android Settings", EditorStyles.boldLabel);
-                RenderToggle(MRConfig.AndroidMultiThreadedRendering, "Disable Multi-Threaded Rendering");
-                RenderToggle(MRConfig.AndroidMinSdkVersion, "Set Minimum API Level");
-            }
+                    EditorGUILayout.LabelField("MSBuild for Unity Support", EditorStyles.boldLabel);
+                    EditorGUILayout.HelpBox("Enable this for additional HoloLens 2 features, like hand joint remoting and depth LSR mode.", MessageType.Info);
+                    RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
+                }
+                else
+                {
+                    trackToggles[MRConfig.MicrophoneCapability] = false;
+                    trackToggles[MRConfig.InternetClientCapability] = false;
+                    trackToggles[MRConfig.SpatialPerceptionCapability] = false;
+#if UNITY_2019_3_OR_NEWER
+                    trackToggles[MRConfig.EyeTrackingCapability] = false;
+#endif
+                }
 
-            if (MixedRealityOptimizeUtils.IsBuildTargetIOS())
-            {
-                EditorGUILayout.LabelField("iOS Settings", EditorStyles.boldLabel);
-                RenderToggle(MRConfig.IOSMinOSVersion, "Set Required OS Version");
-                RenderToggle(MRConfig.IOSArchitecture, "Set Required Architecture");
-                RenderToggle(MRConfig.IOSCameraUsageDescription, "Set Camera Usage Descriptions");
+                if (MixedRealityOptimizeUtils.IsBuildTargetAndroid())
+                {
+                    EditorGUILayout.LabelField("Android Settings", EditorStyles.boldLabel);
+                    RenderToggle(MRConfig.AndroidMultiThreadedRendering, "Disable Multi-Threaded Rendering");
+                    RenderToggle(MRConfig.AndroidMinSdkVersion, "Set Minimum API Level");
+                }
+
+                if (MixedRealityOptimizeUtils.IsBuildTargetIOS())
+                {
+                    EditorGUILayout.LabelField("iOS Settings", EditorStyles.boldLabel);
+                    RenderToggle(MRConfig.IOSMinOSVersion, "Set Required OS Version");
+                    RenderToggle(MRConfig.IOSArchitecture, "Set Required Architecture");
+                    RenderToggle(MRConfig.IOSCameraUsageDescription, "Set Camera Usage Descriptions");
+                }
             }
         }
 

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -181,6 +181,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
                 RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
 #endif
+                EditorGUILayout.Space();
+
+                EditorGUILayout.LabelField("MSBuild for Unity Support", EditorStyles.boldLabel);
+                EditorGUILayout.HelpBox("Enable this for additional HoloLens 2 features, like hand joint remoting and depth LSR mode.", MessageType.Info);
                 RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
             }
             else

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -169,7 +169,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path");
 #endif // UNITY_2019_3_OR_NEWER
             RenderToggle(MRConfig.SpatialAwarenessLayer, "Set Default Spatial Awareness Layer");
-            RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
             EditorGUILayout.Space();
 
             if (MixedRealityOptimizeUtils.IsBuildTargetUWP())
@@ -182,6 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
                 RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
 #endif
+                RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
             }
             else
             {

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -165,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.VirtualRealitySupported, "Enable Legacy XR");
 #else
-                RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR Supported");
+                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR Supported");
 #endif // UNITY_2019_3_OR_NEWER
                 }
 #if UNITY_2019_3_OR_NEWER
@@ -178,19 +178,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                 if (MixedRealityOptimizeUtils.IsBuildTargetUWP())
                 {
-                    EditorGUILayout.LabelField("UWP Capabilities", EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField("MSBuild for Unity Support", EditorStyles.boldLabel);
+                    EditorGUILayout.HelpBox("Enable this for additional HoloLens 2 features, like hand joint remoting and depth LSR mode.", MessageType.Info);
+                    RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
+                    EditorGUILayout.Space();
 
+                    EditorGUILayout.LabelField("UWP Capabilities", EditorStyles.boldLabel);
                     RenderToggle(MRConfig.MicrophoneCapability, "Enable Microphone Capability");
                     RenderToggle(MRConfig.InternetClientCapability, "Enable Internet Client Capability");
                     RenderToggle(MRConfig.SpatialPerceptionCapability, "Enable Spatial Perception Capability");
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
 #endif
-                    EditorGUILayout.Space();
-
-                    EditorGUILayout.LabelField("MSBuild for Unity Support", EditorStyles.boldLabel);
-                    EditorGUILayout.HelpBox("Enable this for additional HoloLens 2 features, like hand joint remoting and depth LSR mode.", MessageType.Info);
-                    RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
                 }
                 else
                 {

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -101,9 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.VisibleMetaFiles, new ConfigGetter(() => { return IsVisibleMetaFiles(); }) },
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
             // with legacy requirements.
-#pragma warning disable 0618
-            { Configurations.VirtualRealitySupported, new ConfigGetter(() => { return PlayerSettings.virtualRealitySupported; }) },
-#pragma warning restore 0618
+            { Configurations.VirtualRealitySupported, new ConfigGetter(() => { return XRSettingsUtilities.LegacyXREnabled; }) },
             { Configurations.SinglePassInstancing, new ConfigGetter(() => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); }) },
             { Configurations.SpatialAwarenessLayer, new ConfigGetter(() => { return HasSpatialAwarenessLayer(); }) },
             { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return IsMSBuildForUnityEnabled(); }, BuildTarget.WSAPlayer) },

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -99,8 +99,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.LatestScriptingRuntime, new ConfigGetter(() => { return IsLatestScriptingRuntime(); }) },
             { Configurations.ForceTextSerialization, new ConfigGetter(() => { return IsForceTextSerialization(); }) },
             { Configurations.VisibleMetaFiles, new ConfigGetter(() => { return IsVisibleMetaFiles(); }) },
-            // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
-            // with legacy requirements.
             { Configurations.VirtualRealitySupported, new ConfigGetter(() => { return XRSettingsUtilities.LegacyXREnabled; }) },
             { Configurations.SinglePassInstancing, new ConfigGetter(() => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); }) },
             { Configurations.SpatialAwarenessLayer, new ConfigGetter(() => { return HasSpatialAwarenessLayer(); }) },
@@ -132,16 +130,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         };
 
         // The configure functions for each type of setting
-        private static Dictionary<Configurations, Action> ConfigurationSetters = new Dictionary<Configurations, Action>()
+        private static readonly Dictionary<Configurations, Action> ConfigurationSetters = new Dictionary<Configurations, Action>()
         {
             { Configurations.LatestScriptingRuntime, () => { SetLatestScriptingRuntime(); } },
             { Configurations.ForceTextSerialization,  () => { SetForceTextSerialization(); } },
             { Configurations.VisibleMetaFiles,  () => { SetVisibleMetaFiles(); } },
-            // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
-            // with legacy requirements.
-#pragma warning disable 0618
-            { Configurations.VirtualRealitySupported,  () => { PlayerSettings.virtualRealitySupported = true; } },
-#pragma warning restore 0618
+            { Configurations.VirtualRealitySupported,  () => { XRSettingsUtilities.LegacyXREnabled = true; } },
             { Configurations.SinglePassInstancing,  () => { MixedRealityOptimizeUtils.SetSinglePassInstanced(); } },
             { Configurations.SpatialAwarenessLayer,  () => { SetSpatialAwarenessLayer(); } },
             { Configurations.EnableMSBuildForUnity, () => { PackageManifestUpdater.EnsureMSBuildForUnity(); } },

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #pragma warning restore 0618
             { Configurations.SinglePassInstancing, new ConfigGetter(() => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); }) },
             { Configurations.SpatialAwarenessLayer, new ConfigGetter(() => { return HasSpatialAwarenessLayer(); }) },
-            { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return IsMSBuildForUnityEnabled(); }) },
+            { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return IsMSBuildForUnityEnabled(); }, BuildTarget.WSAPlayer) },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.SpatialPerception); }, BuildTarget.WSAPlayer) },

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -52,46 +52,91 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             IOSCameraUsageDescription,
         };
 
-        // The check functions for each type of setting
-        private static readonly Dictionary<Configurations, Func<bool>> ConfigurationGetters = new Dictionary<Configurations, Func<bool>>()
+        private class ConfigGetter
         {
-            { Configurations.LatestScriptingRuntime,  () => { return IsLatestScriptingRuntime(); } },
-            { Configurations.ForceTextSerialization,  () => { return IsForceTextSerialization(); } },
-            { Configurations.VisibleMetaFiles,  () => { return IsVisibleMetaFiles(); } },
+            /// <summary>
+            /// Array of build targets where the get action is valid
+            /// </summary>
+            public BuildTarget[] ValidTargets;
+
+            /// <summary>
+            /// Action to perform to determine if the current configuration is correctly enabled
+            /// </summary>
+            public Func<bool> GetAction;
+
+            public ConfigGetter(Func<bool> get, BuildTarget target = BuildTarget.NoTarget)
+            {
+                GetAction = get;
+                ValidTargets = new BuildTarget[] { target };
+            }
+
+            public ConfigGetter(Func<bool> get, BuildTarget[] targets)
+            {
+                GetAction = get;
+                ValidTargets = targets;
+            }
+
+            /// <summary>
+            /// Returns true if the active build target is contained in the ValidTargets list or the list contains a BuildTarget.NoTarget entry, false otherwise
+            /// </summary>
+            public bool IsActiveBuildTargetValid()
+            {
+                foreach (var buildTarget in ValidTargets)
+                {
+                    if (buildTarget == BuildTarget.NoTarget || buildTarget == EditorUserBuildSettings.activeBuildTarget)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        // The check functions for each type of setting
+        private static readonly Dictionary<Configurations, ConfigGetter> ConfigurationGetters = new Dictionary<Configurations, ConfigGetter>()
+        {
+            { Configurations.LatestScriptingRuntime, new ConfigGetter(() => { return IsLatestScriptingRuntime(); }) },
+            { Configurations.ForceTextSerialization, new ConfigGetter(() => { return IsForceTextSerialization(); }) },
+            { Configurations.VisibleMetaFiles, new ConfigGetter(() => { return IsVisibleMetaFiles(); }) },
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
             // with legacy requirements.
 #pragma warning disable 0618
-            { Configurations.VirtualRealitySupported,  () => { return PlayerSettings.virtualRealitySupported; } },
+            { Configurations.VirtualRealitySupported, new ConfigGetter(() => { return PlayerSettings.virtualRealitySupported; }) },
 #pragma warning restore 0618
-            { Configurations.SinglePassInstancing,  () => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); } },
-            { Configurations.SpatialAwarenessLayer,  () => { return HasSpatialAwarenessLayer(); } },
-            { Configurations.EnableMSBuildForUnity, () => { return IsMSBuildForUnityEnabled(); } },
+            { Configurations.SinglePassInstancing, new ConfigGetter(() => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); }) },
+            { Configurations.SpatialAwarenessLayer, new ConfigGetter(() => { return HasSpatialAwarenessLayer(); }) },
+            { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return IsMSBuildForUnityEnabled(); }) },
 
             // UWP Capabilities
-            { Configurations.SpatialPerceptionCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.SpatialPerception); } },
-            { Configurations.MicrophoneCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.Microphone); } },
-            { Configurations.InternetClientCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.InternetClient); } },
+            { Configurations.SpatialPerceptionCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.SpatialPerception); }, BuildTarget.WSAPlayer) },
+            { Configurations.MicrophoneCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.Microphone); }, BuildTarget.WSAPlayer) },
+            { Configurations.InternetClientCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.InternetClient); }, BuildTarget.WSAPlayer) },
 #if UNITY_2019_3_OR_NEWER
-            { Configurations.EyeTrackingCapability,  () => { return PlayerSettings.WSA.GetCapability(PlayerSettings.WSACapability.GazeInput); } },
+            { Configurations.EyeTrackingCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.GazeInput); }, BuildTarget.WSAPlayer) },
 #endif // UNITY_2019_3_OR_NEWER
 
             // Android Settings
-            { Configurations.AndroidMultiThreadedRendering, () => { return PlayerSettings.GetMobileMTRendering(BuildTargetGroup.Android) == false; } },
-            { Configurations.AndroidMinSdkVersion, () => { return PlayerSettings.Android.minSdkVersion >= MinAndroidSdk; } },
+            { Configurations.AndroidMultiThreadedRendering, 
+                new ConfigGetter(() => { return PlayerSettings.GetMobileMTRendering(BuildTargetGroup.Android) == false; }, BuildTarget.Android) },
+            { Configurations.AndroidMinSdkVersion,
+                new ConfigGetter(() => { return PlayerSettings.Android.minSdkVersion >= MinAndroidSdk; }, BuildTarget.Android) },
 
             // iOS Settings
-            { Configurations.IOSMinOSVersion, () => {
+            { Configurations.IOSMinOSVersion, new ConfigGetter(() => {
                     float version;
                     if (!float.TryParse(PlayerSettings.iOS.targetOSVersionString, out version)) { return false; }
-                    return version >= iOSMinOsVersion; } },
-            { Configurations.IOSArchitecture, () => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture; } },
-            { Configurations.IOSCameraUsageDescription, () => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); } },
+                    return version >= iOSMinOsVersion; }, BuildTarget.iOS) },
+            { Configurations.IOSArchitecture, 
+                new ConfigGetter(() => { return PlayerSettings.GetArchitecture(BuildTargetGroup.iOS) == RequirediOSArchitecture; }, BuildTarget.iOS) },
+            { Configurations.IOSCameraUsageDescription, 
+                new ConfigGetter(() => { return !string.IsNullOrWhiteSpace(PlayerSettings.iOS.cameraUsageDescription); }, BuildTarget.iOS) },
         };
 
         // The configure functions for each type of setting
         private static Dictionary<Configurations, Action> ConfigurationSetters = new Dictionary<Configurations, Action>()
         {
-            { Configurations.LatestScriptingRuntime,  () => { SetLatestScriptingRuntime(); } },
+            { Configurations.LatestScriptingRuntime, () => { SetLatestScriptingRuntime(); } },
             { Configurations.ForceTextSerialization,  () => { SetForceTextSerialization(); } },
             { Configurations.VisibleMetaFiles,  () => { SetVisibleMetaFiles(); } },
             // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
@@ -130,7 +175,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             if (ConfigurationGetters.ContainsKey(config))
             {
-                return ConfigurationGetters[config].Invoke();
+                var configGetter = ConfigurationGetters[config];
+                if (configGetter.IsActiveBuildTargetValid())
+                {
+                    return configGetter.GetAction.Invoke();
+                }
             }
 
             return false;
@@ -154,9 +203,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <returns>true if entire project is configured as recommended, false otherwise</returns>
         public static bool IsProjectConfigured()
         {
-            foreach (var getter in ConfigurationGetters)
+            foreach (var configGetter in ConfigurationGetters)
             {
-                if (!getter.Value.Invoke())
+                if (configGetter.Value.IsActiveBuildTargetValid() && !configGetter.Value.GetAction.Invoke())
                 {
                     return false;
                 }
@@ -325,6 +374,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 PlayerSettings.SetVirtualRealitySupported(targetGroup, true);
             }
 #pragma warning restore 0618
+        }
+
+        private static bool GetCapability(PlayerSettings.WSACapability capability)
+        {
+            return MixedRealityOptimizeUtils.IsBuildTargetUWP() ? PlayerSettings.WSA.GetCapability(capability) : true;
         }
     }
 }


### PR DESCRIPTION
## Overview

Cherry-picks #7199 and additionally gates the MSBuildForUnity option behind the UWP build target.

![image](https://user-images.githubusercontent.com/3580640/73568824-044bb700-441e-11ea-9be1-f7f77eb23e52.png)

## Changes
- Helps with #6947 by disabling MSBuild for Unity import unless the UWP build target is selected. 