### PR TITLE
Ensure camera is looking at cube and input system ticks.

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerBehaviorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerBehaviorTests.cs
@@ -172,15 +172,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.AddComponent<NearInteractionGrabbable>();
-            cube.transform.position = Vector3.zero;
+            cube.transform.position = Vector3.forward;
+            TestUtilities.PlayspaceToOriginLookingForward();
 
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);
 
             TestContext.Out.WriteLine("Show both hands near grabbable cube");
-            yield return rightHand.Show(Vector3.zero);
-            yield return leftHand.Show(Vector3.zero);
-            yield return new WaitForFixedUpdate();
+            yield return rightHand.Show(cube.transform.position);
+            yield return leftHand.Show(cube.transform.position);
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             PointerStateContainer grabOn = new PointerStateContainer()
             {


### PR DESCRIPTION
## Overview
Makes TestGrab more reliable by ensuring camera is looking at cube on start and waiting for input system to update before checking pointers.

## Changes
- Fixes: #7359


## Verification
Verified by running tests 100 times in a row.

> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
