### PR TITLE
improvements to version dropdown

### DIFF
--- a/web/version.js
+++ b/web/version.js
@@ -6,37 +6,56 @@ function createDropdown()
 	
 	//--------------------------------------
 
+	
+	// get web root path
+	var script = document.getElementById('dropdownScript');
+	var scriptPath = script.src;
+	var versionIndex = scriptPath.lastIndexOf('version/');
+	var rootDir = scriptPath;
+	var currentVersionName = defaultTitle;
+	if (versionIndex > 0)
+	{
+		rootDir = scriptPath.substring(0, versionIndex);
+		// currently we're in a different version - extract version name
+		for (var i = 0; i < versionArray.length; i++)
+		{
+			if (scriptPath.indexOf(versionArray[i]) > 0)
+			{
+				currentVersionName = versionArray[i];
+				break;
+			}
+		}
+	}
+	else
+	{
+		rootDir = scriptPath.substring(0, scriptPath.lastIndexOf('web/'));
+	}
+	
+	// create dropdown button
 	var versionDropDiv = document.getElementById('versionDropdown');
 	var btn = document.createElement('button');
 	btn.className = "dropbtn";
-	var btnText = document.createTextNode("Version");
+	var buttonName = "Version - " + currentVersionName;
+	var btnText = document.createTextNode(buttonName);
 	btn.appendChild(btnText);
 	var innerDiv = document.createElement('div');
 	innerDiv.className = "version-dropdown-content";
 	versionDropDiv.appendChild(btn);
 	versionDropDiv.appendChild(innerDiv);
 
-	// get web root path
-	var script = document.getElementById('dropdownScript');
-	var scriptPath = script.src;
-	var versionIndex = scriptPath.lastIndexOf('version/');
-	var rootDir = scriptPath;
-	if (versionIndex > 0)
+	// create default entry
+	if (currentVersionName != defaultTitle)
 	{
-		rootDir = scriptPath.substring(0, versionIndex);
+		createEntry(innerDiv, defaultTitle, rootDir+"README.html");
 	}
-	else
-	{
-		rootDir = scriptPath.substring(0, scriptPath.lastIndexOf('web/'));
-	}
-
-	// create default
-	createEntry(innerDiv, defaultTitle, rootDir+"README.html");
 	
 	// create version entries
 	for (i = 0; i<versionArray.length; i++)
 	{
-		createEntry(innerDiv, versionArray[i], rootDir+"version/"+versionArray[i]+"/README.html");
+		if (versionArray[i] != currentVersionName)
+		{
+			createEntry(innerDiv, versionArray[i], rootDir+"version/"+versionArray[i]+"/README.html");
+		}
 	}
 }
 

--- a/web/version.js
+++ b/web/version.js
@@ -5,32 +5,24 @@ function createDropdown()
 	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "releases/2.3.0"]; // list of all versions in the version folder
 	
 	//--------------------------------------
-
 	
 	// get web root path
 	var script = document.getElementById('dropdownScript');
 	var scriptPath = script.src;
-	var versionIndex = scriptPath.lastIndexOf('version/');
-	var rootDir = scriptPath;
 	var currentVersionName = defaultTitle;
-	if (versionIndex > 0)
+	var rootDir = scriptPath.substring(0, scriptPath.lastIndexOf('web/'));
+	
+	// figure out in which version we're currently working in
+	for (var i = 0; i < versionArray.length; i++)
 	{
-		rootDir = scriptPath.substring(0, versionIndex);
-		// currently we're in a different version - extract version name
-		for (var i = 0; i < versionArray.length; i++)
+		var currentUrl = window.location.href.toString();
+		if (currentUrl.indexOf(versionArray[i]) > 0)
 		{
-			if (scriptPath.indexOf(versionArray[i]) > 0)
-			{
-				currentVersionName = versionArray[i];
-				break;
-			}
+			currentVersionName = versionArray[i];
+			break;
 		}
 	}
-	else
-	{
-		rootDir = scriptPath.substring(0, scriptPath.lastIndexOf('web/'));
-	}
-	
+		
 	// create dropdown button
 	var versionDropDiv = document.getElementById('versionDropdown');
 	var btn = document.createElement('button');


### PR DESCRIPTION
## Overview
- added currently active version of docs to version selector
- removed currently active version from drop down list 
- removed some unnecessary code / cleanup in the version script

![image](https://user-images.githubusercontent.com/36998103/75458027-1bc28500-5975-11ea-9406-00a6aad9ed04.png)

## Fixes
At least a temporary fix for users who get thrown out of the version specific documentation by clicking the direct links on the front page - that way they can see which version they're currently in on any page of the docs