### PR TITLE
Improve Hand Mesh Performance

### DIFF
--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityHandTrackingProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityHandTrackingProfile.cs
@@ -57,15 +57,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </remarks>
         public bool EnableHandMeshVisualization
         {
-            get
-            {
-                return IsSupportedApplicationMode(handMeshVisualizationModes);
-            }
-
-            set
-            {
-                handMeshVisualizationModes = UpdateSupportedApplicationMode(value, handMeshVisualizationModes);
-            }
+            get => IsSupportedApplicationMode(handMeshVisualizationModes);
+            set => handMeshVisualizationModes = UpdateSupportedApplicationMode(value, handMeshVisualizationModes);
         }
 
         /// <summary>
@@ -79,15 +72,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </remarks>
         public bool EnableHandJointVisualization
         {
-            get
-            {
-                return IsSupportedApplicationMode(handJointVisualizationModes);
-            }
-
-            set
-            {
-                handJointVisualizationModes = UpdateSupportedApplicationMode(value, handJointVisualizationModes);
-            }
+            get => IsSupportedApplicationMode(handJointVisualizationModes);
+            set => handJointVisualizationModes = UpdateSupportedApplicationMode(value, handJointVisualizationModes);
         }
 
         [EnumFlags]
@@ -97,14 +83,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SupportedApplicationModes handMeshVisualizationModes = 0;
         public SupportedApplicationModes HandMeshVisualizationModes
         {
-            get
-            {
-                return handMeshVisualizationModes;
-            }
-            set
-            {
-                handMeshVisualizationModes = value;
-            }
+            get => handMeshVisualizationModes;
+            set => handMeshVisualizationModes = value;
         }
 
         [EnumFlags]
@@ -114,14 +94,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private SupportedApplicationModes handJointVisualizationModes = 0;
         public SupportedApplicationModes HandJointVisualizationModes
         {
-            get
-            {
-                return handJointVisualizationModes;
-            }
-            set
-            {
-                handJointVisualizationModes = value;
-            }
+            get => handJointVisualizationModes;
+            set => handJointVisualizationModes = value;
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Extensions/SystemNumericsExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/SystemNumericsExtensions.cs
@@ -16,6 +16,16 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
+        /// TODO: Troy - convert
+        /// </summary>
+        public static void ConvertToUnityVector3(this System.Numerics.Vector3 source, ref UnityEngine.Vector3 target)
+        {
+            target.x = source.X;
+            target.y = source.Y;
+            target.z = -source.Z;
+        }
+
+        /// <summary>
         /// Converts this System.Numerics Quaternion to a UnityEngine Quaternion.
         /// </summary>
         /// <param name="quaternion">The quaternion to convert.</param>
@@ -24,5 +34,17 @@ namespace Microsoft.MixedReality.Toolkit
         {
             return new UnityEngine.Quaternion(-quaternion.X, -quaternion.Y, quaternion.Z, quaternion.W);
         }
+
+        /// <summary>
+        /// TODO: Troy - convert
+        /// </summary>
+        public static void ConvertToUnityQuaternion(this System.Numerics.Quaternion source, ref UnityEngine.Quaternion target)
+        {
+            target.x = -source.X;
+            target.y = -source.Y;
+            target.z = source.Z;
+            target.w = source.W;
+        }
+
     }
 }

--- a/Assets/MRTK/Core/Extensions/SystemNumericsExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/SystemNumericsExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// TODO: Troy - convert
+        /// Converts this System.Numerics Vector3 to a UnityEngine Vector3 format, storing values directly in referenced parameter
         /// </summary>
         public static void ConvertToUnityVector3(this System.Numerics.Vector3 source, ref UnityEngine.Vector3 target)
         {
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// TODO: Troy - convert
+        /// Converts this System.Numerics Quaternion to a UnityEngine Quaternion, storing values directly in referenced parameter
         /// </summary>
         public static void ConvertToUnityQuaternion(this System.Numerics.Quaternion source, ref UnityEngine.Quaternion target)
         {

--- a/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
@@ -14,40 +14,40 @@ namespace Microsoft.MixedReality.Toolkit.Input
         void OnHandMeshUpdated(InputEventData<HandMeshInfo> eventData);
     }
 
-    // See BaseHandVisualizer.OnHandMeshUpdated for an example of how to use the
-    // hand mesh info to render a mesh.
+    /// <summary>
+    /// TODO: Troy - better comment
+    /// See BaseHandVisualizer.OnHandMeshUpdated for an example of how to use the hand mesh info to render a mesh.
+    /// </summary>
     public class HandMeshInfo
     {
-        // The vertices of the hand mesh in the initial coordinate system
+        /// <summary>
+        /// The vertices of the hand mesh in the initial coordinate system
+        /// </summary>
         public Vector3[] vertices;
-
-        // TODO: Troy -> add conversion*
-        // Mesh triangle indices
-        public int[] triangles;
-
-        /*
-         *                     uint indexCount = handMeshObserver.TriangleIndexCount;
-                    ushort[] indices = new ushort[indexCount];
-                    handMeshObserver.GetTriangleIndices(indices);
-                    handMeshTriangleIndices = new int[indexCount];
-                    Array.Copy(indices, handMeshTriangleIndices, (int)handMeshObserver.TriangleIndexCount);
-        */
 
         /// <summary>
         /// Mesh triangle indices
         /// </summary>
-        public ushort[] indices;
+        public int[] triangles;
 
-        // Hand mesh normals, in initial coordinate system
+        /// <summary>
+        /// Hand mesh normals, in initial coordinate system
+        /// </summary>
         public Vector3[] normals;
 
-        // UV mapping of the hand. TODO: Give more specific details about UVs.
+        /// <summary>
+        /// UV mapping of the hand. TODO: Give more specific details about UVs.
+        /// </summary>
         public Vector2[] uvs;
 
-        // Translation to apply to mesh to go from initial coordinates to world coordinates
+        /// <summary>
+        /// Translation to apply to mesh to go from initial coordinates to world coordinates
+        /// </summary>
         public Vector3 position;
 
-        // Rotation to apply to mesh to go from initial coordinates to world coordinates
+        /// <summary>
+        /// Rotation to apply to mesh to go from initial coordinates to world coordinates
+        /// </summary>
         public Quaternion rotation;
     }
 }

--- a/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
@@ -21,8 +21,22 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // The vertices of the hand mesh in the initial coordinate system
         public Vector3[] vertices;
 
+        // TODO: Troy -> add conversion*
         // Mesh triangle indices
         public int[] triangles;
+
+        /*
+         *                     uint indexCount = handMeshObserver.TriangleIndexCount;
+                    ushort[] indices = new ushort[indexCount];
+                    handMeshObserver.GetTriangleIndices(indices);
+                    handMeshTriangleIndices = new int[indexCount];
+                    Array.Copy(indices, handMeshTriangleIndices, (int)handMeshObserver.TriangleIndexCount);
+        */
+
+        /// <summary>
+        /// Mesh triangle indices
+        /// </summary>
+        public ushort[] indices;
 
         // Hand mesh normals, in initial coordinate system
         public Vector3[] normals;
@@ -37,3 +51,4 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Quaternion rotation;
     }
 }
+ 

--- a/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
@@ -15,38 +15,37 @@ namespace Microsoft.MixedReality.Toolkit.Input
     }
 
     /// <summary>
-    /// TODO: Troy - better comment
-    /// See BaseHandVisualizer.OnHandMeshUpdated for an example of how to use the hand mesh info to render a mesh.
+    /// Stores pointers and transform information for Hand Mesh data provided by current platform. This is the data container for the IMixedRealityHandMeshHandler input system event interface.
     /// </summary>
     public class HandMeshInfo
     {
         /// <summary>
-        /// The vertices of the hand mesh in the initial coordinate system
+        /// Pointer to vertices buffer of the hand mesh in the local coordinate system (i.e relative to center of hand)
         /// </summary>
         public Vector3[] vertices;
 
         /// <summary>
-        /// Mesh triangle indices
+        /// Pointer to the triangle indices buffer of the hand mesh. 
         /// </summary>
         public int[] triangles;
 
         /// <summary>
-        /// Hand mesh normals, in initial coordinate system
+        /// Pointer to the normals buffer of the hand mesh in the local coordinate system
         /// </summary>
         public Vector3[] normals;
 
         /// <summary>
-        /// UV mapping of the hand. TODO: Give more specific details about UVs.
+        /// Pointer to UV mapping of the hand mesh triangles
         /// </summary>
         public Vector2[] uvs;
 
         /// <summary>
-        /// Translation to apply to mesh to go from initial coordinates to world coordinates
+        /// Translation to apply to mesh to go from local coordinates to world coordinates
         /// </summary>
         public Vector3 position;
 
         /// <summary>
-        /// Rotation to apply to mesh to go from initial coordinates to world coordinates
+        /// Rotation to apply to mesh to go from local coordinates to world coordinates
         /// </summary>
         public Quaternion rotation;
     }

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -157,7 +157,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return;
             }
 
-            if (handMeshFilter == null &&
+            bool newMesh = handMeshFilter == null;
+
+            if (newMesh &&
                 CoreServices.InputSystem?.InputSystemProfile != null &&
                 CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile != null &&
                 CoreServices.InputSystem.InputSystemProfile.HandTrackingProfile.HandMeshPrefab != null)
@@ -184,13 +186,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 mesh.vertices = eventData.InputData.vertices;
-                mesh.normals = eventData.InputData.normals;
-                mesh.triangles = eventData.InputData.triangles;
                 lastHandMeshVertices = eventData.InputData.vertices;
 
-                if (eventData.InputData.uvs != null && eventData.InputData.uvs.Length > 0)
+                if (newMesh || meshChanged)
                 {
-                    mesh.uv = eventData.InputData.uvs;
+                    mesh.normals = eventData.InputData.normals;
+                    mesh.triangles = eventData.InputData.triangles;
+
+                    if (eventData.InputData.uvs?.Length > 0)
+                    {
+                        mesh.uv = eventData.InputData.uvs;
+                    }
                 }
 
                 if (meshChanged)

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -186,11 +186,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 mesh.vertices = eventData.InputData.vertices;
+                mesh.normals = eventData.InputData.normals;
                 lastHandMeshVertices = eventData.InputData.vertices;
 
                 if (newMesh || meshChanged)
-                {
-                    mesh.normals = eventData.InputData.normals;
+                {                    
                     mesh.triangles = eventData.InputData.triangles;
 
                     if (eventData.InputData.uvs?.Length > 0)

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -130,7 +130,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                     
                     Parallel.For(0, handMeshObserver.VertexCount, i =>
                     {
-                        //neutralPoseVertices[i] = neutralVertexAndNormals[i].Position.ToUnityVector3();
                         neutralVertexAndNormals[i].Position.ConvertToUnityVector3(ref neutralPoseVertices[i]);
                     });
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -127,14 +127,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                     var neutralVertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
                     HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
                     handMeshVertexState.GetVertices(neutralVertexAndNormals);
-
-                    // TODO: Troy - parrelize
-                    /*
-                    for (int i = 0; i < handMeshObserver.VertexCount; i++)
-                    {
-                        neutralPoseVertices[i] = neutralVertexAndNormals[i].Position.ToUnityVector3();
-                    }
-                    */
                     
                     Parallel.For(0, handMeshObserver.VertexCount, i =>
                     {
@@ -172,14 +164,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                             vertexAndNormals[i].Normal.ConvertToUnityVector3(ref handMeshNormalsUnity[i]);
                         });
                         
-                        /*
-                        // TODO: Compare*
-                        for (int i = 0; i < handMeshObserver.VertexCount; i++)
-                        {
-                            handMeshVerticesUnity[i] = vertexAndNormals[i].Position.ToUnityVector3();
-                            handMeshNormalsUnity[i] = vertexAndNormals[i].Normal.ToUnityVector3();
-                        }*/
-
                         HandMeshInfo handMeshInfo = new HandMeshInfo
                         {
                             vertices = handMeshVerticesUnity,

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -137,7 +137,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                     Parallel.For(0, handMeshObserver.VertexCount,
                     i =>
                     {
-                        neutralPoseVertices[i] = neutralVertexAndNormals[i].Position.ToUnityVector3();
+                        //neutralPoseVertices[i] = neutralVertexAndNormals[i].Position.ToUnityVector3();
+                        neutralVertexAndNormals[i].Position.ConvertToUnityVector3(ref neutralPoseVertices[i]);
                     });
 
                     // Compute UV mapping
@@ -168,8 +169,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                         Parallel.For(0, handMeshObserver.VertexCount,
                         i =>
                         {
-                            handMeshVerticesUnity[i] = vertexAndNormals[i].Position.ToUnityVector3();
-                            handMeshNormalsUnity[i] = vertexAndNormals[i].Normal.ToUnityVector3();
+                            vertexAndNormals[i].Position.ConvertToUnityVector3(ref handMeshVerticesUnity[i]);
+                            vertexAndNormals[i].Normal.ConvertToUnityVector3(ref handMeshNormalsUnity[i]);
+
+                            //handMeshVerticesUnity[i] = vertexAndNormals[i].Position.ToUnityVector3();
+                            //handMeshNormalsUnity[i] = vertexAndNormals[i].Normal.ToUnityVector3();
                         });
 
                         // TODO: Compare*


### PR DESCRIPTION
## Overview
This PR is part of an upcoming set to address some of the hand mesh tracking performance issues. This particular PR fixes the problem of constant re-allocation and re-assignment of mesh data every frame. With this change, the MRTK hand interaction example scene renders at 60 FPS with one hand mesh shown. Unfortunately, two hand meshes will easily kick it below 60 still.  

To achieve this improvement, there were two primary changes in this PR:
1) Create re-usable vertex/normal buffers in WindowsMixedRealityArticulatedHandDefinition both for the Windows API buffer (i.e HandMeshVertex) and the UnityEngine.Vector3 vertex/normal buffers. These buffer pointers are passed through HandMeshInfo in the OnHandMeshUpdated events. 
**BEFORE** this change, MRTK was allocating 4 arrays of Vector3's every frame. One handmesh is ~453 vertices => 4 * sizeof(vector3) [12 bytes] * 453 => **21.744 MB per frame**

2) Update BaseHandVisualizer to only update the vertices & normals property of the mesh every frame. The triangles/indices and UV properties are only updated if the mesh changes size or if it's the first time the mesh is being set. 

3. More minor but also added conversion extension functions that allow conversion of a System.Numerics.Vector3 to UnityEngine.Vector3 effectively in-place by using pass-by-reference. This was the construction, copy and assignment are avoided since this operation is executed every frame for ~500 vertices & ~500 normals.

Use of Parralel.For concurrency instead of for-iteration loop is about 2.5-2.7x faster. Setting only the vertices/normals property every update (since triangles/uvs remain same) is about 2.8x-3x faster. There is also significant speed improvements for not re-allocating the 21MB of data every frame but this was not measured directly. 

Future Potential PR work:
1) Look at updating MRTK to utilize new Mesh.SetVertexBufferData() and related functions in 2019.3+ to maximize performance
2) Save HandMesh data into file like HandJoints to leverage in editor with InputSimulationService?
3) [MINOR] EnableHandMeshVisualization and HandJoint are both pulled from Profile instead of service?

## Changes
- Fixes: #7170 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
