### PR TITLE
Reset IsEyeCalibrationValid to null if no data for determining is available

### DIFF
--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
@@ -50,6 +50,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         /// <param name="provider">The provider raising the event.</param>
         /// <param name="userIsEyeCalibrated">Boolean whether the user is eye calibrated or not.</param>
-        void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool userIsEyeCalibrated);
+        void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool? userIsEyeCalibrated);
     }
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -136,8 +136,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             if (WindowsMixedRealityUtilities.SpatialCoordinateSystem == null || !eyesApiAvailable)
             {
+                Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, null);
                 return;
             }
+
+            bool? isCalibrationValid = null;
 
             SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(WindowsMixedRealityUtilities.SpatialCoordinateSystem, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
             if (pointerPose != null)
@@ -145,8 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 var eyes = pointerPose.Eyes;
                 if (eyes != null)
                 {
-                    Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
-
+                    isCalibrationValid = eyes.IsCalibrationValid;
                     if (eyes.Gaze.HasValue)
                     {
                         Ray newGaze = new Ray(eyes.Gaze.Value.Origin.ToUnityVector3(), eyes.Gaze.Value.Direction.ToUnityVector3());
@@ -160,6 +162,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                 }
             }
+
+            Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, isCalibrationValid);
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -544,7 +544,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Timestamp = timestamp;
         }
 
-        public void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool userIsEyeCalibrated)
+        public void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool? userIsEyeCalibrated)
         {
             this.IsEyeCalibrationValid = userIsEyeCalibrated;
         }


### PR DESCRIPTION
## Overview
Right now if a device loses the users eyes, the calibration status remains unchanged until eyes are again found. By resetting the `bool?` back to null if no eyes can be found developers can respond to eye lost status changes.

## Changes
Resets EyeCalibrationIsValid to null if there is no eye data available to indicate validity.