### PR TITLE
additional eye tracking setup docs

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -12,7 +12,7 @@ We will go into detail on how to address each of them further below.
 
 1. An _'Eye Gaze Data Provider'_ must be added to the input system. This provides eye tracking data from the platform.
 2. The _'GazeInput'_ capability must be enabled in the application manifest.
-   **Currently this is only available in Visual Studio and through the MRTK build tool**
+   **This capability can be set in Unity 2019, but in Unity 2018 and earlier this capability is only available in Visual Studio and through the MRTK build tool**
 3. The HoloLens **must** be eye calibrated for the current user. Check out our [sample for detecting whether a user is eye calibrated or not](EyeTracking_IsUserCalibrated.md).
 
 ### A note on the GazeInput capability
@@ -24,9 +24,9 @@ you need to make sure that the 'Gaze Input Capability' is checked on the 'Appx B
 ![MRTK Build Tools](../Images/EyeTracking/mrtk_et_buildsetup.png)
 
 This tooling will find the AppX manifest after the Unity build is completed and manually add the GazeInput capability.
-**Note that this tooling is NOT active when using Unity's built-in Build Window** (i.e. File -> Build Settings).
+**Prior to Unity 2019, this tooling is NOT active when using Unity's built-in Build Window** (i.e. File -> Build Settings).
 
-When using Unity's build window, the capability will need to be manually added after the Unity build, as follows:
+Prior to Unity 2019, when using Unity's build window, the capability will need to be manually added after the Unity build, as follows:
 1. Open your compiled Visual Studio project and then open the _'Package.appxmanifest'_ in your solution.
 2. Make sure to tick the _'GazeInput'_ checkbox under _Capabilities_. If you don't see a _'GazeInput'_ capability, check that your system meets the [prerequisites for using MRTK](../GettingStartedWithTheMRTK.md#prerequisites) (in particular the Windows SDK version).
 

--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -28,7 +28,7 @@ This tooling will find the AppX manifest after the Unity build is completed and 
 
 When using Unity's build window, the capability will need to be manually added after the Unity build, as follows:
 1. Open your compiled Visual Studio project and then open the _'Package.appxmanifest'_ in your solution.
-2. Make sure to tick the _'GazeInput'_ checkbox under _Capabilities_.
+2. Make sure to tick the _'GazeInput'_ checkbox under _Capabilities_. If you don't see a _'GazeInput'_ capability, check that your system meets the [prerequisites for using MRTK](../GettingStartedWithTheMRTK.md#prerequisites) (in particular the Windows SDK version).
 
 _Please note:_
 You only have to do this if you build into a new build folder.

--- a/Documentation/EyeTracking/EyeTracking_BasicSetup.md
+++ b/Documentation/EyeTracking/EyeTracking_BasicSetup.md
@@ -32,7 +32,7 @@ Prior to Unity 2019, when using Unity's build window, the capability will need t
 
 _Please note:_
 You only have to do this if you build into a new build folder.
-This means that if you had already built your Unity project and set up the appxmanifest before and now target the same folder again, the appxmanifest should stay untouched.
+This means that if you had already built your Unity project and set up the appxmanifest before and now target the same folder again, you will not need to reapply your changes.
 
 ## Setting up eye tracking step-by-step
 


### PR DESCRIPTION
## Overview

Follow on to #7615 based on feedback from @sostel.

## Changes

* add back the note about checking MRTK prerequisites if you don't see a GazeInput capability
* doc that capability was added in Unity 2019
* clarify "should stay untouched"

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
