### PR TITLE
clarify some things I noticed in the eye tracking setup docs

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -25,7 +25,14 @@ you need to make sure that the 'Gaze Input Capability' is checked on the 'Appx B
 
 This tooling will find the AppX manifest after the Unity build is completed and manually add the GazeInput capability.
 **Note that this tooling is NOT active when using Unity's built-in Build Window** (i.e. File -> Build Settings).
-When using Unity's build window, the capability will need to manually added after the Unity build.
+
+When using Unity's build window, the capability will need to manually added after the Unity build, as follows:
+1. Open your compiled Visual Studio project and then open the _'Package.appxmanifest'_ in your solution.
+2. Make sure to tick the _'GazeInput'_ checkbox under _Capabilities_.
+
+_Please note:_
+You only have to do this if you build into a new build folder.
+This means that if you had already built your Unity project and set up the appxmanifest before and now target the same folder again, the appxmanifest should stay untouched.
 
 ## Setting up eye tracking step-by-step
 
@@ -46,7 +53,7 @@ You can simply select _DefaultMixedRealityToolkitConfigurationProfile_ and then 
 
 - Click on the _'Input'_ tab in your MRTK profile.
 - To edit the default one ( _'DefaultMixedRealityInputSystemProfile'_ ), click the _'Clone'_ button next to it. A _'Clone Profile'_ menu appears. Simply click on _'Clone'_ at the bottom of that menu.
-- Double click on your new input profile and select _'+ Add Data Provider'_.
+- Double click on your new input profile, expand _'Input Data Providers'_, and select _'+ Add Data Provider'_.
 - Create a new data provider:
   - Under **Type** select _'Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input'_ -> _'WindowsMixedRealityEyeGazeDataProvider'_
   - For **Platform(s)** select _'Windows Universal'_.
@@ -63,6 +70,7 @@ For this, it is better to ensure frequent tests of your eye-based interactions o
 1. **Enable simulated eye tracking**:
     - Click on the _'Input'_ tab in your MRTK configuration profile.
     - From there, navigate to _'Input Data Providers'_ -> _'Input Simulation Service'_.
+    - Clone the _'DefaultMixedRealityInputSimpulationProfile'_ to make changes to it.
     - Check the _'Simulate Eye Position'_ checkbox.
 
     ![MRTK](../Images/EyeTracking/mrtk_setup_eyes_simulate.jpg)
@@ -72,7 +80,7 @@ In general, it is recommended to avoid showing an eye gaze cursor or if absolute
 We do recommend to hide the default head gaze cursor that is attached to the MRTK gaze pointer profile by default.
     - Navigate to your MRTK configuration profile -> _'Input'_ -> _'Pointers'_
     - Clone the _'DefaultMixedRealityInputPointerProfile'_ to make changes to it.
-    - At the top of the _'Pointer Settings'_, you should assign an invisible cursor prefab to the _'GazeCursor'_. If you downloaded the MRTK Examples folder, you can simply reference the included _'EyeGazeCursor'_ prefab.
+    - At the top of the _'Pointer Settings'_, you should assign an invisible cursor prefab to the _'GazeCursor'_. You can do this by selecting the _'EyeGazeCursor'_ prefab from the MRTK Foundation.
 
 ### Enabling eye-based gaze in the gaze provider
 
@@ -92,32 +100,7 @@ Now that your scene is set up to use eye tracking, let's take a look at how to a
 
 ### Testing your Unity app on a HoloLens 2
 
-Building your app with eye tracking should be similar to how you would compile other HoloLens 2 MRTK apps.
-The only difference is that the *'Gaze Input'* capability is unfortunately not yet supported by Unity under 'Player Settings -> Publishing Settings -> Capabilities'.
-To use eye tracking on your HoloLens 2 device, you need to manually edit the package manifest that is part of your built Visual Studio project.
-
-Follow these steps:
-
-1. Build your Unity project as you would normally do for _HoloLens 2_.
-2. Open your compiled Visual Studio project and then open the _'Package.appxmanifest'_ in your solution.
-3. Make sure to tick the _'GazeInput'_ checkbox under _Capabilities_.
-
-_Please note:_
-You only have to do this if you build into a new build folder.
-This means that if you had already built your Unity project and set up the appxmanifest before and now target the same folder again, the appxmanifest should stay untouched.
-
-![Enabling Gaze Input in Visual Studio](../Images/EyeTracking/mrtk_et_gazeinput.jpg)
-
-You don't see a _'GazeInput'_ capability?
-
-- Check that your system meets the [prerequisites for using MRTK](../GettingStartedWithTheMRTK.md#prerequisites) (in particular the Windows SDK version).
-- You can also manually add the entry by opening the appxmanifest in an XML editor and adding the following:
-
-```xml
-  <Capabilities>
-    <DeviceCapability Name="gazeInput" />
-  </Capabilities>
-```
+Building your app with eye tracking should be similar to how you would compile other HoloLens 2 MRTK apps. Be sure that you have enabled the *'Gaze Input'* capability as described above in the section *A note on the GazeInput capability*.
 
 #### Eye calibration
 

--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -26,7 +26,7 @@ you need to make sure that the 'Gaze Input Capability' is checked on the 'Appx B
 This tooling will find the AppX manifest after the Unity build is completed and manually add the GazeInput capability.
 **Note that this tooling is NOT active when using Unity's built-in Build Window** (i.e. File -> Build Settings).
 
-When using Unity's build window, the capability will need to manually added after the Unity build, as follows:
+When using Unity's build window, the capability will need to be manually added after the Unity build, as follows:
 1. Open your compiled Visual Studio project and then open the _'Package.appxmanifest'_ in your solution.
 2. Make sure to tick the _'GazeInput'_ checkbox under _Capabilities_.
 

--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -100,7 +100,7 @@ Now that your scene is set up to use eye tracking, let's take a look at how to a
 
 ### Testing your Unity app on a HoloLens 2
 
-Building your app with eye tracking should be similar to how you would compile other HoloLens 2 MRTK apps. Be sure that you have enabled the *'Gaze Input'* capability as described above in the section *A note on the GazeInput capability*.
+Building your app with eye tracking should be similar to how you would compile other HoloLens 2 MRTK apps. Be sure that you have enabled the *'Gaze Input'* capability as described above in the section [*A note on the GazeInput capability*](#a-note-on-the-gazeinput-capability).
 
 #### Eye calibration
 


### PR DESCRIPTION
* Two different sections discussed workarounds for the GazeInput capability that is not yet available in Unity. I consolidated them into the first section (A note on the GazeInput capability) and stripped the second section (Testing your Unity app on a HoloLens 2) down to a simple reminder. I don't think the information about hand-editing the XML is necessary--people who are interested in that could make the edit in MRTK or Visual Studio and then look into the resulting changes for themselves.
* Added step to expand _'Input Data Providers' -- it isn't expanded by default and someone wouldn't see _'+ Add Data Provider'_ if that isn't expanded.
* Added step to clone DefaultMixedRealityInputSimpulationProfile.
* EyeGazeCursor now seems to be in Foundation, so MRTK Examples aren't needed.

[EDIT: Removed doc changes related to IsEyeTrackingEnabled based on @keveleigh feedback.]

>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
