### PR TITLE
Update ci-release.yml

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -37,6 +37,7 @@ jobs:
 
 - job: ReleaseSigning
   dependsOn: CIReleaseValidation
+  timeoutInMinutes: 90
   pool:
     name: Package ES Lab E
   steps:


### PR DESCRIPTION
our signing job takes longer than originally expected. increase the timeout from 60 to 90 min