### PR TITLE
Update foldouts that didn't have toggleOnLabelClick set to true

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
             controllerRenderList.Clear();
 
-            showControllerDefinitions = EditorGUILayout.Foldout(showControllerDefinitions, "Controller Definitions");
+            showControllerDefinitions = EditorGUILayout.Foldout(showControllerDefinitions, "Controller Definitions", true);
             if (showControllerDefinitions)
             {
                 using (var outerVerticalScope = new GUILayout.VerticalScope())

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/HandJointServiceInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/HandJointServiceInspector.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
             ShowHandJointFoldout = SessionState.GetBool(ShowHandJointFoldoutKey, false);
-            ShowHandJointFoldout = EditorGUILayout.Foldout(ShowHandJointFoldout, "Visible Hand Joints");
+            ShowHandJointFoldout = EditorGUILayout.Foldout(ShowHandJointFoldout, "Visible Hand Joints", true);
             SessionState.SetBool(ShowHandJointFoldoutKey, ShowHandJointFoldout);
 
             if (ShowHandJointFoldout)


### PR DESCRIPTION
## Overview

These were the only two `EditorGUILayout.Foldout`s that didn't have `toggleOnLabelClick` set to true. For user convenience, I've updated them.