### PR TITLE
Update deprecated MRTK configurator enum value for 2019.3

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -175,7 +175,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #endif // UNITY_2019_3_OR_NEWER
                 }
 #if UNITY_2019_3_OR_NEWER
-                RenderToggle(MRConfig.SinglePassInstancing, "Set Single Pass Instanced rendering path (legacy XR API)");
+                RenderToggle(MRConfig.OptimalRenderingPath, "Set Single Pass Instanced rendering path (legacy XR API)");
 #else
 #if UNITY_ANDROID
                 RenderToggle(MRConfig.OptimalRenderingPath, "Set Single Pass Stereo rendering path");


### PR DESCRIPTION
## Overview

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7525 deprecated an enum value but didn't update the Unity 2019.3 path with the new one. This was leading to an obsolete warning when opening.