### PR TITLE
Deprecate SetupConfiguration in BaseController

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/OpenVRDeviceManager.cs
@@ -119,16 +119,10 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             var inputSource = inputSystem?.RequestNewGenericInputSource($"{currentControllerType} Controller {controllingHand}", pointers, InputSourceType.Controller);
             var detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, controllingHand, inputSource, null) as GenericOpenVRController;
 
-            if (detectedController == null)
-            {
-                Debug.LogError($"Failed to create {controllerType.Name} controller");
-                return null;
-            }
-
-            if (!detectedController.SetupConfiguration(controllerType))
+            if (detectedController == null || !detectedController.Enabled)
             {
                 // Controller failed to be set up correctly.
-                Debug.LogError($"Failed to set up {controllerType.Name} controller");
+                Debug.LogError($"Failed to create {controllerType.Name} controller");
                 // Return null so we don't raise the source detected.
                 return null;
             }

--- a/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
+++ b/Assets/MixedRealityToolkit.Providers/OpenVR/WindowsMixedRealityOpenVRMotionController.cs
@@ -23,8 +23,10 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         public WindowsMixedRealityOpenVRMotionController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions)
         {
-            PointerOffsetAngle = -30f;
         }
+
+        /// <inheritdoc />
+        public override float PointerOffsetAngle { get; protected set; } = -30f;
 
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultLeftHandedInteractions => new[]
@@ -59,19 +61,5 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             new MixedRealityInteractionMapping(10, "Thumbstick Position", AxisType.DualAxis, DeviceInputType.ThumbStick, ControllerMappingLibrary.AXIS_4, ControllerMappingLibrary.AXIS_5, false, true),
             new MixedRealityInteractionMapping(11, "Thumbstick Press", AxisType.Digital, DeviceInputType.ButtonPress,  KeyCode.JoystickButton19),
         };
-
-        /// <summary>
-        /// Setup the default interactions, then update the spatial pointer rotation with the preconfigured offset angle.
-        /// </summary>
-        public override void SetupDefaultInteractions()
-        {
-            base.SetupDefaultInteractions();
-
-            Assert.AreEqual(Interactions[0].Description, "Spatial Pointer", "The first interaction mapping is no longer the Spatial Pointer. Please update.");
-
-            MixedRealityPose startingRotation = MixedRealityPose.ZeroIdentity;
-            startingRotation.Rotation *= Quaternion.AngleAxis(PointerOffsetAngle, Vector3.left);
-            Interactions[0].PoseData = startingRotation;
-        }
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
@@ -31,7 +31,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
 #if UNITY_WSA
-
         /// <summary>
         /// The last updated source state reading for this Windows Mixed Reality Source.
         /// </summary>
@@ -352,7 +351,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         }
 
         #endregion Update data functions
-
 #endif // UNITY_WSA
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MixedRealityToolkit.Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -45,12 +45,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
         /// <summary>
         /// Update the controller data from XR SDK.
         /// </summary>

--- a/Assets/MixedRealityToolkit.Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/XRSDK/XRSDKDeviceManager.cs
@@ -134,17 +134,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
             IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
             IMixedRealityPointer[] pointers = RequestPointers(currentControllerType, controllingHand);
             IMixedRealityInputSource inputSource = inputSystem?.RequestNewGenericInputSource($"{currentControllerType} Controller {controllingHand}", pointers, inputSourceType);
+            GenericXRSDKController detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, controllingHand, inputSource, null) as GenericXRSDKController;
 
-            if (!(Activator.CreateInstance(controllerType, TrackingState.NotTracked, controllingHand, inputSource, null) is GenericXRSDKController detectedController))
-            {
-                Debug.LogError($"Failed to create {controllerType.Name} controller");
-                return null;
-            }
-
-            if (!detectedController.SetupConfiguration(controllerType))
+            if (detectedController == null || !detectedController.Enabled)
             {
                 // Controller failed to be set up correctly.
-                Debug.LogError($"Failed to set up {controllerType.Name} controller");
+                Debug.LogError($"Failed to create {controllerType.Name} controller");
                 // Return null so we don't raise the source detected.
                 return null;
             }

--- a/Assets/MixedRealityToolkit.Services/InputSimulation/BaseInputSimulationService.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSimulation/BaseInputSimulationService.cs
@@ -123,16 +123,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             System.Type controllerType = simulationMode == HandSimulationMode.Gestures ? typeof(SimulatedGestureHand) : typeof(SimulatedArticulatedHand);
-            if (controller == null)
-            {
-                Debug.LogError($"Failed to create {controllerType} controller");
-                return null;
-            }
-
-            if (!controller.SetupConfiguration(controllerType))
+            
+            if (controller == null || !controller.Enabled)
             {
                 // Controller failed to be setup correctly.
-                Debug.LogError($"Failed to Setup {controllerType} controller");
+                Debug.LogError($"Failed to create {controllerType} controller");
                 // Return null so we don't raise the source detected.
                 return null;
             }

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Input.UnityInput;
 using Microsoft.MixedReality.Toolkit.OpenVR.Input;
 using NUnit.Framework;
@@ -25,8 +26,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void MouseControllerUpdateTest()
         {
-            MouseController controller = new MouseController(TrackingState.NotApplicable, Utilities.Handedness.Any);
-            controller.SetupDefaultInteractions();
+            IMixedRealityInputSource inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Mouse Controller");
+            MouseController controller = new MouseController(TrackingState.NotApplicable, Utilities.Handedness.Any, inputSource);
 
             // Tests
             Assert.That(() => controller.Update(), Throws.Nothing);
@@ -35,8 +36,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void XboxControllerUpdateTest()
         {
-            XboxController controller = new XboxController(TrackingState.NotApplicable, Utilities.Handedness.None);
-            controller.SetupDefaultInteractions();
+            IMixedRealityInputSource inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Xbox Controller");
+            XboxController controller = new XboxController(TrackingState.NotApplicable, Utilities.Handedness.None, inputSource);
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -44,11 +45,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void GenericOpenVRControllerUpdateTest()
         {
-            GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions();
-
-            GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions();
+            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left OpenVR Controller");
+            GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
+            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right OpenVR Controller");
+            GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -57,8 +57,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void OculusRemoteControllerUpdateTest()
         {
-            OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None);
-            controller.SetupDefaultInteractions();
+            IMixedRealityInputSource inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Oculus Remote Controller");
+            OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None, inputSource);
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -66,11 +66,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void OculusTouchControllerUpdateTest()
         {
-            OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions();
-
-            OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions();
+            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Oculus Touch Controller");
+            OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
+            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Oculus Touch Controller");
+            OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -79,11 +78,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void ViveKnucklesControllerUpdateTest()
         {
-            ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions();
-
-            ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions();
+            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Knuckles Controller");
+            ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
+            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Knuckles Controller");
+            ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -92,11 +90,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void ViveWandControllerUpdateTest()
         {
-            ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions();
-
-            ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions();
+            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Vive Wand Controller");
+            ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
+            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Vive Wand Controller");
+            ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -105,11 +102,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void WindowsMixedRealityOpenVRMotionControllerUpdateTest()
         {
-            WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left);
-            leftController.SetupDefaultInteractions();
-
-            WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right);
-            rightController.SetupDefaultInteractions();
+            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Motion Controller");
+            WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
+            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Motion Controller");
+            WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/ControllerMappingTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Input.UnityInput;
 using Microsoft.MixedReality.Toolkit.OpenVR.Input;
 using NUnit.Framework;
@@ -26,8 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void MouseControllerUpdateTest()
         {
-            IMixedRealityInputSource inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Mouse Controller");
-            MouseController controller = new MouseController(TrackingState.NotApplicable, Utilities.Handedness.Any, inputSource);
+            MouseController controller = new MouseController(TrackingState.NotApplicable, Utilities.Handedness.Any);
 
             // Tests
             Assert.That(() => controller.Update(), Throws.Nothing);
@@ -36,8 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void XboxControllerUpdateTest()
         {
-            IMixedRealityInputSource inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Xbox Controller");
-            XboxController controller = new XboxController(TrackingState.NotApplicable, Utilities.Handedness.None, inputSource);
+            XboxController controller = new XboxController(TrackingState.NotApplicable, Utilities.Handedness.None);
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -45,10 +42,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void GenericOpenVRControllerUpdateTest()
         {
-            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left OpenVR Controller");
-            GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
-            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right OpenVR Controller");
-            GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
+            GenericOpenVRController leftController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            GenericOpenVRController rightController = new GenericOpenVRController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -57,8 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void OculusRemoteControllerUpdateTest()
         {
-            IMixedRealityInputSource inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Oculus Remote Controller");
-            OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None, inputSource);
+            OculusRemoteController controller = new OculusRemoteController(TrackingState.NotTracked, Utilities.Handedness.None);
 
             TestGenericJoystickControllerUpdate(controller);
         }
@@ -66,10 +60,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void OculusTouchControllerUpdateTest()
         {
-            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Oculus Touch Controller");
-            OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
-            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Oculus Touch Controller");
-            OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
+            OculusTouchController leftController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            OculusTouchController rightController = new OculusTouchController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -78,10 +70,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void ViveKnucklesControllerUpdateTest()
         {
-            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Knuckles Controller");
-            ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
-            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Knuckles Controller");
-            ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
+            ViveKnucklesController leftController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            ViveKnucklesController rightController = new ViveKnucklesController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -90,10 +80,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void ViveWandControllerUpdateTest()
         {
-            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Vive Wand Controller");
-            ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
-            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Vive Wand Controller");
-            ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
+            ViveWandController leftController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            ViveWandController rightController = new ViveWandController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);
@@ -102,10 +90,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void WindowsMixedRealityOpenVRMotionControllerUpdateTest()
         {
-            IMixedRealityInputSource leftInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Left Motion Controller");
-            WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left, leftInputSource);
-            IMixedRealityInputSource rightInputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Right Motion Controller");
-            WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right, rightInputSource);
+            WindowsMixedRealityOpenVRMotionController leftController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Left);
+            WindowsMixedRealityOpenVRMotionController rightController = new WindowsMixedRealityOpenVRMotionController(TrackingState.NotTracked, Utilities.Handedness.Right);
 
             TestGenericJoystickControllerUpdate(leftController);
             TestGenericJoystickControllerUpdate(rightController);

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -307,7 +307,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// Moves the the hand from startPos to endPos.
+        /// Moves the hand from startPos to endPos.
         /// </summary>
         /// <remarks>
         /// Note that numSteps defaults to a value of -1, which is a sentinel value to indicate that the

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -26,12 +26,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IsPositionApproximate = false;
             IsRotationAvailable = false;
 
-            if (IsControllerMappingEnabled())
+            if (IsControllerMappingEnabled() && InputSource != null)
             {
                 Type controllerType = GetType();
 
                 if (GetControllerVisualizationProfile() != null &&
-                    GetControllerVisualizationProfile().RenderMotionControllers)
+                    GetControllerVisualizationProfile().RenderMotionControllers &&
+                    Application.isPlaying)
                 {
                     TryRenderControllerModel(controllerType, InputSource.SourceType);
                 }

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                 }
 
-                // If no controller mappings found, warn the user. Does not stop the project from running.
+                // If no controller mappings found, try to use default interactions.
                 if (Interactions == null || Interactions.Length < 1)
                 {
                     SetupDefaultInteractions();
@@ -77,15 +77,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // We still don't have controller mappings, so this may be a custom controller.
                     if (Interactions == null || Interactions.Length < 1)
                     {
-                        Debug.LogWarning($"No Controller interaction mappings found for {controllerType}.");
+                        Debug.LogWarning($"No controller interaction mappings found for {controllerType}.");
                         return;
                     }
                 }
 
+                // If no profile was found, warn the user. Does not stop the project from running.
                 if (!profileFound)
                 {
-                    Debug.LogWarning($"No controller profile found for type {controllerType}, please ensure all controllers are defined in the configured MixedRealityControllerConfigurationProfile.");
-                    return;
+                    Debug.LogWarning($"No controller profile found for type {controllerType}; please ensure all controllers are defined in the configured MixedRealityControllerConfigurationProfile.");
                 }
             }
 

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -26,22 +26,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IsPositionApproximate = false;
             IsRotationAvailable = false;
 
-            if (IsControllerMappingEnabled() && InputSource != null)
+            Type controllerType = GetType();
+
+            if (IsControllerMappingEnabled() && Interactions == null)
             {
-                Type controllerType = GetType();
-
-                if (GetControllerVisualizationProfile() != null &&
-                    GetControllerVisualizationProfile().RenderMotionControllers &&
-                    Application.isPlaying)
-                {
-                    TryRenderControllerModel(controllerType, InputSource.SourceType);
-                }
-
                 // We can only enable controller profiles if mappings exist.
                 var controllerMappings = GetControllerMappings();
 
                 // Have to test that a controller type has been registered in the profiles,
-                // else its Unity Input manager mappings will not have been set up by the inspector.
+                // else its Unity input manager mappings will not have been set up by the inspector.
                 bool profileFound = false;
                 if (controllerMappings != null)
                 {
@@ -88,6 +81,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     Debug.LogWarning($"No controller profile found for type {controllerType}; please ensure all controllers are defined in the configured MixedRealityControllerConfigurationProfile.");
                 }
+            }
+
+            if (GetControllerVisualizationProfile() != null &&
+                GetControllerVisualizationProfile().RenderMotionControllers &&
+                InputSource != null)
+            {
+                TryRenderControllerModel(controllerType, InputSource.SourceType);
             }
 
             Enabled = true;

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -26,6 +26,69 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IsPositionApproximate = false;
             IsRotationAvailable = false;
 
+            if (IsControllerMappingEnabled())
+            {
+                Type controllerType = GetType();
+
+                if (GetControllerVisualizationProfile() != null &&
+                    GetControllerVisualizationProfile().RenderMotionControllers)
+                {
+                    TryRenderControllerModel(controllerType, InputSource.SourceType);
+                }
+
+                // We can only enable controller profiles if mappings exist.
+                var controllerMappings = GetControllerMappings();
+
+                // Have to test that a controller type has been registered in the profiles,
+                // else its Unity Input manager mappings will not have been set up by the inspector.
+                bool profileFound = false;
+                if (controllerMappings != null)
+                {
+                    for (int i = 0; i < controllerMappings.Length; i++)
+                    {
+                        if (controllerMappings[i].ControllerType.Type == controllerType)
+                        {
+                            profileFound = true;
+
+                            // If it is an exact match, assign interaction mappings.
+                            if (controllerMappings[i].Handedness == ControllerHandedness &&
+                                controllerMappings[i].Interactions.Length > 0)
+                            {
+                                MixedRealityInteractionMapping[] profileInteractions = controllerMappings[i].Interactions;
+                                MixedRealityInteractionMapping[] newInteractions = new MixedRealityInteractionMapping[profileInteractions.Length];
+
+                                for (int j = 0; j < profileInteractions.Length; j++)
+                                {
+                                    newInteractions[j] = new MixedRealityInteractionMapping(profileInteractions[j]);
+                                }
+
+                                AssignControllerMappings(newInteractions);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // If no controller mappings found, warn the user. Does not stop the project from running.
+                if (Interactions == null || Interactions.Length < 1)
+                {
+                    SetupDefaultInteractions();
+
+                    // We still don't have controller mappings, so this may be a custom controller.
+                    if (Interactions == null || Interactions.Length < 1)
+                    {
+                        Debug.LogWarning($"No Controller interaction mappings found for {controllerType}.");
+                        return;
+                    }
+                }
+
+                if (!profileFound)
+                {
+                    Debug.LogWarning($"No controller profile found for type {controllerType}, please ensure all controllers are defined in the configured MixedRealityControllerConfigurationProfile.");
+                    return;
+                }
+            }
+
             Enabled = true;
         }
 
@@ -94,70 +157,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Sets up the configuration based on the Mixed Reality Controller Mapping Profile.
         /// </summary>
         /// <param name="controllerType">The type this controller represents.</param>
+        [Obsolete("This method is no longer used. Configuration now happens in the constructor.")]
         public bool SetupConfiguration(Type controllerType)
         {
-            if (IsControllerMappingEnabled())
-            {
-                if (GetControllerVisualizationProfile() != null &&
-                    GetControllerVisualizationProfile().RenderMotionControllers)
-                {
-                    TryRenderControllerModel(controllerType, InputSource.SourceType);
-                }
-
-                // We can only enable controller profiles if mappings exist.
-                var controllerMappings = GetControllerMappings();
-
-                // Have to test that a controller type has been registered in the profiles,
-                // else its Unity Input manager mappings will not have been set up by the inspector.
-                bool profileFound = false;
-                if (controllerMappings != null)
-                {
-                    for (int i = 0; i < controllerMappings.Length; i++)
-                    {
-                        if (controllerMappings[i].ControllerType.Type == controllerType)
-                        {
-                            profileFound = true;
-
-                            // If it is an exact match, assign interaction mappings.
-                            if (controllerMappings[i].Handedness == ControllerHandedness &&
-                                controllerMappings[i].Interactions.Length > 0)
-                            {
-                                MixedRealityInteractionMapping[] profileInteractions = controllerMappings[i].Interactions;
-                                MixedRealityInteractionMapping[] newInteractions = new MixedRealityInteractionMapping[profileInteractions.Length];
-
-                                for (int j = 0; j < profileInteractions.Length; j++)
-                                {
-                                    newInteractions[j] = new MixedRealityInteractionMapping(profileInteractions[j]);
-                                }
-
-                                AssignControllerMappings(newInteractions);
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // If no controller mappings found, warn the user. Does not stop the project from running.
-                if (Interactions == null || Interactions.Length < 1)
-                {
-                    SetupDefaultInteractions();
-
-                    // We still don't have controller mappings, so this may be a custom controller.
-                    if (Interactions == null || Interactions.Length < 1)
-                    {
-                        Debug.LogWarning($"No Controller interaction mappings found for {controllerType}.");
-                        return false;
-                    }
-                }
-
-                if (!profileFound)
-                {
-                    Debug.LogWarning($"No controller profile found for type {controllerType}, please ensure all controllers are defined in the configured MixedRealityControllerConfigurationProfile.");
-                    return false;
-                }
-            }
-
-            return true;
+            // If the constructor succeeded in finding interactions, Enabled will be true.
+            return Enabled;
         }
 
         /// <summary>

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -158,7 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Sets up the configuration based on the Mixed Reality Controller Mapping Profile.
         /// </summary>
         /// <param name="controllerType">The type this controller represents.</param>
-        [Obsolete("This method is no longer used. Configuration now happens in the constructor.")]
+        [Obsolete("This method is no longer used. Configuration now happens in the constructor. You can check this controller's Enabled property for configuration state.")]
         public bool SetupConfiguration(Type controllerType)
         {
             // If the constructor succeeded in finding interactions, Enabled will be true.

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
@@ -16,12 +16,35 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         public GenericJoystickController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
+            // Update the spatial pointer rotation with the preconfigured offset angle
+            if (PointerOffsetAngle != 0f)
+            {
+                MixedRealityInteractionMapping pointerMapping = null;
+                foreach (MixedRealityInteractionMapping mapping in Interactions)
+                {
+                    if (mapping.InputType == DeviceInputType.SpatialPointer)
+                    {
+                        pointerMapping = mapping;
+                        break;
+                    }
+                }
+
+                if (pointerMapping == null)
+                {
+                    Debug.LogWarning($"A pointer offset is defined for {GetType()}, but no spatial pointer mapping could be found.");
+                    return;
+                }
+
+                MixedRealityPose startingRotation = MixedRealityPose.ZeroIdentity;
+                startingRotation.Rotation *= Quaternion.AngleAxis(PointerOffsetAngle, Vector3.left);
+                pointerMapping.PoseData = startingRotation;
+            }
         }
 
         /// <summary>
         /// The pointer's offset angle.
         /// </summary>
-        public float PointerOffsetAngle { get; protected set; } = 0f;
+        public virtual float PointerOffsetAngle { get; protected set; } = 0f;
 
         private Vector2 dualAxisPosition = Vector2.zero;
         private MixedRealityPose pointerOffsetPose = MixedRealityPose.ZeroIdentity;

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/GenericJoystickController.cs
@@ -17,11 +17,12 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
             // Update the spatial pointer rotation with the preconfigured offset angle
-            if (PointerOffsetAngle != 0f)
+            if (PointerOffsetAngle != 0f && Interactions != null)
             {
                 MixedRealityInteractionMapping pointerMapping = null;
-                foreach (MixedRealityInteractionMapping mapping in Interactions)
+                for (int i = 0; i < Interactions.Length; i++)
                 {
+                    MixedRealityInteractionMapping mapping = Interactions[i];
                     if (mapping.InputType == DeviceInputType.SpatialPointer)
                     {
                         pointerMapping = mapping;

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -150,7 +150,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                 }
             }
 
-            Controller.SetupConfiguration(typeof(MouseController));
             Service?.RaiseSourceDetected(Controller.InputSource, Controller);
         }
 

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/MouseDeviceManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         "Unity Mouse Device Manager",
         "Profiles/DefaultMixedRealityMouseInputProfile.asset",
         "MixedRealityToolkit.SDK",
-        requiresProfile: true)]  
+        requiresProfile: true)]
     public class MouseDeviceManager : BaseInputDeviceManager, IMixedRealityMouseDeviceManager
     {
         /// <summary>
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             {
                 Handedness[] handednesses = controllerAttribute.SupportedHandedness;
                 Debug.Assert(
-                    handednesses.Length == 1 && handednesses[0] == Handedness.Any, 
+                    handednesses.Length == 1 && handednesses[0] == Handedness.Any,
                     "Unexpected mouse handedness declared in MixedRealityControllerAttribute");
             }
 
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             if (Controller != null)
             {
                 Service?.RaiseSourceLost(Controller.InputSource, Controller);
-                
+
                 RecyclePointers(Controller.InputSource);
 
                 Controller = null;

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityJoystickManager.cs
@@ -183,15 +183,10 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             var inputSource = inputSystem?.RequestNewGenericInputSource($"{controllerType.Name} Controller", sourceType: InputSourceType.Controller);
             var detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, Handedness.None, inputSource, null) as GenericJoystickController;
 
-            if (detectedController == null)
-            {
-                Debug.LogError($"Failed to create {controllerType.Name} controller");
-                return null;
-            }
-
-            if (!detectedController.SetupConfiguration(controllerType))
+            if (detectedController == null || !detectedController.Enabled)
             {
                 // Controller failed to be setup correctly.
+                Debug.LogError($"Failed to create {controllerType.Name} controller");
                 // Return null so we don't raise the source detected.
                 return null;
             }

--- a/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -139,7 +139,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                     }
                 }
 
-                controller.SetupConfiguration(typeof(UnityTouchController));
                 ActiveTouches.Add(touch.fingerId, controller);
             }
 


### PR DESCRIPTION
## Overview

`SetupConfiguration` was only ever called directly after creating the class. It wasn't abstract or virtual, so it couldn't be overridden. It takes in the class' its own type in order to perform some action, which all the information for is present at the time the constructor is called.

This PR moves all work done by `SetupConfiguration` into the constructor. Any custom class' constructor can do additional setup work as needed.

## Changes
- Part of #5847 
