### PR TITLE
fixed some links and added a note about nuget and unity 2019

### DIFF
--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # Microsoft Mixed Reality Toolkit release notes
 
-- [Version 2.3.0](#version-220)
+- [Version 2.3.0](#version-230)
 - [Version 2.2.0](#version-220)
 - [Version 2.1.0](#version-210)
 - [Version 2.0.1](#version-201)
@@ -30,6 +30,9 @@ The following software is required.
 - [Unity](https://unity3d.com/get-unity/download) 2018.4 LTS or 2019 (2019.3 recommended)
 
 **NuGet requirements**
+
+> [!NOTE] 
+> NuGet packages require Unity version 2018.4 LTS. MRTK 2.3.0 does not support NuGet in combination with 2019.3.
 
 If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), the following software is recommended.
 
@@ -126,19 +129,19 @@ A hand physics extension service has been added to allow for using physics inter
 **Non-native keyboard (Experimental)**
 
 A keyboard that can be used on platforms which do not provide native keyboard support.
-([#6492](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6573))
+([#6492](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6492))
 
 <img src="https://user-images.githubusercontent.com/168492/73916489-5b181d00-4872-11ea-9c1e-7ef6738a9f6f.png" width="400">
 
 **Hand coach (Experimental)**
 
 Hand animations that can give helpful hints for gestures users should perform.
-([#6493](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/1493))
+([#6943](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6943))
 
 <img src="https://user-images.githubusercontent.com/168492/73916521-771bbe80-4872-11ea-80ce-c117253e3c24.png" width="400">
 
 **Follow solver (Experimental)**
-A solver that matches HoloLens 2 shell behavior. ([#6981](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/1493))
+A solver that matches HoloLens 2 shell behavior. ([#6981](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6981))
 
 <img src="https://user-images.githubusercontent.com/47415945/71829132-d338ca80-309b-11ea-97eb-9afc341a21ed.gif" width="400">
 
@@ -161,7 +164,7 @@ Improved ability to configure constraints for object manipulation.
 
 <img src="https://user-images.githubusercontent.com/168492/73964662-7a8d6500-48c7-11ea-9345-3183ca1bd85c.png" width="400">
 
-We are hoping to eventually deprecate ManipulationHandler and BoundingBox in favor of these more robust components. ([#6294](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6924))
+We are hoping to eventually deprecate ManipulationHandler and BoundingBox in favor of these more robust components. ([#6924](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6924))
 
 **UnityAR package contents moved into Foundation**
 


### PR DESCRIPTION
some of our links in the 2.3.0 release notes were leading to wrong articles
also added a note about Unity 2019.3 with nuget on top of the article, so users won't find out about it too late

fixes: #7410 