### PR TITLE
Adding the Dock Control to the TOC

### DIFF
--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -237,6 +237,8 @@
       href: ../Assets/MRTK/SDK/Experimental/HandCoach/README_HandCoach.md
     - name: Pulse Shader
       href: ../Assets/MRTK/SDK/Experimental/PulseShader/README.md
+    - name: Dock Control
+      href: ../Assets/MRTK/SDK/Experimental/Dock/README_Dock.md
 - name: Contributing
   items:
   - name: Contributing Overview


### PR DESCRIPTION
## Overview

Adding a reference to the Dock Control to the table of contents.

## Verification

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
