### PR TITLE
Add initial stale configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,25 @@
+# MRTK stale configuration
+# In order to ensure that the issues on Github remain somewhat fresh
+# and update to date (i.e. aren't tracking releases from over a year)
+# ago which have seen significant churn, we're using Stale Bot
+# (https://github.com/apps/stale) to mark issues as stale and then close
+# ones that haven't seen updates in a long time.
+daysUntilStale: 150
+daysUntilClose: 30
+# Below are labels that are exempt from stale checks
+exemptLabels:
+  # Exempt because feature requests are generally still relevant later
+  # and get closed when we complete them - unlike bugs which can often
+  # become no longer relevant as we have a bunch of churn in fixes for
+  # and area
+  - Feature Request
+staleLabel: Stale
+markComment: >
+  This issue has been marked as stale by an automated process because
+  it has not had any recent activity. It will be automatically closed
+  in 30 days if no further activity occurs. If this is still an issue
+  please add a new comment with more recent details and repro steps.
+closeComment: >
+  This issue has been closed by an automated process because it is
+  stale. If this is still an issue please add a new comment with more
+  recent details and repro steps.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # MRTK stale configuration
 # In order to ensure that the issues on Github remain somewhat fresh
-# and update to date (i.e. aren't tracking releases from over a year)
-# ago which have seen significant churn, we're using Stale Bot
+# and up to date (i.e. aren't tracking releases from over a year
+# ago which have seen significant churn), we're using Stale Bot
 # (https://github.com/apps/stale) to mark issues as stale and then close
 # ones that haven't seen updates in a long time.
 daysUntilStale: 150


### PR DESCRIPTION
This change adds an initial stale configuration for stale bot.

Going through our past issues, we have a lot of issues that were open for older version of the MRTK (i.e. release candidate and even pre-RC). While many of these have been addressed during our fixes/churn in the past, there's a non-trivial amount of time it takes to comb through a lot of stale issues.

There's likely to be some portion of the issues that actually are still relevant - these will still be marked stale, but can become un-stale as folks comment (or reopen issues that get closed). The hope really is here that the only old issues that we carry forward are ones that people are actively looking for fixes for (i.e. it gives us more data to know which issues to target).

Some rationale of the time:

Stale time of 150 - originally going to be chosen as 120 (i.e. average release cycle time times 2, so that we can have line of sight on issues that have been affecting folks for the past couple of releases). Historically we've seen a decent amount of things get resolved between two releases. Chosen to be 150 just to give a little more time before we consider things to be stale.

Close time of 180 (i.e. 150 + 30) - Arbitrarily chosen to be a month to give folks time to react + keep the issue open.