### PR TITLE
Add check EyesPose.IsSupported to only call APIs when supported

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -64,6 +64,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 "Windows.UI.Input.Spatial",
                 "SpatialPointerPose",
                 "Eyes");
+
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+            if (eyesApiAvailable)
+            {
+                eyesApiAvailable &= EyesPose.IsSupported();
+            }
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 
         public bool SmoothEyeTracking { get; set; } = false;
@@ -96,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             if (eyesApiAvailable)
             {
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-                return (capability == MixedRealityCapability.EyeTracking) && EyesPose.IsSupported();
+                return (capability == MixedRealityCapability.EyeTracking);
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             }
 
@@ -180,7 +187,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// </summary>
         private async void AskForETPermission()
         {
-            if (!askedForETAccessAlready)  // Making sure this is only triggered once
+            if (!askedForETAccessAlready) // Making sure this is only triggered once
             {
                 askedForETAccessAlready = true;
                 await EyesPose.RequestAccessAsync();
@@ -249,7 +256,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 smoothedGaze.direction = newGaze.Value.direction;
                 smoothedGaze.origin = newGaze.Value.origin;
                 confidenceOfSaccade = 0;
-                isSaccading = false;
             }
             else
             {


### PR DESCRIPTION
## Overview

Even if the API is present, it's possible eye tracking isn't actually supported on the current device. This ensures we don't actually call the APIs unless they're both present and supported.

@jwittner it'd be good if you can test this in your scenario! I wasn't able to repro your stack exactly, but did see other exceptions in your same scenario that this fixes.

## Changes
- Fixes: #7482 
