### PR TITLE
Add CanEditMultipleObjects tag

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/FollowSolver/FollowInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Experimental/FollowSolver/FollowInspector.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
 {
     [CustomEditor(typeof(Follow))]
+    [CanEditMultipleObjects]
     public class FollowEditor : SolverInspector
     {
         // Orientation

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.UI.Editor
 {
     [CustomEditor(typeof(Interactable))]
+    [CanEditMultipleObjects]
     public class InteractableInspector : UnityEditor.Editor
     {
         protected Interactable instance;

--- a/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/InBetweenInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/Utilities/Solvers/InBetweenInspector.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 {
     [CustomEditor(typeof(InBetween))]
+    [CanEditMultipleObjects]
     public class InBetweenEditor : SolverInspector
     {
         private SerializedProperty secondTrackedTargetTypeProperty;

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingBoxInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingBoxInspector.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// A custom editor for the ClippingBox to allow for specification of the framing bounds.
     /// </summary>
     [CustomEditor(typeof(ClippingBox))]
+    [CanEditMultipleObjects]
     public class ClippingBoxEditor : ClippingPrimitiveEditor
     {
         /// <inheritdoc/>

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPlaneInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPlaneInspector.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// A custom editor for the ClippingPlaneEditor to allow for specification of the framing bounds.
     /// </summary>
     [CustomEditor(typeof(ClippingPlane))]
+    [CanEditMultipleObjects]
     public class ClippingPlaneEditor : ClippingPrimitiveEditor
     {
         /// <inheritdoc/>

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingPrimitiveInspector.cs
@@ -12,6 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// An abstract editor component to improve the editor experience with ClippingPrimitives.
     /// </summary>
     [CustomEditor(typeof(ClippingPrimitive))]
+    [CanEditMultipleObjects]
     public abstract class ClippingPrimitiveEditor : UnityEditor.Editor
     {
         /// <summary>

--- a/Assets/MixedRealityToolkit/Inspectors/ClippingSphereInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ClippingSphereInspector.cs
@@ -11,6 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     /// A custom editor for the ClippingSphere to allow for specification of the framing bounds.
     /// </summary>
     [CustomEditor(typeof(ClippingSphere))]
+    [CanEditMultipleObjects]
     public class ClippingSphereEditor : ClippingPrimitiveEditor
     {
         /// <inheritdoc/>


### PR DESCRIPTION
## Overview
Adding CanEditMultipleObjects tag to some components

https://docs.unity3d.com/ScriptReference/CanEditMultipleObjects.html

## Changes
- Related: #4165

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
