### PR TITLE
Fix Unity 2019.3 build

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -162,8 +162,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <returns>The current Unity finger bone converted into an MRTK joint.</returns>
         private TrackedHandJoint ConvertToTrackedHandJoint(HandFinger finger, int index)
         {
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityXRSDKArticulatdHand.ConvertToTrackedHandJoint");
-
             switch (finger)
             {
                 case HandFinger.Thumb: return (index == 0) ? TrackedHandJoint.Wrist : TrackedHandJoint.ThumbMetacarpalJoint + index - 1;
@@ -173,8 +171,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 case HandFinger.Pinky: return TrackedHandJoint.PinkyMetacarpal + index;
                 default: return TrackedHandJoint.None;
             }
-
-            Profiler.EndSample(); // ConvertToTrackedHandJoint
         }
 
         #endregion Update data functions

--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
+using UnityEngine.Profiling;
 using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Input


### PR DESCRIPTION
## Overview

#7590 introduced some breaks when opened in Unity 2019.3. This fixes them, by adding a missing namespace and removing unreachable code.