### PR TITLE
Remove incorrect obsolete from WindowsSpeechInputProvider

### DIFF
--- a/Assets/MRTK/Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -46,7 +46,6 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="name">Friendly name of the service.</param>
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
-        [Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
         public WindowsSpeechInputProvider(
             IMixedRealityInputSystem inputSystem,
             string name = null,


### PR DESCRIPTION
## Overview

When the registrar was removed from the constructor in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6457, it looks like the new constructor was accidentally also marked with `Obsolete`. This PR removes that. The old constructor is still obsolete.