### PR TITLE
Clean up warnings in PointerClickHandler

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/PointerClickHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/PointerClickHandler.cs
@@ -15,15 +15,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         [SerializeField]
         [Tooltip("The input actions to be recognized on pointer up.")]
-        private InputActionEventPair onPointerUpActionEvent;
+        private InputActionEventPair onPointerUpActionEvent = default(InputActionEventPair);
 
         [SerializeField]
         [Tooltip("The input actions to be recognized on pointer down.")]
-        private InputActionEventPair onPointerDownActionEvent;
+        private InputActionEventPair onPointerDownActionEvent = default(InputActionEventPair);
 
         [SerializeField]
         [Tooltip("The input actions to be recognized on pointer clicked.")]
-        private InputActionEventPair onPointerClickedActionEvent;
+        private InputActionEventPair onPointerClickedActionEvent = default(InputActionEventPair);
 
         private void Awake()
         {


### PR DESCRIPTION
## Overview

Although this script is deprecated, it's currently throwing some build warnings:

![image](https://user-images.githubusercontent.com/3580640/75732312-03b97100-5ca7-11ea-957b-064ea31c3038.png)

This PR fixes them up.