### PR TITLE
Fix missing assembly error on 2019.3

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
-using UnityEngine.Experimental.UIElements;
 using MRConfig = Microsoft.MixedReality.Toolkit.Utilities.Editor.MixedRealityProjectConfigurator.Configurations;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor

--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -184,10 +184,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                 if (MixedRealityOptimizeUtils.IsBuildTargetUWP())
                 {
+#if !UNITY_2019_3_OR_NEWER
                     EditorGUILayout.LabelField("MSBuild for Unity Support", EditorStyles.boldLabel);
                     EditorGUILayout.HelpBox("Enable this for additional HoloLens 2 features, like hand joint remoting and depth LSR mode.", MessageType.Info);
                     RenderToggle(MRConfig.EnableMSBuildForUnity, "Enable MSBuild for Unity");
                     EditorGUILayout.Space();
+#endif // !UNITY_2019_3_OR_NEWER
+
 
                     EditorGUILayout.LabelField("UWP Capabilities", EditorStyles.boldLabel);
                     RenderToggle(MRConfig.MicrophoneCapability, "Enable Microphone Capability");
@@ -195,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     RenderToggle(MRConfig.SpatialPerceptionCapability, "Enable Spatial Perception Capability");
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.EyeTrackingCapability, "Enable Eye Gaze Input Capability");
-#endif
+#endif // UNITY_2019_3_OR_NEWER
                 }
                 else
                 {
@@ -204,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     trackToggles[MRConfig.SpatialPerceptionCapability] = false;
 #if UNITY_2019_3_OR_NEWER
                     trackToggles[MRConfig.EyeTrackingCapability] = false;
-#endif
+#endif // UNITY_2019_3_OR_NEWER
                 }
 
                 if (MixedRealityOptimizeUtils.IsBuildTargetAndroid())


### PR DESCRIPTION
An errant, unused using statement was causing a missing assembly error on Unity 2019.3.

This change also adds in a missing #if !UNITY_2019_3_OR_NEWER in the configuration dialog as it was attempting to access a dictionary key that will not exist.