### PR TITLE
Unity hangs after switching to UWP in 2019.3

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -1448,6 +1448,7 @@ namespace Microsoft.MixedReality.Toolkit
             // and shouldn't be run during that time.
             if (EditorApplication.isPlayingOrWillChangePlaymode ||
                 EditorApplication.isCompiling ||
+                EditorApplication.isUpdating ||
                 BuildPipeline.isBuildingPlayer)
             {
                 return;


### PR DESCRIPTION
It looks like on latest Unity, there's some changes in Unity that make it susceptible to a hang when swapping platforms (when there is code in OnValidate that's doing the wrong stuff - i.e. destroying things).

This surfaces because the MixedRealityToolkit.cs code has OnValidate which is running on platform switch (which under the covers does way more work than is necessary on validate). This is a patch fix to make it so that during asset import, we don't do this work, which resolves this particular version of this issue)

Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7299