### PR TITLE
Update adapter version in WSA.Player.Template.props.template

### DIFF
--- a/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.Player.Template.props.template
+++ b/Assets/MixedRealityToolkit.Tools/MSBuild/MSBuildMRTKTemplates/WSA.Player.Template.props.template
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DotNetWinRTVersion>0.5.1037</DotNetWinRTVersion>
+    <DotNetWinRTVersion>0.5.1045</DotNetWinRTVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="$(DotNetWinRTVersion)" ExcludeAssets="Compile" />


### PR DESCRIPTION
## Overview

This was previously updated in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7267 but this template wasn't changed. It doesn't cause problems, since MRTK didn't need to be built against a newer version, but we should keep it up to date.