### PR TITLE
Remove unreachable code from WMRDeviceManager

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -75,11 +75,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     case MixedRealityCapability.ArticulatedHand:
                     case MixedRealityCapability.GGVHand:
                         return WindowsInputSpatial.SpatialInteractionManager.IsSourceKindSupported(WindowsInputSpatial.SpatialInteractionSourceKind.Hand);
-                        break;
 
                     case MixedRealityCapability.MotionController:
                         return WindowsInputSpatial.SpatialInteractionManager.IsSourceKindSupported(WindowsInputSpatial.SpatialInteractionSourceKind.Controller);
-                        break;
                 }
 #endif // WINDOWS_UWP
             }


### PR DESCRIPTION
## Overview

These `break`s are added after `returns`, so they're unreachable and throw warnings.

![image](https://user-images.githubusercontent.com/3580640/75585328-a911e200-5a26-11ea-8243-e20414ca5821.png)
