### PR TITLE
Removing specific formatting for GLTF mesh-primitive attributes

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -284,7 +284,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 
         private static List<string> GetGltfMeshPrimitiveAttributes(string jsonString)
         {
-            var regex = new Regex("(?<Attributes>\"attributes\"[^}]+})");
+            var regex = new Regex("\"attributes\" ?: ?(?<Data>{[^}]+})");
             return GetGltfMeshPrimitiveAttributes(jsonString, regex);
         }
 
@@ -301,7 +301,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
 
             for (var i = 0; i < matches.Count; i++)
             {
-                jsonObjects.Add(matches[i].Groups["Attributes"].Captures[0].Value.Replace("\"attributes\":", string.Empty));
+                jsonObjects.Add(matches[i].Groups["Data"].Captures[0].Value);
             }
 
             return jsonObjects;


### PR DESCRIPTION
## Overview

The GLTF parser expected attributes of mesh primitives to have a specific formatting, like this:

```json
{
    "attributes": {
         "POSITION" : 0,
         "NORMAL" : 1,
         "TEXCOORD_0" : 2
    },
    "indices" : 3
}
````

(Note the lack of spaces between "attributes" and the following colon). Generally 

## Changes

- Removing requirement for specific formatting in attributes.
- Fixes: #7223 



## Verification

Try loading the following GLTF-Model without this change and with this change:
[cube.zip](https://github.com/microsoft/MixedRealityToolkit-Unity/files/4260435/cube.zip)
