### PR TITLE
Add size utility calculator for editor

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
+{
+    /// <summary>
+    /// Editor utility class to discern world space sizing of objects in scene
+    /// </summary>
+    public static class SizeUtilities
+    {
+        /// <summary>
+        /// Finds the first Renderer type component on the selected GameObject in scene and returns it's world space bounds size.
+        /// </summary>
+        [MenuItem("GameObject/MRTK/Renderer Size", false, 0)]
+        public static void RendererSize()
+        {
+            if (Selection.activeGameObject == null)
+            {
+                Debug.Log("No selected gameobject is available to calculate Renderer size.");
+                return;
+            }
+
+            var renderer = Selection.activeGameObject.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                Debug.Log($"Renderer on GameObject \"{renderer.name}\" has world-space bounds size of {renderer.bounds.size}");
+            }
+            else
+            {
+                Debug.Log($"No Renderer component found on {Selection.activeGameObject}");
+            }
+        }
+
+        /// <summary>
+        /// Finds all Collider type components on the selected GameObject in scene and returns their world space bounds size.
+        /// </summary>
+        [MenuItem("GameObject/MRTK/Collider Size", false, 0)]
+        public static void ColliderSize()
+        {
+            if (Selection.activeGameObject == null)
+            {
+                Debug.Log("No selected gameobject is available to calculate Collider size.");
+                return;
+            }
+
+            var colliders = Selection.activeGameObject.GetComponents<Collider>();
+            if (colliders != null)
+            {
+                Debug.Log($"Following Collider components found on \"{Selection.activeGameObject}\"");
+                foreach (var c in colliders)
+                {
+                    Debug.Log($"Collider of type {c.GetType()} has world-space bounds size of {c.bounds.size}");
+                }
+            }
+            else
+            {
+                Debug.Log($"No Collider components found on {Selection.activeGameObject}");
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs.meta
+++ b/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1e0d371b9c97e64faea3ce7dd35d5c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
It can be quite annoying to know what the world-space size of an object is in Unity, especially with multiple hierarchy transforms applied. 

This PR adds a editor utility that allows one to get the Renderer or Collider world space bounds sizes for a selected GameObject. 

Right click gameobject > MRTK > Render/Collider Size => See output results in debug log console

![size-utility](https://user-images.githubusercontent.com/25975362/77484629-3fe47b00-6de8-11ea-8af9-ab5e155ab574.gif)

## Changes
- Fixes: # .

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
