### PR TITLE
Prevent test freeze during gltf test

### DIFF
--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
@@ -15,8 +15,11 @@ using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
 using NUnit.Framework;
 using System.Collections;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
@@ -24,7 +27,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     public class GltfTests
     {
         private const string AvocadoCustomAttrGuid = "fea29429b97dbb14b97820f56c74060a";
+        private AsyncCoroutineRunner asyncCoroutineRunner;
+        [SetUp]
+        public void Setup()
+        {
+            PlayModeTestUtilities.Setup();
+            asyncCoroutineRunner = new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();
+        }
 
+        [TearDown]
+        public void TearDown()
+        {
+            PlayModeTestUtilities.TearDown();
+            GameObject.Destroy(asyncCoroutineRunner.gameObject);
+        }
+        
         private IEnumerator WaitForTask(Task task)
         {
             while (!task.IsCompleted) { yield return null; }
@@ -32,6 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
         }
 
+        #region Tests
         /// <summary>
         /// Performs basic check that a glTF loads and contains data
         /// </summary>
@@ -82,7 +100,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int temperature = gltfObject.accessors[temperatureIdx].count;
             Assert.AreEqual(100, temperature);
         }
-
+        #endregion
+        
     }
 }
 #endif

--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
@@ -14,8 +14,6 @@ using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema;
 using Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization;
 using NUnit.Framework;
 using System.Collections;
-using System.IO;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEditor;


### PR DESCRIPTION
## Overview
The gltf tests were sporadically "freezing" with the test runner pausing indefinitely. I've added setup and teardown methods that the other UI methods use. This on it own didn't stop the freezing. It seemed it would freeze every other time. 

What seemed to really fix it was the manual addition of the `AsyncCoroutineRunner`. I think this relates to https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6362.


## Changes
This resolves an issue introduced in this pull request: https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7535

## Verification
To verify you should be able to re-run all playmode tests locally and see it not blocking. Additionally, kick off a CI build.

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
