### PR TITLE
Update the doccomments about how to handle eye tracking loss.

### DIFF
--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="userIsEyeCalibrated">Boolean whether the user is eye calibrated or not.</param>
         /// <remarks>
         /// Note that this function is not invoked when eye tracking is lost - use IsEyeTrackingAvailable
-        /// to detect wen eye tracking is lost.
+        /// to detect when eye tracking is lost.
         /// </remarks>
         void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool userIsEyeCalibrated);
     }

--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeGazeProvider.cs
@@ -60,6 +60,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         /// <param name="provider">The provider raising the event.</param>
         /// <param name="userIsEyeCalibrated">Boolean whether the user is eye calibrated or not.</param>
+        /// <remarks>
+        /// Note that this function is not invoked when eye tracking is lost - use IsEyeTrackingAvailable
+        /// to detect wen eye tracking is lost.
+        /// </remarks>
         void UpdateEyeTrackingStatus(IMixedRealityEyeGazeDataProvider provider, bool userIsEyeCalibrated);
     }
 }


### PR DESCRIPTION
A follow up from https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7515, modifying the doccomments to reflect what to expect when using this interface.

Based on comments on that PR it looks like using the IsEyeTrackingAvailable property is the way to know when eye tracking is gone.

Note that this is still not exactly complete because there's no event that a developer can use to listen to changes on this property (you have to poll).