### PR TITLE
Cleanup some missed usages of SetupConfiguration

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -642,7 +642,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 if (interactionSource.kind == InteractionSourceKind.Hand)
                 {
                     detectedController = new WindowsMixedRealityArticulatedHand(TrackingState.NotTracked, controllingHand, inputSource);
-                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityArticulatedHand)))
+                    if (!detectedController.Enabled)
                     {
                         // Controller failed to be setup correctly.
                         // Return null so we don't raise the source detected.
@@ -652,7 +652,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 else if (interactionSource.kind == InteractionSourceKind.Controller)
                 {
                     detectedController = new WindowsMixedRealityController(TrackingState.NotTracked, controllingHand, inputSource);
-                    if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityController)))
+                    if (!detectedController.Enabled)
                     {
                         // Controller failed to be setup correctly.
                         // Return null so we don't raise the source detected.
@@ -668,7 +668,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             else
             {
                 detectedController = new WindowsMixedRealityGGVHand(TrackingState.NotTracked, controllingHand, inputSource);
-                if (!detectedController.SetupConfiguration(typeof(WindowsMixedRealityGGVHand)))
+                if (!detectedController.Enabled)
                 {
                     // Controller failed to be setup correctly.
                     // Return null so we don't raise the source detected.

--- a/Assets/MixedRealityToolkit/Providers/BaseController.cs
+++ b/Assets/MixedRealityToolkit/Providers/BaseController.cs
@@ -148,10 +148,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Sets up the configuration based on the Mixed Reality Controller Mapping Profile.
         /// </summary>
-        [Obsolete("The second parameter is no longer used. This method now reads from the controller's input source.")]
+        [Obsolete("This method is no longer used. Configuration now happens in the constructor. You can check this controller's Enabled property for configuration state.")]
         public bool SetupConfiguration(Type controllerType, InputSourceType inputSourceType = InputSourceType.Controller)
         {
-            return SetupConfiguration(controllerType);
+            // If the constructor succeeded in finding interactions, Enabled will be true.
+            return Enabled;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview

#7375 deprecated `SetupConfiguration` from the BaseController class, but not all instances were properly cleaned up. This PR removes those remaining instances.

It also updates the previously deprecated `SetupConfiguration` method signature (https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6653) to point to `Enabled` instead of the other deprecated method.