### PR TITLE
Update pipeline to include MixedReality.Toolkit.Test.Utilities 

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -101,7 +101,7 @@ jobs:
       arguments: '$(Build.SourcesDirectory)\artifacts\release -tmpDir $(Build.ArtifactStagingDirectory)'
   
   - powershell: |
-      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/Microsoft.MixedReality.Toolkit.Tests.*"
+      Remove-Item "$(Build.SourcesDirectory)/artifacts/release/Microsoft.MixedReality.Toolkit.Tests.*" -Exclude "*.Utilities.*"
     displayName: "Delete MixedReality.Toolkit.Tests package from the release artifacts"
 
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
## Overview
A step in our mrtk_ci_release pipeline is to delete the MixedReality.Toolkit.Tests package for the release, but the pipeline also removed the MixedReality.Toolkit.Test.Utilities in this process.  

This update excludes the MixedReality.Toolkit.Tests.Utilities from the MixedReality.Toolkit.Tests removal step.

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
