### PR TITLE
Add RequireComponent to CursorContextManipulationHandler

### DIFF
--- a/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/CursorContextManipulationHandler.cs
+++ b/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/CursorContextManipulationHandler.cs
@@ -2,13 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Physics;
-using Microsoft.MixedReality.Toolkit.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -16,6 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// This script provides cursor context for the manipulation handler
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/CursorContextManipulationHandler")]
+    [RequireComponent(typeof(ManipulationHandler))]
     public class CursorContextManipulationHandler : MonoBehaviour
     {
         private ManipulationHandler manipulationHandler;

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -273,8 +273,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
             VerifyCursorContextFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorContextEnum.MoveCross);
 
-            Object.Destroy(manipulationHandler);
             Object.Destroy(cursorContextManipulationHandler);
+            Object.Destroy(manipulationHandler);
         }
 
         [UnityTest]

--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/BaseCursorTests.cs
@@ -226,8 +226,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return new WaitForFixedUpdate();
             yield return null;
 
-            cube.AddComponent<ManipulationHandler>();
-            var temp = cube.AddComponent<CursorContextManipulationHandler>();
+            ManipulationHandler manipulationHandler = cube.AddComponent<ManipulationHandler>();
+            CursorContextManipulationHandler cursorContextManipulationHandler = cube.AddComponent<CursorContextManipulationHandler>();
             yield return new WaitForFixedUpdate();
             yield return null;
 
@@ -273,8 +273,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
             VerifyCursorContextFromPointers(inputSystem.FocusProvider.GetPointers<ShellHandRayPointer>(), CursorContextEnum.MoveCross);
 
-            Object.Destroy(cube.GetComponent<ManipulationHandler>());
-            Object.Destroy(cube.GetComponent<CursorContextManipulationHandler>());
+            Object.Destroy(manipulationHandler);
+            Object.Destroy(cursorContextManipulationHandler);
         }
 
         [UnityTest]


### PR DESCRIPTION
## Overview

This will prevent the migration step from running, as of https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7244.

This fixes the case where this script assumed the presence of ManipulationHandler. I chose this fix over `EnsureComponent`, because we have existing code that prevents migration based on `RequireComponent`.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7465
