### PR TITLE
Fixing Solver Tests Which Fail Locally

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/PlayModeTests/SolverTests.cs
@@ -479,8 +479,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(CameraCache.Main.transform.position.x, tapToPlaceObj.target.transform.position.x, "The tap to place object position.x does not match the camera position.x");
 
             // Tap to place has a 0.5 sec timer between clicks to make sure a double click does not get registered
-            // We need to wait at least 30 frames until another click is called or tap to place will ignore the action
-            yield return WaitForFrames(30);
+            // We need to wait at least 0.5 secs until another click is called or tap to place will ignore the action
+            yield return new WaitForSeconds(0.5f);
 
             // Click object to stop placement
             yield return leftHand.Click();
@@ -538,8 +538,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.True(initialObjPosition != tapToPlaceObj.target.transform.position);
 
             // Tap to place has a 0.5 sec timer between clicks to make sure a double click does not get registered
-            // We need to wait at least 30 frames until another click is called or tap to place will ignore the action
-            yield return WaitForFrames(30);
+            // We need to wait at least 0.5 secs until another click is called or tap to place will ignore the action
+            yield return new WaitForSeconds(0.5f);
 
             // Click to stop the placement
             yield return leftHand.Click();


### PR DESCRIPTION
## Overview

A handful of tests fail locally for me, and not within our Azure pipeline. These two solver tests appear to fail due to the assumption that the test runner runs at 60fps. I'm not actually sure if the test runner runs at a certain vsync or as fast as it can? Anyway, changing two waits to be frame rate independent.

Before:
![before](https://user-images.githubusercontent.com/13305729/75846119-23789400-5d90-11ea-8e41-8c42b3b674ae.PNG)

After:
![after](https://user-images.githubusercontent.com/13305729/75846122-24a9c100-5d90-11ea-9d39-22453e67452d.PNG)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7483 (partially)

## Verification
Please run the test runner locally.

>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
