### PR TITLE
Use a less interesting version of the exception to work around the nuget/build step

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -150,11 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     charIconLookup.Add(charIcon.Name, charIcon.Character);
                 }
             }
-            catch (NullReferenceException)
-            {
-                Debug.LogWarning("There's a null element in your icon set. Icon lookup by name will be disabled until this is resolved.");
-            }
-            catch (UnassignedReferenceException)
+            catch (System.Exception)
             {
                 Debug.LogWarning("There's a null element in your icon set. Icon lookup by name will be disabled until this is resolved.");
             }


### PR DESCRIPTION
## Overview
The mrtk_CI build is currently broken due to the usage of UnassignedReferenceException. This is really weird and totally not clear from the get go, but something that we've dealt with in the past (see https://github.com/microsoft/MixedRealityToolkit-Unity/pull/5215/files#diff-5a24b3ab8cfc7d46cbb7d009ef8b0424) because the build step when we run msbuild and generate player binaries.

This purely to unblock the build, despite it being less correct (i.e. it would be great to actually use UnassignedReferenceException and not just Exception)

Separately we have some workstreams going that should make it so that we can reasonably use things like that but we're not quite there yet.