### PR TITLE
Update release notes, upgrade guide, roadmap and authors list for 2.3.0 release

### DIFF
--- a/Documentation/Authors.md
+++ b/Documentation/Authors.md
@@ -8,6 +8,10 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - Alex Cooper
 - Alexees
 - andreiborodin
+- artsouflMS
+- Austin Ha
+- Bertrand Oustrière
+- Bertrand75014
 - Cameron-Micka
 - CDiaz-MS
 - chbecker-ms
@@ -23,6 +27,7 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - gejohnst
 - gilbdev
 - googlan
+- graycelee
 - Jarodshow
 - jbienzms
 - Jerome Humbert
@@ -32,6 +37,7 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - julenka
  -julianloehr-kg
 - jwittner
+- Kent1LG
 - keveleigh
 - killerantz
 - LaneMax
@@ -40,6 +46,7 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - lukastonneMS
 - macborow
 - MenelvagorMilsom
+- michael-house
 - mpkoz
 - ms738
 - myrandaGoesToSpace
@@ -49,12 +56,14 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - paco-ms
 - phosphoer
 - provencher
+- Quentin LG
 - radicalad
 - Railboy
 - ritijain
 - ryzngard
 - sgwin
 - SimonDarksideJ
+- sloh-ms
 - sostel
 - stefan.wasserbauer
 - StephenHodgson
@@ -62,6 +71,7 @@ The Microsoft Mixed Reality Toolkit is a collaborative project containing contri
 - tarukosu
 - thalbern
 - Troy-Ferrell
+- vaoliva
 - wassx
 - Weasy666
 - witian

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -39,8 +39,7 @@ Themes:
 - Stability
 - Developer education
 - User Experience
-- Hand Extensibility
-- Platform expansion
+- Platform expansion: Hands
 
 **Stability**
 
@@ -57,12 +56,7 @@ Quality and stability are the top priority for this and all Microsoft Mixed Real
 - Graduating experimental features
 - Tests to ensure features do not regress
 
-**Hand extensibility**
-
-Hand extensibility includes refactors (non-breaking change) that to allow features, such as customizable pointing rays to be easily implemented without need for
-modifying MRTK source.
-
-**Platform expansion**
+**Platform expansion: Hands**
 
 As part of the hand extensibility theme, MRTK plans on adding support for the Leap Motion hands controller and Oculus Quest. Support for Leap Motion is expected to be made available on both Unity 2018.4 and 2019. Oculus Quest, including articulated hands, will be delivered via [Unity's new XR platform](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/).
 

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -4,14 +4,17 @@ This document outlines the roadmap of the Mixed Reality Toolkit.
 
 ## Current release
 
-[Microsoft Mixed Reality Toolkit v2.1.0](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.1.0)
+[Microsoft Mixed Reality Toolkit v2.3.0](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.3.0)
 
 ## Upcoming releases
 
 | Product | Description | Timeline | Project board |
 | --- | --- | --- | --- |
-| [MRTK V2.3](#230) | Next iteration of MRTK | January 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/10 |
-| [MRTK V2.4](#240) | Future iteration of MRTK | TBD | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
+| [MRTK V2.4](#240) | Next iteration of MRTK | March 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
+| [MRTK V2.5](#250) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
+| [MRTK V2.6](#260) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
+| [MRTK V2.7](#270) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
+| [MRTK V2.8](#280) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
 
 Release details, including backlog items, can be found on the [GitHub milestone pages](https://github.com/Microsoft/MixedRealityToolkit-Unity/milestones). The complete set of open issues can also be found on [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/issues).
 
@@ -23,56 +26,60 @@ The Mixed Reality Toolkit will require Unity 2018.4.
 
 > When Unity releases an LTS (Long Term Support) product, the Mixed Reality Toolkit will update to the LTS release. MRTK will also support the latest non-beta (ex: 2019.1) tech branch version of Unity, at the time at which MRTK was released.
 
-### 2.3.0
+### 2.4.0
 
-The version 2.3.0 plan has been finalized. While some details may change as the iteration progresses, the following describes the overall plan for the next MRTK release. For the latest status of the release, please visit the [milestone page]( https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/10).
+For the latest status of the release, please visit the [milestone page]( https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11).
 
 Status: In development
 
-Timeline: January 2029
+Timeline: March 2020
 
 Themes:
 
 - Stability
 - Developer education
-- Unity 2019.3 XR SDK support
 - User Experience
-- Iterate on mobile AR support
+- Hand Extensibility
 
 **Stability**
 
 Quality and stability are the top priority for this and all Microsoft Mixed Reality Toolkit releases. We will continue to prioritize customer and partner issues that impact the stability of MRTK components.
 
-The MRTK build and deploy tools remain a continued area of stability and quality focus.
-
 **Developer education**
 
 [Developer documentation](https://microsoft.github.io/MixedRealityToolkit-Unity) and example scenes are, like stability, an ongoing priority for the MRTK team.
 
-**Unity 2019.3 XR SDK support**
-
-XR SDK is Unity's new mixed reality platform. The Microsoft Mixed Reality Toolkit is committed to supporting our customers on this new platform. All new platform support in MRTK is expected to be delivered via XR SDK.
-
 **User Experience**
 
-User experience (UX) work will include:
-
 - Bug fixes
-- Making it easier to add MRTK UX elements to projects
-- Bounding box and manipulator updates
-- New features
-    - Tap to place (HoloToolkit feature)
-    - Follow solver (https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5713)
+- Hololens Shell parity
+- Graduating experimental features
+- Tests to ensure features do not regress
 
-**Iterate on mobile AR**
+**Hand extensibility**
 
-The Mixed Reality Toolkit will gain experimental support for spatial awareness (planes and points) on mobile AR platforms (Android ARCore and iOS ARKit) via ARFoundation. Refinements to the camera support module shipped in version 2.2.0 are also planned.
+Hand extensibility includes refactors (non-breaking change) that to allow features, such as customizable pointing rays to be easily implemented without need for
+modifying MRTK source.
 
-### 2.4.0
+### 2.5.0
 
-The planning for version 2.4.0 is in the early stages. All of the details below are subject to change. For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11).
+For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/12). All of the details below are subject to change.
 
-Status: Early planning
+Status: Planning
+
+Timeline: TBD 2020
+
+Themes:
+
+- Stability
+- Developer education
+- User Experience
+
+### 2.6.0
+
+For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/14). All of the details below are subject to change.
+
+Status: Planning
 
 Timeline: TBD
 
@@ -80,10 +87,45 @@ Themes:
 
 - Stability
 - Developer education
-
-Potential areas of focus
-
-- Leap Motion support (Unity 2018 and Unity 2019)
-- Enhanced MRTK modularity
-- Integration of Azure services
 - User Experience
+
+### 2.7.0
+
+For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/15). All of the details below are subject to change.
+
+Status: Planning
+
+Timeline: TBD
+
+Themes:
+
+- Stability
+- Developer education
+- User Experience
+
+### 2.8.0
+
+For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/16). All of the details below are subject to change.
+
+Status: Planning
+
+Timeline: TBD
+
+Themes:
+
+- Stability
+- Developer education
+- User Experience
+
+## Backlog
+
+The following list highlights some of the key investments the MRTK team intends to pursue.
+
+- Platform expansion
+- Extensibility
+- Modularity
+- Accessibility features
+- Globalization enhancements
+- Packaging
+- Cloud service support
+- Tools

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -11,10 +11,10 @@ This document outlines the roadmap of the Mixed Reality Toolkit.
 | Product | Description | Timeline | Project board |
 | --- | --- | --- | --- |
 | [MRTK V2.4](#240) | Next iteration of MRTK | March 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
-| [MRTK V2.5](#250) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
-| [MRTK V2.6](#260) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
-| [MRTK V2.7](#270) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
-| [MRTK V2.8](#280) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
+| [MRTK V2.5](#250) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/12 |
+
+Releases are centered around themes (ex: large feature areas) and are scheduled to occur approximately every 8 weeks.
+
 
 Release details, including backlog items, can be found on the [GitHub milestone pages](https://github.com/Microsoft/MixedRealityToolkit-Unity/milestones). The complete set of open issues can also be found on [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/issues).
 
@@ -68,48 +68,6 @@ For the latest information, please consult [GitHub](https://github.com/microsoft
 Status: Planning
 
 Timeline: TBD 2020
-
-Themes:
-
-- Stability
-- Developer education
-- User Experience
-
-### 2.6.0
-
-For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/14). All of the details below are subject to change.
-
-Status: Planning
-
-Timeline: TBD
-
-Themes:
-
-- Stability
-- Developer education
-- User Experience
-
-### 2.7.0
-
-For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/15). All of the details below are subject to change.
-
-Status: Planning
-
-Timeline: TBD
-
-Themes:
-
-- Stability
-- Developer education
-- User Experience
-
-### 2.8.0
-
-For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/16). All of the details below are subject to change.
-
-Status: Planning
-
-Timeline: TBD
 
 Themes:
 

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -11,7 +11,6 @@ This document outlines the roadmap of the Mixed Reality Toolkit.
 | Product | Description | Timeline | Project board |
 | --- | --- | --- | --- |
 | [MRTK V2.4](#240) | Next iteration of MRTK | March 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/11 |
-| [MRTK V2.5](#250) | Future iteration of MRTK | TBD 2020 | https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/12 |
 
 Releases are centered around themes (ex: large feature areas) and are scheduled to occur approximately every 8 weeks.
 
@@ -32,7 +31,7 @@ For the latest status of the release, please visit the [milestone page]( https:/
 
 Status: In development
 
-Timeline: March 2020
+Timeline: March/April 2020
 
 Themes:
 
@@ -59,20 +58,6 @@ Quality and stability are the top priority for this and all Microsoft Mixed Real
 **Platform expansion: Hands**
 
 As part of the hand extensibility theme, MRTK plans on adding support for the Leap Motion hands controller and Oculus Quest. Support for Leap Motion is expected to be made available on both Unity 2018.4 and 2019. Oculus Quest, including articulated hands, will be delivered via [Unity's new XR platform](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/).
-
-### 2.5.0
-
-For the latest information, please consult [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/milestone/12). All of the details below are subject to change.
-
-Status: Planning
-
-Timeline: TBD 2020
-
-Themes:
-
-- Stability
-- Developer education
-- User Experience
 
 ## Backlog
 

--- a/Documentation/Contributing/Roadmap.md
+++ b/Documentation/Contributing/Roadmap.md
@@ -40,6 +40,7 @@ Themes:
 - Developer education
 - User Experience
 - Hand Extensibility
+- Platform expansion
 
 **Stability**
 
@@ -60,6 +61,10 @@ Quality and stability are the top priority for this and all Microsoft Mixed Real
 
 Hand extensibility includes refactors (non-breaking change) that to allow features, such as customizable pointing rays to be easily implemented without need for
 modifying MRTK source.
+
+**Platform expansion**
+
+As part of the hand extensibility theme, MRTK plans on adding support for the Leap Motion hands controller and Oculus Quest. Support for Leap Motion is expected to be made available on both Unity 2018.4 and 2019. Oculus Quest, including articulated hands, will be delivered via [Unity's new XR platform](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/).
 
 ### 2.5.0
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -155,28 +155,12 @@ MRTK does not fully support profile swapping at runtime. This feature is being i
 
 **Unity 2018: .NET Backend and AR Foundation**
 
-There is an issue in Unity 2018 where, when building a Universal Windows Platform project using the .NET scripting backend, the Unity AR Foundation package will fail to install.
+There is an issue in Unity 2018 where, building a Universal Windows Platform project using the .NET scripting backend, the Unity AR Foundation package will fail.
 
 To work around this issue, please perform one of the following steps:
 
 - Switch the scripting backend to IL2CPP
 - In the Build Settings window, uncheck **Unity C# Projects"
-
-**Unity 2018: .NET Backend and DotNetWinRT plugin**
-
-There is an issue that impacts compiling an application when using the .NET backend and version 0.5.1037 of the DotNetWinRT plugin (acquired by checking Enabling MS Build for Unity in the configure dialog).
-
-This issue can be worked around by switching to the IL2CPP backend or performing the following steps.
-
-- In the Project Window
-  - Expand **Assets**
-  - Expand **MixedRealityToolkit.Providers**
-  - Expand **WindowsMixedReality**
-  - Expand **DotNetAdapter**
-  - Delete the **Plugins** folder
-- Close and reopen Unity
-
-This will cause the MRTK to restore the latest version of the DotNetWinRT package.
 
 ## Version 2.2.0
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -37,6 +37,9 @@ If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), th
 
 The 2.3.0 release has some changes that may impact application projects. Breaking change details, including mitigation guidance, can be found in the [**Updating 2.2.0 to 2.3.0**](Updating.md#updating-220-to-230) article.
 
+> [!NOTE]
+> At this time, it is not supported to switch between using .unitypackage files and NuGet.
+
 **Updating using .unitypackage files**
 
 For the smoothest upgrade path, please use the following steps.

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -93,21 +93,9 @@ If your project was created using the [Mixed Reality Toolkit NuGet packages](MRT
 
 **Support for Unity 2019.3 new XR platform (Experimental)**
 
-MRTK has added initial support for Unity 2019.3's new XR platform. When using the Windows XR plugin, it is recommended using version **2.0.4 (preview.3)** or newer.
+MRTK has added initial support for [Unity 2019.3's new XR platform](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/). When using the Windows XR plugin, it is recommended using version **2.0.4 (preview.3)** or newer.
 
 Please see [Known issues](#known-issues-in-230) for details on known limitations.
-
-**Better handing of compiling when using dependencies**
-
-This version of MRTK improves upon the support added in 2.2.0 to recognize and enable compilation when dependencies (ex: DotNetWinRT plugin) are required.
-
-Support has been added to automatically add or remove preprocessor defines based on the presence of the required packages and or components. This allows application projects to be more resilient to adding and removing packages. 
-
-**Common MixedRealityToolkit.Plugins folder**
-
-Previous versions of MRTK would place plugins acquired via MSBuild for Unity to a directory co-located with the .csproj file used to specify them. This version updates the .csproj file(s) to place the plugins in a shared MixedRealityToolkit.Plugins folder.
-
-This change helps address issues such as [#6972](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6972).
 
 **Hand physics extension service**
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -16,6 +16,7 @@
 - Microsoft HoloLens (1st gen)
 - Windows Mixed Reality Immersive headsets
 - OpenVR
+- (Experimental) Unity 2019.3 XR platform
 - (Experimental) Mobile AR
   - Android
   - iOS
@@ -36,9 +37,188 @@ If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), th
 
 The 2.3.0 release has some changes that may impact application projects. Breaking change details, including mitigation guidance, can be found in the [**Updating 2.2.0 to 2.3.0**](Updating.md#updating-220-to-230) article.
 
+**Updating using .unitypackage files**
+
+For the smoothest upgrade path, please use the following steps.
+
+1. Close Unity
+1. Inside the *Assets* folder, delete most of the **MixedRealityToolkit** folders, along with their .meta files (the project may not have all listed folders)
+    - MixedRealityToolkit
+    - MixedRealityToolkit.Examples
+    - MixedRealityToolkit.Extensions
+    > [!NOTE]
+    > If additional extensions have been installed, please make a backup prior to deleting these folders.
+    - MixedRealityToolkit.Providers
+    - MixedRealityToolkit.SDK
+    - MixedRealityToolkit.Services
+    - MixedRealityToolkit.Staging
+    > [!NOTE]
+    > The contents of the MixedRealityToolkit.Staging folder have been moved into the MixedRealityToolkit.Providers folder in MRTK 2.3.0.
+    - MixedRealityToolkit.Tools
+    > [!IMPORTANT]
+    > Do NOT delete the **MixedRealityToolkit.Generated** folder, or its .meta file.
+1. Delete the **Library** folder
+1. Re-open the project in Unity
+1. Import the new unity packages
+    - Foundation - _Import this package first_
+    - (Optional) Tools
+    - (Optional) Extensions
+    > [!NOTE]
+    > If additional extensions had been installed, they may need to be re-imported.
+    - (Optional) Examples
+1. Close Unity and Delete the **Library** folder. This step is necessary to force Unity to refresh its
+   asset database and reconcile existing custom profiles.
+1. Launch Unity, and for each scene in the project
+    - Delete **MixedRealityToolkit** and **MixedRealityPlayspace**, if present, from the hierarchy. This will delete the main camera, but it will be re-created in the next step. If any properties of the main camera have been manually changed, these will have to be re-applied manually once the new camera is created.
+    - Select **MixedRealityToolkit -> Add to Scene and Configure**
+    - Select **MixedRealityToolkit -> Utilities -> Update -> Controller Mapping Profiles** (only needs to be done once)
+            - This will update any custom Controller Mapping Profiles with updated axes and data, while leaving your custom-assigned input actions intact
+
+**Updating from NuGet**
+
+If your project was created using the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), please use the following steps.
+
+1. Select **NuGet > Manage NuGet Packages**
+1. Select the **Online** tab and click **Refresh**
+1. Select the **Installed** tab
+1. Click the **Update** button for each installed package
+    - Microsoft.MixedReality.Toolkit.Foundation
+    - Microsoft.MixedReality.Toolkit.Providers.UnityAR
+    - Microsoft.MixedReality.Toolkit.Tools
+    - Microsoft.MixedReality.Toolkit.Extensions
+    - Microsoft.MixedReality.Toolkit.Examples
+1. Close and re-open the project in Unity
+
 ### What's new in 2.3.0
 
+**Support for Unity 2019.3 new XR platform (Experimental)**
+
+MRTK has added initial support for Unity 2019.3's new XR platform. When using the Windows XR plugin, it is recommended using version **2.0.4 (preview.3)** or newer.
+
+Please see [Known issues](#known-issues-in-230) details on known limitations.
+
+**Better handing of compiling when using dependencies**
+
+This version of MRTK improves upon the support added in 2.2.0 to recognize and enable compilation when dependencies (ex: DotNetWinRT plugin) are required.
+
+Support has been added to automatically add or remove preprocessor defines based on the presence of the required packages and or components. This allows application projects to be more resilient to adding and removing packages. 
+
+**Common MixedRealityToolkit.Plugins folder**
+
+Previous versions of MRTK would place plugins acquired via MSBuild for Unity to a directory co-located with the .csproj file used to specify them. This version updates the .csproj file(s) to place the plugins in a shared MixedRealityToolkit.Plugins folder.
+
+This change helps address issues such as [#6972](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6972).
+
+**Hand physics extension service**
+
+A hand physics extension service has been added to allow for using physics interactions with the HoloLens 2 articulated hands ([#6573](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6573)).
+
+![Hand physics](https://user-images.githubusercontent.com/1186832/68795768-77efdc00-0606-11ea-8fb9-b0e4191bdb05.gif)
+
+**Pinch Slider orientation**
+
+The Pinch Slider has been updated to orient TrackVisuals, TickMarks and ThumbRoot based on the sliderAxis orientation ([#6858](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6858))
+
+![Y axis slier](https://user-images.githubusercontent.com/42405657/71687606-37a31380-2d96-11ea-84b5-ffe2368f8b57.JPG)
+![X axis slider](https://user-images.githubusercontent.com/42405657/71687640-4984b680-2d96-11ea-9f59-7732a91edd1b.JPG)
+
+**UX control prefabs updated to use PressableButton**
+
+The following prefabs are now using the PressableButton component instead of TouchHandler for near interaction ([7070](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7070))
+
+- AnimationButton
+- Button
+- ButtonHoloLens1
+- ButtonHoloLens1Toggle
+- CheckBox
+- RadialSet
+- ToggleButton
+- ToggleSwitch
+- UnityUIButton
+- UnityUICheckboxButton
+- UnityUIRadialButton
+- UnityUIToggleButton
+
+![Updated UX prefabs](https://user-images.githubusercontent.com/36998103/72457296-30303100-37be-11ea-827f-d144a65348ff.gif)
+
 ### Known issues in 2.3.0
+
+**Issues with the Unity 2019.3 new XR platform on Windows Mixed Reality**
+
+The following issues are known when using the new XR platform and version **2.0.4 (preview.3)** of the Windows XR Plugin:
+
+- AirTap does not work on HoloLens (HoloLens 2 and 1st generation)
+- Pointers are using the wrong coordinate system on HoloLens 2 and immersive devices
+
+It is recommended to periodically check **Window** > **Package Manager** for newer versions of the Windows XR plugin.
+
+**Windows Mixed Reality gesture support on Unity 2019.3 when using the new XR platfom**
+
+This release of MRTK does not contain an implementation for Windows Mixed Reality gestures using the new XR platform. It will be added in a future version of MRTK.
+
+**Specifying the Depth Reprojection mode in the Windows Mixed Reality Camera Settings Provider is not supported on Unity 2019.3 and Windows XR plugin**
+
+This issue is expected to be fixed with upcoming releases of MRTK and the Windows XR plugin.
+
+**Mixed Reality Capture setting**
+
+This feature is currently not working correctly on Unity 2019.3.0f6. This issue impacts both the legacy and the new XR platform.
+
+**Long paths**
+
+When building on Windows, there is a MAX_PATH limit of 255 characters. Unity is affected by these limits and may fail to build a binary if its resolved output path is longer than 255 characters.
+
+This can manifest as CS0006 errors in Visual Studio that look like:
+
+> CS0006: Metadata file 'C:\path\to\longer\file\that\is\longer\than\255\characters\mrtk.long.binary.name.dll' could not be found.
+
+This can be worked around by moving the Unity project folder closer to the root of the drive, for example:
+
+> C:\src\project
+
+Please see [this issue](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5469) for more background information.
+
+**Runtime profile swapping**
+
+MRTK does not fully support profile swapping at runtime. This feature is being investigated for a future release. Please see issues [4289](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4289),
+[5465](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5465) and
+[5466](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5466) for more information.
+
+**Unity 2018: .NET Backend and AR Foundation**
+
+There is an issue in Unity 2018 where, when building a Universal Windows Platform project using the .NET scripting backend, the Unity AR Foundation package will fail to install.
+
+To work around this issue, please perform one of the following steps:
+
+- Switch the scripting backend to IL2CPP
+- In the Build Settings window, uncheck **Unity C# Projects"
+
+**Unity 2018: .NET Backend and DotNetWinRT plugin**
+
+There is an issue that impacts compiling an application when using the .NET backend and the DotNetWinRT plugin (acquired by checking Enabling MS Build for Unity in the configure dialog).
+
+This issue can be worked around by switching to the IL2CPP backend or performing the following steps.
+
+- Close Unity
+- In the project's folder
+  - Open **Packages\manifest.json**
+  - Delete the line containing **"com.microsoft.msbuildforunity"**
+  - Save the file
+- Open Unity
+- In the Project Window
+  - Expand **Assets**
+  - Expand **MixedRealityToolkit.Providers**
+  - Expand **WindowsMixedReality**
+  - Expand **DotNetAdapter**
+  - Delete the **Plugins** folder
+
+> [!NOTE]
+> Performing these steps will remove support for
+> 
+> - Articulated hand and eye remoting on HoloLens 2
+> - Specifying the Depth Reprojection Method in the Windows Mixed Reality Camera Settings Provider
+
+A fix for this issue will be released in an updated version of the Microsoft.Windows.MixedReality.DotNetWinRT NuGet package. Once it is available, MSBuild for Unity can be re-added to the project via the Unity Package Manager to acquire the latest plugin. 
 
 ## Version 2.2.0
 
@@ -118,7 +298,7 @@ If your project was created using the [Mixed Reality Toolkit NuGet packages](MRT
     - Microsoft.MixedReality.Toolkit.Tools
     - Microsoft.MixedReality.Toolkit.Extensions
     - Microsoft.MixedReality.Toolkit.Examples
-1. Re-open the project in Unity
+1. Close and re-open the project in Unity
 
 ### What's new in 2.2.0
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -110,25 +110,6 @@ The Pinch Slider has been updated to orient TrackVisuals, TickMarks and ThumbRoo
 ![Y axis slier](https://user-images.githubusercontent.com/42405657/71687606-37a31380-2d96-11ea-84b5-ffe2368f8b57.JPG)
 ![X axis slider](https://user-images.githubusercontent.com/42405657/71687640-4984b680-2d96-11ea-9f59-7732a91edd1b.JPG)
 
-**UX control prefabs updated to use PressableButton**
-
-The following prefabs are now using the PressableButton component instead of TouchHandler for near interaction ([7070](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7070))
-
-- AnimationButton
-- Button
-- ButtonHoloLens1
-- ButtonHoloLens1Toggle
-- CheckBox
-- RadialSet
-- ToggleButton
-- ToggleSwitch
-- UnityUIButton
-- UnityUICheckboxButton
-- UnityUIRadialButton
-- UnityUIToggleButton
-
-![Updated UX prefabs](https://user-images.githubusercontent.com/36998103/72457296-30303100-37be-11ea-827f-d144a65348ff.gif)
-
 ### Known issues in 2.3.0
 
 **Issues with the Unity 2019.3 new XR platform on Windows Mixed Reality**
@@ -183,30 +164,19 @@ To work around this issue, please perform one of the following steps:
 
 **Unity 2018: .NET Backend and DotNetWinRT plugin**
 
-There is an issue that impacts compiling an application when using the .NET backend and the DotNetWinRT plugin (acquired by checking Enabling MS Build for Unity in the configure dialog).
+There is an issue that impacts compiling an application when using the .NET backend and version 0.5.1037 of the DotNetWinRT plugin (acquired by checking Enabling MS Build for Unity in the configure dialog).
 
 This issue can be worked around by switching to the IL2CPP backend or performing the following steps.
 
-- Close Unity
-- In the project's folder
-  - Open **Packages\manifest.json**
-  - Delete the line containing **"com.microsoft.msbuildforunity"**
-  - Save the file
-- Open Unity
 - In the Project Window
   - Expand **Assets**
   - Expand **MixedRealityToolkit.Providers**
   - Expand **WindowsMixedReality**
   - Expand **DotNetAdapter**
   - Delete the **Plugins** folder
+- Close and reopen Unity
 
-> [!NOTE]
-> Performing these steps will remove support for
-> 
-> - Articulated hand and eye remoting on HoloLens 2
-> - Specifying the Depth Reprojection Method in the Windows Mixed Reality Camera Settings Provider
-
-A fix for this issue will be released in an updated version of the Microsoft.Windows.MixedReality.DotNetWinRT NuGet package. Once it is available, MSBuild for Unity can be re-added to the project via the Unity Package Manager to acquire the latest plugin. 
+This will cause the MRTK to restore the latest version of the DotNetWinRT package.
 
 ## Version 2.2.0
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -20,6 +20,11 @@ The private ControllerPoseSynchronizer.handedness field has been marked as obsol
 
 The public ControllerPoseSynchronizer.Handedness property's setter has been removed ([#7012](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7012)). 
 
+**MSBuild for Unity**
+
+This version of MRTK uses a newer version of MSBuild for Unity than previous releases. During project load, if the older version is listed in the Unity Package Manger
+manifest, the configuration dialog will appear, with the Enable MSBuild for Unity option checked. Applying will perform an upgrade.
+
 **ScriptingUtilities**
 
 The ScriptingUtilities class has been marked as obsolete and has been replaced by ScriptUtilities, in the Microsoft.MixedReality.Toolkit.Editor.Utilities assembly. The new class refines previous behavior and adds support for removing scripting definitions.

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -43,6 +43,25 @@ Spatial observers built upon the `BaseSpatialObserver` class now honor the value
 
 No changes are required to take advantage of this fix.
 
+**UX control prefabs updated to use PressableButton**
+
+The following prefabs are now using the PressableButton component instead of TouchHandler for near interaction ([7070](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7070))
+
+- AnimationButton
+- Button
+- ButtonHoloLens1
+- ButtonHoloLens1Toggle
+- CheckBox
+- RadialSet
+- ToggleButton
+- ToggleSwitch
+- UnityUIButton
+- UnityUICheckboxButton
+- UnityUIRadialButton
+- UnityUIToggleButton
+
+Application code may require updating due to this change.
+
 **WindowsMixedRealityUtilities namespace**
 
 The namespace of WindowsMixedRealityUtilities changed from Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input to Microsoft.MixedReality.Toolkit.WindowsMixedReality ([#6863](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6989)).

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -1,7 +1,7 @@
 # Updating the Microsoft Mixed Reality Toolkit
 
-- [2.1.0 to 2.2.0](#updating-210-to-220)
 - [2.2.0 to 2.3.0](#updating-220-to-230)
+- [2.1.0 to 2.2.0](#updating-210-to-220)
 - [2.0.0 to 2.1.0](#updating-200-to-210)
 - [RC2 to 2.0.0](#updating-rc2-to-200)
 
@@ -14,11 +14,35 @@
 
 ### API changes in 2.3.0
 
-#### ScriptingUtilities.cs
+**ControllerPoseSynchronizer**
 
-The ScriptingUtilities.cs file was moved from the MixedRealityToolkit\Utilities folder to MixedRealityToolkit\Utilities\Editor. As a result, the class has been moved to the Microsoft.MixedReality.Toolkit.Editor.Utilities assembly.
+The private ControllerPoseSynchronizer.handedness field has been marked as obsolete. This should have minimal impact on applications as the field is not visible outside of its class.
 
-In addition, the `AppendScriptingDefinitions` method has a new signature.  It no longer takes the fileName argument.
+The public ControllerPoseSynchronizer.Handedness property's setter has been removed ([#7012](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7012)). 
+
+**ScriptingUtilities**
+
+The ScriptingUtilities class has been marked as obsolete and has been replaced by ScriptUtilities, in the Microsoft.MixedReality.Toolkit.Editor.Utilities assembly. The new class refines previous behavior and adds support for removing scripting definitions.
+
+While existing code will continue to function in version 2.3.0, it is recommended to update to the new class.
+
+**ShellHandRayPouinter**
+
+The lineRendererSelected and lineRendererNoTarget members of the ShellHandRayPointer class have been replaced by lineMaterialSelected and lineMaterialNoTarget, respectively ([#6863](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6863)).
+
+Please replace lineRendererSelected with lineMaterialSelected and/or lineRendererNoTarget with lineMaterialNoTarget to resolve compile errors.
+
+**Spatial observer StarupBehavior**
+
+Spatial observers built upon the `BaseSpatialObserver` class now honor the value of StartupBehavior when re-enabled ([#6919](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6919)).
+
+No changes are required to take advantage of this fix.
+
+**WindowsMixedRealityUtilities namespace**
+
+The namespace of WindowsMixedRealityUtilities changed from Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input to Microsoft.MixedReality.Toolkit.WindowsMixedReality ([#6863](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6989)).
+
+Please update #using statements to resolve compile errors.
 
 ## Updating 2.1.0 to 2.2.0
 
@@ -26,11 +50,11 @@ In addition, the `AppendScriptingDefinitions` method has a new signature.  It no
 
 ### API changes in 2.2.0
 
-#### IMixedRealityBoundarySystem.Contains
+**IMixedRealityBoundarySystem.Contains**
 
 This method previously took in a specific, Unity-defined experimental enum. It now takes in an MRTK-defined enum that's identical to the Unity enum. This change helps prepare the MRTK for Unity's future boundary APIs.
 
-#### MixedRealityServiceProfileAttribute
+**MixedRealityServiceProfileAttribute**
 
 To better describe the requirements for supporting a profile, the MixedRealityServiceProfileAttribute has been updated to add an optional collection of excluded types. As part of this change, the ServiceType property has been changed from Type to Type[] and been renamed to RequiredTypes.
 


### PR DESCRIPTION
This change updates the release notes and upgrade guide with information on the changes and known issues in the upcoming MRTK 2.3.0 release.

Additionally, the roadmap has been updated to remove 2.3.0, add details on 2.4.0 and early looks at releases that are further out.

The list of authors has also been refreshed to add our newest contributors!

Fixes: #6922 and #7149