### PR TITLE
Follow-up pass on Dialog PR

### DIFF
--- a/Assets/MRTK/Examples/Experimental/Dialog/DialogExampleController.cs
+++ b/Assets/MRTK/Examples/Experimental/Dialog/DialogExampleController.cs
@@ -1,15 +1,10 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Experimental.Dialog;
+using UnityEngine;
 
-namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
+namespace Microsoft.MixedReality.Examples.Experimental.Dialog
 {
     /// <summary>
     /// This class is used as an example controller to show how to instantiate and launch two different kind of Dialog.
@@ -20,6 +15,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         [SerializeField]
         [Tooltip("Assign DialogLarge_192x192.prefab")]
         private GameObject dialogPrefabLarge;
+
         /// <summary>
         /// Large Dialog example prefab to display
         /// </summary>
@@ -32,6 +28,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         [SerializeField]
         [Tooltip("Assign DialogMediume_192x128.prefab")]
         private GameObject dialogPrefabMedium;
+
         /// <summary>
         /// Medium Dialog example prefab to display
         /// </summary>
@@ -44,6 +41,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         [SerializeField]
         [Tooltip("Assign DialogSmall_192x96.prefab")]
         private GameObject dialogPrefabSmall;
+
         /// <summary>
         /// Small Dialog example prefab to display
         /// </summary>
@@ -58,7 +56,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogLarge()
         {
-            Dialog confDialog = Dialog.Open(DialogPrefabLarge, DialogButtonType.OK, "Confirmation Dialog, Large, Far", "This is an example of a large dialog with only one button, placed at near interaction range", false);
+            Dialog.Open(DialogPrefabLarge, DialogButtonType.OK, "Confirmation Dialog, Large, Far", "This is an example of a large dialog with only one button, placed at near interaction range", false);
         }
 
         /// <summary>
@@ -78,7 +76,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogMedium()
         {
-            Dialog confDialog = Dialog.Open(DialogPrefabMedium, DialogButtonType.OK, "Confirmation Dialog, Medium, Near", "This is an example of a medium dialog with only one button, placed at near interaction range", true);
+            Dialog.Open(DialogPrefabMedium, DialogButtonType.OK, "Confirmation Dialog, Medium, Near", "This is an example of a medium dialog with only one button, placed at near interaction range", true);
         }
 
         /// <summary>
@@ -98,7 +96,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         /// </summary>
         public void OpenConfirmationDialogSmall()
         {
-            Dialog confDialog = Dialog.Open(DialogPrefabSmall, DialogButtonType.OK, "Confirmation Dialog, Small, Far", "This is an example of a small dialog with only one button, placed at near interaction range", false);
+            Dialog.Open(DialogPrefabSmall, DialogButtonType.OK, "Confirmation Dialog, Small, Far", "This is an example of a small dialog with only one button, placed at near interaction range", false);
         }
 
         /// <summary>
@@ -117,7 +115,7 @@ namespace Microsoft.MixedReality.Examples.Experimental.DialogTest
         {
             if (obj.Result == DialogButtonType.Yes)
             {
-                Debug.Log(obj.Result);       
+                Debug.Log(obj.Result);
             }
         }
     }

--- a/Assets/MRTK/Examples/Experimental/Dialog/DialogExampleController.cs
+++ b/Assets/MRTK/Examples/Experimental/Dialog/DialogExampleController.cs
@@ -4,7 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Experimental.Dialog;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Examples.Experimental.Dialog
+namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.DialogTest
 {
     /// <summary>
     /// This class is used as an example controller to show how to instantiate and launch two different kind of Dialog.

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/Dialog.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/Dialog.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System;
@@ -31,8 +29,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         protected DialogResult result;
         /// <summary>
         /// Can be used to monitor result instead of events
-        /// </summary>        
-        public DialogResult Result => result;        
+        /// </summary>
+        public DialogResult Result => result;
 
         protected void Launch(DialogResult newResult)
         {

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/Dialog.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/Dialog.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
@@ -12,14 +11,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
     public abstract class Dialog : MonoBehaviour
     {
         /// <summary>
-        /// It's used to keep track of the current state in which the Dialog is
+        /// The current state of the Dialog.
         /// </summary>
-        protected DialogState state = DialogState.Uninitialized;
-        public DialogState State
-        {
-            get => state;
-            set => state = value;
-        }
+        public DialogState State { get; set; } = DialogState.Uninitialized;
 
         /// <summary>
         /// Called after user has clicked a button and the dialog has finished closing
@@ -45,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
 
         /// <summary>
         /// Opens dialog, waits for input, then closes
-        /// </summary>        
+        /// </summary>
         protected IEnumerator RunDialogOverTime()
         {
             // Create buttons and set up message
@@ -68,14 +62,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
             yield return StartCoroutine(CloseDialog());
             State = DialogState.Closed;
             // Callback
-            if (OnClosed != null)
-            {
-                OnClosed(result);
-            }
+            OnClosed?.Invoke(result);
             // Wait a moment to give scripts a chance to respond
             yield return null;
             // Destroy ourselves
-            GameObject.Destroy(gameObject);
+            Destroy(gameObject);
             yield break;
         }
 
@@ -116,13 +107,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         /// the title and message have been set.
         /// Perform here any operations that you'd like
         /// Lays out the buttons on the dialog
-        /// Eg using an ObjectCollection                        
+        /// Eg using an ObjectCollection
         /// </summary>
         protected abstract void FinalizeLayout();
 
         /// <summary>
         /// Set the title and message using the result
-        /// Eg using TextMesh components 
+        /// E.g. using TextMesh components 
         /// </summary>
         protected abstract void SetTitleAndMessage();
 

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/Dialog.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/Dialog.cs
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         /// the title and message have been set.
         /// Perform here any operations that you'd like
         /// Lays out the buttons on the dialog
-        /// Eg using an ObjectCollection
+        /// E.g. using an ObjectCollection
         /// </summary>
         protected abstract void FinalizeLayout();
 

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButton.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 
@@ -21,15 +19,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
             set => buttonText = value;
         }
 
-        private DialogShell parentDialog;
         /// <summary>
         /// A reference to the Dialog that this button is on.
         /// </summary>
-        public DialogShell ParentDialog
-        {
-            get => parentDialog;
-            set => parentDialog = value;
-        }
+        public DialogShell ParentDialog { get; set; }
 
         /// <summary>
         /// The type description of the button
@@ -37,21 +30,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         public DialogButtonType ButtonTypeEnum;
 
         /// <summary>
-        /// event handler that runs when button is clicked.
+        /// Event handler that runs when button is clicked.
         /// Dismisses the parent dialog.
         /// </summary>
         /// <param name="obj">Caller GameObject</param>
         public void OnButtonClicked(GameObject obj)
         {
-            if (parentDialog != null)
+            if (ParentDialog != null)
             {
-                parentDialog.Result.Result = ButtonTypeEnum;
-                parentDialog.DismissDialog();
+                ParentDialog.Result.Result = ButtonTypeEnum;
+                ParentDialog.DismissDialog();
             }
         }
 
         /// <summary>
-        /// Setter Method to set the Text at the top of the Dialog.
+        /// Setter method to set the text at the top of the Dialog.
         /// </summary>
         /// <param name="title">Title of the button</param>
         public void SetTitle(string title)

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButton.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButton.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -25,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         public DialogShell ParentDialog
         {
             get => parentDialog;
-            set => parentDialog = value;            
+            set => parentDialog = value;
         }
 
         /// <summary>

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButtonType.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButtonType.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
 {
     /// <summary>
-    /// Enum describing the style (caption) of button on a Dialog.
+    /// The style (caption) of button on a Dialog.
     /// </summary>
     [Flags]
     public enum DialogButtonType

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButtonType.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogButtonType.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System;
 using System.Collections;
@@ -16,13 +14,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
     [Flags]
     public enum DialogButtonType
     {
-        None = 0,
-        Close = 1,
-        Confirm = 2,
-        Cancel = 4,
-        Accept = 8,
-        Yes = 16,
-        No = 32,
-        OK = 64
+        None = 0 << 0,
+        Close = 1 << 0,
+        Confirm = 1 << 1,
+        Cancel = 1 << 2,
+        Accept = 1 << 3,
+        Yes = 1 << 4,
+        No = 1 << 5,
+        OK = 1 << 6
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogResult.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogResult.cs
@@ -1,83 +1,38 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
 {
     public class DialogResult
     {
         /// <summary>
-        /// Title for the dialog to display
-        /// </summary>
-        private string title = string.Empty;
-        /// <summary>
         /// The public property to get and set the Title
         /// string (topmost) on the Dialog.
         /// </summary>
-        public string Title
-        {
-            get => title;
-            set => title = value;
-        }
+        public string Title { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Message for the dialog to display
-        /// </summary>
-        private string message = string.Empty;
         /// <summary>
         /// The public property to get and set the Message
         /// string of the dialog.
         /// </summary>
-        public string Message
-        {
-            get => message;
-            set => message = value;
-        }
+        public string Message { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Which buttons to generate
-        /// </summary>
-        private DialogButtonType buttons = DialogButtonType.Close;
         /// <summary>
         /// Property defining the button type[s]
         /// on the dialog.
         /// </summary>
-        public DialogButtonType Buttons
-        {
-            get => buttons;
-            set => buttons = value;
-        }
+        public DialogButtonType Buttons { get; set; } = DialogButtonType.Close;
 
-        /// <summary>
-        /// The button type that was pressed to close the dialog
-        /// </summary>
-        private DialogButtonType result = DialogButtonType.Close;
         /// <summary>
         /// Property reporting the Result of the Dialog:
         /// Which button was clicked to dismiss it.
         /// </summary>
-        public DialogButtonType Result
-        {
-            get => result;
-            set => result = value;
-        }
+        public DialogButtonType Result { get; set; } = DialogButtonType.Close;
 
-        /// <summary>
-        /// Variable that can be use to pass an object to the dialog
-        /// so to have it back with the result
-        /// </summary>
-        private System.Object variable;
         /// <summary>
         /// The public property to get and set the variable
         /// object of the dialog
         /// </summary>
-        public System.Object Variable
-        {
-            get => variable;
-            set => variable = value;
-        }
+        public object Variable { get; set; }
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogResult.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogResult.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System.Collections;
 using System.Collections.Generic;
@@ -22,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         public string Title
         {
             get => title;
-            set => title = value;            
+            set => title = value;
         }
 
         /// <summary>
@@ -36,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         public string Message
         {
             get => message;
-            set => message = value;            
+            set => message = value;
         }
 
         /// <summary>
@@ -50,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         public DialogButtonType Buttons
         {
             get => buttons;
-            set => buttons = value;            
+            set => buttons = value;
         }
 
         /// <summary>

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogShell.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogShell.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System;
 using System.Collections;
@@ -19,7 +17,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
     public class DialogShell : Dialog
     {
         private GameObject[] twoButtonSet;
-
 
         [SerializeField]
         [Tooltip("Title text of the dialog")]
@@ -55,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
             //Get List of ButtonTypes that should be created on Dialog
             List<DialogButtonType> buttonTypes = new List<DialogButtonType>();
             foreach (DialogButtonType buttonType in Enum.GetValues(typeof(DialogButtonType)))
-            {                
+            {
                 // If this button type flag is set
                 if (buttonType != DialogButtonType.None && result.Buttons.HasFlag(buttonType))
                 {
@@ -76,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
             {
                 // If we have two buttons then do step 1, else 0
                 int step = buttonTypes.Count >= 2 ? 1 : 0;
-                for (int i = 0; i < buttonTypes.Count && i<2; ++i)
+                for (int i = 0; i < buttonTypes.Count && i < 2; ++i)
                 {
                     twoButtonSet[i] = buttonsOnDialog[i + step].gameObject;
                     buttonsOnDialog[i + step].SetTitle(buttonTypes[i].ToString());
@@ -119,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         /// </summary>
         protected override void SetTitleAndMessage()
         {
-            if(titleText != null)
+            if (titleText != null)
             {
                 titleText.text = Result.Title;
             }

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogShell.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogShell.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -21,6 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         [SerializeField]
         [Tooltip("Title text of the dialog")]
         private TextMeshPro titleText = null;
+
         /// <summary>
         /// Title text of the dialog
         /// </summary>
@@ -33,6 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         [SerializeField]
         [Tooltip("Description text of the dialog")]
         private TextMeshPro descriptionText = null;
+
         /// <summary>
         /// Description text of the dialog
         /// </summary>
@@ -43,10 +44,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         }
 
         /// <inheritdoc />
-        protected override void FinalizeLayout()
-        {
-        }
+        protected override void FinalizeLayout() { }
 
+        /// <inheritdoc />
         protected override void GenerateButtons()
         {
             //Get List of ButtonTypes that should be created on Dialog
@@ -132,8 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         /// </summary>
         public void DismissDialog()
         {
-            state = DialogState.InputReceived;
+            State = DialogState.InputReceived;
         }
-
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogState.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogState.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
 {
     /// <summary>
-    /// Enum that describes the current state of a Dialog.
+    /// Describes the current state of a Dialog.
     /// </summary>
     public enum DialogState
     {

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogState.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogState.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
## Overview

* Mostly formatting and slight comment updates for clarity.
* Also added a missing MSFT license header to a file which was ported from a licensed script in HTK: https://github.com/microsoft/MixedRealityToolkit-Unity/blob/htk_release/Assets/HoloToolkit/UX/Scripts/Dialog/DialogButton.cs
* Slightly updated existing headers to match our current style
* Updated to [auto properties where possible](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Contributing/CodingGuidelines.html#access-modifiers).
* Updated a flags enum [to match our guidance](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Contributing/CodingGuidelines.html#review-enum-use-for-bitfields).

## Changes
- Follow-up to #6925 