### PR TITLE
Device capability manifest support for uwp builds

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/BuildAndDeploy/UwpAppxBuildToolsTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Build.Editor;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Xml.Linq;
 using System.Linq;
 
@@ -208,6 +209,33 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Build.Editor
             UwpAppxBuildTools.AddCapability(rootElement, rootElement.GetDefaultNamespace() + "DeviceCapability", "gazeInput");
             AssertSingleGazeInputCapability(rootElement);
         }
+
+        /// <summary>
+        /// Validates that AddCapabilities adds a capability.
+        /// </summary>
+        [Test]
+        public void TestAddCapabilities_Adds()
+        {
+            XElement rootElement = XElement.Parse(TestManifest);
+            UwpAppxBuildTools.AddCapabilities(rootElement, new List<string>() { "gazeInput" });
+            AssertSingleGazeInputCapability(rootElement);
+        }
+
+        /// <summary>
+        /// Validates that AddCapabilities will only add a capability if
+        /// it doesn't already exist.
+        /// </summary>
+        [Test]
+        public void TestAddCapabilities_AddsOnce()
+        {
+            XElement rootElement = XElement.Parse(TestManifest);
+            UwpAppxBuildTools.AddCapabilities(rootElement, new List<string>() { "gazeInput" });
+            AssertSingleGazeInputCapability(rootElement);
+
+            UwpAppxBuildTools.AddCapabilities(rootElement, new List<string>() { "gazeInput", "gazeInput" });
+            AssertSingleGazeInputCapability(rootElement);
+        }
+
         #endregion
 
         #region AssemblyCSharp Tests

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -549,7 +549,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// <summary>
         /// Adds the given capabilities to the manifest.
         /// </summary>
-        private static void AddCapabilities(XElement rootNode, List<string> capabilities)
+        public static void AddCapabilities(XElement rootNode, List<string> capabilities)
         {
             foreach(string capability in capabilities)
             {

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -484,6 +485,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var uwpBuildInfo = buildInfo as UwpBuildInfo;
 
             Debug.Assert(uwpBuildInfo != null);
+            if (uwpBuildInfo.DeviceCapabilities != null)
+            {
+                AddCapabilities(rootElement, uwpBuildInfo.DeviceCapabilities);
+            }
             if (uwpBuildInfo.GazeInputCapabilityEnabled)
             {
                 AddGazeInputCapability(rootElement);
@@ -539,6 +544,17 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         public static void AddGazeInputCapability(XElement rootNode)
         {
             AddCapability(rootNode, rootNode.GetDefaultNamespace() + "DeviceCapability", "gazeInput");
+        }
+
+        /// <summary>
+        /// Adds the given capabilities to the manifest.
+        /// </summary>
+        private static void AddCapabilities(XElement rootNode, List<string> capabilities)
+        {
+            foreach(string capability in capabilities)
+            {
+                AddCapability(rootNode, rootNode.GetDefaultNamespace() + "DeviceCapability", capability);
+            }
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -551,7 +551,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// </summary>
         public static void AddCapabilities(XElement rootNode, List<string> capabilities)
         {
-            foreach(string capability in capabilities)
+            foreach (string capability in capabilities)
             {
                 AddCapability(rootNode, rootNode.GetDefaultNamespace() + "DeviceCapability", capability);
             }

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.Build.Editor
@@ -51,5 +52,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// Assembly-CSharp project.
         /// </summary>
         public bool AllowUnsafeCode { get; set; } = false;
+
+        /// <summary>
+        /// When present, adds a DeviceCapability for each entry
+        /// in the list to the manifest
+        /// </summary>
+        public List<string> DeviceCapabilities { get; set; } = null;
     }
 }


### PR DESCRIPTION
## Overview
Adjusted MRTK build scripts to allow callers of UWP build tools to specify arbitrary device capabilities
