### PR TITLE
Fix visual rotation theme for toggling local vs world space rotation

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes/Model_BuckyTheme.asset
@@ -145,6 +145,27 @@ MonoBehaviour:
         Quaternion: {x: 0, y: 0, z: 0, w: 0}
         AudioClip: {fileID: 0}
         Animation: {fileID: 0}
+    - Name: Local Rotation
+      Tooltip: Should the theme manipulate the target's local rotation or world space
+        rotation
+      Type: 15
+      Value:
+        Name: 
+        String: 
+        Bool: 0
+        Int: 0
+        Float: 0
+        Texture: {fileID: 0}
+        Material: {fileID: 0}
+        Shader: {fileID: 0}
+        GameObject: {fileID: 0}
+        Vector2: {x: 0, y: 0}
+        Vector3: {x: 0, y: 0, z: 0}
+        Vector4: {x: 0, y: 0, z: 0, w: 0}
+        Color: {r: 0, g: 0, b: 0, a: 0}
+        Quaternion: {x: 0, y: 0, z: 0, w: 0}
+        AudioClip: {fileID: 0}
+        Animation: {fileID: 0}
     easing:
       Enabled: 1
       Curve:

--- a/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableThemeBase.cs
@@ -222,5 +222,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             return Mathf.RoundToInt((e - s) * t) + s;
         }
+
+        protected ThemeProperty GetThemeProperty(int index)
+        {
+            if (index >= 0)
+            {
+                if (Properties != null && Properties.Count > index)
+                {
+                    return Properties[index];
+                }
+
+                // If Theme's data does not have desired property, return defaults.
+                // If index is not in range, throw exception to fail fast. 
+                return GetDefaultThemeDefinition().CustomProperties[index];
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Overview
The InteractableRotationTheme was originally designed to modify the local rotation values of the host target object. Although the original rotation and property setter components of the class correctly controlled the localEulerAngles property, the property getter component returned the host objects euler angles in world space.

This change fixes this bug as well as introduces a new theme property to the class that allows consumers to control whether values should be applied in local space or world space.

Added test to verify this functionality.

This PR is an extension from @Bertrand75014 's original PR #7081 

![local-rotation](https://user-images.githubusercontent.com/25975362/75098402-a3218a00-556a-11ea-9e24-3bb0322afe2e.gif)

## Changes
- Fixes: #7080 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
