### PR TITLE
Add IsPropertyAvailable and IsTypeAvailable to WindowsApiChecker

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
@@ -4,10 +4,6 @@
 using Microsoft.MixedReality.Toolkit.CameraSystem;
 using Microsoft.MixedReality.Toolkit.Utilities;
 
-#if WINDOWS_UWP
-using Windows.Foundation.Metadata;
-#endif // WINDOWS_UWP
-
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 {
     /// <summary>
@@ -53,9 +49,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
         private WindowsMixedRealityCameraSettingsProfile Profile => ConfigurationProfile as WindowsMixedRealityCameraSettingsProfile;
 
-#if WINDOWS_UWP
-        private static readonly bool isTryGetViewConfigurationSupported = ApiInformation.IsMethodPresent("Windows.Graphics.Holographic.HolographicDisplay", "TryGetViewConfiguration");
-#endif // WINDOWS_UWP
+        private static readonly bool isTryGetViewConfigurationSupported = Windows.Utilities.WindowsApiChecker.IsMethodAvailable(
+            "Windows.Graphics.Holographic",
+            "HolographicDisplay",
+            "TryGetViewConfiguration");
 
         private WindowsMixedRealityReprojectionUpdater reprojectionUpdater = null;
 
@@ -102,6 +99,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
             }
         }
 
-        #endregion IMixedRealityCameraSettings
+#endregion IMixedRealityCameraSettings
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
@@ -99,6 +99,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
             }
         }
 
-#endregion IMixedRealityCameraSettings
+        #endregion IMixedRealityCameraSettings
     }
 }

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityReprojectionUpdater.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/WindowsMixedRealityReprojectionUpdater.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
+using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using UnityEngine;
 
 #if UNITY_WSA && DOTNETWINRT_PRESENT
-using Microsoft.Windows.Foundation.Metadata;
-#endif
+using System.Collections.Generic;
+#endif // UNITY_WSA && DOTNETWINRT_PRESENT
 
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 {
@@ -23,7 +23,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 #if UNITY_WSA && DOTNETWINRT_PRESENT
         private readonly Dictionary<uint, bool> cameraIdToSupportsAutoPlanar = new Dictionary<uint, bool>();
 
-        private static readonly bool isDepthReprojectionModeSupported = ApiInformation.IsPropertyPresent("Windows.Graphics.Holographic.HolographicCameraRenderingParameters", "DepthReprojectionMethod");
+        private static readonly bool isDepthReprojectionModeSupported = WindowsApiChecker.IsPropertyAvailable(
+            "Windows.Graphics.Holographic",
+            "HolographicCameraRenderingParameters",
+            "DepthReprojectionMethod");
 
         private void OnPostRender()
         {

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System.Collections.Generic;
 
 #if UNITY_WSA
@@ -11,12 +12,10 @@ using UnityEngine.XR.WSA.Input;
 using System;
 using UnityEngine;
 #if WINDOWS_UWP
-using Windows.Foundation.Metadata;
 using Windows.Perception;
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
 #elif DOTNETWINRT_PRESENT
-using Microsoft.Windows.Foundation.Metadata;
 using Microsoft.Windows.Perception;
 using Microsoft.Windows.Perception.People;
 using Microsoft.Windows.UI.Input.Spatial;
@@ -41,9 +40,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
             handDefinition = new WindowsMixedRealityArticulatedHandDefinition(inputSource, controllerHandedness);
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-            articulatedHandApiAvailable = ApiInformation.IsMethodPresent("Windows.UI.Input.Spatial.SpatialInteractionSourceState", "TryGetHandPose");
-#endif
+            articulatedHandApiAvailable = WindowsApiChecker.IsMethodAvailable(
+                "Windows.UI.Input.Spatial",
+                "SpatialInteractionSourceState",
+                "TryGetHandPose");
         }
 
         /// <summary>
@@ -54,6 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
         private readonly WindowsMixedRealityArticulatedHandDefinition handDefinition;
+        private readonly bool articulatedHandApiAvailable = false;
 
         #region IMixedRealityHand Implementation
 
@@ -84,7 +85,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
         }
 
-        private readonly bool articulatedHandApiAvailable = false;
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 
         #region Update data functions

--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -3,17 +3,16 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 #if WINDOWS_UWP
-using Windows.Foundation.Metadata;
 using Windows.Perception;
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
 #elif UNITY_WSA && DOTNETWINRT_PRESENT
-using Microsoft.Windows.Foundation.Metadata;
 using Microsoft.Windows.Perception;
 using Microsoft.Windows.Perception.People;
 using Microsoft.Windows.UI.Input.Spatial;
@@ -61,9 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             uint priority,
             BaseMixedRealityProfile profile) : base(inputSystem, name, priority, profile)
         {
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-            eyesApiAvailable = ApiInformation.IsPropertyPresent("Windows.UI.Input.Spatial.SpatialPointerPose", "Eyes");
-#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+            eyesApiAvailable = WindowsApiChecker.IsPropertyAvailable(
+                "Windows.UI.Input.Spatial",
+                "SpatialPointerPose",
+                "Eyes");
         }
 
         public bool SmoothEyeTracking { get; set; } = false;

--- a/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
@@ -6,7 +6,9 @@ using UnityEngine;
 
 #if WINDOWS_UWP
 using Windows.Foundation.Metadata;
-#endif
+#elif (UNITY_WSA && DOTNETWINRT_PRESENT)
+using Microsoft.Windows.Foundation.Metadata;
+#endif // WINDOWS_UWP)
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
 {
@@ -20,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void CheckApiContracts()
         {
-// Disable the obsolete warning to enable setting the properties for legacy code.
+            // Disable the obsolete warning to enable setting the properties for legacy code.
 #pragma warning disable 0618
 #if WINDOWS_UWP
             UniversalApiContractV8_IsAvailable = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8);
@@ -52,48 +54,83 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
             string className,
             string methodName)
         {
-#if WINDOWS_UWP
+#if WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
             return ApiInformation.IsMethodPresent($"{namespaceName}.{className}", methodName);
 #else
             return false;
-#endif // WINDOWS_UWP
+#endif // WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
         }
 
         /// <summary>
-        /// 
+        /// Checks to see if the requested property is present on the current platform.
+        /// </summary>
+        /// <param name="namespaceName">The namespace (ex: "Windows.UI.Input.Spatial") containing the class.</param>
+        /// <param name="className">The name of the class containing the method (ex: "SpatialPointerPose").</param>
+        /// <param name="propertyName">The name of the method (ex: "Eyes").</param>
+        /// <returns>True if the property is available and can be called. Otherwise, false.</returns>
+        public static bool IsPropertyAvailable(
+            string namespaceName,
+            string className,
+            string propertyName)
+        {
+#if WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
+            return ApiInformation.IsPropertyPresent($"{namespaceName}.{className}", propertyName);
+#else
+            return false;
+#endif // WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
+        }
+
+        /// <summary>
+        /// Checks to see if the requested type is present on the current platform.
+        /// </summary>
+        /// <param name="namespaceName">The namespace (ex: "Windows.UI.Input.Spatial") containing the class.</param>
+        /// <param name="typeName">The name of the class containing the method (ex: "SpatialPointerPose").</param>
+        /// <returns>True if the type is available and can be called. Otherwise, false.</returns>
+        public static bool IsTypeAvailable(
+            string namespaceName,
+            string typeName)
+        {
+#if WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
+            return ApiInformation.IsTypePresent($"{namespaceName}.{typeName}");
+#else
+            return false;
+#endif // UNITY_WSA && WINDOWS_UWP || (UNITY_WSA && DOTNETWINRT_PRESENT)
+        }
+
+        /// <summary>
         /// Is the Universal API Contract v8.0 Available?
         /// </summary>
-        [Obsolete("The UniversalApiContractV8_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
+        [Obsolete("The UniversalApiContractV8_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         public static bool UniversalApiContractV8_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v7.0 Available?
         /// </summary>
-        [Obsolete("The UniversalApiContractV7_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
+        [Obsolete("The UniversalApiContractV7_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         public static bool UniversalApiContractV7_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v6.0 Available?
         /// </summary>
-        [Obsolete("The UniversalApiContractV6_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
+        [Obsolete("The UniversalApiContractV6_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         public static bool UniversalApiContractV6_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v5.0 Available?
         /// </summary>
-        [Obsolete("The UniversalApiContractV5_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
+        [Obsolete("The UniversalApiContractV5_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         public static bool UniversalApiContractV5_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v4.0 Available?
         /// </summary>
-        [Obsolete("The UniversalApiContractV4_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
+        [Obsolete("The UniversalApiContractV4_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         public static bool UniversalApiContractV4_IsAvailable { get; private set; }
 
         /// <summary>
         /// Is the Universal API Contract v3.0 Available?
         /// </summary>
-        [Obsolete("The UniversalApiContractV3_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use ApiInformation.IsMethodPresent().")]
+        [Obsolete("The UniversalApiContractV3_IsAvailable property is obsolete and will be removed from a future version of MRTK. Please use IsMethodAvailable(), IsPropertyAvailable() or IsTypeAvailable().")]
         public static bool UniversalApiContractV3_IsAvailable { get; private set; }
     }
 }

--- a/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
+++ b/Assets/MixedRealityToolkit/Utilities/WindowsApiChecker.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 using Windows.Foundation.Metadata;
 #elif (UNITY_WSA && DOTNETWINRT_PRESENT)
 using Microsoft.Windows.Foundation.Metadata;
-#endif // WINDOWS_UWP)
+#endif // WINDOWS_UWP
 
 namespace Microsoft.MixedReality.Toolkit.Windows.Utilities
 {


### PR DESCRIPTION
This change adds IsPropertyAvailale and IsTypeAvailable methods to the WindowsApiChecker class and updates MRTK code to use them instead of directly calling ApiInformation.Is*Present().

Fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7426