### PR TITLE
Add offset for correct palm rotation on XR SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ MSBuildForUnity.Common.props
 /*.msb4u.sln.meta
 *.msb4u.sln.meta
 Dependencies*
+Nuget.config*

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -44,6 +44,11 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         private static readonly HandFinger[] handFingers = Enum.GetValues(typeof(HandFinger)) as HandFinger[];
         private readonly List<Bone> fingerBones = new List<Bone>();
 
+        // The rotation offset between the reported grip pose of a hand and the palm joint orientation.
+        // These values were calculated by comparing the platform's reported grip pose and palm pose.
+        private static readonly Quaternion rightPalmOffset = new Quaternion(Mathf.Sqrt(0.125f), Mathf.Sqrt(0.125f), -Mathf.Sqrt(1.5f) / 2.0f, Mathf.Sqrt(1.5f) / 2.0f);
+        private static readonly Quaternion leftPalmOffset = new Quaternion(Mathf.Sqrt(0.125f), -Mathf.Sqrt(0.125f), Mathf.Sqrt(1.5f) / 2.0f, Mathf.Sqrt(1.5f) / 2.0f);
+
 #if WINDOWS_UWP && WMR_ENABLED
         private readonly List<object> states = new List<object>();
 #endif // WINDOWS_UWP && WMR_ENABLED
@@ -126,7 +131,9 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                         }
 
                         // Unity doesn't provide a palm joint, so we synthesize one here
-                        unityJointPoses[TrackedHandJoint.Palm] = CurrentControllerPose;
+                        MixedRealityPose palmPose = CurrentControllerPose;
+                        palmPose.Rotation *= (ControllerHandedness == Handedness.Left ? leftPalmOffset : rightPalmOffset);
+                        unityJointPoses[TrackedHandJoint.Palm] = palmPose;
                     }
                 }
 

--- a/Assets/MixedRealityToolkit/Definitions/Utilities/ArticulatedHandPose.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Utilities/ArticulatedHandPose.cs
@@ -215,7 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             return null;
         }
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         /// <summary>
         /// Load pose data from files.
         /// </summary>
@@ -247,7 +247,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             handPoses.Clear();
         }
-        #endif
+#endif
 
         /// Utility class to serialize hand pose as a dictionary with full joint names
         [Serializable]


### PR DESCRIPTION
## Overview

XR SDK doesn't provide a palm pose for HL2 articulated hands, so we synthesize one in MRTK.
Instead of passing the grip pose in directly though, it needs a rotation offset to align with the expected coordinate system of other hand joints.

Also adds the new MSB4U-generated NuGet.config to the .gitignore.

Before this change: 
![image](https://user-images.githubusercontent.com/3580640/73778671-6b2fdf80-4740-11ea-903d-f6e13e8dbb54.png)

After:
![image](https://user-images.githubusercontent.com/3580640/73778684-6ff49380-4740-11ea-804f-b65126f6b1ea.png)


## Changes
- Part of #7003

