### PR TITLE
Mrtk bb bounds calculation fix

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1759,8 +1759,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else
             {
-                Bounds bounds = GetTargetBounds();
                 TargetBounds = Target.AddComponent<BoxCollider>();
+                Bounds bounds = GetTargetBounds();
 
                 TargetBounds.center = bounds.center;
                 TargetBounds.size = bounds.size;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1814,7 +1814,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 Debug.Assert(childTransform != rigRoot);
 
-                ExtractBounds(childTransform);
+                ExtractBounds(childTransform, boundsCalculationMethod);
             }
 
             Transform targetTransform = Target.transform;
@@ -1822,10 +1822,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // In case we found nothing and this is the Target, we add it's inevitable collider's bounds
             if (totalBoundsCorners.Count == 0 && Target == gameObject)
             {
-                BoundsCalculationMethod currentCalculationMethod = boundsCalculationMethod;
-                boundsCalculationMethod = BoundsCalculationMethod.ColliderOnly;
-                ExtractBounds(targetTransform);
-                boundsCalculationMethod = currentCalculationMethod;
+                ExtractBounds(targetTransform, BoundsCalculationMethod.ColliderOnly);
             }
 
             Bounds finalBounds = new Bounds(targetTransform.InverseTransformPoint(totalBoundsCorners[0]), Vector3.zero);
@@ -1838,7 +1835,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return finalBounds;
         }
 
-        private void ExtractBounds(Transform childTransform)
+        private void ExtractBounds(Transform childTransform, BoundsCalculationMethod boundsCalculationMethod)
         {
             KeyValuePair<Transform, Collider> colliderByTransform;
             KeyValuePair<Transform, Bounds> rendererBoundsByTransform;

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1799,7 +1799,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // This can only happen by name unless there is a better idea of tracking the rigRoot that needs destruction
 
             List<Transform> childTransforms = new List<Transform>();
-            childTransforms.Add(Target.transform);
+            if (Target != null && Target != gameObject)
+            {
+                childTransforms.Add(Target.transform);
+            }
 
             foreach (Transform childTransform in Target.transform)
             {
@@ -1844,7 +1847,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly ||
                     boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer)
                 {
-                    AddColliderBoundsToTarget(colliderByTransform);
+                    if (AddColliderBoundsToTarget(colliderByTransform) && boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer) { continue; }
                     if (boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly) { continue; }
                 }
 
@@ -1852,7 +1855,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 if (boundsCalculationMethod != BoundsCalculationMethod.ColliderOnly)
                 {
-                    AddRendererBoundsToTarget(rendererBoundsByTransform);
+                    if (AddRendererBoundsToTarget(rendererBoundsByTransform) && boundsCalculationMethod == BoundsCalculationMethod.RendererOverCollider) { continue; }
                     if (boundsCalculationMethod == BoundsCalculationMethod.RendererOnly) { continue; }
                 }
 
@@ -1874,21 +1877,25 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return finalBounds;
         }
 
-        private void AddRendererBoundsToTarget(KeyValuePair<Transform, Bounds> rendererBoundsByTarget)
+        private bool AddRendererBoundsToTarget(KeyValuePair<Transform, Bounds> rendererBoundsByTarget)
         {
-            if (rendererBoundsByTarget.Key == null) { return; }
+            if (rendererBoundsByTarget.Key == null) { return false; }
 
             Vector3[] cornersToWorld = null;
             rendererBoundsByTarget.Value.GetCornerPositions(rendererBoundsByTarget.Key, ref cornersToWorld);
             totalBoundsCorners.AddRange(cornersToWorld);
+
+            return true;
         }
 
-        private void AddColliderBoundsToTarget(KeyValuePair<Transform, Collider> colliderByTransform)
+        private bool AddColliderBoundsToTarget(KeyValuePair<Transform, Collider> colliderByTransform)
         {
             if (colliderByTransform.Key != null)
             {
                 BoundsExtensions.GetColliderBoundsPoints(colliderByTransform.Value, totalBoundsCorners, 0);
             }
+
+            return colliderByTransform.Key != null;
         }
 
         private void SetMaterials()

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1797,7 +1797,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // This can only happen by name unless there is a better idea of tracking the rigRoot that needs destruction
 
             List<Transform> childTransforms = new List<Transform>();
-            if (Target != null && Target != gameObject)
+            if (Target != gameObject)
             {
                 childTransforms.Add(Target.transform);
             }
@@ -1817,15 +1817,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 ExtractBounds(childTransform);
             }
 
+            Transform targetTransform = Target.transform;
+
+            // In case we found nothing and this is the Target, we add it's inevitable collider's bounds
             if (totalBoundsCorners.Count == 0 && Target == gameObject)
             {
                 BoundsCalculationMethod currentCalculationMethod = boundsCalculationMethod;
                 boundsCalculationMethod = BoundsCalculationMethod.ColliderOnly;
-                ExtractBounds(Target.transform);
+                ExtractBounds(targetTransform);
                 boundsCalculationMethod = currentCalculationMethod;
             }
-
-            Transform targetTransform = Target.transform;
 
             Bounds finalBounds = new Bounds(targetTransform.InverseTransformPoint(totalBoundsCorners[0]), Vector3.zero);
 

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1814,16 +1814,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 Debug.Assert(childTransform != rigRoot);
 
-                ExtractBounds(childTransform, boundsCalculationMethod);
+                ExtractBoundsCorners(childTransform, boundsCalculationMethod);
             }
 
             Transform targetTransform = Target.transform;
 
             // In case we found nothing and this is the Target, we add it's inevitable collider's bounds
+
             if (totalBoundsCorners.Count == 0 && Target == gameObject)
             {
-                ExtractBounds(targetTransform, BoundsCalculationMethod.ColliderOnly);
+                ExtractBoundsCorners(targetTransform, BoundsCalculationMethod.ColliderOnly);
             }
+
+            // Gather all corners and calculate their bounds
 
             Bounds finalBounds = new Bounds(targetTransform.InverseTransformPoint(totalBoundsCorners[0]), Vector3.zero);
 
@@ -1835,7 +1838,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return finalBounds;
         }
 
-        private void ExtractBounds(Transform childTransform, BoundsCalculationMethod boundsCalculationMethod)
+        private void ExtractBoundsCorners(Transform childTransform, BoundsCalculationMethod boundsCalculationMethod)
         {
             KeyValuePair<Transform, Collider> colliderByTransform;
             KeyValuePair<Transform, Bounds> rendererBoundsByTransform;
@@ -1871,7 +1874,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly ||
                 boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer)
             {
-                if (AddColliderBoundsToTarget(colliderByTransform) && boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer ||
+                if (AddColliderBoundsCornersToTarget(colliderByTransform) && boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer ||
                     boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly) { return; }
             }
 
@@ -1879,15 +1882,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (boundsCalculationMethod != BoundsCalculationMethod.ColliderOnly)
             {
-                if (AddRendererBoundsToTarget(rendererBoundsByTransform) && boundsCalculationMethod == BoundsCalculationMethod.RendererOverCollider ||
+                if (AddRendererBoundsCornersToTarget(rendererBoundsByTransform) && boundsCalculationMethod == BoundsCalculationMethod.RendererOverCollider ||
                     boundsCalculationMethod == BoundsCalculationMethod.RendererOnly) { return; }
             }
 
             // Do the collider for the one case that we chose RendererOverCollider and did not find a renderer
-            AddColliderBoundsToTarget(colliderByTransform);
+            AddColliderBoundsCornersToTarget(colliderByTransform);
         }
 
-        private bool AddRendererBoundsToTarget(KeyValuePair<Transform, Bounds> rendererBoundsByTarget)
+        private bool AddRendererBoundsCornersToTarget(KeyValuePair<Transform, Bounds> rendererBoundsByTarget)
         {
             if (rendererBoundsByTarget.Key == null) { return false; }
 
@@ -1898,7 +1901,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return true;
         }
 
-        private bool AddColliderBoundsToTarget(KeyValuePair<Transform, Collider> colliderByTransform)
+        private bool AddColliderBoundsCornersToTarget(KeyValuePair<Transform, Collider> colliderByTransform)
         {
             if (colliderByTransform.Key == null) { return false; }
             

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1847,16 +1847,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 if (boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly ||
                     boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer)
                 {
-                    if (AddColliderBoundsToTarget(colliderByTransform) && boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer) { continue; }
-                    if (boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly) { continue; }
+                    if (AddColliderBoundsToTarget(colliderByTransform) && boundsCalculationMethod == BoundsCalculationMethod.ColliderOverRenderer ||
+                        boundsCalculationMethod == BoundsCalculationMethod.ColliderOnly) { continue; }
                 }
 
                 // Encapsulate the renderer bounds if criteria match
 
                 if (boundsCalculationMethod != BoundsCalculationMethod.ColliderOnly)
                 {
-                    if (AddRendererBoundsToTarget(rendererBoundsByTransform) && boundsCalculationMethod == BoundsCalculationMethod.RendererOverCollider) { continue; }
-                    if (boundsCalculationMethod == BoundsCalculationMethod.RendererOnly) { continue; }
+                    if (AddRendererBoundsToTarget(rendererBoundsByTransform) && boundsCalculationMethod == BoundsCalculationMethod.RendererOverCollider ||
+                        boundsCalculationMethod == BoundsCalculationMethod.RendererOnly) { continue; }
                 }
 
                 // Do the collider for the one case that we chose RendererOverCollider and did not find a renderer


### PR DESCRIPTION
## Overview
- The BoundingBox now properly ignores a collider when a renderer is found in case of RendererOverCollider and does the same vice versa
- In case the BoundingBox has itself as the target, it ignores itself so its own BoxCollider is not taken into account when calculating bounds

## Changes
- Fixes: ##7300