### PR TITLE
Update docs for MSB4U resolution troubleshooting and add additional notes

### DIFF
--- a/Documentation/README_ExampleHub.md
+++ b/Documentation/README_ExampleHub.md
@@ -8,7 +8,7 @@ MRTK Examples Hub is a Unity scene that makes it easy to experience multiple sce
 
 ## Prerequisite
 
-MRTK Examples Hub uses [Scene Transition Service](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Extensions/SceneTransitionService/SceneTransitionServiceOverview.html) and related scripts. If you are using MRTK through Unity packages, please import **Microsoft.MixedReality.Toolkit.Unity.Extensions.x.x.x.unitypackage** which is part of the [release packages](https://github.com/microsoft/MixedRealityToolkit-Unity/releases). If you are using MRTK through the repository clone, you should already have **MixedRealityToolkit.Extensions** folder in your project.
+MRTK Examples Hub uses [Scene Transition Service](Extensions/SceneTransitionService/SceneTransitionServiceOverview.md) and related scripts. If you are using MRTK through Unity packages, please import **Microsoft.MixedReality.Toolkit.Unity.Extensions.x.x.x.unitypackage** which is part of the [release packages](https://github.com/microsoft/MixedRealityToolkit-Unity/releases). If you are using MRTK through the repository clone, you should already have **MixedRealityToolkit.Extensions** folder in your project.
 
 ## MRTKExamplesHub scene and the scene system
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -108,6 +108,8 @@ After MSBuild for Unity is enabled, a Dependencies folder will be created in the
 
 This folder is created by MSBuild for Unity and will be recreated when packages are restored. When using source control, such as GitHub, it can be safely added to exclude / ignore lists (ex: .gitignore).
 
+You can also add the .bin and .obj folders in MixedRealityToolkit.Providers / Windows Mixed Reality / Shared / DotNetAdapter to your ignore list. These represent staging folders for individual csproj package resolution but are hidden from Unity's Asset view. The root Dependencies folder is the central location where the used copies are placed.
+
 **<project>.Dependencies.msb4u**
 
 MSBuild for Unity creates two files in the project's Assets folder; NuGet.config and <project>.Dependencies.msb4u.csproj. These files are used by MSBuild for Unity and will be recreated as needed.

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -114,6 +114,7 @@ MSBuild for Unity creates two files in the project's Assets folder; NuGet.config
 
 When using source control, such as GitHub, these files can be safely added to exclude / ignore lists (ex: .gitignore).
 
+After MRTK has enabled MSBuild for Unity, additional custom NuGet dependencies can be declared and resolved as well. This process is described in [MSBuild for Unity's documentation](https://github.com/microsoft/MSBuildForUnity/blob/master/Documentation/CoreScenarios.md#scenario-1-adding-nuget-dependency-to-unity-project).
 
 **Hand physics extension service**
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -108,7 +108,7 @@ After MSBuild for Unity is enabled, a Dependencies folder will be created in the
 
 This folder is created by MSBuild for Unity and will be recreated when packages are restored. When using source control, such as GitHub, it can be safely added to exclude / ignore lists (ex: .gitignore).
 
-You can also add the .bin and .obj folders in MixedRealityToolkit.Providers / Windows Mixed Reality / Shared / DotNetAdapter to your ignore list. These represent staging folders for individual csproj package resolution but are hidden from Unity's Asset view. The root Dependencies folder is the central location where the used copies are placed.
+You can also add the .bin and .obj folders in MixedRealityToolkit.Providers / WindowsMixedReality / Shared / DotNetAdapter to your ignore list. These represent staging folders for individual csproj package resolution but are hidden from Unity's Asset view. The root Dependencies folder is the central location where the used copies are placed.
 
 **<project>.Dependencies.msb4u**
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -35,7 +35,7 @@ For the first point, the best way to check is to open Window -> Package Manager 
 
 #### DotNetWinRT NuGet package resolution
 
-For the second point, the best way to check is to search the Assets folder for DotNetWinRT.dll. If this doesn't exist, navigate to MixedRealityToolkit.Providers / WindowsMixedReality / Shared / DotNetAdapter in the Project view and select DotNetAdapter.csproj. Assuming part 1 did succeed, there should be a custom inspector with Build, Rebuild, and Clean buttons. Try clicking Build or Rebuild, and then re-search for DotNetWinRT.dll. If that DLL now exists, this step succeeded.
+For the second point, the best way to check is to search the Assets folder for DotNetWinRT.dll. If this doesn't exist, navigate to the Assets folder in the Project view and select `[ProjectName].Dependencies.msb4u.csproj`. Assuming part 1 did succeed, there should be a custom inspector with Build, Rebuild, and Clean buttons. Try clicking Build or Rebuild, and then re-search for DotNetWinRT.dll. If that DLL now exists, this step succeeded.
 
 ![DotNetAdapter Inspector](../Images/Tools/Remoting/DotNetAdapterInspector.png)
 


### PR DESCRIPTION
## Overview

1. Adds a note on using MSB4U for your own project dependencies as well as MRTK's
1. Adds a note on the .bin and .obj folders that can be safely added to your gitignore
    1. These folders are in this repo's .gitignore, but I don't believe that's distributed via our unity packages since it begins with a `.` and is thus ignored by Unity
1. Fixes the .csproj reference for step 2 of troubleshooting the DotNetWinRT dependency