### PR TITLE
Minor updates to build window

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MixedRealityToolkit.Tools/BuildWindow/BuildDeployWindow.cs
@@ -708,6 +708,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 {
                     if (GUILayout.Button("Test Connection", GUILayout.Width(128f)))
                     {
+                        lastTestConnectionTime = null;
+
                         EditorApplication.delayCall += async () =>
                         {
                             lastTestConnectionSuccessful = await ConnectToDevice();

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         /// </summary>
         public static bool UseSSL
         {
-            get => EditorPreferences.Get(EDITOR_PREF_USE_SSL, true);
+            get => EditorPreferences.Get(EDITOR_PREF_USE_SSL, false);
             set => EditorPreferences.Set(EDITOR_PREF_USE_SSL, value);
         }
 


### PR DESCRIPTION
## Overview
Make UseSSL default to false. Issues with using device portal on HTTPS vs HTTP atm. @keveleigh do you remember/know anything about this?

Also, update last connection time to null when a new test connection has been initiated but not validated yet. This way the UI updates to help indicate a change has occurred.

## Changes
- Fixes: # .


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
