### PR TITLE
Update UnityAR nuspec based on the new path depth

### DIFF
--- a/Assets/MRTK/Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
+++ b/Assets/MRTK/Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
@@ -24,9 +24,9 @@
     <file src="**" exclude="*.nuspec;*.nuspec.meta;*.props;*.props.meta;*.targets;*.targets.meta" target="MRTK\" />
 
     <!-- Reuse MixedReality.Toolkit.targets, as the MSBuild logic is the same for all MRTK nuget packages. -->
-    <file src="..\..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Providers.UnityAR.targets" />
+    <file src="..\..\..\MixedRealityToolkit\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Providers.UnityAR.targets" />
 
-    <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR.*" target="Plugins\" />
+    <file src="..\..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR.*" target="Plugins\" />
     <!-- The following line is commented out because of a path length issue -->
     <!-- <file src="..\..\..\..\Assets\MixedRealityToolkit.Providers\UnityAR\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\MixedRealityToolkit.Providers\UnityAR" /> -->
   </files>


### PR DESCRIPTION
This change fixes the CI NuGet packaging step that was broken by moving the Providers packages down a level in the folder heirarchy (#7491)