### PR TITLE
Switch from API contract version to IsMethodPresent (#6886)

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine.XR.WSA.Input;
 using Windows.Foundation;
-using Windows.Foundation.Metadata;
 using Windows.Perception;
 using Windows.Storage.Streams;
 using Windows.UI.Input.Spatial;

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -27,7 +27,10 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
             // GetForCurrentView and GetDetectedSourcesAtTimestamp were both introduced in the same Windows version.
             // We need only check for one of them.
-            if (ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.Surfaces.SpatialInteractionManager", "GetForCurrentView"))
+            if (WindowsApiChecker.IsMethodAvailable(
+                "Windows.UI.Input.Spatial",
+                "SpatialInteractionManager",
+                "GetForCurrentView"))
             {
                 IReadOnlyList<SpatialInteractionSourceState> sources = null;
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Extensions/InteractionSourceExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine.XR.WSA.Input;
 using Windows.Foundation;
+using Windows.Foundation.Metadata;
 using Windows.Perception;
 using Windows.Storage.Streams;
 using Windows.UI.Input.Spatial;
@@ -24,7 +25,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         {
             IAsyncOperation<IRandomAccessStreamWithContentType> returnValue = null;
 
-            if (WindowsApiChecker.UniversalApiContractV5_IsAvailable)
+            // GetForCurrentView and GetDetectedSourcesAtTimestamp were both introduced in the same Windows version.
+            // We need only check for one of them.
+            if (ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.Surfaces.SpatialInteractionManager", "GetForCurrentView"))
             {
                 IReadOnlyList<SpatialInteractionSourceState> sources = null;
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Windows.Input;
+using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System;
 using UnityEngine;
 
@@ -15,7 +16,6 @@ using WsaGestureSettings = UnityEngine.XR.WSA.Input.GestureSettings;
 #endif // UNITY_WSA
 
 #if WINDOWS_UWP
-using Windows.Foundation.Metadata;
 using WindowsInputSpatial = global::Windows.UI.Input.Spatial;
 #endif // WINDOWS_UWP
 
@@ -64,13 +64,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-            bool canQuerySourceKindSupport = false;
-
-#if WINDOWS_UWP
-            canQuerySourceKindSupport = ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.SpatialInteractionManager", "IsSourceKindSupported");
-#endif // WINDOWS_UWP
-
-            if (canQuerySourceKindSupport)
+            if (WindowsApiChecker.IsMethodAvailable(
+                "Windows.UI.Input.Spatial",
+                "SpatialInteractionManager",
+                "IsSourceKindSupported"))
             {
 #if WINDOWS_UWP
                 switch (capability)

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Windows.Input;
-using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System;
 using UnityEngine;
 
@@ -16,6 +15,7 @@ using WsaGestureSettings = UnityEngine.XR.WSA.Input.GestureSettings;
 #endif // UNITY_WSA
 
 #if WINDOWS_UWP
+using Windows.Foundation.Metadata;
 using WindowsInputSpatial = global::Windows.UI.Input.Spatial;
 #endif // WINDOWS_UWP
 
@@ -64,7 +64,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-            if (WindowsApiChecker.UniversalApiContractV8_IsAvailable) // Windows 10 1903 or later
+            bool canQuerySourceKindSupport = false;
+
+#if WINDOWS_UWP
+            canQuerySourceKindSupport = ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.SpatialInteractionManager", "IsSourceKindSupported");
+#endif // WINDOWS_UWP
+
+            if (canQuerySourceKindSupport)
             {
 #if WINDOWS_UWP
                 switch (capability)
@@ -72,13 +78,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     case MixedRealityCapability.ArticulatedHand:
                     case MixedRealityCapability.GGVHand:
                         return WindowsInputSpatial.SpatialInteractionManager.IsSourceKindSupported(WindowsInputSpatial.SpatialInteractionSourceKind.Hand);
+                        break;
 
                     case MixedRealityCapability.MotionController:
                         return WindowsInputSpatial.SpatialInteractionManager.IsSourceKindSupported(WindowsInputSpatial.SpatialInteractionSourceKind.Controller);
+                        break;
                 }
 #endif // WINDOWS_UWP
             }
-            else // Pre-Windows 10 1903.
+            else
             {
                 if (!UnityEngine.XR.WSA.HolographicSettings.IsDisplayOpaque)
                 {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -13,6 +13,7 @@ using UnityEngine.XR.WSA;
 #endif // UNITY_WSA
 
 #if WINDOWS_UWP
+using Windows.Foundation.Metadata;
 using WindowsSpatialSurfaces = global::Windows.Perception.Spatial.Surfaces;
 #endif // WINDOWS_UWP
 
@@ -143,12 +144,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-            if (WindowsApiChecker.UniversalApiContractV4_IsAvailable)
-            {
 #if WINDOWS_UWP
+            if (ApiInformation.IsMethodPresent("Windows.Perception.Spatial.Surfaces.SpatialSurfaceObserver", "IsSupported"))
+            {
                 return (capability == MixedRealityCapability.SpatialAwarenessMesh) && WindowsSpatialSurfaces.SpatialSurfaceObserver.IsSupported();
-#endif // WINDOWS_UWP
             }
+#endif // WINDOWS_UWP
 
             return false;
         }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -144,12 +144,15 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-#if WINDOWS_UWP
-            if (ApiInformation.IsMethodPresent("Windows.Perception.Spatial.Surfaces.SpatialSurfaceObserver", "IsSupported"))
+            if (WindowsApiChecker.IsMethodAvailable(
+                "Windows.Perception.Spatial.Surfaces",
+                "SpatialSurfaceObserver",
+                "IsSupported"))
             {
+#if WINDOWS_UWP
                 return (capability == MixedRealityCapability.SpatialAwarenessMesh) && WindowsSpatialSurfaces.SpatialSurfaceObserver.IsSupported();
-            }
 #endif // WINDOWS_UWP
+            }
 
             return false;
         }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -13,7 +13,6 @@ using UnityEngine.XR.WSA;
 #endif // UNITY_WSA
 
 #if WINDOWS_UWP
-using Windows.Foundation.Metadata;
 using WindowsSpatialSurfaces = global::Windows.Perception.Spatial.Surfaces;
 #endif // WINDOWS_UWP
 

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -58,7 +58,15 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override bool CheckCapability(MixedRealityCapability capability)
         {
-            if (WindowsApiChecker.UniversalApiContractV8_IsAvailable) // Windows 10 1903 or later
+            bool hasCapability = false;
+
+            bool canQuerySourceKindSupport = false;
+
+#if WINDOWS_UWP
+            canQuerySourceKindSupport = ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.SpatialInteractionManager", "IsSourceKindSupported");
+#endif // WINDOWS_UWP
+
+            if (canQuerySourceKindSupport)
             {
 #if WINDOWS_UWP
                 switch (capability)

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -60,13 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         {
             bool hasCapability = false;
 
-            bool canQuerySourceKindSupport = false;
-
-#if WINDOWS_UWP
-            canQuerySourceKindSupport = ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.SpatialInteractionManager", "IsSourceKindSupported");
-#endif // WINDOWS_UWP
-
-            if (canQuerySourceKindSupport)
+            if (WindowsApiChecker.IsMethodAvailable(
+                "Windows.UI.Input.Spatial",
+                "SpatialInteractionManager",
+                "IsSourceKindSupported"))
             {
 #if WINDOWS_UWP
                 switch (capability)

--- a/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 #if WINDOWS_UWP
@@ -14,6 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
     /// </summary>
     /// <remarks> See https://docs.microsoft.com/uwp/extension-sdks/windows-universal-sdk
     /// for a full list of contracts.</remarks>
+    [Obsolete("The WindowsApiChecker class is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
     public static class WindowsApiChecker
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
@@ -35,35 +37,41 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
             UniversalApiContractV3_IsAvailable = false;
 #endif
         }
-		
+
         /// <summary>
         /// Is the Universal API Contract v8.0 Available?
         /// </summary>
+        [Obsolete("The UniversalApiContractV8_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
         public static bool UniversalApiContractV8_IsAvailable { get; private set; }
-        
+
         /// <summary>
         /// Is the Universal API Contract v7.0 Available?
         /// </summary>
+        [Obsolete("The UniversalApiContractV7_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
         public static bool UniversalApiContractV7_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v6.0 Available?
         /// </summary>
+        [Obsolete("The UniversalApiContractV6_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
         public static bool UniversalApiContractV6_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v5.0 Available?
         /// </summary>
+        [Obsolete("The UniversalApiContractV5_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
         public static bool UniversalApiContractV5_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v4.0 Available?
         /// </summary>
+        [Obsolete("The UniversalApiContractV4_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
         public static bool UniversalApiContractV4_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v3.0 Available?
         /// </summary>
+        [Obsolete("The UniversalApiContractV3_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
         public static bool UniversalApiContractV3_IsAvailable { get; private set; }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
@@ -15,12 +15,13 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
     /// </summary>
     /// <remarks> See https://docs.microsoft.com/uwp/extension-sdks/windows-universal-sdk
     /// for a full list of contracts.</remarks>
-    [Obsolete("The WindowsApiChecker class is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
     public static class WindowsApiChecker
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void CheckApiContracts()
         {
+// Disable the obsolete warning to enable setting the properties for legacy code.
+#pragma warning disable 0618
 #if WINDOWS_UWP
             UniversalApiContractV8_IsAvailable = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8);
             UniversalApiContractV7_IsAvailable = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7);
@@ -35,10 +36,31 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
             UniversalApiContractV5_IsAvailable = false;
             UniversalApiContractV4_IsAvailable = false;
             UniversalApiContractV3_IsAvailable = false;
-#endif
+#endif // WINDOWS_UWP
+#pragma warning restore 0618
         }
 
         /// <summary>
+        /// Checks to see if the requested method is present on the current platform.
+        /// </summary>
+        /// <param name="namespaceName">The namespace (ex: "Windows.UI.Input.Spatial") containing the class.</param>
+        /// <param name="className">The name of the class containing the method (ex: "SpatialInteractionMananger").</param>
+        /// <param name="methodName">The name of the method (ex: "IsSourceKindSupported").</param>
+        /// <returns>True if the method is available and can be called. Otherwise, false.</returns>
+        public static bool IsMethodAvailable(
+            string namespaceName,
+            string className,
+            string methodName)
+        {
+#if WINDOWS_UWP
+            return ApiInformation.IsMethodPresent($"{namespaceName}.{className}", methodName);
+#else
+            return false;
+#endif // WINDOWS_UWP
+        }
+
+        /// <summary>
+        /// 
         /// Is the Universal API Contract v8.0 Available?
         /// </summary>
         [Obsolete("The UniversalApiContractV8_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]


### PR DESCRIPTION
This change adds IsMethodAvailble() to WindowsApiChecker and marks the UniversalApiContractV#_IsAvailble properties as obsolete.

References tot he contract version check in MRTK have been updated to use the new method.

Fixes: #6886