### PR TITLE
Only try to get textureCoord2 is the shared mesh is readable

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityRaycastHit.cs
@@ -34,7 +34,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 distance = hitInfo.distance;
                 triangleIndex = hitInfo.triangleIndex;
                 textureCoord = hitInfo.textureCoord;
-                textureCoord2 = hitInfo.textureCoord2;
+                MeshCollider meshCollider = hitInfo.collider as MeshCollider;
+                if (meshCollider == null || meshCollider.sharedMesh.isReadable)
+                {
+                    textureCoord2 = hitInfo.textureCoord2;
+                }
+                else
+                {
+                    textureCoord2 = Vector2.zero;
+                }
                 transform = hitInfo.transform;
                 lightmapCoord = hitInfo.lightmapCoord;
                 collider = hitInfo.collider;

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -956,7 +956,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private static readonly ProfilerMarker UpdatePointerPerfMarker = new ProfilerMarker("[MRTK] FocusProvider.UpdatPointer");
+        private static readonly ProfilerMarker UpdatePointerPerfMarker = new ProfilerMarker("[MRTK] FocusProvider.UpdatePointer");
 
         private void UpdatePointer(PointerData pointerData)
         {


### PR DESCRIPTION
## Overview

Adds a guard to not try to get `textureCoord2` if the shared mesh isn't readable.

I'm also fine with leaving this code as-is, if we think this is something we should recommend instead ("Make sure to check `Read/Write Enabled` on your asset bundle meshes" or something?).

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7632