### PR TITLE
Genericize gazeProvider ref in GGVPointer

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         private MixedRealityInputAction poseAction = MixedRealityInputAction.None;
 
-        private GazeProvider gazeProvider;
+        private IMixedRealityGazeProvider gazeProvider;
         private Vector3 sourcePosition;
         private bool isSelectPressed;
         private Handedness lastControllerHandedness;
@@ -283,7 +283,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             base.OnEnable();
 
-            gazeProvider = CoreServices.InputSystem.GazeProvider as GazeProvider;
+            gazeProvider = CoreServices.InputSystem.GazeProvider;
             BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
             if (c != null)
             {


### PR DESCRIPTION
## Overview

This private reference is currently pointing to the MRTK-implemented `GazeProvider` type. Since we allow devs to create their own, it'd be good to only reference the interface. It doesn't look like we had a specific dependency on our implementation.

Fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7566