### PR TITLE
Fix some Unity object null comparisons and test infrastructure

### DIFF
--- a/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsService.cs
+++ b/Assets/MixedRealityToolkit.Extensions/HandPhysicsService/HandPhysicsService.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
             {
                 if (HandJointService.IsHandTracked(jointKinematicBody.HandednessType))
                 {
-                    jointKinematicBody.Joint = jointKinematicBody.Joint ?? HandJointService.RequestJointTransform(jointKinematicBody.JointType, jointKinematicBody.HandednessType);
+                    jointKinematicBody.Joint = jointKinematicBody.Joint != null ? jointKinematicBody.Joint : HandJointService.RequestJointTransform(jointKinematicBody.JointType, jointKinematicBody.HandednessType);
                     jointKinematicBody.UpdateState(jointKinematicBody.Joint != null);
                 }
                 else

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityHandTrackingProfileTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Definitions/Devices/MixedRealityHandTrackingProfileTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
@@ -17,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         [Test]
         public void TestEditorOnlyChanges()
         {
-            MixedRealityHandTrackingProfile profile = new MixedRealityHandTrackingProfile();
+            MixedRealityHandTrackingProfile profile = ScriptableObject.CreateInstance<MixedRealityHandTrackingProfile>();
             profile.HandJointVisualizationModes = SupportedApplicationModes.Editor | SupportedApplicationModes.Player;
             profile.HandMeshVisualizationModes = SupportedApplicationModes.Editor | SupportedApplicationModes.Player;
 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/ProjectPreferencesTest.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/ProjectPreferencesTest.cs
@@ -4,17 +4,16 @@
 using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 using NUnit.Framework;
 using System.Collections.Generic;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
 {
     /// <summary>
     /// Test structure to test <see cref="Microsoft.MixedReality.Toolkit.Utilities.Editor.ProjectPreferences"/>
     /// </summary>
-    public class ProjectPreferencesTest : MonoBehaviour
+    public class ProjectPreferencesTest
     {
         private const string BaseKey = "ProjectPreferencesTest_";
-        private static Dictionary<string, object> TestData = new Dictionary<string, object>
+        private static readonly Dictionary<string, object> TestData = new Dictionary<string, object>
         {
             { BaseKey + typeof(bool).Name, (object)true },
             { BaseKey + typeof(float).Name, (object)2.3f },
@@ -68,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Core.Utilities.Editor
         }
 
         /// <summary>
-        /// Validate that the default value provided with Get is returned for new prefernce entries
+        /// Validate that the default value provided with Get is returned for new preference entries
         /// </summary>
         [Test]
         public void TestDefaultValues()

--- a/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MixedRealityToolkit/Providers/Hands/BaseHandVisualizer.cs
@@ -158,7 +158,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             if (handMeshFilter == null &&
-                CoreServices.InputSystem?.InputSystemProfile?.HandTrackingProfile?.HandMeshPrefab != null)
+                CoreServices.InputSystem?.InputSystemProfile != null &&
+                CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile != null &&
+                CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab != null)
             {
                 handMeshFilter = Instantiate(CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab).GetComponent<MeshFilter>();
                 lastHandMeshVertices = handMeshFilter.mesh.vertices;


### PR DESCRIPTION
## Overview

1. Fixes two places where we were incorrectly using null propagation and coalescing on Unity objects.
    1. https://blogs.unity3d.com/2014/05/16/custom-operator-should-we-keep-it/
1. Fixes an instance in the tests where we were `new`ing a scriptable object
    1. `Microsoft.MixedReality.Toolkit.Input.MixedRealityHandTrackingProfile must be instantiated using the ScriptableObject.CreateInstance method instead of new MixedRealityHandTrackingProfile.`
1. Fixes an instance where one of our test classes was incorrectly marked as a `MonoBehaviour`
    1. This was causing `You are trying to create a MonoBehaviour using the 'new' keyword.  This is not allowed.  MonoBehaviours can only be added using AddComponent(). Alternatively, your script can inherit from ScriptableObject or no base class at all` on test runs