### PR TITLE
Update test files to load assets via GUID instead of path

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
@@ -12,8 +12,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
 {
     public class InputSystemTests
     {
-        private const string TestInputSystemProfilePath = "Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset";
-        private const string TestEmptyInputSystemProfilePath = "Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestEmptyMixedRealityInputSystemProfile.asset";
+        // Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset
+        private const string TestInputSystemProfileGuid = "9c5be3fea81382342b84623b5b225012";
+        // Tests/EditModeTests/Services/TestProfiles/TestEmptyMixedRealityInputSystemProfile.asset
+        private const string TestEmptyInputSystemProfileGuid = "45c96c8b3073919419eae31f72ca8e4e";
 
         [TearDown]
         public void TearDown()
@@ -69,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void TestEmptyDataProvider()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(TestEmptyInputSystemProfilePath);
+            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(AssetDatabase.GUIDToAssetPath(TestEmptyInputSystemProfileGuid));
 
             var inputSystem = new MixedRealityInputSystem(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile);
             Assert.IsTrue(MixedRealityToolkit.Instance.RegisterService<IMixedRealityInputSystem>(inputSystem));
@@ -88,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(TestInputSystemProfilePath);
+            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(AssetDatabase.GUIDToAssetPath(TestInputSystemProfileGuid));
 
             var inputSystem = new MixedRealityInputSystem(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile);
             Assert.IsTrue(MixedRealityToolkit.Instance.RegisterService<IMixedRealityInputSystem>(inputSystem));

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/InputSystem/InputSystemTests.cs
@@ -14,8 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
     {
         // Tests/EditModeTests/Services/TestProfiles/TestMixedRealityInputSystemProfile.asset
         private const string TestInputSystemProfileGuid = "9c5be3fea81382342b84623b5b225012";
+        private static readonly string TestInputSystemProfilePath = AssetDatabase.GUIDToAssetPath(TestInputSystemProfileGuid);
+
         // Tests/EditModeTests/Services/TestProfiles/TestEmptyMixedRealityInputSystemProfile.asset
         private const string TestEmptyInputSystemProfileGuid = "45c96c8b3073919419eae31f72ca8e4e";
+        private static readonly string TestEmptyInputSystemProfilePath = AssetDatabase.GUIDToAssetPath(TestEmptyInputSystemProfileGuid);
 
         [TearDown]
         public void TearDown()
@@ -71,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void TestEmptyDataProvider()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(AssetDatabase.GUIDToAssetPath(TestEmptyInputSystemProfileGuid));
+            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(TestEmptyInputSystemProfilePath);
 
             var inputSystem = new MixedRealityInputSystem(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile);
             Assert.IsTrue(MixedRealityToolkit.Instance.RegisterService<IMixedRealityInputSystem>(inputSystem));
@@ -90,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(AssetDatabase.GUIDToAssetPath(TestInputSystemProfileGuid));
+            MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealityInputSystemProfile>(TestInputSystemProfilePath);
 
             var inputSystem = new MixedRealityInputSystem(MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile);
             Assert.IsTrue(MixedRealityToolkit.Instance.RegisterService<IMixedRealityInputSystem>(inputSystem));

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
     {
         // Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
         private const string TestSpatialAwarenessSystemProfileGuid = "757d72d70f9c56144b05346288682e00";
+        private static readonly string TestSpatialAwarenessSystemProfilePath = AssetDatabase.GUIDToAssetPath(TestSpatialAwarenessSystemProfileGuid);
 
         [TearDown]
         public void TearDown()
@@ -66,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
         public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(AssetDatabase.GUIDToAssetPath(TestSpatialAwarenessSystemProfileGuid));
+            MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(TestSpatialAwarenessSystemProfilePath);
 
             var spatialAwarenessSystem = new MixedRealitySpatialAwarenessSystem(MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile);
 

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/SpatialAwareness/SpatialAwarenessSystemTests.cs
@@ -12,7 +12,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
 {
     public class SpatialAwarenessSystemTests
     {
-        private const string TestSpatialAwarenessSystemProfilePath = "Assets/MixedRealityToolkit.Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset";
+        // Tests/EditModeTests/Services/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
+        private const string TestSpatialAwarenessSystemProfileGuid = "757d72d70f9c56144b05346288682e00";
 
         [TearDown]
         public void TearDown()
@@ -65,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.SpatialAwarenessSystem
         public void TestDataProviderRegistration()
         {
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
-            MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(TestSpatialAwarenessSystemProfilePath);
+            MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(AssetDatabase.GUIDToAssetPath(TestSpatialAwarenessSystemProfileGuid));
 
             var spatialAwarenessSystem = new MixedRealitySpatialAwarenessSystem(MixedRealityToolkit.Instance.ActiveProfile.SpatialAwarenessSystemProfile);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ButtonConfigHelperTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ButtonConfigHelperTests.cs
@@ -72,14 +72,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             buttonIconSetObject.ApplyModifiedProperties();
 
             // These calls should not fail even if we have null / empty elements.
-            Texture2D quadIcon;
-            Assert.IsFalse(buttonIconSet.TryGetQuadIcon("EmptyIcon", out quadIcon));
-
-            Sprite spritecon;
-            Assert.IsFalse(buttonIconSet.TryGetSpriteIcon("EmptyIcon", out spritecon));
-
-            uint charIcon;
-            Assert.IsFalse(buttonIconSet.TryGetCharIcon("EmptyIcon", out charIcon));
+            Assert.IsFalse(buttonIconSet.TryGetQuadIcon("EmptyIcon", out _));
+            Assert.IsFalse(buttonIconSet.TryGetSpriteIcon("EmptyIcon", out _));
+            Assert.IsFalse(buttonIconSet.TryGetCharIcon("EmptyIcon", out _));
             yield break;
         }
 
@@ -93,26 +88,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             ButtonIconSet buttonIconSet = ScriptableObject.CreateInstance<ButtonIconSet>();
 
             // The icon set will nave no quad icons.
-            Texture2D quadIcon;
             Assert.IsNotNull(buttonIconSet.QuadIcons);
             Assert.IsTrue(buttonIconSet.QuadIcons.Length == 0);
-            Assert.IsFalse(buttonIconSet.TryGetQuadIcon("EmptyIcon", out quadIcon));
+            Assert.IsFalse(buttonIconSet.TryGetQuadIcon("EmptyIcon", out _));
 
             // The icon set will nave no sprite icons.
-            Sprite spritecon;
             Assert.IsNotNull(buttonIconSet.SpriteIcons);
             Assert.IsTrue(buttonIconSet.SpriteIcons.Length == 0);
-            Assert.IsFalse(buttonIconSet.TryGetSpriteIcon("EmptyIcon", out spritecon));
+            Assert.IsFalse(buttonIconSet.TryGetSpriteIcon("EmptyIcon", out _));
 
             // The icon set should have the following icons by default.
-            uint charIcon;
             Assert.IsNotNull(buttonIconSet.CharIcons);
-            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarAdjust", out charIcon));
-            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarClose", out charIcon));
-            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarDone", out charIcon));
-            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarHide", out charIcon));
-            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarShow", out charIcon));
-            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarHome", out charIcon));
+            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarAdjust", out _));
+            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarClose", out _));
+            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarDone", out _));
+            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarHide", out _));
+            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarShow", out _));
+            Assert.IsTrue(buttonIconSet.TryGetCharIcon("AppBarHome", out _));
             yield break;
         }
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ButtonConfigHelperTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ButtonConfigHelperTests.cs
@@ -21,8 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class ButtonConfigHelperTests : BasePlayModeTests
     {
-        private const string PressableButtonHoloLens2PrefabGuid = "3f1f46cbecbe08e46a303ccfdb5b498a";
-
         [UnityTest]
         /// <summary>
         /// Test adding a config helper to a game object and attempting to modify it.
@@ -114,11 +112,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestPressableButtonHololens2Prefab()
         {
-            GameObject buttonObject = InstantiateButtonFromGuid(Vector3.zero, Quaternion.identity, PressableButtonHoloLens2PrefabGuid);
+            GameObject buttonObject = InstantiateButtonFromPath(Vector3.zero, Quaternion.identity, TestButtonUtilities.PressableHoloLens2PrefabPath);
             ButtonConfigHelper bch = buttonObject.GetComponent<ButtonConfigHelper>();
 
             bch.MainLabelText = "MainLabelText";
-            Assert.AreEqual(bch.MainLabelText, "MainLabelText"); 
+            Assert.AreEqual(bch.MainLabelText, "MainLabelText");
 
             bch.SeeItSayItLabelText = "SeeItSayItLabelText";
             Assert.AreEqual(bch.SeeItSayItLabelText, "SeeItSayItLabelText");
@@ -141,10 +139,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield break;
         }
 
-        private GameObject InstantiateButtonFromGuid(Vector3 position, Quaternion rotation, string guid)
+        private GameObject InstantiateButtonFromPath(Vector3 position, Quaternion rotation, string path)
         {
             // Load interactable prefab
-            Object interactablePrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(guid), typeof(Object));
+            Object interactablePrefab = AssetDatabase.LoadAssetAtPath(path, typeof(Object));
             GameObject result = Object.Instantiate(interactablePrefab) as GameObject;
             Assert.IsNotNull(result);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/ButtonConfigHelperTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/ButtonConfigHelperTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class ButtonConfigHelperTests : BasePlayModeTests
     {
-        private static string PressableButtonHoloLens2PrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab";
+        private const string PressableButtonHoloLens2PrefabGuid = "3f1f46cbecbe08e46a303ccfdb5b498a";
 
         [UnityTest]
         /// <summary>
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestPressableButtonHololens2Prefab()
         {
-            GameObject buttonObject = InstantiateButtonFromPath(Vector3.zero, Quaternion.identity, PressableButtonHoloLens2PrefabPath);
+            GameObject buttonObject = InstantiateButtonFromGuid(Vector3.zero, Quaternion.identity, PressableButtonHoloLens2PrefabGuid);
             ButtonConfigHelper bch = buttonObject.GetComponent<ButtonConfigHelper>();
 
             bch.MainLabelText = "MainLabelText";
@@ -141,10 +141,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield break;
         }
 
-        private GameObject InstantiateButtonFromPath(Vector3 position, Quaternion rotation, string path)
+        private GameObject InstantiateButtonFromGuid(Vector3 position, Quaternion rotation, string guid)
         {
             // Load interactable prefab
-            Object interactablePrefab = AssetDatabase.LoadAssetAtPath(path, typeof(Object));
+            Object interactablePrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(guid), typeof(Object));
             GameObject result = Object.Instantiate(interactablePrefab) as GameObject;
             Assert.IsNotNull(result);
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public class CoreServicesTests
     {
         /// <summary>
-        /// Test if we can register and deregister a core MRTK service
+        /// Test if we can register and unregister a core MRTK service
         /// </summary>
         /// <returns>enumerator for Unity</returns>
         [UnityTest]

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
@@ -23,7 +23,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public class CoreServicesTests
     {
         // SDK/Experimental/ServiceManagers/Camera/Prefabs/CameraSystem.prefab
-        private const string cameraSystemPrefabGuid = "8a5d96f565aaee14ca3e07575bb9ce80";
+        private const string CameraSystemPrefabGuid = "8a5d96f565aaee14ca3e07575bb9ce80";
+        private static readonly string CameraSystemPrefabPath = AssetDatabase.GUIDToAssetPath(CameraSystemPrefabGuid);
 
         /// <summary>
         /// Test if we can register and unregister a core MRTK service
@@ -34,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             TestUtilities.InitializeCamera();
 
-            UnityEngine.Object cameraSystemPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(cameraSystemPrefabGuid), typeof(UnityEngine.Object));
+            UnityEngine.Object cameraSystemPrefab = AssetDatabase.LoadAssetAtPath(CameraSystemPrefabPath, typeof(UnityEngine.Object));
             Assert.IsNull(CoreServices.CameraSystem);
 
             GameObject cameraSystem1 = UnityEngine.Object.Instantiate(cameraSystemPrefab) as GameObject;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/CoreServicesTests.cs
@@ -22,6 +22,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class CoreServicesTests
     {
+        // SDK/Experimental/ServiceManagers/Camera/Prefabs/CameraSystem.prefab
+        private const string cameraSystemPrefabGuid = "8a5d96f565aaee14ca3e07575bb9ce80";
+
         /// <summary>
         /// Test if we can register and unregister a core MRTK service
         /// </summary>
@@ -31,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             TestUtilities.InitializeCamera();
 
-            UnityEngine.Object cameraSystemPrefab = AssetDatabase.LoadAssetAtPath("Assets/MixedRealityToolkit.SDK/Experimental/ServiceManagers/Camera/Prefabs/CameraSystem.prefab", typeof(UnityEngine.Object));
+            UnityEngine.Object cameraSystemPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(cameraSystemPrefabGuid), typeof(UnityEngine.Object));
             Assert.IsNull(CoreServices.CameraSystem);
 
             GameObject cameraSystem1 = UnityEngine.Object.Instantiate(cameraSystemPrefab) as GameObject;
@@ -49,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.IsNull(CoreServices.CameraSystem);
 
-            GameObject cameraSystem2 = UnityEngine.Object.Instantiate(cameraSystemPrefab) as GameObject;
+            UnityEngine.Object.Instantiate(cameraSystemPrefab);
             Assert.IsNotNull(CoreServices.CameraSystem);
         }
     }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         // SDK/Features/UX/Prefabs/AppBar/AppBar.prefab
         private const string appBarPrefabGuid = "83c02591e2867124181bcd3bcb65e288";
+        private static readonly string appBarPrefabLink = AssetDatabase.GUIDToAssetPath(appBarPrefabGuid);
 
         /// <summary>
         /// Instantiates a bounds control at boundsControlStartCenter
@@ -674,7 +675,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             TestUtilities.PlayspaceToOriginLookingForward();
 
             boundsControl.transform.localScale = boundsControlStartScale;
-            Object appBarPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(appBarPrefabGuid), typeof(Object));
+            Object appBarPrefab = AssetDatabase.LoadAssetAtPath(appBarPrefabLink, typeof(Object));
             Assert.IsNotNull(appBarPrefab, "Couldn't load app bar prefab from assetdatabase");
             GameObject appBarGameObject = Object.Instantiate(appBarPrefab) as GameObject;
             Assert.IsNotNull(appBarGameObject, "Couldn't instantiate appbar prefab");

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
     public class BoundsControlTests
     {
         #region Utilities
+
         [SetUp]
         public void Setup()
         {
@@ -76,6 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             TestUtilities.AssertAboutEqual(bounds.size, boundsControlStartScale, "bounds control incorrect size at start");
             yield return null;
         }
+
         #endregion
 
         /// <summary>
@@ -138,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            // This particular test is sensitive to the number of test frames, and is run at at slower pace.
+            // This particular test is sensitive to the number of test frames and is run at a slower pace.
             int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, initialHandPosition);
@@ -240,8 +242,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Test bounds control rotation via hololens 1 interaction / GGV
         /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
+        /// Test bounds control rotation via HoloLens 1 interaction / GGV
         /// </summary>
         [UnityTest]
         public IEnumerator RotateViaHololens1Interaction()
@@ -524,7 +526,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(frontRightCornerPos);
             yield return null;
 
-            // we're in poximity scaling range - check if proximity scaling wasn't applied
+            // we're in proximity scaling range - check if proximity scaling wasn't applied
             Assert.AreEqual(proximityScaledVisual.localScale, defaultHandleSize, "Handle was scaled even though proximity effect wasn't active");
 
             //// reset hand

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -245,8 +245,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
         /// Test bounds control rotation via HoloLens 1 interaction / GGV
+        /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
         /// </summary>
         [UnityTest]
         public IEnumerator RotateViaHololens1Interaction()

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -44,7 +44,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         private readonly Vector3 boundsControlStartCenter = Vector3.forward * 1.5f;
         private readonly Vector3 boundsControlStartScale = Vector3.one * 0.5f;
-        private static readonly string appBarPrefabLink = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/AppBar/AppBar.prefab";
+
+        // SDK/Features/UX/Prefabs/AppBar/AppBar.prefab
+        private const string appBarPrefabGuid = "83c02591e2867124181bcd3bcb65e288";
+
         /// <summary>
         /// Instantiates a bounds control at boundsControlStartCenter
         /// transform is at scale boundsControlStartScale
@@ -671,7 +674,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             TestUtilities.PlayspaceToOriginLookingForward();
 
             boundsControl.transform.localScale = boundsControlStartScale;
-            Object appBarPrefab = AssetDatabase.LoadAssetAtPath(appBarPrefabLink, typeof(Object));
+            Object appBarPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(appBarPrefabGuid), typeof(Object));
             Assert.IsNotNull(appBarPrefab, "Couldn't load app bar prefab from assetdatabase");
             GameObject appBarGameObject = Object.Instantiate(appBarPrefab) as GameObject;
             Assert.IsNotNull(appBarGameObject, "Couldn't instantiate appbar prefab");

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            
+
             Vector3 rightCornerInteractionPoint = new Vector3(0.184f, 0.078f, 0.79f); // position of hand for far interacting with front right corner 
             Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
             Vector3 scalePoint = new Vector3(0.165f, 0.267f, 0.794f); // end position for far interaction scaling
@@ -375,13 +375,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            BoxCollider boxCollider = boundsControl.GetComponent<BoxCollider>();           
+            BoxCollider boxCollider = boundsControl.GetComponent<BoxCollider>();
             PlayModeTestUtilities.PushHandSimulationProfile();
             PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
             CameraCache.Main.transform.LookAt(boundsControl.gameObject.transform.Find("rigRoot/corner_3").transform);
 
-            var startHandPos = CameraCache.Main.transform.TransformPoint(new Vector3( 0.1f, 0f, 1.5f));
+            var startHandPos = CameraCache.Main.transform.TransformPoint(new Vector3(0.1f, 0f, 1.5f));
             TestHand rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(startHandPos);
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
@@ -679,7 +679,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             appBarGameObject.transform.localScale = Vector3.one * 5.0f;
             appBar.Target = boundsControl;
-            appBarGameObject.SetActive(true);          
+            appBarGameObject.SetActive(true);
 
             // manipulation coords
             Vector3 rightCornerInteractionPoint = new Vector3(0.184f, 0.078f, 0.79f); // position of hand for far interacting with front right corner 
@@ -711,7 +711,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(scalePoint);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             endBounds = boundsControl.GetComponent<BoxCollider>().bounds;
-            Vector3 expectedScaleCenter = new Vector3(0.0453f, 0.0453f, 1.455f); 
+            Vector3 expectedScaleCenter = new Vector3(0.0453f, 0.0453f, 1.455f);
             Vector3 expectedScaleSize = Vector3.one * 0.59f;
             TestUtilities.AssertAboutEqual(endBounds.center, expectedScaleCenter, "endBounds incorrect center");
             TestUtilities.AssertAboutEqual(endBounds.size, expectedScaleSize, "endBounds incorrect size");

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -24,7 +24,7 @@ using UnityEngine.TestTools;
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
     /// <summary>
-    /// Class that tests various types of Interactable buttons and UX components. 
+    /// Class that tests various types of Interactable buttons and UX components.
     /// Validates various forms of input (i.e speech etc) against various configurations of Interactable.
     /// </summary>
     public class InteractableTests : BasePlayModeTests
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             TestButtonUtilities.InstantiateDefaultButton(
                 TestButtonUtilities.DefaultButtonType.DefaultPushButton,
-                out Interactable interactable, 
+                out Interactable interactable,
                 out Transform translateTargetObject);
 
             interactable.transform.position = new Vector3(10f, 0.0f, 0.5f);
@@ -644,9 +644,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                 Assert.True(wasClicked, "Toggle button was not clicked");
                 Assert.AreEqual((i + 1) % 2, interactable.CurrentDimension, $"Toggle button is in incorrect toggle state on click {i}");
-                
+
                 // Make sure the button depth is back at the starting position
-                Assert.True(frontPlateTransform.localPosition == frontPlateStartPosition, "Toggle button front plate did not return to starting position.");                
+                Assert.True(frontPlateTransform.localPosition == frontPlateStartPosition, "Toggle button front plate did not return to starting position.");
             }
 
             GameObject.Destroy(interactable.gameObject);
@@ -705,7 +705,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 TestButtonUtilities.DefaultButtonType.DefaultHL2Button,
                 out Interactable interactable,
                 out Transform interactableTransform);
-            
+
             interactable.transform.position = new Vector3(0.0f, 0.1f, 0.4f);
             Assert.True(interactable.IsEnabled);
 
@@ -817,12 +817,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             GameObject.Destroy(result);
         }
 
-            #region Test Helpers
+        #region Test Helpers
 
-            /// <summary>
-            /// Generates an interactable from primitives and assigns a select action.
-            /// </summary>
-            private void AssembleInteractableButton(out Interactable interactable, out Transform translateTargetObject, string selectActionDescription = "Select")
+        /// <summary>
+        /// Generates an interactable from primitives and assigns a select action.
+        /// </summary>
+        private void AssembleInteractableButton(out Interactable interactable, out Transform translateTargetObject, string selectActionDescription = "Select")
         {
             // Assemble an interactable out of a set of primitives
             // This will be the button housing
@@ -908,10 +908,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             interactableToggleCollection.ToggleList = toggleCollection.GetComponentsInChildren<Interactable>();
         }
 
-        private IEnumerator RunGlobalClick(IMixedRealityInputSource defaultInputSource, 
-            MixedRealityInputAction inputAction, 
-            Vector3 targetStartPosition, 
-            Transform translateTargetObject, 
+        private IEnumerator RunGlobalClick(IMixedRealityInputSource defaultInputSource,
+            MixedRealityInputAction inputAction,
+            Vector3 targetStartPosition,
+            Transform translateTargetObject,
             bool shouldTranslate = true)
         {
             yield return TestInputUtilities.ExecuteGlobalClick(defaultInputSource, inputAction, () =>

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -32,11 +32,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const float ButtonReleaseAnimationDelay = 0.25f;
         private const float EaseDelay = 0.25f;
 
-        private const string RadialSetPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab";
-        private const string RadialPrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Radial.prefab";
-        private const string DisabledOnStartPrefabAssetPath = "Assets/MixedRealityToolkit.Tests/PlayModeTests/Prefabs/Model_PushButton_DisabledOnStart.prefab";
-
-        private const string DisabledInitializedPrefabAssetPath = @"Assets\MixedRealityToolkit.Tests\PlayModeTests\Prefabs\TestInteractableInitialize.prefab";
+        // SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab
+        private const string RadialSetPrefabAssetGuid = "8b83134143223104c9bc3865a565cab3";
+        // SDK/Features/UX/Interactable/Prefabs/Radial.prefab
+        private const string RadialPrefabAssetGuid = "0f83fa6afa56ead46bbd762156f1137e";
+        // Tests/PlayModeTests/Prefabs/Model_PushButton_DisabledOnStart.prefab
+        private const string DisabledOnStartPrefabAssetGuid = "19bd42ed40b63a746af7320db5558f86";
+        // Tests\PlayModeTests\Prefabs\TestInteractableInitialize.prefab
+        private const string DisabledInitializedPrefabAssetGuid = "0401ea9158809914798d0a74023e3779";
 
         private readonly Color DefaultColor = Color.blue;
         private readonly Color FocusColor = Color.yellow;
@@ -492,7 +495,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestButtonUtilities.InstantiatePressableButtonPrefab(
                 new Vector3(0.025f, 0.05f, 0.5f),
                 TestButtonUtilities.DefaultRotation,
-                DisabledOnStartPrefabAssetPath,
+                AssetDatabase.GUIDToAssetPath(DisabledOnStartPrefabAssetGuid),
                 "Cylinder",
                 out Interactable interactable,
                 out Transform pressButtonCylinder);
@@ -571,7 +574,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestRadialSetPrefab()
         {
-            var radialSet = TestButtonUtilities.InstantiateInteractableFromPath(Vector3.forward, Quaternion.identity, RadialSetPrefabAssetPath);
+            var radialSet = TestButtonUtilities.InstantiateInteractableFromPath(Vector3.forward, Quaternion.identity, AssetDatabase.GUIDToAssetPath(RadialSetPrefabAssetGuid));
             var firstRadialButton = radialSet.transform.Find("Radial (1)").GetComponent<Interactable>();
             var secondRadialButton = radialSet.transform.Find("Radial (2)").GetComponent<Interactable>();
             var thirdRadialButton = radialSet.transform.Find("Radial (3)").GetComponent<Interactable>();
@@ -777,7 +780,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestForceInitialize()
         {
-            Object checkboxesPrefab = AssetDatabase.LoadAssetAtPath(DisabledInitializedPrefabAssetPath, typeof(Object));
+            Object checkboxesPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(DisabledInitializedPrefabAssetGuid), typeof(Object));
             var result = Object.Instantiate(checkboxesPrefab, Vector3.forward * 1.0f, Quaternion.identity) as GameObject;
             var interactables = result.GetComponentsInChildren<Interactable>(true);
 
@@ -899,7 +902,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Instantiate radial prefabs with toggleCollection as the parent
             for (int i = 0; i < numRadials; i++)
             {
-                var radial = TestButtonUtilities.InstantiateInteractableFromPath(pos + new Vector3(0.1f, i * 0.1f, 0), Quaternion.identity, RadialPrefabAssetPath);
+                var radial = TestButtonUtilities.InstantiateInteractableFromPath(pos + new Vector3(0.1f, i * 0.1f, 0), Quaternion.identity, AssetDatabase.GUIDToAssetPath(RadialPrefabAssetGuid));
                 radial.name = "Radial " + i;
                 Assert.IsNotNull(radial);
                 radial.transform.parent = toggleCollection.transform;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/InteractableTests.cs
@@ -34,12 +34,19 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         // SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab
         private const string RadialSetPrefabAssetGuid = "8b83134143223104c9bc3865a565cab3";
+        private static readonly string RadialSetPrefabAssetPath = AssetDatabase.GUIDToAssetPath(RadialSetPrefabAssetGuid);
+
         // SDK/Features/UX/Interactable/Prefabs/Radial.prefab
         private const string RadialPrefabAssetGuid = "0f83fa6afa56ead46bbd762156f1137e";
+        private static readonly string RadialPrefabAssetPath = AssetDatabase.GUIDToAssetPath(RadialPrefabAssetGuid);
+
         // Tests/PlayModeTests/Prefabs/Model_PushButton_DisabledOnStart.prefab
         private const string DisabledOnStartPrefabAssetGuid = "19bd42ed40b63a746af7320db5558f86";
-        // Tests\PlayModeTests\Prefabs\TestInteractableInitialize.prefab
+        private static readonly string DisabledOnStartPrefabAssetPath = AssetDatabase.GUIDToAssetPath(DisabledOnStartPrefabAssetGuid);
+
+        // Tests/PlayModeTests/Prefabs/TestInteractableInitialize.prefab
         private const string DisabledInitializedPrefabAssetGuid = "0401ea9158809914798d0a74023e3779";
+        private static readonly string DisabledInitializedPrefabAssetPath = AssetDatabase.GUIDToAssetPath(DisabledInitializedPrefabAssetGuid);
 
         private readonly Color DefaultColor = Color.blue;
         private readonly Color FocusColor = Color.yellow;
@@ -495,7 +502,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestButtonUtilities.InstantiatePressableButtonPrefab(
                 new Vector3(0.025f, 0.05f, 0.5f),
                 TestButtonUtilities.DefaultRotation,
-                AssetDatabase.GUIDToAssetPath(DisabledOnStartPrefabAssetGuid),
+                DisabledOnStartPrefabAssetPath,
                 "Cylinder",
                 out Interactable interactable,
                 out Transform pressButtonCylinder);
@@ -574,7 +581,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestRadialSetPrefab()
         {
-            var radialSet = TestButtonUtilities.InstantiateInteractableFromPath(Vector3.forward, Quaternion.identity, AssetDatabase.GUIDToAssetPath(RadialSetPrefabAssetGuid));
+            var radialSet = TestButtonUtilities.InstantiateInteractableFromPath(Vector3.forward, Quaternion.identity, RadialSetPrefabAssetPath);
             var firstRadialButton = radialSet.transform.Find("Radial (1)").GetComponent<Interactable>();
             var secondRadialButton = radialSet.transform.Find("Radial (2)").GetComponent<Interactable>();
             var thirdRadialButton = radialSet.transform.Find("Radial (3)").GetComponent<Interactable>();
@@ -780,7 +787,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestForceInitialize()
         {
-            Object checkboxesPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(DisabledInitializedPrefabAssetGuid), typeof(Object));
+            Object checkboxesPrefab = AssetDatabase.LoadAssetAtPath(DisabledInitializedPrefabAssetPath, typeof(Object));
             var result = Object.Instantiate(checkboxesPrefab, Vector3.forward * 1.0f, Quaternion.identity) as GameObject;
             var interactables = result.GetComponentsInChildren<Interactable>(true);
 
@@ -902,7 +909,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Instantiate radial prefabs with toggleCollection as the parent
             for (int i = 0; i < numRadials; i++)
             {
-                var radial = TestButtonUtilities.InstantiateInteractableFromPath(pos + new Vector3(0.1f, i * 0.1f, 0), Quaternion.identity, AssetDatabase.GUIDToAssetPath(RadialPrefabAssetGuid));
+                var radial = TestButtonUtilities.InstantiateInteractableFromPath(pos + new Vector3(0.1f, i * 0.1f, 0), Quaternion.identity, RadialPrefabAssetPath);
                 radial.name = "Radial " + i;
                 Assert.IsNotNull(radial);
                 radial.transform.parent = toggleCollection.transform;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/LoadingIndicatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/LoadingIndicatorTests.cs
@@ -23,10 +23,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab
         private const string progressIndicatorLoadingBarPrefabGuid = "57d2436112e7d424da7e9a8e41c608dc";
+        private static readonly string progressIndicatorLoadingBarPrefabPath = AssetDatabase.GUIDToAssetPath(progressIndicatorLoadingBarPrefabGuid);
+
         // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab
         private const string progressIndicatorRotatingObjectPrefabGuid = "274fde8ad8cd85a4a88acb4c2c892028";
+        private static readonly string progressIndicatorRotatingObjectPrefabPath = AssetDatabase.GUIDToAssetPath(progressIndicatorRotatingObjectPrefabGuid);
+        
         // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab
         private const string progressIndicatorRotatingOrbsPrefabGuid = "65fa42bb01c733c42b05a4e91628f494";
+        private static readonly string progressIndicatorRotatingOrbsPrefabPath = AssetDatabase.GUIDToAssetPath(progressIndicatorRotatingOrbsPrefabGuid);
 
         /// <summary>
         /// Tests that prefab can be opened and closed at runtime.
@@ -36,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject progressIndicatorObject;
             IProgressIndicator progressIndicator;
-            InstantiatePrefab(progressIndicatorLoadingBarPrefabGuid, out progressIndicatorObject, out progressIndicator);
+            InstantiatePrefab(progressIndicatorLoadingBarPrefabPath, out progressIndicatorObject, out progressIndicator);
             Task testTask = TestOpenCloseProgressIndicatorAsync(progressIndicatorObject, progressIndicator);
             while (!testTask.IsCompleted)
             {
@@ -56,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject progressIndicatorObject;
             IProgressIndicator progressIndicator;
-            InstantiatePrefab(progressIndicatorRotatingObjectPrefabGuid, out progressIndicatorObject, out progressIndicator);
+            InstantiatePrefab(progressIndicatorRotatingObjectPrefabPath, out progressIndicatorObject, out progressIndicator);
             Task testTask = TestOpenCloseProgressIndicatorAsync(progressIndicatorObject, progressIndicator);
             while (!testTask.IsCompleted)
             {
@@ -76,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject progressIndicatorObject;
             IProgressIndicator progressIndicator;
-            InstantiatePrefab(progressIndicatorRotatingOrbsPrefabGuid, out progressIndicatorObject, out progressIndicator);
+            InstantiatePrefab(progressIndicatorRotatingOrbsPrefabPath, out progressIndicatorObject, out progressIndicator);
             Task testTask = TestOpenCloseProgressIndicatorAsync(progressIndicatorObject, progressIndicator, 3f);
             while (!testTask.IsCompleted)
             {
@@ -123,13 +128,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(progressIndicator.State == ProgressIndicatorState.Closed, "Progress indicator was not closed after close async call: " + progressIndicator.State);
         }
 
-        private void InstantiatePrefab(string guid, out GameObject progressIndicatorObject, out IProgressIndicator progressIndicator)
+        private void InstantiatePrefab(string path, out GameObject progressIndicatorObject, out IProgressIndicator progressIndicator)
         {
             progressIndicatorObject = null;
             progressIndicator = null;
 
 #if UNITY_EDITOR
-            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(guid));
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
             progressIndicatorObject = Object.Instantiate(prefab);
             progressIndicator = (IProgressIndicator)progressIndicatorObject.GetComponent(typeof(IProgressIndicator));
 #endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/LoadingIndicatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/LoadingIndicatorTests.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #if !WINDOWS_UWP
 // When the .NET scripting backend is enabled and C# projects are built
 // Unity doesn't include the required assemblies (i.e. the ones below).
 // Given that the .NET backend is deprecated by Unity at this point it's we have
 // to work around this on our end.
-using Microsoft.MixedReality.Toolkit.Input;
+
 using Microsoft.MixedReality.Toolkit.UI;
 using NUnit.Framework;
 using System.Collections;
@@ -23,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string progressIndicatorLoadingBarPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab";
         private const string progressIndicatorRotatingObjectPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab";
         private const string progressIndicatorRotatingOrbsPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab";
-        
+
         /// <summary>
         /// Tests that prefab can be opened and closed at runtime.
         /// </summary>
@@ -124,11 +125,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             progressIndicatorObject = null;
             progressIndicator = null;
 
-            #if UNITY_EDITOR
+#if UNITY_EDITOR
             GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
             progressIndicatorObject = GameObject.Instantiate(prefab);
             progressIndicator = (IProgressIndicator)progressIndicatorObject.GetComponent(typeof(IProgressIndicator));
-            #endif
+#endif
         }
     }
 }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/LoadingIndicatorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/LoadingIndicatorTests.cs
@@ -21,9 +21,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     class ProgressIndicatorTests
     {
-        private const string progressIndicatorLoadingBarPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab";
-        private const string progressIndicatorRotatingObjectPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab";
-        private const string progressIndicatorRotatingOrbsPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab";
+        // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorLoadingBar.prefab
+        private const string progressIndicatorLoadingBarPrefabGuid = "57d2436112e7d424da7e9a8e41c608dc";
+        // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab
+        private const string progressIndicatorRotatingObjectPrefabGuid = "274fde8ad8cd85a4a88acb4c2c892028";
+        // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab
+        private const string progressIndicatorRotatingOrbsPrefabGuid = "65fa42bb01c733c42b05a4e91628f494";
 
         /// <summary>
         /// Tests that prefab can be opened and closed at runtime.
@@ -33,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject progressIndicatorObject;
             IProgressIndicator progressIndicator;
-            InstantiatePrefab(progressIndicatorLoadingBarPrefabPath, out progressIndicatorObject, out progressIndicator);
+            InstantiatePrefab(progressIndicatorLoadingBarPrefabGuid, out progressIndicatorObject, out progressIndicator);
             Task testTask = TestOpenCloseProgressIndicatorAsync(progressIndicatorObject, progressIndicator);
             while (!testTask.IsCompleted)
             {
@@ -53,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject progressIndicatorObject;
             IProgressIndicator progressIndicator;
-            InstantiatePrefab(progressIndicatorRotatingObjectPrefabPath, out progressIndicatorObject, out progressIndicator);
+            InstantiatePrefab(progressIndicatorRotatingObjectPrefabGuid, out progressIndicatorObject, out progressIndicator);
             Task testTask = TestOpenCloseProgressIndicatorAsync(progressIndicatorObject, progressIndicator);
             while (!testTask.IsCompleted)
             {
@@ -73,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             GameObject progressIndicatorObject;
             IProgressIndicator progressIndicator;
-            InstantiatePrefab(progressIndicatorRotatingOrbsPrefabPath, out progressIndicatorObject, out progressIndicator);
+            InstantiatePrefab(progressIndicatorRotatingOrbsPrefabGuid, out progressIndicatorObject, out progressIndicator);
             Task testTask = TestOpenCloseProgressIndicatorAsync(progressIndicatorObject, progressIndicator, 3f);
             while (!testTask.IsCompleted)
             {
@@ -120,14 +123,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(progressIndicator.State == ProgressIndicatorState.Closed, "Progress indicator was not closed after close async call: " + progressIndicator.State);
         }
 
-        private void InstantiatePrefab(string path, out GameObject progressIndicatorObject, out IProgressIndicator progressIndicator)
+        private void InstantiatePrefab(string guid, out GameObject progressIndicatorObject, out IProgressIndicator progressIndicator)
         {
             progressIndicatorObject = null;
             progressIndicator = null;
 
 #if UNITY_EDITOR
-            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
-            progressIndicatorObject = GameObject.Instantiate(prefab);
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(guid));
+            progressIndicatorObject = Object.Instantiate(prefab);
             progressIndicator = (IProgressIndicator)progressIndicatorObject.GetComponent(typeof(IProgressIndicator));
 #endif
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             GameObject.Destroy(pinchSliderObject);
             PlayModeTestUtilities.PopHandSimulationProfile();
         }
-        
+
         /// <summary>
         /// Tests that interactable raises proper events
         /// </summary>
@@ -352,7 +352,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             sliderObject.transform.eulerAngles = rotation;
         }
         #endregion Private methods
-
     }
 }
 #endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
@@ -15,7 +15,6 @@ using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -24,7 +23,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 {
     class PinchSliderTests
     {
-        const string defaultPinchSliderPrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab";
+        // SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab
+        private const string defaultPinchSliderPrefabGuid = "1093263a89abe47499cccf7dcb08effb";
 
         [SetUp]
         public void Setup()
@@ -342,7 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private void InstantiateDefaultSliderPrefab(Vector3 position, Vector3 rotation, out GameObject sliderObject, out PinchSlider pinchSlider)
         {
             // Load interactable prefab
-            Object sliderPrefab = AssetDatabase.LoadAssetAtPath(defaultPinchSliderPrefabPath, typeof(Object));
+            Object sliderPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(defaultPinchSliderPrefabGuid), typeof(Object));
             sliderObject = Object.Instantiate(sliderPrefab) as GameObject;
             pinchSlider = sliderObject.GetComponent<PinchSlider>();
             Assert.IsNotNull(pinchSlider);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PinchSliderTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         // SDK/Features/UX/Prefabs/Sliders/PinchSlider.prefab
         private const string defaultPinchSliderPrefabGuid = "1093263a89abe47499cccf7dcb08effb";
+        private static readonly string defaultPinchSliderPrefabPath = AssetDatabase.GUIDToAssetPath(defaultPinchSliderPrefabGuid);
 
         [SetUp]
         public void Setup()
@@ -342,7 +343,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private void InstantiateDefaultSliderPrefab(Vector3 position, Vector3 rotation, out GameObject sliderObject, out PinchSlider pinchSlider)
         {
             // Load interactable prefab
-            Object sliderPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(defaultPinchSliderPrefabGuid), typeof(Object));
+            Object sliderPrefab = AssetDatabase.LoadAssetAtPath(defaultPinchSliderPrefabPath, typeof(Object));
             sliderObject = Object.Instantiate(sliderPrefab) as GameObject;
             pinchSlider = sliderObject.GetComponent<PinchSlider>();
             Assert.IsNotNull(pinchSlider);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -29,8 +29,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </summary>
     public class PointerTests
     {
-        private const string LinePointerPrefab = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab";
-        private const string CurvePointerPrefab = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab";
+        // SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
+        private const string LinePointerGuid = "d5b94136462644c9873bb3347169ae7e";
+        // SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab
+        private const string CurvePointerGuid = "c4fd3c6fc7ff484eb434775066e7f327";
 
         [SetUp]
         public void Setup()
@@ -56,10 +58,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             BaseEventSystem.enableDanglingHandlerDiagnostics = false;
 
-            var linePointer = CreatePointerPrefab<LinePointer>(LinePointerPrefab,
+            var linePointer = CreatePointerPrefab<LinePointer>(LinePointerGuid,
                 out IMixedRealityInputSource lineInputSource, out IMixedRealityController lineController);
 
-            var curvePointer = CreatePointerPrefab<TeleportPointer>(CurvePointerPrefab,
+            var curvePointer = CreatePointerPrefab<TeleportPointer>(CurvePointerGuid,
                     out IMixedRealityInputSource curveInputSource, out IMixedRealityController curveController);
 
             Assert.IsNotNull(linePointer);
@@ -327,12 +329,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         #region Helpers
 
-        private static T CreatePointerPrefab<T>(string prefabPath,
+        private static T CreatePointerPrefab<T>(string prefabGuid,
                                                 out IMixedRealityInputSource inputSource,
                                                 out IMixedRealityController controller)
             where T : IMixedRealityPointer
         {
-            var pointerPrefab = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(prefabPath);
+            var pointerPrefab = AssetDatabase.LoadAssetAtPath<Object>(AssetDatabase.GUIDToAssetPath(prefabGuid));
             var result = PrefabUtility.InstantiatePrefab(pointerPrefab) as GameObject;
             T pointer = result.GetComponent<T>();
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -31,8 +31,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         // SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab
         private const string LinePointerGuid = "d5b94136462644c9873bb3347169ae7e";
+        private static readonly string LinePointerPrefab = AssetDatabase.GUIDToAssetPath(LinePointerGuid);
+
         // SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab
         private const string CurvePointerGuid = "c4fd3c6fc7ff484eb434775066e7f327";
+        private static readonly string CurvePointerPrefab = AssetDatabase.GUIDToAssetPath(CurvePointerGuid);
 
         [SetUp]
         public void Setup()
@@ -58,10 +61,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             BaseEventSystem.enableDanglingHandlerDiagnostics = false;
 
-            var linePointer = CreatePointerPrefab<LinePointer>(LinePointerGuid,
+            var linePointer = CreatePointerPrefab<LinePointer>(LinePointerPrefab,
                 out IMixedRealityInputSource lineInputSource, out IMixedRealityController lineController);
 
-            var curvePointer = CreatePointerPrefab<TeleportPointer>(CurvePointerGuid,
+            var curvePointer = CreatePointerPrefab<TeleportPointer>(CurvePointerPrefab,
                     out IMixedRealityInputSource curveInputSource, out IMixedRealityController curveController);
 
             Assert.IsNotNull(linePointer);
@@ -329,12 +332,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         #region Helpers
 
-        private static T CreatePointerPrefab<T>(string prefabGuid,
+        private static T CreatePointerPrefab<T>(string prefabPath,
                                                 out IMixedRealityInputSource inputSource,
                                                 out IMixedRealityController controller)
             where T : IMixedRealityPointer
         {
-            var pointerPrefab = AssetDatabase.LoadAssetAtPath<Object>(AssetDatabase.GUIDToAssetPath(prefabGuid));
+            var pointerPrefab = AssetDatabase.LoadAssetAtPath<Object>(prefabPath);
             var result = PrefabUtility.InstantiatePrefab(pointerPrefab) as GameObject;
             T pointer = result.GetComponent<T>();
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Test that the same PokePointer
         /// 1) is not destroyed
-        /// 2) retreived and re-used from the pointer cache
+        /// 2) retrieved and re-used from the pointer cache
         /// 3) still click buttons and provides input after re-use
         /// </summary>
         [UnityTest]

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PointerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// <summary>
     /// Tests to verify pointer state and pointer direction
     /// </summary>
-    public class PointerTests 
+    public class PointerTests
     {
         private const string LinePointerPrefab = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/DefaultControllerPointer.prefab";
         private const string CurvePointerPrefab = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab";
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             BaseEventSystem.enableDanglingHandlerDiagnostics = false;
 
-            var linePointer = CreatePointerPrefab<LinePointer>(LinePointerPrefab, 
+            var linePointer = CreatePointerPrefab<LinePointer>(LinePointerPrefab,
                 out IMixedRealityInputSource lineInputSource, out IMixedRealityController lineController);
 
             var curvePointer = CreatePointerPrefab<TeleportPointer>(CurvePointerPrefab,
@@ -329,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private static T CreatePointerPrefab<T>(string prefabPath,
                                                 out IMixedRealityInputSource inputSource,
-                                                out IMixedRealityController controller) 
+                                                out IMixedRealityController controller)
             where T : IMixedRealityPointer
         {
             var pointerPrefab = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(prefabPath);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -687,7 +687,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            GameObject testButton = InstantiateDefaultPressableButton(PressableButtonHoloLens2Guid);
+            GameObject testButton = InstantiateDefaultPressableButton(TestButtonUtilities.PressableHoloLens2PrefabPath);
             testButton.transform.position = new Vector3(0, 0, 1);
             testButton.transform.localScale = Vector3.one * 1.5f;
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             float distance = Mathf.Abs(buttonComponent.MaxPushDistance) + Mathf.Abs(buttonComponent.StartPushDistance);
             distance = buttonComponent.DistanceSpaceMode == SpaceMode.Local ? distance * buttonComponent.LocalToWorldScale : distance;
             testButton2.transform.position += Vector3.forward * distance;
-            
+
             bool buttonPressed = false;
             buttonComponent.ButtonPressed.AddListener(() =>
             {
@@ -329,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int numSteps = (int)Mathf.Ceil(handReach / (distance * 0.5f)); // Maximum hand speed in order to trigger touch started in the first button before the second button becomes the closest touchable to pointer
 
             yield return hand.Show(new Vector3(0, 0, -handReach / 2));
-            yield return hand.Move(new Vector3(0,0, handReach), numSteps);
+            yield return hand.Move(new Vector3(0, 0, handReach), numSteps);
 
             Assert.IsTrue(buttonPressed, "Button did not get pressed when a second button is nearby");
 
@@ -691,7 +691,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNotNull(interactable);
 
             bool wasClicked = false;
-            interactable.OnClick.AddListener(() => { wasClicked = true; } );
+            interactable.OnClick.AddListener(() => { wasClicked = true; });
 
             yield return PressButtonWithHand();
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -36,37 +36,39 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         // Tests/PlayModeTests/Prefabs/UnitTestCanvas.prefab
         private const string UnitTestCanvasPrefabGuid = "489163bd64fdf84418a1536cefbb4c80";
+        private static readonly string UnitTestCanvasPrefabPath = AssetDatabase.GUIDToAssetPath(UnitTestCanvasPrefabGuid);
 
-        // SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab
-        private const string PressableButtonHoloLens2Guid = "3f1f46cbecbe08e46a303ccfdb5b498a";
+        // SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2UnityUI.prefab
+        private const string PressableButtonHoloLens2UnityUIGuid = "2f626628bde0879488068de0e9f25f8d";
+        private static readonly string PressableButtonHoloLens2UnityUIPath = AssetDatabase.GUIDToAssetPath(PressableButtonHoloLens2UnityUIGuid);
 
         private static readonly Dictionary<string, bool> PressableButtonTestPrefabs = new Dictionary<string, bool>
         {
-            // Key is GUID. Value is whether or not it needs to be placed in a Canvas.
-            { "3f1f46cbecbe08e46a303ccfdb5b498a", false }, // PressableButtonHoloLens2.prefab
-            { "2f626628bde0879488068de0e9f25f8d", true }, // PressableButtonHoloLens2UnityUI.prefab
+            // Key is path. Value is whether or not it needs to be placed in a Canvas.
+            { TestButtonUtilities.PressableHoloLens2PrefabPath, false },
+            { PressableButtonHoloLens2UnityUIPath, true },
         };
 
-        private static IEnumerable<string> PressableButtonsTestPrefabGuids
+        private static IEnumerable<string> PressableButtonsTestPrefabPaths
         {
             get
             {
-                foreach (var prefabGuid in PressableButtonTestPrefabs.Keys)
+                foreach (var prefabPath in PressableButtonTestPrefabs.Keys)
                 {
-                    yield return prefabGuid;
+                    yield return prefabPath;
                 }
             }
         }
 
-        private GameObject InstantiateDefaultPressableButton(string prefabGuid)
+        private GameObject InstantiateDefaultPressableButton(string prefabPath)
         {
-            Object pressableButtonPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(prefabGuid), typeof(Object));
+            Object pressableButtonPrefab = AssetDatabase.LoadAssetAtPath(prefabPath, typeof(Object));
             GameObject testButton = Object.Instantiate(pressableButtonPrefab) as GameObject;
 
-            if (PressableButtonTestPrefabs[prefabGuid])
+            if (PressableButtonTestPrefabs[prefabPath])
             {
                 // Need to place this test button in a Canvas. Instantiate the test canvas and place the button into it.
-                var canvasPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(UnitTestCanvasPrefabGuid), typeof(Object));
+                var canvasPrefab = AssetDatabase.LoadAssetAtPath(UnitTestCanvasPrefabPath, typeof(Object));
                 var canvasObject = (GameObject)Object.Instantiate(canvasPrefab);
                 testButton.transform.SetParent(canvasObject.transform, worldPositionStays: false);
             }
@@ -99,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Tests
 
         [UnityTest]
-        public IEnumerator ButtonInstantiate([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator ButtonInstantiate([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
             yield return null;
@@ -117,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6024
         /// </summary>
         [UnityTest]
-        public IEnumerator ButtonInstantiateDisableThenEnableBeforeStart([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator ButtonInstantiateDisableThenEnableBeforeStart([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -144,7 +146,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6025
         /// </summary>
         [UnityTest]
-        public IEnumerator RotateButton([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator RotateButton([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -184,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// See https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4683
         /// </summary>
         [UnityTest]
-        public IEnumerator PressButtonWithHand([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator PressButtonWithHand([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -220,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test disabling the PressableButton GameObject and re-enabling
         /// </summary>
         [UnityTest]
-        public IEnumerator DisablePressableButton([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator DisablePressableButton([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -265,7 +267,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// if hands were moving too fast in low framerate
         /// </summary>
         [UnityTest]
-        public IEnumerator PressButtonFast([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator PressButtonFast([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -302,7 +304,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Tests if button pressed event is triggered when a second button is overlapping right behind the first button
         /// </summary>
         [UnityTest]
-        public IEnumerator PressButtonWhenSecondButtonIsNearby([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator PressButtonWhenSecondButtonIsNearby([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton1 = InstantiateDefaultPressableButton(prefabFilename);
             GameObject testButton2 = InstantiateDefaultPressableButton(prefabFilename);
@@ -345,7 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// This test verifies that buttons will trigger with far interaction
         /// </summary>
         [UnityTest]
-        public IEnumerator TriggerButtonFarInteraction([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator TriggerButtonFarInteraction([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -398,7 +400,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
-        public IEnumerator ScaleWorldDistances([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator ScaleWorldDistances([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             // instantiate scene and button
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
@@ -451,7 +453,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
-        public IEnumerator SwitchWorldToLocalDistanceMode([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator SwitchWorldToLocalDistanceMode([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             // instantiate scene and button
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
@@ -521,7 +523,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
-        public IEnumerator ScaleLocalDistances([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator ScaleLocalDistances([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             // instantiate scene and button
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
@@ -574,7 +576,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// This tests the release behavior of a button
         /// </summary>
         [UnityTest]
-        public IEnumerator ReleaseButton([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
+        public IEnumerator ReleaseButton([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
             TestUtilities.PlayspaceToOriginLookingForward();

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -34,37 +34,36 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         #region Utilities
 
-        private static string PrefabDirectoryPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs";
-        private static string UnitTestCanvasPrefabPath = "Assets/MixedRealityToolkit.Tests/PlayModeTests/Prefabs/UnitTestCanvas.prefab";
+        // Tests/PlayModeTests/Prefabs/UnitTestCanvas.prefab
+        private const string UnitTestCanvasPrefabGuid = "489163bd64fdf84418a1536cefbb4c80";
 
-        private static Dictionary<string, bool> PressableButtonTestPrefabs = new Dictionary<string, bool>
+        private static readonly Dictionary<string, bool> PressableButtonTestPrefabs = new Dictionary<string, bool>
         {
-            // Key is file name.  Value is whether or not it needs to be placed in a Canvas.
-            { "PressableButtonHoloLens2.prefab", false },
-            { "PressableButtonHoloLens2UnityUI.prefab", true },
+            // Key is GUID. Value is whether or not it needs to be placed in a Canvas.
+            { "3f1f46cbecbe08e46a303ccfdb5b498a", false }, // PressableButtonHoloLens2.prefab
+            { "2f626628bde0879488068de0e9f25f8d", true }, // PressableButtonHoloLens2UnityUI.prefab
         };
 
-        public static IEnumerable<string> PressableButtonsTestPrefabFilenames
+        private static IEnumerable<string> PressableButtonsTestPrefabGuids
         {
             get
             {
-                foreach (var prefabFilename in PressableButtonTestPrefabs.Keys)
+                foreach (var prefabGuid in PressableButtonTestPrefabs.Keys)
                 {
-                    yield return prefabFilename;
+                    yield return prefabGuid;
                 }
             }
         }
 
-        private GameObject InstantiateDefaultPressableButton(string prefabFilename)
+        private GameObject InstantiateDefaultPressableButton(string prefabGuid)
         {
-            var path = Path.Combine(PrefabDirectoryPath, prefabFilename);
-            Object pressableButtonPrefab = AssetDatabase.LoadAssetAtPath(path, typeof(Object));
+            Object pressableButtonPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(prefabGuid), typeof(Object));
             GameObject testButton = Object.Instantiate(pressableButtonPrefab) as GameObject;
 
-            if (PressableButtonTestPrefabs[prefabFilename])
+            if (PressableButtonTestPrefabs[prefabGuid])
             {
-                // Need to place this test button in a Canvas.  Instantiate the test canvas and place the button into it.
-                var canvasPrefab = AssetDatabase.LoadAssetAtPath(UnitTestCanvasPrefabPath, typeof(Object));
+                // Need to place this test button in a Canvas. Instantiate the test canvas and place the button into it.
+                var canvasPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(UnitTestCanvasPrefabGuid), typeof(Object));
                 var canvasObject = (GameObject)Object.Instantiate(canvasPrefab);
                 testButton.transform.SetParent(canvasObject.transform, worldPositionStays: false);
             }
@@ -97,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Tests
 
         [UnityTest]
-        public IEnumerator ButtonInstantiate([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator ButtonInstantiate([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
             yield return null;
@@ -115,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6024
         /// </summary>
         [UnityTest]
-        public IEnumerator ButtonInstantiateDisableThenEnableBeforeStart([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator ButtonInstantiateDisableThenEnableBeforeStart([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -142,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6025
         /// </summary>
         [UnityTest]
-        public IEnumerator RotateButton([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator RotateButton([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -182,7 +181,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// See https://github.com/microsoft/MixedRealityToolkit-Unity/issues/4683
         /// </summary>
         [UnityTest]
-        public IEnumerator PressButtonWithHand([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator PressButtonWithHand([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -218,7 +217,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test disabling the PressableButton GameObject and re-enabling
         /// </summary>
         [UnityTest]
-        public IEnumerator DisablePressableButton([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator DisablePressableButton([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -263,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// if hands were moving too fast in low framerate
         /// </summary>
         [UnityTest]
-        public IEnumerator PressButtonFast([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator PressButtonFast([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -300,7 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Tests if button pressed event is triggered when a second button is overlapping right behind the first button
         /// </summary>
         [UnityTest]
-        public IEnumerator PressButtonWhenSecondButtonIsNearby([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator PressButtonWhenSecondButtonIsNearby([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton1 = InstantiateDefaultPressableButton(prefabFilename);
             GameObject testButton2 = InstantiateDefaultPressableButton(prefabFilename);
@@ -343,7 +342,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// This test verifies that buttons will trigger with far interaction
         /// </summary>
         [UnityTest]
-        public IEnumerator TriggerButtonFarInteraction([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator TriggerButtonFarInteraction([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
 
@@ -396,7 +395,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
-        public IEnumerator ScaleWorldDistances([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator ScaleWorldDistances([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             // instantiate scene and button
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
@@ -449,7 +448,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
-        public IEnumerator SwitchWorldToLocalDistanceMode([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator SwitchWorldToLocalDistanceMode([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             // instantiate scene and button
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
@@ -519,7 +518,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         [UnityTest]
-        public IEnumerator ScaleLocalDistances([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator ScaleLocalDistances([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             // instantiate scene and button
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
@@ -572,7 +571,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// This tests the release behavior of a button
         /// </summary>
         [UnityTest]
-        public IEnumerator ReleaseButton([ValueSource(nameof(PressableButtonsTestPrefabFilenames))] string prefabFilename)
+        public IEnumerator ReleaseButton([ValueSource(nameof(PressableButtonsTestPrefabGuids))] string prefabFilename)
         {
             GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
             TestUtilities.PlayspaceToOriginLookingForward();
@@ -712,6 +711,5 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #endregion
     }
 }
-
 
 #endif

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/PressableButtonTests.cs
@@ -37,6 +37,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // Tests/PlayModeTests/Prefabs/UnitTestCanvas.prefab
         private const string UnitTestCanvasPrefabGuid = "489163bd64fdf84418a1536cefbb4c80";
 
+        // SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab
+        private const string PressableButtonHoloLens2Guid = "3f1f46cbecbe08e46a303ccfdb5b498a";
+
         private static readonly Dictionary<string, bool> PressableButtonTestPrefabs = new Dictionary<string, bool>
         {
             // Key is GUID. Value is whether or not it needs to be placed in a Canvas.
@@ -682,7 +685,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            GameObject testButton = InstantiateDefaultPressableButton("PressableButtonHoloLens2.prefab");
+            GameObject testButton = InstantiateDefaultPressableButton(PressableButtonHoloLens2Guid);
             testButton.transform.position = new Vector3(0, 0, 1);
             testButton.transform.localScale = Vector3.one * 1.5f;
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         // SDK/Features/UX/Prefabs/Slate/Slate.prefab
         private const string slatePrefabAssetGuid = "937ce507dd7ee334ba569554e24adbdd";
+        private static readonly string slatePrefabAssetPath = AssetDatabase.GUIDToAssetPath(slatePrefabAssetGuid);
 
         GameObject panObject;
         HandInteractionPanZoom panZoom;
@@ -205,7 +206,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </summary>
         private void InstantiateFromPrefab(Vector3 position)
         {
-            UnityEngine.Object prefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(slatePrefabAssetGuid), typeof(UnityEngine.Object));
+            UnityEngine.Object prefab = AssetDatabase.LoadAssetAtPath(slatePrefabAssetPath, typeof(UnityEngine.Object));
             panObject = UnityEngine.Object.Instantiate(prefab) as GameObject;
             Assert.IsNotNull(panObject);
             panObject.transform.position = position;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SlateTests.cs
@@ -10,21 +10,21 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using NUnit.Framework;
 using System.Collections;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.UI;
-using Microsoft.MixedReality.Toolkit.Input;
-using System;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
 {
     public class SlateTests
     {
-        const string slatePrefabAssetPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Slate/Slate.prefab";
+        // SDK/Features/UX/Prefabs/Slate/Slate.prefab
+        private const string slatePrefabAssetGuid = "937ce507dd7ee334ba569554e24adbdd";
 
         GameObject panObject;
         HandInteractionPanZoom panZoom;
@@ -205,7 +205,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </summary>
         private void InstantiateFromPrefab(Vector3 position)
         {
-            UnityEngine.Object prefab = AssetDatabase.LoadAssetAtPath(slatePrefabAssetPath, typeof(UnityEngine.Object));
+            UnityEngine.Object prefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(slatePrefabAssetGuid), typeof(UnityEngine.Object));
             panObject = UnityEngine.Object.Instantiate(prefab) as GameObject;
             Assert.IsNotNull(panObject);
             panObject.transform.position = position;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpatialObserverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpatialObserverTests.cs
@@ -27,8 +27,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         // Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
         private const string TestSpatialAwarenessSystemProfileGuid = "c992bdb3ac45cd44d856b0198a3ee85d";
+        private static readonly string TestSpatialAwarenessSystemProfilePath = AssetDatabase.GUIDToAssetPath(TestSpatialAwarenessSystemProfileGuid);
+
         // Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile_ManualStart.asset
         private const string TestSpatialAwarenessSystemProfileGuid_ManualStart = "d38d502ad0bcb3447b106d550fd5a371";
+        private static readonly string TestSpatialAwarenessSystemProfilePath_ManualStart = AssetDatabase.GUIDToAssetPath(TestSpatialAwarenessSystemProfileGuid_ManualStart);
 
         /// <summary>
         /// Test default case of Auto-Start SpatialObjectMeshObserver observer type and SpatialAwarenessSystem in editor
@@ -37,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestAutoStartObserver()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfileGuid);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -65,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestManualStartObserver()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfileGuid_ManualStart);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath_ManualStart);
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -107,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestDisableSpatialAwarenessSystem()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfileGuid);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
 
             mrtkProfile.IsSpatialAwarenessSystemEnabled = false;
 
@@ -117,13 +120,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNull(CoreServices.SpatialAwarenessSystem);
         }
 
-        private static MixedRealityToolkitConfigurationProfile CreateMRTKTestProfile(string spatialAwarenessSystemGuid)
+        private static MixedRealityToolkitConfigurationProfile CreateMRTKTestProfile(string spatialAwarenessSystemPath)
         {
             var mrtkProfile = ScriptableObject.CreateInstance<MixedRealityToolkitConfigurationProfile>();
 
             mrtkProfile.SpatialAwarenessSystemSystemType = new SystemType(typeof(MixedRealitySpatialAwarenessSystem));
             mrtkProfile.IsSpatialAwarenessSystemEnabled = true;
-            mrtkProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(AssetDatabase.GUIDToAssetPath(spatialAwarenessSystemGuid));
+            mrtkProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(spatialAwarenessSystemPath);
 
             return mrtkProfile;
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpatialObserverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SpatialObserverTests.cs
@@ -25,8 +25,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     /// </summary>
     public class SpatialObserverTests
     {
-        private const string TestSpatialAwarenessSystemProfilePath = "Assets/MixedRealityToolkit.Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset";
-        private const string TestSpatialAwarenessSystemProfilePath_ManualStart = "Assets/MixedRealityToolkit.Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile_ManualStart.asset";
+        // Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile.asset
+        private const string TestSpatialAwarenessSystemProfileGuid = "c992bdb3ac45cd44d856b0198a3ee85d";
+        // Tests/PlayModeTests/TestProfiles/TestMixedRealitySpatialAwarenessSystemProfile_ManualStart.asset
+        private const string TestSpatialAwarenessSystemProfileGuid_ManualStart = "d38d502ad0bcb3447b106d550fd5a371";
 
         /// <summary>
         /// Test default case of Auto-Start SpatialObjectMeshObserver observer type and SpatialAwarenessSystem in editor
@@ -35,7 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestAutoStartObserver()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfileGuid);
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -63,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestManualStartObserver()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath_ManualStart);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfileGuid_ManualStart);
             TestUtilities.InitializeMixedRealityToolkit(mrtkProfile);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
@@ -105,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestDisableSpatialAwarenessSystem()
         {
-            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfilePath);
+            var mrtkProfile = CreateMRTKTestProfile(TestSpatialAwarenessSystemProfileGuid);
 
             mrtkProfile.IsSpatialAwarenessSystemEnabled = false;
 
@@ -115,13 +117,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNull(CoreServices.SpatialAwarenessSystem);
         }
 
-        private static MixedRealityToolkitConfigurationProfile CreateMRTKTestProfile(string spatialAwarenessSystemPath)
+        private static MixedRealityToolkitConfigurationProfile CreateMRTKTestProfile(string spatialAwarenessSystemGuid)
         {
             var mrtkProfile = ScriptableObject.CreateInstance<MixedRealityToolkitConfigurationProfile>();
 
             mrtkProfile.SpatialAwarenessSystemSystemType = new SystemType(typeof(MixedRealitySpatialAwarenessSystem));
             mrtkProfile.IsSpatialAwarenessSystemEnabled = true;
-            mrtkProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(spatialAwarenessSystemPath);
+            mrtkProfile.SpatialAwarenessSystemProfile = AssetDatabase.LoadAssetAtPath<MixedRealitySpatialAwarenessSystemProfile>(AssetDatabase.GUIDToAssetPath(spatialAwarenessSystemGuid));
 
             return mrtkProfile;
         }

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utils/TestButtonUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utils/TestButtonUtilities.cs
@@ -30,27 +30,27 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         };
 
         /// <summary>
-        /// Asset Path to default model push button prefab asset
+        /// Asset path to default model push button prefab asset
         /// </summary>
         public const string DefaultInteractablePrefabAssetPath = "Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab";
 
         /// <summary>
-        /// Asset path to default Hololens 2 Pressable Button prefab asset
+        /// Asset path to default HoloLens 2 Pressable Button prefab asset
         /// </summary>
         public const string PressableHoloLens2PrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab";
 
         /// <summary>
-        /// Asset path to default Hololens 2 Toggle Pressable Button prefab asset
+        /// Asset path to default HoloLens 2 Toggle Pressable Button prefab asset
         /// </summary>
         public const string PressableHoloLens2TogglePrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Toggle.prefab";
 
         /// <summary>
-        /// Rought amount of time for press action on button
+        /// Amount of time for press action on button
         /// </summary>
         public const float ButtonPressAnimationDelay = 0.25f;
 
         /// <summary>
-        /// Rought amount of time for release action on button
+        /// Amount of time for release action on button
         /// </summary>
         public const float ButtonReleaseAnimationDelay = 0.25f;
 

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utils/TestButtonUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utils/TestButtonUtilities.cs
@@ -105,8 +105,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Instantiates Pressable Button based on list of arguments provided
         /// </summary>
-        public static void InstantiatePressableButtonPrefab(Vector3 position, Quaternion rotation, 
-            string prefabPath, string translateTargetPath, 
+        public static void InstantiatePressableButtonPrefab(Vector3 position, Quaternion rotation,
+            string prefabPath, string translateTargetPath,
             out Interactable interactable, out Transform translateTargetTransform)
         {
             // Load interactable prefab

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utils/TestButtonUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/Utils/TestButtonUtilities.cs
@@ -32,17 +32,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Asset path to default model push button prefab asset
         /// </summary>
-        public const string DefaultInteractablePrefabAssetPath = "Assets/MixedRealityToolkit.Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab";
+        public static readonly string DefaultInteractablePrefabAssetPath = AssetDatabase.GUIDToAssetPath(DefaultInteractablePrefabAssetGuid);
 
         /// <summary>
         /// Asset path to default HoloLens 2 Pressable Button prefab asset
         /// </summary>
-        public const string PressableHoloLens2PrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab";
+        public static readonly string PressableHoloLens2PrefabPath = AssetDatabase.GUIDToAssetPath(PressableHoloLens2PrefabGuid);
 
         /// <summary>
         /// Asset path to default HoloLens 2 Toggle Pressable Button prefab asset
         /// </summary>
-        public const string PressableHoloLens2TogglePrefabPath = "Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Toggle.prefab";
+        public static readonly string PressableHoloLens2TogglePrefabPath = AssetDatabase.GUIDToAssetPath(PressableHoloLens2TogglePrefabGuid);
 
         /// <summary>
         /// Amount of time for press action on button
@@ -70,6 +70,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private static readonly string[] AssetPaths = { DefaultInteractablePrefabAssetPath, PressableHoloLens2PrefabPath, PressableHoloLens2TogglePrefabPath };
         private static readonly string[] TranslateTargetPaths = { "Cylinder", "CompressableButtonVisuals/FrontPlate", "CompressableButtonVisuals/FrontPlate" };
         private static readonly Quaternion[] DefaultRotations = { DefaultRotation, Quaternion.LookRotation(Vector3.forward), Quaternion.LookRotation(Vector3.forward) };
+
+        // Examples/Demos/UX/Interactables/Prefabs/Model_PushButton.prefab
+        private const string DefaultInteractablePrefabAssetGuid = "29a6f5316e0868e47adff5eee8945193";
+
+        // SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab
+        private const string PressableHoloLens2PrefabGuid = "3f1f46cbecbe08e46a303ccfdb5b498a";
+
+        // SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Toggle.prefab
+        private const string PressableHoloLens2TogglePrefabGuid = "64790b91b91094d49942373c4e83c237";
 
         /// <summary>
         /// Instantiate and configure one of the <see cref="DefaultButtonType"/> types.

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
@@ -376,11 +376,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator TestTextureTheme()
         {
-            const string TexturePathState0 = @"Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Textures/Panel_albedo.png";
-            Texture texState0 = AssetDatabase.LoadAssetAtPath<Texture>(TexturePathState0);
+            // Examples/Demos/StandardShader/Textures/Panel_albedo.png
+            const string TexturePathState0 = "7b551659cf4349242ba72d82b4f9cdc7";
+            Texture texState0 = AssetDatabase.LoadAssetAtPath<Texture>(AssetDatabase.GUIDToAssetPath(TexturePathState0));
 
-            const string TexturePathState1 = @"Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Textures/Checker_albedo.png";
-            Texture texState1 = AssetDatabase.LoadAssetAtPath<Texture>(TexturePathState1);
+            // Examples/Demos/StandardShader/Textures/Checker_albedo.png
+            const string TexturePathState1 = "e2cd08a4d181dcc4ea7beb0992656c7e";
+            Texture texState1 = AssetDatabase.LoadAssetAtPath<Texture>(AssetDatabase.GUIDToAssetPath(TexturePathState1));
 
             var defaultStateValues = new List<List<ThemePropertyValue>>()
             {

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/VisualThemeTests.cs
@@ -293,12 +293,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             };
 
             yield return TestTheme<ScaleOffsetColorTheme, MeshRenderer>(defaultStateValues,
-                (theme) => 
+                (theme) =>
                 {
                     Assert.AreEqual(state0, theme.Host.transform.localScale);
                     Assert.AreEqual(state0Offset, theme.Host.transform.position);
                 },
-                (theme) => 
+                (theme) =>
                 {
                     Assert.AreEqual(state1, theme.Host.transform.localScale);
                     Assert.AreEqual(state1Offset, theme.Host.transform.position);
@@ -508,7 +508,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         private IEnumerator TestShaderTheme<T>(
-            List<List<ThemePropertyValue>> stateValues, 
+            List<List<ThemePropertyValue>> stateValues,
             params Action<MaterialPropertyBlock>[] stateTests)
             where T : InteractableThemeBase
         {
@@ -527,7 +527,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 };
             }
 
-            yield return TestTheme<T, AudioSource>(targetHost, stateValues,convertedStateTests);
+            yield return TestTheme<T, AudioSource>(targetHost, stateValues, convertedStateTests);
         }
 
         private bool AreEulerEquals(Vector3 eulerA, Vector3 eulerB)

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities/TestUtilities.cs
@@ -111,6 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 p.LookAt(Vector3.zero);
             });
         }
+
         /// <summary>
         /// Forces the playspace camera to face forward.
         /// </summary>

--- a/Assets/MixedRealityToolkit.Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MixedRealityToolkit.Tests/TestUtilities/TestUtilities.cs
@@ -231,9 +231,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [MenuItem("Mixed Reality Toolkit/Utilities/Update/Icons/Tests")]
         private static void UpdateTestScriptIcons()
         {
-            var testDirectories = MixedRealityToolkitFiles.GetDirectories(MixedRealityToolkitModuleType.Tests);
-            var directories = MixedRealityToolkitFiles.GetDirectories(MixedRealityToolkitModuleType.Tests);
-
             Texture2D icon = null;
 
             foreach (string iconPath in MixedRealityToolkitFiles.GetFiles("StandardAssets/Icons"))
@@ -250,6 +247,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 Debug.Log("Couldn't find test icon.");
                 return;
             }
+            
+            IEnumerable<string> testDirectories = MixedRealityToolkitFiles.GetDirectories(MixedRealityToolkitModuleType.Tests);
 
             foreach (string directory in testDirectories)
             {

--- a/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/ServiceInspectors/ServiceFacadeInspector.cs
@@ -32,41 +32,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 #endif
         }
 
-        private static List<string> dataProviderList = new List<string>();
-        private static Dictionary<Type, Type> inspectorTypeLookup = new Dictionary<Type, Type>();
-        private static Dictionary<Type, IMixedRealityServiceInspector> inspectorInstanceLookup = new Dictionary<Type, IMixedRealityServiceInspector>();
+        private static readonly List<string> dataProviderList = new List<string>();
+        private static readonly Dictionary<Type, Type> inspectorTypeLookup = new Dictionary<Type, Type>();
+        private static readonly Dictionary<Type, IMixedRealityServiceInspector> inspectorInstanceLookup = new Dictionary<Type, IMixedRealityServiceInspector>();
         private static bool initializedServiceInspectorLookup = false;
 
-        Color proHeaderColor = (Color)new Color32(56, 56, 56, 255);
-        Color defaultHeaderColor = (Color)new Color32(194, 194, 194, 255);
+        private Color proHeaderColor = new Color32(56, 56, 56, 255);
+        private Color defaultHeaderColor = new Color32(194, 194, 194, 255);
 
-        const int headerXOffset = 48;
-
-        [SerializeField]
-        private Texture2D logoLightTheme = null;
-
-        [SerializeField]
-        private Texture2D logoDarkTheme = null;
-
-        protected virtual void Awake()
-        {
-            string assetPath = "StandardAssets/Textures";
-
-            if (logoLightTheme == null)
-            {
-                logoLightTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath($"{assetPath}/MRTK_Logo_Black.png"), typeof(Texture2D));
-            }
-
-            if (logoDarkTheme == null)
-            {
-                logoDarkTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath($"{assetPath}/MRTK_Logo_White.png"), typeof(Texture2D));
-            }
-        }
+        private const int headerXOffset = 48;
 
         protected override void OnHeaderGUI()
         {
             ServiceFacade facade = (ServiceFacade)target;
-            
+
             // Draw a rect over the top of the existing header label
             var labelRect = EditorGUILayout.GetControlRect(false, 0f);
             labelRect.height = EditorGUIUtility.singleLineHeight;
@@ -96,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
             }
 
             if (!MixedRealityToolkit.IsInitialized || !MixedRealityToolkit.Instance.HasActiveProfile)
-            {   
+            {
                 return;
             }
 
@@ -145,7 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         }
 
         /// <summary>
-        /// Draws the custom inspector gui for all of the service's interfaces that have custom inspectors.
+        /// Draws the custom inspector GUI for all of the service's interfaces that have custom inspectors.
         /// </summary>
         private bool DrawInspector(ServiceFacade facade)
         {
@@ -320,7 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
         }
 
         /// <summary>
-        /// Draws scene gui for facade.
+        /// Draws scene GUI for facade.
         /// </summary>
         private static void DrawSceneGUI(SceneView sceneView)
         {

--- a/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -12,7 +12,6 @@ using Object = UnityEngine.Object;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
-
     /// <summary>
     /// This class has handy inspector utilities and functions.
     /// </summary>

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -51,9 +51,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private enum SearchType
         {
             /// <summary>
-            /// This indicates
+            /// Search for a file.
             /// </summary>
             File,
+            /// <summary>
+            /// Search for a folder.
+            /// </summary>
             Folder,
         }
 
@@ -433,7 +436,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private static void TryToCreateGeneratedFolder()
         {
-            // Always add the the MixedRealityToolkit.Generated folder to Assets
+            // Always add the MixedRealityToolkit.Generated folder to Assets
             var generatedDirs = GetDirectories(MixedRealityToolkitModuleType.Generated);
             if (generatedDirs == null || !generatedDirs.Any())
             {


### PR DESCRIPTION
## Overview

In preparation for #7409, this updates all tests to load assets via GUID instead of hardcoded path. This will make our tests more robust to folder / path changes in the future, while also potentially alerting us to GUID changes that we'll need to mitigate.

## Changes
- Fixes: #7438 
