### PR TITLE
Update eye tracking documentation

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
+++ b/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
@@ -52,5 +52,7 @@ CoreServices.InputSystem.EyeGazeProvider.GazeOrigin +
 CoreServices.InputSystem.EyeGazeProvider.GazeDirection.normalized * defaultDistanceInMeters;
 ```
 
----
-[Back to "Eye tracking in the MixedRealityToolkit"](EyeTracking_Main.md)
+## See also
+- [MRTK Eye Tracking Overview](EyeTracking_Main.md)
+- [MRTK Eye Tracking setup](EyeTracking_BasicSetup.md)
+

--- a/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
+++ b/Documentation/EyeTracking/EyeTracking_EyeGazeProvider.md
@@ -1,11 +1,12 @@
 # Accessing eye tracking data in your Unity script
 
-The following assumes that you followed the steps for setting up eye tracking in your MRTK scene (see [Basic MRTK setup to use eye tracking](EyeTracking_BasicSetup.md)).
-To access eye tracking data in your MonoBehaviour scripts is easy! Simply use *CoreServices.InputSystem.EyeGazeProvider*.
+This article assumes one has understanding for setting up eye tracking in an MRTK scene (see [Basic MRTK setup to use eye tracking](EyeTracking_BasicSetup.md)).
+Accessing eye tracking data in a MonoBehaviour script is easy! Simply use *CoreServices.InputSystem.EyeGazeProvider*.
 
-## CoreServices.InputSystem.EyeGazeProvider
+## IMixedRealityEyeGazeProvider
 
-While the *CoreServices.InputSystem.EyeGazeProvider* provides several helpful variables, the key ones for eye tracking input are the following:
+Eye tracking configuration in MRTK is configured via the [`IMixedRealityEyeGazeProvider`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityEyeGazeProvider) interface. Using [CoreServices.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides the default gaze provider implementation registered in the toolkit at runtime.
+Useful properties of the `EyeGazeProvider` is outlined below.
 
 - **UseEyeTracking**:
 True if eye tracking hardware is available and the user has given permission to use eye tracking in the app.
@@ -30,7 +31,7 @@ This will return the *head* gaze direction if 'IsEyeGazeValid' is false.
 
 - **HitInfo**, **HitPosition**, **HitNormal**, etc.:
 Information about the currently gazed at target.
-Again, if 'IsEyeGazeValid' is false, this will be based on the user's *head* gaze.
+Again, if `IsEyeGazeValid` is false, this will be based on the user's *head* gaze.
 
 ## Examples for using CoreServices.InputSystem.EyeGazeProvider
 
@@ -53,6 +54,8 @@ CoreServices.InputSystem.EyeGazeProvider.GazeDirection.normalized * defaultDista
 ```
 
 ## See also
+
 - [MRTK Eye Tracking Overview](EyeTracking_Main.md)
 - [MRTK Eye Tracking setup](EyeTracking_BasicSetup.md)
-
+- [MRTK Eye Tracking Calibration](EyeTracking_IsUserCalibrated.md)
+- [HoloLens 2 Eye Tracking Documentation](https://docs.microsoft.com/windows/mixed-reality/eye-tracking)

--- a/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
+++ b/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
@@ -71,5 +71,9 @@ Once the notification is dismissed, it will slowly decrease its size and fade ou
    }
 ```
 
----
-[Back to "Eye tracking in the MixedRealityToolkit"](EyeTracking_Main.md)
+## See also
+
+- [MRTK Eye Tracking Overview](EyeTracking_Main.md)
+- [MRTK Eye Tracking setup](EyeTracking_BasicSetup.md)
+- [MRTK Eye Tracking via Code](EyeTracking_EyeGazeProvider.md)
+- [HoloLens 2 Eye Tracking Documentation](https://docs.microsoft.com/windows/mixed-reality/eye-tracking)

--- a/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
+++ b/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
@@ -2,9 +2,9 @@
 
 ![Screenshot from eye calibration notification](../Images/EyeTracking/mrtk_et_calibration_notification_example.jpg)
 
-## To be or not to be eye calibrated
+## Overview
 
-If eye tracking is a fundamental part of your app experience, you may wish to ensure that the user's eye calibration is valid.
+If eye tracking is a fundamental part of your app experience, one may wish to ensure that the user's eye calibration is valid.
 The main reason for it to be invalid is that the user has chosen to skip the eye tracking calibration when putting on the device.
 
 This page covers the following:
@@ -16,8 +16,9 @@ This page covers the following:
 
 ### How to detect the eye calibration state
 
-The [CoreServices.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides a `bool?` property called `IsEyeGazeValid`.
-It returns null if no information from the eye tracker is available yet.
+Eye tracking configuration in MRTK is configured via the [`IMixedRealityEyeGazeProvider`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityEyeGazeProvider) interface. 
+
+Using [CoreServices.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides the default gaze provider implementation registered in the toolkit at runtime. `IMixedRealityEyeGazeProvider.IsEyeGazeValid` returns a `bool?` which is null if no information from the eye tracker is available yet.
 Once data has been received, it will either return true or false to indicate that the user's eye tracking calibration is valid or invalid.
 
 ### Sample eye calibration notification - step-by-step
@@ -33,14 +34,16 @@ This includes slowly increasing its size and opacity on activation.
 Once the notification is dismissed, it will slowly decrease its size and fade out.
 
    - Attached to the *_EyeCalibrationChecker_ game object* is the [EyeCalibrationChecker](xref:Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.EyeCalibrationChecker) script which exposes two Unity Events:
-      - OnEyeCalibrationDetected()
-      - OnNoEyeCalibrationDetected()
+      - `OnEyeCalibrationDetected()`
+      - `OnNoEyeCalibrationDetected()`
 
    - These events will only trigger if the calibration status changes. Hence, if a user chooses to dismiss the notification, the notification will not show up again until
       - The app gets restarted
       - A valid user has been detected and then a new uncalibrated user has put the device on
 
-   - For testing whether the animations and events are triggered correctly, the EyeCalibrationChecker script possesses a `bool editorTestUserIsCalibrated` flag. For example, when the app is running in the Unity Editor you can test, whether the notification automatically pops up once the calibration status changes from true to false and whether it automatically dismisses the notification again once the status changes from false to true.
+   - For testing whether the animations and events are triggered correctly, the EyeCalibrationChecker script possesses a `bool editorTestUserIsCalibrated` flag. For example, when running in the Unity Editor, one can test:
+      1. Whether the notification automatically pops up once the calibration status changes from true to false
+      1. Whether it automatically dismisses the notification again once the status changes from false to true.
 
 ```c#
     private bool? prevCalibrationStatus = null;

--- a/Documentation/EyeTracking/EyeTracking_Main.md
+++ b/Documentation/EyeTracking/EyeTracking_Main.md
@@ -16,7 +16,13 @@ Finally, we also describe how to set up a fresh scene with the core components t
 
 3. [Accessing eye tracking data via Code](EyeTracking_BasicSetup.md)
 
+4. [Validate eye tracking calibration on device](EyeTracking_IsUserCalibrated.md)
+
+EyeTracking/EyeTracking_IsUserCalibrated.md
+
 ## See also
 
 - [MRTK Eye Tracking setup](EyeTracking_BasicSetup.md)
 - [MRTK Eye Tracking via Code](EyeTracking_EyeGazeProvider.md)
+- [MRTK Eye Tracking Calibration](EyeTracking_IsUserCalibrated.md)
+- [HoloLens 2 Eye Tracking Documentation](https://docs.microsoft.com/windows/mixed-reality/eye-tracking) 

--- a/Documentation/EyeTracking/EyeTracking_Main.md
+++ b/Documentation/EyeTracking/EyeTracking_Main.md
@@ -1,17 +1,22 @@
 # Eye tracking in the Mixed Reality Toolkit
 
-![Eye tracking in MRTK](../../Documentation/Images/EyeTracking/mrtk_et_compilation.png)
+![Eye tracking in MRTK](../Images/EyeTracking/mrtk_et_compilation.png)
 
 _HoloLens 2_ offers an exciting and powerful new input: Eye tracking!
 Eye tracking enables users to quickly and effortlessly engage with holograms across their view and can make your system smarter by better identifying a user's intention. Check out Microsoft's Mixed Reality [documentation on eye tracking on HoloLens 2](https://docs.microsoft.com/windows/mixed-reality/eye-tracking) for more details, such as explaining powerful applications and design guidelines for eye tracking in mixed reality.
 
-New to eye tracking? No problem! We have created a number of videos, tutorials and samples to get you started in the [Mixed Reality Toolkit](https://github.com/Microsoft/MixedRealityToolkit-Unity)!
-We recommend starting by exploring some of the existing eye tracking samples that demonstrate best practices for eye-based interactions.
+New to eye tracking? No problem! There are a number of videos, tutorials and samples to get you started in the [Mixed Reality Toolkit](https://github.com/Microsoft/MixedRealityToolkit-Unity)!
+It is recommend starting by exploring some of the existing eye tracking samples that demonstrate best practices for eye-based interactions.
 You can then use these samples to pull the parts that seem relevant to you into your app.
 Finally, we also describe how to set up a fresh scene with the core components to get eye tracking working in your app.
 
 1. [MRTK eye tracking samples](EyeTracking_ExamplesOverview.md)
 
-2. [A fresh start - Basic MRTK eye tracking setup](EyeTracking_BasicSetup.md)
+2. [MRTK eye tracking setup](EyeTracking_BasicSetup.md)
 
----
+3. [Accessing eye tracking data via Code](EyeTracking_BasicSetup.md)
+
+## See also
+
+- [MRTK Eye Tracking setup](EyeTracking_BasicSetup.md)
+- [MRTK Eye Tracking via Code](EyeTracking_EyeGazeProvider.md)

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -90,7 +90,7 @@
       - name: Input Providers Overview
         href: Input/InputProviders.md
       - name: Creating an input data provider
-      href: Input/CreateDataProvider.md
+        href: Input/CreateDataProvider.md
     - name: Controllers
       href: Input/Controllers.md
     - name: Eyes

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -90,11 +90,19 @@
       - name: Input Providers Overview
         href: Input/InputProviders.md
       - name: Creating an input data provider
-        href: Input/CreateDataProvider.md
+      href: Input/CreateDataProvider.md
     - name: Controllers
       href: Input/Controllers.md
     - name: Eyes
-      href: EyeTracking/EyeTracking_Main.md
+      items:
+      - name: Overview
+        href: EyeTracking/EyeTracking_Main.md
+      - name: Getting Started
+        href: EyeTracking/EyeTracking_BasicSetup.md
+      - name: Access Data via Code
+        href: EyeTracking/EyeTracking_EyeGazeProvider.md
+      - name: Validate Tracking Calibration
+        href: EyeTracking/EyeTracking_IsUserCalibrated.md
     - name: Gaze
       href: Input/Gaze.md
     - name: Gestures


### PR DESCRIPTION
## Overview
This change cleans up and organizes some of the existing documentation around eye tracking for MRTK. Many of the doc pages were not visible in the table of contents. Also grouped relevant links to a "See also" section in each article. Cleaned up some of the wording, formatting, adding xref links, removing informal uses, etc.

## Changes
- Fixes: #6341 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
