### PR TITLE
Update to the latest DotNetWinRT and MSBuild for Unity packages

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -14,7 +14,7 @@
     <releaseNotes>$releaseNotes$</releaseNotes>
     <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
-      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1037" />
+      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1043" />
     </dependencies>
     <contentFiles>
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
@@ -19,7 +19,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" Version="1.0.85" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.1037" />
+    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.1043" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" Version="1.0.85" />

--- a/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private static string[] MSBuildRegistryScopes = new string[] { "com.microsoft" };
 
         internal const string MSBuildPackageName = "com.microsoft.msbuildforunity";
-        internal const string MSBuildPackageVersion = "0.9.1-20200131.12";
+        internal const string MSBuildPackageVersion = "0.9.1-20200131.14";
 
         /// <summary>
         /// Finds and returns the fully qualified path to the Unity Package Manager manifest


### PR DESCRIPTION
This change updates the minimum versions of DotNetWinRT and MSBuild for Unity to 0.5.1043 and 0.9.1-20200131.14, respectively.

Fixes build issue when using the .NET backend