### PR TITLE
Optimize Mesh Data Project Configurator

### DIFF
--- a/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MixedRealityToolkit/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             { MRConfig.EnableMSBuildForUnity, true },
 #endif // !UNITY_2019_3_OR_NEWER
+            { MRConfig.OptimizeMeshData, true },
             // UWP Capabilities
             { MRConfig.MicrophoneCapability, true },
             { MRConfig.InternetClientCapability, true },
@@ -180,6 +181,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path");
 #endif // UNITY_2019_3_OR_NEWER
                 RenderToggle(MRConfig.SpatialAwarenessLayer, "Set default Spatial Awareness layer");
+                EditorGUILayout.HelpBox("The \"Optimize Mesh Data\" player setting can drastically increase build times. It is recommended to disable this setting during development and re-enable during final build creation.", MessageType.Info);
+                RenderToggle(MRConfig.OptimizeMeshData, "Disable Optimize Mesh Data");
+
                 EditorGUILayout.Space();
 
                 if (MixedRealityOptimizeUtils.IsBuildTargetUWP())

--- a/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MixedRealityToolkit/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -33,6 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             SinglePassInstancing,
             SpatialAwarenessLayer,
             EnableMSBuildForUnity,
+            OptimizeMeshData,
 
             // WSA Capabilities
             SpatialPerceptionCapability = 1000,
@@ -105,6 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             { Configurations.EnableMSBuildForUnity, new ConfigGetter(() => { return PackageManifestUpdater.IsMSBuildForUnityEnabled(); }, BuildTarget.WSAPlayer) },
 #endif // !UNITY_2019_3_OR_NEWER
+            { Configurations.OptimizeMeshData, new ConfigGetter(() => { return !PlayerSettings.stripUnusedMeshComponents; }) },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability, new ConfigGetter(() => { return GetCapability(PlayerSettings.WSACapability.SpatialPerception); }, BuildTarget.WSAPlayer) },
@@ -143,6 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             { Configurations.EnableMSBuildForUnity, () => { PackageManifestUpdater.EnsureMSBuildForUnity(); } },
 #endif // !UNITY_2019_3_OR_NEWER
+            { Configurations.OptimizeMeshData,  () => { PlayerSettings.stripUnusedMeshComponents = false; } },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => { PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true); } },


### PR DESCRIPTION
## Overview

The project configurator now warns against optimizing mesh data during development.

![image](https://user-images.githubusercontent.com/13305729/76343574-8b156e80-62bd-11ea-84cc-95b8f2c719ba.png)

I've heard this brought up by a few community members, but was never able to reproduce this within the MRTK Unity project. Build times in current _mrtk_development_:

```
Compiled shader 'Mixed Reality Toolkit/Standard' in 6.47s
    d3d11 (total internal programs: 21504, unique: 7168)
```


But, I opened a project  the other day and did encounter an issue with shader compilation taking upward of 5 minutes. After doing some poking around I narrowed the issue down to the "Optimize Mesh Data" in the player settings.

If you need this setting, I would recommend disabling it while iterating on your application and only enabling it when you go to make final builds. The "Optimize Mesh Data" settings tries to remove unused vertex attributes within your application. It does this by **running over every shader pass in every material that is on every mesh in the build. (You can see why this would take awhile in mid to large size projects.)**

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6629 (partially)

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
