### PR TITLE
Match access modifier

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBoxHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// <param name="colliderBounds">The collider bounds the corner points are calculated from</param>
         /// <param name="boundsPoints">The corner points calculated from the collider points</param>
-        internal void UpdateNonAABoundsCornerPositions(BoxCollider colliderBounds, List<Vector3> boundsPoints)
+        public void UpdateNonAABoundsCornerPositions(BoxCollider colliderBounds, List<Vector3> boundsPoints)
         {
             if (colliderBounds != targetBounds || rawBoundingCornersObtained == false)
             {


### PR DESCRIPTION
Update the access modifier of the new method `UpdateNonAABoundsCornerPositions` to match the Obsolete method `UpdateNonAABoundingBoxCornerPositions`
