### PR TITLE
Update the PokePointer to avoid unnecessary work in OnValidate.

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -124,8 +124,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected void OnValidate()
         {
-            Debug.Assert(line != null, this);
-            Debug.Assert(visuals != null, this);
             touchableDistance = Mathf.Max(touchableDistance, 0);
             sceneQueryBufferSize = Mathf.Max(sceneQueryBufferSize, 1);
         }


### PR DESCRIPTION
## Overview
There are still a few places that have unnecessary OnValidate calls, which per https://github.com/microsoft/MixedRealityToolkit-Unity/pull/4899 and https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4202#issuecomment-495765433 isn't being used correctly in all cases.

In this case, the adjustment to some of the properties (i.e. touchableDistance/sceneQueryBufferSize) actually is fine, it's just the asserts that actually don't make sense.

Nevertheless this just moves things to Awake to be consistent with the way we've fixed some of other other OnValidate calls.

## Changes
- Fixes: #https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7213