### PR TITLE
Update the ci-release pipeline to ensure that nuget.exe is actually in the path

### DIFF
--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -93,6 +93,9 @@ jobs:
     parameters:
       ConfigName: "$(Build.ArtifactStagingDirectory)/configs/MRTKNuGetSignConfig.xml"
 
+  - task: NuGetToolInstaller@1
+    displayName: 'Ensure NuGet.exe is installed and in PATH'
+
   - task: PowerShell@2
     displayName: 'Validate release packages are signed'
     inputs:


### PR DESCRIPTION
I'm seeing an issue in the signing portion of the build where there's a failure to start the validation process (i.e. using nuget verify). It line that's triggering it is the one that's running the nuget command, so my best hypothesis now is that there's some build agent change that removed the nuget.exe tool from the path.

Trying this out to see if it resolves the issue.