### PR TITLE
Changed the logic of MsBuild prerelease parsing so that it is not affected by current culture.

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/PackageManifestUpdaterTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/PackageManifestUpdaterTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
             success = PackageManifestUpdater.TryGetVersionComponents("0.9.1-20200131.12", out version, out prerelease);
             Assert.IsTrue(success);
             Assert.AreEqual(version, new Version(0, 9, 1));
-            Assert.AreEqual(prerelease, float.Parse("20200131.12"));
+            Assert.AreEqual(prerelease, 20200131.12f);
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using UnityEditor.PackageManager;
@@ -66,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 {
                     // Parse the float component
                     string prereleaseString = versionComponents[1].Trim(trimChars);
-                    if (float.TryParse(prereleaseString, out prerelease))
+                    if (float.TryParse(prereleaseString, NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out prerelease))
                     {
                         return true;
                     }


### PR DESCRIPTION
## Overview

Previous parsing logic was failing when current culture was set to one that uses decimal comma instead of decimal point.

See also the list of countries that use decimal commas: https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_comma
