### PR TITLE
Update FindFilesInAssets to only search AssetDatabase

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/UnityAR/Editor/ConfigurationChecker/UnityARConfigurationChecker.cs
+++ b/Assets/MixedRealityToolkit.Providers/UnityAR/Editor/ConfigurationChecker/UnityARConfigurationChecker.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
         /// - If AR Foundation has been installed via the Unity Package Manager, add the appropriate assembly references
         ///   - Unity 2018: Unity.XR.ARFoundation
         ///   - Unity 2019 and newer: Unity.XR.ARFoundation, UnityEngine.SpatialTracking
-        /// - If AR Foundation has been uninstalled, remove the assembly references. 
+        /// - If AR Foundation has been uninstalled, remove the assembly references.
         /// - Save the Microsoft.MixedReality.Toolkit.Providers.UnityAR.asmdef file
         /// This will result in Unity reloading the assembly with the appropriate dependencies.
         /// </remarks>

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitFilesTests.cs
@@ -101,6 +101,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core
             Assert.IsNotNull(resolvedPath);
         }
 
+        /// <summary>
+        /// Validates that FileUtilities.FindFilesInAssets can find this test script in the asset database.
+        /// </summary>
+        [Test]
+        public void TestFileUtilitiesFindFilesInAssets()
+        {
+            FileInfo[] files = FileUtilities.FindFilesInAssets("MixedRealityToolkitFilesTests.cs");
+            Assert.IsTrue(files.Length == 1);
+        }
+
         [TearDown]
         public void CleanupTests()
         {

--- a/Assets/MixedRealityToolkit/Utilities/Editor/FileUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/FileUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -13,14 +14,35 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public static class FileUtilities
     {
         /// <summary>
-        /// Locates the files that match the specified name within the Assets folder (application data path) structure.
+        /// Locates the files that match the specified name within the Assets folder structure.
         /// </summary>
         /// <param name="fileName">The name of the file to locate (ex: "TestFile.asmdef")</param>
+        /// <param name="searchFullFileSystem">If true, searches the full application data path. If false, only searches Unity's known asset database.</param>
         /// <returns>Array of FileInfo objects representing the located file(s).</returns>
-        public static FileInfo[] FindFilesInAssets(string fileName)
+        public static FileInfo[] FindFilesInAssets(string fileName, bool searchFullFileSystem = false)
         {
-            DirectoryInfo root = new DirectoryInfo(Application.dataPath);
-            return FindFiles(fileName, root);
+            if (searchFullFileSystem)
+            {
+                DirectoryInfo root = new DirectoryInfo(Application.dataPath);
+                return FindFiles(fileName, root);
+            }
+            else
+            {
+                // FindAssets doesn't take a file extension
+                string[] assetGuids = AssetDatabase.FindAssets(Path.GetFileNameWithoutExtension(fileName));
+                List<FileInfo> fileInfos = new List<FileInfo>();
+                for (int i = 0; i < assetGuids.Length; i++)
+                {
+                    string assetPath = AssetDatabase.GUIDToAssetPath(assetGuids[i]);
+                    // Since this is an asset search without extension, some filenames may contain parts of other filenames.
+                    // Therefore, double check that the path actually contains the filename with extension.
+                    if (assetPath.Contains(fileName))
+                    {
+                        fileInfos.Add(new FileInfo(assetPath));
+                    }
+                }
+                return fileInfos.ToArray();
+            }
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/ScriptingUtilities.cs
+++ b/Assets/MixedRealityToolkit/Utilities/ScriptingUtilities.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #if UNITY_EDITOR
-using UnityEngine;
-using UnityEditor;
-using System.IO;
 using System;
-using System.Runtime.CompilerServices;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
     /// <summary>
-    /// A set of utilities to configure script compilation. 
+    /// A set of utilities to configure script compilation.
     /// </summary>
     [Obsolete("The ScriptingUtilities class is obsolete and will be removed from a future version of MRTK. Please use the ScriptUtilities class.")]
     public static class ScriptingUtilities
@@ -22,15 +22,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         /// <param name="fileName">The name of an optional file locate before appending.</param>
         /// <returns>
-        /// <param name="targetGroup">The build target group for which the sybmols are to be defined.</param>
+        /// <param name="targetGroup">The build target group for which the symbols are to be defined.</param>
         /// <param name="symbols">Array of symbols to define.</param>
         /// <remarks>
         /// To always append the symbols, pass null (or the empty string) for the fileName parameter.
         /// </remarks>
         [Obsolete("ScriptingUtilties.AppendScriptingDefinitions is obsolete and will be removed from a future version of MRTK. Please use FileUtilities.FindFilesInAssets and ScriptUtilties.AppendScriptingDefinitions.")]
         public static void AppendScriptingDefinitions(
-            string fileName, 
-            BuildTargetGroup targetGroup, 
+            string fileName,
+            BuildTargetGroup targetGroup,
             string[] symbols)
         {
             // Note: Typically, obsolete methods are re-implemented using the replacement versions.

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -53,9 +53,10 @@ If you're running into conflicts or other issues due to the presence of the DotN
 
 You can also temporarily remove the adapter to workaround your issue via the following steps:
 
-1. In Unity, go to Window -> Package Manager and uninstall MSBuild for Unity
-1. Search for DotNetWinRT.dll in your assets list in Unity and either delete the DLL or delete the Plugins (MRTK 2.2 or earlier) or Dependencies (MRTK 2.3 or later) folder that contains it a few levels up. That should remove these conflicting namespaces, while keeping MRTK around
-1. If you run the MRTK Configurator again, make sure you don't re-enable MSBuild for Unity
+1. In Unity, go to Window -> Package Manager and uninstall MSBuild for Unity.
+1. Search for DotNetWinRT.dll in your assets list in Unity and either delete the DLL or delete the Plugins (MRTK 2.2 or earlier) or Dependencies (MRTK 2.3 or later) folder that contains it a few levels up. That should remove these conflicting namespaces, while keeping MRTK around.
+1. (Optional) Navigate to MixedRealityToolkit.Providers / WindowsMixedReality / Shared / DotNetAdapter in your file explorer (not Unity's Assets view) and delete the `.bin` and `.obj` folders. This removes the local cache of NuGet restored packages for DotNetWinRT.
+1. If you run the MRTK Configurator again, make sure you don't re-enable MSBuild for Unity.
 
 ## Connecting to the HoloLens
 


### PR DESCRIPTION
## Overview

The configuration checker for DotNetWinRT searched the filesystem instead of just Unity's visible assets. This was leading to a case where, because MSBuildForUnity 0.9.1 resolves nuget dependencies to a non-Unity-visible local cache before resolving the root dependencies folder, this checker was seeing DLLs that weren't actually visible to Unity.
This helps improve the steps for uninstalling MSBuildForUnity.

Also, added a test, updated some formatting, and added a line to the docs describing removing those local cache folders.