### PR TITLE
Check for null focusedWindow before showing notification

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/EditorAssemblyReloadManager.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/EditorAssemblyReloadManager.cs
@@ -27,7 +27,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 {
                     EditorApplication.LockReloadAssemblies();
 
-                    if (!Application.isBatchMode)
+                    if ((EditorWindow.focusedWindow != null) &&
+                        !Application.isBatchMode)
                     {
                         EditorWindow.focusedWindow.ShowNotification(new GUIContent("Assembly reloading temporarily paused."));
                     }
@@ -37,7 +38,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     EditorApplication.UnlockReloadAssemblies();
                     EditorApplication.delayCall += () => AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
 
-                    if (!Application.isBatchMode)
+                    if ((EditorWindow.focusedWindow != null) &&
+                        !Application.isBatchMode)
                     {
                         EditorWindow.focusedWindow.ShowNotification(new GUIContent("Assembly reloading resumed."));
                     }


### PR DESCRIPTION
Unity's documentation states that EditorApplication.focusedWindow is allowed to be null. Before referencing that value to call ShowNotification, MRTK should confirm that the value is valid.