### PR TITLE
Fix the DirectionalIndicator's handling of destroyed target game objects

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/DirectionalIndicator.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/Features/Utilities/DirectionalIndicator.cs
@@ -36,51 +36,58 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         [Min(0.0f)]
         public float ViewOffset = 0.3f;
 
-        private bool wasVisible = true;
+        private bool indicatorShown = false;
 
         protected override void Start()
         {
             base.Start();
 
-            SetVisible(IsVisible());
+            SetIndicatorVisibility(ShouldShowIndicator());
         }
 
         private void Update()
         {
-            bool isVisible = IsVisible();
-            if (isVisible != wasVisible)
+            bool showIndicator = ShouldShowIndicator();
+            if (showIndicator != indicatorShown)
             {
-                SetVisible(isVisible);
+                SetIndicatorVisibility(showIndicator);
             }
         }
 
-        private bool IsVisible()
+        private bool ShouldShowIndicator()
         {
             if (DirectionalTarget == null || SolverHandler.TransformTarget == null)
             {
                 return false;
             }
 
-            return MathUtilities.IsInFOV(DirectionalTarget.position, SolverHandler.TransformTarget,
+            return !MathUtilities.IsInFOV(DirectionalTarget.position, SolverHandler.TransformTarget,
                 VisibilityScaleFactor * CameraCache.Main.fieldOfView, VisibilityScaleFactor * CameraCache.Main.GetHorizontalFieldOfViewDegrees(),
                 CameraCache.Main.nearClipPlane, CameraCache.Main.farClipPlane);
         }
 
-        private void SetVisible(bool isVisible)
+        private void SetIndicatorVisibility(bool showIndicator)
         {
-            SolverHandler.UpdateSolvers = !isVisible;
+            SolverHandler.UpdateSolvers = showIndicator;
 
             foreach (var renderer in GetComponentsInChildren<Renderer>())
             {
-                renderer.enabled = !isVisible;
+                renderer.enabled = showIndicator;
             }
 
-            wasVisible = isVisible;
+            indicatorShown = showIndicator;
         }
 
         /// <inheritdoc />
         public override void SolverUpdate()
         {
+            // SolverUpdate is generally called in LateUpdate, at a time when it's possible that the DirectionalTarget
+            // has already been destroyed. This ensures that if the object has been destroyed, we don't access invalid
+            if (DirectionalTarget == null)
+            {
+                return;
+            }
+
             // This is the frame of reference to use when solving for the position of this.gameobject
             // The frame of reference will likely be the main camera
             var solverReferenceFrame = SolverHandler.TransformTarget;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -445,7 +445,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Experimental
 
         /// <summary>
-        /// Test solver system's ability to add multiple solvers at runtime and switch between them.
+        /// Tests that the DirectionalIndicator can be instatiated through code.
         /// </summary>
         [UnityTest]
         public IEnumerator TestDirectionalIndicator()
@@ -482,6 +482,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             directionTarget.transform.position = 5.0f * Vector3.forward;
 
             yield return WaitForFrames(2);
+            Assert.IsFalse(indicatorMesh.enabled);
+
+            // Get back to a position where the directional indicator should be visible
+            directionTarget.transform.position = -10.0f * Vector3.right;
+            yield return WaitForFrames(2);
+            Assert.LessOrEqual(Vector3.Angle(indicatorSolver.transform.up, directionTarget.transform.position.normalized), ANGLE_THRESHOLD);
+            Assert.IsTrue(indicatorMesh.enabled);
+
+            // Destroy the object and then validate that the mesh is no longer visible
+            Object.Destroy(directionTarget);
+            yield return null;
             Assert.IsFalse(indicatorMesh.enabled);
         }
 


### PR DESCRIPTION
## Overview
A couple of issues here:

1. As mentioned in the issue, the naming of IsVisible is somewhat confusing because it refers to whether or not the target itself is visible, but then is used to control the visibility of ourselves (in the negated form, obviously) further down the line. I opted to change it to reflect how we're going to be changing our own visibility, rather, than whether or not the target itself was actually visible.
2. Even with that fix, there's still an exception because SolverUpdate() is called in LateUpdate, after the target object could have been destroyed. This makes it so that we only do SolverUpdate() stuff in the target object is still around.

Also added a test to verify that it's been fixed!

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7334