### PR TITLE
Data gets converted only when accessed

### DIFF
--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
@@ -16,14 +16,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Response body from the resource.
         /// </summary>
-        public string ResponseBody => cachedResponseBody ?? (cachedResponseBody = responseBodyAction?.Invoke());
-        private string cachedResponseBody;
+        public string ResponseBody => responseBody ?? (responseBody = responseBodyAction?.Invoke());
+        private string responseBody;
         private System.Func<string> responseBodyAction;
 
         /// <summary>
         /// Response data from the resource.
         /// </summary>
-        public byte[] ResponseData => responseDataAction?.Invoke();
+        public byte[] ResponseData => responseData ?? (responseData = responseDataAction?.Invoke());
+        private byte[] responseData;
         private System.Func<byte[]> responseDataAction;
 
         /// <summary>
@@ -37,9 +38,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public Response(bool successful, string responseBody, byte[] responseData, long responseCode)
         {
             Successful = successful;
-            responseBodyAction = responseBody == null ? null : (System.Func<string>)(() => responseBody);
-            cachedResponseBody = null;
-            responseDataAction = responseData == null ? null : (System.Func<byte[]>)(() => responseData);
+            responseBodyAction = null;
+            this.responseBody = responseBody;
+            responseDataAction = null;
+            this.responseData = responseData;
             ResponseCode = responseCode;
         }
 
@@ -47,8 +49,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             Successful = successful;
             this.responseBodyAction = responseBodyAction;
-            cachedResponseBody = null;
+            responseBody = null;
             this.responseDataAction = responseDataAction;
+            responseData = null;
             ResponseCode = responseCode;
         }
     }

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
@@ -16,12 +16,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Response body from the resource.
         /// </summary>
-        public string ResponseBody { get; }
+        public string ResponseBody => responseBodyAction?.Invoke();
+        private System.Func<string> responseBodyAction;
 
         /// <summary>
         /// Response data from the resource.
         /// </summary>
-        public byte[] ResponseData { get; }
+        public byte[] ResponseData => responseDataAction?.Invoke();
+        private System.Func<byte[]> responseDataAction;
 
         /// <summary>
         /// Response code from the resource.
@@ -34,8 +36,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public Response(bool successful, string responseBody, byte[] responseData, long responseCode)
         {
             Successful = successful;
-            ResponseBody = responseBody;
-            ResponseData = responseData;
+            responseBodyAction = responseBody == null ? null : (System.Func<string>)(() => responseBody);
+            responseDataAction = responseData == null ? null : (System.Func<byte[]>)(() => responseData);
+            ResponseCode = responseCode;
+        }
+
+        public Response(bool successful, System.Func<string> responseBodyAction, System.Func<byte[]> responseDataAction, long responseCode)
+        {
+            Successful = successful;
+            this.responseBodyAction = responseBodyAction;
+            this.responseDataAction = responseDataAction;
             ResponseCode = responseCode;
         }
     }

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
@@ -16,7 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Response body from the resource.
         /// </summary>
-        public string ResponseBody => responseBodyAction?.Invoke();
+        public string ResponseBody => cachedString ?? (cachedString = responseBodyAction?.Invoke());
+        private string cachedString;
         private System.Func<string> responseBodyAction;
 
         /// <summary>
@@ -37,6 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             Successful = successful;
             responseBodyAction = responseBody == null ? null : (System.Func<string>)(() => responseBody);
+            cachedString = null;
             responseDataAction = responseData == null ? null : (System.Func<byte[]>)(() => responseData);
             ResponseCode = responseCode;
         }
@@ -45,6 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             Successful = successful;
             this.responseBodyAction = responseBodyAction;
+            cachedString = null;
             this.responseDataAction = responseDataAction;
             ResponseCode = responseCode;
         }

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Response.cs
@@ -16,8 +16,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Response body from the resource.
         /// </summary>
-        public string ResponseBody => cachedString ?? (cachedString = responseBodyAction?.Invoke());
-        private string cachedString;
+        public string ResponseBody => cachedResponseBody ?? (cachedResponseBody = responseBodyAction?.Invoke());
+        private string cachedResponseBody;
         private System.Func<string> responseBodyAction;
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             Successful = successful;
             responseBodyAction = responseBody == null ? null : (System.Func<string>)(() => responseBody);
-            cachedString = null;
+            cachedResponseBody = null;
             responseDataAction = responseData == null ? null : (System.Func<byte[]>)(() => responseData);
             ResponseCode = responseCode;
         }
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             Successful = successful;
             this.responseBodyAction = responseBodyAction;
-            cachedString = null;
+            cachedResponseBody = null;
             this.responseDataAction = responseDataAction;
             ResponseCode = responseCode;
         }

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
@@ -243,8 +243,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 }
 
                 string responseHeaders = webRequest.GetResponseHeaders().Aggregate(string.Empty, (current, header) => $"\n{header.Key}: {header.Value}");
-                Debug.LogError($"REST Error: {webRequest.responseCode}\n{webRequest.downloadHandler?.text}{responseHeaders}");
-                return new Response(false, () => $"{responseHeaders}\n{webRequest.downloadHandler?.text}", () => webRequest.downloadHandler?.data, webRequest.responseCode);
+                string downloadHandlerText = webRequest.downloadHandler?.text;
+                Debug.LogError($"REST Error: {webRequest.responseCode}\n{downloadHandlerText}{responseHeaders}");
+                return new Response(false, $"{responseHeaders}\n{downloadHandlerText}", webRequest.downloadHandler?.data, webRequest.responseCode);
             }
 
             return new Response(true, () => webRequest.downloadHandler?.text, () => webRequest.downloadHandler?.data, webRequest.responseCode);

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
@@ -244,10 +244,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
                 string responseHeaders = webRequest.GetResponseHeaders().Aggregate(string.Empty, (current, header) => $"\n{header.Key}: {header.Value}");
                 Debug.LogError($"REST Error: {webRequest.responseCode}\n{webRequest.downloadHandler?.text}{responseHeaders}");
-                return new Response(false, $"{responseHeaders}\n{webRequest.downloadHandler?.text}", webRequest.downloadHandler?.data, webRequest.responseCode);
+                return new Response(false, () => $"{responseHeaders}\n{webRequest.downloadHandler?.text}", () => webRequest.downloadHandler?.data, webRequest.responseCode);
             }
 
-            return new Response(true, webRequest.downloadHandler?.text, webRequest.downloadHandler?.data, webRequest.responseCode);
+            return new Response(true, () => webRequest.downloadHandler?.text, () => webRequest.downloadHandler?.data, webRequest.responseCode);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -859,10 +859,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
                 string responseHeaders = webRequest.GetResponseHeaders().Aggregate(string.Empty, (current, header) => $"\n{header.Key}: {header.Value}");
                 Debug.LogError($"REST Auth Error: {webRequest.responseCode}\n{webRequest.downloadHandler?.text}{responseHeaders}");
-                return new Response(false, webRequest.downloadHandler?.text, webRequest.downloadHandler?.data, webRequest.responseCode);
+                return new Response(false, () => webRequest.downloadHandler?.text, () => webRequest.downloadHandler?.data, webRequest.responseCode);
             }
 
-            return new Response(true, webRequest.GetResponseHeader("Set-Cookie"), webRequest.downloadHandler?.data, webRequest.responseCode);
+            return new Response(true, () => webRequest.GetResponseHeader("Set-Cookie"), () => webRequest.downloadHandler?.data, webRequest.responseCode);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -858,8 +858,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 }
 
                 string responseHeaders = webRequest.GetResponseHeaders().Aggregate(string.Empty, (current, header) => $"\n{header.Key}: {header.Value}");
-                Debug.LogError($"REST Auth Error: {webRequest.responseCode}\n{webRequest.downloadHandler?.text}{responseHeaders}");
-                return new Response(false, () => webRequest.downloadHandler?.text, () => webRequest.downloadHandler?.data, webRequest.responseCode);
+                string downloadHandlerText = webRequest.downloadHandler?.text;
+                Debug.LogError($"REST Auth Error: {webRequest.responseCode}\n{downloadHandlerText}{responseHeaders}");
+                return new Response(false, $"{downloadHandlerText}", webRequest.downloadHandler?.data, webRequest.responseCode);
             }
 
             return new Response(true, () => webRequest.GetResponseHeader("Set-Cookie"), () => webRequest.downloadHandler?.data, webRequest.responseCode);


### PR DESCRIPTION
## Overview
The DownloadHandler performs data conversion in the case of accessing its text property.
For requests not using it, that's unnecessary CPU and garbage.
The PR moves the access into the Response, where executed only when needed.

## Changes
- Fixes: #7526