### PR TITLE
Update meta for openvr_api

### DIFF
--- a/Assets/MRTK/Providers/OpenVR/Headers/openvr_api.cs.meta
+++ b/Assets/MRTK/Providers/OpenVR/Headers/openvr_api.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d26b9eddedb33d48be044bb268a57c7
+guid: bb2436c915708d344810f86516a94570
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Overview

The meta for this script wasn't updated when it was added in https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6374. This can cause other packages, like SteamVR, to overwrite the file and cause compilation errors in MRTK.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7588