### PR TITLE
Fixes issue where sphere pointer can grab overlapping non-target layer objects

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -344,7 +344,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public RayStep[] Rays { get; protected set; } = { new RayStep(Vector3.zero, Vector3.forward) };
 
         /// <inheritdoc />
-        public LayerMask[] PrioritizedLayerMasksOverride { get; set; }
+        public virtual LayerMask[] PrioritizedLayerMasksOverride { get; set; }
 
         /// <inheritdoc />
         public IMixedRealityFocusHandler FocusTarget { get; set; }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -344,7 +344,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public RayStep[] Rays { get; protected set; } = { new RayStep(Vector3.zero, Vector3.forward) };
 
         /// <inheritdoc />
-        public virtual LayerMask[] PrioritizedLayerMasksOverride { get; set; }
+        public LayerMask[] PrioritizedLayerMasksOverride { get; set; }
 
         /// <inheritdoc />
         public IMixedRealityFocusHandler FocusTarget { get; set; }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using UnityEngine;
 using UnityEngine.Profiling;
 
@@ -50,7 +51,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <remarks>
         /// Only [NearInteractionGrabbables](xref:Microsoft.MixedReality.Toolkit.Input.NearInteractionGrabbable) in one of the LayerMasks will raise events.
         /// </remarks>
+        [Obsolete("Use PrioritizedLayerMasksOverride instead")]
         public LayerMask[] GrabLayerMasks => grabLayerMasks;
+
+        public override LayerMask[] PrioritizedLayerMasksOverride
+        {
+            get => grabLayerMasks;
+          set => grabLayerMasks = value;
+        }
 
         [SerializeField]
         [Tooltip("Specify whether queries for grabbable objects hit triggers.")]
@@ -118,7 +126,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void Awake()
         {
-            PrioritizedLayerMasksOverride = GrabLayerMasks;
             queryBufferNearObjectRadius = new SpherePointerQueryInfo(sceneQueryBufferSize, NearObjectRadius);
             queryBufferInteractionRadius = new SpherePointerQueryInfo(sceneQueryBufferSize, SphereCastRadius);
         }
@@ -139,17 +146,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Vector3 endPoint = Vector3.forward * SphereCastRadius;
                 Rays[0].UpdateRayStep(ref pointerPosition, ref endPoint);
 
-                for (int i = 0; i < GrabLayerMasks.Length; i++)
+                for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
                 {
-                    if (queryBufferNearObjectRadius.TryUpdateQueryBufferForLayerMask(GrabLayerMasks[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                    if (queryBufferNearObjectRadius.TryUpdateQueryBufferForLayerMask(PrioritizedLayerMasksOverride[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
                     {
                         break;
                     }
                 }
 
-                for (int i = 0; i < GrabLayerMasks.Length; i++)
+                for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
                 {
-                    if (queryBufferInteractionRadius.TryUpdateQueryBufferForLayerMask(GrabLayerMasks[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                    if (queryBufferInteractionRadius.TryUpdateQueryBufferForLayerMask(PrioritizedLayerMasksOverride[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
                     {
                         break;
                     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -4,7 +4,6 @@
 using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using System;
 using UnityEngine;
 using UnityEngine.Profiling;
 
@@ -51,14 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <remarks>
         /// Only [NearInteractionGrabbables](xref:Microsoft.MixedReality.Toolkit.Input.NearInteractionGrabbable) in one of the LayerMasks will raise events.
         /// </remarks>
-        [Obsolete("Use PrioritizedLayerMasksOverride instead")]
         public LayerMask[] GrabLayerMasks => grabLayerMasks;
-
-        public override LayerMask[] PrioritizedLayerMasksOverride
-        {
-            get => grabLayerMasks;
-          set => grabLayerMasks = value;
-        }
 
         [SerializeField]
         [Tooltip("Specify whether queries for grabbable objects hit triggers.")]
@@ -145,6 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 Vector3 endPoint = Vector3.forward * SphereCastRadius;
                 Rays[0].UpdateRayStep(ref pointerPosition, ref endPoint);
+                PrioritizedLayerMasksOverride = PrioritizedLayerMasksOverride ?? GrabLayerMasks;
 
                 for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -118,6 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void Awake()
         {
+            PrioritizedLayerMasksOverride = GrabLayerMasks;
             queryBufferNearObjectRadius = new SpherePointerQueryInfo(sceneQueryBufferSize, NearObjectRadius);
             queryBufferInteractionRadius = new SpherePointerQueryInfo(sceneQueryBufferSize, SphereCastRadius);
         }
@@ -138,19 +139,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 Vector3 endPoint = Vector3.forward * SphereCastRadius;
                 Rays[0].UpdateRayStep(ref pointerPosition, ref endPoint);
 
-                var layerMasks = PrioritizedLayerMasksOverride ?? GrabLayerMasks;
-
-                for (int i = 0; i < layerMasks.Length; i++)
+                for (int i = 0; i < GrabLayerMasks.Length; i++)
                 {
-                    if (queryBufferNearObjectRadius.TryUpdateQueryBufferForLayerMask(layerMasks[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                    if (queryBufferNearObjectRadius.TryUpdateQueryBufferForLayerMask(GrabLayerMasks[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
                     {
                         break;
                     }
                 }
 
-                for (int i = 0; i < layerMasks.Length; i++)
+                for (int i = 0; i < GrabLayerMasks.Length; i++)
                 {
-                    if (queryBufferInteractionRadius.TryUpdateQueryBufferForLayerMask(layerMasks[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                    if (queryBufferInteractionRadius.TryUpdateQueryBufferForLayerMask(GrabLayerMasks[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
                     {
                         break;
                     }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1251,6 +1251,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                         // a NearInteractionGrabbable component on it.
                                         // FIXME: This is assuming only the grab pointer is using SceneQueryType.SphereOverlap,
                                         //        but there may be other pointers using the same query type which have different semantics.
+                                        //        See github issue https://github.com/microsoft/MixedRealityToolkit-Unity/issues/3758 
                                         if (collider.GetComponent<NearInteractionGrabbable>() == null)
                                         {
                                             continue;
@@ -1259,7 +1260,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                         // If location is in the collider the closestPoint will be inside.
                                         // FIXME: this implementation is heavily flawed because the distance to the closest point is always 0 when the
                                         // point is inside the collider. This breaks cases like when 2 overlapping objects are selectable. We need to 
-                                        // address these cases with a smarter approach in the future
+                                        // address these cases with a smarter approach in the future.
+                                        //        See github issue https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7629
                                         Vector3 closestPointToCollider = collider.ClosestPoint(testPoint);
                                         float distance = (testPoint - closestPointToCollider).sqrMagnitude;
                                         if (distance < closestDistance)

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1226,40 +1226,48 @@ namespace Microsoft.MixedReality.Toolkit.Input
                                 Array.Resize<Collider>(ref colliders, maxQuerySceneResults);
                             }
 
-                            int numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(pointer.Rays[i].Origin, pointer.SphereCastRadius, colliders, ~UnityEngine.Physics.IgnoreRaycastLayer);
+                            Vector3 testPoint = pointer.Rays[i].Origin;
+                            Vector3 objectHitPoint = testPoint;
+                            GameObject closest = null;
+                            float closestDistance = Mathf.Infinity;
+                            int totalNumColliders = 0;
 
-                            if (numColliders > 0)
+                            // Go through each layerMask and ensure perform the appropriate OverlapSphereCalculation
+                            // Since this is usually done when a pointer passes a IsInteractionEnabled, maybe we can cache the selected colliders inside the pointer?
+                            foreach (LayerMask layerMask in prioritizedLayerMasks)
                             {
-                                if (numColliders >= maxQuerySceneResults)
+                                int numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(pointer.Rays[i].Origin, pointer.SphereCastRadius, colliders, layerMask);
+                                totalNumColliders += numColliders;
+                                if (numColliders > 0)
                                 {
-                                    Debug.LogWarning($"Maximum number of {numColliders} colliders found in FocusProvider overlap query. Consider increasing the focus query buffer size in the input profile.");
-                                }
-
-                                Vector3 testPoint = pointer.Rays[i].Origin;
-                                GameObject closest = null;
-                                float closestDistance = Mathf.Infinity;
-                                Vector3 objectHitPoint = testPoint;
-
-                                for (int colliderIndex = 0; colliderIndex < numColliders; colliderIndex++)
-                                {
-                                    Collider collider = colliders[colliderIndex];
-                                    // Policy: in order for an collider to be near interactable it must have
-                                    // a NearInteractionGrabbable component on it.
-                                    // FIXME: This is assuming only the grab pointer is using SceneQueryType.SphereOverlap,
-                                    //        but there may be other pointers using the same query type which have different semantics.
-                                    if (collider.GetComponent<NearInteractionGrabbable>() == null)
+                                    if (totalNumColliders >= maxQuerySceneResults)
                                     {
-                                        continue;
+                                        Debug.LogWarning($"Maximum number of {totalNumColliders} colliders found in FocusProvider overlap query. Consider increasing the focus query buffer size in the input profile.");
                                     }
-                                    // From https://docs.unity3d.com/ScriptReference/Collider.ClosestPoint.html
-                                    // If location is in the collider the closestPoint will be inside.
-                                    Vector3 closestPointToCollider = collider.ClosestPoint(testPoint);
-                                    float distance = (testPoint - closestPointToCollider).sqrMagnitude;
-                                    if (distance < closestDistance)
+                                    for (int colliderIndex = 0; colliderIndex < numColliders; colliderIndex++)
                                     {
-                                        closestDistance = distance;
-                                        closest = collider.gameObject;
-                                        objectHitPoint = closestPointToCollider;
+                                        Collider collider = colliders[colliderIndex];
+                                        // Policy: in order for an collider to be near interactable it must have
+                                        // a NearInteractionGrabbable component on it.
+                                        // FIXME: This is assuming only the grab pointer is using SceneQueryType.SphereOverlap,
+                                        //        but there may be other pointers using the same query type which have different semantics.
+                                        if (collider.GetComponent<NearInteractionGrabbable>() == null)
+                                        {
+                                            continue;
+                                        }
+                                        // From https://docs.unity3d.com/ScriptReference/Collider.ClosestPoint.html
+                                        // If location is in the collider the closestPoint will be inside.
+                                        // FIXME: this implementation is heavily flawed because the distance to the closest point is always 0 when the
+                                        // point is inside the collider. This breaks cases like when 2 overlapping objects are selectable. We need to 
+                                        // address these cases with a smarter approach in the future
+                                        Vector3 closestPointToCollider = collider.ClosestPoint(testPoint);
+                                        float distance = (testPoint - closestPointToCollider).sqrMagnitude;
+                                        if (distance < closestDistance)
+                                        {
+                                            closestDistance = distance;
+                                            closest = collider.gameObject;
+                                            objectHitPoint = closestPointToCollider;
+                                        }
                                     }
                                 }
                                 if (closest != null)

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -31,6 +31,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // Grabbable cube that we want to be manipulating
         private GameObject cube;
 
+        // Grabbable cube that we want to be manipulating to tests overlaps
+        private GameObject overlapRect;
+
         // Initializes MRTK, instantiates the test content prefab and adds a pointer handler to the test collider
         [SetUp]
         public override void Setup()
@@ -39,17 +42,28 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             float centerZ = 2.0f;
             float scale = 0.2f;
+            colliderSurfaceZ = centerZ - scale * 0.5f;
             cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.transform.localPosition = new Vector3(0, 0, centerZ);
             cube.transform.localScale = Vector3.one * scale;
-
-            colliderSurfaceZ = centerZ - scale * 0.5f;
 
             var collider = cube.GetComponentInChildren<Collider>();
             Assert.IsNotNull(collider);
 
             var grabbable = cube.AddComponent<NearInteractionGrabbable>();
             Assert.IsNotNull(grabbable);
+            
+            float overlapCenterZ = centerZ;
+            overlapRect = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            overlapRect.transform.localPosition = new Vector3(0, 0, overlapCenterZ);
+            overlapRect.transform.localScale = new Vector3(1.5f,1.5f,1f) * scale;
+            overlapRect.SetActive(false);
+
+            var overlapCollider = overlapRect.GetComponentInChildren<Collider>();
+            Assert.IsNotNull(overlapCollider);
+
+            var overlapGrabbable = overlapRect.AddComponent<NearInteractionGrabbable>();
+            Assert.IsNotNull(overlapGrabbable);
         }
 
         [TearDown]
@@ -107,6 +121,52 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
             Assert.True(pointer.IsNearObject);
             Assert.True(pointer.IsInteractionEnabled);
+        }
+
+        /// <summary>
+        /// Verifies that SpherePointer correctly returns IsNearObject and IsInteractionEnabled
+        /// when 
+        /// </summary>
+        [UnityTest]
+        public IEnumerator GrabLayerMasksWithOverlap()
+        {
+            // Initialize hand
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(Vector3.zero);
+            yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+
+            var pointer = rightHand.GetPointer<SpherePointer>();
+            Assert.IsNotNull(pointer, "Expected to find SpherePointer in the hand controller");
+            Vector3 interactionEnabledPos = new Vector3(0.05f, 0, colliderSurfaceZ - pointer.SphereCastRadius);
+
+            Assert.False(pointer.IsNearObject);
+            Assert.False(pointer.IsInteractionEnabled);
+
+            //Initialize overlap cube
+            overlapRect.SetActive(true);
+
+            // Set layer to spatial mesh, which sphere pointer should be ignoring
+            // assumption: layer 31 is the spatial mesh layer
+            cube.SetLayerRecursively(31);
+            yield return null;
+            Assert.False(pointer.IsNearObject);
+            Assert.False(pointer.IsInteractionEnabled);
+
+            // Move hand to object, IsNearObject, IsInteractionEnabled should be true
+            yield return rightHand.MoveTo(interactionEnabledPos);
+            Assert.True(CoreServices.InputSystem.FocusProvider.GetFocusedObject(pointer) == overlapRect, " the overlapping rectangle was not in focus");
+
+            // Set cube layer back to default
+            // Set overlapRect layer to spatial mesh, which sphere pointer should be ignoring
+            // assumption: layer 31 is the spatial mesh layer
+            overlapRect.SetLayerRecursively(31);
+            cube.SetLayerRecursively(0);
+            yield return null;
+            Assert.True(CoreServices.InputSystem.FocusProvider.GetFocusedObject(pointer) == cube, " the inner cube was not in focus");
+
+            //Reinitialize the overlapRect
+            overlapRect.SetLayerRecursively(0);
+            overlapRect.SetActive(false);
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         /// <summary>
         /// Verifies that SpherePointer correctly returns IsNearObject and IsInteractionEnabled
-        /// when 
+        /// and only objects on the correct grabbable layer are in focus
         /// </summary>
         [UnityTest]
         public IEnumerator GrabLayerMasksWithOverlap()
@@ -142,10 +142,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
-            //Initialize overlap cube
+            //Initialize overlapRect
             overlapRect.SetActive(true);
 
-            // Set layer to spatial mesh, which sphere pointer should be ignoring
+            // Set the cube's layer to spatial mesh, which sphere pointer should be ignoring
             // assumption: layer 31 is the spatial mesh layer
             cube.SetLayerRecursively(31);
             yield return null;
@@ -155,16 +155,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Move hand to object, IsNearObject, IsInteractionEnabled should be true
             yield return rightHand.MoveTo(interactionEnabledPos);
             Assert.True(CoreServices.InputSystem.FocusProvider.GetFocusedObject(pointer) == overlapRect, " the overlapping rectangle was not in focus");
+            Assert.True(pointer.IsNearObject);
+            Assert.True(pointer.IsInteractionEnabled);
 
-            // Set cube layer back to default
-            // Set overlapRect layer to spatial mesh, which sphere pointer should be ignoring
+            // Set cube's layer back to default
+            // Set overlapRect's layer to spatial mesh, which sphere pointer should be ignoring
             // assumption: layer 31 is the spatial mesh layer
             overlapRect.SetLayerRecursively(31);
             cube.SetLayerRecursively(0);
             yield return null;
             Assert.True(CoreServices.InputSystem.FocusProvider.GetFocusedObject(pointer) == cube, " the inner cube was not in focus");
 
-            //Reinitialize the overlapRect
+            // Reinitialize the overlapRect
             overlapRect.SetLayerRecursively(0);
             overlapRect.SetActive(false);
         }


### PR DESCRIPTION
## Overview
Currently there is an issue where the sphere pointer that targets a specific layer can mistakenly grab an object that's not on that layer. This occurs when the non-target layer object is encapsulated/overlapped inside a target layer object. The error occurred because the pointers of type SceneQueryType.SphereOverlap where not processed properly by the focus provider

## Changes
- Fixes: #7620
