### PR TITLE
Made NonNativeKeyboard touchable

### DIFF
--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Prefabs/NonNativeKeyboard.prefab
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Prefabs/NonNativeKeyboard.prefab
@@ -12617,6 +12617,7 @@ GameObject:
   - component: {fileID: 114593871428788132}
   - component: {fileID: 6050639456931552995}
   - component: {fileID: 583446739}
+  - component: {fileID: 6363978764271269843}
   m_Layer: 0
   m_Name: NonNativeKeyboard
   m_TagString: Untagged
@@ -12767,6 +12768,19 @@ MonoBehaviour:
   additionalOffset: {x: 0, y: 0, z: 0}
   additionalRotation: {x: 0, y: 0, z: 0}
   updateSolvers: 1
+--- !u!114 &6363978764271269843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c72a967253428ca4896d1e2639256334, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _clickSound: {fileID: 8300000, guid: 291bf9326e517b0489c2ee53d0a6a63f, type: 3}
 --- !u!1 &146124
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.MixedReality.Toolkit.Input;
+using UnityEngine;
+using UnityEngine.UI;
+
+
+namespace Microsoft.MixedReality.Toolkit.Experimental.UI
+{
+    public class NonNativeKeyboardTouchAssistant : MonoBehaviour
+    {
+#pragma warning disable 0649
+        [SerializeField]
+        private AudioClip _clickSound;
+#pragma warning restore 0649
+
+
+        private AudioSource _clickSoundPlayer;
+
+        private void Start()
+        {
+            var capabilityChecker = CoreServices.InputSystem as IMixedRealityCapabilityCheck;
+
+            if(capabilityChecker != null && capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand))
+            {
+                EnableTouch();
+            }
+        }
+
+        private void EnableTouch()
+        {
+            _clickSoundPlayer = gameObject.AddComponent<AudioSource>();
+            _clickSoundPlayer.playOnAwake = false;
+            _clickSoundPlayer.spatialize = true;
+            _clickSoundPlayer.clip = _clickSound;
+            var buttons = GetComponentsInChildren<Button>();
+            foreach (var button in buttons)
+            {
+                var ni = button.gameObject.AddComponent<NearInteractionTouchableUnityUI>();
+                ni.EventsToReceive = TouchableEventType.Pointer;
+                button.onClick.AddListener(PlayClick);
+            }
+        }
+
+        private void PlayClick()
+        {
+            if (_clickSound != null)
+            {
+                _clickSoundPlayer.Play();
+            }
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
@@ -7,11 +7,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
     public class NonNativeKeyboardTouchAssistant : MonoBehaviour
     {
-#pragma warning disable 0649
-        [SerializeField]
-        private AudioClip _clickSound;
-#pragma warning restore 0649
-
+        [SerializeField] 
+        private AudioClip _clickSound = null;
 
         private AudioSource _clickSoundPlayer;
 

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             var buttons = GetComponentsInChildren<Button>();
             foreach (var button in buttons)
             {
-                var ni = button.gameObject.AddComponent<NearInteractionTouchableUnityUI>();
+                var ni = button.gameObject.EnsureComponent<NearInteractionTouchableUnityUI>();
                 ni.EventsToReceive = TouchableEventType.Pointer;
                 button.onClick.AddListener(PlayClick);
             }

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
@@ -2,15 +2,17 @@
 using UnityEngine;
 using UnityEngine.UI;
 
-
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 {
+    /// <summary>
+    /// Adds touch events to the NonNativeKeyboard buttons (and a tap sound)
+    /// </summary>
     public class NonNativeKeyboardTouchAssistant : MonoBehaviour
     {
         [SerializeField] 
-        private AudioClip _clickSound = null;
+        private AudioClip clickSound = null;
 
-        private AudioSource _clickSoundPlayer;
+        private AudioSource clickSoundPlayer;
 
         private void Start()
         {
@@ -24,10 +26,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void EnableTouch()
         {
-            _clickSoundPlayer = gameObject.AddComponent<AudioSource>();
-            _clickSoundPlayer.playOnAwake = false;
-            _clickSoundPlayer.spatialize = true;
-            _clickSoundPlayer.clip = _clickSound;
+            clickSoundPlayer = gameObject.AddComponent<AudioSource>();
+            clickSoundPlayer.playOnAwake = false;
+            clickSoundPlayer.spatialize = true;
+            clickSoundPlayer.clip = clickSound;
             var buttons = GetComponentsInChildren<Button>();
             foreach (var button in buttons)
             {
@@ -39,9 +41,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void PlayClick()
         {
-            if (_clickSound != null)
+            if (clickSound != null)
             {
-                _clickSoundPlayer.Play();
+                clickSoundPlayer.Play();
             }
         }
     }

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs.meta
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c72a967253428ca4896d1e2639256334
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

This makes the nonnative keyboard prefab respond to touch events

## Changes
Added a new behaviour NonNativeKeyboardTouchAssistant to the NonNativeKeyboard that enables touch when articulated hand support is detected. By request of @provencher after reading http://dotnetbyexample.blogspot.com/2020/04/migrating-to-mrtk2-using-non-native.html

