### PR TITLE
Fix validate themes persistence to serialized object

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
+++ b/Assets/MixedRealityToolkit.SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
@@ -94,6 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                     {
                         theme.States = states.objectReferenceValue as States;
                         theme.ValidateDefinitions();
+                        serializedObject.Update();
                     }
                 }
 


### PR DESCRIPTION
## Overview
If state objects change and themes are validated to match this new state model, the inspector needs to update it's serializedobject tracking the property.

## Changes
- Fixes: #6800

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
