### PR TITLE
Update DotNetWinRT dependency version

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -14,7 +14,7 @@
     <releaseNotes>$releaseNotes$</releaseNotes>
     <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
-      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1044" />
+      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1045" />
     </dependencies>
     <contentFiles>
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
@@ -19,7 +19,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" Version="1.0.85" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.1044" />
+    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.1045" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" Version="1.0.85" />


### PR DESCRIPTION
## Overview

Per https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7191#issuecomment-583081841, a new version has been shipped that should fix the issue when ASA and DotNetWinRT are both imported.