### PR TITLE
Tap to Place Tests

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Scripts/HideTapToPlaceLabel.cs
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Solvers/Scripts/HideTapToPlaceLabel.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers;
+using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos
 {

--- a/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/TapToPlace.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Utilities/Solvers/TapToPlace.cs
@@ -3,13 +3,11 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
-using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.Serialization;
+using UnityPhysics = UnityEngine.Physics;
 
-namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
+namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 {
     /// <summary>
     /// Tap to place is a far interaction component used to place objects on a surface.
@@ -171,9 +169,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 
         private int ignoreRaycastLayer;
 
-        // The current ray is based on the TrackedTargetType (Controller Ray, Head, Hand Joint).
-        // The following properties are updated each frame while the game object is selected to determine
-        // object placement if there is a hit on a surface.
+        /// <summary>
+        /// The current ray is based on the TrackedTargetType (Controller Ray, Head, Hand Joint).
+        /// The following properties are updated each frame while the game object is selected to determine
+        /// object placement if there is a hit on a surface.
+        /// </summary>
         protected RayStep CurrentRay;
 
         protected bool DidHitSurface;
@@ -191,6 +191,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
             base.Start();
 
             Debug.Assert(IsColliderPresent, $"The game object {gameObject.name} does not have a collider attached, please attach a collider to use Tap to Place");
+
+            // When a game object is created via script, the bounds of the collider remain at the default size 
+            // of (1, 1, 1) which always returns a 0.5 SurfaceNormalOffset.  Adding SyncTransforms updates the
+            // size of the collider to match the game object before we calculate the SurfaceNormalOffset.
+            UnityPhysics.SyncTransforms();
 
             SurfaceNormalOffset = gameObject.GetComponent<Collider>().bounds.extents.z;
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -559,7 +559,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Test code configurability for tap to place. Events for tap to place by default are triggered by 
         /// OnPointerClicked.  Code configurability for tap to place is calling Start/Stop Placement instead of 
-        /// clicking to select an object.
+        /// clicking to select an object.  This test uses AutoStart to start placing the object and StopPlacement.
         /// </summary>
         [UnityTest]
         public IEnumerator TestTapToPlaceCodeConfigurability()
@@ -570,14 +570,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
             tapToPlaceObj.target.transform.position = Vector3.forward;
             TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+            
+            // Start Placing the object immediately
+            tapToPlace.AutoStart = true;
 
             Vector3 handStartPosition = new Vector3(0, -0.1f, 0.6f);
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handStartPosition);
 
-            // Start the placement via code instead of click from the hand
-            tapToPlace.StartPlacement();
-
+            // Make sure the object is being placed after setting AutoStart
             Assert.True(tapToPlace.IsBeingPlaced);
 
             // Move the playspace to simulate head movement

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -476,7 +476,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             // Make sure the target obj has followed the head
-            Assert.AreEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
+            Assert.AreEqual(CameraCache.Main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
 
             // Tap to place has a 0.5 sec timer between clicks to make sure a double click does not get registered
             // We need to wait at least 30 frames until another click is called or tap to place will ignore the action
@@ -498,7 +498,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             // Make sure the target obj is NOT following the head
-            Assert.AreNotEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x matches camera position.x, when it should not");
+            Assert.AreNotEqual(CameraCache.Main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x matches camera position.x, when it should not");
         }
 
         /// <summary>
@@ -590,7 +590,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             // Make sure the target obj is following the head
-            Assert.AreEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
+            Assert.AreEqual(CameraCache.Main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
 
             // Stop the placement via code instead of click from the hand
             tapToPlace.StopPlacement();
@@ -600,14 +600,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Move the playspace to simulate head movement again
             MixedRealityPlayspace.PerformTransformation(p =>
             {
-                p.position = Vector3.left * 1.5f;
+                p.position = Vector3.right;
             });
 
             yield return new WaitForFixedUpdate();
             yield return null;
 
             // Make sure the target obj is NOT following the head
-            Assert.AreNotEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x matches the camera position.x, when it should not");
+            Assert.AreNotEqual(CameraCache.Main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x matches the camera position.x, when it should not");
         }
 
         /// <summary>
@@ -628,8 +628,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             colliderObj2.transform.localScale = new Vector3(0.3f, 0.3f, 0.05f);
             colliderObj2.transform.position = new Vector3(-0.3f, 0, 1.5f);
 
-            yield return PlayModeTestUtilities.WaitForEnterKey();
-
             // Create a cube with Tap to Place attached
             var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
             tapToPlaceObj.target.transform.position = Vector3.forward * 2;
@@ -642,8 +640,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Vector3 handStartPosition = new Vector3(0, -0.15f, 0.5f);
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handStartPosition);
-
-            yield return PlayModeTestUtilities.WaitForEnterKey();
 
             // Start the placement via code instead of click from the hand
             tapToPlace.StartPlacement();
@@ -660,8 +656,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
             Assert.True(tapToPlaceObj.target.transform.position.z < colliderObj1.transform.position.z);
-
-            yield return PlayModeTestUtilities.WaitForEnterKey();
 
             // Stop the placement via code instead of click from the hand
             tapToPlace.StopPlacement();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -944,8 +944,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Solver solver = AddSolverComponent<T>(cube);
 
-            Debug.Log("Bounds Size on Start: " + cube.GetComponent<Collider>().bounds.size);
-
             SolverHandler handler = cube.GetComponent<SolverHandler>();
             Assert.IsNotNull(handler, "GetComponent<SolverHandler>() returned null");
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -441,6 +441,235 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestUtilities.AssertAboutEqual(testObjects.target.transform.position, Vector3.forward * 2.0f, "RadialView solver did not place object in center of view");
         }
 
+        #region TapToPlace Tests
+        /// <summary>
+        /// Test the default behavior for Tap to Place.  The default behavior has the target object following the head.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceOnClickHead()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create a cube with Tap to Place attached and Head (default) as the TrackedTargetType 
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
+            tapToPlaceObj.target.transform.position = Vector3.forward;
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            // Set hand position 
+            Vector3 handStartPosition = new Vector3(0, -0.1f, 0.6f);
+            var leftHand = new TestHand(Handedness.Left);
+            yield return leftHand.Show(handStartPosition);
+
+            // Select Tap to Place Obj
+            yield return leftHand.Click();
+
+            // Make sure the object is being placed
+            Assert.True(tapToPlace.IsBeingPlaced);
+
+            // Move the playspace to simulate head movement
+            MixedRealityPlayspace.PerformTransformation(p =>
+            {
+                p.position = Vector3.left * 1.5f;
+            });
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // Make sure the target obj has followed the head
+            Assert.AreEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
+
+            // Tap to place has a 0.5 sec timer between clicks to make sure a double click does not get registered
+            // We need to wait at least 30 frames until another click is called or tap to place will ignore the action
+            yield return WaitForFrames(30);
+
+            // Click object to stop placement
+            yield return leftHand.Click();
+
+            // Make sure the object is not being placed after the click
+            Assert.False(tapToPlace.IsBeingPlaced);
+
+            // Move the playspace to simulate head movement again
+            MixedRealityPlayspace.PerformTransformation(p =>
+            {
+                p.position = Vector3.right;
+            });
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // Make sure the target obj is NOT following the head
+            Assert.AreNotEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x matches camera position.x, when it should not");
+        }
+
+        /// <summary>
+        /// Test the controller ray as the Tracked Target Type for an object with tap to place attached.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceOnClickControllerRay()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create a cube with Tap to Place attached
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
+            tapToPlaceObj.target.transform.position = Vector3.forward;
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            // Switch the TrackedTargetType to Controller Ray
+            SolverHandler tapToPlaceSolverHandler = tapToPlaceObj.handler;
+            tapToPlaceSolverHandler.TrackedTargetType = TrackedObjectType.ControllerRay;
+
+            // Set hand position
+            Vector3 handStartPosition = new Vector3(0, -0.1f, 0.6f);
+            var leftHand = new TestHand(Handedness.Left);
+            yield return leftHand.Show(handStartPosition);
+
+            Vector3 initialObjPosition = tapToPlaceObj.target.transform.position;
+
+            yield return leftHand.Click();
+
+            // Make sure the object is being placed after selection
+            Assert.True(tapToPlace.IsBeingPlaced);
+
+            // Move hand, object should follow
+            yield return leftHand.Move(Vector3.forward);
+            yield return leftHand.Move(Vector3.up);
+
+            // Make sure the object starting position is different from the current position
+            Assert.True(initialObjPosition != tapToPlaceObj.target.transform.position);
+
+            // Tap to place has a 0.5 sec timer between clicks to make sure a double click does not get registered
+            // We need to wait at least 30 frames until another click is called or tap to place will ignore the action
+            yield return WaitForFrames(30);
+
+            // Click to stop the placement
+            yield return leftHand.Click();
+
+            // Make sure the object is not being placed
+            Assert.False(tapToPlace.IsBeingPlaced);
+
+            // Get new position of the object after it is placed
+            Vector3 newPosition = tapToPlaceObj.target.transform.position;
+
+            // Move hand, the object should NOT move
+            yield return leftHand.Move(Vector3.back, 30);
+
+            Assert.True(newPosition == tapToPlaceObj.target.transform.position);
+        }
+
+        /// <summary>
+        /// Test code configurability for tap to place. Events for tap to place by default are triggered by 
+        /// OnPointerClicked.  Code configurability for tap to place is calling Start/Stop Placement instead of 
+        /// clicking to select an object.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceCodeConfigurability()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create a cube with Tap to Place attached
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
+            tapToPlaceObj.target.transform.position = Vector3.forward;
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            Vector3 handStartPosition = new Vector3(0, -0.1f, 0.6f);
+            var leftHand = new TestHand(Handedness.Left);
+            yield return leftHand.Show(handStartPosition);
+
+            // Start the placement via code instead of click from the hand
+            tapToPlace.StartPlacement();
+
+            Assert.True(tapToPlace.IsBeingPlaced);
+
+            // Move the playspace to simulate head movement
+            MixedRealityPlayspace.PerformTransformation(p =>
+            {
+                p.position = Vector3.left * 1.5f;
+            });
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // Make sure the target obj is following the head
+            Assert.AreEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
+
+            // Stop the placement via code instead of click from the hand
+            tapToPlace.StopPlacement();
+
+            Assert.False(tapToPlace.IsBeingPlaced);
+
+            // Move the playspace to simulate head movement again
+            MixedRealityPlayspace.PerformTransformation(p =>
+            {
+                p.position = Vector3.left * 1.5f;
+            });
+
+            yield return new WaitForFixedUpdate();
+            yield return null;
+
+            // Make sure the target obj is NOT following the head
+            Assert.AreNotEqual(Camera.main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x matches the camera position.x, when it should not");
+        }
+
+        /// <summary>
+        /// Tests tap to place object placement if there is a surface hit on another collider through Start/StopPlacement calls
+        /// instead of OnPointerClicked.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceColliderTests()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create a scene with 2 cubes
+            GameObject colliderObj1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            colliderObj1.transform.localScale = new Vector3(0.3f, 0.3f, 0.05f);
+            colliderObj1.transform.position = new Vector3(0.3f, 0, 1.5f);
+
+            GameObject colliderObj2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            colliderObj2.transform.localScale = new Vector3(0.3f, 0.3f, 0.05f);
+            colliderObj2.transform.position = new Vector3(-0.3f, 0, 1.5f);
+
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // Create a cube with Tap to Place attached
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
+            tapToPlaceObj.target.transform.position = Vector3.forward * 2;
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            // Switching the TrackedTargetType to Controller Ray
+            SolverHandler tapToPlaceSolverHandler = tapToPlaceObj.handler;
+            tapToPlaceSolverHandler.TrackedTargetType = TrackedObjectType.ControllerRay;
+
+            Vector3 handStartPosition = new Vector3(0, -0.15f, 0.5f);
+            var leftHand = new TestHand(Handedness.Left);
+            yield return leftHand.Show(handStartPosition);
+
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // Start the placement via code instead of click from the hand
+            tapToPlace.StartPlacement();
+            yield return null;
+
+            Assert.True(tapToPlace.IsBeingPlaced);
+
+            // Move hand, object should follow
+            yield return leftHand.Move(new Vector3(-0.15f, 0, 0), 30);
+            Assert.True(tapToPlaceObj.target.transform.position.z < colliderObj1.transform.position.z);
+
+            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            Assert.True(tapToPlaceObj.target.transform.position.z > colliderObj1.transform.position.z);
+
+            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            Assert.True(tapToPlaceObj.target.transform.position.z < colliderObj1.transform.position.z);
+
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // Stop the placement via code instead of click from the hand
+            tapToPlace.StopPlacement();
+
+            Assert.False(tapToPlace.IsBeingPlaced);
+        }
+
+        #endregion
 
         #region Experimental
 
@@ -714,6 +943,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             cube.transform.localScale = new Vector3(0.1f, 0.2f, 0.1f);
 
             Solver solver = AddSolverComponent<T>(cube);
+
+            Debug.Log("Bounds Size on Start: " + cube.GetComponent<Collider>().bounds.size);
 
             SolverHandler handler = cube.GetComponent<SolverHandler>();
             Assert.IsNotNull(handler, "GetComponent<SolverHandler>() returned null");


### PR DESCRIPTION
## Overview
Added 4 tests for Tap to Place:
1. Tests default behavior with the head as the TrackedTargetType
2. Tests default behavior with Controller Ray as the TrackedTargetType
3. Tests code configurability with the head as the TrackedTargetType
4. Tests object placement with colliders in the scene, uses Start/StopPlacement calls instead of clicking  

While writing the collider test I found that if an object is created via script, the bounds of the collider do not get updated before SurfaceNormalOffset is stored.   `UnityPhysics.SyncTransforms()` was added to TapToPlace before SurfaceNormalOffset is stored. Thanks @julenka 

There was also a namespace update for HideTapToPlaceLabel and TapToPlace, thanks to @keveleigh for pointing that out.

## Changes
- Fixes: #7362 
