### PR TITLE
Add null checks for gazeProviderPointingData

### DIFF
--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -569,7 +569,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 hitResultUi.Clear();
                 RaycastGraphics(gazeProviderPointingData.Pointer, gazeProviderPointingData.GraphicEventData, prioritizedLayerMasks, hitResultUi);
 
-                // set gaze hit according to distance and priorization layer mask
+                // set gaze hit according to distance and prioritization layer mask
                 gazeHitResult = GetPrioritizedHitResult(hitResult3d, hitResultUi, prioritizedLayerMasks);
             }
 
@@ -1452,7 +1452,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
         #endregion
 
-
         #region IPointerPreferences Implementation
         private List<PointerPreferences> customPointerBehaviors = new List<PointerPreferences>();
 
@@ -1582,6 +1581,5 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
         #endregion
-
     }
 }

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -551,21 +551,28 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             // The gaze hit result may be populated from previous raycasts this frame, only recompute
             // another raycast if it's not populated
-            if (gazeHitResult == null && gazeProviderPointingData != null)
+            if (gazeHitResult == null)
             {
-                // get 3d hit
-                hitResult3d.Clear();
-                var raycastProvider = CoreServices.InputSystem.RaycastProvider;
-                LayerMask[] prioritizedLayerMasks = (gazeProviderPointingData.Pointer.PrioritizedLayerMasksOverride ?? FocusLayerMasks);
-                QueryScene(gazeProviderPointingData.Pointer, raycastProvider, prioritizedLayerMasks,
-                    hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
+                if (gazeProviderPointingData != null)
+                {
+                    // get 3d hit
+                    hitResult3d.Clear();
+                    var raycastProvider = CoreServices.InputSystem.RaycastProvider;
+                    LayerMask[] prioritizedLayerMasks = (gazeProviderPointingData.Pointer.PrioritizedLayerMasksOverride ?? FocusLayerMasks);
+                    QueryScene(gazeProviderPointingData.Pointer, raycastProvider, prioritizedLayerMasks,
+                        hitResult3d, maxQuerySceneResults, focusIndividualCompoundCollider);
 
-                // get ui hit
-                hitResultUi.Clear();
-                RaycastGraphics(gazeProviderPointingData.Pointer, gazeProviderPointingData.GraphicEventData, prioritizedLayerMasks, hitResultUi);
+                    // get ui hit
+                    hitResultUi.Clear();
+                    RaycastGraphics(gazeProviderPointingData.Pointer, gazeProviderPointingData.GraphicEventData, prioritizedLayerMasks, hitResultUi);
 
-                // set gaze hit according to distance and prioritization layer mask
-                gazeHitResult = GetPrioritizedHitResult(hitResult3d, hitResultUi, prioritizedLayerMasks);
+                    // set gaze hit according to distance and prioritization layer mask
+                    gazeHitResult = GetPrioritizedHitResult(hitResult3d, hitResultUi, prioritizedLayerMasks);
+                }
+                else
+                {
+                    return;
+                }
             }
 
             CoreServices.InputSystem.GazeProvider.UpdateGazeInfoFromHit(gazeHitResult.raycastHit);

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -538,12 +538,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (!IsSetupValid) { return; }
 
             UpdatePointers();
-
-            if (gazeProviderPointingData?.Pointer != null)
-            {
-                UpdateGazeProvider();
-            }
-
+            UpdateGazeProvider();
             UpdateFocusedObjects();
 
             PrimaryPointer = primaryPointerSelector?.Update();

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -553,7 +553,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // another raycast if it's not populated
             if (gazeHitResult == null)
             {
-                if (gazeProviderPointingData != null)
+                if (gazeProviderPointingData?.Pointer != null)
                 {
                     // get 3d hit
                     hitResult3d.Clear();

--- a/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
+++ b/Assets/MixedRealityToolkit.Services/InputSystem/FocusProvider.cs
@@ -556,7 +556,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             // The gaze hit result may be populated from previous raycasts this frame, only recompute
             // another raycast if it's not populated
-            if (gazeHitResult == null)
+            if (gazeHitResult == null && gazeProviderPointingData != null)
             {
                 // get 3d hit
                 hitResult3d.Clear();
@@ -1006,7 +1006,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     pointerData.UpdateHit(hit);
 
                     // set gaze hit result - make sure to include unity ui hits
-                    if (pointerData.Pointer.PointerId == gazeProviderPointingData.Pointer.PointerId)
+                    if (gazeProviderPointingData?.Pointer != null && pointerData.Pointer.PointerId == gazeProviderPointingData.Pointer.PointerId)
                     {
                         gazeHitResult = hit;
                     }
@@ -1423,7 +1423,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             for (var i = 0; i < eventData.InputSource.Pointers.Length; i++)
             {
                 // Special unregistration for Gaze
-                if (gazeProviderPointingData != null && eventData.InputSource.Pointers[i].PointerId == gazeProviderPointingData.Pointer.PointerId)
+                if (gazeProviderPointingData?.Pointer != null && eventData.InputSource.Pointers[i].PointerId == gazeProviderPointingData.Pointer.PointerId)
                 {
                     // If the source lost is the gaze input source, then reset it.
                     if (eventData.InputSource.SourceId == CoreServices.InputSystem.GazeProvider?.GazeInputSource.SourceId)

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -386,6 +386,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Ensures the focus provider runs its update loop properly without a gaze provider.
+        /// Also tests that a gaze provider can successfully be cleaned up at runtime.
         /// </summary>
         [UnityTest]
         public IEnumerator TestFocusProviderWithoutGaze()

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -385,6 +385,36 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsNull(shellHandRayPointer.Result?.CurrentPointerTarget, $"{noPriorityCube.name} should NOT be raycast target by shell hand ray pointer");
         }
 
+        /// <summary>
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestFocusProviderWithoutGaze()
+        {
+            IMixedRealityInputSystem inputSystem = PlayModeTestUtilities.GetInputSystem();
+            yield return null;
+
+            InputSimulationService inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+            yield return null;
+
+            // Put up a hand to ensure there's a second pointer, which will keep the FocusProvider UpdatePointers loop spinning
+            yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService);
+
+            // Verify that the GazeProvider exists at the start
+            Assert.IsTrue(inputSystem.GazeProvider as MonoBehaviour != null, "Gaze provider should exist at start");
+            yield return null;
+
+            // Destroy the GazeProvider
+            Object.Destroy(inputSystem.GazeProvider as MonoBehaviour);
+            yield return null;
+
+            // Verify that the GazeProvider no longer exists
+            Assert.IsTrue(inputSystem.GazeProvider as MonoBehaviour == null, "Gaze provider should no longer exist");
+            yield return null;
+
+            // Hide the hand for other tests
+            yield return PlayModeTestUtilities.HideHand(Handedness.Right, inputSimulationService);
+        }
+
         private static GameObject CreateTestCube(Vector3 position, float scale = 0.2f)
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/FocusProviderTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test that the gaze cursor behaves properly with articulated hand pointers.
         /// </summary>
         [UnityTest]
         public IEnumerator TestGazeCursorArticulated()
@@ -72,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         /// <summary>
         /// Ensure that the gaze provider hit result is not null when looking at an object,
-        /// even when the hand is up
+        /// even when the hand is up.
         /// </summary>
         [UnityTest]
         public IEnumerator TestGazeProviderTargetNotNull()


### PR DESCRIPTION
## Overview

This change is needed since the gaze provider isn't a required pointer. Some scenarios need to support the lack of a gaze pointer.

In those cases, this pointing data is never initialized and can null ref in a few spots.

## Changes
- Fixes: #7427 