### PR TITLE
Fix install appx on local via MRTK deploy window

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -269,7 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                     using (new EditorGUILayout.HorizontalScope())
                     {
-                        string analysisTimeLabel = lastAnalyzedTime == null ? "Click analysis button for MRTK to scan your currently opened scene" : "Scanned " + GetRelativeTime(lastAnalyzedTime);
+                        string analysisTimeLabel = lastAnalyzedTime == null ? "Click analysis button for MRTK to scan your currently opened scene" : "Scanned " + lastAnalyzedTime.Value.GetRelativeTime();
                         EditorGUILayout.LabelField(analysisTimeLabel);
 
                         if (GUILayout.Button("Analyze Scene", GUILayout.Width(160f)))
@@ -604,30 +604,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private bool IsHololensTargeted()
         {
             return PerfTarget == PerformanceTarget.AR_Headsets && MixedRealityOptimizeUtils.IsBuildTargetUWP();
-        }
-
-        private static string GetRelativeTime(DateTime? time)
-        {
-            if (time == null) return string.Empty;
-
-            var delta = new TimeSpan(DateTime.UtcNow.Ticks - time.Value.Ticks);
-
-            if (Math.Abs(delta.TotalDays) > 1.0)
-            {
-                return (int)Math.Abs(delta.TotalDays) + " days ago";
-            }
-            else if (Math.Abs(delta.TotalHours) > 1.0)
-            {
-                return (int)Math.Abs(delta.TotalHours) + " hours ago";
-            }
-            else if (Math.Abs(delta.TotalMinutes) > 1.0)
-            {
-                return (int)Math.Abs(delta.TotalMinutes) + " minutes ago";
-            }
-            else 
-            {
-                return (int)Math.Abs(delta.TotalSeconds) + " seconds ago";
-            }
         }
 
         #endregion

--- a/Assets/MixedRealityToolkit/Extensions/DateTimeExtensions.cs
+++ b/Assets/MixedRealityToolkit/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Microsoft.MixedReality.Toolkit
+{
+    /// <summary>
+    /// <see cref="System.DateTime"/> Extensions.
+    /// </summary>
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        /// Gets string literal for relative time from now since the DateTime provided. String output is in most appropriate "x time units ago"
+        /// Example: If DateTime provided is 30 seconds before now, then result will be "30 seconds ago"
+        /// </summary>
+        /// <param name="time">DateTime in UTC to compare against DateTime.UtcNow</param>
+        /// <returns>Encoded string.</returns>
+        public static string GetRelativeTime(this DateTime time)
+        {
+            var delta = new TimeSpan(DateTime.UtcNow.Ticks - time.Ticks);
+
+            if (Math.Abs(delta.TotalDays) > 1.0)
+            {
+                return (int)Math.Abs(delta.TotalDays) + " days ago";
+            }
+            else if (Math.Abs(delta.TotalHours) > 1.0)
+            {
+                return (int)Math.Abs(delta.TotalHours) + " hours ago";
+            }
+            else if (Math.Abs(delta.TotalMinutes) > 1.0)
+            {
+                return (int)Math.Abs(delta.TotalMinutes) + " minutes ago";
+            }
+            else
+            {
+                return (int)Math.Abs(delta.TotalSeconds) + " seconds ago";
+            }
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit/Extensions/DateTimeExtensions.cs.meta
+++ b/Assets/MixedRealityToolkit/Extensions/DateTimeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec124977f18b65143a87328ae508dc4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DataStructures/DeviceInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DataStructures/DeviceInfo.cs
@@ -90,5 +90,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             MachineName = machineName;
             CsrfToken = string.Empty;
         }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return IP + (string.IsNullOrEmpty(MachineName) ? string.Empty : $" [{MachineName}]");
+        }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -340,15 +340,29 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
         {
             Debug.Assert(!string.IsNullOrEmpty(appFullPath));
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
-            if (!isAuth) { return false; }
+            if (!isAuth) 
+            { 
+                return false; 
+            }
 
-            Debug.Log($"Starting install on {targetDevice.MachineName}...");
+            Debug.Log($"Starting app install on {targetDevice.ToString()}...");
 
             // Calculate the cert and dependency paths
             string fileName = Path.GetFileName(appFullPath);
             string certFullPath = Path.ChangeExtension(appFullPath, ".cer");
             string certName = Path.GetFileName(certFullPath);
-            string depPath = $@"{Path.GetDirectoryName(appFullPath)}\Dependencies\x86\";
+
+            string arch = "ARM";
+            if (appFullPath.Contains("x86"))
+            {
+                arch = "x86";
+            }
+            else if (appFullPath.Contains("ARM64"))
+            {
+                arch = "ARM64";
+            }
+
+            string depPath = $@"{Path.GetDirectoryName(appFullPath)}\Dependencies\{arch}\";
 
             var form = new WWWForm();
 
@@ -406,7 +420,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                     return await InstallAppAsync(appFullPath, targetDevice, waitForDone);
                 }
 
-                Debug.LogError($"Failed to install {fileName} on {targetDevice.MachineName}.");
+                Debug.LogError($"Failed to install {fileName} on {targetDevice.ToString()}.");
                 return false;
             }
 
@@ -420,10 +434,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 switch (status)
                 {
                     case AppInstallStatus.InstallSuccess:
-                        Debug.Log($"Successfully installed {fileName} on {targetDevice.MachineName}.");
+                        Debug.Log($"Successfully installed {fileName} on {targetDevice.ToString()}.");
                         return true;
                     case AppInstallStatus.InstallFail:
-                        Debug.LogError($"Failed to install {fileName} on {targetDevice.MachineName}.");
+                        Debug.LogError($"Failed to install {fileName} on {targetDevice.ToString()}.");
                         return false;
                 }
             }
@@ -479,14 +493,14 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 return false;
             }
 
-            Debug.Log($"Attempting to uninstall {packageName} on {targetDevice.MachineName}...");
+            Debug.Log($"Attempting to uninstall {packageName} on {targetDevice.ToString()}...");
 
             string query = $"{string.Format(InstallQuery, FinalizeUrl(targetDevice.IP))}?package={UnityWebRequest.EscapeURL(appInfo.PackageFullName)}";
             var response = await Rest.DeleteAsync(query, targetDevice.Authorization);
 
             if (response.Successful)
             {
-                Debug.Log($"Successfully uninstalled {packageName} on {targetDevice.MachineName}.");
+                Debug.Log($"Successfully uninstalled {packageName} on {targetDevice.ToString()}.");
             }
             else
             if (!response.Successful)
@@ -496,7 +510,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                     return await UninstallAppAsync(packageName, targetDevice);
                 }
 
-                Debug.LogError($"Failed to uninstall {packageName} on {targetDevice.MachineName}");
+                Debug.LogError($"Failed to uninstall {packageName} on {targetDevice.ToString()}");
                 Debug.LogError(response.ResponseBody);
                 return false;
             }


### PR DESCRIPTION
## Overview
There were a few issues found when testing the deploy window against local machine/hololens usb testing. 

For local machine, InstallAppOnDeviceAsync() would check for the Install.ps1 script but would only select if it is was the only script. This fix looks for the script directly.

If trying to deploy an x64 app to HoloLens, the install appx would fail but not report anything to the user. Added debug.log

DevicePortal.InstallAppAsync() would try to embed revelant dependencies with the install request. However, this was hardcoded to look for the x86 folder. The fix is to look at the appx path to determine what architecture is being targeted. 

Some general GUI fixes. Added UI to indicate if last test connection to target was successful or not. Also, sharing code with new datetime string conversion which is now in DateTimeExtensions class

![image](https://user-images.githubusercontent.com/25975362/75400105-14d33e00-58b3-11ea-88e7-20f98ec258d5.png)


## Changes
- Fixes: #6877 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
