### PR TITLE
Cherry-pick pull request #7186 from wiwei/ignoremsb4ugenerated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ doc/
 Assets/MixedRealityToolkit.Providers/WindowsMixedReality/DotNetAdapter/Plugins*
 MSBuildForUnity.Common.props
 .obj
+/*.msb4u.csproj.meta
+*.msb4u.csproj.meta
+/*.msb4u.sln.meta
+*.msb4u.sln.meta


### PR DESCRIPTION
## Overview

Update the .gitignore to ignore the MSBuildForUnity generated csproj and sln files.