### PR TITLE
Fix possible follow object stuck behind player

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/FollowSolver/Follow.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/FollowSolver/Follow.cs
@@ -422,7 +422,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             }
             else
             {
-                float angle = -AngleBetweenVectorAndPlane(toTarget, refUp);
+                float angle = -AngleBetweenOnPlane(toTarget, currentRefForward, refRight);
                 float minMaxAngle = MaxViewVerticalDegrees * 0.5f;
 
                 if (angle < -minMaxAngle)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -610,6 +610,38 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.LessOrEqual(Mathf.Abs(yAngle()), maxYAngle, "Follow exceeded the max vertical angular bounds");
         }
 
+        /// <summary>
+        /// Test the Follow solver angular clamp options
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestFollowStuckBehind()
+        {
+            // Instantiate our test GameObject with solver.
+            var testObjects = InstantiateTestSolver<Follow>();
+            var followSolver = (Follow)testObjects.solver;
+            followSolver.MoveToDefaultDistanceLerpTime = 0;
+            testObjects.handler.TrackedTargetType = TrackedObjectType.Head;
+            var targetTransform = testObjects.target.transform;
+
+            // variables and lambdas to test direction remains within bounds
+            Vector3 toTarget() => targetTransform.position - CameraCache.Main.transform.position;
+
+            // Test without rotation
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            Assert.Greater(Vector3.Dot(CameraCache.Main.transform.forward, toTarget()), 0, "Follow behind the player");
+
+            // Test y axis rotation
+            MixedRealityPlayspace.PerformTransformation(p => p.Rotate(Vector3.up, 180));
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            Assert.Greater(Vector3.Dot(CameraCache.Main.transform.forward, toTarget()), 0, "Follow behind the player");
+        }
+
         #endregion
 
         #region Test Helpers


### PR DESCRIPTION
## Overview
Discovered a possible issue with the follow solver. Although it was hard to repro, it was possible to get the follow object stuck in the inverted leashing frustum. This fix uses the angle from `toTarget` to the reference yz plane for horizontal leashing, but uses the angle from `currentRefForward` and `toTarget` projected onto the reference yz plane for vertical leashing. This ensures that positions in the inverted leashing frustum are not valid leasing positions.