### PR TITLE
Update nuget package license links

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MixedRealityToolkit.Examples/MixedReality.Toolkit.Examples.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
+++ b/Assets/MixedRealityToolkit.Extensions/MixedReality.Toolkit.Extensions.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Assets/MixedRealityToolkit.Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
+++ b/Assets/MixedRealityToolkit.Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
+++ b/Assets/MixedRealityToolkit.Tests/MixedReality.Toolkit.Tests.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities/MixedReality.Toolkit.Tests.Utilities.nuspec
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities/MixedReality.Toolkit.Tests.Utilities.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MixedRealityToolkit.Tools/MixedReality.Toolkit.Tools.nuspec
@@ -5,7 +5,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft,MixedReality</owners>
-    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/License.txt</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/releases/2.3.0/License.txt</licenseUrl>
     <projectUrl>https://aka.ms/MRTK</projectUrl>
     <iconUrl>https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Images/MRTK_Logo_NuGet.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
Nuget licenses should point to the documentation for the specific release. This change updates to .../releases/2.3.0/...

NOTE: The link will _not_ resolve until the release branch is created.