### PR TITLE
Now offsetting from surface

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -466,7 +466,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // (This may not be strictly accurate for extremely wobbly pointers, but it should produce usable results)
                     float distanceToTarget = Vector3.Distance(Pointer.Rays[0].Origin, focusDetails.Point);
                     lookForward = -RayStep.GetDirectionByDistance(Pointer.Rays, distanceToTarget);
-                    targetPosition = focusDetails.Point + (lookForward * surfaceCursorDistance);
+                    targetPosition = focusDetails.Point + (focusDetails.Normal * surfaceCursorDistance);
                     Vector3 lookRotation = Vector3.Slerp(focusDetails.Normal, lookForward, lookRotationBlend);
                     targetRotation = Quaternion.LookRotation(lookRotation == Vector3.zero ? lookForward : lookRotation, Vector3.up);
 


### PR DESCRIPTION
## Overview
BaseCursor now offsets from surfaces, not along the player view direction

## Screenshots

I used .5f as the offset for clarification

The orange line is the view direction

old: Here, the cursor offsets along the view direction
![image](https://user-images.githubusercontent.com/32508825/74583663-97adec00-4fc9-11ea-9b44-2ed662afd6b2.png)

new: Here, it offsets along the surface normal
![image](https://user-images.githubusercontent.com/32508825/74583522-13a73480-4fc8-11ea-8d60-55bb2d914801.png)


## Changes
- Fixes: #7325