### PR TITLE
Update the valid size of the glb buffers according to the spec

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -259,7 +259,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
                 return null;
             }
 
-            Debug.Assert(gltfObject.buffers[0].byteLength == chunk1Length, "chunk 1 & buffer 0 length mismatch");
+            // Per the spec, "byte length of BIN chunk could be up to 3 bytes bigger than JSON-defined buffer.byteLength to satisfy GLB padding requirements"
+            // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-stored-buffer
+            Debug.Assert(gltfObject.buffers[0].byteLength <= chunk1Length && gltfObject.buffers[0].byteLength >= chunk1Length - 3, "chunk 1 & buffer 0 length mismatch");
 
             gltfObject.buffers[0].BufferData = new byte[chunk1Length];
             Array.Copy(glbData, stride * 7 + chunk0Length, gltfObject.buffers[0].BufferData, 0, chunk1Length);


### PR DESCRIPTION
## Overview

The `GltfUtility` had an assert that the the bin chunk should be the same length as the JSON-defined buffer. The spec actually states that this can be up to 3 bytes different due to .glb padding.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/5417