### PR TITLE
Update documentation to reflect the new MRTK folder hierarchy

### DIFF
--- a/Documentation/Architecture/InputSystem/ControllersPointersAndFocus.md
+++ b/Documentation/Architecture/InputSystem/ControllersPointersAndFocus.md
@@ -43,7 +43,7 @@ Because a single controller can have multiple pointers (for example, the articul
 For example, as the user’s hand approaches a pressable button, the [`ShellHandRayPointer`](xref:Microsoft.MixedReality.Toolkit.Input.ShellHandRayPointer) should stop showing, and the [`PokePointer`](xref:Microsoft.MixedReality.Toolkit.Input.PokePointer) should be engaged.
 
 This is handled by the [`DefaultPointerMediator`](xref:Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator),
-which is responsible for determining which pointers are active, based on the state of all pointers. One of the key things this does is [disable far pointers when a near pointer is close to an object](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs#L127).
+which is responsible for determining which pointers are active, based on the state of all pointers. One of the key things this does is disable far pointers when a near pointer is close to an object (please see [`DefaultPointerMediator`](xref:Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator)).
 
 It's possible to provide an alternate implementation of the pointer mediator by changing the [`PointerMediator`](xref:Microsoft.MixedReality.Toolkit.Input.MixedRealityPointerProfile.PointerMediator) property on the pointer profile.
 

--- a/Documentation/Architecture/InputSystem/CoreSystem.md
+++ b/Documentation/Architecture/InputSystem/CoreSystem.md
@@ -8,11 +8,8 @@ At the heart of the input system is the [InputSystem](../../Input/Overview.md), 
 
 This service is responsible for:
 
-- Reading the [input system profile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit/Definitions/InputSystem/MixedRealityInputSystemProfile.cs)
-- Starting the various device managers (for example, [OpenVR](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Providers/OpenVR/OpenVRDeviceManager.cs),
-  [Windows Mixed Reality](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs),
-  [Unity Touch](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit/Providers/UnityInput/UnityTouchDeviceManager.cs)).
-  The set of device managers that are instantiated is configured by the input system profile.
+- Reading the [input system profile](../../MixedRealityConfigurationGuide.md#input-system-settings)
+- Starting the configured [data providers](../../Input/InputProviders.md) (for example, `Windows Mixed Reality Device Manager` and `OpenVR Device Manager`).
 - Instantiation of the [GazeProvider](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityGazeProvider), which is a component that is responsible for providing HoloLens (1st generation) style head gaze information
   in addition to HoloLens 2 style eye gaze information.
 - Instantiation of the [FocusProvider](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityFocusProvider), which is a component that is responsible for determining objects that have focus. This
@@ -70,7 +67,7 @@ The basic flow of a device manager involves:
 
 1. The device manager is instantiated by the input system service.
 2. The device manager registers with its underlying system (for example, the Windows Mixed Reality
-   device manager will register for [gesture and interaction events](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealityDeviceManager.cs#L651)).
+   device manager will register for [input](../../Input/InputEvents.md) and [gesture](../../Input/Gestures.md#gesture-events) events.
 3. It creates controllers that it discovers from the underlying system (for example
    the provider could detect the presence of articulated hands)
 4. In its Update() loop, call UpdateController() to poll for the new state of the underlying system

--- a/Documentation/Boundary/BoundarySystemGettingStarted.md
+++ b/Documentation/Boundary/BoundarySystemGettingStarted.md
@@ -40,7 +40,7 @@ The [Boundary System uses a configuration profile](ConfiguringBoundaryVisualizat
 ![Boundary Visualization Options](../../Documentation/Images/Boundary/BoundaryVisualizationProfile.png)
 
 > [!NOTE]
-> Users of the default profile ([DefaultMixedRealityBoundaryVisualizationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityBoundaryVisualizationProfile.asset)) will have the boundary system pre-configured to display a floor plane, the play area and the tracked area.
+> Users of the default profile, `DefaultMixedRealityBoundaryVisualizationProfile` (Assets/MRTK/SDK/Profiles) will have the boundary system pre-configured to display a floor plane, the play area and the tracked area.
 
 ## Build and deploy
 

--- a/Documentation/CameraSystem/CreateSettingsProvider.md
+++ b/Documentation/CameraSystem/CreateSettingsProvider.md
@@ -3,7 +3,7 @@
 The Camera system is an extensible system for providing support for platform specific camera configurations. To add support for a new camera configuration, a custom settings provider may be required.
 
 > [!NOTE]
-> The complete source code used in this example can be found in the **MixedRealityToolkit.Extensions\Providers\Experimental\UnityAR** folder after importing the **Microsoft.MixedReality.Toolkit.Unity.Extensions** package.
+> The complete source code used in this example can be found in the **MRTK/Providers/UnityAR** folder.
 
 ## Namespace and folder structure
 
@@ -43,7 +43,7 @@ Microsoft.MixedReality.Toolkit (ex: *Microsoft.MixedReality.Toolkit.CameraSystem
 
 **Folder structure**
 
-All code must be located in a folder beneath MixedRealityToolkit.Providers (ex: MixedRealityToolkit.Providers\UnityAR).
+All code must be located in a folder beneath MRTK/Providers (ex: MRTK/Providers/UnityAR).
 
 ## Define the camera settings object
 

--- a/Documentation/Contributing/BreakingChanges.md
+++ b/Documentation/Contributing/BreakingChanges.md
@@ -22,16 +22,16 @@ A change is a breaking change if it satisfies any of the conditions in the [List
 
 - The asset in question is in the foundation package (i.e. it's in one of the following folders):
 
-  - MixedRealityToolkit/
-  - MixedRealityToolkit.Providers/
-  - MRTK.Services/
-  - MixedRealityToolkit.SDK/
-  - MixedRealityToolkit.Extensions
+  - MRTK/Core
+  - MRTK/Providers/
+  - MRTK/Services/
+  - MRTK/SDK/
+  - MRTK/Extensions
 
 - The asset in question does not belong to the experimental namespace.
 
 > [!IMPORTANT]
-> Any asset that sits in the examples package (i.e. part of the MixedRealityToolkit.Examples/ folder) is subject to change at any time, as assets there are designed to be copied and viewed by consumers as 'reference implementations' but are not part of the core set of APIs and assets. Assets in the experimental namespace (or more generally, features labelled as experimental) are ones that get published before all due diligence has been done (i.e. tests, UX iteration, documentation) and is published early to get feedback sooner.  However, because they don't have tests and documentation, and because we likely haven't nailed down all of the interactions and designs, we publish them in a state where the public should assume that they can and will change (i.e. be modified, completely removed, etc).
+> Any asset that sits in the examples package (i.e. part of the MRTK/Examples/ folder) is subject to change at any time, as assets there are designed to be copied and viewed by consumers as 'reference implementations' but are not part of the core set of APIs and assets. Assets in the experimental namespace (or more generally, features labelled as experimental) are ones that get published before all due diligence has been done (i.e. tests, UX iteration, documentation) and is published early to get feedback sooner.  However, because they don't have tests and documentation, and because we likely haven't nailed down all of the interactions and designs, we publish them in a state where the public should assume that they can and will change (i.e. be modified, completely removed, etc).
 >
 > See [Experimental features](../Contributing/ExperimentalFeatures.md) for more information.
 

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -99,7 +99,7 @@ Omitting the namespace for an interface, class or data type will cause your chan
 
 When adding new MonoBehaviour scripts with a pull request, ensure the [`AddComponentMenu`](https://docs.unity3d.com/ScriptReference/AddComponentMenu.html) attribute is applied to all applicable files. This ensures the component is easily discoverable in the editor under the *Add Component* button. The attribute flag is not necessary if the component cannot show up in editor such as an abstract class.
 
-In the example below, the *Package here* should be filled with the package location of the component. If placing an item in *MixedRealityToolkit.SDK* folder, then the package will be *SDK*. If placing an item in the *MixedRealityToolkit* folder, then use *Core* as the string to insert.
+In the example below, the *Package here* should be filled with the package location of the component. If placing an item in *MRTK/SDK* folder, then the package will be *SDK*.
 
 ```c#
 [AddComponentMenu("Scripts/MRTK/{Package here}/MyNewComponent")]
@@ -172,7 +172,7 @@ Furthermore, try to decorate the custom inspector class with a [`CanEditMultiple
 
 When adding new ScriptableObject scripts, ensure the [`CreateAssetMenu`](https://docs.unity3d.com/ScriptReference/CreateAssetMenu.html) attribute is applied to all applicable files. This ensures the component is easily discoverable in the editor via the asset creation menus. The attribute flag is not necessary if the component cannot show up in editor such as an abstract class.
 
-In the example below, the *Subfolder* should be filled with the MRTK subfolder, if applicable. If placing an item in *MixedRealityToolkit.Providers* folder, then the package will be *Providers*. If placing an item in the *MixedRealityToolkit* folder, set this to "Profiles".
+In the example below, the *Subfolder* should be filled with the MRTK subfolder, if applicable. If placing an item in *MRTK/Providers* folder, then the package will be *Providers*. If placing an item in the *MRTK/Core* folder, set this to "Profiles".
 
 In the example below, the *MyNewService | MyNewProvider* should be filled with the your new class' name, if applicable. If placing an item in the *MixedRealityToolkit* folder, leave this string out.
 

--- a/Documentation/Contributing/ExperimentalFeatures.md
+++ b/Documentation/Contributing/ExperimentalFeatures.md
@@ -56,7 +56,7 @@ public static void MyCommand()
 Adding a component menu:
 
 ```c#
-[AddComponentMenu("Mixed Reality Toolkit/Experimental/MyCommand")]
+[AddComponentMenu("MRTK/Experimental/MyCommand")]
 ```
 
 ## Documentation

--- a/Documentation/Contributing/ExperimentalFeatures.md
+++ b/Documentation/Contributing/ExperimentalFeatures.md
@@ -6,7 +6,7 @@ Some features the MRTK team works on appear to have a lot of initial value even 
 
 If a component is marked experimental you can expect the following:
 
-- An example scene demonstrating usage, located under `MixedRealityToolkit.Examples\Experimental` sub-folder
+- An example scene demonstrating usage, located under `MRTK/Examples/Experimental` sub-folder
 - Experimental features may not have docs.
 - They probably don't have tests.
 - Experimental features are subject to change.
@@ -17,7 +17,7 @@ If a component is marked experimental you can expect the following:
 
 Experimental code should go into a top-level experimental folder followed by the experimental feature name. For example, if trying to contribute a new feature FooBar, put code in the following:
 
-- Example scenes, scripts go into `MRTK.Examples/Experimental/FooBar/`
+- Example scenes, scripts go into `MRTK/Examples/Experimental/FooBar/`
 - Component scripts, prefabs go into `MRTK/SDK/Experimental/FooBar/`
 - Component inspectors go into `MRTK/SDK/Inspectors/Experimental/FooBar`
 
@@ -26,10 +26,10 @@ When using sub-folders under the experimental feature name, try to mirror the sa
 For example, solvers would go under
 `MRTK/SDK/Experimental/FooBar/Features/Utilities/Solvers/FooBarSolver.cs`
 
-Keep scenes in a scene folder near the top: `MRTK.Examples/Experimental/FooBar/Scenes/FooBarExample.unity`
+Keep scenes in a scene folder near the top: `MRTK/Examples/Experimental/FooBar/Scenes/FooBarExample.unity`
 
 > [!NOTE]
-> We considered not having a single Experimental root folder and instead putting Experimental under say `MRTK.Examples/HandTracking/Scenes/Experimental/HandBasedMenuExample.unity`. We decided to go with folders at the base to make the experimental features easier to discover.
+> We considered not having a single Experimental root folder and instead putting Experimental under say `MRTK/Examples/HandTracking/Scenes/Experimental/HandBasedMenuExample.unity`. We decided to go with folders at the base to make the experimental features easier to discover.
 
 ### Experimental code should be in a special namespace
 
@@ -56,7 +56,7 @@ public static void MyCommand()
 Adding a component menu:
 
 ```c#
-[AddComponentMenu("MRTK/Experimental/MyCommand")]
+[AddComponentMenu("Mixed Reality Toolkit/Experimental/MyCommand")]
 ```
 
 ## Documentation
@@ -74,9 +74,9 @@ Any regressions you make to the MRTK core code would result in your pull request
 
 Aim to have zero changes in folders other than experimental folders. Here is a list of folders that can have experimental changes:
 
-- MRTK/SDK\Experimental
-- MRTK/SDK\Inspectors\Experimental
-- MixedRealityToolkit.Examples\Experimental
+- MRTK/SDK/Experimental
+- MRTK/SDK/Inspectors/Experimental
+- MRTK/Examples/Experimental
 
 Changes outside of these folders should be treated very carefully. If your experimental feature must include changes to MRTK core code, consider splitting out MRTK changes into a separate pull request that includes tests and documentation.
 
@@ -92,7 +92,7 @@ For example, in [this ScrollableObjectCollection PR](https://github.com/microsof
 
 People need to see how to use your feature, and how to test it.
 
-Provide an example under MRTK.Examples/Experimental/YOUR_FEATURE
+Provide an example under MRTK/Examples/Experimental/YOUR_FEATURE
 
 ### Minimize user visible flaws in experimental features
 

--- a/Documentation/Contributing/Feature_Contribution_Process.md
+++ b/Documentation/Contributing/Feature_Contribution_Process.md
@@ -80,9 +80,9 @@ Most feature implementations can be broken down into 3 main parts:
 
 ### Manager implementation requirements
 
-* Assembly Definitions for code outside of the `MixedRealityToolkit` folder.
+* Assembly Definitions for code outside of the `MRTK/Core` folder.
   * This ensures features are self-contained and have no dependencies to other features.
-* Be defined using an interface found in `MixedRealityToolkit/Definitions/<FeatureName>System`.
+* Be defined using an interface found in `MRTK/Core/Definitions/<FeatureName>System`.
 * A feature's concrete manager implementation should inherit directly from `BaseManager` or `MixedRealityEventManager` if they will raise events.
 * A feature's concrete manager implementation should setup and verify that the scene is ready for that system to use in `Initialize`.
 * A feature's concrete manager should also clean up after themselves removing anything created in the scene in `Destroy`.
@@ -90,9 +90,9 @@ Most feature implementations can be broken down into 3 main parts:
   * If the feature is a core feature, this should be hard coded into the `MixedRealityToolkit` and `CoreServices` and added to the `MixedRealityConfigurationProfile`.
     * This includes being able to specify a concrete implementation via dropdown using `SystemType`.
     * Features should have a configuration profile that derives from a scriptable object.
-    * A default configuration profile located in `MixedRealityToolkit.SDK/Profiles` and be assigned in the default configuration profile for the Mixed Reality Manager
+    * A default configuration profile located in `MRTK/SDK/Profiles` and be assigned in the default configuration profile for the Mixed Reality Manager
   * If this feature is **not** a core feature, then it must be registered using the extension service configuration profile and implement `IMixedRealityExtensionService`.
-* Have a default implementation located in `MRTK.Services/<FeatureName>`
+* Have a default implementation located in `MRTK/Services/<FeatureName>`
 * Events that can be raised with the system should be defined in the interface, with all the required parameters for initializing the event data.
 
 ### Event data implementation requirements

--- a/Documentation/Contributing/UnitTests.md
+++ b/Documentation/Contributing/UnitTests.md
@@ -112,7 +112,7 @@ New play mode tests can inherit [BasePlayModeTests](xref:Microsoft.MixedReality.
 
 To create a new play mode test:
 
-* Navigate to Assets > MixedRealityToolkit.Tests > PlayModeTests
+* Navigate to Assets > MRTK > Tests > PlayModeTests
 * Right click, Create > Testing > C# Test Script
 * Replace the default template with the skeleton below
 
@@ -203,7 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
 ### Edit mode tests
 
-Edit mode tests are executed in Unity's edit mode and can be added under the **MixedRealityToolkit.Tests** > **EditModeTests** folder in the Mixed Reality Toolkit repo.
+Edit mode tests are executed in Unity's edit mode and can be added under the **MRTK** > **Tests** > **EditModeTests** folder in the Mixed Reality Toolkit repo.
 To create a new test the following template can be used:
 
 ```c#
@@ -255,8 +255,8 @@ Consider placing the test in a folder hierarchy that is similar to its correspon
 For example:
 
 ```md
-Non-Test: Assets/MixedRealityToolkit/Utilities/InterestingUtilityClass.cs
-Test: Assets/MixedRealityToolkit.Tests/EditModeTests/Core/Utilities/InterestingUtilityClassTest.cs
+Non-Test: Assets/MRTK/Core/Utilities/InterestingUtilityClass.cs
+Test: Assets/MRTK/Tests/EditModeTests/Core/Utilities/InterestingUtilityClassTest.cs
 ```
 
 This is to ensure that there's a clear an obvious way of finding each class's corresponding test class,

--- a/Documentation/Diagnostics/DiagnosticsSystemGettingStarted.md
+++ b/Documentation/Diagnostics/DiagnosticsSystemGettingStarted.md
@@ -33,7 +33,7 @@ The following steps presume use of the MixedRealityToolkit object. Steps require
     ![Select the Diagnostics System Implementation](../../Documentation/Images/Diagnostics/DiagnosticsSelectSystemType.png)
 
 > [!NOTE]
-> Users of the default profile, [DefaultMixedRealityToolkitConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset), will have the diagnostics system pre-configured to use the [`MixedRealityDiagnosticsSystem`](xref:Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem) object.
+> Users of the default profile, `DefaultMixedRealityToolkitConfigurationProfile` (Assets/MRTK/SDK/Profiles), will have the diagnostics system pre-configured to use the [`MixedRealityDiagnosticsSystem`](xref:Microsoft.MixedReality.Toolkit.Diagnostics.MixedRealityDiagnosticsSystem) object.
 
 ### Configure diagnostic options
 

--- a/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
+++ b/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
@@ -1,12 +1,12 @@
 # Eye tracking examples in MRTK
 
-This topic describes how to quickly get started with eye tracking in MRTK by building on [MRTK eye tracking examples](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking).
+This topic describes how to quickly get started with eye tracking in MRTK by building on MRTK eye tracking examples (Assets/MRTK/Examples/Demos/EyeTracking).
 These samples let you experience one of our new magical input capabilities: **Eye tracking**!
 The demo includes various use cases, ranging from implicit eye-based activations to how to seamlessly combine information about what you are looking at with **voice** and **hand** input.
 This enables users to quickly and effortlessly select and move holographic content across their view simply by looking at a target and saying _'Select'_ or performing a hand gesture.
 The demos also include an example for eye-gaze-directed scroll, pan and zoom of text and images on a slate.
 Finally, an example is provided for recording and visualizing the user's visual attention on a 2D slate.
-In the following section, you will find more details on what each of the different samples in the [MRTK eye tracking example package](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking) includes:
+In the following section, you will find more details on what each of the different samples in the MRTK eye tracking example package (Assets/MRTK/Examples/Demos/EyeTracking) includes:
 
 ![List of eye tracking scenes](../Images/EyeTracking/mrtk_et_list_et_scenes.jpg)
 

--- a/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
+++ b/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
@@ -1,11 +1,11 @@
 # Accessing eye tracking data in your Unity script
 
 The following assumes that you followed the steps for setting up eye tracking in your MRTK scene (see [Basic MRTK setup to use eye tracking](EyeTracking_BasicSetup.md)).
-To access eye tracking data in your MonoBehaviour scripts is easy! Simply use *MixedRealityToolkit.InputSystem.EyeGazeProvider*.
+To access eye tracking data in your MonoBehaviour scripts is easy! Simply use *CoreSystems.InputSystem.EyeGazeProvider*.
 
-## MixedRealityToolkit.InputSystem.EyeGazeProvider
+## CoreSystems.InputSystem.EyeGazeProvider
 
-While the *MixedRealityToolkit.InputSystem.EyeGazeProvider* provides several helpful variables, the key ones for eye tracking input are the following:
+While the *CoreSystems.InputSystem.EyeGazeProvider* provides several helpful variables, the key ones for eye tracking input are the following:
 
 - **UseEyeTracking**:
 True if eye tracking hardware is available and the user has given permission to use eye tracking in the app.
@@ -32,7 +32,7 @@ This will return the *head* gaze direction if 'IsEyeGazeValid' is false.
 Information about the currently gazed at target.
 Again, if 'IsEyeGazeValid' is false, this will be based on the user's *head* gaze.
 
-## Examples for using MixedRealityToolkit.InputSystem.EyeGazeProvider
+## Examples for using CoreSystems.InputSystem.EyeGazeProvider
 
 Here is an example from the [FollowEyeGaze.cs](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.FollowEyeGaze):
 
@@ -40,7 +40,7 @@ Here is an example from the [FollowEyeGaze.cs](xref:Microsoft.MixedReality.Toolk
 
 ```c#
 // Show the object at the hit position of the user's eye gaze ray with the target.
-gameObject.transform.position = MixedRealityToolkit.InputSystem.EyeGazeProvider.HitPosition;
+gameObject.transform.position = CoreSystems.InputSystem.EyeGazeProvider.HitPosition;
 ```
 
 - Showing a visual asset at a fixed distance from where the user is currently looking:
@@ -48,8 +48,8 @@ gameObject.transform.position = MixedRealityToolkit.InputSystem.EyeGazeProvider.
 ```c#
 // If no target is hit, show the object at a default distance along the gaze ray.
 gameObject.transform.position =
-MixedRealityToolkit.InputSystem.EyeGazeProvider.GazeOrigin +
-MixedRealityToolkit.InputSystem.EyeGazeProvider.GazeDirection.normalized * defaultDistanceInMeters;
+CoreSystems.InputSystem.EyeGazeProvider.GazeOrigin +
+CoreSystems.InputSystem.EyeGazeProvider.GazeDirection.normalized * defaultDistanceInMeters;
 ```
 
 ---

--- a/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
+++ b/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
@@ -1,11 +1,11 @@
 # Accessing eye tracking data in your Unity script
 
 The following assumes that you followed the steps for setting up eye tracking in your MRTK scene (see [Basic MRTK setup to use eye tracking](EyeTracking_BasicSetup.md)).
-To access eye tracking data in your MonoBehaviour scripts is easy! Simply use *CoreSystems.InputSystem.EyeGazeProvider*.
+To access eye tracking data in your MonoBehaviour scripts is easy! Simply use *CoreServices.InputSystem.EyeGazeProvider*.
 
-## CoreSystems.InputSystem.EyeGazeProvider
+## CoreServices.InputSystem.EyeGazeProvider
 
-While the *CoreSystems.InputSystem.EyeGazeProvider* provides several helpful variables, the key ones for eye tracking input are the following:
+While the *CoreServices.InputSystem.EyeGazeProvider* provides several helpful variables, the key ones for eye tracking input are the following:
 
 - **UseEyeTracking**:
 True if eye tracking hardware is available and the user has given permission to use eye tracking in the app.
@@ -32,7 +32,7 @@ This will return the *head* gaze direction if 'IsEyeGazeValid' is false.
 Information about the currently gazed at target.
 Again, if 'IsEyeGazeValid' is false, this will be based on the user's *head* gaze.
 
-## Examples for using CoreSystems.InputSystem.EyeGazeProvider
+## Examples for using CoreServices.InputSystem.EyeGazeProvider
 
 Here is an example from the [FollowEyeGaze.cs](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.FollowEyeGaze):
 
@@ -40,7 +40,7 @@ Here is an example from the [FollowEyeGaze.cs](xref:Microsoft.MixedReality.Toolk
 
 ```c#
 // Show the object at the hit position of the user's eye gaze ray with the target.
-gameObject.transform.position = CoreSystems.InputSystem.EyeGazeProvider.HitPosition;
+gameObject.transform.position = CoreServices.InputSystem.EyeGazeProvider.HitPosition;
 ```
 
 - Showing a visual asset at a fixed distance from where the user is currently looking:
@@ -48,8 +48,8 @@ gameObject.transform.position = CoreSystems.InputSystem.EyeGazeProvider.HitPosit
 ```c#
 // If no target is hit, show the object at a default distance along the gaze ray.
 gameObject.transform.position =
-CoreSystems.InputSystem.EyeGazeProvider.GazeOrigin +
-CoreSystems.InputSystem.EyeGazeProvider.GazeDirection.normalized * defaultDistanceInMeters;
+CoreServices.InputSystem.EyeGazeProvider.GazeOrigin +
+CoreServices.InputSystem.EyeGazeProvider.GazeDirection.normalized * defaultDistanceInMeters;
 ```
 
 ---

--- a/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
+++ b/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
@@ -16,7 +16,7 @@ This page covers the following:
 
 ### How to detect the eye calibration state
 
-The [CoreSystems.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a `bool?` property called `IsEyeGazeValid`.
+The [CoreServices.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a `bool?` property called `IsEyeGazeValid`.
 It returns null if no information from the eye tracker is available yet.
 Once data has been received, it will either return true or false to indicate that the user's eye tracking calibration is valid or invalid.
 

--- a/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
+++ b/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
@@ -16,13 +16,13 @@ This page covers the following:
 
 ### How to detect the eye calibration state
 
-The [MixedRealityToolkit.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a `bool?` property called `IsEyeGazeValid`.
+The [CoreSystems.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a `bool?` property called `IsEyeGazeValid`.
 It returns null if no information from the eye tracker is available yet.
 Once data has been received, it will either return true or false to indicate that the user's eye tracking calibration is valid or invalid.
 
 ### Sample eye calibration notification - step-by-step
 
-1. Open the [MRTK eye tracking example package](https://github.com/Microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking)
+1. Open the MRTK eye tracking example package (Assets/MRTK/Examples/Demos/EyeTracking)
 
 2. Load _EyeTrackingDemo-00-RootScene.unity_ scene
 

--- a/Documentation/EyeTracking/EyeTracking_Navigation.md
+++ b/Documentation/EyeTracking/EyeTracking_Navigation.md
@@ -5,7 +5,7 @@
 Imagine you are reading information on a slate and when you reach the end of the displayed text, the text automatically scrolls up to reveal more content. Or you can fluently zoom in where you are looking at. The map also automatically adjusts the content to keep the things of interest within your field of view. Another interesting application is the hands-free observation of 3D holograms by automatically bringing the parts of the hologram that you are looking at to the front. These are some of the examples that are described on this page in context of eye-supported navigation.
 
 The following descriptions assume that you are already familiar with how to [set up eye tracking in your MRTK scene](EyeTracking_BasicSetup.md) and with the basics of [accessing eye tracking data](EyeTracking_TargetSelection.md) in MRTK Unity.
-The examples discussed in the following are all part of the [EyeTrackingDemo-03-Navigation.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity)
+The examples discussed in the following are all part of the `EyeTrackingDemo-03-Navigation` (Assets/MRTK/Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation)
 scene.
 
 **Summary:** Auto scroll of text, eye-gaze-supported pan and zoom of a virtual map, hands-free gaze-directed 3D rotation.
@@ -14,7 +14,7 @@ scene.
 
 Auto scroll enables the user to scroll through texts without lifting a finger.
 Simply continue reading and the text will automatically scroll up or down depending on where the user is looking.
-You can start off from the example provided in [EyeTrackingDemo-03-Navigation.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity).
+You can start off from the example provided in `EyeTrackingDemo-03-Navigation` (Assets/MRTK/Examples/Demos/EyeTracking/Scenes).
 This example uses a [TextMesh](https://docs.unity3d.com/ScriptReference/TextMesh.html) component to allow for flexibly loading and formatting new text.
 To enable auto scroll, simply add the following two scripts to your collider component of the textbox:
 
@@ -80,7 +80,7 @@ You can tweak several parameters that are listed below to limit how fast and in 
 
 As you can imagine, having this behavior active at all times may quickly become pretty distracting in a crowded scene.
 This is why you may want to start out with this behavior disabled and then enable it quickly using voice commands.
-Alternatively, we added an example in [EyeTrackingDemo-03-Navigation.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity)
+Alternatively, we added an example in `EyeTrackingDemo-03-Navigation` (Assets/MRTK/Examples/Demos/EyeTracking/Scenes)
 to use [TargetMoveToCamera](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.TargetMoveToCamera) for which you can select a focused target and it flies in front of you - simply say *"Come to me"*.
 
 Once in the near mode, the auto rotation mode is automatically enabled.

--- a/Documentation/EyeTracking/EyeTracking_TargetSelection.md
+++ b/Documentation/EyeTracking/EyeTracking_TargetSelection.md
@@ -111,8 +111,7 @@ Given that eye gaze can be very different to other pointer inputs, you may want 
 For this purpose, you would use the [`BaseEyeFocusHandler`](xref:Microsoft.MixedReality.Toolkit.Input.BaseEyeFocusHandler) which is specific to eye tracking and which derives from the [`BaseFocusHandler`](xref:Microsoft.MixedReality.Toolkit.Input.BaseFocusHandler).
 As mentioned before, it will only trigger if eye gaze targeting is currently the primary pointer input (i.e., no hand ray is active). For more information, see [How to support eye gaze + hand gestures](EyeTracking_EyesAndHands.md).
 
-Here is an example from [EyeTrackingDemo-03-Navigation.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-03-Navigation.unity
-).
+Here is an example from `EyeTrackingDemo-03-Navigation` (Assets/MRTK/Examples/Demos/EyeTracking/Scenes).
 In this demo, there are two 3D holograms that will turn depending on which part of the object is looked at:
 If the user looks at the left side of the hologram, then that part will slowly move towards the front facing the user.
 If the right side is looked at, then that part will slowly move to the front.
@@ -181,7 +180,7 @@ In the following, we walk you through a few examples for how to use _EyeTracking
 
 ### Example #1: Eye-supported smart notifications
 
-In [EyeTrackingDemo-02-TargetSelection.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-02-TargetSelection.unity),
+In `EyeTrackingDemo-02-TargetSelection` (Assets/MRTK/Examples/Demos/EyeTracking/Scenes),
 you can find an example for _'smart attentive notifications'_ that react to your eye gaze.
 These are 3D text boxes that can be placed in the scene and that will smoothly enlarge and turn toward the user when being looked at to ease legibility. While the user is reading the notification, the information keeps getting displayed crisp and clear. After reading it and looking away from the notification, the notification will automatically be dismissed and fades out. To achieve all this, there are a few generic behavior scripts that are not specific to eye tracking at all, such as:
 
@@ -213,7 +212,7 @@ Otherwise this can quickly feel extremely overwhelming.
 
 ### Example #2: Holographic gem rotates slowly when looking at it
 
-Similar to Example #1, we can easily create a hover feedback for our holographic gems in [EyeTrackingDemo-02-TargetSelection.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/EyeTracking/Scenes/EyeTrackingDemo-02-TargetSelection.unity) scene that will slowly rotate in a constant direction and at a constant speed (in contrast to the rotation example from above) when being looked at. All you need is to trigger the rotation of the holographic gem from the _EyeTrackingTarget_'s _WhileLookingAtTarget()_ event. Here are a few more details:
+Similar to Example #1, we can easily create a hover feedback for our holographic gems in `EyeTrackingDemo-02-TargetSelection` (Assets/MRTK/Examples/Demos/EyeTracking/Scenes) scene that will slowly rotate in a constant direction and at a constant speed (in contrast to the rotation example from above) when being looked at. All you need is to trigger the rotation of the holographic gem from the _EyeTrackingTarget_'s _WhileLookingAtTarget()_ event. Here are a few more details:
 
 1. Create a generic script that includes a public function to rotate the GameObject it is attached to. Below is an example from _RotateWithConstSpeedDir.cs_ where we can tweak the rotation direction and speed from the Unity Editor.
 

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -136,7 +136,7 @@ The [hand interaction examples scene](README_HandInteractionExamples.md) article
 
 To try the hand interaction scene, do the following steps.
 
-1. Open the **HandInteractionExamples** scene under `Assets\MixedRealityToolkit.Examples\Demos\HandTracking\Scenes\HandInteractionExamples`
+1. Open the **HandInteractionExamples** scene under `Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples`
 
 1. You may get a prompt asking you to import "TMP Essentials".
 

--- a/Documentation/Input/CreateDataProvider.md
+++ b/Documentation/Input/CreateDataProvider.md
@@ -6,7 +6,7 @@ a custom input data provider may be required.
 This article describes how to create custom data providers, also called device managers, for the input system. The example code shown here is
 from the [`WindowsMixedRealityDeviceManager`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityDeviceManager).
 
-> The complete code used in this example can be found in the MixedRealityToolkit.Providers\WindowsMixedReality folder.
+> The complete code used in this example can be found in the MRTK/Providers/WindowsMixedReality folder.
 
 ## Namespace and folder structure
 
@@ -16,7 +16,7 @@ new data providers to the MRTK will vary on a case-by-case basis and will be com
 > [!Important]
 > If an input system data provider is being submitted to the [Mixed Reality Toolkit repository](https://github.com/Microsoft/MixedRealityToolkit-Unity), the
 namespace **must** begin with Microsoft.MixedReality.Toolkit (ex: Microsoft.MixedReality.Toolkit.WindowsMixedReality) and the code should be
-located in a folder beneath MixedRealityToolkit.Providers (ex: MixedRealityToolkit.Providers\WindowsMixedReality).
+located in a folder beneath MRTK/Providers (ex: MRTK/Providers/WindowsMixedReality).
 
 ### Namespace
 
@@ -102,7 +102,7 @@ The next step is to add the logic for managing the input devices, including any 
 
  The example of the `WindowsMixedRealityDeviceManager` defines and implements the following controller classes.
 
-> The source code for each of these classes can be found in the MixedRealityToolkit.Providers\WindowsMixedReality folder.
+> The source code for each of these classes can be found in the MRTK/Providers/WindowsMixedReality folder.
 
 - WindowsMixedRealityArticulatedHand.cs
 - WindowsMixedRealityController.cs
@@ -128,7 +128,7 @@ Next, apply the [`MixedRealityController`](xref:Microsoft.MixedReality.Toolkit.I
 
 The next step is to define the set of interaction mappings supported by the controller. For devices that receive their data via Unity's Input class, the [controller mapping tool](../Tools/ControllerMappingTool.md) is a helpful resource to confirm the correct axis and button mappings to assign to interactions.
 
-The following example is abbreviated from the `GenericOpenVRController` class, located in the MixedRealityToolkit.Providers\OpenVR folder.
+The following example is abbreviated from the `GenericOpenVRController` class, located in the MRTK/Providers/OpenVR folder.
 
 ```c#
 public override MixedRealityInteractionMapping[] DefaultLeftHandedInteractions => new[]

--- a/Documentation/Input/Dictation.md
+++ b/Documentation/Input/Dictation.md
@@ -28,6 +28,6 @@ Once you have a dictation service set up, you can use the [`DictationHandler`](x
 
 ## Example scene
 
-**Dictation** scene in `MixedRealityToolkit.Examples\Demos\Input\Scenes\Dictation` shows the `DictationHandler` script in use. If you need more control, you can either extend this script or create your own implementing [`IMixedRealityDictationHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityDictationHandler) to receive dictation events directly.
+**Dictation** scene in `MRTK/Examples/Demos/Input/Scenes/Dictation` shows the `DictationHandler` script in use. If you need more control, you can either extend this script or create your own implementing [`IMixedRealityDictationHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityDictationHandler) to receive dictation events directly.
 
 <img src="../../Documentation/Images/Input/DictationDemo.png" width="80%" class="center">

--- a/Documentation/Input/Gestures.md
+++ b/Documentation/Input/Gestures.md
@@ -58,6 +58,6 @@ There are two principal chains of events, depending on user input:
 
 ## Example scene
 
-The **HandInteractionGestureEventsExample** scene in `MixedRealityToolkit.Examples\Demos\HandTracking\Scenes` shows how to use the pointer Result to spawn an object at the hit location.
+The **HandInteractionGestureEventsExample** (Assets/MRTK/Examples/Demos/HandTracking/Scenes) scene shows how to use the pointer Result to spawn an object at the hit location.
 
-[Gesture Tester script](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Script/GestureTester.cs) is an example implementation to visualize gesture events via GameObjects. The handler functions change the color of indicator objects and display the last recorded event in text objects in the scene.
+The `GestureTester` (Assets/MRTK/Examples/Demos/HandTracking/Script) script is an example implementation to visualize gesture events via GameObjects. The handler functions change the color of indicator objects and display the last recorded event in text objects in the scene.

--- a/Documentation/Input/HowToAddNearInteractivity.md
+++ b/Documentation/Input/HowToAddNearInteractivity.md
@@ -12,7 +12,7 @@ Three key steps are required to listen for touch and/or grab input events on a p
 
 1. Ensure a [SpherePointer](Pointers.md#spherepointer) is registered in the *MRTK Pointer profile*.
 
-    The default MRTK profile and the default HoloLens 2 profile already contain a *SpherePointer*. One can confirm a SpherePointer will be created by selecting the MRTK Configuration Profile and navigating to **Input** > **Pointers** > **Pointer Options**. The default `GrabPointer` (Assets/MRTK/SDK/Features/UX/Prefabs/Pointers) prefab should be listed with a *Controller Type* of *Articulated Hand*. A custom prefab can be utilized as long as it implements the [`SpherePointer`](xref:Microsoft.MixedReality.Toolkit.Input.SpherePointer) class.
+    The default MRTK profile and the default HoloLens 2 profile already contain a *SpherePointer*. One can confirm a SpherePointer will be created by selecting the MRTK Configuration Profile and navigating to **Input** > **Pointers** > **Pointer Options**. The default `GrabPointer` prefab (Assets/MRTK/SDK/Features/UX/Prefabs/Pointers) should be listed with a *Controller Type* of *Articulated Hand*. A custom prefab can be utilized as long as it implements the [`SpherePointer`](xref:Microsoft.MixedReality.Toolkit.Input.SpherePointer) class.
 
     ![Grab Pointer Profile Example](../Images/Input/Pointers/GrabPointer_MRTKProfile.png)
 

--- a/Documentation/Input/HowToAddNearInteractivity.md
+++ b/Documentation/Input/HowToAddNearInteractivity.md
@@ -12,7 +12,7 @@ Three key steps are required to listen for touch and/or grab input events on a p
 
 1. Ensure a [SpherePointer](Pointers.md#spherepointer) is registered in the *MRTK Pointer profile*.
 
-    The default MRTK profile and the default HoloLens 2 profile already contain a *SpherePointer*. One can confirm a SpherePointer will be created by selecting the MRTK Configuration Profile and navigating to **Input** > **Pointers** > **Pointer Options**. The default [GrabPointer](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/GrabPointer.prefab) prefab, under *MRTK.SDK/Features/UX/Prefabs/Pointers/*, should be listed with a *Controller Type* of *Articulated Hand*. A custom prefab can be utilized as long as it implements the [`SpherePointer`](xref:Microsoft.MixedReality.Toolkit.Input.SpherePointer) class.
+    The default MRTK profile and the default HoloLens 2 profile already contain a *SpherePointer*. One can confirm a SpherePointer will be created by selecting the MRTK Configuration Profile and navigating to **Input** > **Pointers** > **Pointer Options**. The default `GrabPointer` (Assets/MRTK/SDK/Features/UX/Prefabs/Pointers) prefab should be listed with a *Controller Type* of *Articulated Hand*. A custom prefab can be utilized as long as it implements the [`SpherePointer`](xref:Microsoft.MixedReality.Toolkit.Input.SpherePointer) class.
 
     ![Grab Pointer Profile Example](../Images/Input/Pointers/GrabPointer_MRTKProfile.png)
 
@@ -53,7 +53,7 @@ The process for adding touch interactions on UnityUI elements is different than 
 
 For **both** types of UX elements though, ensure a [PokePointer](Pointers.md#pokepointer) is registered in the *MRTK Pointer profile*.
 
-The default MRTK profile and the default HoloLens 2 profile already contain a *PokePointer*. One can confirm a PokePointer will be created by selecting the MRTK Configuration Profile and navigate to **Input** > **Pointers** > **Pointer Options**. The default [PokePointer](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers/PokePointer.prefab) prefab, under *MRTK.SDK/Features/UX/Prefabs/Pointers/*, should be listed with a *Controller Type* of *Articulated Hand*. A custom prefab can be utilized as long as it implements the [`PokePointer`](xref:Microsoft.MixedReality.Toolkit.Input.PokePointer) class.
+The default MRTK profile and the default HoloLens 2 profile already contain a *PokePointer*. One can confirm a PokePointer will be created by selecting the MRTK Configuration Profile and navigate to **Input** > **Pointers** > **Pointer Options**. The default `PokePointer` (Assets/MRTK/SDK/Features/UX/Prefabs/Pointers) prefab should be listed with a *Controller Type* of *Articulated Hand*. A custom prefab can be utilized as long as it implements the [`PokePointer`](xref:Microsoft.MixedReality.Toolkit.Input.PokePointer) class.
 
 ![Poke Pointer Profile Example](../Images/Input/Pointers/PokePointer_MRTKProfile.png)
 

--- a/Documentation/Input/InputActions.md
+++ b/Documentation/Input/InputActions.md
@@ -58,6 +58,6 @@ If you want more control, you can implement the [`IMixedRealityInputActionHandle
 
 ## Examples
 
-See `MixedRealityToolkit.Examples\Demos\Input\Scenes\InputActions` for an example scene showing how to create an action, map it to controller, speech and gesture inputs and use it to rotate an object on command.
+See `MRTK/Examples/Demos/Input/Scenes/InputActions` for an example scene showing how to create an action, map it to controller, speech and gesture inputs and use it to rotate an object on command.
 
 <img src="../../Documentation/Images/Input/InputActionsExample.PNG" style="max-width:100%;">

--- a/Documentation/Input/Pointers.md
+++ b/Documentation/Input/Pointers.md
@@ -268,7 +268,7 @@ private void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEve
 }
 ```
 
-The `PointerResultExample` (Assets/MRTK/Examples/Demos/Input/Scenes/PointerResult/PointerResultExample.unity) scene shows how to use the pointer [`Result`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer.Result) to spawn an object at the hit location.
+The `PointerResultExample` scene (Assets/MRTK/Examples/Demos/Input/Scenes/PointerResult/PointerResultExample.unity) shows how to use the pointer [`Result`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer.Result) to spawn an object at the hit location.
 
 <img src="../../Documentation/Images/Input/PointerResultExample.png" style="max-width:100%;">
 

--- a/Documentation/Input/Pointers.md
+++ b/Documentation/Input/Pointers.md
@@ -33,15 +33,15 @@ Each Pointer entry is defined by the following set of data:
 
 - *Pointer Prefab* - This prefab asset will be instantiated when a controller matching the specified controller type and handedness starts being tracked.
 
-It is possible to have multiple pointers associated with a controller. For example, in the [default HoloLens 2 profile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2InputSystemProfile.asset)
+It is possible to have multiple pointers associated with a controller. For example, in `DefaultHoloLens2InputSystemProfile` (Assets/MRTK/SDK/Profiles/HoloLens2/)
 the articulated hand controller is associated with the *PokePointer*, *GrabPointer*, and the *DefaultControllerPointer* (i.e hand rays).
 
 > [!NOTE]
-> MRTK provides a set of pointer prefabs in *Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers*. A new custom prefab can be built as long as it contains one of the pointer scripts in *Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Pointers* or any other script implementing [`IMixedRealityPointer`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer).
+> MRTK provides a set of pointer prefabs in *Assets/MRTK/SDK/Features/UX/Prefabs/Pointers*. A new custom prefab can be built as long as it contains one of the pointer scripts in *Assets/MRTK/SDK/Features/UX/Scripts/Pointers* or any other script implementing [`IMixedRealityPointer`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer).
 
 ### Default pointer classes
 
-The following classes are the out-of-box MRTK pointers available and defined in the default *MRTK Pointer Profile* outlined above. Each pointer prefab provided under *Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Pointers* contains one of the pointer components attached.
+The following classes are the out-of-box MRTK pointers available and defined in the default *MRTK Pointer Profile* outlined above. Each pointer prefab provided under *Assets/MRTK/SDK/Features/UX/Prefabs/Pointers* contains one of the pointer components attached.
 
 ![MRTK Default Pointers](../Images/Input/Pointers/MRTK_Pointers.png)
 
@@ -250,7 +250,7 @@ private void OnDisable()
 }
 ```
 
-The [PrimaryPointerExample scene](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PrimaryPointer/PrimaryPointerExample.unity) shows how to use the [`PrimaryPointerChangedHandler`](xref:Microsoft.MixedReality.Toolkit.Input.PrimaryPointerChangedHandler) for events to respond to a new primary pointer.
+The `PrimaryPointerExample` (Assets/MRTK/Examples/Demos/Input/Scenes/PrimaryPointer) scene shows how to use the [`PrimaryPointerChangedHandler`](xref:Microsoft.MixedReality.Toolkit.Input.PrimaryPointerChangedHandler) for events to respond to a new primary pointer.
 
 <img src="../../Documentation/Images/Pointers/PrimaryPointerExample.png" style="max-width:100%;">
 
@@ -268,7 +268,7 @@ private void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEve
 }
 ```
 
-The [PointerResultExample scene](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MixedRealityToolkit.Examples/Demos/Input/Scenes/PointerResult/PointerResultExample.unity) shows how to use the pointer [`Result`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer.Result) to spawn an object at the hit location.
+The `PointerResultExample` (Assets/MRTK/Examples/Demos/Input/Scenes/PointerResult/PointerResultExample.unity) scene shows how to use the pointer [`Result`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer.Result) to spawn an object at the hit location.
 
 <img src="../../Documentation/Images/Input/PointerResultExample.png" style="max-width:100%;">
 

--- a/Documentation/Input/Speech.md
+++ b/Documentation/Input/Speech.md
@@ -22,6 +22,6 @@ Alternatively, developers can implement the [`IMixedRealitySpeechHandler`](xref:
 
 ## Example scene
 
-The **SpeechInputExample** scene, in `MixedRealityToolkit.Examples\Demos\Input\Scenes\Speech`, shows how to use speech. You can also listen to speech command events directly in your own script by implementing [`IMixedRealitySpeechHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealitySpeechHandler) (see table of [event handlers](InputEvents.md)).
+The **SpeechInputExample** scene, in `MRTK/Examples/Demos/Input/Scenes/Speech`, shows how to use speech. You can also listen to speech command events directly in your own script by implementing [`IMixedRealitySpeechHandler`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealitySpeechHandler) (see table of [event handlers](InputEvents.md)).
 
 <img src="../../Documentation/Images/Input/SpeechExampleScene.png" width="750px">

--- a/Documentation/MRTK_PackageContents.md
+++ b/Documentation/MRTK_PackageContents.md
@@ -13,20 +13,20 @@ The Microsoft.MixedRealityToolkit.Unity.Foundation package includes the core com
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MixedRealityToolkit | | Interface and type definitions, base classes, standard shader. |
-| MixedRealityToolkit.Providers | | |
+| MRTK\Core | | Interface and type definitions, base classes, standard shader. |
+| MRTK\Providers | | |
 | | [ObjectMeshObserver](SpatialAwareness/SpatialObjectMeshObserver.md) | Spatial awareness observer using a 3D model as the data. |
 | | OpenVR | Support for OpenVR devices. |
 | | [UnityAR](CameraSystem/UnityArCameraSettings.md) | (Experimental) Camera settings provider enabling MRTK use with mobile AR devices. |
 | | WindowsMixedReality | Support for Windows Mixed Reality devices, including Microsoft HoloLens and immersive headsets. |
 | | WindowsVoiceInput | Support for speech and dictation on Microsoft Windows platforms. |
 | | XRSDK | (Experimental) Support for [Unity's new XR framework](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/) in Unity 2019.3. |
-| MixedRealityToolkit.SDK | | |
+| MRTK\SDK | | |
 | | Experimental | Experimental features, including shaders, user interface controls and individual system managers. |
 | | Features | Functionality that builds upon the Foundation package. |
 | | Profiles | Default profiles for the Microsoft Mixed Reality Toolkit systems and services. |
 | | StandardAssets | Common assets; models, textures, materials, etc. |
-| MRTK.Services | | |
+| MRTK\Services | | |
 | | [BoundarySystem](Boundary/BoundarySystemGettingStarted.md) | System implementing VR boundary support. |
 | | [CameraSystem](CameraSystem/CameraSystemOverview.md) | System implementing camera configuration and management. |
 | | [DiagnosticsSystem](Diagnostics/DiagnosticsSystemGettingStarted.md) | System implementing in application diagnostics, for example a visual profiler. |
@@ -46,7 +46,7 @@ The optional Microsoft.MixedRealityToolkit.Unity.Extensions package includes add
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MixedRealityToolkit.Extensions | |
+| MRTK\Extensions | |
 | | HandPhysicsService | Service that adds physics support to articulated hands. |
 | | LostTrackingService | Service that simplifies handing of tracking loss on Microsoft HoloLens devices. |
 | | [SceneTransitionService](Extensions/SceneTransitionService/SceneTransitionServiceOverview.md) | Service that simplifies adding smooth scene transitions. |
@@ -61,7 +61,7 @@ These tools are located in the **Mixed Reality Toolkit > Utilities** menu in the
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MixedRealityToolkit.Tools | |
+| MRTK\Tools | |
 | | [DependencyWindow](Tools/DependencyWindow.md) | Tool that creates a dependency graph of assets in a project. |
 | | [ExtensionServiceCreator](Tools/ExtensionServiceCreationWizard.md) | Wizard to assist in creating extension services. |
 | | [OptimizeWindow](Tools/OptimizeWindow.md) | Utility to help automate configuring a mixed reality project for the best performance in Unity. |
@@ -79,7 +79,7 @@ The optional Microsoft.MixedRealityToolkit.Unity.Examples package includes demon
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MixedRealityToolkit.Examples | | |
+| MRTK\Examples | | |
 | | Demos | Simple scenes illustrating one or two related features. |
 | | Experimental | Demo scenes illustrating experimental features. |
 | | Inspectors | Unity Editor inspectors used by demo scenes. |

--- a/Documentation/MRTK_PackageContents.md
+++ b/Documentation/MRTK_PackageContents.md
@@ -13,20 +13,20 @@ The Microsoft.MixedRealityToolkit.Unity.Foundation package includes the core com
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MRTK\Core | | Interface and type definitions, base classes, standard shader. |
-| MRTK\Providers | | |
+| MRTK/Core | | Interface and type definitions, base classes, standard shader. |
+| MRTK/Providers | | |
 | | [ObjectMeshObserver](SpatialAwareness/SpatialObjectMeshObserver.md) | Spatial awareness observer using a 3D model as the data. |
 | | OpenVR | Support for OpenVR devices. |
 | | [UnityAR](CameraSystem/UnityArCameraSettings.md) | (Experimental) Camera settings provider enabling MRTK use with mobile AR devices. |
 | | WindowsMixedReality | Support for Windows Mixed Reality devices, including Microsoft HoloLens and immersive headsets. |
 | | WindowsVoiceInput | Support for speech and dictation on Microsoft Windows platforms. |
 | | XRSDK | (Experimental) Support for [Unity's new XR framework](https://blogs.unity3d.com/2020/01/24/unity-xr-platform-updates/) in Unity 2019.3. |
-| MRTK\SDK | | |
+| MRTK/SDK | | |
 | | Experimental | Experimental features, including shaders, user interface controls and individual system managers. |
 | | Features | Functionality that builds upon the Foundation package. |
 | | Profiles | Default profiles for the Microsoft Mixed Reality Toolkit systems and services. |
 | | StandardAssets | Common assets; models, textures, materials, etc. |
-| MRTK\Services | | |
+| MRTK/Services | | |
 | | [BoundarySystem](Boundary/BoundarySystemGettingStarted.md) | System implementing VR boundary support. |
 | | [CameraSystem](CameraSystem/CameraSystemOverview.md) | System implementing camera configuration and management. |
 | | [DiagnosticsSystem](Diagnostics/DiagnosticsSystemGettingStarted.md) | System implementing in application diagnostics, for example a visual profiler. |
@@ -46,7 +46,7 @@ The optional Microsoft.MixedRealityToolkit.Unity.Extensions package includes add
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MRTK\Extensions | |
+| MRTK/Extensions | |
 | | HandPhysicsService | Service that adds physics support to articulated hands. |
 | | LostTrackingService | Service that simplifies handing of tracking loss on Microsoft HoloLens devices. |
 | | [SceneTransitionService](Extensions/SceneTransitionService/SceneTransitionServiceOverview.md) | Service that simplifies adding smooth scene transitions. |
@@ -61,7 +61,7 @@ These tools are located in the **Mixed Reality Toolkit > Utilities** menu in the
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MRTK\Tools | |
+| MRTK/Tools | |
 | | [DependencyWindow](Tools/DependencyWindow.md) | Tool that creates a dependency graph of assets in a project. |
 | | [ExtensionServiceCreator](Tools/ExtensionServiceCreationWizard.md) | Wizard to assist in creating extension services. |
 | | [OptimizeWindow](Tools/OptimizeWindow.md) | Utility to help automate configuring a mixed reality project for the best performance in Unity. |
@@ -79,7 +79,7 @@ The optional Microsoft.MixedRealityToolkit.Unity.Examples package includes demon
 
 | Folder | Component | Description |
 | --- | --- | --- |
-| MRTK\Examples | | |
+| MRTK/Examples | | |
 | | Demos | Simple scenes illustrating one or two related features. |
 | | Experimental | Demo scenes illustrating experimental features. |
 | | Inspectors | Unity Editor inspectors used by demo scenes. |

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -15,7 +15,7 @@ The main configuration profile, which is attached to the *MixedRealityToolkit* G
 
 ![MRTK configuration profile](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ActiveConfiguration.png)
 
-All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets\MRTK\SDK\Profiles
+All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets/MRT/KSDK/Profiles.
 
 > [!IMPORTANT]
 > DefaultHoloLens2ConfigurationProfile is optimized for HoloLens 2. See [Profiles](Profiles/Profiles.md) for the details.

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -15,7 +15,7 @@ The main configuration profile, which is attached to the *MixedRealityToolkit* G
 
 ![MRTK configuration profile](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ActiveConfiguration.png)
 
-All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets\MixedRealityToolkit.SDK\Profiles
+All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets\MRTK\SDK\Profiles
 
 > [!IMPORTANT]
 > DefaultHoloLens2ConfigurationProfile is optimized for HoloLens 2. See [Profiles](Profiles/Profiles.md) for the details.

--- a/Documentation/Packaging/MRTK_Modularization.md
+++ b/Documentation/Packaging/MRTK_Modularization.md
@@ -26,12 +26,12 @@ At this moment, the MRTK is imported as a single foundation package (ignoring fo
 
 It is possible to uncheck arbitrary items during the import of the Foundation package. However, it's not recommended to do this at an early stage in development as it might break functionality. After having figured out the final feature set of an app, pruning unneeded providers and services can be done on the following folders:
 
-- MRTK.Services
-- MixedRealityToolkit.Providers
-- MixedRealityToolkit.SDK\Features
+- MRTK/Services
+- MRTK/Providers
+- MRTK/SDK/Features
 
 > [!NOTE]
-> MRTK v2 **_requires_** the contents of the Assets\MixedRealityToolkit folder.
+> MRTK v2.x **_requires_** the contents of the Assets/MRTK/Core folder.
 
 ## Upcoming features
 

--- a/Documentation/Profiles/Profiles.md
+++ b/Documentation/Profiles/Profiles.md
@@ -2,7 +2,7 @@
 
 One of the main ways that the MRTK is configured is through the many profiles available in the foundation package. The main [`MixedRealityToolkit`](xref:Microsoft.MixedReality.Toolkit.MixedRealityToolkit) object in a scene will have the active profile, which is essentially a ScriptableObject. The top level MRTK Configuration Profile contains sub-profile data for each core of the primary core systems, each of which are designed to configure the behavior of their corresponding sub-systems. Furthermore, these sub-profiles are also Scriptable Objects and thus can contain references to other profile objects one level below them. There is essentially an entire tree of connected profiles that make up the configuration information for how to initialize the MRTK sub-systems and features.
 
-For example, the Input system's behavior is governed by an [input system profile object](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityInputSystemProfile.asset). It's highly recommended to always modify the profile ScriptableObject assets via the in-editor inspector.
+For example, the Input system's behavior is governed by an input system profile, for example the `DefaultMixedRealityInputSystemProfile` (Assets/MRTK/SDK/Profiles). It's highly recommended to always modify the profile ScriptableObject assets via the in-editor inspector.
 
 <img src="../../Documentation/Images/Profiles/input_profile.png" width="650px" style="display:block;">
 <sup>Profile Inspector</sup>
@@ -12,7 +12,7 @@ For example, the Input system's behavior is governed by an [input system profile
 
 ## Default profile
 
-The MRTK provides a set of default profiles which cover most platforms and scenarios that the MRTK supports. For example, when you select the [DefaultMixedRealityToolkitConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset) you will be able to try out scenarios on VR (OpenVR, WMR) and HoloLens (1 and 2).
+The MRTK provides a set of default profiles which cover most platforms and scenarios that the MRTK supports. For example, when you select the `DefaultMixedRealityToolkitConfigurationProfile` (Assets/MRTK/SDK/Profiles) you will be able to try out scenarios on VR (OpenVR, WMR) and HoloLens (1 and 2).
 
 Note that because this is a general use profile, it's not optimized for any particular use case. If you want to have
 more performant/specific settings that are better on other platforms, see the other profiles below, which are slightly tweaked to be better on their respective platforms.
@@ -20,7 +20,7 @@ more performant/specific settings that are better on other platforms, see the ot
 ## HoloLens 2 profile
 
 The MRTK also provides a default profile that is optimized for deployment and testing on
-the HoloLens 2: [DefaultHoloLens2ConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset).
+the HoloLens 2: `DefaultHoloLens2ConfigurationProfile` (Assets/MRTK/SDK/Profiles/HoloLens2).
 
 When prompted to choose a profile for the MixedRealityToolkit object, use this profile instead
 of the default selected profile.

--- a/Documentation/README_AppBar.md
+++ b/Documentation/README_AppBar.md
@@ -6,7 +6,7 @@ App bar is a UI component that is used together with the [bounding box](README_B
 
 ## How to use app bar
 
-Drag and drop [AppBar.prefab](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/AppBar/AppBar.prefab) into the scene hierarchy. In the inspector panel of the component, assign any object with a bounding box as the *Target Bounding Box* to add the app bar to it.
+Drag and drop `AppBar` (Assets/MRTK/SDK/Features/UX/Prefabs/AppBar/AppBar.prefab) into the scene hierarchy. In the inspector panel of the component, assign any object with a bounding box as the *Target Bounding Box* to add the app bar to it.
 
 **Important:** The bounding box activation option for the target object should be 'Activate Manually'.
 

--- a/Documentation/README_BoundingBox.md
+++ b/Documentation/README_BoundingBox.md
@@ -2,7 +2,7 @@
 
 ![Bounding box](../Documentation/Images/BoundingBox/MRTK_BoundingBox_Main.png)
 
-The [`BoundingBox.cs`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs) script provides basic functionality for transforming objects in mixed reality. A bounding box will show a cube around the hologram to indicate that it can be interacted with. Handles on the corners and edges of the cube allow scaling or rotating the object. The bounding box also reacts to user input. On HoloLens 2, for example, the bounding box responds to finger proximity, providing visual feedback to help perceive the distance from the object. All interactions and visuals can be easily customized.
+The [`BoundingBox.cs`](xref:Microsoft.MixedReality.Toolkit.UI.BoundingBox) script provides basic functionality for transforming objects in mixed reality. A bounding box will show a cube around the hologram to indicate that it can be interacted with. Handles on the corners and edges of the cube allow scaling or rotating the object. The bounding box also reacts to user input. On HoloLens 2, for example, the bounding box responds to finger proximity, providing visual feedback to help perceive the distance from the object. All interactions and visuals can be easily customized.
 
 For more information, see [Bounding box and App bar](https://docs.microsoft.com/windows/mixed-reality/app-bar-and-bounding-box) in the Windows Dev Center.
 
@@ -115,11 +115,11 @@ There are several options to activate the bounding box interface.
 
 ### Scale minimum
 
-The minimum allowed scale. This property is deprecated and it is preferable to add a [`MinMaxScaleConstraint`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs) script. If this script is added, the minimum scale will be taken from it instead of from the bounding box.
+The minimum allowed scale. This property is deprecated and it is preferable to add a [`MinMaxScaleConstraint`](xref:Microsoft.MixedReality.Toolkit.UI.MinMaxScaleConstraint) script. If this script is added, the minimum scale will be taken from it instead of from the bounding box.
 
 ### Scale maximum
 
-The maximum allowed scale. This property is deprecated and it is preferable to add a [`MinMaxScaleConstraint`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs) script. If this script is added, the maximum scale will be taken from it instead of from the bounding box.
+The maximum allowed scale. This property is deprecated and it is preferable to add a [`MinMaxScaleConstraint`](xref:Microsoft.MixedReality.Toolkit.UI.MinMaxScaleConstraint) script. If this script is added, the maximum scale will be taken from it instead of from the bounding box.
 
 ### Box display
 
@@ -144,7 +144,7 @@ Bounding box provides the following events. This example uses these events to pl
 
 ## Handle styles
 
-By default, when you just assign the [`BoundingBox.cs`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs) script, it will show the handle of the HoloLens 1st gen style. To use HoloLens 2 style handles, you need to assign proper handle prefabs and materials.
+By default, when you just assign the [`BoundingBox.cs`](xref:Microsoft.MixedReality.Toolkit.UI.BoundingBox) script, it will show the handle of the HoloLens 1st gen style. To use HoloLens 2 style handles, you need to assign proper handle prefabs and materials.
 
 ![Bounding Box](../Documentation/Images/BoundingBox/MRTK_BoundingBox_HandleStyles1.png)
 

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -6,14 +6,14 @@ A button gives the user a way to trigger an immediate action. It is one of the m
 
 ## Button prefabs in MRTK
 
-Examples of the button prefabs under ``MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs`` folder
+Examples of the button prefabs under ``MRTK/SDK/Features/UX/Interactable/Prefabs`` folder
 
 ### Unity UI Image/Graphic based buttons
 
-* [`UnityUIInteractableButton.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/UnityUIInteractableButton.prefab)
-* [`PressableButtonUnityUI.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUI.prefab)
-* [`PressableButtonUnityUICircular.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUICircular.prefab)
-* [`PressableButtonHoloLens2UnityUI.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2UnityUI.prefab)
+* `UnityUIInteractableButton.prefab`
+* `PressableButtonUnityUI.prefab`
+* `PressableButtonUnityUICircular.prefab`
+* `PressableButtonHoloLens2UnityUI.prefab`
 
 ### Collider based buttons
 
@@ -27,9 +27,9 @@ Examples of the button prefabs under ``MixedRealityToolkit.SDK/Features/UX/Inter
 |  ![ButtonHoloLens1](../Documentation/Images/Button/MRTK_Button_HoloLens1.png) **ButtonHoloLens1** | ![PressableRoundButton](../Documentation/Images/Button/MRTK_Button_Round.png) **PressableRoundButton** | ![Button](../Documentation/Images/Button/MRTK_Button_Base.png) **Button** |
 | HoloLens 1st gen's shell style button | Round shape push button | Basic button |
 
-The [`Button.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/Button.prefab) is based on the [Interactable](README_Interactable.md) concept to provide easy UI controls for buttons or other types of interactive surfaces. The baseline button supports all available input methods, including articulated hand input for the near interactions as well as gaze + air-tap for the far interactions. You can also use voice command to trigger the button.
+The `Button` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/Button.prefab) is based on the [Interactable](README_Interactable.md) concept to provide easy UI controls for buttons or other types of interactive surfaces. The baseline button supports all available input methods, including articulated hand input for the near interactions as well as gaze + air-tap for the far interactions. You can also use voice command to trigger the button.
 
-[`PressableButtonHoloLens2.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab) is HoloLens 2's shell style button that supports the precise movement of the button for the direct hand tracking input. It combines `Interactable` script with `PressableButton` script.
+`PressableButtonHoloLens2` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab) is HoloLens 2's shell style button that supports the precise movement of the button for the direct hand tracking input. It combines `Interactable` script with `PressableButton` script.
 
 ## How to use pressable buttons
 
@@ -41,11 +41,11 @@ Create a Canvas in your scene (GameObject -> UI -> Canvas). In the Inspector pan
 * Click "Add NearInteractionTouchableUnityUI"
 * Set the Rect Transform component's X, Y, and Z scale to 0.001
 
-Then, drag [`PressableButtonUnityUI.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUI.prefab), [`PressableButtonUnityUICircular.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUICircular.prefab), or [`PressableButtonHoloLens2UnityUI.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2UnityUI.prefab) onto the Canvas.
+Then, drag `PressableButtonUnityUI` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUI.prefab), `PressableButtonUnityUICircular` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonUnityUICircular.prefab), or `PressableButtonHoloLens2UnityUI` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2UnityUI.prefab) onto the Canvas.
 
 ### Collider based buttons
 
-Simply drag [`PressableButtonHoloLens2.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab) or [`PressableButtonHoloLens2Unplated.prefab`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Unplated.prefab) into the scene. These button prefabs are already configured to have audio-visual feedback for the various types of inputs, including articulated hand input and gaze.
+Simply drag `PressableButtonHoloLens2` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab) or `PressableButtonHoloLens2Unplated` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Unplated.prefab) into the scene. These button prefabs are already configured to have audio-visual feedback for the various types of inputs, including articulated hand input and gaze.
 
 The events exposed in the prefab itself as well as the [Interactable](README_Interactable.md) component can be used to trigger additional actions. The pressable buttons in the [HandInteractionExample scene](README_HandInteractionExamples.md) use Interactable's *OnClick* event to trigger a change in the color of a cube. This event gets triggered for different types of input methods such as gaze, air-tap, hand-ray, as well as physical button presses through the pressable button script.
 

--- a/Documentation/README_ExampleHub.md
+++ b/Documentation/README_ExampleHub.md
@@ -8,11 +8,11 @@ MRTK Examples Hub is a Unity scene that makes it easy to experience multiple sce
 
 ## Prerequisite
 
-MRTK Examples Hub uses [Scene Transition Service](Extensions/SceneTransitionService/SceneTransitionServiceOverview.md) and related scripts. If you are using MRTK through Unity packages, please import **Microsoft.MixedReality.Toolkit.Unity.Extensions.x.x.x.unitypackage** which is part of the [release packages](https://github.com/microsoft/MixedRealityToolkit-Unity/releases). If you are using MRTK through the repository clone, you should already have **MixedRealityToolkit.Extensions** folder in your project.
+MRTK Examples Hub uses [Scene Transition Service](Extensions/SceneTransitionService/SceneTransitionServiceOverview.md) and related scripts. If you are using MRTK through Unity packages, please import **Microsoft.MixedReality.Toolkit.Unity.Extensions.x.x.x.unitypackage** which is part of the [release packages](https://github.com/microsoft/MixedRealityToolkit-Unity/releases). If you are using MRTK through the repository clone, you should already have the **MRTK/Extensions** folder in your project.
 
 ## MRTKExamplesHub scene and the scene system
 
-Open **MRTKExamplesHub.unity** which is located at `MixedRealityToolkit.Examples/Experimental/Demos/ExamplesHub/Scenes/` It is an empty scene with MixedRealityToolkit, MixedRealityPlayspace and LoadHubOnStartup. This scene is configured to use MRTK's Scene System. Click `MixedRealitySceneSystem` under MixedRealityToolkit. It will display the Scene System's information in the Inspector panel.
+Open **MRTKExamplesHub.unity** which is located at `MRTK/Examples/Experimental/Demos/ExamplesHub/Scenes/` It is an empty scene with MixedRealityToolkit, MixedRealityPlayspace and LoadHubOnStartup. This scene is configured to use MRTK's Scene System. Click `MixedRealitySceneSystem` under MixedRealityToolkit. It will display the Scene System's information in the Inspector panel.
 
 <br/><br/><img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHub_Hierarchy.png" width="300">
 <br/><br/><img src="../Documentation/Images/ExamplesHub/MRTK_ExamplesHub_Inspector1.png" width="450">

--- a/Documentation/README_FingertipVisualization.md
+++ b/Documentation/README_FingertipVisualization.md
@@ -2,7 +2,7 @@
 
 ![Fingertip visualization](../Documentation/Images/Fingertip/MRTK_FingertipVisualization_Main.png)
 
-The fingertip affordance helps the user recognize the distance from the target object. The ring shape visual adjusts its size based on the distance from the fingertip to the object. The fingertip visualization is primarily controlled by the [FingerCursor.prefab](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Cursors/FingerCursor.prefab) (and script) which is spawned as the cursor prefab of the *PokePointer*. Other components of the visualization include the *ProximityLight* script, and *MixedRealityStandard* shader.
+The fingertip affordance helps the user recognize the distance from the target object. The ring shape visual adjusts its size based on the distance from the fingertip to the object. The fingertip visualization is primarily controlled by the `FingerCursor` (Assets/MRTK/SDK/Features/UX/Prefabs/Cursors/FingerCursor.prefab) (and script) which is spawned as the cursor prefab of the *PokePointer*. Other components of the visualization include the *ProximityLight* script, and *MixedRealityStandard* shader.
 
 ## How to use the fingertip visualization
 

--- a/Documentation/README_HandInteractionExamples.md
+++ b/Documentation/README_HandInteractionExamples.md
@@ -2,7 +2,7 @@
 
 ![Hand Interaction Examples](../Documentation/Images/MRTK_Examples.png)
 
-The [HandInteractionExamples.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity) example scene contains various types of interactions and UI controls that highlight articulated hand input.
+The `HandInteractionExamples` (Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity) example scene contains various types of interactions and UI controls that highlight articulated hand input.
 
 > [!NOTE]
 > This example scene uses *TextMesh Pro*. To open the scene, click *'Import TMP Essentials'* when the respective prompt is shown during the import of the scene. Unity will then import TextMesh Pro packages.

--- a/Documentation/README_HandJointChaser.md
+++ b/Documentation/README_HandJointChaser.md
@@ -5,7 +5,7 @@ This example scene demonstrates how to use Solver to attach objects to the hand 
 
 ## Example scene
 
-You can find the example scene **HandJointChaserExample** scene in the MixedRealityToolkit.Examples package under `Demos/Input/Scenes/`.
+You can find the example scene **HandJointChaserExample** scene in the `Assets/MRTK/Examples` folder under `Demos/Input/Scenes/`.
 
 ## Solver handler
 

--- a/Documentation/README_Interactable.md
+++ b/Documentation/README_Interactable.md
@@ -20,7 +20,7 @@ The component allows for three primary sections of configuration:
 
 *States* is a [ScriptableObject](https://docs.unity3d.com/Manual/class-ScriptableObject.html) parameter that defines the interactions phases, like press or observed, for [Interactable Profiles](#interactable-profiles) and [Visual Themes](VisualThemes.md).
 
-The [**DefaultInteractableStates**](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) ships with MRTK out-of-box and is the default parameter for *Interactable* components.
+The **DefaultInteractableStates** (Assets/MRTK/SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) ships with MRTK out-of-box and is the default parameter for *Interactable* components.
 
 ![States ScriptableObject example in inspector](Images/Interactable/DefaultInteractableStates.png)
 
@@ -37,7 +37,7 @@ The *DefaultInteractableStates* asset contains four states and utilizes the [`In
 A bit value (#) is assigned to the state depending on the order in the list.
 
 > [!NOTE]
-> It is generally recommended to utilize the [**DefaultInteractableStates**](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) when creating *Interactable* components.
+> It is generally recommended to utilize the **DefaultInteractableStates** (Assets/MRTK/SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) when creating *Interactable* components.
 >
 > However, there are 17 Interactable states available that can be used to drive themes, though some are meant to be driven by other components. Here is a list of those with built-in functionality.
 >
@@ -235,7 +235,7 @@ bool isSelected = myInteractable.IsToggled;
 
 It is common to have a list of toggle buttons where only one can be active at any given time, also known as a radial set or radio buttons etc.
 
-Use the [`InteractableToggleCollection`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableToggleCollection) component to enable this functionality. This control ensures only one *Interactable* is toggled on at any given time. The [*RadialSet* prefab](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab) is also a great starting point out-of-box.
+Use the [`InteractableToggleCollection`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableToggleCollection) component to enable this functionality. This control ensures only one *Interactable* is toggled on at any given time. The *RadialSet* (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/RadialSet.prefab) is also a great starting point out-of-box.
 
 To create a custom radial button group:
 

--- a/Documentation/README_Interactable.md
+++ b/Documentation/README_Interactable.md
@@ -149,7 +149,7 @@ Custom events can be created in two main ways:
 
 #### Example of extending `ReceiverBase`
 
-The [`CustomInteractablesReceiver`](xref:Microsoft.MixedReality.Toolkit.UI) class under `MixedRealityToolkit.Examples` displays status information about an *Interactable* and is an example of how to create a custom Event Receiver.
+The [`CustomInteractablesReceiver`](xref:Microsoft.MixedReality.Toolkit.UI) class displays status information about an *Interactable* and is an example of how to create a custom Event Receiver.
 
 ```c#
 public CustomInteractablesReceiver(UnityEvent ev) : base(ev, "CustomEvent")

--- a/Documentation/README_MRTKStandardShader.md
+++ b/Documentation/README_MRTKStandardShader.md
@@ -6,12 +6,12 @@ MRTK Standard shading system utilizes a single, flexible shader that can achieve
 
 ## Example scenes
 
-You can find the shader material examples in the **MaterialGallery** scene under:
-[MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes) All materials in this scene are using the MRTK/Standard shader.
+You can find the shader material examples in the **MaterialGallery** scene under 
+`MRTK/Examples/Demos/StandardShader/Scenes/`. All materials in this scene are using the MRTK/Standard shader.
 
 ![Material Gallery](../Documentation/Images/MRTKStandardShader/MRTK_MaterialGallery.jpg)
 
-You can find a comparison scene to compare and test the MRTK/Standard shader against the Unity/Standard shader example in the **StandardMaterialComparison** scene under: [MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes)
+You can find a comparison scene to compare and test the MRTK/Standard shader against the Unity/Standard shader example in the **StandardMaterialComparison** scene under `MRTK/Examples/Demos/StandardShader/Scenes/`.
 
 ![Material Comparison](../Documentation/Images/MRTKStandardShader/MRTK_StandardMaterialComparison.gif)
 
@@ -130,7 +130,7 @@ Below are extra details on a handful of feature details available with the MRTK/
 
 ### Primitive clipping
 
-Performant plane, sphere, and box shape clipping with the ability to specify which side of the primitive to clip against (inside or outside). You can find a scene that demonstrates advanced usage of clipping primitives in the  **ClippingExamples** scene under: [MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes)
+Performant plane, sphere, and box shape clipping with the ability to specify which side of the primitive to clip against (inside or outside). You can find a scene that demonstrates advanced usage of clipping primitives in the  **ClippingExamples** scene under `[MRTK/Examples/Demos/StandardShader/Scenes/`.
 
 ![primitive clipping](../Documentation/Images/MRTKStandardShader/MRTK_PrimitiveClipping.gif)
 
@@ -144,7 +144,7 @@ Performant plane, sphere, and box shape clipping with the ability to specify whi
 
 ### Mesh outlines
 
-Many mesh outline techniques are done using a [post processing](https://docs.unity3d.com/Manual/PostProcessingOverview.html) technique. Post processing provides great quality outlines, but can be prohibitively expensive on many Mixed Reality devices. You can find a scene that demonstrates usage of mesh outlines in the  **OutlineExamples** scene under: [MixedRealityToolkit.Examples/Demos/StandardShader/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/StandardShader/Scenes)
+Many mesh outline techniques are done using a [post processing](https://docs.unity3d.com/Manual/PostProcessingOverview.html) technique. Post processing provides great quality outlines, but can be prohibitively expensive on many Mixed Reality devices. You can find a scene that demonstrates usage of mesh outlines in the  **OutlineExamples** scene under `MRTK/Examples/Demos/StandardShader/Scenes/`.
 
 <img src="../Documentation/Images/MRTKStandardShader/MRTK_MeshOutline.jpg" width="900">
 

--- a/Documentation/README_MRTKStandardShader.md
+++ b/Documentation/README_MRTKStandardShader.md
@@ -130,7 +130,7 @@ Below are extra details on a handful of feature details available with the MRTK/
 
 ### Primitive clipping
 
-Performant plane, sphere, and box shape clipping with the ability to specify which side of the primitive to clip against (inside or outside). You can find a scene that demonstrates advanced usage of clipping primitives in the  **ClippingExamples** scene under `[MRTK/Examples/Demos/StandardShader/Scenes/`.
+Performant plane, sphere, and box shape clipping with the ability to specify which side of the primitive to clip against (inside or outside). You can find a scene that demonstrates advanced usage of clipping primitives in the  **ClippingExamples** scene under `MRTK/Examples/Demos/StandardShader/Scenes`.
 
 ![primitive clipping](../Documentation/Images/MRTKStandardShader/MRTK_PrimitiveClipping.gif)
 

--- a/Documentation/README_ManipulationHandler.md
+++ b/Documentation/README_ManipulationHandler.md
@@ -10,8 +10,6 @@ Add the `ManipulationHandler` script component to a GameObject. Make sure to als
 
 To make the object respond to near articulated hand input, add the `NearInteractionGrabbable` script as well.
 
-If you wish to set minimum or maximum values for the object's scale, you can add a [`TransformScaleHandler`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs) script.
-
 ![Manipulation Handler](../Documentation/Images/ManipulationHandler/MRTK_ManipulationHandler_Howto.png)
 
 ## Inspector properties

--- a/Documentation/README_ObjectCollection.md
+++ b/Documentation/README_ObjectCollection.md
@@ -6,9 +6,9 @@ Object collection is a script to help lay out an array of objects in predefined 
 
 ## Object collection scripts
 
-- [`GridObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs) supports Cylinder, Plane, Sphere, Radial surface types
-- [`ScatterObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/ScatterObjectCollection.cs) supports scattered style collection  
-- [`TileGridObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/TileGridObjectCollection.cs) provides some additional options to GridObjectCollection. **Note:** TileGridObjectCollection does not extend [`GridObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs), and has several bugs (see [issue 6237](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6237)). Therefore, it is recommended to use [`GridObjectCollection`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs).
+- [`GridObjectCollection`](xref:Microsoft.MixedReality.Toolkit.Utilities.GridObjectCollection) supports Cylinder, Plane, Sphere, Radial surface types
+- [`ScatterObjectCollection`](xref:Microsoft.MixedReality.Toolkit.Utilities.ScatterObjectCollection) supports scattered style collection  
+- [`TileGridObjectCollection`](xref:Microsoft.MixedReality.Toolkit.Utilities.TileGridObjectCollection) provides some additional options to GridObjectCollection. **Note:** TileGridObjectCollection does not extend [`GridObjectCollection`](xref:Microsoft.MixedReality.Toolkit.Utilities.GridObjectCollection), and has several bugs (see [issue 6237](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6237)). Therefore, it is recommended to use [`GridObjectCollection`](xref:Microsoft.MixedReality.Toolkit.Utilities.GridObjectCollection).
 
 |![Grid Object Collection - Cylinder](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionCylinder.png) Grid Object Collection - Cylinder | ![Grid Object Collection - Sphere](../Documentation/Images/ObjectCollection/MRTK_ObjectCollectionSphere.png) Grid Object Collection - Sphere |
 |:--- | :--- |
@@ -43,7 +43,7 @@ Use the **Layout** field to specify the row / column order that children are lai
 
 ## Object collection examples
 
-The [ObjectCollectionExamples.unity](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/UX/Collections/Scenes/ObjectCollectionExamples.unity) example scene contains various examples of object collection types.
+The `ObjectCollectionExamples` (Assets/MRTK/Examples/Demos/UX/Collections/Scenes/ObjectCollectionExamples.unity) example scene contains various examples of object collection types.
 
 [Periodic table of the elements](https://github.com/Microsoft/MRDesignLabs_Unity_PeriodicTable) is an example app that demonstrates how object collections work. It uses object collection to layout the 3D element boxes in different shapes.
 

--- a/Documentation/README_ObjectManipulator.md
+++ b/Documentation/README_ObjectManipulator.md
@@ -120,7 +120,7 @@ If there is no manipulation, you will still get hover events with the following 
 
 Constraints can be used to limit manipulation in some way. For example, some applications may require rotation, but also require that the object remain upright. In this case, a `RotationAxisConstraint` can be added to the object and used to limit rotation to y-axis rotation. MRTK provides a number of constraints, all of which are described below.
 
-It is also possible to define new constraints and use them to create unique manipulation behaviour that may be needed for some applications. To do this, create a script that inherits from [`TransformConstraint`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/Constraints/TransformConstraint.cs) and implement the abstract `ConstraintType` property and the abstract `ApplyConstraint` method. Upon adding a new constraint to the object, it should constrain manipulation in the way that was defined. This new constraint should also show in the object manipulator [constraint fields](#constraints).
+It is also possible to define new constraints and use them to create unique manipulation behaviour that may be needed for some applications. To do this, create a script that inherits from [`TransformConstraint`](xref:Microsoft.MixedReality.Toolkit.UI.TransformConstraint) and implement the abstract `ConstraintType` property and the abstract `ApplyConstraint` method. Upon adding a new constraint to the object, it should constrain manipulation in the way that was defined. This new constraint should also show in the object manipulator [constraint fields](#constraints).
 
 All of the constraints provided by MRTK share the following properties:
 

--- a/Documentation/README_Sliders.md
+++ b/Documentation/README_Sliders.md
@@ -6,8 +6,7 @@ Sliders are UI components that allow you to continuously change a value by movin
 
 ## Example scene
 
-You can find examples in the **SliderExample** scene under:
-[MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes/](/Assets/MixedRealityToolkit.Examples/Demos/UX/Slider/Scenes)
+You can find examples in the **SliderExample** scene under `MRTK/Examples/Demos/UX/Slider/Scenes/`.
 
 ## How to use sliders
 

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -174,7 +174,7 @@ Finally, surfaces farther than the `MaxRaycastDistance` property setting will be
 
 ![Hand Menu UX Example](Images/Solver/MRTK_UX_HandMenu.png)
 
-The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behavior provides a solver that constrains the tracked object to a region safe for hand constrained content (such as hand UI, menus, etc). Safe regions are considered areas that don't intersect with the hand. A derived class of [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) called [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is also included to demonstrate a common behavior of activating the solver tracked object when the palm is facing the user. For example use of this behavior please see the HandBasedMenuExample scene under: [MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes)
+The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behavior provides a solver that constrains the tracked object to a region safe for hand constrained content (such as hand UI, menus, etc). Safe regions are considered areas that don't intersect with the hand. A derived class of [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) called [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is also included to demonstrate a common behavior of activating the solver tracked object when the palm is facing the user. For example use of this behavior please see the HandBasedMenuExample scene under `MRTK/Examples/Demos/HandTracking/Scenes/`.
 
 Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) property for additional documentation. A few properties are defined in more detail below.
 
@@ -186,7 +186,7 @@ Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.Mi
 
 <img src="Images/Solver/MRTK_Solver_HandConstraintSafeZones.png" width="450">
 
-* **Activation Events**: Currently the [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) triggers four activation events. These events can be used in many different combinations to create unique [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behaviors, please see the HandBasedMenuExample scene under: [MixedRealityToolkit.Examples/Demos/HandTracking/Scenes/](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/HandTracking/Scenes) for examples of these behaviors.
+* **Activation Events**: Currently the [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) triggers four activation events. These events can be used in many different combinations to create unique [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behaviors, please see the HandBasedMenuExample scene under `MRTK/Examples/Demos/HandTracking/Scenes/` for examples of these behaviors.
 
     * *OnHandActivate*: triggers when a hand satisfies the IsHandActive method
     * *OnHandDeactivate*: triggers when the IsHandActive method is no longer satisfied.
@@ -215,7 +215,7 @@ If the directional target is viewable by the user, or whatever frame of referenc
 
 ![Directional Indicator example scene](Images/Solver/DirectionalIndicatorExampleScene.gif)
 
-*[Directional Indicator Example Scene](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Examples/Experimental/Solvers/DirectionalIndicatorExample.unity)*
+*[Directional Indicator Example Scene](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MRTK/Examples/Experimental/Solvers/DirectionalIndicatorExample.unity)*
 
 ## See also
 

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -215,7 +215,7 @@ If the directional target is viewable by the user, or whatever frame of referenc
 
 ![Directional Indicator example scene](Images/Solver/DirectionalIndicatorExampleScene.gif)
 
-*[Directional Indicator Example Scene](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MRTK/Examples/Experimental/Solvers/DirectionalIndicatorExample.unity)*
+*Directional Indicator Example Scene (Assets/MRTK/Examples/Experimental/Solvers/DirectionalIndicatorExample.unity)*
 
 ## See also
 

--- a/Documentation/README_SystemKeyboard.md
+++ b/Documentation/README_SystemKeyboard.md
@@ -36,4 +36,4 @@ private void Update()
 
 ## System keyboard example
 
-You can see a simple example of how to bring up system keyboard in [`MixedRealityKeyboard.cs`](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Experimental/Features/UX/MixedRealityKeyboard.cs)
+You can see a simple example of how to bring up system keyboard in `MixedRealityKeyboard.cs` (Assets/MRTK/SDK/Experimental/Features/UX/MixedRealityKeyboard.cs)

--- a/Documentation/README_TapToPlace.md
+++ b/Documentation/README_TapToPlace.md
@@ -86,7 +86,7 @@ Tap to Place object selection timing can also be controlled via `StartPlacement(
 
 ## Tap to Place Example Scene
 
-The Tap to Place example scene consists of 4 placeable objects, each with a different configuration. The example scene contains walls to show the surface placement behavior that are disabled by default in the hierarchy. The example scene can be found in the Microsoft.MixedReality.Toolkit.Unity.Examples unity package found on the [Release Page](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases). The scene location is: *MixedRealityToolkit.Examples/Demos/Solvers/Scenes/TapToPlaceExample.unity*
+The Tap to Place example scene consists of 4 placeable objects, each with a different configuration. The example scene contains walls to show the surface placement behavior that are disabled by default in the hierarchy. The example scene can be found in the Microsoft.MixedReality.Toolkit.Unity.Examples unity package found on the [Release Page](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases). The scene location is: *MRTK.Examples/Demos/Solvers/Scenes/TapToPlaceExample.unity*
 
 ![TapToPlaceExampleScene](Images/Solver/TapToPlace/TapToPlaceExampleScene.gif)
 

--- a/Documentation/README_TextPrefab.md
+++ b/Documentation/README_TextPrefab.md
@@ -14,7 +14,7 @@ UI Text Mesh prefab (Assets/MRTK/SDK/StandardAssets/Prefabs/Text) with optimized
 
 ## Fonts
 
-Open-source fonts (/Assets/MRTK/Core/StandardAssets/Fonts) included in Mixed Reality Toolkit.
+Open-source fonts (Assets/MRTK/Core/StandardAssets/Fonts) included in Mixed Reality Toolkit.
 
 > [!IMPORTANT]
 > Text Prefab uses the open source font 'Selawik'. To use Text Prefab with a different font, please import the font file and follow the instructions below. Below example shows how to use 'Segoe UI' font with Text Prefab.

--- a/Documentation/README_TextPrefab.md
+++ b/Documentation/README_TextPrefab.md
@@ -6,7 +6,7 @@ These prefabs are optimized for the rendering quality in Windows Mixed Reality. 
 
 ### 3DTextPrefab
 
-3D Text Mesh prefab (MRTK/SDK/StandardAssets/Prefabs/Text) with optimized scaling factor at 2-meter distance. (Please read the instructions below)
+3D Text Mesh prefab (Assets/MRTK/SDK/StandardAssets/Prefabs/Text) with optimized scaling factor at 2-meter distance. (Please read the instructions below)
 
 ### UITextPrefab
 

--- a/Documentation/README_TextPrefab.md
+++ b/Documentation/README_TextPrefab.md
@@ -4,17 +4,17 @@ These prefabs are optimized for the rendering quality in Windows Mixed Reality. 
 
 ## Prefabs
 
-### [3DTextPrefab.prefab](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text)
+### 3DTextPrefab
 
-3D Text Mesh prefab with optimized scaling factor at 2-meter distance. (Please read the instructions below)
+3D Text Mesh prefab (MRTK/SDK/StandardAssets/Prefabs/Text) with optimized scaling factor at 2-meter distance. (Please read the instructions below)
 
-### [UITextPrefab.prefab](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MixedRealityToolkit.SDK/StandardAssets/Prefabs/Text)
+### UITextPrefab
 
-UI Text Mesh prefab with optimized scaling factor at 2-meter distance. (Please read the instructions below)
+UI Text Mesh prefab (Assets/MRTK/SDK/StandardAssets/Prefabs/Text) with optimized scaling factor at 2-meter distance. (Please read the instructions below)
 
-## [Fonts](/Assets/MixedRealityToolkit/StandardAssets/Fonts)
+## Fonts
 
-Open-source fonts included in Mixed Reality Toolkit.
+Open-source fonts (/Assets/MRTK/Core/StandardAssets/Fonts) included in Mixed Reality Toolkit.
 
 > [!IMPORTANT]
 > Text Prefab uses the open source font 'Selawik'. To use Text Prefab with a different font, please import the font file and follow the instructions below. Below example shows how to use 'Segoe UI' font with Text Prefab.

--- a/Documentation/README_Tooltip.md
+++ b/Documentation/README_Tooltip.md
@@ -1,6 +1,6 @@
 # Tooltip
 
-![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Main.png)
+![Tooltip](Images/Tooltip/MRTK_Tooltip_Main.png)
 
 Tooltips are usually used to convey a hint or extra information upon closer inspection of an object. Tooltips can be used to annotate objects in the physical environment.
 
@@ -8,8 +8,8 @@ Tooltips are usually used to convey a hint or extra information upon closer insp
 
 A tooltip can be added directly to the hierarchy and targeted to an object.
 
-To use this method simply add a game object and one of the tooltip prefabs (Assets/MRTK/SDK/Features/UX/Prefabs/Tooltips) to the scene hierarchy. In the prefab's inspector panel, expand the *Tool Tip* (script). Select a tip state and configure the tooltip.  Enter the respective text for the tool tip in the text field. Expand the *ToolTipConnector* (Script) and drag the object that is to have the tooltip from the hierarchy into the field labelled *Target*. This attaches the tooltip to the object.
-![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Connector.png)
+To use this method simply add a game object and one of the tooltip prefabs (Assets/MRTK/SDK/Features/UX/Prefabs/Tooltips) to the scene hierarchy. In the prefab's inspector panel, expand the [`ToolTip`](xref:Microsoft.MixedReality.Toolkit.UI.ToolTip) script. Select a tip state and configure the tooltip.  Enter the respective text for the tool tip in the text field. Expand the [`ToolTipConnector`](xref:Microsoft.MixedReality.Toolkit.UI.ToolTipConnector) script and drag the object that is to have the tooltip from the hierarchy into the field labelled *Target*. This attaches the tooltip to the object.
+![Tooltip](Images/Tooltip/MRTK_Tooltip_Connector.png)
 
 This use assumes a tooltip that is always showing or that is shown / hidden via script by changing the tooltip state property of the tooltip component.
 
@@ -21,4 +21,4 @@ A tooltip can be dynamically added to an object at runtime as well as pre-set to
 
 In the example scenes (Assets/MRTK/Examples/Demos/UX/Tooltips/Scenes), you will be able to find various examples of tooltips.
 
-![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Examples.png)
+![Tooltip](Images/Tooltip/MRTK_Tooltip_Examples.png)

--- a/Documentation/README_Tooltip.md
+++ b/Documentation/README_Tooltip.md
@@ -8,17 +8,17 @@ Tooltips are usually used to convey a hint or extra information upon closer insp
 
 A tooltip can be added directly to the hierarchy and targeted to an object.
 
-To use this method simply add a game object and one of the [tooltip prefabs](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Prefabs/Tooltips) to the scene hierarchy. In the prefab's inspector panel, expand the *Tool Tip* (script). Select a tip state and configure the tooltip.  Enter the respective text for the tool tip in the text field. Expand the *ToolTipConnector* (Script) and drag the object that is to have the tooltip from the hierarchy into the field labelled *Target*. This attaches the tooltip to the object.
+To use this method simply add a game object and one of the tooltip prefabs (Assets/MRTK/SDK/Features/UX/Prefabs/Tooltips) to the scene hierarchy. In the prefab's inspector panel, expand the *Tool Tip* (script). Select a tip state and configure the tooltip.  Enter the respective text for the tool tip in the text field. Expand the *ToolTipConnector* (Script) and drag the object that is to have the tooltip from the hierarchy into the field labelled *Target*. This attaches the tooltip to the object.
 ![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Connector.png)
 
 This use assumes a tooltip that is always showing or that is shown / hidden via script by changing the tooltip state property of the tooltip component.
 
 ## Dynamically spawning tooltips
 
-A tooltip can be dynamically added to an object at runtime as well as pre-set to show and hide on a tap or focus. Simply add the [`ToolTipSpawner`](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs) script to any game object. Delays for appearing and disappearing can be set in the scripts inspector as well as a lifetime so that the tooltip will disappear after a set duration. Tooltips also feature style properties such as background visuals in the spawner script. By default the tooltip will be anchored to the object with the spawner script. This can be changed by assigning a GameObject to the anchor field.
+A tooltip can be dynamically added to an object at runtime as well as pre-set to show and hide on a tap or focus. Simply add the [`ToolTipSpawner`](xref:Microsoft.MixedReality.Toolkit.UI.ToolTipSpawner) script to any game object. Delays for appearing and disappearing can be set in the scripts inspector as well as a lifetime so that the tooltip will disappear after a set duration. Tooltips also feature style properties such as background visuals in the spawner script. By default the tooltip will be anchored to the object with the spawner script. This can be changed by assigning a GameObject to the anchor field.
 
 ## Example scene
 
-In the [example scene files](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Examples/Demos/UX/Tooltips/Scenes), you will be able to find various examples of tooltips.
+In the example scenes (Assets/MRTK/Examples/Demos/UX/Tooltips/Scenes), you will be able to find various examples of tooltips.
 
 ![Tooltip](../Documentation/Images/Tooltip/MRTK_Tooltip_Examples.png)

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -44,7 +44,7 @@ This version of MRTK modifies the layout of the MRTK folder structure. This chan
 | MixedRealityToolkit.Tests | MRTK\Tests |
 | MixedRealityToolkit.Tools | MRTK\Tools |
 
-> [!NOTE]
+> [!IMPORTANT]
 > The `MixedRealityToolkit.Generated` contains customer generated files and remains unchanged.
 
 **WindowsApiChecker: IsMethodAvailable(), IsPropertyAvailable() and IsTypeAvailable()**

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -29,6 +29,24 @@ If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), th
 
 ### What's new in 2.4.0
 
+**MRTK folder layout changes**
+
+This version of MRTK modifies the layout of the MRTK folder structure. This change encapsulates all MRTK code into a single folder hierarchy and reduces the total path length of all MRTK files.
+
+| Previous Folder | New Folder |
+| --- | --- |
+| MixedRealityToolkit | MRTK\Core |
+| MixedRealityToolkit.Examples | MRTK\Examples |
+| MixedRealityToolkit.Extensions | MRTK\Extensions |
+| MixedRealityToolkit.Providers | MRTK\Providers |
+| MixedRealityToolkit.SDK | MRTK\SDK |
+| MixedRealityToolkit.Services | MRTK\Services |
+| MixedRealityToolkit.Tests | MRTK\Tests |
+| MixedRealityToolkit.Tools | MRTK\Tools |
+
+> [!NOTE]
+> The `MixedRealityToolkit.Generated` contains customer generated files and remains unchanged.
+
 **WindowsApiChecker: IsMethodAvailable(), IsPropertyAvailable() and IsTypeAvailable()**
 
 This version of MRTK adds three new methods to the `WindowsApiChecker` class: `IsMethodAvailable`, `IsPropertyAvailable` and `IsTypeAvailable`. These methods allow for checking for feature support on Windows 10 and are prefered over using the `UniversalApiContractV#_IsAvailable` properties.

--- a/Documentation/ServiceUtilities/MixedRealityServiceRegistryAndIMixedRealityServiceRegistrar.md
+++ b/Documentation/ServiceUtilities/MixedRealityServiceRegistryAndIMixedRealityServiceRegistrar.md
@@ -36,7 +36,7 @@ of one or more services. Components that implement IMixedRealityServiceRegistrar
 adding and removing the data within the MixedRealityServiceRegistry. The [MixedRealityToolkit](xref:Microsoft.MixedReality.Toolkit.MixedRealityToolkit)
 object is one such component.
 
-Other registrars can be found in the MixedRealityToolkit.SDK.Experimental.Features
+Other registrars can be found in the MRTK/SDK/Experimental/Features
 folder. These components can be used to add single service (ex: Spatial Awareness) support
 to an application. These single service managers are listed below.
 

--- a/Documentation/SpatialAwareness/CreateDataProvider.md
+++ b/Documentation/SpatialAwareness/CreateDataProvider.md
@@ -5,7 +5,7 @@ The Spatial Awareness system is an extensible system for providing applications 
 This article describes how to create [custom data providers](../Architecture/SystemsExtensionsProviders.md), also called Spatial Observers, for the Spatial Awareness system. The example code shown here is from the [`SpatialObjectMeshObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.SpatialObjectMeshObserver) class implementation which is [useful for loading 3D mesh data in-editor](SpatialObjectMeshObserver.md).
 
 > [!NOTE]
-> The complete source code used in this example can be found in the [MixedRealityToolkit.Providers\ObjectMeshObserver folder](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.Providers/ObjectMeshObserver).
+> The complete source code used in this example can be found in the `Assets/MRTK/Providers/ObjectMeshObserver` folder.
 
 ## Namespace and folder structure
 
@@ -41,11 +41,11 @@ Where the *ContosoSpatialAwareness* folder contains the implementation of the da
 
 If a spatial awareness system data provider is being submitted to the [Mixed Reality Toolkit repository](https://github.com/Microsoft/MixedRealityToolkit-Unity), the namespace **must** begin with Microsoft.MixedReality.Toolkit (ex: *Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver*)
 
- and the code should be located in a folder beneath MixedRealityToolkit.Providers (ex: *MixedRealityToolkit.Providers\ObjectMeshObserver*).
+ and the code should be located in a folder beneath MRTK/Providers (ex: *MRTK/Providers/ObjectMeshObserver*).
 
 **Folder structure**
 
-All code should be located in a folder beneath MixedRealityToolkit.Providers (ex: MixedRealityToolkit.Providers\ObjectMeshObserver).
+All code should be located in a folder beneath MRTK/Providers (ex: MRTK/Providers/ObjectMeshObserver).
 
 ## Define the spatial data object
 
@@ -174,7 +174,7 @@ private void SendMeshObjects()
 ```
 
 > [!NOTE]
-> The [`SpatialObjectMeshObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.SpatialObjectMeshObserver) does not raise `OnObservationUpdated` events since the 3D model is only loaded once. The implementation in the [`WindowsMixedRealitySpatialMeshObserver` file](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/WindowsMixedRealitySpatialMeshObserver.cs) provides an example of raising an `OnObservationUpdated` event for an observed mesh.
+> The [`SpatialObjectMeshObserver`](xref:Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver.SpatialObjectMeshObserver) class does not raise `OnObservationUpdated` events since the 3D model is only loaded once. The implementation in the [`WindowsMixedRealitySpatialMeshObserver`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness.WindowsMixedRealitySpatialMeshObserver) class provides an example of raising an `OnObservationUpdated` event for an observed mesh.
 
 ## Create the profile and inspector
 

--- a/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.md
+++ b/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.md
@@ -23,9 +23,9 @@ The Mixed Reality Toolkit ships with a few default pre-configured profiles. Some
 
 | Profile | System Enabled by Default |
 | --- | --- |
-| [DefaultHoloLens1ConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens1/DefaultHoloLens1ConfigurationProfile.asset) | False |
-| [DefaultHoloLens2ConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/HoloLens2/DefaultHoloLens2ConfigurationProfile.asset) | False |
-| [DefaultMixedRealityToolkitConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset) | True |
+| `DefaultHoloLens1ConfigurationProfile` (Assets/MRTK/SDK/Profiles/HoloLens1) | False |
+| `DefaultHoloLens2ConfigurationProfile` (Assets/MRTK/SDK/Profiles/HoloLens2) | False |
+| `DefaultMixedRealityToolkitConfigurationProfile` (Assets/MRTK/SDK/Profiles) | True |
 
 1. Select the MixedRealityToolkit object in the scene hierarchy to open in the Inspector Panel.
 
@@ -57,7 +57,7 @@ The Spatial Awareness system is similar in that data providers supply the system
 1. [Modify configuration properties on the observer](ConfiguringSpatialAwarenessMeshObserver.md) as necessary
 
 > [!NOTE]
-> Users of the [DefaultMixedRealityToolkitConfigurationProfile](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.SDK/Profiles/DefaultMixedRealityToolkitConfigurationProfile.asset) will have the Spatial Awareness system pre-configured for the Windows Mixed Reality platform which uses
+> Users of the `DefaultMixedRealityToolkitConfigurationProfile` (Assets/MRTK/SDK/Profiles) will have the Spatial Awareness system pre-configured for the Windows Mixed Reality platform which uses
 the [`WindowsMixedRealitySpatialMeshObserver`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness.WindowsMixedRealitySpatialMeshObserver) class.
 
 ### Build and deploy

--- a/Documentation/SpatialAwareness/UsageGuide.md
+++ b/Documentation/SpatialAwareness/UsageGuide.md
@@ -103,7 +103,7 @@ observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.Occlusion;
 
 Components can implement the `IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>` and then register with the Spatial Awareness system to receive Mesh Observation events.
 
-The `DemoSpatialMeshHandler` (Assets/MixedRealityToolkit.Examples/Demos/SpatialAwareness/Scripts) script is a useful example and starting point for listening to Mesh Observer events.
+The `DemoSpatialMeshHandler` (Assets/MRTK/Examples/Demos/SpatialAwareness/Scripts) script is a useful example and starting point for listening to Mesh Observer events.
 
 This is a simplified example of *DemoSpatialMeshHandler* script and Mesh Observation event listening.
 

--- a/Documentation/SpatialAwareness/UsageGuide.md
+++ b/Documentation/SpatialAwareness/UsageGuide.md
@@ -103,7 +103,7 @@ observer.DisplayOption = SpatialAwarenessMeshDisplayOptions.Occlusion;
 
 Components can implement the `IMixedRealitySpatialAwarenessObservationHandler<SpatialAwarenessMeshObject>` and then register with the Spatial Awareness system to receive Mesh Observation events.
 
-The [DemoSpatialMeshHandler](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Examples/Demos/SpatialAwareness/Scripts/DemoSpatialMeshHandler.cs) script is a useful example and starting point for listening to Mesh Observer events.
+The `DemoSpatialMeshHandler` (Assets/MixedRealityToolkit.Examples/Demos/SpatialAwareness/Scripts) script is a useful example and starting point for listening to Mesh Observer events.
 
 This is a simplified example of *DemoSpatialMeshHandler* script and Mesh Observation event listening.
 

--- a/Documentation/Tools/ControllerMappingTool.md
+++ b/Documentation/Tools/ControllerMappingTool.md
@@ -8,7 +8,7 @@ This tool is very useful when developing support for a new hardware controller. 
 
 ## Using the controller mapping tool
 
-To get started with the controller mapping tool, navigate to **MixedRealityToolkit.Tools\RuntimeTools\Tools\ControllerMappingTool** and open the **ControllerMappingTool** scene. Once the scene has been loaded, the project can either be run in the editor, using play mode, or built and run on a device.
+To get started with the controller mapping tool, navigate to **MRTK/Tools/RuntimeTools/Tools/ControllerMappingTool** and open the **ControllerMappingTool** scene. Once the scene has been loaded, the project can either be run in the editor, using play mode, or built and run on a device.
 
 To examine Unity's mappings for a controller:
 

--- a/Documentation/Tools/DependencyWindow.md
+++ b/Documentation/Tools/DependencyWindow.md
@@ -1,7 +1,7 @@
 
 # Dependency window
 
-In Unity, it is often difficult to gleam which assets are being used, and what is referencing them. The "Find References in Scene" option works great when you are only concerned with the current scene, but what about your entire Unity project? This is where the [Dependency Window](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Tools/DependencyWindow) can be useful.
+In Unity, it is often difficult to gleam which assets are being used, and what is referencing them. The "Find References in Scene" option works great when you are only concerned with the current scene, but what about your entire Unity project? This is where the **Dependency Window** (Assets/MRTK/Tools/DependencyWindow) can be useful.
 
 The Dependency Window displays how assets reference and depend on each other. Dependencies are calculated by parsing guids within project YAML files (note, script to script dependencies are not considered).
 

--- a/Documentation/Tools/ExtensionServiceCreationWizard.md
+++ b/Documentation/Tools/ExtensionServiceCreationWizard.md
@@ -9,7 +9,7 @@ Launch the wizard from the main menu: **MixedRealityToolkit/Utilities/Create Ext
 
 ## Editing your service script
 
-By default, your new script assets will be generated in the MRTK/Extensions folder. Once you've completed the wizard, navigate here and open your new service script.
+By default, your new script assets will be generated in the `MixedRealityToolkit.Generated/Extensions` folder. Once you've completed the wizard, navigate here and open your new service script.
 
 Generated service scripts include some prompts similar to new MonoBehaviour scripts. They will let you know where to initialize and update your service.
 

--- a/Documentation/Tools/ExtensionServiceCreationWizard.md
+++ b/Documentation/Tools/ExtensionServiceCreationWizard.md
@@ -9,7 +9,7 @@ Launch the wizard from the main menu: **MixedRealityToolkit/Utilities/Create Ext
 
 ## Editing your service script
 
-By default, your new script assets will be generated in the MixedRealityToolkit.Extensions folder. Once you've completed the wizard, navigate here and open your new service script.
+By default, your new script assets will be generated in the MRTK/Extensions folder. Once you've completed the wizard, navigate here and open your new service script.
 
 Generated service scripts include some prompts similar to new MonoBehaviour scripts. They will let you know where to initialize and update your service.
 

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -41,7 +41,7 @@ The best way to check is to search the Assets folder for DotNetWinRT.dll. If thi
 
 #### DotNetAdapter.csproj missing
 
-If the previous step didn't succeed, it's good to double check that the appropriate csproj exists in your project. Check under MixedRealityToolkit.Providers / WindowsMixedReality / Shared / DotNetAdapter and check that DotNetAdapter.csproj exists. One common case where this file might not exist is if your .gitignore ignores csproj files and you've committed the MRTK files to a remote repo. In this case, please make sure you force add DotNetAdapter.csproj with `git add -f [path/to]/DotNetAdapter.csproj` to make sure it gets committed and cloned for all other collaborators or computers.
+If the previous step didn't succeed, it's good to double check that the appropriate csproj exists in your project. Check under MRTK / Providers / WindowsMixedReality / Shared / DotNetAdapter and check that DotNetAdapter.csproj exists. One common case where this file might not exist is if your .gitignore ignores csproj files and you've committed the MRTK files to a remote repo. In this case, please make sure you force add DotNetAdapter.csproj with `git add -f [path/to]/DotNetAdapter.csproj` to make sure it gets committed and cloned for all other collaborators or computers.
 
 #### `DOTNETWINRT_PRESENT` #define written into player settings
 
@@ -56,7 +56,7 @@ installed and present in the PATH environment variable. If neither of those requ
  true, this error may manifest in the Unity console:
 
 ```cmd
-Win32Exception: ApplicationName='dotnet', CommandLine='msbuild DotNetAdapter.csproj -restore  -v:minimal -p:NuGetInteractive=true  -t:Build -p:Configuration=Release -nologo', CurrentDirectory='C:\src\Assets\MixedRealityToolkit.Providers\WindowsMixedReality\Shared\DotNetAdapter', Native error= The system cannot find the file specified.
+Win32Exception: ApplicationName='dotnet', CommandLine='msbuild DotNetAdapter.csproj -restore  -v:minimal -p:NuGetInteractive=true  -t:Build -p:Configuration=Release -nologo', CurrentDirectory='C:\src\Assets\MRTK\Providers\WindowsMixedReality\Shared\DotNetAdapter', Native error= The system cannot find the file specified.
 ```
 
 The solution to this is to ensure that the [.NET Core CLI tools are installed](https://docs.microsoft.com/dotnet/core/tools/?tabs=netcore2x) and reboot the system to force all apps to get a refreshed system path.
@@ -71,7 +71,7 @@ You can also temporarily remove the adapter to workaround your issue via the fol
 
 1. In Unity, go to Window -> Package Manager and uninstall MSBuild for Unity.
 1. Search for DotNetWinRT.dll in your assets list in Unity and either delete the DLL or delete the Plugins (MRTK 2.2 or earlier) or Dependencies (MRTK 2.3 or later) folder that contains it a few levels up. That should remove these conflicting namespaces, while keeping MRTK around.
-1. (Optional) Navigate to MixedRealityToolkit.Providers / WindowsMixedReality / Shared / DotNetAdapter in your file explorer (not Unity's Assets view) and delete the `.bin` and `.obj` folders. This removes the local cache of NuGet restored packages for DotNetWinRT.
+1. (Optional) Navigate to MRTK / Providers / WindowsMixedReality / Shared / DotNetAdapter in your file explorer (not Unity's Assets view) and delete the `.bin` and `.obj` folders. This removes the local cache of NuGet restored packages for DotNetWinRT.
 1. If you run the MRTK Configurator again, make sure you don't re-enable MSBuild for Unity.
 
 ## Connecting to the HoloLens

--- a/Documentation/Tools/ScreenshotUtility.md
+++ b/Documentation/Tools/ScreenshotUtility.md
@@ -1,7 +1,7 @@
 
 # Screenshot utility
 
-Often taking screenshots in Unity for documentation and promotional imagery can be burdensome and the output often looks less than desirable. This is where the [ScreenshotUtility](https://github.com/Microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MixedRealityToolkit.Tools/ScreenshotUtility) class comes into play.
+Often taking screenshots in Unity for documentation and promotional imagery can be burdensome and the output often looks less than desirable. This is where the `ScreenshotUtility` (Assets/MixedRealityToolkit.Tools/ScreenshotUtility) class comes into play.
 
 The ScreenshotUtility class aides in taking screenshots via menu items and public APIs within the Unity editor. Screenshots can be captured at various resolutions and with transparent clear colors for use in easy post compositing of images. Taking screenshots from a standalone build is not supported by this tool.
 

--- a/Documentation/Tools/ScreenshotUtility.md
+++ b/Documentation/Tools/ScreenshotUtility.md
@@ -1,7 +1,7 @@
 
 # Screenshot utility
 
-Often taking screenshots in Unity for documentation and promotional imagery can be burdensome and the output often looks less than desirable. This is where the `ScreenshotUtility` (Assets/MixedRealityToolkit.Tools/ScreenshotUtility) class comes into play.
+Often taking screenshots in Unity for documentation and promotional imagery can be burdensome and the output often looks less than desirable. This is where the `ScreenshotUtility` (xref:Microsoft.MixedReality.Toolkit.Utilities.Editor.ScreenshotUtility) class comes into play.
 
 The ScreenshotUtility class aides in taking screenshots via menu items and public APIs within the Unity editor. Screenshots can be captured at various resolutions and with transparent clear colors for use in easy post compositing of images. Taking screenshots from a standalone build is not supported by this tool.
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -77,14 +77,17 @@ uses hard coded paths to MRTK resources, they will need to be updated per the fo
 
 | Previous Folder | New Folder |
 | --- | --- |
-| MixedRealityToolkit | MRTK\Core |
-| MixedRealityToolkit.Examples | MRTK\Examples |
-| MixedRealityToolkit.Extensions | MRTK\Extensions |
-| MixedRealityToolkit.Providers | MRTK\Providers |
-| MixedRealityToolkit.SDK | MRTK\SDK |
-| MixedRealityToolkit.Services | MRTK\Services |
-| MixedRealityToolkit.Tests | MRTK\Tests |
-| MixedRealityToolkit.Tools | MRTK\Tools |
+| MixedRealityToolkit | MRTK/Core |
+| MixedRealityToolkit.Examples | MRTK/Examples |
+| MixedRealityToolkit.Extensions | MRTK/Extensions |
+| MixedRealityToolkit.Providers | MRTK/Providers |
+| MixedRealityToolkit.SDK | MRTK/SDK |
+| MixedRealityToolkit.Services | MRTK/Services |
+| MixedRealityToolkit.Tests | MRTK/Tests |
+| MixedRealityToolkit.Tools | MRTK/Tools |
+
+> [!IMPORTANT]
+> The `MixedRealityToolkit.Generated` contains customer generated files and remains unchanged.
 
 ### API changes in 2.4.0
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -67,7 +67,24 @@ If your project was created using the [Mixed Reality Toolkit NuGet packages](MRT
 
 ## Updating 2.3.0 to 2.4.0
 
+[Folder renames](#folder-renames-in-240)
 [API changes](#api-changes-in-240)
+
+### Folder renames in 2.4.0
+
+The MixedRealityToolkit folders have been renamed and moved into a common hierarchy in version 2.4. If an application
+uses hard coded paths to MRTK resources, they will need to be updated per the following table.
+
+| Previous Folder | New Folder |
+| --- | --- |
+| MixedRealityToolkit | MRTK\Core |
+| MixedRealityToolkit.Examples | MRTK\Examples |
+| MixedRealityToolkit.Extensions | MRTK\Extensions |
+| MixedRealityToolkit.Providers | MRTK\Providers |
+| MixedRealityToolkit.SDK | MRTK\SDK |
+| MixedRealityToolkit.Services | MRTK\Services |
+| MixedRealityToolkit.Tests | MRTK\Tests |
+| MixedRealityToolkit.Tools | MRTK\Tools |
 
 ### API changes in 2.4.0
 

--- a/Documentation/VisualThemes.md
+++ b/Documentation/VisualThemes.md
@@ -20,7 +20,7 @@ Example Theme configuration assets can be found under `MRTK/SDK/Features/UX/Inte
 
 ### States
 
-When creating a new [`Theme`](xref:Microsoft.MixedReality.Toolkit.UI.Theme), the first thing to set is what states are available. The *States* property indicates how many values a Theme configuration needs to define as there will be one value per state. In the example image above, the [default states defined for the Interactable](README_Interactable.md#general-input-settings) component are *Default*, *Focus*, *Pressed*, and *Disabled*. These are defined in the `DefaultInteractableStates` (Assets/MRTK/SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) asset file.
+When creating a new [`Theme`](xref:Microsoft.MixedReality.Toolkit.UI.Theme), the first thing to set is what states are available. The *States* property indicates how many values a Theme configuration needs to define as there will be one value per state. In the example image above, the [default states defined for the Interactable](README_Interactable.md#general-input-settings) component are *Default*, *Focus*, *Pressed*, and *Disabled*. These are defined in the `DefaultInteractableStates` (Assets/MRTK/SDK/Features/UX/Interactable/States) asset file.
 
 To create a new [`State`](xref:Microsoft.MixedReality.Toolkit.UI.States) asset:
 
@@ -107,7 +107,7 @@ MRTK ships with a default set of Theme Engines listed below:
 - [`InteractableTextureTheme`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableTextureTheme)
 - [`ScaleOffsetColorTheme`](xref:Microsoft.MixedReality.Toolkit.UI.ScaleOffsetColorTheme)
 
-The default Theme Engines can be found under [MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Scripts/VisualThemes/ThemeEngines).
+The default Theme Engines can be found under `MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines`.
 
 ### Custom theme engines
 

--- a/Documentation/VisualThemes.md
+++ b/Documentation/VisualThemes.md
@@ -14,13 +14,13 @@ To create a new [`Theme`](xref:Microsoft.MixedReality.Toolkit.UI.Theme) asset:
 1) Right click in the *Project Window*
 1) Select **Create** > **Mixed Reality Toolkit** > **Theme**
 
-Example Theme configuration assets can be found under [MixedRealityToolkit.SDK/Features/UX/Interactable/Themes](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/Themes).
+Example Theme configuration assets can be found under `MRTK/SDK/Features/UX/Interactable/Themes`.
 
 ![Theme ScriptableObject example in inspector](Images/VisualThemes/ThemeInspectorExample.png)
 
 ### States
 
-When creating a new [`Theme`](xref:Microsoft.MixedReality.Toolkit.UI.Theme), the first thing to set is what states are available. The *States* property indicates how many values a Theme configuration needs to define as there will be one value per state. In the example image above, the [default states defined for the Interactable](README_Interactable.md#general-input-settings) component are *Default*, *Focus*, *Pressed*, and *Disabled*. These are defined in the [DefaultInteractableStates](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_release/Assets/MixedRealityToolkit.SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) asset file.
+When creating a new [`Theme`](xref:Microsoft.MixedReality.Toolkit.UI.Theme), the first thing to set is what states are available. The *States* property indicates how many values a Theme configuration needs to define as there will be one value per state. In the example image above, the [default states defined for the Interactable](README_Interactable.md#general-input-settings) component are *Default*, *Focus*, *Pressed*, and *Disabled*. These are defined in the `DefaultInteractableStates` (Assets/MRTK/SDK/Features/UX/Interactable/States/DefaultInteractableStates.asset) asset file.
 
 To create a new [`State`](xref:Microsoft.MixedReality.Toolkit.UI.States) asset:
 


### PR DESCRIPTION
This change updates the relevant portions of the documentation to reflect the new MRTK folder hierarchy. The majority of the changes were to replace links to files in specific GitHub paths with either relative path references or xrefs into the API documentation.

Some other changes include some minor updates to the content and a swap from '\' to '/' in paths.