### PR TITLE
Add option to lock gaze cursor [Issue #6350]

### DIFF
--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -341,9 +341,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 if (hitResult.hitObject != CurrentPointerTarget)
                 {
                     Pointer.OnPreCurrentPointerTargetChange();
-
-                    // Set to default:
-                    Pointer.IsTargetPositionLockedOnFocusLock = true;
                 }
 
                 PreviousPointerTarget = CurrentPointerTarget;

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -500,7 +500,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             Profiler.EndSample(); // InitializeGazePointer
 
-            // Initialize gaze pointer to not lock on focus
+            // Initialize gaze pointer
             gazePointer.IsTargetPositionLockedOnFocusLock = lockCursorWhenFocusLocked;
 
             return gazePointer;

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -27,6 +27,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private const float MovementThreshold = 0.01f;
 
         [SerializeField]
+        [Tooltip("If true, the gaze cursor will stay locked on the object when the pointer's focus is locked, otherwise it will continue following the head's direction")]
+        private bool lockCursorWhenFocusLocked = false;
+
+        [SerializeField]
         [Tooltip("If true, the gaze cursor will disappear when the pointer's focus is locked, to prevent the cursor from floating idly in the world.")]
         private bool setCursorInvisibleWhenFocusLocked = false;
 
@@ -495,6 +499,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             Profiler.EndSample(); // InitializeGazePointer
+
+            // Initialize gaze pointer to not lock on focus
+            gazePointer.IsTargetPositionLockedOnFocusLock = lockCursorWhenFocusLocked;
 
             return gazePointer;
         }


### PR DESCRIPTION
## Overview
Added a togglable option to the GazeCursor so it doesn't stick to objects when selecting them. Now by default the gaze cursor will remain fixed at the center of the screen similar to HoloLens 1 behavior.

## Changes
- Fixes: #6350 

Prior default behavior
![GazeTargetLocked](https://user-images.githubusercontent.com/39840334/78196241-a1cf6100-7436-11ea-9560-def3deadf219.gif)

New default behavior
![GazeCentered](https://user-images.githubusercontent.com/39840334/78196246-a431bb00-7436-11ea-896b-879111089895.gif)

