### PR TITLE
removed controller query about spatial position in scrolling object collection

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MixedRealityToolkit.SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -2088,44 +2088,36 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         ///<inheritdoc/>
         void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            if (eventData.Pointer.Controller.IsPositionAvailable)
+            //Quick check for the global listener to bail if the object is not in the list
+            if (eventData.Pointer?.Result?.CurrentPointerTarget == null
+                || !ContainsNode(eventData.Pointer.Result.CurrentPointerTarget.transform) || initialFocusedObject != null)
             {
-                //Quick check for the global listener to bail if the object is not in the list
-                if (eventData.Pointer?.Result?.CurrentPointerTarget == null 
-                    || !ContainsNode(eventData.Pointer.Result.CurrentPointerTarget.transform) || initialFocusedObject != null)
-                {
-                    return;
-                }
-
-                currentPointer = eventData.Pointer;
-
-                currentPointer.IsTargetPositionLockedOnFocusLock = false;
-
-                pointerHitPoint = currentPointer.Result.Details.Point;
-                pointerHitDistance = currentPointer.Result.Details.RayDistance;
-
-                initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
-
-                //Reset the scroll state
-                scrollVelocity = 0.0f;
-
-                if (TryGetPointerPositionOnPlane(out initialPointerPos))
-                {
-                    initialPressTime = Time.time;
-                    initialScrollerPos = scrollContainer.transform.localPosition;
-                    velocityState = VelocityState.None;
-
-                    isTouched = false;
-                    isEngaged = true;
-                    isDragging = false;
-
-                    TouchStarted?.Invoke(initialFocusedObject);
-                }
+                return;
             }
-            else
+
+            currentPointer = eventData.Pointer;
+
+            currentPointer.IsTargetPositionLockedOnFocusLock = false;
+
+            pointerHitPoint = currentPointer.Result.Details.Point;
+            pointerHitDistance = currentPointer.Result.Details.RayDistance;
+
+            initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
+
+            //Reset the scroll state
+            scrollVelocity = 0.0f;
+
+            if (TryGetPointerPositionOnPlane(out initialPointerPos))
             {
-                //not sure what to do with this pointer
-                Debug.Log(name + " intercepted a pointer from " + gameObject.name + ". " + eventData.Pointer.PointerName + ", but don't know what to do with it.");
+                initialPressTime = Time.time;
+                initialScrollerPos = scrollContainer.transform.localPosition;
+                velocityState = VelocityState.None;
+
+                isTouched = false;
+                isEngaged = true;
+                isDragging = false;
+
+                TouchStarted?.Invoke(initialFocusedObject);
             }
         }
 


### PR DESCRIPTION
there's a check that queries if the input controller currently used is setting a (spatial) position.
This prevents all platforms that won't have this information to interact / scroll the scroll view.

I haven't found a reason for this check to be there as none of the interactions in scrolling object collection is relying on that position but instead using the pointer result which is available for those platforms as well. 

Also we shouldn't use any controller specific code in any of the UX controls but instead work with the data the pointer provides us. 

I've removed this check now to allow users to use the control on android / touch platforms 

## Changes
- Fixes: #7404 

