### PR TITLE
Update NearInteractionGrabbable to not warn when there is actually a valid collider on the game object

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionGrabbable.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/NearInteractionGrabbable.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -31,16 +30,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Emit exception on initialization, when we know grab interaction is used 
             // on this object to make an error clearly visible.
 
-            var collider = gameObject.GetComponent<Collider>();
-
-            if((collider as BoxCollider) == null && 
-                (collider as CapsuleCollider) == null &&
-                (collider as SphereCollider) == null &&
-                ((collider as MeshCollider) == null || (collider as MeshCollider).convex == false))
+            // Note that there can be multiple colliders on an object - as long as one
+            // of them are of the valid type, this object will work with NearInteractionGrabbable
+            Collider[] colliders = gameObject.GetComponents<Collider>();
+            bool containsValidCollider = false;
+            for (int i = 0; i < colliders.Length && !containsValidCollider; i++)
             {
-                Debug.LogException(new InvalidOperationException("NearInteractionGrabbable requires a " +
+                Collider collider = colliders[i];
+                containsValidCollider =
+                    (collider is BoxCollider) ||
+                    (collider is CapsuleCollider) ||
+                    (collider is SphereCollider) ||
+                    (collider is MeshCollider && (collider as MeshCollider).convex);
+            }
+
+            if (!containsValidCollider)
+            {
+                Debug.LogError("NearInteractionGrabbable requires a " +
                     "BoxCollider, SphereCollider, CapsuleCollider or a convex MeshCollider on an object. " +
-                    "Otherwise grab interaction will not work correctly."));
+                    "Otherwise grab interaction will not work correctly.");
             }
         }
     }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionGrabbableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionGrabbableTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// and at least one of them is valid
         /// </summary>
         [UnityTest]
-        public IEnumerator TestMultipleColiders()
+        public IEnumerator TestMultipleColliders()
         {
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionGrabbableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionGrabbableTests.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using NUnit.Framework;
+using System.Collections;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class NearInteractionGrabbableTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+            PlayModeTestUtilities.EnsureInputModule();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+        }
+
+        /// <summary>
+        /// Verify that NearInteractionGrabbable logs an error when created without an appropriate collider.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestNoCollider()
+        {
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            // Cubes are created with a BoxCollider by default so it has to be removed
+            // in order to test the no collider case.
+            var collider = testObject.GetComponent<Collider>();
+            Object.Destroy(collider);
+            yield return null;
+
+            LogAssert.Expect(LogType.Error,
+                new Regex("NearInteractionGrabbable requires a BoxCollider, SphereCollider, CapsuleCollider or a convex MeshCollider on an object.*"));
+            testObject.AddComponent<NearInteractionGrabbable>();
+            yield return null;
+
+            GameObject.Destroy(testObject);
+            yield return null;
+        }
+
+        /// <summary>
+        /// Verify that NearInteractionGrabbable doesn't log an error when given an appropriate collider.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestValidCollider()
+        {
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            testObject.AddComponent<NearInteractionGrabbable>();
+            yield return null;
+
+            GameObject.Destroy(testObject);
+            yield return null;
+        }
+
+        /// <summary>
+        /// Verify that NearInteractionGrabbable doesn't log an error when there are multiple colliders
+        /// and at least one of them is valid
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestMultipleColiders()
+        {
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            // Purposely destroy the collider so that we can add new ones in a specific order (such
+            // that the invalid collider is the first that would be retrieved from a GetComponent
+            // call)
+            var collider = testObject.GetComponent<Collider>();
+            Object.Destroy(collider);
+            yield return null;
+
+            // Convex mesh colliders are not valid.
+            var meshCollider = testObject.AddComponent<MeshCollider>();
+            meshCollider.convex = false;
+
+            // Box colliders are valid.
+            testObject.AddComponent<BoxCollider>();
+
+            testObject.AddComponent<NearInteractionGrabbable>();
+            yield return null;
+
+            GameObject.Destroy(testObject);
+            yield return null;
+        }
+
+    }
+}
+#endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionGrabbableTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/NearInteractionGrabbableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28429463fec511e4fba8dc59b63b1c2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Updates the validation in NearInteractionGrabbable to not log an error when there is actually a valid collider on the object. If the first collider on a game object isn't valid (i.e. it's not one of the supported colliders) we currently log an error (by newing up an exception, which we don't even throw).

This changes it so that if there is at least a single supported collider type, we don't log an error.

Also this changes it to just by an error log instead of newing an exception (and then logging the exception). Not much of a need to new up an exception only to not throw it.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7342