### PR TITLE
Fix the broken UWP app build

### DIFF
--- a/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/GameObjectExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -179,7 +179,7 @@ namespace Microsoft.MixedReality.Toolkit
                 }
 
                 var monoBehaviourType = monoBehaviour.GetType();
-                var attributes = Attribute.GetCustomAttributes(monoBehaviourType);
+                var attributes = monoBehaviourType.GetCustomAttributes<Attribute>(true);
 
                 foreach (var attribute in attributes)
                 {


### PR DESCRIPTION
Our CI build got broken due to a change that used the API:

Attributes.GetCustomAttributes

This function doesn't exist in UWP .NET, but Type.GetCustomAttributes does.

The other possibility here was to make this function an editor-only extension (should really only be used in editor-land only). 