### PR TITLE
RequireComponent checker

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
@@ -5,6 +5,8 @@
 
 using Microsoft.MixedReality.Toolkit.Experimental.Utilities;
 using Microsoft.MixedReality.Toolkit.UI;
+using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -174,15 +176,19 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void DrawDeprecated()
         {
-            System.Collections.Generic.List<System.Type> requiringTypes = new System.Collections.Generic.List<System.Type>();
-            if ((target as ManipulationHandler).gameObject.IsComponentRequired<ManipulationHandler>(requiringTypes))
+            List<Type> requiringTypes;
+
+            if ((target as ManipulationHandler).gameObject.IsComponentRequired<ManipulationHandler>(out requiringTypes))
             {
                 string requiringComponentNames = null;
+
                 for (int i = 0; i < requiringTypes.Count; i++)
                 {
                     requiringComponentNames += "- " + requiringTypes[i].FullName;
                     if (i < requiringTypes.Count - 1)
+                    {
                         requiringComponentNames += '\n';
+                    }
                 }
 
                 EditorGUILayout.HelpBox($"This component is deprecated. Please migrate object to up to date version. Remove the RequiredComponentAttribute from:\n{requiringComponentNames}", MessageType.Error);

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
@@ -174,7 +174,22 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private void DrawDeprecated()
         {
-            EditorGUILayout.HelpBox("This component is deprecated. Please migrate object to up to date version", UnityEditor.MessageType.Warning);
+            System.Collections.Generic.List<System.Type> requiringTypes = new System.Collections.Generic.List<System.Type>();
+            if ((target as ManipulationHandler).gameObject.IsComponentRequired<ManipulationHandler>(requiringTypes))
+            {
+                string requiringComponentNames = null;
+                for (int i = 0; i < requiringTypes.Count; i++)
+                {
+                    requiringComponentNames += "- " + requiringTypes[i].FullName;
+                    if (i < requiringTypes.Count - 1)
+                        requiringComponentNames += '\n';
+                }
+
+                EditorGUILayout.HelpBox($"This component is deprecated. Please migrate object to up to date version. Remove the RequiredComponentAttribute from:\n{requiringComponentNames}", MessageType.Error);
+                return;
+            }
+
+            EditorGUILayout.HelpBox("This component is deprecated. Please migrate object to up to date version", MessageType.Warning);
             if (GUILayout.Button("Migrate Object"))
             {
 #if UNITY_EDITOR

--- a/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
@@ -158,5 +158,47 @@ namespace Microsoft.MixedReality.Toolkit
         {
             UnityObjectExtensions.DestroyObject(gameObject, t);
         }
+
+        /// <summary>
+        /// Checks if any MonoBehaviour on the given GameObject is using the RequireComponentAttribute requiring type T
+        /// </summary>
+        /// <typeparam name="T">The potentially required component</typeparam>
+        /// <param name="gameObject">the GameObject requiring the component</param>
+        /// <param name="requiringTypes">A list of types that do require the component in question</param>
+        /// <returns></returns>
+        public static bool IsComponentRequired<T>(this GameObject gameObject, List<Type> requiringTypes) where T : Component
+        {
+            var genericType = typeof(T);
+            bool requiringComponent = false;
+
+            foreach (var monoBehaviour in gameObject.GetComponents<MonoBehaviour>())
+            {
+                if (monoBehaviour == null)
+                {
+                    continue;
+                }
+
+                var monoBehaviourType = monoBehaviour.GetType();
+                var attributes = Attribute.GetCustomAttributes(monoBehaviourType);
+                foreach (var attribute in attributes)
+                {
+                    var requireComponentAttribute = attribute as RequireComponent;
+                    if (requireComponentAttribute != null)
+                    {
+                        if (requireComponentAttribute.m_Type0 == genericType ||
+                            requireComponentAttribute.m_Type1 == genericType ||
+                            requireComponentAttribute.m_Type2 == genericType)
+                        {
+                            if (requiringTypes != null)
+                                requiringTypes.Add(monoBehaviourType);
+
+                            requiringComponent = true;
+                        }
+                    }
+                }
+            }
+
+            return requiringComponent;
+        }
     }
 }

--- a/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
@@ -166,10 +166,10 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="gameObject">the GameObject requiring the component</param>
         /// <param name="requiringTypes">A list of types that do require the component in question</param>
         /// <returns></returns>
-        public static bool IsComponentRequired<T>(this GameObject gameObject, List<Type> requiringTypes) where T : Component
+        public static bool IsComponentRequired<T>(this GameObject gameObject, out List<Type> requiringTypes) where T : Component
         {
             var genericType = typeof(T);
-            bool requiringComponent = false;
+            requiringTypes = null;
 
             foreach (var monoBehaviour in gameObject.GetComponents<MonoBehaviour>())
             {
@@ -180,6 +180,7 @@ namespace Microsoft.MixedReality.Toolkit
 
                 var monoBehaviourType = monoBehaviour.GetType();
                 var attributes = Attribute.GetCustomAttributes(monoBehaviourType);
+
                 foreach (var attribute in attributes)
                 {
                     var requireComponentAttribute = attribute as RequireComponent;
@@ -189,16 +190,18 @@ namespace Microsoft.MixedReality.Toolkit
                             requireComponentAttribute.m_Type1 == genericType ||
                             requireComponentAttribute.m_Type2 == genericType)
                         {
-                            if (requiringTypes != null)
-                                requiringTypes.Add(monoBehaviourType);
+                            if (requiringTypes == null)
+                            {
+                                requiringTypes = new List<Type>();
+                            }
 
-                            requiringComponent = true;
+                            requiringTypes.Add(monoBehaviourType);
                         }
                     }
                 }
             }
 
-            return requiringComponent;
+            return requiringTypes != null;
         }
     }
 }

--- a/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
@@ -165,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <typeparam name="T">The potentially required component</typeparam>
         /// <param name="gameObject">the GameObject requiring the component</param>
         /// <param name="requiringTypes">A list of types that do require the component in question</param>
-        /// <returns></returns>
+        /// <returns>true if <typeparamref name="T"/> appears in any RequireComponentAttribute, otherwise false </returns>
         public static bool IsComponentRequired<T>(this GameObject gameObject, out List<Type> requiringTypes) where T : Component
         {
             var genericType = typeof(T);


### PR DESCRIPTION
## Overview
Added a generic method that collects all MonoBehaviours on a GameObject that require a certain component and returns their names.
changed of ObjectManipulatorMigrationHandler shows its info box on the ManipulationHandlerComponent. It now shows an error and what component needs their RequireComponentAttribute removed, as well as disables the migrate button until that's done

## Changes
- Fixes: #7243