### PR TITLE
Reduce raycast allocations, update performance markers

### DIFF
--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -190,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// </summary>
         /// <remarks>Sorts all hit objects first by layerMask, then by distance.</remarks>
         /// <returns>The minimum distance hit within the first layer that has hits.</returns>
-        public static bool TryGetPrioritizedPhysicsHit(
+        private static bool TryGetPrioritizedPhysicsHit(
             RaycastHit[] hits,
             int hitCount,
             LayerMask[] priorityLayers,

--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
 
         public const int MaxRaycastHitCount = 32;
         public const int MaxSphereCastHitCount = 32;
-        private static readonly RaycastHit[] RaycastHits= new RaycastHit[MaxRaycastHitCount];
+        private static readonly RaycastHit[] RaycastHits = new RaycastHit[MaxRaycastHitCount];
         private static readonly RaycastHit[] SphereCastHits = new RaycastHit[MaxSphereCastHitCount];
 
         /// <summary>

--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -39,13 +39,20 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 Debug.Assert(maxDistance > 0, "Length must be longer than zero!");
                 Debug.Assert(step.Direction != Vector3.zero, "Invalid step direction!");
 
-                int hitCount = UnityEngine.Physics.RaycastNonAlloc(
-                    step.Origin,
-                    step.Direction,
-                    RaycastHits,
-                    maxDistance,
-                    (prioritizedLayerMasks.Length == 1) ? (int)prioritizedLayerMasks[0] : UnityEngine.Physics.AllLayers);
-                return TryGetPrioritizedPhysicsHit(RaycastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+                bool result = false;
+                if (prioritizedLayerMasks.Length == 1)
+                {
+                    // If there is only one priority, don't prioritize
+                    result = UnityEngine.Physics.Raycast(step.Origin, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0]);
+                }
+                else
+                {
+                    // Raycast across all layers and prioritize
+                    int hitCount = UnityEngine.Physics.RaycastNonAlloc(step.Origin, step.Direction, RaycastHits, maxDistance, UnityEngine.Physics.AllLayers);
+                    result = TryGetPrioritizedPhysicsHit(RaycastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+                }
+
+                return result;
             }
         }
 
@@ -140,14 +147,20 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         {
             using (RaycastSpherePhysicsStepPerfMarker.Auto())
             {
-                int hitCount = UnityEngine.Physics.SphereCastNonAlloc(
-                    step.Origin,
-                    radius,
-                    step.Direction,
-                    SphereCastHits,
-                    maxDistance,
-                    (prioritizedLayerMasks.Length == 1) ? (int)prioritizedLayerMasks[0] : UnityEngine.Physics.AllLayers);
-                return TryGetPrioritizedPhysicsHit(SphereCastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+                bool result = false;
+                if (prioritizedLayerMasks.Length == 1)
+                {
+                    // If there is only one priority, don't prioritize
+                    result = UnityEngine.Physics.SphereCast(step.Origin, radius, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0]);
+                }
+                else
+                {
+                    // Raycast across all layers and prioritize
+                    int hitCount = UnityEngine.Physics.SphereCastNonAlloc(step.Origin, radius, step.Direction, SphereCastHits, maxDistance, UnityEngine.Physics.AllLayers);
+                    result = TryGetPrioritizedPhysicsHit(SphereCastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+                }
+
+                return result;
             }
         }
 

--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -1,14 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
+using UnityEngine.EventSystems;
 
 namespace Microsoft.MixedReality.Toolkit.Physics
 {
     public static class MixedRealityRaycaster
     {
         public static bool DebugEnabled = false;
+
+        public const int MaxRaycastHitCount = 32;
+        public const int MaxSphereCastHitCount = 32;
+        private static readonly RaycastHit[] RaycastHits= new RaycastHit[MaxRaycastHitCount];
+        private static readonly RaycastHit[] SphereCastHits = new RaycastHit[MaxSphereCastHitCount];
 
         /// <summary>
         /// Simple raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>.
@@ -19,27 +25,37 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             return RaycastSimplePhysicsStep(step, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
         }
 
+        private static readonly ProfilerMarker RaycastSimplePhysicsStepPerfMarker = new ProfilerMarker("[MRTK] MixedRealityRaycaster.RaycastSimplePhysicsStep");
+
         /// <summary>
         /// Simple raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/> within a specified maximum distance.
         /// </summary>
         /// <returns>Whether or not the raycast hit something.</returns>
         public static bool RaycastSimplePhysicsStep(RayStep step, float maxDistance, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
-            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastSimplePhysicsStep");
+            using (RaycastSimplePhysicsStepPerfMarker.Auto())
+            {
+                Debug.Assert(maxDistance > 0, "Length must be longer than zero!");
+                Debug.Assert(step.Direction != Vector3.zero, "Invalid step direction!");
 
-            Debug.Assert(maxDistance > 0, "Length must be longer than zero!");
-            Debug.Assert(step.Direction != Vector3.zero, "Invalid step direction!");
+                bool result = false;
+                if (prioritizedLayerMasks.Length == 1)
+                {
+                    // If there is only one priority, don't prioritize
+                    result = UnityEngine.Physics.Raycast(step.Origin, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0]);
+                }
+                else
+                {
+                    // Raycast across all layers and prioritize
+                    int hitCount = UnityEngine.Physics.RaycastNonAlloc(step.Origin, step.Direction, RaycastHits, maxDistance, UnityEngine.Physics.AllLayers);
+                    result = TryGetPrioritizedPhysicsHit(RaycastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+                }
 
-            bool result = prioritizedLayerMasks.Length == 1
-                // If there is only one priority, don't prioritize
-                ? UnityEngine.Physics.Raycast(step.Origin, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0])
-                // Raycast across all layers and prioritize
-                : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.RaycastAll(step.Origin, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
-
-            Profiler.EndSample(); // RaycastSimplePhysicsStep
-
-            return result;
+                return result;
+            }
         }
+
+        private static readonly ProfilerMarker RaycastBoxPhysicsStepPerfMarker = new ProfilerMarker("[MRTK] MixedRealityRaycaster.RaycastBoxPhysicsStep");
 
         /// <summary>
         /// Box raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/>.
@@ -47,68 +63,68 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>Whether or not the raycast hit something.</returns>
         public static bool RaycastBoxPhysicsStep(RayStep step, Vector3 extents, Vector3 targetPosition, Matrix4x4 matrix, float maxDistance, LayerMask[] prioritizedLayerMasks, int raysPerEdge, bool isOrthographic, bool focusIndividualCompoundCollider, out Vector3[] points, out Vector3[] normals, out bool[] hits)
         {
-            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastBoxPhysicsStep");
-
-            if (Application.isEditor && DebugEnabled)
+            using (RaycastBoxPhysicsStepPerfMarker.Auto())
             {
-                Debug.DrawLine(step.Origin, step.Origin + step.Direction * 10.0f, Color.green);
-            }
-
-            extents /= (raysPerEdge - 1);
-
-            int halfRaysPerEdge = (int)((raysPerEdge - 1) * 0.5f);
-            int numRays = raysPerEdge * raysPerEdge;
-            bool hitSomething = false;
-
-            points = new Vector3[numRays];
-            normals = new Vector3[numRays];
-            hits = new bool[numRays];
-
-            int index = 0;
-
-            for (int x = -halfRaysPerEdge; x <= halfRaysPerEdge; x += 1)
-            {
-                for (int y = -halfRaysPerEdge; y <= halfRaysPerEdge; y += 1)
+                if (Application.isEditor && DebugEnabled)
                 {
-                    Vector3 offset = matrix.MultiplyVector(new Vector3(x * extents.x, y * extents.y, 0));
-
-                    Vector3 origin = step.Origin;
-                    Vector3 direction = (targetPosition + offset) - step.Origin;
-
-                    if (isOrthographic)
-                    {
-                        origin += offset;
-                        direction = step.Direction;
-                    }
-
-                    RaycastHit rayHit;
-                    hits[index] = RaycastSimplePhysicsStep(new RayStep(origin, direction.normalized * maxDistance), prioritizedLayerMasks, focusIndividualCompoundCollider, out rayHit);
-
-                    if (hits[index])
-                    {
-                        hitSomething = true;
-                        points[index] = rayHit.point;
-                        normals[index] = rayHit.normal;
-
-                        if (Application.isEditor && DebugEnabled)
-                        {
-                            Debug.DrawLine(origin, points[index], Color.yellow);
-                        }
-                    }
-                    else
-                    {
-                        if (Application.isEditor && DebugEnabled)
-                        {
-                            Debug.DrawLine(origin, origin + direction * 3.0f, Color.gray);
-                        }
-                    }
-
-                    index++;
+                    Debug.DrawLine(step.Origin, step.Origin + step.Direction * 10.0f, Color.green);
                 }
-            }
 
-            Profiler.EndSample(); // RaycastBoxPhysicsStep
-            return hitSomething;
+                extents /= (raysPerEdge - 1);
+
+                int halfRaysPerEdge = (int)((raysPerEdge - 1) * 0.5f);
+                int numRays = raysPerEdge * raysPerEdge;
+                bool hitSomething = false;
+
+                points = new Vector3[numRays];
+                normals = new Vector3[numRays];
+                hits = new bool[numRays];
+
+                int index = 0;
+
+                for (int x = -halfRaysPerEdge; x <= halfRaysPerEdge; x += 1)
+                {
+                    for (int y = -halfRaysPerEdge; y <= halfRaysPerEdge; y += 1)
+                    {
+                        Vector3 offset = matrix.MultiplyVector(new Vector3(x * extents.x, y * extents.y, 0));
+
+                        Vector3 origin = step.Origin;
+                        Vector3 direction = (targetPosition + offset) - step.Origin;
+
+                        if (isOrthographic)
+                        {
+                            origin += offset;
+                            direction = step.Direction;
+                        }
+
+                        RaycastHit rayHit;
+                        hits[index] = RaycastSimplePhysicsStep(new RayStep(origin, direction.normalized * maxDistance), prioritizedLayerMasks, focusIndividualCompoundCollider, out rayHit);
+
+                        if (hits[index])
+                        {
+                            hitSomething = true;
+                            points[index] = rayHit.point;
+                            normals[index] = rayHit.normal;
+
+                            if (Application.isEditor && DebugEnabled)
+                            {
+                                Debug.DrawLine(origin, points[index], Color.yellow);
+                            }
+                        }
+                        else
+                        {
+                            if (Application.isEditor && DebugEnabled)
+                            {
+                                Debug.DrawLine(origin, origin + direction * 3.0f, Color.gray);
+                            }
+                        }
+
+                        index++;
+                    }
+                }
+
+                return hitSomething;
+            }
         }
 
         /// <summary>
@@ -120,22 +136,31 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             return RaycastSpherePhysicsStep(step, radius, step.Length, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
         }
 
+        private static readonly ProfilerMarker RaycastSpherePhysicsStepPerfMarker = new ProfilerMarker("[MRTK] MixedRealityRaycaster.RaycastSpherePhysicsStep");
+
         /// <summary>
         /// Sphere raycasts each physics <see cref="Microsoft.MixedReality.Toolkit.Physics.RayStep"/> within a specified maximum distance.
         /// </summary>
         /// <returns>Whether or not the raycast hit something.</returns>
         public static bool RaycastSpherePhysicsStep(RayStep step, float radius, float maxDistance, LayerMask[] prioritizedLayerMasks, bool focusIndividualCompoundCollider, out RaycastHit physicsHit)
         {
-            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastSpherePhysicsStep");
+            using (RaycastSpherePhysicsStepPerfMarker.Auto())
+            {
+                bool result = false;
+                if (prioritizedLayerMasks.Length == 1)
+                {
+                    // If there is only one priority, don't prioritize
+                    result = UnityEngine.Physics.SphereCast(step.Origin, radius, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0]);
+                }
+                else
+                {
+                    // Raycast across all layers and prioritize
+                    int hitCount = UnityEngine.Physics.SphereCastNonAlloc(step.Origin, radius, step.Direction, SphereCastHits, maxDistance, UnityEngine.Physics.AllLayers);
+                    result = TryGetPrioritizedPhysicsHit(SphereCastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
+                }
 
-            bool result = prioritizedLayerMasks.Length == 1
-                // If there is only one priority, don't prioritize
-                ? UnityEngine.Physics.SphereCast(step.Origin, radius, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0])
-                // Raycast across all layers and prioritize
-                : TryGetPrioritizedPhysicsHit(UnityEngine.Physics.SphereCastAll(step.Origin, radius, step.Direction, maxDistance, UnityEngine.Physics.AllLayers), prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
-
-            Profiler.EndSample(); // RaycastSpherePhysicsStep
-            return result;
+                return result;
+            }
         }
 
         /// <summary>
@@ -143,46 +168,77 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// </summary>
         /// <remarks>Sorts all hit objects first by layerMask, then by distance.</remarks>
         /// <returns>The minimum distance hit within the first layer that has hits.</returns>
-        public static bool TryGetPrioritizedPhysicsHit(RaycastHit[] hits, LayerMask[] priorityLayers, bool focusIndividualCompoundCollider, out RaycastHit raycastHit)
+        public static bool TryGetPrioritizedPhysicsHit(
+            RaycastHit[] hits,
+            LayerMask[] priorityLayers,
+            bool focusIndividualCompoundCollider,
+            out RaycastHit raycastHit)
         {
-            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.TryGetPrioritizedPhysicsHit");
+            return TryGetPrioritizedPhysicsHit(
+                hits,
+                hits.Length,
+                priorityLayers,
+                focusIndividualCompoundCollider,
+                out raycastHit);
+        }
 
-            raycastHit = default(RaycastHit);
+        private static readonly ProfilerMarker TryGetPrioritizedPhysicsHitPerfMarker = new ProfilerMarker("[MRTK] MixedRealityRaycaster.TryGetPrioritizedPhysicsHit");
 
-            if (hits.Length == 0)
+        /// <summary>
+        /// Tries to get the prioritized physics raycast hit based on the prioritized layer masks.
+        /// </summary>
+        /// <remarks>Sorts all hit objects first by layerMask, then by distance.</remarks>
+        /// <returns>The minimum distance hit within the first layer that has hits.</returns>
+        public static bool TryGetPrioritizedPhysicsHit(
+            RaycastHit[] hits,
+            int hitCount,
+            LayerMask[] priorityLayers,
+            bool focusIndividualCompoundCollider,
+            out RaycastHit raycastHit)
+        {
+            using (TryGetPrioritizedPhysicsHitPerfMarker.Auto())
             {
-                Profiler.EndSample(); // TryGetPrioritizedPhysicsHit - no hits
-                return false;
-            }
+                raycastHit = default(RaycastHit);
 
-            for (int layerMaskIdx = 0; layerMaskIdx < priorityLayers.Length; layerMaskIdx++)
-            {
-                RaycastHit? minHit = null;
-
-                for (int hitIdx = 0; hitIdx < hits.Length; hitIdx++)
+                if (hits.Length < hitCount)
                 {
-                    RaycastHit hit = hits[hitIdx];
-                    GameObject targetGameObject = focusIndividualCompoundCollider ? hit.collider.gameObject : hit.transform.gameObject;
+                    Debug.LogError("TryGetPrioritizedPhysicsHit: hitCount is larger than the hits array.");
+                    return false;
+                }
 
-                    if (targetGameObject.layer.IsInLayerMask(priorityLayers[layerMaskIdx]) &&
-                        (minHit == null || hit.distance < minHit.Value.distance))
+                if (hitCount == 0)
+                {
+                    return false;
+                }
+
+                for (int layerMaskIdx = 0; layerMaskIdx < priorityLayers.Length; layerMaskIdx++)
+                {
+                    RaycastHit? minHit = null;
+
+                    for (int hitIdx = 0; hitIdx < hitCount; hitIdx++)
                     {
-                        minHit = hit;
+                        RaycastHit hit = hits[hitIdx];
+                        GameObject targetGameObject = focusIndividualCompoundCollider ? hit.collider.gameObject : hit.transform.gameObject;
+
+                        if (targetGameObject.layer.IsInLayerMask(priorityLayers[layerMaskIdx]) &&
+                            (minHit == null || hit.distance < minHit.Value.distance))
+                        {
+                            minHit = hit;
+                        }
+                    }
+
+                    if (minHit != null)
+                    {
+                        raycastHit = minHit.Value;
+                        return true;
                     }
                 }
 
-                if (minHit != null)
-                {
-                    raycastHit = minHit.Value;
-                    Profiler.EndSample(); // TryGetPrioritizedPhysicstHit - success
-                    return true;
-                }
+                return false;
             }
-
-            Profiler.EndSample(); // TryGetPrioritizedPhysicsHit
-
-            return false;
         }
+
+        private static readonly ProfilerMarker RaycastPlanePhysicsStepPerfMarker = new ProfilerMarker("[MRTK] MixedRealityRaycaster.RaycastSpherePhysicsStep");
 
         /// <summary>
         /// Intersection test of ray step with given plane.
@@ -190,21 +246,20 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         /// <returns>Whether the ray step intersects the ray step.</returns>
         public static bool RaycastPlanePhysicsStep(RayStep step, Plane plane, out Vector3 hitPoint)
         {
-            Profiler.BeginSample("[MRTK] MixedRealityRaycaster.RaycastPlanePhysicsStep");
-
-            if (plane.Raycast(step, out float intersectDistance))
+            using (RaycastPlanePhysicsStepPerfMarker.Auto())
             {
-                if (intersectDistance <= step.Length)
+                if (plane.Raycast(step, out float intersectDistance))
                 {
-                    hitPoint = ((Ray)step).GetPoint(intersectDistance);
-                    Profiler.EndSample(); // RaycastPlanePhysicsStep - success
-                    return true;
+                    if (intersectDistance <= step.Length)
+                    {
+                        hitPoint = ((Ray)step).GetPoint(intersectDistance);
+                        return true;
+                    }
                 }
-            }
 
-            hitPoint = Vector3.zero;
-            Profiler.EndSample(); // RaycastPlanePhysicsStep
-            return false;
+                hitPoint = Vector3.zero;
+                return false;
+            }
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Runtime;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -38,20 +39,13 @@ namespace Microsoft.MixedReality.Toolkit.Physics
                 Debug.Assert(maxDistance > 0, "Length must be longer than zero!");
                 Debug.Assert(step.Direction != Vector3.zero, "Invalid step direction!");
 
-                bool result = false;
-                if (prioritizedLayerMasks.Length == 1)
-                {
-                    // If there is only one priority, don't prioritize
-                    result = UnityEngine.Physics.Raycast(step.Origin, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0]);
-                }
-                else
-                {
-                    // Raycast across all layers and prioritize
-                    int hitCount = UnityEngine.Physics.RaycastNonAlloc(step.Origin, step.Direction, RaycastHits, maxDistance, UnityEngine.Physics.AllLayers);
-                    result = TryGetPrioritizedPhysicsHit(RaycastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
-                }
-
-                return result;
+                int hitCount = UnityEngine.Physics.RaycastNonAlloc(
+                    step.Origin,
+                    step.Direction,
+                    RaycastHits,
+                    maxDistance,
+                    (prioritizedLayerMasks.Length == 1) ? (int)prioritizedLayerMasks[0] : UnityEngine.Physics.AllLayers);
+                return TryGetPrioritizedPhysicsHit(RaycastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
             }
         }
 
@@ -146,20 +140,14 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         {
             using (RaycastSpherePhysicsStepPerfMarker.Auto())
             {
-                bool result = false;
-                if (prioritizedLayerMasks.Length == 1)
-                {
-                    // If there is only one priority, don't prioritize
-                    result = UnityEngine.Physics.SphereCast(step.Origin, radius, step.Direction, out physicsHit, maxDistance, prioritizedLayerMasks[0]);
-                }
-                else
-                {
-                    // Raycast across all layers and prioritize
-                    int hitCount = UnityEngine.Physics.SphereCastNonAlloc(step.Origin, radius, step.Direction, SphereCastHits, maxDistance, UnityEngine.Physics.AllLayers);
-                    result = TryGetPrioritizedPhysicsHit(SphereCastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
-                }
-
-                return result;
+                int hitCount = UnityEngine.Physics.SphereCastNonAlloc(
+                    step.Origin,
+                    radius,
+                    step.Direction,
+                    SphereCastHits,
+                    maxDistance,
+                    (prioritizedLayerMasks.Length == 1) ? (int)prioritizedLayerMasks[0] : UnityEngine.Physics.AllLayers);
+                return TryGetPrioritizedPhysicsHit(SphereCastHits, hitCount, prioritizedLayerMasks, focusIndividualCompoundCollider, out physicsHit);
             }
         }
 


### PR DESCRIPTION
This change is a continuation of the work begun in #7600 and add/updates profiler markers related to raycasting.

It also replaces calls to Physics.RaycastAll and Physics.SphereCastAll with RaycastNonAlloc and SphereCastNonAlloc to reduce potential GC pressure.

NOTE: The max hit count has been set to 32 in this change. We can discuss refining this number based on customer feedback.