### PR TITLE
Update cached coordinate system whenever the underlying IntPtr changes

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -72,19 +72,26 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         {
             get
             {
-                if (spatialCoordinateSystem == null && UtilitiesProvider != null && UtilitiesProvider.ISpatialCoordinateSystemPtr != IntPtr.Zero)
+                if (UtilitiesProvider != null)
                 {
+                    IntPtr newSpatialCoordinateSystemPtr = UtilitiesProvider.ISpatialCoordinateSystemPtr;
+                    if (newSpatialCoordinateSystemPtr != currentSpatialCoordinateSystemPtr && newSpatialCoordinateSystemPtr != IntPtr.Zero)
+                    {
 #if ENABLE_DOTNET
-                    spatialCoordinateSystem = GetSpatialCoordinateSystem(UtilitiesProvider.ISpatialCoordinateSystemPtr);
+                        spatialCoordinateSystem = GetSpatialCoordinateSystem(newSpatialCoordinateSystemPtr);
 #elif WINDOWS_UWP
-                    spatialCoordinateSystem = Marshal.GetObjectForIUnknown(UtilitiesProvider.ISpatialCoordinateSystemPtr) as SpatialCoordinateSystem;
+                        spatialCoordinateSystem = Marshal.GetObjectForIUnknown(newSpatialCoordinateSystemPtr) as SpatialCoordinateSystem;
 #elif DOTNETWINRT_PRESENT
-                    spatialCoordinateSystem = SpatialCoordinateSystem.FromNativePtr(UtilitiesProvider.ISpatialCoordinateSystemPtr);
+                        spatialCoordinateSystem = SpatialCoordinateSystem.FromNativePtr(newSpatialCoordinateSystemPtr);
 #endif
+                        currentSpatialCoordinateSystemPtr = newSpatialCoordinateSystemPtr;
+                    }
                 }
                 return spatialCoordinateSystem;
             }
         }
+
+        private static IntPtr currentSpatialCoordinateSystemPtr = IntPtr.Zero;
 
         /// <summary>
         /// Access the underlying native current holographic frame.

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/XRSDKWindowsMixedRealityUtilitiesProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/XRSDKWindowsMixedRealityUtilitiesProvider.cs
@@ -23,14 +23,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             IntPtr.Zero;
 #endif
 
-        /// <inheritdoc />
-        IntPtr IWindowsMixedRealityUtilitiesProvider.IHolographicFramePtr
-        {
-            get
-            {
-                // NOTE: Currently unable to access HolographicFrame in XR SDK.
-                return IntPtr.Zero;
-            }
-        }
+        /// <summary>
+        /// Currently unable to access HolographicFrame in XR SDK. Always returns IntPtr.Zero.
+        /// </summary>
+        IntPtr IWindowsMixedRealityUtilitiesProvider.IHolographicFramePtr => IntPtr.Zero;
     }
 }


### PR DESCRIPTION
## Overview

Instead of assuming only one SpatialCoordinateSystem will ever exist, this change checks the `IntPtr`s to detect when the underlying root coordinate system has changed.

This helps scenarios like recentering, when a dev / user wants to realign the experience in a specific alignment. Can also help in scenarios when tracking is list and the original coordinate system is never regained. Might help in the scenario when a new scene is loaded, but I haven't tested this yet.

## Changes
- Part of #7003, maybe helps with https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6974