### PR TITLE
Fix save when creating a new file

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/AssemblyDefinition.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/AssemblyDefinition.cs
@@ -205,14 +205,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             FileInfo file = new FileInfo(fileName);
-            bool readOnly = file.IsReadOnly;
+
+            bool readOnly = (file.Exists) ? file.IsReadOnly : false;
             if (readOnly)
             {
                 file.IsReadOnly = false;
             }
 
             Debug.Log($"Saving {fileName}");
-            File.WriteAllText(fileName, JsonUtility.ToJson(this, true));
+            using (StreamWriter writer = new StreamWriter(fileName, false))
+            {
+                writer.Write(JsonUtility.ToJson(this, true));
+            }
 
             if (readOnly)
             {


### PR DESCRIPTION
@CDiaz-MS found an issue where saving a newly created AssemblyDefinition object would fail.

This change
- checks for file existence before inquring about the readonly attribute
- switches from File.WriteAllText to StreamWriter.Write