### PR TITLE
Fix MixedRealityToolkit.Generated folder creation location

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -404,10 +404,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 // AssetDatabase.CreateFolder must be called to create each child of the asset folder
                 // path individually. 
-                // Calling AssetDatabase.CreateFolder("Assets", "MixedRealityToolkit.Generated/CustomProfiles")
-                // generates a folder that looks like "Assets/MixedRealityToolkit.Generated_CustomProfiles".
-                AssetDatabase.CreateFolder("Assets", "MixedRealityToolkit.Generated");
+                
+                // Create the MixedRealityToolkit.Generated folder at the root of the Assets
+                MixedRealityToolkitFiles.TryToCreateGeneratedFolder("Assets/");
+
                 AssetDatabase.CreateFolder("Assets/MixedRealityToolkit.Generated", "CustomProfiles");
+
             }
             return AssetDatabase.LoadAssetAtPath(DefaultCustomProfileFolder, typeof(Object));
         }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityProfileCloneWindow.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -24,7 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             public SubProfileAction(
                 ProfileCloneBehavior behavior,
                 SerializedProperty property,
-                Object substitutionReference, 
+                Object substitutionReference,
                 System.Type profileType)
             {
                 Behavior = behavior;
@@ -46,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private const string AdvancedModeKey = "MRTK_ProfileCloneWindow_AdvancedMode_Key";
         private static bool AdvancedMode = false;
-        private const string DefaultCustomProfileFolder = "Assets/MixedRealityToolkit.Generated/CustomProfiles";
+        protected static string DefaultCustomProfileFolder => Path.Combine(MixedRealityToolkitFiles.MapModulePath(MixedRealityToolkitModuleType.Generated), "CustomProfiles");
         private const string IsCustomProfileProperty = "isCustomProfile";
         private static readonly Vector2 MinWindowSizeBasic = new Vector2(500, 180);
         private const float SubProfileSizeMultiplier = 95f;
@@ -241,7 +242,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     cloneWindow.Close();
                 }
-            }   
+            }
 
             // If there are no sub profiles, limit the max so the window isn't spawned too large
             if (subProfileActions.Count <= 0 || !AdvancedMode)
@@ -400,16 +401,15 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 return targetFolder;
             }
 
-            if (!AssetDatabase.IsValidFolder(DefaultCustomProfileFolder))
+            string customProfilesFolderPath = DefaultCustomProfileFolder;
+            if (!AssetDatabase.IsValidFolder(customProfilesFolderPath))
             {
                 // AssetDatabase.CreateFolder must be called to create each child of the asset folder
                 // path individually. 
-                
-                // Create the MixedRealityToolkit.Generated folder at the root of the Assets
-                MixedRealityToolkitFiles.TryToCreateGeneratedFolder("Assets/");
 
-                AssetDatabase.CreateFolder("Assets/MixedRealityToolkit.Generated", "CustomProfiles");
-
+                // If the packages have been imported via NugetForUnity, MixedRealityToolkitFiles.GetGeneratedFolder
+                // will also create the MixedRealityToolkit.Generated Folder and return the path to the folder.
+                AssetDatabase.CreateFolder(MixedRealityToolkitFiles.GetGeneratedFolder, "CustomProfiles");
             }
             return AssetDatabase.LoadAssetAtPath(DefaultCustomProfileFolder, typeof(Object));
         }

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -408,14 +408,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             modFolders.Add(normalizedFolder);
-
-            if (module == MixedRealityToolkitModuleType.Core)
-            {
-                TryToCreateGeneratedFolder(folderPath);
-            }
         }
 
-        private static void TryToCreateGeneratedFolder(string folderPath)
+        public static void TryToCreateGeneratedFolder(string folderPath)
         {
             var generatedDirs = GetDirectories(MixedRealityToolkitModuleType.Generated);
             if (generatedDirs == null || !generatedDirs.Any())

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private static Task searchForFoldersTask = null;
         private static CancellationTokenSource searchForFoldersToken;
 
-        private static string NormalizeSeparators(string path) => 
+        private static string NormalizeSeparators(string path) =>
             path?.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
         private static string FormatSeparatorsForUnity(string path) => path?.Replace('\\', '/');
@@ -350,6 +350,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return moduleNameMap.TryGetValue(packageFolder, out moduleType) ? moduleType : MixedRealityToolkitModuleType.None;
         }
 
+        /// <summary>
+        /// Creates the MixedRealityToolkit.Generated folder if it does not exist and returns the 
+        /// path to the generated folder.
+        /// </summary>
+        public static string GetGeneratedFolder
+        {
+            get
+            {
+                TryToCreateGeneratedFolder();
+                return MapModulePath(MixedRealityToolkitModuleType.Generated);
+            }
+        }
+
         private static async Task SearchForFoldersAsync(string rootPath)
         {
             if (searchForFoldersToken != null)
@@ -376,6 +389,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         ct.ThrowIfCancellationRequested();
                     }
                 }
+
+                // Create the Generated folder, if the user tries to delete the Generated folder it will be created again
+                TryToCreateGeneratedFolder();
             }
             catch (OperationCanceledException)
             {
@@ -410,13 +426,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             modFolders.Add(normalizedFolder);
         }
 
-        public static void TryToCreateGeneratedFolder(string folderPath)
+        private static void TryToCreateGeneratedFolder()
         {
+            // Always add the the MixedRealityToolkit.Generated folder to Assets
             var generatedDirs = GetDirectories(MixedRealityToolkitModuleType.Generated);
             if (generatedDirs == null || !generatedDirs.Any())
             {
-                string parentFolderPath = Directory.GetParent(folderPath).FullName;
-                string generatedFolderPath = Path.Combine(parentFolderPath, "MixedRealityToolkit.Generated");
+                string generatedFolderPath = Path.Combine("Assets", "MixedRealityToolkit.Generated");
                 if (!Directory.Exists(generatedFolderPath))
                 {
                     Directory.CreateDirectory(generatedFolderPath);


### PR DESCRIPTION
## Overview
The MixedRealityToolkit.Generated folder was created twice. Once in the Foundation package, and again at the root of the Assets folder when a profile was cloned.

![image](https://user-images.githubusercontent.com/53493796/73693494-301fa480-468b-11ea-85af-cfc783a609b1.png)

This fix removes the additional call to generate the MixedRealityToolkit.Generated within MixedRealityToolkitFiles to isolate a call to generate the folder in the MixedRealityProfileCloneWindow.

The MixedRealityToolkit.Generated folder now appears only at the root of the Assets folder.


## Changes
- Fixes: #7184


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
