### PR TITLE
Improve FocusProvider perf (slightly)

### DIFF
--- a/Assets/MRTK/Core/Providers/GenericPointer.cs
+++ b/Assets/MRTK/Core/Providers/GenericPointer.cs
@@ -72,10 +72,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return isInteractionEnabled && IsActive; }
             set
             {
-                isInteractionEnabled = value;
-                if (BaseCursor != null)
+                if (isInteractionEnabled != value)
                 {
-                    BaseCursor.SetVisibility(value);
+                    isInteractionEnabled = value;
+                    if (BaseCursor != null)
+                    {
+                        BaseCursor.SetVisibility(value);
+                    }
                 }
             }
         }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1138,14 +1138,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
             if (gazePointer != null)
             {
+                bool wasGazePointerActive = gazePointerStateMachine.IsGazePointerActive;
+
                 gazePointerStateMachine.UpdateState(
                     NumNearPointersActive,
                     NumFarPointersActive,
                     numFarPointersWithoutCursorActive,
                     CoreServices.InputSystem.EyeGazeProvider.IsEyeTrackingEnabledAndValid);
 
-                // The gaze cursor's visibility is controlled by IsInteractionEnabled
-                gazePointer.IsInteractionEnabled = gazePointerStateMachine.IsGazePointerActive;
+                bool isGazePointerActive = gazePointerStateMachine.IsGazePointerActive;
+
+                if (wasGazePointerActive != isGazePointerActive)
+                {
+                    // The gaze cursor's visibility is controlled by IsInteractionEnabled
+                    gazePointer.IsInteractionEnabled = isGazePointerActive;
+                }
             }
 
             Profiler.EndSample(); // ReconcilePointers

--- a/Assets/MRTK/Services/InputSystem/GazePointerVisibilityStateMachine.cs
+++ b/Assets/MRTK/Services/InputSystem/GazePointerVisibilityStateMachine.cs
@@ -18,26 +18,33 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         private enum GazePointerState
         {
-            // When the application starts up, the gaze pointer should be active
+            /// <summary>
+            /// When the application starts up, the gaze pointer should be active.
+            /// </summary>
             Initial,
 
-            // If head gaze is in use, then the gaze pointer is active when no hands are visible, after "select"
-            // If eye gaze is use, then the gaze pointer is active when no far pointers are active.
+            /// <summary>
+            /// If head gaze is in use, then the gaze pointer is active when no hands are visible, after "select".
+            /// If eye gaze is use, then the gaze pointer is active when no far pointers are active.
+            /// </summary>
             GazePointerActive,
 
-            // If head gaze is in use, then the gaze pointer is inactive as soon as motion controller or
-            // articulated hand pointers appear.
-            // If eye gaze is in use, then the gaze pointer is inactive when far pointers are active.
+            /// <summary>
+            /// If head gaze is in use, then the gaze pointer is inactive as soon as motion controller or
+            /// articulated hand pointers appear.
+            /// If eye gaze is in use, then the gaze pointer is inactive when far pointers are active.
+            /// </summary>
             GazePointerInactive
         }
+
         private GazePointerState gazePointerState = GazePointerState.Initial;
         private bool activateGazeKeywordIsSet = false;
         private bool eyeGazeValid = false;
 
-        public bool IsGazePointerActive
-        {
-            get { return gazePointerState != GazePointerState.GazePointerInactive; }
-        }
+        /// <summary>
+        /// Whether the state machine is currently in a state where the gaze pointer should be active.
+        /// </summary>
+        public bool IsGazePointerActive => gazePointerState != GazePointerState.GazePointerInactive;
 
         /// <summary>
         /// Updates the state machine based on the number of near pointers, the number of far pointers,


### PR DESCRIPTION
## Overview

Since `IsInteractionEnabled` calls into the cursor to set its visibility, which might involve setting a GameObject active or not, there's a slight perf cost to going down this property / method stack every frame.

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/e30acbd2705111e600b6f220863cce6b4fe42e62/Assets/MRTK/Core/Providers/GenericPointer.cs#L69-L81

I instead added change checks to both `IsInteractionEnabled` and the point where the state machine is queried for the gaze pointer's current state.

I also updated some docs and formatting.