### PR TITLE
Refactor down SetupDefaultInteractions into BaseController

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/GenericOpenVRController.cs
@@ -145,12 +145,6 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         };
 
         /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(controllerHandedness == Handedness.Left ? DefaultLeftHandedInteractions : DefaultRightHandedInteractions);
-        }
-
-        /// <inheritdoc />
         public override void UpdateController()
         {
             if (!Enabled) { return; }

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/OculusRemoteController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/OculusRemoteController.cs
@@ -28,11 +28,5 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             new MixedRealityInteractionMapping(1, "Button.One", AxisType.Digital, DeviceInputType.ButtonPress, KeyCode.JoystickButton0),
             new MixedRealityInteractionMapping(2, "Button.Two", AxisType.Digital, DeviceInputType.ButtonPress, KeyCode.JoystickButton1),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -63,9 +63,9 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         /// <summary>
         /// Setup the default interactions, then update the spatial pointer rotation with the preconfigured offset angle.
         /// </summary>
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
+        public override void SetupDefaultInteractions()
         {
-            base.SetupDefaultInteractions(controllerHandedness);
+            base.SetupDefaultInteractions();
 
             Assert.AreEqual(Interactions[0].Description, "Spatial Pointer", "The first interaction mapping is no longer the Spatial Pointer. Please update.");
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
@@ -30,12 +30,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
 #if UNITY_WSA
 
         /// <summary>

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void MouseControllerUpdateTest()
         {
             MouseController controller = new MouseController(TrackingState.NotApplicable, Utilities.Handedness.Any);
-            controller.SetupDefaultInteractions(Utilities.Handedness.Any);
+            controller.SetupDefaultInteractions();
 
             // Tests
             Assert.That(() => controller.Update(), Throws.Nothing);
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void XboxControllerUpdateTest()
         {
             XboxController controller = new XboxController(TrackingState.NotApplicable, Utilities.Handedness.None);
-            controller.SetupDefaultInteractions(Utilities.Handedness.None);
+            controller.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -45,10 +45,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void GenericOpenVRControllerUpdateTest()
         {
             GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions();
 
             GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void OculusRemoteControllerUpdateTest()
         {
             OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None);
-            controller.SetupDefaultInteractions(Utilities.Handedness.None);
+            controller.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -67,10 +67,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void OculusTouchControllerUpdateTest()
         {
             OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions();
 
             OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -80,10 +80,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void ViveKnucklesControllerUpdateTest()
         {
             ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions();
 
             ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -93,10 +93,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void ViveWandControllerUpdateTest()
         {
             ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions();
 
             ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -106,10 +106,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void WindowsMixedRealityOpenVRMotionControllerUpdateTest()
         {
             WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions(Utilities.Handedness.Left);
+            leftController.SetupDefaultInteractions();
 
             WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions(Utilities.Handedness.Right);
+            rightController.SetupDefaultInteractions();
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -163,7 +163,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Assign the default interactions based on controller handedness, if necessary. 
         /// </summary>
-        public abstract void SetupDefaultInteractions(Handedness controllerHandedness);
+        public virtual void SetupDefaultInteractions(Handedness controllerHandedness)
+        {
+            switch (controllerHandedness)
+            {
+                case Handedness.Left:
+                    AssignControllerMappings(DefaultLeftHandedInteractions);
+                    break;
+                case Handedness.Right:
+                    AssignControllerMappings(DefaultRightHandedInteractions);
+                    break;
+                default:
+                    AssignControllerMappings(DefaultInteractions);
+                    break;
+            }
+        }
 
         /// <summary>
         /// Load the Interaction mappings for this controller from the configured Controller Mapping profile

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // If no controller mappings found, warn the user.  Does not stop the project from running.
                 if (Interactions == null || Interactions.Length < 1)
                 {
-                    SetupDefaultInteractions(ControllerHandedness);
+                    SetupDefaultInteractions();
 
                     // We still don't have controller mappings, so this may be a custom controller. 
                     if (Interactions == null || Interactions.Length < 1)

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -161,11 +161,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Assign the default interactions based on controller handedness, if necessary. 
+        /// Assign the default interactions based on controller handedness, if necessary.
         /// </summary>
-        public virtual void SetupDefaultInteractions(Handedness controllerHandedness)
+        [Obsolete("The handedness parameter is no longer used. This method now reads from the controller's handedness.")]
+        public virtual void SetupDefaultInteractions(Handedness controllerHandedness) => SetupDefaultInteractions();
+
+        /// <summary>
+        /// Assign the default interactions based on this controller's handedness, if necessary.
+        /// </summary>
+        public virtual void SetupDefaultInteractions()
         {
-            switch (controllerHandedness)
+            switch (ControllerHandedness)
             {
                 case Handedness.Left:
                     AssignControllerMappings(DefaultLeftHandedInteractions);

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHand.cs
@@ -36,12 +36,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
         #region Protected InputSource Helpers
 
         #region Gesture Definitions

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
@@ -46,12 +46,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// </summary>
         protected MixedRealityPose CurrentControllerPose = MixedRealityPose.ZeroIdentity;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            // Generic Unity controllers will not have default interactions
-        }
-
         /// <summary>
         /// Update the controller data from Unity's Input Manager
         /// </summary>

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseController.cs
@@ -42,12 +42,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             new MixedRealityInteractionMapping(9, "Mouse Button 6", AxisType.Digital, DeviceInputType.ButtonPress, KeyCode.Mouse6),
         };
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
         private MixedRealityPose controllerPose = MixedRealityPose.ZeroIdentity;
 
         private IMixedRealityMouseDeviceManager mouseDeviceManager = null;

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchController.cs
@@ -57,9 +57,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         private MixedRealityPose lastPose = MixedRealityPose.ZeroIdentity;
 
         /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
+        public override void SetupDefaultInteractions()
         {
-            AssignControllerMappings(DefaultInteractions);
+            base.SetupDefaultInteractions();
+
             if (CoreServices.InputSystem?.InputSystemProfile.GesturesProfile != null)
             {
                 var gestures = CoreServices.InputSystem.InputSystemProfile.GesturesProfile.Gestures;

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/XboxController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/XboxController.cs
@@ -45,11 +45,5 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             new MixedRealityInteractionMapping(14, "X", AxisType.Digital, DeviceInputType.ButtonPress,KeyCode.JoystickButton2),
             new MixedRealityInteractionMapping(15, "Y", AxisType.Digital, DeviceInputType.ButtonPress,KeyCode.JoystickButton3),
         };
-
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
     }
 }

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -38,7 +38,9 @@ If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), th
 
 ### Upgrading projects to 2.4.0
 
-*Coming soon*
+#### Custom controller classes
+
+Custom controller classes previously had to define `SetupDefaultInteractions(Handedness)`. This method has been made obsolete in 2.4, as the handedness parameter was redundant with the controller class' own handedness. The new method has no parameters. Additionally, many controller classes defined this the same way (`AssignControllerMappings(DefaultInteractions);`), so the full call has been refactored down into `BaseController` and made an optional override instead of required.
 
 ### What's new in 2.4.0
 


### PR DESCRIPTION
## Overview

`SetupDefaultInteractions` was originally abstract. As pointed out in #5847, it's possible not all controllers would need to implement this, even though they'll be required to.
Additionally, this method took in a specific handedness, even though the controller class itself has a handedness that's passed in with its constructor.
I refactored down a combination of the actual implementations of this class (which were largely identical) and made it virtual, for classes that still need to override the behavior.

## Changes
- Part of #5847 
