### PR TITLE
Fixing Unity Editor Wireframe Shading Mode Error

### DIFF
--- a/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
+++ b/Assets/MixedRealityToolkit/StandardAssets/Shaders/MixedRealityStandard.shader
@@ -111,83 +111,6 @@ Shader "Mixed Reality Toolkit/Standard"
 
     SubShader
     {
-        // Extracts information for lightmapping, GI (emission, albedo, ...)
-        // This pass it not used during regular rendering.
-        Pass
-        {
-            Name "Meta"
-            Tags { "LightMode" = "Meta" }
-
-            CGPROGRAM
-
-            #pragma vertex vert
-            #pragma fragment frag
-
-            #pragma shader_feature _EMISSION
-            #pragma shader_feature _CHANNEL_MAP
-
-            #include "UnityCG.cginc"
-            #include "UnityMetaPass.cginc"
-
-            // This define will get commented in by the UpgradeShaderForLightweightRenderPipeline method.
-            //#define _LIGHTWEIGHT_RENDER_PIPELINE
-
-            struct v2f
-            {
-                float4 vertex : SV_POSITION;
-                float2 uv : TEXCOORD0;
-            };
-
-            float4 _MainTex_ST;
-
-            v2f vert(appdata_full v)
-            {
-                v2f o;
-                o.vertex = UnityMetaVertexPosition(v.vertex, v.texcoord1.xy, v.texcoord2.xy, unity_LightmapST, unity_DynamicLightmapST);
-                o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
-
-                return o;
-            }
-
-            sampler2D _MainTex;
-            sampler2D _ChannelMap;
-
-            fixed4 _Color;
-            fixed4 _EmissiveColor;
-
-#if defined(_LIGHTWEIGHT_RENDER_PIPELINE)
-            CBUFFER_START(_LightBuffer)
-            float4 _MainLightPosition;
-            half4 _MainLightColor;
-            CBUFFER_END
-#else
-            fixed4 _LightColor0;
-#endif
-
-            half4 frag(v2f i) : SV_Target
-            {
-                UnityMetaInput output;
-                UNITY_INITIALIZE_OUTPUT(UnityMetaInput, output);
-
-                output.Albedo = tex2D(_MainTex, i.uv) * _Color;
-#if defined(_EMISSION)
-#if defined(_CHANNEL_MAP)
-                output.Emission += tex2D(_ChannelMap, i.uv).b * _EmissiveColor;
-#else
-                output.Emission += _EmissiveColor;
-#endif
-#endif
-#if defined(_LIGHTWEIGHT_RENDER_PIPELINE)
-                output.SpecularColor = _MainLightColor.rgb;
-#else
-                output.SpecularColor = _LightColor0.rgb;
-#endif
-
-                return UnityMetaFragment(output);
-            }
-            ENDCG
-        }
-
         Pass
         {
             Name "Main"
@@ -1209,6 +1132,84 @@ Shader "Mixed Reality Toolkit/Standard"
                 return output;
             }
 
+            ENDCG
+        }
+
+        // Extracts information for lightmapping, GI (emission, albedo, ...)
+        // This pass it not used during regular rendering.
+        Pass
+        {
+            Name "Meta"
+            Tags { "LightMode" = "Meta" }
+
+            CGPROGRAM
+
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #pragma shader_feature EDITOR_VISUALIZATION
+            #pragma shader_feature _EMISSION
+            #pragma shader_feature _CHANNEL_MAP
+
+            #include "UnityCG.cginc"
+            #include "UnityMetaPass.cginc"
+
+            // This define will get commented in by the UpgradeShaderForLightweightRenderPipeline method.
+            //#define _LIGHTWEIGHT_RENDER_PIPELINE
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            float4 _MainTex_ST;
+
+            v2f vert(appdata_full v)
+            {
+                v2f o;
+                o.vertex = UnityMetaVertexPosition(v.vertex, v.texcoord1.xy, v.texcoord2.xy, unity_LightmapST, unity_DynamicLightmapST);
+                o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
+
+                return o;
+            }
+
+            sampler2D _MainTex;
+            sampler2D _ChannelMap;
+
+            fixed4 _Color;
+            fixed4 _EmissiveColor;
+
+#if defined(_LIGHTWEIGHT_RENDER_PIPELINE)
+            CBUFFER_START(_LightBuffer)
+            float4 _MainLightPosition;
+            half4 _MainLightColor;
+            CBUFFER_END
+#else
+            fixed4 _LightColor0;
+#endif
+
+            half4 frag(v2f i) : SV_Target
+            {
+                UnityMetaInput output;
+                UNITY_INITIALIZE_OUTPUT(UnityMetaInput, output);
+
+                output.Albedo = tex2D(_MainTex, i.uv) * _Color;
+#if defined(_EMISSION)
+#if defined(_CHANNEL_MAP)
+                output.Emission += tex2D(_ChannelMap, i.uv).b * _EmissiveColor;
+#else
+                output.Emission += _EmissiveColor;
+#endif
+#endif
+#if defined(_LIGHTWEIGHT_RENDER_PIPELINE)
+                output.SpecularColor = _MainLightColor.rgb;
+#else
+                output.SpecularColor = _LightColor0.rgb;
+#endif
+
+                return UnityMetaFragment(output);
+            }
             ENDCG
         }
     }


### PR DESCRIPTION
## Overview

When selecting the wireframe shading mode within the Unity Editor's scene viewport objects using the MRTK/Standard shader would occasionally render their wireframe representation in the wrong location (the model's identity location). Note, the coffee cup appears as a large version of itself at the origin:

![image](https://user-images.githubusercontent.com/13305729/74565340-e5711880-4f25-11ea-809d-f355bd147791.png)

I was able to narrow the issue down to the meta pass within the shader, it appears UnityMetaVertexPosition is not respecting the EDITOR_VISUALIZATION keyword. Moving the meta pass as the second pass (or anything but the first pass) seems to fix the issue. Unity now specifies the meta pass as the last pass in the Unity/Standard shader (IIRC this was not the case originally?) so this may be an undocumented requirement. 

Moving the meta pass to be the second pass declared within the MRTK/Standard shader fixes the issue with editor wireframe visualization.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6726


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch

I tested these changes within editor and on a HoloLens 2. I also created a scene with lightmaps to verify data from the meta pass was still being piped though. 
