### PR TITLE
Hide visual profiler while MRC is running

### DIFF
--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityDiagnosticsSystem.cs
@@ -65,6 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             visualProfiler.WindowOffset = WindowOffset;
             visualProfiler.WindowScale = WindowScale;
             visualProfiler.WindowFollowSpeed = WindowFollowSpeed;
+            visualProfiler.ShowProfilerDuringMRC = ShowProfilerDuringMRC;
         }
 
         private MixedRealityToolkitVisualProfiler visualProfiler = null;
@@ -91,6 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             WindowOffset = profile.WindowOffset;
             WindowScale = profile.WindowScale;
             WindowFollowSpeed = profile.WindowFollowSpeed;
+            ShowProfilerDuringMRC = profile.ShowProfilerDuringMRC;
 
             CreateVisualizations();
         }
@@ -372,6 +374,30 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                     if (visualProfiler != null)
                     {
                         visualProfiler.WindowFollowSpeed = windowFollowSpeed;
+                    }
+                }
+            }
+        }
+
+        private bool showProfilerDuringMRC = false;
+
+        /// <summary>
+        /// If the diagnostics profiler should be visible while a mixed reality capture is happening on HoloLens.
+        /// </summary>
+        /// <remarks>This is not usually recommended, as MRC can have an effect on an app's frame rate.</remarks>
+        public bool ShowProfilerDuringMRC
+        {
+            get { return showProfilerDuringMRC; }
+
+            set
+            {
+                if (value != showProfilerDuringMRC)
+                {
+                    showProfilerDuringMRC = value;
+
+                    if (visualProfiler != null)
+                    {
+                        visualProfiler.ShowProfilerDuringMRC = showProfilerDuringMRC;
                     }
                 }
             }

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -55,11 +55,11 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             set { isVisible = value; }
         }
 
-        private bool ShouldShowProfiler => isVisible
+        private bool ShouldShowProfiler =>
 #if WINDOWS_UWP
-            && (appCapture == null || !appCapture.IsCapturingVideo || showProfilerDuringMRC)
+            (appCapture == null || !appCapture.IsCapturingVideo || showProfilerDuringMRC) &&
 #endif // WINDOWS_UWP
-            ;
+            isVisible;
 
         [SerializeField, Tooltip("Should the frame info (colored bars) be displayed.")]
         private bool frameInfoVisible = true;

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -69,12 +69,6 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             set { frameInfoVisible = value; }
         }
 
-        private bool ShouldShowFrameInfo => frameInfoVisible
-#if WINDOWS_UWP
-            && (appCapture == null || !appCapture.IsCapturingVideo)
-#endif // WINDOWS_UWP
-            ;
-
         [SerializeField, Tooltip("Should memory stats (used, peak, and limit) be displayed.")]
         private bool memoryStatsVisible = true;
 
@@ -83,12 +77,6 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             get { return memoryStatsVisible; }
             set { memoryStatsVisible = value; }
         }
-
-        private bool ShouldShowMemoryStats => memoryStatsVisible
-#if WINDOWS_UWP
-            && (appCapture == null || !appCapture.IsCapturingVideo)
-#endif // WINDOWS_UWP
-            ;
 
         [SerializeField, Tooltip("The amount of time, in seconds, to collect frames for frame rate calculation.")]
         private float frameSampleRate = 0.1f;
@@ -348,7 +336,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
                 }
 
                 // Update frame colors.
-                if (ShouldShowFrameInfo)
+                if (frameInfoVisible)
                 {
                     for (int i = frameRange - 1; i > 0; --i)
                     {
@@ -366,7 +354,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             }
 
             // Draw frame info.
-            if (ShouldShowProfiler && ShouldShowFrameInfo)
+            if (ShouldShowProfiler && frameInfoVisible)
             {
                 Matrix4x4 parentLocalToWorldMatrix = window.localToWorldMatrix;
 
@@ -387,7 +375,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             }
 
             // Update memory statistics.
-            if (ShouldShowProfiler && ShouldShowMemoryStats)
+            if (ShouldShowProfiler && memoryStatsVisible)
             {
                 ulong limit = AppMemoryUsageLimit;
 
@@ -430,7 +418,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
             // Update visibility state.
             window.gameObject.SetActive(ShouldShowProfiler);
-            memoryStats.gameObject.SetActive(ShouldShowMemoryStats);
+            memoryStats.gameObject.SetActive(memoryStatsVisible);
         }
 
         private Vector3 CalculateWindowPosition(Transform cameraTransform)
@@ -503,12 +491,12 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private void CalculateBackgroundSize()
         {
-            if (ShouldShowMemoryStats)
+            if (memoryStatsVisible)
             {
                 background.localPosition = backgroundOffsets[0];
                 background.localScale = backgroundScales[0];
             }
-            else if (ShouldShowFrameInfo)
+            else if (frameInfoVisible)
             {
                 background.localPosition = backgroundOffsets[1];
                 background.localScale = backgroundScales[1];
@@ -604,7 +592,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
             }
 
             window.gameObject.SetActive(ShouldShowProfiler);
-            memoryStats.gameObject.SetActive(ShouldShowMemoryStats);
+            memoryStats.gameObject.SetActive(memoryStatsVisible);
         }
 
         private void BuildFrameRateStrings()

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -4,11 +4,12 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Text;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 #if WINDOWS_UWP
 using Windows.Media.Capture;
 using Windows.System;
+#else
+using UnityEngine.Profiling;
 #endif
 
 namespace Microsoft.MixedReality.Toolkit.Diagnostics

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private bool ShouldShowProfiler => isVisible
 #if WINDOWS_UWP
-            && appCapture != null && !appCapture.IsCapturingVideo
+            && (appCapture == null || !appCapture.IsCapturingVideo)
 #endif // WINDOWS_UWP
             ;
 
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private bool ShouldShowFrameInfo => frameInfoVisible
 #if WINDOWS_UWP
-            && appCapture != null && !appCapture.IsCapturingVideo
+            && (appCapture == null || !appCapture.IsCapturingVideo)
 #endif // WINDOWS_UWP
             ;
 
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private bool ShouldShowMemoryStats => memoryStatsVisible
 #if WINDOWS_UWP
-            && appCapture != null && !appCapture.IsCapturingVideo
+            && (appCapture == null || !appCapture.IsCapturingVideo)
 #endif // WINDOWS_UWP
             ;
 

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private bool ShouldShowProfiler => isVisible
 #if WINDOWS_UWP
-            && (appCapture == null || !appCapture.IsCapturingVideo)
+            && (appCapture == null || !appCapture.IsCapturingVideo || showProfilerDuringMRC)
 #endif // WINDOWS_UWP
             ;
 
@@ -123,6 +123,20 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         {
             get { return windowFollowSpeed; }
             set { windowFollowSpeed = Mathf.Abs(value); }
+        }
+
+        [SerializeField]
+        [Tooltip("If the diagnostics profiler should be visible while a mixed reality capture is happening on HoloLens.")]
+        private bool showProfilerDuringMRC = false;
+
+        /// <summary>
+        /// If the diagnostics profiler should be visible while a mixed reality capture is happening on HoloLens.
+        /// </summary>
+        /// <remarks>This is not usually recommended, as MRC can have an effect on an app's frame rate.</remarks>
+        public bool ShowProfilerDuringMRC
+        {
+            get { return showProfilerDuringMRC; }
+            set { showProfilerDuringMRC = value; }
         }
 
         [Header("UI Settings")]

--- a/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
+++ b/Assets/MixedRealityToolkit.Services/DiagnosticsSystem/MixedRealityToolkitVisualProfiler.cs
@@ -503,7 +503,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
 
         private void CalculateBackgroundSize()
         {
-            if (ShouldShowFrameInfo && ShouldShowMemoryStats || ShouldShowMemoryStats)
+            if (ShouldShowMemoryStats)
             {
                 background.localPosition = backgroundOffsets[0];
                 background.localScale = backgroundScales[0];

--- a/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Diagnostics/MixedRealityDiagnosticsProfile.cs
@@ -109,6 +109,14 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics
         /// </summary>
         public Material DefaultInstancedMaterial => defaultInstancedMaterial;
 
-        
+        [SerializeField]
+        [Tooltip("If the diagnostics profiler should be visible while a mixed reality capture is happening on HoloLens.")]
+        private bool showProfilerDuringMRC = false;
+
+        /// <summary>
+        /// If the diagnostics profiler should be visible while a mixed reality capture is happening on HoloLens.
+        /// </summary>
+        /// <remarks>This is not usually recommended, as MRC can have an effect on an app's frame rate.</remarks>
+        public bool ShowProfilerDuringMRC => showProfilerDuringMRC;
     }
 }

--- a/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Profiles/MixedRealityDiagnosticsSystemProfileInspector.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.﻿
 
 using Microsoft.MixedReality.Toolkit.Editor;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using UnityEditor;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Diagnostics.Editor
 {
@@ -18,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics.Editor
         private SerializedProperty windowOffset;
         private SerializedProperty windowScale;
         private SerializedProperty windowFollowSpeed;
+        private SerializedProperty showProfilerDuringMRC;
 
         private const string ProfileTitle = "Diagnostic Settings";
         private const string ProfileDescription = "Diagnostic visualizations can help monitor system resources and performance inside an application.";
@@ -37,6 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics.Editor
             windowOffset = serializedObject.FindProperty("windowOffset");
             windowScale = serializedObject.FindProperty("windowScale");
             windowFollowSpeed = serializedObject.FindProperty("windowFollowSpeed");
+            showProfilerDuringMRC = serializedObject.FindProperty("showProfilerDuringMRC");
         }
 
         public override void OnInspectorGUI()
@@ -71,6 +71,12 @@ namespace Microsoft.MixedReality.Toolkit.Diagnostics.Editor
                     EditorGUILayout.PropertyField(windowOffset);
                     EditorGUILayout.PropertyField(windowScale);
                     EditorGUILayout.PropertyField(windowFollowSpeed);
+                }
+
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("HoloLens Settings", EditorStyles.boldLabel);
+                {
+                    EditorGUILayout.PropertyField(showProfilerDuringMRC);
                 }
 
                 serializedObject.ApplyModifiedProperties();

--- a/Documentation/Diagnostics/UsingVisualProfiler.md
+++ b/Documentation/Diagnostics/UsingVisualProfiler.md
@@ -14,7 +14,7 @@ While developing an application, focus on multiple parts of the scene as the Vis
 
 ## Visual profiler interface
 
-![Visual Profiler Interface](../../Documentation/Images/Diagnostics/VisualProfiler.png)
+![Visual Profiler Interface](../Images/Diagnostics/VisualProfiler.png)
 
 The Visual Profiler interface includes the following components:
 
@@ -32,6 +32,9 @@ The specific platform and hardware configuration will play a significant role in
 - Microsoft HoloLens: 60
 - Windows Mixed Reality Ultra: 90
 
+> [!NOTE]
+> Due to [frame rate throttling on HoloLens when default MRC is active](https://docs.microsoft.com/windows/mixed-reality/mixed-reality-capture-for-developers#what-to-expect-when-mrc-is-enabled-on-hololens), the visual profiler hides itself while videos and photos are captured.
+
 ### Frame time
 
 To the right of the frame rate is the frame time, in milliseconds, spent on the CPU. To achieve the target frame rates mentioned previously, an application can spend the following amount of time per frame:
@@ -45,7 +48,7 @@ GPU time is planned to be added in a future release.
 
 The frame graph provides a graphical display of the application frame rate history.
 
-![Visual Profiler Frame Graph](../../Documentation/Images/Diagnostics/VisualProfilerMissedFrames.png)
+![Visual Profiler Frame Graph](../Images/Diagnostics/VisualProfilerMissedFrames.png)
 
 When using the application, look for missed frames which indicate that the application is not hitting its target frame rate and may need optimization work.
 
@@ -53,7 +56,7 @@ When using the application, look for missed frames which indicate that the appli
 
 The memory utilization display allows for easy understanding of how the current view is impacting an application's memory consumption.
 
-![Visual Profiler Frame Graph](../../Documentation/Images/Diagnostics/VisualProfilerMemory.png)
+![Visual Profiler Frame Graph](../Images/Diagnostics/VisualProfilerMemory.png)
 
 When using the application, look for total memory usage. Key indicators include nearing the memory limit and rapid changes in usage.
 

--- a/Documentation/Diagnostics/UsingVisualProfiler.md
+++ b/Documentation/Diagnostics/UsingVisualProfiler.md
@@ -33,7 +33,7 @@ The specific platform and hardware configuration will play a significant role in
 - Windows Mixed Reality Ultra: 90
 
 > [!NOTE]
-> Due to [frame rate throttling on HoloLens when default MRC is active](https://docs.microsoft.com/windows/mixed-reality/mixed-reality-capture-for-developers#what-to-expect-when-mrc-is-enabled-on-hololens), the visual profiler hides itself while videos and photos are captured.
+> Due to [frame rate throttling on HoloLens when default MRC is active](https://docs.microsoft.com/windows/mixed-reality/mixed-reality-capture-for-developers#what-to-expect-when-mrc-is-enabled-on-hololens), the visual profiler hides itself while videos and photos are captured. This setting can be overridden in the diagnostics system profile.
 
 ### Frame time
 


### PR DESCRIPTION
## Overview

Adds some `AppCapture` API calls to detect when MRC is running and auto-hide the profiler.

## Changes

- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7369