### PR TITLE
Cherry-pick #7205 to 2.2.1

### DIFF
--- a/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
+++ b/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityUtilities.cs
@@ -62,20 +62,23 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         {
             get
             {
-#if ENABLE_DOTNET
-                return spatialCoordinateSystem ?? (spatialCoordinateSystem = GetSpatialCoordinateSystem(WorldManager.GetNativeISpatialCoordinateSystemPtr()));
-#elif WINDOWS_UWP
-                return spatialCoordinateSystem ?? (spatialCoordinateSystem = Marshal.GetObjectForIUnknown(WorldManager.GetNativeISpatialCoordinateSystemPtr()) as SpatialCoordinateSystem);
-#elif DOTNETWINRT_PRESENT
-                var spatialCoordinateSystemPtr = WorldManager.GetNativeISpatialCoordinateSystemPtr();
-                if (spatialCoordinateSystem == null && spatialCoordinateSystemPtr != IntPtr.Zero)
+                IntPtr newSpatialCoordinateSystemPtr = WorldManager.GetNativeISpatialCoordinateSystemPtr();
+                if (newSpatialCoordinateSystemPtr != currentSpatialCoordinateSystemPtr && newSpatialCoordinateSystemPtr != IntPtr.Zero)
                 {
-                    spatialCoordinateSystem = SpatialCoordinateSystem.FromNativePtr(WorldManager.GetNativeISpatialCoordinateSystemPtr());
+#if ENABLE_DOTNET
+                    spatialCoordinateSystem = GetSpatialCoordinateSystem(newSpatialCoordinateSystemPtr);
+#elif WINDOWS_UWP
+                    spatialCoordinateSystem = Marshal.GetObjectForIUnknown(newSpatialCoordinateSystemPtr) as SpatialCoordinateSystem;
+#elif DOTNETWINRT_PRESENT
+                    spatialCoordinateSystem = SpatialCoordinateSystem.FromNativePtr(newSpatialCoordinateSystemPtr);
+#endif
+                    currentSpatialCoordinateSystemPtr = newSpatialCoordinateSystemPtr;
                 }
                 return spatialCoordinateSystem;
-#endif
             }
         }
+
+        private static IntPtr currentSpatialCoordinateSystemPtr = IntPtr.Zero;
 
         /// <summary>
         /// Access the underlying native current holographic frame.


### PR DESCRIPTION
## Overview

Instead of assuming only one SpatialCoordinateSystem will ever exist, this change checks the `IntPtr`s to detect when the underlying root coordinate system has changed.

This helps scenarios like recentering, when a dev / user wants to realign the experience in a specific alignment. Can also help in scenarios when tracking is list and the original coordinate system is never regained. Also helps in the scenario when a new scene is loaded.

Note: This PR is going into an upcoming hotfix release of 2.2. It is already fixed in the current release of 2.3.

## Changes
- Fixes: #6974 