### PR TITLE
Update ARFoundation Doc for 2.3

### DIFF
--- a/Documentation/CrossPlatform/UsingARFoundation.md
+++ b/Documentation/CrossPlatform/UsingARFoundation.md
@@ -2,7 +2,7 @@
 
 ## Install required packages
 
-1. Download and import the **Microsoft.MixedReality.Toolkit.Foundation** package, from [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v2.3.0) or [NuGet](../MRTKNuGetPackage.md)
+1. Download and import the **Microsoft.MixedReality.Toolkit.Unity.Foundation** package, from [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v2.3.0) or [NuGet](../MRTKNuGetPackage.md)
 
 1. In the Unity Package Manager (UPM), install the following packages:
 

--- a/Documentation/CrossPlatform/UsingARFoundation.md
+++ b/Documentation/CrossPlatform/UsingARFoundation.md
@@ -2,12 +2,7 @@
 
 ## Install required packages
 
-1. Download and import the **Microsoft.MixedReality.Toolkit.Providers.UnityAR** package, from [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v2.2.0) or [NuGet](../MRTKNuGetPackage.md)
-
-    > [!NOTE]
-    > After you import the the UnityAR package, you will see the following error:
-    > *Assembly has reference to non-existent assembly 'Unity.XR.ARFoundation' (Assets/MixedRealityToolkit.Staging/UnityAR/Microsoft.MixedReality.Toolkit.Providers.UnityAR.asmdef)*
-    ". To resolve, install the correct version of ARFoundation listed below.
+1. Download and import the **Microsoft.MixedReality.Toolkit.Foundation** package, from [GitHub](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v2.3.0) or [NuGet](../MRTKNuGetPackage.md)
 
 1. In the Unity Package Manager (UPM), install the following packages:
 
@@ -18,19 +13,12 @@
     | AR Foundation  <br/> Version: 1.5.0 - preview 6 | AR Foundation  <br/> Version: 1.5.0 - preview 6 | For Unity 2018.4, this package is included as a preview. To view package: Window > Package Manager > Advanced > Show Preview Packages|
     | ARCore XR Plugin <br/> Version: 2.1.2 | ARKit XR Plugin <br/> Version: 2.1.2 | |
 
-    **Unity 2019.x**
+    **Unity 2019.3.x**
 
     | **Android** | **iOS** |
     | --- | --- |
     | AR Foundation  <br/> Version: 2.1.4 |  AR Foundation  <br/> Version: 2.1.4 |
     | ARCore XR Plugin <br/> Version: 2.1.2 | ARKit XR Plugin <br/> Version: 2.1.2 |
-
-1. If using Unity 2019.x, the assembly definition file for the Unity AR provider needs to be modified to have the **UnityEngine.SpatialTracking** reference added.
-
-    > [!NOTE]
-    > MRTK will automatically update the assembly definition based on the version of Unity in which the project has been loaded. This information is presented here for reference.
-
-    ![Unity AR assembly definition](../Images/CrossPlatform/UnityArAssemblyReferences.png)
 
 ## Enabling the Unity AR camera settings provider
 


### PR DESCRIPTION
## Overview
The ARFoundation capabilities are now in the Foundation package and not the separate UnityAR package, this change is now reflected in the Android/iOS doc.  Also changed 2019.x to 2019.3.

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
