### PR TITLE
Add controller mapping migration tests

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityControllerMappingProfileTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityControllerMappingProfileTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.OpenVR.Input;
+using NUnit.Framework;
+using UnityEditor;
+
+public class MixedRealityControllerMappingProfileTests
+{
+    /// <summary>
+    /// Verifies that the TestMixedRealityControllerMappingProfile was successfully updated.
+    /// </summary>
+    [Test]
+    public void TestControllerMappingProfileUpdate()
+    {
+        MixedRealityControllerMapping[] testMappingsChanged = new MixedRealityControllerMapping[]
+        {
+            new MixedRealityControllerMapping(typeof(ViveWandController),
+                Microsoft.MixedReality.Toolkit.Utilities.Handedness.Left),
+            new MixedRealityControllerMapping(typeof(ViveWandController),
+                Microsoft.MixedReality.Toolkit.Utilities.Handedness.Right)
+        };
+
+        testMappingsChanged[0].SetDefaultInteractionMapping();
+        testMappingsChanged[1].SetDefaultInteractionMapping();
+
+        testMappingsChanged[0].Interactions[1] = new MixedRealityInteractionMapping(1, "Fake mapping",
+            Microsoft.MixedReality.Toolkit.Utilities.AxisType.Digital, DeviceInputType.ButtonNearTouch);
+
+        bool wereMappingsUpdated = false;
+
+        foreach (MixedRealityControllerMapping mapping in testMappingsChanged)
+        {
+            if (mapping.UpdateInteractionSettingsFromDefault())
+            {
+                wereMappingsUpdated = true;
+            }
+        }
+
+        Assert.IsTrue(wereMappingsUpdated, "No mappings were updated. This test should always need an update.");
+    }
+
+    /// <summary>
+    /// Verifies that the DefaultMixedRealityControllerMappingProfile didn't need updating.
+    /// </summary>
+    [Test]
+    public void TestNoControllerMappingProfileUpdate()
+    {
+        foreach (string guid in AssetDatabase.FindAssets("t:MixedRealityControllerMappingProfile DefaultMixedRealityControllerMappingProfile"))
+        {
+            MixedRealityControllerMappingProfile asset = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(guid), typeof(MixedRealityControllerMappingProfile)) as MixedRealityControllerMappingProfile;
+
+            bool wereMappingsUpdated = false;
+
+            foreach (MixedRealityControllerMapping mapping in asset.MixedRealityControllerMappings)
+            {
+                if (mapping.ControllerType.Type == null)
+                {
+                    continue;
+                }
+
+                if (mapping.UpdateInteractionSettingsFromDefault())
+                {
+                    wereMappingsUpdated = true;
+                }
+            }
+
+            Assert.IsFalse(wereMappingsUpdated, "DefaultMixedRealityControllerMappingProfile needed an update. This should never be checked in needing an update.");
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityControllerMappingProfileTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityControllerMappingProfileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bebf61eb63ec19408576d952a2ea9f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/EventSystemTests.cs.meta
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/EventSystemTests.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 731058d908be67544b92b0341f29d906, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -64,7 +64,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-
         private static Type[] controllerMappingTypes;
 
         public static Type[] ControllerMappingTypes { get { CollectControllerTypes(); return controllerMappingTypes; } }

--- a/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
+++ b/Assets/MixedRealityToolkit/Definitions/Devices/MixedRealityControllerMappingProfile.cs
@@ -38,9 +38,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [MenuItem("Mixed Reality Toolkit/Utilities/Update/Controller Mapping Profiles")]
         private static void UpdateAllControllerMappingProfiles()
         {
-            foreach (string guid in AssetDatabase.FindAssets("t:MixedRealityControllerMappingProfile"))
+            string[] guids = AssetDatabase.FindAssets("t:MixedRealityControllerMappingProfile");
+            string[] assetPaths = new string[guids.Length];
+            for (int i = 0; i < guids.Length; i++)
             {
-                MixedRealityControllerMappingProfile asset = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(guid), typeof(MixedRealityControllerMappingProfile)) as MixedRealityControllerMappingProfile;
+                string guid = guids[i];
+                assetPaths[i] = AssetDatabase.GUIDToAssetPath(guid);
+
+                MixedRealityControllerMappingProfile asset = AssetDatabase.LoadAssetAtPath(assetPaths[i], typeof(MixedRealityControllerMappingProfile)) as MixedRealityControllerMappingProfile;
 
                 List<MixedRealityControllerMapping> updatedMappings = new List<MixedRealityControllerMapping>();
 
@@ -60,8 +65,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 asset.mixedRealityControllerMappings = updatedMappings.ToArray();
-                EditorUtility.SetDirty(asset);
             }
+            AssetDatabase.ForceReserializeAssets(assetPaths);
         }
 
         private static Type[] controllerMappingTypes;


### PR DESCRIPTION
## Overview

Adds some tests to catch the bug reported in #7405.

Also:

1. Updates a test script with the test icon
1. Fixes a quirk I found while testing this fix, where the mapping profiles aren't automatically saved when the update menu item is clicked
1. Removes an extra line from the controller mapping profile definition

## Changes
- Follow-up to #7406 