### PR TITLE
Remove unused bool from WMRDeviceManager

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -58,8 +58,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override bool CheckCapability(MixedRealityCapability capability)
         {
-            bool hasCapability = false;
-
             if (WindowsApiChecker.IsMethodAvailable(
                 "Windows.UI.Input.Spatial",
                 "SpatialInteractionManager",


### PR DESCRIPTION
## Overview

This bool was added in #7402, but is unused. This is causing a warning in Unity.

```
Assets\MixedRealityToolkit.Providers\WindowsMixedReality\XRSDK\WindowsMixedRealityDeviceManager.cs(61,18): warning CS0219: The variable 'hasCapability' is assigned but its value is never used
```