### PR TITLE
restore missing line in release notes

### DIFF
--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -12,6 +12,8 @@
 - [What's new](#whats-new-in-230)
 - [Known issues](#known-issues-in-230)
 
+This release of the Microsoft Mixed Reality Toolkit supports the following devices and platforms.
+
 - Microsoft HoloLens 2
 - Microsoft HoloLens (1st gen)
 - Windows Mixed Reality Immersive headsets


### PR DESCRIPTION
The release notes were missing a line of text separating the 2.3.0 hyperlinks and describing the next list.

This change adds back "This release of the Microsoft Mixed Reality Toolkit supports the following devices and platforms."