### PR TITLE
MRTK Configurator keeps showing up 2019.3

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -102,7 +102,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.VirtualRealitySupported, new ConfigGetter(() => { return XRSettingsUtilities.LegacyXREnabled; }) },
             { Configurations.SinglePassInstancing, new ConfigGetter(() => { return MixedRealityOptimizeUtils.IsSinglePassInstanced(); }) },
             { Configurations.SpatialAwarenessLayer, new ConfigGetter(() => { return HasSpatialAwarenessLayer(); }) },
+#if !UNITY_2019_3_OR_NEWER
             { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return PackageManifestUpdater.IsMSBuildForUnityEnabled(); }, BuildTarget.WSAPlayer) },
+#endif // !UNITY_2019_3_OR_NEWER
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.SpatialPerception); }, BuildTarget.WSAPlayer) },
@@ -138,7 +140,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { Configurations.VirtualRealitySupported,  () => { XRSettingsUtilities.LegacyXREnabled = true; } },
             { Configurations.SinglePassInstancing,  () => { MixedRealityOptimizeUtils.SetSinglePassInstanced(); } },
             { Configurations.SpatialAwarenessLayer,  () => { SetSpatialAwarenessLayer(); } },
+#if !UNITY_2019_3_OR_NEWER
             { Configurations.EnableMSBuildForUnity, () => { PackageManifestUpdater.EnsureMSBuildForUnity(); } },
+#endif // !UNITY_2019_3_OR_NEWER
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true); } },


### PR DESCRIPTION
## Overview
The MRTK Configurator window keeps showing up on 2019.3 because there's a certain configurator setting (enabling MSBuildForUnity) that is configured to not show up in the UI (i.e. there's no checkbox for MSBuildForUnity in 2019), but the code in the backend still checks to see if it's enabled (and will keep popping up the window if it's not enable).

The other root/underlying confusion here is how there are multiple dictionaries and sources of data, where maintaining multiple is tricky.

Another issue that we should probably solve (in a future case) is having a test that validates that IsProjectConfigured returns true after applying the defaults on a given project.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7332