### PR TITLE
Pass correct Unity version for each of the agent pools

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -18,6 +18,7 @@ jobs:
   - template: templates/common-Unity2019.yml
     parameters:
       packagingEnabled: false
+      UnityVersion: $(Unity2019Version)
 
 - job: DailyUnity2018Validation
   timeoutInMinutes: 120
@@ -31,3 +32,4 @@ jobs:
   - template: templates/ci-common.yml
     parameters:
       packagingEnabled: false
+      UnityVersion: $(Unity2018Version)

--- a/pipelines/ci-packaging-dontpublish.yml
+++ b/pipelines/ci-packaging-dontpublish.yml
@@ -17,3 +17,4 @@ jobs:
     parameters:
       packagingEnabled: true
       packagePublishing: false
+      UnityVersion: $(Unity2018Version)

--- a/pipelines/ci-packaging-internal.yml
+++ b/pipelines/ci-packaging-internal.yml
@@ -17,3 +17,4 @@ jobs:
     parameters:
       packagingEnabled: true
       packagePublishing: true
+      UnityVersion: $(Unity2018VersionInternal)

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.3.7f1
+    - Unity2018.4.6f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
@@ -17,3 +17,4 @@ jobs:
     parameters:
       packagingEnabled: true
       packagePublishing: true
+      UnityVersion: $(Unity2018Version)

--- a/pipelines/ci-release.yml
+++ b/pipelines/ci-release.yml
@@ -19,11 +19,13 @@ jobs:
   pool:
     name: Analog On-Prem
     demands:
-    - Unity2018.4.12f1  # variable expansion not allowed here
+    - Unity2018.4.12f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
   - template: templates/compilemsbuild.yml
+    parameters:
+      UnityVersion: $(Unity2018VersionInternal)
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.SourcesDirectory)\NuGet'

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -11,10 +11,11 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.3.7f1
+    - Unity2018.4.6f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
   - template: templates/ci-common.yml
     parameters:
       packagingEnabled: false
+      UnityVersion: $(Unity2018Version)

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -1,6 +1,10 @@
 variables:
+  # Unity version on AIPMR build agents
   Unity2018Version: Unity2018.4.6f1
   Unity2019Version: Unity2019.2.0f1
+  # Unity version on internal build agents (release builds)
+  Unity2018VersionInternal: Unity2018.4.12f1
+  Unity2019VersionInternal: Unity2019.2.0f1
   MRTKVersion: 2.4.0
   MRTKReleaseTag: ''  # final version component, e.g. 'RC2.1' or empty string
   ToolsRepoName: mixedrealitytoolkit.build

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -30,6 +30,6 @@ jobs:
       # the set of changed files, so that we can save some time. There's no need to
       # check unchanged files for code style/doc style violations.
       scopedValidation: true
-      UnityVersion: ${Unity2018Version}
+      UnityVersion: $(Unity2018Version)
 
   - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -30,4 +30,6 @@ jobs:
       # the set of changed files, so that we can save some time. There's no need to
       # check unchanged files for code style/doc style violations.
       scopedValidation: true
+      UnityVersion: ${Unity2018Version}
+
   - template: templates/end.yml

--- a/pipelines/templates/assetretargeting.yml
+++ b/pipelines/templates/assetretargeting.yml
@@ -1,9 +1,11 @@
 # [Template] Run Unity asset retargetting for NuGet packages.
+parameters:
+  UnityVersion: ""
 
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${Env:${{ parameters.UnityVersion }}} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    $outDir = "$(Build.ArtifactStagingDirectory)\build"
    $logFile = New-Item -Path "$outDir\build\retargeting_log.log" -ItemType File -Force

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -14,6 +14,8 @@ steps:
     UnityVersion: ${{ parameters.UnityVersion }}
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/unitypackages.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
   - template: package.yml
   - ${{ if eq(parameters.packagePublishing, true) }}:
     - template: publishpackages.yml

--- a/pipelines/templates/ci-common.yml
+++ b/pipelines/templates/ci-common.yml
@@ -2,12 +2,16 @@
 parameters:
   packagingEnabled: true
   packagePublishing: true
+  UnityVersion: ""
 
 steps:
 - template: common.yml
   parameters:
     buildUWPDotNet: false
+    UnityVersion: ${{ parameters.UnityVersion }}
 - template: compilemsbuild.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
 - ${{ if eq(parameters.packagingEnabled, true) }}:
   - template: tasks/unitypackages.yml
   - template: package.yml

--- a/pipelines/templates/common-Unity2019.yml
+++ b/pipelines/templates/common-Unity2019.yml
@@ -1,4 +1,6 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
+parameters:
+  UnityVersion: ""
 
 steps:
 # Build UWP ARM64.
@@ -7,11 +9,11 @@ steps:
     Arch: 'arm64'
     Platform: 'UWP'
     PackagingDir: 'ARM64'
-    UnityVer: ${Env:$(Unity2019Version)}
+    UnityVersion: ${{ parameters.UnityVersion }}
     PublishArtifacts: true
 
 - template: tests.yml
   parameters:
-    UnityVer: ${Env:$(Unity2019Version)}
+    UnityVersion: ${{ parameters.UnityVersion }}
 
 - template: end.yml

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -47,6 +47,8 @@ steps:
 # notifications earlier in the CI process.
 - ${{ if eq(parameters.runTests, true) }}:
   - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
 
 # Build UWP x86
 - ${{ if eq(parameters.buildUWPX86, true) }}:

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -1,5 +1,6 @@
 # [Template] Common build tasks shared between CI builds and PR validation.
 parameters:
+  UnityVersion: ""
   buildStandalone: true
   buildUWPArm: true
   buildUWPDotNet: true
@@ -40,6 +41,7 @@ steps:
     parameters:
       Arch: 'x86'
       Platform: 'Standalone'
+      UnityVersion: ${{ parameters.UnityVersion }}
 
 # Tests should run earlier in the process, so that engineers can get test failure
 # notifications earlier in the CI process.
@@ -53,6 +55,7 @@ steps:
       Arch: 'x86'
       Platform: 'UWP'
       PublishArtifacts: true
+      UnityVersion: ${{ parameters.UnityVersion }}
 
 # Build UWP ARM
 - ${{ if eq(parameters.buildUWPArm, true) }}:
@@ -62,6 +65,7 @@ steps:
       Platform: 'UWP'
       PublishArtifacts: true
       PackagingDir: 'ARM'
+      UnityVersion: ${{ parameters.UnityVersion }}
 
 # Build UWP x86 .NET backend
 - ${{ if eq(parameters.buildUWPDotNet, true) }}:
@@ -71,3 +75,4 @@ steps:
       Platform: 'UWP'
       PublishArtifacts: true
       ScriptingBackend: '.NET'
+      UnityVersion: ${{ parameters.UnityVersion }}

--- a/pipelines/templates/compilemsbuild.yml
+++ b/pipelines/templates/compilemsbuild.yml
@@ -1,7 +1,11 @@
 # [Template] Generate MSBuild projects and compile projects for Nuget.
+parameters:
+  UnityVersion: ""
 
 steps:
 - template: generateprojects.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}
 
 - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2  # NuGetCommand
   inputs:
@@ -107,3 +111,5 @@ steps:
   displayName: 'Build Player WSA'
 
 - template: assetretargeting.yml
+  parameters:
+    UnityVersion: ${{ parameters.UnityVersion }}

--- a/pipelines/templates/generateprojects.yml
+++ b/pipelines/templates/generateprojects.yml
@@ -1,9 +1,11 @@
 # [Template] Run a Unity script that generates MSBuild projects.
+parameters:
+  UnityVersion: ""
 
 steps:
 - powershell: |
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${Env:$(Unity2018Version)} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem ${Env:${{ parameters.UnityVersion }}} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    $outDir = "$(Build.ArtifactStagingDirectory)\build"
    $logFile = New-Item -Path "$outDir\build\projectgeneration_log.log" -ItemType File -Force

--- a/pipelines/templates/tasks/unitybuild.yml
+++ b/pipelines/templates/tasks/unitybuild.yml
@@ -7,12 +7,13 @@ parameters:
   ScriptingBackend: 'default'  # [optional] default|.NET
   PublishArtifacts: false
   PackagingDir: 'Win32'
-  UnityVer: ${Env:$(Unity2018Version)}
+  UnityVersion: ""
 
 steps:
 - powershell: |
+   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
    # Find unity.exe as Start-UnityEditor currently doesn't support arbitrary parameters
-   $editor = Get-ChildItem ${{ parameters.UnityVer }} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    # The build output goes to a unique combination of Platform + Arch + ScriptingBackend to ensure that
    # each build will have a fresh destination folder.

--- a/pipelines/templates/tasks/unitypackages.yml
+++ b/pipelines/templates/tasks/unitypackages.yml
@@ -1,6 +1,7 @@
 # [Template] Builds and publishes .unitypackages
 parameters:
   version: '$(MRTKVersion)-$(Build.BuildNumber)'
+  UnityVersion: ""
 
 steps:
 - task: PowerShell@2
@@ -9,7 +10,7 @@ steps:
     targetType: filePath
     filePath: ./scripts/packaging/unitypackage.ps1
     arguments: >
-      -UnityDirectory ${Env:$(Unity2018Version)}
+      -UnityDirectory ${Env:${{ parameters.UnityVersion }}}
       -OutputDirectory $(Build.ArtifactStagingDirectory)\build\unitypackages\output
       -RepoDirectory $(Get-Location)
       -LogDirectory $(Build.ArtifactStagingDirectory)\build\unitypackages\logs

--- a/pipelines/templates/tests.yml
+++ b/pipelines/templates/tests.yml
@@ -1,11 +1,12 @@
 # [Template] Run MRTK tests.
 
 parameters:
-  UnityVer: ${Env:$(Unity2018Version)}
+  UnityVersion: ""
 
 steps:
 - powershell: |
-   $editor = Get-ChildItem ${{ parameters.UnityVer }} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
+   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    Write-Host "======================= EditMode Tests ======================="
    
@@ -29,7 +30,8 @@ steps:
   displayName: 'Run EditMode tests'
 
 - powershell: |
-   $editor = Get-ChildItem ${{ parameters.UnityVer }} -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
+   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
    Write-Host "======================= PlayMode Tests ======================="
    


### PR DESCRIPTION
This change addresses problems introduced in PR #7390 - i.e. it allows to use a different version of Unity when building on internal agents.
Unfortunately, it turns out that variable expansion still doesn't work when specifying agent capabilities, so I wasn't able to remove all duplication (although I made sure that the version numbers in "demands" sections are filled in consistently)
