### PR TITLE
Use discard instead of saving unused variable for playspace

### DIFF
--- a/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
+++ b/Assets/MixedRealityToolkit/Services/MixedRealityToolkit.cs
@@ -486,7 +486,7 @@ namespace Microsoft.MixedReality.Toolkit
             CameraCache.Main.transform.rotation = Quaternion.identity;
 
             // This will create the playspace
-            Transform playspace = MixedRealityPlayspace.Transform;
+            _ = MixedRealityPlayspace.Transform;
 
             bool addedComponents = false;
             if (!Application.isPlaying)


### PR DESCRIPTION
## Overview

Clearing out old branches and found this commit leftover from some old PRs.
Small change, but there's no point in creating this variable since we don't use it and only need the property call to happen.