### PR TITLE
Add another troubleshooting step for msb4u integration

### DIFF
--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -25,7 +25,7 @@ configure the project using the following steps.
 
 ### Debugging HoloLens 2 remoting via Unity package import
 
-If HoloLens 2 hand joints and eye tracking aren't working over remoting, there are three common points of potential issues. They're listed below in the order they should be checked.
+If HoloLens 2 hand joints and eye tracking aren't working over remoting, there are a few common points of potential issues. They're listed below in the order they should be checked.
 
 #### MSBuildForUnity package import via writing into the package.manifest
 
@@ -56,6 +56,20 @@ You can also temporarily remove the adapter to workaround your issue via the fol
 1. In Unity, go to Window -> Package Manager and uninstall MSBuild for Unity
 1. Search for DotNetWinRT.dll in your assets list in Unity and either delete the DLL or delete the Plugins (MRTK 2.2 or earlier) or Dependencies (MRTK 2.3 or later) folder that contains it a few levels up. That should remove these conflicting namespaces, while keeping MRTK around
 1. If you run the MRTK Configurator again, make sure you don't re-enable MSBuild for Unity
+
+### Failure to find dotnet.exe
+
+MSBuild for Unity depends on dotnet.exe existing in the system path - dotnet.exe must both be
+installed and present in the PATH environment variable. If neither of those requirements are
+ true, this error may manifest in the Unity console:
+
+```
+Win32Exception: ApplicationName='dotnet', CommandLine='msbuild DotNetAdapter.csproj -restore  -v:minimal -p:NuGetInteractive=true  -t:Build -p:Configuration=Release -nologo', CurrentDirectory='C:\src\Assets\MixedRealityToolkit.Providers\WindowsMixedReality\Shared\DotNetAdapter', Native error= The system cannot find the file specified.
+```
+
+The solution to this is to ensure that the [.NET Core CLI tools are installed]
+(https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x) and reboot the system
+for force all apps to get a refreshed system path.
 
 ## Connecting to the HoloLens
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -45,19 +45,7 @@ For the third point, navigate to the Unity Player Settings. From there, under th
 
 ![DotNetWinRT Present](../Images/Tools/Remoting/DotNetWinRTPresent.png)
 
-After all three of those, hand joints over remoting should be working! If not, there might be something misconfigured in the profiles for general hand joints on-device. In that case, please [reach out on one of our help resources](../GettingStartedWithTheMRTK.md#getting-help).
-
-### Removing HoloLens 2-specific remoting support
-
-If you're running into conflicts or other issues due to the presence of the DotNetWinRT adapter, please [reach out on one of our help resources](../GettingStartedWithTheMRTK.md#getting-help).
-
-You can also temporarily remove the adapter to workaround your issue via the following steps:
-
-1. In Unity, go to Window -> Package Manager and uninstall MSBuild for Unity
-1. Search for DotNetWinRT.dll in your assets list in Unity and either delete the DLL or delete the Plugins (MRTK 2.2 or earlier) or Dependencies (MRTK 2.3 or later) folder that contains it a few levels up. That should remove these conflicting namespaces, while keeping MRTK around
-1. If you run the MRTK Configurator again, make sure you don't re-enable MSBuild for Unity
-
-### Failure to find dotnet.exe
+#### Failure to find dotnet.exe
 
 MSBuild for Unity depends on dotnet.exe existing in the system path - dotnet.exe must both be
 installed and present in the PATH environment variable. If neither of those requirements are
@@ -70,6 +58,18 @@ Win32Exception: ApplicationName='dotnet', CommandLine='msbuild DotNetAdapter.csp
 The solution to this is to ensure that the [.NET Core CLI tools are installed]
 (https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x) and reboot the system
 for force all apps to get a refreshed system path.
+
+If hand joints over remoting are still not working after following the above steps, there might be something misconfigured in the profiles for general hand joints on-device. In that case, please [reach out on one of our help resources](../GettingStartedWithTheMRTK.md#getting-help).
+
+### Removing HoloLens 2-specific remoting support
+
+If you're running into conflicts or other issues due to the presence of the DotNetWinRT adapter, please [reach out on one of our help resources](../GettingStartedWithTheMRTK.md#getting-help).
+
+You can also temporarily remove the adapter to workaround your issue via the following steps:
+
+1. In Unity, go to Window -> Package Manager and uninstall MSBuild for Unity
+1. Search for DotNetWinRT.dll in your assets list in Unity and either delete the DLL or delete the Plugins (MRTK 2.2 or earlier) or Dependencies (MRTK 2.3 or later) folder that contains it a few levels up. That should remove these conflicting namespaces, while keeping MRTK around
+1. If you run the MRTK Configurator again, make sure you don't re-enable MSBuild for Unity
 
 ## Connecting to the HoloLens
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -57,7 +57,7 @@ Win32Exception: ApplicationName='dotnet', CommandLine='msbuild DotNetAdapter.csp
 
 The solution to this is to ensure that the [.NET Core CLI tools are installed]
 (https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x) and reboot the system
-for force all apps to get a refreshed system path.
+to force all apps to get a refreshed system path.
 
 If hand joints over remoting are still not working after following the above steps, there might be something misconfigured in the profiles for general hand joints on-device. In that case, please [reach out on one of our help resources](../GettingStartedWithTheMRTK.md#getting-help).
 


### PR DESCRIPTION
One person who recently tried out the remoting work was hitting an error "file not found" when going through the dotnet/msbuild restore steps.

The actual cause was because Unity Hub was installed and launched first, which took a snapshot of the system PATH variable, which at the time lacked the reference to the location of dotnet.exe. Then, even though they were closing/restarting Unity itself, because Unity Hub was never closed, future instances of Unity would inherit the stale, old path of Unity Hub, leading it to see like it was permanently busted.

The simple solution here is just to reboot the machine (the other solution is to manually kill Unity Hub.exe using task manager).

Either way the error is super cryptic, and just adding a note here to reboot (simplest solution) in case someone else out there encounters this.