### PR TITLE
Update the documentation version list to add 2.3.0

### DIFF
--- a/web/version.js
+++ b/web/version.js
@@ -2,7 +2,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; // title in the dropdown for the root version of the docs
-	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "prerelease/2.3.0_stabilization"]; // list of all versions in the version folder
+	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "releases/2.3.0"]; // list of all versions in the version folder
 	
 	//--------------------------------------
 


### PR DESCRIPTION
This change replaces "prerelease/2.3.0_stabilization" with "releases/2.3.0" in the documentation version list.

Please _do not_ merge until the 2.3.0 release has been completed.