### PR TITLE
Add profiler instrumentation to MRTK's raycast logic

### DIFF
--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Physics
 {
@@ -24,14 +25,20 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>Whether or not the raycast hit something.</returns>
         public static bool RaycastSimplePhysicsStep(RayStep step, float maxDistance, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
+            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastSimplePhysicsStep");
+
             Debug.Assert(maxDistance > 0, "Length must be longer than zero!");
             Debug.Assert(step.Direction != Vector3.zero, "Invalid step direction!");
 
-            return prioritizedLayerMasks.Length == 1
+            bool result = prioritizedLayerMasks.Length == 1
                 // If there is only one priority, don't prioritize
                 ? UnityEngine.Physics.Raycast(step.Origin, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0])
                 // Raycast across all layers and prioritize
                 : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.RaycastAll(step.Origin, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+
+            Profiler.EndSample(); // RaycastSimplePhysicsStep
+
+            return result;
         }
 
         /// <summary>
@@ -40,6 +47,8 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>Whether or not the raycast hit something.</returns>
         public static bool RaycastBoxPhysicsStep(RayStep step, Vector3 extents, Vector3 targetPosition, Matrix4x4 matrix, float maxDistance, LayerMask[] prioritizedLayerMasks, int raysPerEdge, bool isOrthographic, bool focusIndividualCompoundCollider, out Vector3[] points, out Vector3[] normals, out bool[] hits)
         {
+            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastBoxPhysicsStep");
+
             if (Application.isEditor && DebugEnabled)
             {
                 Debug.DrawLine(step.Origin, step.Origin + step.Direction * 10.0f, Color.green);
@@ -98,6 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 }
             }
 
+            Profiler.EndSample(); // RaycastBoxPhysicsStep
             return hitSomething;
         }
 
@@ -116,11 +126,16 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>Whether or not the raycast hit something.</returns>
         public static bool RaycastSpherePhysicsStep(RayStep step, float radius, float maxDistance, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
-            return prioritizedLayerMasks.Length == 1
+            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastSpherePhysicsStep");
+
+            bool result = prioritizedLayerMasks.Length == 1
                 // If there is only one priority, don't prioritize
                 ? UnityEngine.Physics.SphereCast(step.Origin, radius, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0])
                 // Raycast across all layers and prioritize
                 : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.SphereCastAll(step.Origin, radius, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+
+            Profiler.EndSample(); // RaycastSpherePhysicsStep
+            return result;
         }
 
         /// <summary>
@@ -130,10 +145,13 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>The minimum distance hit within the first layer that has hits.</returns>
         public static bool TryGetPrioritizedPhysicsHit(RaycastHit[] hits, LayerMask[] priorityLayers, bool focusIndividualCompoundCollider, out RaycastHit raycastHit)
         {
+            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.TryGetPrioritizedPhysicsHit");
+
             raycastHit = default(RaycastHit);
 
             if (hits.Length == 0)
             {
+                Profiler.EndSample(); // TryGetPrioritizedPhysicsHit - no hits
                 return false;
             }
 
@@ -156,9 +174,12 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 if (minHit != null)
                 {
                     raycastHit = minHit.Value;
+                    Profiler.EndSample(); // TryGetPrioritizedPhysicstHit - success
                     return true;
                 }
             }
+
+            Profiler.EndSample(); // TryGetPrioritizedPhysicsHit
 
             return false;
         }
@@ -169,16 +190,20 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>Whether the ray step intersects the ray step.</returns>
         public static bool RaycastPlanePhysicsStep(RayStep step, Plane plane, out Vector3 hitPoint)
         {
+            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastPlanePhysicsStep");
+
             if (plane.Raycast(step, out float intersectDistance))
             {
                 if (intersectDistance <= step.Length)
                 {
                     hitPoint = ((Ray)step).GetPoint(intersectDistance);
+                    Profiler.EndSample(); // RaycastPlanePhysicsStep - success
                     return true;
                 }
             }
 
             hitPoint = Vector3.zero;
+            Profiler.EndSample(); // RaycastPlanePhysicsStep
             return false;
         }
     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -139,6 +140,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         public override void OnPreSceneQuery()
         {
+            Profiler.BeginSample("[MRTK] PokePointer.OnPreSceneQuery");
+
             if (Rays == null)
             {
                 Rays = new RayStep[1];
@@ -187,10 +190,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             closestProximityTouchable = newClosestTouchable;
 
             visuals.SetActive(IsActive);
+
+            Profiler.EndSample(); // OnPreSceneQuery
         }
 
         private bool FindClosestTouchableForLayerMask(LayerMask layerMask, out BaseNearInteractionTouchable closest, out float closestDistance, out Vector3 closestNormal)
         {
+            Profiler.BeginSample("[MRTK] PokePointer.FindClosestTouchableForLayerMask");
+
             closest = null;
             closestDistance = float.PositiveInfinity;
             closestNormal = Vector3.zero;
@@ -239,16 +246,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
 
+            Profiler.EndSample(); // FindClosestTouchableForLayerMask
             return closest != null;
         }
 
         /// <inheritdoc />
         public override void OnPostSceneQuery()
         {
+            Profiler.BeginSample("[MRTK] PokePointer.OnPostSceneQuery");
+
             base.OnPostSceneQuery();
 
             if (!IsActive)
             {
+                Profiler.EndSample(); // OnPostSceneQuery - early exit
                 return;
             }
 
@@ -301,6 +312,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             PreviousPosition = Position;
+
+            Profiler.EndSample(); // OnPostSceneQuery
         }
 
         /// <inheritdoc />

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -124,6 +125,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
+            Profiler.BeginSample("[MRTK] SpherePointer.OnPreSceneQuery");
+
             if (Rays == null)
             {
                 Rays = new RayStep[1];
@@ -153,6 +156,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                 }
             }
+
+            Profiler.EndSample(); // OnPreSceneQuery
         }
 
         /// <summary>
@@ -162,6 +167,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool TryGetNearGraspPoint(out Vector3 result)
         {
+            Profiler.BeginSample("[MRTK] SpherePointer.TryGetNearGraspPoint");
+
             // If controller is of kind IMixedRealityHand, return average of index and thumb
             if (Controller != null && Controller is IMixedRealityHand)
             {
@@ -173,6 +180,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     if (thumb != null)
                     {
                         result = 0.5f * (index.Position + thumb.Position);
+                        Profiler.EndSample(); // TryGetNearGraspPoint - success
                         return true;
                     }
                 }
@@ -180,16 +188,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
             else
             {
                 result = Position;
+                Profiler.EndSample(); // TryGetNearGraspPoint - success
                 return true;
             }
 
             result = Vector3.zero;
+            Profiler.EndSample(); // TryGetNearGraspPoint
             return false;
         }
 
         /// <inheritdoc />
         public bool TryGetDistanceToNearestSurface(out float distance)
         {
+            Profiler.BeginSample("[MRTK] SpherePointer.TryGetDistanceToNearestSurface");
+
             var focusProvider = CoreServices.InputSystem?.FocusProvider;
             if (focusProvider != null)
             {
@@ -197,17 +209,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (focusProvider.TryGetFocusDetails(this, out focusDetails))
                 {
                     distance = focusDetails.RayDistance;
+                    Profiler.EndSample(); // TryGetDistanceToNearestSurface - success
                     return true;
                 }
             }
 
             distance = 0.0f;
+            Profiler.EndSample(); // TryGetDistanceToNearestSurface
             return false;
         }
 
         /// <inheritdoc />
         public bool TryGetNormalToNearestSurface(out Vector3 normal)
         {
+            Profiler.BeginSample("[MRTK] SpherePointer.TryGetNormalToNearestSurface");
+
             var focusProvider = CoreServices.InputSystem?.FocusProvider;
             if (focusProvider != null)
             {
@@ -215,11 +231,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (focusProvider.TryGetFocusDetails(this, out focusDetails))
                 {
                     normal = focusDetails.Normal;
+                    Profiler.EndSample(); // TryGetNormalToNearestSurface - success
                     return true;
                 }
             }
 
             normal = Vector3.forward;
+            Profiler.EndSample(); // TryGetNormalToNearestSurface
             return false;
         }
 
@@ -268,6 +286,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <param name="ignoreCollidersNotInFOV">Whether to ignore colliders that are not visible.</param>
             public bool TryUpdateQueryBufferForLayerMask(LayerMask layerMask, Vector3 pointerPosition, QueryTriggerInteraction triggerInteraction, bool ignoreCollidersNotInFOV)
             {
+                Profiler.BeginSample("[MRTK] SpherePointerQueryInfo.TryUpdateQueryBufferForLayerMask");
+
                 grabbable = null;
                 numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(
                     pointerPosition,
@@ -302,9 +322,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                     if (grabbable != null)
                     {
+                        Profiler.EndSample(); // TryUpdateQueryBufferForLayerMask
                         return true;
                     }
                 }
+
+                Profiler.EndSample(); // TryUpdateQueryBufferForLayerMask
                 return false;
             }
 

--- a/Assets/MRTK/Services/InputSystem/DefaultRaycastProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/DefaultRaycastProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Physics;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -39,23 +40,36 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool Raycast(RayStep step, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo)
         {
+            Profiler.BeginSample("[MRTK] DefaultRaycastProvider.Raycast");
+
             bool result = MixedRealityRaycaster.RaycastSimplePhysicsStep(step, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out RaycastHit physicsHit);
             hitInfo = new MixedRealityRaycastHit(result, physicsHit);
+
+            Profiler.EndSample(); // Raycast
             return result;
         }
 
         /// <inheritdoc />
         public bool SphereCast(RayStep step, float radius, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out MixedRealityRaycastHit hitInfo)
         {
+            Profiler.BeginSample("[MRTK] DefaultRaycastProvider.SphereCast");
+
             var result = MixedRealityRaycaster.RaycastSpherePhysicsStep(step, radius, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out RaycastHit physicsHit);
             hitInfo = new MixedRealityRaycastHit(result, physicsHit);
+
+            Profiler.EndSample(); // SphereCast
             return result;
         }
 
         /// <inheritdoc />
         public RaycastResult GraphicsRaycast(EventSystem eventSystem, PointerEventData pointerEventData, LayerMask[] layerMasks)
         {
-            return eventSystem.Raycast(pointerEventData, layerMasks);
+            Profiler.BeginSample("[MRTK] DefaultRaycastProvider.GraphicsRaycast");
+
+            RaycastResult result = eventSystem.Raycast(pointerEventData, layerMasks);
+
+            Profiler.EndSample(); // GraphicsRaycast
+            return result;
         }
     }
 }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -887,20 +887,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns>Pointer Data if the pointing source is registered.</returns>
         private bool TryGetPointerData(IMixedRealityPointer pointer, out PointerData data)
         {
-            Profiler.BeginSample("[MRTK] FocusProvider.TryGetPointerData");
-
             foreach (var pointerData in pointers)
             {
                 if (pointerData.Pointer.PointerId == pointer.PointerId)
                 {
                     data = pointerData;
-                    Profiler.EndSample(); // TryGetPointerData - success
                     return true;
                 }
             }
 
             data = null;
-            Profiler.EndSample(); // TryGetPointerData
             return false;
         }
 

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -887,16 +887,20 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <returns>Pointer Data if the pointing source is registered.</returns>
         private bool TryGetPointerData(IMixedRealityPointer pointer, out PointerData data)
         {
+            Profiler.BeginSample("[MRTK] FocusProvider.TryGetPointerData");
+
             foreach (var pointerData in pointers)
             {
                 if (pointerData.Pointer.PointerId == pointer.PointerId)
                 {
                     data = pointerData;
+                    Profiler.EndSample(); // TryGetPointerData - success
                     return true;
                 }
             }
 
             data = null;
+            Profiler.EndSample(); // TryGetPointerData
             return false;
         }
 


### PR DESCRIPTION
This change extends the input system profiler markers (#7590) to the raycast implementation.