### PR TITLE
Add notes about Dependencies folder and *.msb4u.csproj file

### DIFF
--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -102,6 +102,15 @@ MRTK has added initial support for [Unity 2019.3's new XR platform](https://blog
 
 Please see [Known issues](#known-issues-in-230) for details on known limitations.
 
+**Assets/Dependencies folder**
+
+After MSBuild for Unity is enabled, a Dependencies folder will be created in the project. This folder contains the plugins (ex: DotNetWinRT) that are imported, by MRTK.
+
+**<project>.Dependencies.msb4u**
+
+MSBuild for Unity creates two files in the project's Assets folder; NuGet.config and <project>.Dependencies.msb4u.csproj. These files are used by MSBuild for Unity and will be recreated as needed. When using source control, such as GitHub, these files can be safely added to exlude / ignore lists (ex: .gitignore).
+
+
 **Hand physics extension service**
 
 A hand physics extension service has been added to allow for using physics interactions with the HoloLens 2 articulated hands ([#6573](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6573)).

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -106,9 +106,13 @@ Please see [Known issues](#known-issues-in-230) for details on known limitations
 
 After MSBuild for Unity is enabled, a Dependencies folder will be created in the project. This folder contains the plugins (ex: DotNetWinRT) that are imported, by MRTK.
 
+This folder is created by MSBuild for Unity and will be recreated when packages are restored. When using source control, such as GitHub, it can be safely added to exclude / ignore lists (ex: .gitignore).
+
 **<project>.Dependencies.msb4u**
 
-MSBuild for Unity creates two files in the project's Assets folder; NuGet.config and <project>.Dependencies.msb4u.csproj. These files are used by MSBuild for Unity and will be recreated as needed. When using source control, such as GitHub, these files can be safely added to exlude / ignore lists (ex: .gitignore).
+MSBuild for Unity creates two files in the project's Assets folder; NuGet.config and <project>.Dependencies.msb4u.csproj. These files are used by MSBuild for Unity and will be recreated as needed.
+
+When using source control, such as GitHub, these files can be safely added to exclude / ignore lists (ex: .gitignore).
 
 
 **Hand physics extension service**


### PR DESCRIPTION
As pointed out in #7255, the 2.3.0 release notes do not mention the new Dependencies folder or the <project>.Dependencies.msb4u.csproj file.

This change adds entries into the "What's new section"