### PR TITLE
Feature/gltf custom attrs

### DIFF
--- a/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfMeshPrimitiveAttributes.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfMeshPrimitiveAttributes.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
 {
@@ -9,21 +10,106 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
     /// Common mesh primitive attributes.
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/mesh.primitive.schema.json
     /// </summary>
-    /// <remarks>
-    /// Application specific semantics are not supported
-    /// </remarks>
-    [Serializable]
-    public class GltfMeshPrimitiveAttributes
+    public class GltfMeshPrimitiveAttributes : ReadOnlyDictionary<string, int>
     {
-        public int POSITION = -1;
-        public int NORMAL = -1;
-        public int TANGENT = -1;
-        public int TEXCOORD_0 = -1;
-        public int TEXCOORD_1 = -1;
-        public int TEXCOORD_2 = -1;
-        public int TEXCOORD_3 = -1;
-        public int COLOR_0 = -1;
-        public int JOINTS_0 = -1;
-        public int WEIGHTS_0 = -1;
+        private const string POSITION_KEY = "POSITION";
+        private const string NORMAL_KEY = "NORMAL";
+        private const string TANGENT_KEY = "TANGENT";
+        private const string TEXCOORD_0_KEY = "TEXCOORD_0";
+        private const string TEXCOORD_1_KEY = "TEXCOORD_1";
+        private const string TEXCOORD_2_KEY = "TEXCOORD_2";
+        private const string TEXCOORD_3_KEY = "TEXCOORD_3";
+        private const string COLOR_0_KEY = "COLOR_0";
+        private const string JOINTS_0_KEY = "JOINTS_0";
+        private const string WEIGHTS_0_KEY = "WEIGHTS_0";
+
+        public GltfMeshPrimitiveAttributes(IDictionary<string, int> dictionary) : base(dictionary)
+        {
+        }
+
+        private int TryGetDefault(string key, int defaultVal)
+        {
+            int index;
+            return TryGetValue(key, out index) ? index : defaultVal;
+        }
+
+        public int POSITION
+        {
+            get
+            {
+                return TryGetDefault(POSITION_KEY, -1);
+            }
+        }
+
+        public int NORMAL
+        {
+            get
+            {
+                return TryGetDefault(NORMAL_KEY, -1);
+            }
+        }
+
+        public int TEXCOORD_0
+        {
+            get
+            {
+                return TryGetDefault(TEXCOORD_0_KEY, -1);
+            }
+        }
+
+        public int TEXCOORD_1
+        {
+            get
+            {
+                return TryGetDefault(TEXCOORD_1_KEY, -1);
+            }
+        }
+
+        public int TEXCOORD_2
+        {
+            get
+            {
+                return TryGetDefault(TEXCOORD_2_KEY, -1);
+            }
+        }
+
+        public int TEXCOORD_3
+        {
+            get
+            {
+                return TryGetDefault(TEXCOORD_3_KEY, -1);
+            }
+        }
+
+        public int COLOR_0
+        {
+            get
+            {
+                return TryGetDefault(COLOR_0_KEY, -1);
+            }
+        }
+
+        public int TANGENT
+        {
+            get
+            {
+                return TryGetDefault(TANGENT_KEY, -1);
+            }
+        }
+        public int WEIGHTS_0
+        {
+            get
+            {
+                return TryGetDefault(WEIGHTS_0_KEY, -1);
+            }
+        }
+
+        public int JOINTS_0
+        {
+            get
+            {
+                return TryGetDefault(JOINTS_0_KEY, -1);
+            }
+        }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -199,7 +199,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
             {
                 for (int j = 0; j < gltfObject.meshes[i].primitives.Length; j++)
                 {
-                    gltfObject.meshes[i].primitives[j].Attributes = JsonUtility.FromJson<GltfMeshPrimitiveAttributes>(meshPrimitiveAttributes[primitiveIndex]);
+                    gltfObject.meshes[i].primitives[j].Attributes = new GltfMeshPrimitiveAttributes(StringIntDictionaryFromJson(meshPrimitiveAttributes[primitiveIndex]));
                     primitiveIndex++;
                 }
             }
@@ -394,5 +394,62 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
             jsonString = jsonString.Substring(0, jsonString.IndexOf("\"", StringComparison.Ordinal));
             return jsonString;
         }
+
+        /// <summary>
+        /// A utility function to work around the JsonUtility inability to deserialize to a dictionary.
+        /// </summary>
+        /// <param name="json">JSON string</param>
+        /// <returns>A dictionary with the key value pairs found in the json</returns>
+        private static Dictionary<string, int> StringIntDictionaryFromJson(string json)
+        {
+            string reformatted = JsonDictionaryToArray(json);
+            StringIntKeyValueArray loadedData = JsonUtility.FromJson<StringIntKeyValueArray>(reformatted);
+            Dictionary<string, int> dictionary = new Dictionary<string, int>();
+            for (int i = 0; i < loadedData.items.Length; i++)
+            {
+                dictionary.Add(loadedData.items[i].key, loadedData.items[i].value);
+            }
+            return dictionary;
+        }
+
+        /// <summary>
+        /// Takes a json object string with key value pairs, and returns a json string
+        /// in the format of `{"items": [{"key": $key_name, "value": $value}]}`.
+        /// This format can be handled by JsonUtility and support an aribtrary number
+        /// of key/value pairs
+        /// </summary>
+        /// <param name="json">JSON string in the format `{"key": $value}`</param>
+        /// <returns>Returns a reformatted JSON string</returns>
+        private static string JsonDictionaryToArray(string json)
+        {
+            string reformatted = "{\"items\": [";
+            string pattern = @"""(\w+)"":\s?(""?\w+""?)";
+            RegexOptions options = RegexOptions.Multiline;
+
+            foreach (Match m in Regex.Matches(json, pattern, options))
+            {
+                string key = m.Groups[1].Value;
+                string value = m.Groups[2].Value;
+
+                reformatted += $"{{\"key\":\"{key}\", \"value\":{value}}},";
+            }
+            reformatted = reformatted.TrimEnd(',');
+            reformatted += "]}";
+            return reformatted;
+        }
+
+        [System.Serializable]
+        private class StringKeyValue
+        {
+            public string key = string.Empty;
+            public int value = 0;
+        }
+
+        [System.Serializable]
+        private class StringIntKeyValueArray
+        {
+            public StringKeyValue[] items = Array.Empty<StringKeyValue>();
+        }
+
     }
 }

--- a/Assets/MRTK/Examples/Demos/Gltf/Models/Avocado/glTF/AvocadoCustomAttr.gltf
+++ b/Assets/MRTK/Examples/Demos/Gltf/Models/Avocado/glTF/AvocadoCustomAttr.gltf
@@ -1,0 +1,144 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 406,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 406,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 406,
+      "type": "VEC4"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5126,
+      "count": 406,
+      "type": "VEC3",
+      "max": [
+        0.02128091,
+        0.06284806,
+        0.0138090011
+      ],
+      "min": [
+        -0.02128091,
+        -4.773855E-05,
+        -0.013809
+      ]
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5123,
+      "count": 2046,
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 5,
+      "componentType": 5123,
+      "count": 100,
+      "type": "SCALAR"
+    }
+  ],
+  "asset": {
+    "generator": "glTF Tools for Unity",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 3248
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 3248,
+      "byteLength": 4872
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 8120,
+      "byteLength": 6496
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 14616,
+      "byteLength": 4872
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 19488,
+      "byteLength": 4092
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "Avocado.bin",
+      "byteLength": 23580
+    }
+  ],
+  "images": [
+    {
+      "uri": "Avocado_baseColor.png"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "TEXCOORD_0": 0,
+            "NORMAL": 1,
+            "TANGENT": 2,
+            "POSITION": 3,
+            "_TEMPERATURE": 5
+          },
+          "indices": 4,
+          "material": 0
+        }
+      ],
+      "name": "Avocado"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 0
+        }
+      },
+      "name": "AvocadoMaterial"
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0,
+      "rotation": [
+        0.0,
+        1.0,
+        0.0,
+        0.0
+      ],
+      "name": "Avocado"
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "textures": [
+    {
+      "source": 0
+    }
+  ]
+}

--- a/Assets/MRTK/Examples/Demos/Gltf/Models/Avocado/glTF/AvocadoCustomAttr.gltf.meta
+++ b/Assets/MRTK/Examples/Demos/Gltf/Models/Avocado/glTF/AvocadoCustomAttr.gltf.meta
@@ -1,0 +1,18 @@
+fileFormatVersion: 2
+guid: fea29429b97dbb14b97820f56c74060a
+ScriptedImporter:
+  fileIDToRecycleName:
+    100000: main/glTF Scene AvocadoCustomAttr
+    100002: main/glTF Scene AvocadoCustomAttr/Avocado
+    400000: main/glTF Scene AvocadoCustomAttr/Transform
+    400002: main/glTF Scene AvocadoCustomAttr/Avocado/Transform
+    2300000: main/glTF Scene AvocadoCustomAttr/Avocado/MeshRenderer
+    3300000: main/glTF Scene AvocadoCustomAttr/Avocado/MeshFilter
+    4300000: Avocado
+    11400000: glTF data
+    100100000: main
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8f83316e73954ae4fa56b79705605b45, type: 3}

--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#if !WINDOWS_UWP
+// When the .NET scripting backend is enabled and C# projects are built
+// The assembly that this file is part of is still built for the player,
+// even though the assembly itself is marked as a test assembly (this is not
+// expected because test assemblies should not be included in player builds).
+// Because the .NET backend is deprecated in 2018 and removed in 2019 and this
+// issue will likely persist for 2018, this issue is worked around by wrapping all
+// play mode tests in this check.
+
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
+using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
+using NUnit.Framework;
+using System.Collections;
+using System.IO;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class GltfTests
+    {
+        private const string AvocadoCustomAttrGuid = "fea29429b97dbb14b97820f56c74060a";
+
+        private IEnumerator WaitForTask(Task task)
+        {
+            while (!task.IsCompleted) { yield return null; }
+            if (task.IsFaulted) { throw task.Exception; }
+            yield return null;
+        }
+
+        /// <summary>
+        /// Performs basic check that a glTF loads and contains data
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestGltfLoads()
+        {
+            // Load glTF
+            string path = AssetDatabase.GUIDToAssetPath(AvocadoCustomAttrGuid);
+            var task = GltfUtility.ImportGltfObjectFromPathAsync(path);
+
+            yield return WaitForTask(task);
+
+            GltfObject gltfObject = task.Result;
+
+            yield return null;
+
+            Assert.IsNotNull(gltfObject);
+            Assert.AreEqual(1, gltfObject.meshes.Length);
+            Assert.AreEqual(1, gltfObject.nodes.Length);
+
+            // Check if mesh variables have been set by attributes
+            Assert.AreEqual(406, gltfObject.meshes[0].Mesh.uv.Length);
+            Assert.AreEqual(406, gltfObject.meshes[0].Mesh.normals.Length);
+            Assert.AreEqual(406, gltfObject.meshes[0].Mesh.tangents.Length);
+            Assert.AreEqual(406, gltfObject.meshes[0].Mesh.vertexCount);
+        }
+
+        /// <summary>
+        /// Tests that custom glTF attributes are parsed and accessible
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestGltfCustomAttributes()
+        {
+            // Load glTF
+            string path = AssetDatabase.GUIDToAssetPath(AvocadoCustomAttrGuid);
+            var task = GltfUtility.ImportGltfObjectFromPathAsync(path);
+
+            yield return WaitForTask(task);
+
+            GltfObject gltfObject = task.Result;
+
+            yield return null;
+
+            // Check for custom attribute
+            int temperatureIdx;
+            gltfObject.meshes[0].primitives[0].Attributes.TryGetValue("_TEMPERATURE", out temperatureIdx);
+
+            int temperature = gltfObject.accessors[temperatureIdx].count;
+            Assert.AreEqual(100, temperature);
+        }
+
+    }
+}
+#endif

--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6785a928e1b1d744a6041d440998ab9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/Microsoft.MixedReality.Toolkit.Tests.PlayModeTests.asmdef
+++ b/Assets/MRTK/Tests/PlayModeTests/Microsoft.MixedReality.Toolkit.Tests.PlayModeTests.asmdef
@@ -13,7 +13,8 @@
         "Microsoft.MixedReality.Toolkit.Async",
         "Microsoft.MixedReality.Toolkit.Services.SpatialAwarenessSystem",
         "Microsoft.MixedReality.Toolkit.Providers.ObjectMeshObserver",
-        "Microsoft.MixedReality.Toolkit.Tests.Utilities"
+        "Microsoft.MixedReality.Toolkit.Tests.Utilities",
+        "Microsoft.MixedReality.Toolkit.Gltf"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -88,6 +88,11 @@ The following WindowsApiChecker properties have been marked as obsolete. Please 
 
 There are no plans to add properties to WindowsApiChecker for future API contract versions.
 
+**GltfMeshPrimitiveAttributes read-only**
+
+The gltf mesh primitive attributes used to be settable, they are now read-only. Their values
+will be set once when deserialized.
+
 ## Updating 2.2.0 to 2.3.0
 
 - [API changes](#api-changes-in-230)


### PR DESCRIPTION
## Overview
This change allows custom attributes to be parsed and stored in a dictionary object.

This pull request changes the glTF `Attributes` from an custom object, `GltfMeshPrimitiveAttributes`  to a dictionary to support arbitrary attributes. `GltfMeshPrimitiveAttributes` is now used as a look up for standard attribute keys.

## Changes
- Fixes: #6953 

## Verification

Two playmode tests have been added. `TestGltfLoads` and `TestGltfCustomAttributes` to provide some basic coverage for the existing glTF loading process and the new addition with custom attributes.