### PR TITLE
Add profiler instrumentation to input handlers and input manager

### DIFF
--- a/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/MixedRealityRaycaster.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Runtime;
 using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.EventSystems;
 
 namespace Microsoft.MixedReality.Toolkit.Physics
 {


### PR DESCRIPTION
This change adds instrumentation to input handlers to help identify the portions of the MRTK update loop that is application code (event handlers). When analyzing, if significant time is spent in these scopes, it is likely the issue is external to the MRTK.

Also instrumented the MixedRealityInputManager as well as migrating from the previous Begin/EndSample syntax to the prefered using (marker.Auto()) { .. }.