### PR TITLE
Fix extension service wizard generation on optional profile

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionConstructorTemplate.txt
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionConstructorTemplate.txt
@@ -1,0 +1,6 @@
+		private #PROFILE_NAME# #PROFILE_FIELD_NAME#;
+
+		public #SERVICE_NAME#(string name,  uint priority,  BaseMixedRealityProfile profile) : base(name, priority, profile) 
+		{
+			#PROFILE_FIELD_NAME# = (#PROFILE_NAME#)profile;
+		}

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionConstructorTemplate.txt.meta
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionConstructorTemplate.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41b9c612c56dddd4691c98456dc221f2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
@@ -7,6 +7,7 @@ namespace #NAMESPACE#
 	public class #SERVICE_NAME# : BaseExtensionService, #INTERFACE_NAME#, IMixedRealityExtensionService
 	{
 #SERVICE_CONSTRUCTOR#
+
 		public override void Initialize()
 		{
 			base.Initialize();

--- a/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
+++ b/Assets/MixedRealityToolkit.Tools/ExtensionServiceCreator/Templates/ExtensionScriptTemplate.txt
@@ -6,20 +6,18 @@ namespace #NAMESPACE#
 	[MixedRealityExtensionService(#SUPPORTED_PLATFORMS_PARAM#)]
 	public class #SERVICE_NAME# : BaseExtensionService, #INTERFACE_NAME#, IMixedRealityExtensionService
 	{
-		private #PROFILE_NAME# #PROFILE_FIELD_NAME#;
-
-		public #SERVICE_NAME#(string name,  uint priority,  BaseMixedRealityProfile profile) : base(name, priority, profile) 
-		{
-			#PROFILE_FIELD_NAME# = (#PROFILE_NAME#)profile;
-		}
-
+#SERVICE_CONSTRUCTOR#
 		public override void Initialize()
 		{
+			base.Initialize();
+
 			// Do service initialization here.
 		}
 
 		public override void Update()
 		{
+			base.Update();
+
 			// Do service updates here.
 		}
 	}


### PR DESCRIPTION
## Overview
When using the extension service wizard creator, if the profile/inspector files (which are marked optional) are not selected and thus not created, then the new service class will throw an error. This is because the service template attempts to always create a private field of the profile instance.

However if no special profile object is created, then the service class does not need the field or the constructor.

Also updated the service template to call base.initialize() and base.update by default. 

## Changes
- Fixes: #5654 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
