### PR TITLE
Fix path to signCheck script

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -97,7 +97,7 @@ jobs:
     displayName: 'Validate release packages are signed'
     inputs:
       targetType: filePath
-      filePath: '$(Build.ArtifactStagingDirectory)\scripts\signCheck.ps1'
+      filePath: '$(ToolsDir)\signCheck.ps1'
       arguments: '$(Build.SourcesDirectory)\artifacts\release -tmpDir $(Build.ArtifactStagingDirectory)'
   
   - powershell: |


### PR DESCRIPTION
I forgot to replace this path in previous PR (see latest MRTK-Release-CI failure). Sorry about that.