### PR TITLE
Fix case where a specific controller handedness is set but only non-handed interactions exist

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseController.cs
+++ b/Assets/MRTK/Core/Providers/BaseController.cs
@@ -180,10 +180,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             switch (ControllerHandedness)
             {
                 case Handedness.Left:
-                    AssignControllerMappings(DefaultLeftHandedInteractions);
+                    AssignControllerMappings(DefaultLeftHandedInteractions ?? DefaultInteractions);
                     break;
                 case Handedness.Right:
-                    AssignControllerMappings(DefaultRightHandedInteractions);
+                    AssignControllerMappings(DefaultRightHandedInteractions ?? DefaultInteractions);
                     break;
                 default:
                     AssignControllerMappings(DefaultInteractions);


### PR DESCRIPTION
## Overview

In many cases, handed interactions are overridden to point to the default interactions in classes that don't need different one:

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/ec3ae303cf832bc532edb57083b7edd96eaeb075/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs#L27-L31

However, this isn't a requirement that we've previously enforced. So, this PR updates the code to double check that the handed interactions aren't null before using them. If they're null, the non-handed default interactions are used.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7528
