### PR TITLE
Add validators to ensure that we don't have mismatched image cases

### DIFF
--- a/Documentation/Input/CreateDataProvider.md
+++ b/Documentation/Input/CreateDataProvider.md
@@ -232,7 +232,7 @@ the file will be located in the ContosoInput\Editor folder. This assembly defini
 
 Once created, the data provider can be registered with the input system and be used in the application.
 
-![Registered input system data providers](../Images/Input/RegisteredServiceProviders.png)
+![Registered input system data providers](../Images/Input/RegisteredServiceProviders.PNG)
 
 ## Packaging and distribution
 

--- a/Documentation/Performance/PerfGettingStarted.md
+++ b/Documentation/Performance/PerfGettingStarted.md
@@ -166,11 +166,11 @@ If estimating the rough performance tradeoff between one shader and another, it 
 
 Unity Standard shader statistics example
 
-![Unity Standard Shader Statistics](../../Documentation/Images/Performance/UnityStandardShader-Stats.png)
+![Unity Standard Shader Statistics](../../Documentation/Images/Performance/UnityStandardShader-Stats.PNG)
 
 MRTK Standard shader statistics example
 
-![MRTK Standard Shader Statistics](../../Documentation/Images/Performance/MRTKStandardShader-Stats.png)
+![MRTK Standard Shader Statistics](../../Documentation/Images/Performance/MRTKStandardShader-Stats.PNG)
 
 ## See also
 

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -178,7 +178,7 @@ The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.Han
 
 Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) property for additional documentation. A few properties are defined in more detail below.
 
-![Hand constraint palm up](Images/Solver/MRTK_Solver_HandConstraintPalmUp.md)
+<img src="Images/Solver/MRTK_Solver_HandConstraintPalmUp.png" width="450">
 
 * **Safe Zone**: The safe zone specifies where on the hand to constrain content. It is recommended that content be placed on the Ulnar Side to avoid overlap with the hand and improved interaction quality. Safe zones are calculated by taking the hands orientation projected into a plane orthogonal to the camera's view and raycasting against a bounding box around the hands. Safe zones are defined to work with [`IMixedRealityHand`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand) but also works with other controller types. It is recommended to explore what each safe zone represents on different controller types.
 

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -178,7 +178,7 @@ The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.Han
 
 Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) property for additional documentation. A few properties are defined in more detail below.
 
-<img src="Images/Solver/MRTK_Solver_HandConstraintPalmUp.png" width="450">
+![Hand constraint palm up](Images/Solver/MRTK_Solver_HandConstraintPalmUp.md)
 
 * **Safe Zone**: The safe zone specifies where on the hand to constrain content. It is recommended that content be placed on the Ulnar Side to avoid overlap with the hand and improved interaction quality. Safe zones are calculated by taking the hands orientation projected into a plane orthogonal to the camera's view and raycasting against a bounding box around the hands. Safe zones are defined to work with [`IMixedRealityHand`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityHand) but also works with other controller types. It is recommended to explore what each safe zone represents on different controller types.
 

--- a/Documentation/SceneSystem/SceneSystemSceneTypes.md
+++ b/Documentation/SceneSystem/SceneSystemSceneTypes.md
@@ -2,7 +2,7 @@
 
 Scenes have been divided into three types, and each type has a different function.
 
-![Scene system in the hierarchy](../Images/SceneSystem/MRTK_SceneSystemEditorSceneHierarchy.png)
+![Scene system in the hierarchy](../Images/SceneSystem/MRTK_SceneSystemEditorSceneHierarchy.PNG)
 
 ## Content scenes
 
@@ -26,7 +26,7 @@ A set of scenes which store lighting information and lighting objects. Only one 
 
 Unity's lighting settings - ambient light, skyboxes, etc - can be tricky to manage when using additive loading because they're tied to individual scenes and override behavior is not straightforward. In practice this can cause confusion when assets are authored in lighting conditions that don't obtain at runtime.
 
-![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemLightingSettings.png)
+![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemLightingSettings.PNG)
 
 The Scene System uses lighting scenes to ensure that these settings remain consistent regardless of what scenes are loaded or active, both in edit mode and in play mode.
 
@@ -36,7 +36,7 @@ To enable this feature, check `Use Lighting Scene` in your profile and populate 
 
 Your profile stores cached copies of the lighting settings kept in your lighting scenes. If those settings change in your lighting scenes, you will need to update your cache to ensure lighting appears as expected in play mode. Your profile will display a warning when it suspects your cached settings are out of date. Clicking `Update Cached Lighting Settings` will load each of your lighting scenes, extract their settings, then store them in your profile.
 
-![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemCachedLightingSettings.png)
+![Scene system lighting settings](../Images/SceneSystem/MRTK_SceneSystemCachedLightingSettings.PNG)
 
 ### Editor behavior
 
@@ -44,6 +44,6 @@ One benefit of using lighting scenes is knowing your content is lit correctly wh
 
 You can change which lighting scene is loaded by opening the Scene System's [service inspector.](../MixedRealityConfigurationGuide.md#editor-utilities) In edit mode you can instantaneously transition between lighting scenes. In play mode, you can preview transitions.
 
-![Scene system inspector](../Images/SceneSystem/MRTK_SceneSystemServiceInspector.png)
+![Scene system inspector](../Images/SceneSystem/MRTK_SceneSystemServiceInspector.PNG)
 
 \**Note: Typically the active scene determines your lighting settings in editor. However we choose not to use this feature to enforce lighting settings, because the active scene is also where newly created objects are placed by default, and lighting scenes are only permitted to contain lighting components. Instead, the current lighting scene's settings are automatically copied to the active scene's settings instead. Keep in mind that this will result in your content scene's lighting settings being over-written.*

--- a/Documentation/hologram-stabilization.md
+++ b/Documentation/hologram-stabilization.md
@@ -58,11 +58,11 @@ For transparent materials using the [MRTK Standard shader](README_MRTKStandardSh
 
 Before
 
-![Depth Buffer Before Fix MRTK Standard Shader](Images/Performance/DepthBufferFixNow_Before.png)
+![Depth Buffer Before Fix MRTK Standard Shader](Images/Performance/DepthBufferFixNow_Before.PNG)
 
 After
 
-![Depth Buffer Fixed MRTK Standard Shader](Images/Performance/DepthBufferFixNow_After.png)
+![Depth Buffer Fixed MRTK Standard Shader](Images/Performance/DepthBufferFixNow_After.PNG)
 
 ##### Text Mesh Pro
 

--- a/scripts/ci/validatedocs.ps1
+++ b/scripts/ci/validatedocs.ps1
@@ -56,6 +56,11 @@ function CheckDocLinks {
     }
 }
 
+# A case-sensitve cache of all checked image paths, so that we can
+# avoid hitting disk when checking for repeated images. Uses System.Collections.Hashtable
+# directly because the default Dictionary in powershell is case-insensitive
+$ResolvedImagePaths = New-Object System.Collections.Hashtable
+
 <#
 .SYNOPSIS
     Given a full path to a markdown file and a relative image path, checks to see if the
@@ -179,12 +184,6 @@ function CheckBrokenImages {
         $hasBrokenImage;
     }
 }
-
-# A case-sensitve cache of all checked image paths, so that we can
-# avoid hitting disk when checking for repeated images. Uses System.Collections.Hashtable
-# directly because the default Dictionary in powershell is case-insensitive
-$ResolvedImagePaths = New-Object System.Collections.Hashtable
-
 
 function CheckDocument {
     [CmdletBinding()]

--- a/scripts/ci/validatedocs.ps1
+++ b/scripts/ci/validatedocs.ps1
@@ -167,7 +167,6 @@ function CheckBrokenImages {
             $images += $match.Groups[1]
         }
         $imgTagMatches = ($FileContent[$LineNumber] | Select-String -Pattern '\"(?!http)([^\"]+\.(?:png|gif|jpg))\"' -AllMatches).Matches
-
         foreach ($match in $imgTagMatches) {
             $images += $match.Groups[1]
         }

--- a/scripts/ci/validatedocs.ps1
+++ b/scripts/ci/validatedocs.ps1
@@ -56,6 +56,136 @@ function CheckDocLinks {
     }
 }
 
+<#
+.SYNOPSIS
+    Given a full path to a markdown file and a relative image path, checks to see if the
+    image actually exists. Note that this does a case-sensitive checking, because
+    some of our documentation endpoints are hosted on case-sensitive environments.
+#>
+function CheckImage {
+    [CmdletBinding()]
+    param(
+        # An absolute path to the markdown file
+        [string]$MarkdownFilePath,
+
+        # The image path string (often relative) within the markdown file
+        # e.g. "../Documentation/Images/image.png"
+        [string]$ImagePath
+    )
+    process {
+        if (!$MarkdownFilePath -or !$ImagePath) {
+            return $false
+        }
+
+        # Resolves the given image based on the location of the markdown file location
+        # For example, given "/path/to/Documentation/subfolder/file.md"
+        # and an image "../Images/image.png", resolves this to:
+        # "/path/to/Documentation/Images/image.png"
+        $markdownFolder = [System.IO.Path]::GetDirectoryName($MarkdownFilePath)
+        $unresolvedPath = Join-Path -Path $markdownFolder -ChildPath $ImagePath
+        $resolvedPath = [System.IO.Path]::GetFullPath($unresolvedPath)
+
+        # It's possible that we could have tested the resolved path already (rare, but
+        # possible) - in that case cache the value so that we don't have to hit the disk again.
+        if (!$ResolvedImagePaths.ContainsKey($resolvedPath)) {
+            # First check to see if the path exists at all - if it doesn't exist,
+            # this is an invalid image.
+            if (-Not (Test-Path $resolvedPath -PathType leaf)) {
+                Write-Host "Image file was not found: "
+                Write-Host $resolvedPath
+                $ResolvedImagePaths[$resolvedPath] = $false
+            } else {
+                # Otherwise we still have to ensure that the image itself matches the
+                # correct case (i.e. image.png vs image.PNG).
+                #
+                # Checking case-sensitive matches is awkward on some OSes (i.e. Windows)
+                # because they are case-insensitive by default. Below is a workaround
+                # that uses regex to avoid the issue.
+                #
+                # Mutate the resolved path by making the last character bracketed by
+                # [], which turns it into a regular expression. This makes it so that
+                # the returned FullName actually reflects the real fullname on disk
+                # rather than the casing that is passed in the regex.
+                $lastCharacter = $resolvedPath.Substring($resolvedPath.Length - 1)
+                $prefix = $resolvedPath.Substring(0, $resolvedPath.Length - 1)
+                $regexPath = "{0}[{1}]" -f $prefix, $lastCharacter
+                $file = Get-Item $regexPath
+
+                # The image path is only valid if the actual case on disk matches
+                # the case written in the markdown file (i.e. the resolved path)
+                $caseAccurateName = $file.FullName
+                $ResolvedImagePaths[$resolvedPath] = ($caseAccurateName -ceq $resolvedPath)
+
+                if (-Not $ResolvedImagePaths[$resolvedPath]) {
+                    Write-Host "Found a case-sensitive mismatch: "
+                    Write-Host "Actual:" + $caseAccurateName
+                    Write-Host "Markdown:" + $resolvedPath
+                }
+            }
+        }
+
+        $ResolvedImagePaths[$resolvedPath]
+    }
+}
+
+<#
+.SYNOPSIS
+    Checks if the given file at the given line contains a reference to an image that doesn't exist (either
+    the image itself doesn't exist or is the wrong case)
+#>
+function CheckBrokenImages {
+    [CmdletBinding()]
+    param(
+        [string]$FileName,
+        [string[]]$FileContent,
+        [int]$LineNumber
+    )
+    process {
+        # There are two different types of image links we have - some are <img> and some are [](image.png)
+        # Below we use two different regexes to capture those (i.e. making sure we're properly pairing the
+        # quotes and parenthesis in order to extract the image path)
+        # Explanation of the regexes:
+        # '\((?!http)([^\)]+\.(?:png|gif|jpg))\)'
+        # Looks for cases like ![](path/to/image.png)
+        # \(                - Looks for the opening ( surrounding (path/to/image.png)
+        # (?!http)          - Filters out absolute HTTP links (we only want to validate images that we control)
+        # (                 - Beginning of the grouping/match (used to extract the image path)
+        # [^\)]+            - Matches any character that isn't the ) character (to ensure that on lines with
+        #                     multiple images, we don't end up matching multiple strings at the same)
+        # \.(?:png|gif|jpg) - Matches a filename that ends in png, gif, or jpg
+        # )                 - Ending of the grouping/match  (used to extract the image path)
+        # \)                - Looks for the closing ) surrounding (path/to/image.png)
+        # The imgTagRegex is similar, except for the opening and closing characters (i.e. "" of ())
+        $images = @()
+        $markdownMatches = ($FileContent[$LineNumber] | Select-String -Pattern '\((?!http)([^\)]+\.(?:png|gif|jpg))\)' -AllMatches).Matches
+        foreach ($match in $markdownMatches) {
+            $images += $match.Groups[1]
+        }
+        $imgTagMatches = ($FileContent[$LineNumber] | Select-String -Pattern '\"(?!http)([^\"]+\.(?:png|gif|jpg))\"' -AllMatches).Matches
+
+        foreach ($match in $imgTagMatches) {
+            $images += $match.Groups[1]
+        }
+
+        $hasBrokenImage = $false;
+        foreach ($image in $images) {
+            if (-Not (CheckImage $FileName $image)) {
+                $hasBrokenImage = $true
+                Write-Host "A broken image link was found in $FileName at line $LineNumber "
+                Write-Host $FileContent[$LineNumber]
+            }
+        }
+
+        $hasBrokenImage;
+    }
+}
+
+# A case-sensitve cache of all checked image paths, so that we can
+# avoid hitting disk when checking for repeated images. Uses System.Collections.Hashtable
+# directly because the default Dictionary in powershell is case-insensitive
+$ResolvedImagePaths = New-Object System.Collections.Hashtable
+
+
 function CheckDocument {
     [CmdletBinding()]
     param(
@@ -70,6 +200,8 @@ function CheckDocument {
         $fileContent = Get-Content $FileName
         for ($i = 0; $i -lt $fileContent.Length; $i++) {
             if (CheckDocLinks $FileName $fileContent $i) {
+                $issueFound = $true
+            } elseif (CheckBrokenImages $FileName $fileContent $i) {
                 $issueFound = $true
             }
         }


### PR DESCRIPTION
## Overview
@CDiaz-MS noticed that our github.io docs had some broken links which were super interesting. There are actually a few different issues that are worth discussing here.

1. The reason the image was broken was because of a case-insensitive issue on the docs update pipeline that we have. At some point in the past, someone changed the name of one of the images from image.png to image.PNG. The markdown image name and the actual image name matched fine, but the problem is the docs pipeline never "noticed" the image filename change from image.png to image.PNG. As a result, it never pushed the change to the gh-pages branch. The reason this happened is because git uses the default case-sensitive setting of the environment it's running in, and at least for our docs pipeline (which use powershell on windows) the default was case-insensitive. The fix there (not captured in this PR) was just to make sure we had the `git config core.ignorecase false` setting. Thanks to @keveleigh  for figuring this part out.
2. We still have other images that are broken when viewed directly within github itself (i.e. looking at the markdown on github.com rather than generated html on github.io). This is because of case-sensitive mismatches between what's in markdown and what is actually on the filesystem. This PR means to avoid that in the future by adding validation to check that the images actually match their real (case-sensitive names) on disk.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7361