### PR TITLE
Fix destroyimmediate for OnValidate() code path

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/MixedRealityInputSystem.cs
@@ -308,12 +308,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (Application.isPlaying)
                 {
                     GazeProvider.GazePointer.BaseCursor.Destroy();
-                    UnityEngine.Object.Destroy(GazeProvider as Component);
                 }
-                else
-                {
-                    UnityEngine.Object.DestroyImmediate(GazeProvider as Component);
-                }
+
+                UnityObjectExtensions.DestroyObject(GazeProvider as Component);
 
                 GazeProvider = null;
             }
@@ -339,12 +336,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     if (Application.isPlaying)
                     {
                         inputModule.DeactivateModule();
-                        UnityEngine.Object.Destroy(inputModule);
                     }
-                    else
-                    {
-                        UnityEngine.Object.DestroyImmediate(inputModule);
-                    }
+
+                    UnityObjectExtensions.DestroyObject(inputModule);
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/UnityObjectExtensions.cs
@@ -36,7 +36,13 @@ namespace Microsoft.MixedReality.Toolkit
             }
             else
             {
-                Object.DestroyImmediate(obj);
+                // Must use DestroyImmediate in edit mode but it is not allowed when called from 
+                // trigger/contact, animation event callbacks or OnValidate. Must use Destroy instead.
+                // Delay call to counter this issue in editor
+                UnityEditor.EditorApplication.delayCall += () =>
+                {
+                    Object.DestroyImmediate(obj);
+                };
             }
         }
 

--- a/Assets/MixedRealityToolkit/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/UnityObjectExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
             else
             {
+            #if UNITY_EDITOR
                 // Must use DestroyImmediate in edit mode but it is not allowed when called from 
                 // trigger/contact, animation event callbacks or OnValidate. Must use Destroy instead.
                 // Delay call to counter this issue in editor
@@ -43,6 +44,9 @@ namespace Microsoft.MixedReality.Toolkit
                 {
                     Object.DestroyImmediate(obj);
                 };
+            #else
+                Object.DestroyImmediate(obj);
+            #endif
             }
         }
 


### PR DESCRIPTION
## Overview
When in edit mode in editor, DestroyImmediate needs to be used except it cannot be called
"during physics trigger/contact, animation event callbacks or OnValidate. "

The MRTK system may be "reset" in the MRTK.OnValidate() if switching scenes or selecting a new profile in which case the old services and components will be destroyed. This triggers an error message in the editor console.

This change delays the DestroyImmediate call to avoid the scenario described above.

## Changes
- Fixes: #6584 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
