### PR TITLE
Update the CI pipeline to enforce comment code style

### DIFF
--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/BaseSpatialAwarenessObject.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/BaseSpatialAwarenessObject.cs
@@ -32,7 +32,6 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// </summary>
         protected BaseSpatialAwarenessObject()
         {
-            //empty for now
         }
     }
 }

--- a/Assets/MRTK/Core/Extensions/Texture2DExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/Texture2DExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit
                 throw new IndexOutOfRangeException();
             }
 
-            Color32 toColor = fillColor; //Implicit cast
+            Color32 toColor = fillColor; // Implicit cast
             Color32[] colors = new Color32[width * height];
             for (int i=0; i < colors.Length; i++)
             {

--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -157,7 +157,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
                     // Else item is valid and exists in our list. Remove from list
                     serviceSet.Remove(facade.Service);
 
-                    //Ensure valid facades are parented under the current MRTK active instance
+                    // Ensure valid facades are parented under the current MRTK active instance
                     if (facade.transform.parent != mrtkTransform)
                     {
                         facade.transform.parent = mrtkTransform;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
@@ -186,8 +186,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                         }
 
                         EditorGUILayout.PropertyField(lightingScenes, includeChildren: true);
-                        //DrawSceneInfoDragAndDrop(lightingScenes);
-
                         EditorGUILayout.Space();
 
                         if (profile.NumLightingScenes > 0)
@@ -215,7 +213,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     // Enable the tag field since we're drawing content scenes
                     SceneInfoDrawer.DrawTagProperty = true;
                     EditorGUILayout.PropertyField(contentScenes, includeChildren: true);
-                    //DrawSceneInfoDragAndDrop(contentScenes);
                 }
             }, ShowSceneSystem_Content_PreferenceKey);
 

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoDrawer.cs
@@ -72,7 +72,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             // Indent our rect, then reset indent to 0 so sub-properties don't get doubly indented
             position = EditorGUI.IndentedRect(position);
-            //position.width = propertyWidth;
             EditorGUI.indentLevel = 0;
 
             // Draw a box around our item

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -158,10 +158,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     changed = true;
                 }
 
-                // This method is no longer reliable
-                // so we're using out cached scenes instead
-                //Scene scene = EditorSceneManager.GetSceneByPath(scenePath);
-                //int buildIndex = scene.buildIndex;
+                
+                // The method is using scenes by path is not reliable (code included
+                // commented out here for reference).
+                // Cached scenes are used instead (see CachedScenes).
+                // Scene scene = EditorSceneManager.GetSceneByPath(scenePath);
+                // int buildIndex = scene.buildIndex;
 
                 int buildIndex = -1;
                 int sceneCount = 0;

--- a/Assets/MRTK/Core/Inspectors/ServiceInspectors/HandJointServiceInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/ServiceInspectors/HandJointServiceInspector.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static Dictionary<TrackedHandJoint, bool> showHandJointSettings;
         private static Dictionary<TrackedHandJoint, string> showHandJointSettingKeys;
 
-        //We want hand preview to always be visible
+        // We want hand preview to always be visible
         public override bool AlwaysDrawSceneGUI { get { return true; } }
 
         public override void DrawInspectorGUI(object target)

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </summary>
     public static class InspectorUIUtility
     {
-        //Colors
+        // Colors
         private static readonly Color PersonalThemeColorTint100 = new Color(1f, 1f, 1f);
         private static readonly Color PersonalThemeColorTint75 = new Color(0.75f, 0.75f, 0.75f);
         private static readonly Color PersonalThemeColorTint50 = new Color(0.5f, 0.5f, 0.5f);

--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -33,7 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public static readonly GUIStyle TitleFoldoutStyle =
           new GUIStyle(EditorStyles.foldout)
           {
-              //fontStyle = FontStyle.,
               fontSize = InspectorUIUtility.TitleFontSize,
           };
 

--- a/Assets/MRTK/Core/Services/BaseEventSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseEventSystem.cs
@@ -433,18 +433,18 @@ namespace Microsoft.MixedReality.Toolkit
     #endregion Utilities
         // Example Event Pattern #############################################################
 
-        //public void RaiseGenericEvent(IEventSource eventSource)
-        //{
-        //    genericEventData.Initialize(eventSource);
-        //    HandleEvent(genericEventData, GenericEventHandler);
-        //}
+        // public void RaiseGenericEvent(IEventSource eventSource)
+        // {
+        //     genericEventData.Initialize(eventSource);
+        //     HandleEvent(genericEventData, GenericEventHandler);
+        // }
 
-        //private static readonly ExecuteEvents.EventFunction<IEventHandler> GenericEventHandler =
-        //    delegate (IEventHandler handler, BaseEventData eventData)
-        //    {
-        //        var casted = ExecuteEvents.ValidateEventData<GenericBaseEventData>(eventData);
-        //        handler.OnEventRaised(casted);
-        //    };
+        // private static readonly ExecuteEvents.EventFunction<IEventHandler> GenericEventHandler =
+        //     delegate (IEventHandler handler, BaseEventData eventData)
+        //     {
+        //         var casted = ExecuteEvents.ValidateEventData<GenericBaseEventData>(eventData);
+        //         handler.OnEventRaised(casted);
+        //     };
 
         // Example Event Pattern #############################################################
     }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -323,7 +323,7 @@ namespace Microsoft.MixedReality.Toolkit
         {
             isInitializing = true;
 
-            //If the Mixed Reality Toolkit is not configured, stop.
+            // If the Mixed Reality Toolkit is not configured, stop.
             if (ActiveProfile == null)
             {
                 if (!Application.isPlaying)

--- a/Assets/MRTK/Core/Utilities/Lines/LineUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/LineUtility.cs
@@ -66,8 +66,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <returns>The calculated point.</returns>
         public static Vector3 GetPointAlongPhysicalParabola(Vector3 origin, Vector3 direction, float velocity, Vector3 gravity, float time)
         {
-            //return (origin + ((direction.normalized * velocity) * time)) + (0.5f * gravity * (time * time));
-
             direction = Vector3.Normalize(direction);
 
             origin.x += ((direction.x * velocity * time) + (0.5f * gravity.x * (time * time)));

--- a/Assets/MRTK/Core/Utilities/Physics/Interpolator.cs
+++ b/Assets/MRTK/Core/Utilities/Physics/Interpolator.cs
@@ -161,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
 
                 transform.position = newPosition;
 
-                //calculate interpolatedVelocity and store position for next frame
+                // Calculate interpolatedVelocity and store position for next frame
                 PositionVelocity = oldPosition - newPosition;
                 oldPosition = newPosition;
             }

--- a/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/ClippingPrimitive.cs
@@ -186,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         protected void LateUpdate()
         {
-            //Deferring the LateUpdate() call to OnCameraPreRender()
+            // Deferring the LateUpdate() call to OnCameraPreRender()
             if (!useOnPreRender)
             {
                 UpdateRenderers();

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -151,8 +151,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 {
                     await GetPowerStateAsync(targetDevice);
                 }
-
-                //Debug.LogError(response.ResponseBody);
                 return null;
             }
 

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBase.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBase.cs
@@ -271,13 +271,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
             // Let's rotate the normalized gesture offset based on camera rotation. Let's check if the zoom direction changed
             Vector3 transfPnt = normalizedOffset;
-            //# Rotate around the y axis
+            // Rotate around the y axis
             transfPnt = Quaternion.AngleAxis(gameObject.transform.rotation.eulerAngles.y, Vector3.down) * transfPnt;
 
-            //# Rotate around the x axis
+            // Rotate around the x axis
             transfPnt = Quaternion.AngleAxis(gameObject.transform.rotation.eulerAngles.x, Vector3.left) * transfPnt;
 
-            //# Rotate around the z axis
+            // Rotate around the z axis
             transfPnt = Quaternion.AngleAxis(gameObject.transform.rotation.eulerAngles.z, Vector3.back) * transfPnt;
 
             if ((navPos.z >= 0) && (transfPnt.z < 0))
@@ -295,10 +295,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         // Update is called once per frame
         protected virtual void Update()
         {
-            //# Let's make sure that the correct GameObject is targeted and update the pan and zoom parameters.
+            // Let's make sure that the correct GameObject is targeted and update the pan and zoom parameters.
             if (UpdateCursorPosInHitBox())
             {
-                //# Dynamically increase hit box size once user looks at this target
+                // Dynamically increase hit box size once user looks at this target
                 if (!wasLookedAtBefore)
                 {
                     wasLookedAtBefore = true;
@@ -309,15 +309,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
                     }
                 }
 
-                //# Pan
+                // Pan
                 AutomaticGazePanning();
 
-                //# Zoom
+                // Zoom
                 UpdateZoom();
             }
             else
             {
-                //# Dynamically decrease hit box size back to original once user isn't looking at this target anymore
+                // Dynamically decrease hit box size back to original once user isn't looking at this target anymore
                 if (wasLookedAtBefore)
                 {
                     wasLookedAtBefore = false;
@@ -356,7 +356,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         /// </summary>
         private void LateUpdate()
         {
-            //# Update offset based on the animation rate and previous offset
+            // Update offset based on the animation rate and previous offset
             if (useSkimProof)
             {
                 if (isFocused)
@@ -372,7 +372,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
             UpdatePanZoom();
 
-            //# Reset rate of change
+            // Reset rate of change
             offsetRate_Pan = new Vector2(0, 0);
             offsetRate_Zoom = new Vector2(0, 0);
         }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBaseRectTransf.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBaseRectTransf.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             offset = LimitPanning();
 
             // Assign new values
-            navRectTransf.anchoredPosition = offset; //pivot
+            navRectTransf.anchoredPosition = offset; // pivot
             navRectTransf.localScale = new Vector3(scale.x, scale.y, 1);
         }
 

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBaseTexture.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBaseTexture.cs
@@ -53,12 +53,12 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             {
                 aspectRatio = newAspectRatio;
 
-                //# Compute and set new scale  
+                // Compute and set new scale  
                 ZoomStop();
                 scale = new Vector2(textureRenderer.transform.localScale.x / aspectRatio, 1f);
                 textureRenderer.materials[0].SetTextureScale(textureTargetID, scale);
 
-                //# Update new values for original ratio
+                // Update new values for original ratio
                 originalRatio = new Vector3(scale.x, scale.y);
 
                 BoxCollider bcoll = textureRenderer.gameObject.GetComponent<BoxCollider>();

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/TargetMoveToCamera.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/TargetMoveToCamera.cs
@@ -99,13 +99,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         {
             if (inTransition)
             {
-                //Vector3 destination; //= CameraCache.Main.transform.position + (CameraCache.Main.transform.forward * DistanceToCamera);
                 Vector3 destination = (isInNearFocusMode) ?
                     (CameraCache.Main.transform.position + (CameraCache.Main.transform.forward * DistanceToCamera))
                     : originalPosition;
 
                 Vector3 incr = (destination - gameObject.transform.position) * Time.deltaTime * speed;
-                //Debug.Log("target is moving "+ incr.magnitude);
 
                 if (Vector3.Distance(destination, transform.position) < minDistToStopTransition)
                 {

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/MoveObjByEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/MoveObjByEyeGaze.cs
@@ -211,11 +211,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
                             {
                                 if (PlacementSurface == PlacementSurfaces.Horizontal)
                                 {
-                                    previewGameObject.transform.position = plausibleLocation.Value + previewGameObject.transform.localScale.y * new Vector3(0, 1, 0) / 2;  //EyeInputManager.Instance.HitPosition + pPreviewGameObj.transform.localScale.y * new Vector3(0, 1, 0);
+                                    previewGameObject.transform.position = plausibleLocation.Value + previewGameObject.transform.localScale.y * new Vector3(0, 1, 0) / 2;  // EyeInputManager.Instance.HitPosition + pPreviewGameObj.transform.localScale.y * new Vector3(0, 1, 0);
                                 }
                                 else
                                 {
-                                    previewGameObject.transform.position = plausibleLocation.Value; //EyeInputManager.Instance.HitPosition;
+                                    previewGameObject.transform.position = plausibleLocation.Value; // EyeInputManager.Instance.HitPosition;
                                 }
                                 prevPreviewPos = previewGameObject.transform.position;
                             }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/LogStructureEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/LogStructureEyeGaze.cs
@@ -54,7 +54,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
             object[] data = new object[]
             { 
-                //-------------------------------
                 // Cam / Head tracking
                 CameraCache.Main.transform.position.x,
                 CameraCache.Main.transform.position.y,

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputPlayback.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputPlayback.cs
@@ -403,7 +403,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
         private Ray? GetEyeRay(string[] split)
         {
             return GetRay(split[9], split[10], split[11], split[12], split[13], split[14]);
-            //TODO: do not hard code indices.
         }
 
         private Ray? GetRay(string ox, string oy, string oz, string dirx, string diry, string dirz)

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/FollowEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/FollowEyeGaze.cs
@@ -41,7 +41,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
                     else
                     {
                         // Show the object at the hit position of the user's eye gaze ray with the target.
-                        //gameObject.transform.position = EyeTrackingTarget.LookedAtPoint;
                         gameObject.transform.position = eyeGazeProvider.GazeOrigin + eyeGazeProvider.GazeDirection.normalized * defaultDistanceInMeters;
                     }
                 }

--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
 
         private void OnEnable()
         {
-            //make sure we find a collection
+            // Make sure we find a collection
             if (scrollCollection == null)
             {
                 scrollCollection = GetComponentInChildren<ScrollingObjectCollection>();
@@ -111,7 +111,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
                 newScroll.SetActive(false);
                 scrollCollection = newScroll.AddComponent<ScrollingObjectCollection>();
 
-                //prevent the scrolling collection from running until we're done dynamically populating it.
+                // Prevent the scrolling collection from running until we're done dynamically populating it.
                 scrollCollection.SetUpAtRuntime = false;
                 scrollCollection.CellHeight = 0.032f;
                 scrollCollection.CellWidth = 0.032f;
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
             }
             else
             {
-                if(loader != null)
+                if (loader != null)
                 {
                     loader.SetActive(true);
                 }
@@ -158,11 +158,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
                 yield return null;
             }
 
-            //Now that the list is populated, hide the loader and show the list
+            // Now that the list is populated, hide the loader and show the list
             loaderViz.SetActive(false);
             scrollCollection.gameObject.SetActive(true);
 
-            //Finally, manually call UpdateCollection to set up the collection
+            // Finally, manually call UpdateCollection to set up the collection
             scrollCollection.UpdateCollection();
         }
 

--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
@@ -191,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
         {
             if(jointKinematicBodies.Count > 0)
             {
-                //Tear down the old kinematicBodies
+                // Tear down the old kinematicBodies
                 foreach (JointKinematicBody jointKinematicBody in jointKinematicBodies)
                 {
                     UnityEngine.Object.Destroy(jointKinematicBody.gameObject);

--- a/Assets/MRTK/Providers/OpenVR/Headers/openvr_api.cs
+++ b/Assets/MRTK/Providers/OpenVR/Headers/openvr_api.cs
@@ -4766,7 +4766,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdMatrix34_t
     {
-        public float m0; //float[3][4]
+        public float m0; // float[3][4]
         public float m1;
         public float m2;
         public float m3;
@@ -4782,7 +4782,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdMatrix33_t
     {
-        public float m0; //float[3][3]
+        public float m0; // float[3][3]
         public float m1;
         public float m2;
         public float m3;
@@ -4795,7 +4795,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdMatrix44_t
     {
-        public float m0; //float[4][4]
+        public float m0; // float[4][4]
         public float m1;
         public float m2;
         public float m3;
@@ -4815,14 +4815,14 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdVector3_t
     {
-        public float v0; //float[3]
+        public float v0; // float[3]
         public float v1;
         public float v2;
     }
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdVector4_t
     {
-        public float v0; //float[4]
+        public float v0; // float[4]
         public float v1;
         public float v2;
         public float v3;
@@ -4830,14 +4830,14 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdVector3d_t
     {
-        public double v0; //double[3]
+        public double v0; // double[3]
         public double v1;
         public double v2;
     }
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdVector2_t
     {
-        public float v0; //float[2]
+        public float v0; // float[2]
         public float v1;
     }
     [StructLayout(LayoutKind.Sequential)]
@@ -4867,7 +4867,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct HmdQuad_t
     {
-        public HmdVector3_t vCorners0; //HmdVector3_t[4]
+        public HmdVector3_t vCorners0; // HmdVector3_t[4]
         public HmdVector3_t vCorners1;
         public HmdVector3_t vCorners2;
         public HmdVector3_t vCorners3;
@@ -4881,11 +4881,11 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct DistortionCoordinates_t
     {
-        public float rfRed0; //float[2]
+        public float rfRed0; // float[2]
         public float rfRed1;
-        public float rfGreen0; //float[2]
+        public float rfGreen0; // float[2]
         public float rfGreen1;
-        public float rfBlue0; //float[2]
+        public float rfBlue0; // float[2]
         public float rfBlue1;
     }
     [StructLayout(LayoutKind.Sequential)]
@@ -5209,7 +5209,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public uint unPacketNum;
         public ulong ulButtonPressed;
         public ulong ulButtonTouched;
-        public VRControllerAxis_t rAxis0; //VRControllerAxis_t[5]
+        public VRControllerAxis_t rAxis0; // VRControllerAxis_t[5]
         public VRControllerAxis_t rAxis1;
         public VRControllerAxis_t rAxis2;
         public VRControllerAxis_t rAxis3;
@@ -5222,7 +5222,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public uint unPacketNum;
         public ulong ulButtonPressed;
         public ulong ulButtonTouched;
-        public VRControllerAxis_t rAxis0; //VRControllerAxis_t[5]
+        public VRControllerAxis_t rAxis0; // VRControllerAxis_t[5]
         public VRControllerAxis_t rAxis1;
         public VRControllerAxis_t rAxis2;
         public VRControllerAxis_t rAxis3;
@@ -5407,7 +5407,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     {
         public HmdVector3_t vPosition;
         public HmdVector3_t vNormal;
-        public float rfTextureCoord0; //float[2]
+        public float rfTextureCoord0; // float[2]
         public float rfTextureCoord1;
     }
     [StructLayout(LayoutKind.Sequential)]
@@ -5687,12 +5687,12 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
     [StructLayout(LayoutKind.Sequential)]
     public struct VRSkeletalSummaryData_t
     {
-        public float flFingerCurl0; //float[5]
+        public float flFingerCurl0; // float[5]
         public float flFingerCurl1;
         public float flFingerCurl2;
         public float flFingerCurl3;
         public float flFingerCurl4;
-        public float flFingerSplay0; //float[4]
+        public float flFingerSplay0; // float[4]
         public float flFingerSplay1;
         public float flFingerSplay2;
         public float flFingerSplay3;

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityUtilities.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                 return Marshal.GetObjectForIUnknown(nativePtr) as SpatialCoordinateSystem;
             }
         }
-#endif //ENABLE_DOTNET
+#endif // ENABLE_DOTNET
 
         /// <summary>
         /// Access the underlying native spatial coordinate system.

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
             UpdateInteractionManagerReading();
 
-            //NOTE: We update the source state data, in case an app wants to query it on source detected.
+            // NOTE: We update the source state data, in case an app wants to query it on source detected.
             for (var i = 0; i < numInteractionManagerStates; i++)
             {
                 GetOrAddController(interactionManagerStates[i]);
@@ -609,7 +609,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <returns>New or Existing Controller Input Source</returns>
         private BaseWindowsMixedRealitySource GetOrAddController(InteractionSource interactionSource, bool addController = true)
         {
-            //If a device is already registered with the ID provided, just return it.
+            // If a device is already registered with the ID provided, just return it.
             if (activeControllers.ContainsKey(interactionSource.id))
             {
                 var controller = activeControllers[interactionSource.id] as BaseWindowsMixedRealitySource;

--- a/Assets/MRTK/Providers/XRSDK/XRSDKSubsystemHelpers.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKSubsystemHelpers.cs
@@ -5,7 +5,7 @@ using UnityEngine.XR;
 
 #if XR_MANAGEMENT_ENABLED
 using UnityEngine.XR.Management;
-#endif //XR_MANAGEMENT_ENABLED
+#endif // XR_MANAGEMENT_ENABLED
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK
 {
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
                 {
                     inputSubsystem = ActiveLoader.GetLoadedSubsystem<XRInputSubsystem>();
                 }
-#endif //XR_MANAGEMENT_ENABLED
+#endif // XR_MANAGEMENT_ENABLED
 
                 return inputSubsystem;
             }

--- a/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogShell.cs
+++ b/Assets/MRTK/SDK/Experimental/Dialog/Scripts/DialogShell.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
         /// <inheritdoc />
         protected override void GenerateButtons()
         {
-            //Get List of ButtonTypes that should be created on Dialog
+            // Get List of ButtonTypes that should be created on Dialog
             List<DialogButtonType> buttonTypes = new List<DialogButtonType>();
             foreach (DialogButtonType buttonType in Enum.GetValues(typeof(DialogButtonType)))
             {
@@ -62,13 +62,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dialog
 
             twoButtonSet = new GameObject[2];
 
-            //Find all buttons on dialog...
+            // Find all buttons on dialog...
             List<DialogButton> buttonsOnDialog = GetAllDialogButtons();
 
-            //set desired buttons active and the rest inactive
+            // Set desired buttons active and the rest inactive
             SetButtonsActiveStates(buttonsOnDialog, buttonTypes.Count);
 
-            //set titles and types
+            // Set titles and types
             if (buttonTypes.Count > 0)
             {
                 // If we have two buttons then do step 1, else 0

--- a/Assets/MRTK/SDK/Experimental/Features/Dwell/DwellHandler.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Dwell/DwellHandler.cs
@@ -196,7 +196,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dwell
 
                 // check intent to resume
                 if (CurrentDwellState == DwellStateType.DwellCanceled
-                    && pointer.InputSourceParent.SourceId == eventData.Pointer.InputSourceParent.SourceId //make sure the returning pointer id is the same
+                    && pointer.InputSourceParent.SourceId == eventData.Pointer.InputSourceParent.SourceId // Make sure the returning pointer id is the same
                     && (DateTime.UtcNow - focusExitTime) <= dwellProfile.TimeToAllowDwellResume)
                 {
                     // Add the time duration focus was away since this is a dwell resume and we need to account for the time that focus was lost for the target.

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -593,7 +593,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
             else if (activation == BoundsControlActivationType.ActivateManually)
             {
-                //activate to create handles etc. then deactivate. 
+                // Activate to create handles etc. then deactivate. 
                 Active = true;
                 Active = false;
             }
@@ -1187,16 +1187,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 return;
             }
 
-            //set link visibility
+            // Set link visibility
             links.ResetVisibility(active);
             links.Flatten(ref flattenedHandles);
 
             boxDisplay.ResetVisibility(active);
 
             bool isVisible = (active == true && wireframeOnly == false);
-            //set corner visibility
+            // Set corner visibility
             scaleHandles.ResetHandleVisibility(isVisible);
-            // set rotation handle visibility
+            // Set rotation handle visibility
             rotationHandles.ResetHandleVisibility(isVisible);
             rotationHandles.FlattenHandles(ref flattenedHandles);
         }

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private bool showOverrideButtons = true;
         private bool showUnityEvents = false;
 
-        //Serialized properties purely for inspector visualization
+        // Serialized properties purely for inspector visualization
         private SerializedProperty nodeList;
         private SerializedProperty releaseDistance;
 
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             momentumEvent = serializedObject.FindProperty("ListMomentumEnded");
 
             disableClippedItems = serializedObject.FindProperty("disableClippedItems");
-            //serialized properties for visualization
+            // Serialized properties for visualization
             nodeList = serializedObject.FindProperty("nodeList");
             releaseDistance = serializedObject.FindProperty("releaseDistance");
         }
@@ -288,7 +288,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             {
                 DisplayTouchPlane(scrollContainer);
 
-                //Display the item number on the list items
+                // Display the item number on the list items
                 for (int i = 0; i <= nodeList.arraySize-1; i++)
                 {
                     var node = nodeList.GetArrayElementAtIndex(i);

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -186,11 +186,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             // 2019/08/14: We show the keyboard even when the keyboard is already visible because on HoloLens 1
             // and WMR the events OnKeyboardShowing and OnKeyboardHiding do not fire
-            //if (state == KeyboardState.Showing)
-            //{
-            //    Debug.Log($"MixedRealityKeyboard.ShowKeyboard called but keyboard already visible.");
-            //    return;
-            //}
+            // if (state == KeyboardState.Showing)
+            // {
+            //     Debug.Log($"MixedRealityKeyboard.ShowKeyboard called but keyboard already visible.");
+            //     return;
+            // }
 
             state = KeyboardState.Showing;
 

--- a/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/SurfacePulse.cs
+++ b/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/SurfacePulse.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.SurfacePulse
 			}
 		}
 
-#endif //UNITY_EDITOR
+#endif // UNITY_EDITOR
 
 		private void OnDestroy()
 		{

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -431,8 +431,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        //Take the previous view and then subtract the column remainder and we add the viewable area as a multiplier (minus 1 since the index is zero based).
-        //The first item not viewable in the list
+        // Take the previous view and then subtract the column remainder and we add the viewable area as a multiplier (minus 1 since the index is zero based).
+        // The first item not viewable in the list
         private int numItemsPostView
         {
             get
@@ -507,7 +507,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private IMixedRealityPointer currentPointer;
 
-        //The initial contact object for the list. this may not always be currentPointer.Result.CurrentPointerTarget
+        // The initial contact object for the list. this may not always be currentPointer.Result.CurrentPointerTarget
         private GameObject initialFocusedObject;
 
         // The point where the original PointerDown occurred
@@ -636,7 +636,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 
                 if (ContainsNode(child, out int nodeIndex) && NodeList[nodeIndex].GetType() != typeof(ScrollingObjectCollectionNode))
                 {
-                    //This node is in the list, but of the wrong type
+                    // This node is in the list, but of the wrong type
                     NodeList[nodeIndex] = new ScrollingObjectCollectionNode(NodeList[nodeIndex]);
                 }
 
@@ -757,7 +757,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     newPos.z = 0.0f;
 
                 }
-                else //left or right
+                else // Left or right
                 {
                     newPos.x = (StepMultiplier(i, Tiers) * CellWidth) + halfCell.x;
                     newPos.y = ((ModuloCheck(i, Tiers) != 0) ? (ModuloCheck(i, Tiers) * CellHeight) + halfCell.y : halfCell.y) * -1;
@@ -826,7 +826,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // put the rotation back
             NodeList[FirstItemInViewIndex].Transform.rotation = origRot;
 
-            //set the first item back to its original state
+            // Set the first item back to its original state
             if (resetActiveState)
             {
                 NodeList[FirstItemInViewIndex].Transform.gameObject.SetActive(false);
@@ -834,18 +834,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             Vector3 viewableCenter = new Vector3();
 
-            //Adjust scale and position of our clipping box
+            // Adjust scale and position of our clipping box
             switch (scrollDirection)
             {
                 case ScrollDirectionType.UpAndDown:
                 default:
 
-                    //apply the viewable area and column/row multiplier
-                    //use a dummy bounds of one to get the local scale to match;
+                    // Apply the viewable area and column/row multiplier
+                    // Use a dummy bounds of one to get the local scale to match;
                     clippingBounds.size = new Vector3((clippingBounds.size.x * Tiers), (clippingBounds.size.y * ViewableArea), clippingBounds.size.z);
                     clipBox.transform.localScale = new Bounds(Vector3.zero, Vector3.one).GetScaleToMatchBounds(clippingBounds, OcclusionScalePadding);
 
-                    //adjust where the center of the clipping box is
+                    // Adjust where the center of the clipping box is
                     viewableCenter.x = (clipBox.transform.localScale.x * 0.5f) - (OcclusionScalePadding.x * 0.5f) + OcclusionPositionPadding.x;
                     viewableCenter.y = (((clipBox.transform.localScale.y * 0.5f) - (OcclusionScalePadding.y * 0.5f)) * -1) + OcclusionPositionPadding.y;
                     viewableCenter.z = OcclusionPositionPadding.z;
@@ -853,21 +853,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 case ScrollDirectionType.LeftAndRight:
 
-                    //Same as above for L <-> R
+                    // Same as above for L <-> R
                     clippingBounds.size = new Vector3(clippingBounds.size.x * ViewableArea, clippingBounds.size.y * Tiers, clippingBounds.size.z);
                     clipBox.transform.localScale = new Bounds(Vector3.zero, Vector3.one).GetScaleToMatchBounds(clippingBounds, OcclusionScalePadding);
 
-                    //Same as above for L <-> R
+                    // Same as above for L <-> R
                     viewableCenter.x = (clipBox.transform.localScale.x * 0.5f) - (OcclusionScalePadding.x * 0.5f) + OcclusionPositionPadding.x;
                     viewableCenter.y = ((clipBox.transform.localScale.y * 0.5f) - (OcclusionScalePadding.y * 0.5f) + OcclusionPositionPadding.y) * -1.0f;
                     viewableCenter.z = OcclusionPositionPadding.z;
                     break;
             }
 
-            //Apply our new values
+            // Apply our new values
             clipBox.transform.localPosition = viewableCenter;
 
-            //add our objects to the clippingBox queue
+            // Add our objects to the clippingBox queue
             AddAllItemsToClippingObject();
         }
 
@@ -877,7 +877,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnEnable()
         {
-            //Register for global input events
+            // Register for global input events
             if (CoreServices.InputSystem != null)
             {
                 CoreServices.InputSystem.RegisterHandler<IMixedRealityInputHandler>(this);
@@ -896,8 +896,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 clipBox.UseOnPreRender = true;
 
-                //Subscribe to the preRender callback on the main camera so we can intercept it and make sure we catch
-                //any dynamically created children in our list
+                // Subscribe to the preRender callback on the main camera so we can intercept it and make sure we catch
+                // any dynamically created children in our list
                 cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
                 cameraMethods.OnCameraPreRender += OnCameraPreRender;
             }
@@ -913,7 +913,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void Update()
         {
-            //early bail, the component isn't set up properly
+            // Early bail, the component isn't set up properly
             if (scrollContainer == null) { return; }
 
             bool nodeLengthCheck = NodeList.Count > (ViewableArea * Tiers);
@@ -925,20 +925,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 ApplyPosition(workingScrollerPos);
             }
 
-            //The scroller has detected input and has a valid pointer
+            // The scroller has detected input and has a valid pointer
             if (isEngaged && TryGetPointerPositionOnPlane(out Vector3 currentPointerPos))
             {
                 Vector3 handDelta = initialPointerPos - currentPointerPos;
                 handDelta = transform.InverseTransformDirection(handDelta);
 
-                //Lets see if this is gonna be a click or a drag
-                //Check the scroller's length state to prevent resetting calculation
+                // Lets see if this is gonna be a click or a drag
+                // Check the scroller's length state to prevent resetting calculation
                 if (!isDragging && nodeLengthCheck)
                 {
-                    //grab the delta value we care about
+                    // Grab the delta value we care about
                     float absAxisHandDelta = (scrollDirection == ScrollDirectionType.UpAndDown) ? Mathf.Abs(handDelta.y) : Mathf.Abs(handDelta.x);
 
-                    //Catch an intentional finger in scroller to stop momentum, this isn't a drag its definitely a stop
+                    // Catch an intentional finger in scroller to stop momentum, this isn't a drag its definitely a stop
                     if (absAxisHandDelta > (handDeltaMagThreshold * 0.1f) || TimeTest(initialPressTime, Time.time, dragTimeThreshold))
                     {
                         scrollVelocity = 0.0f;
@@ -947,38 +947,36 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         isDragging = true;
                         velocityState = VelocityState.None;
 
-                        //now that we're dragging, reset the interacted with interactable if it exists
+                        // Now that we're dragging, reset the interacted with interactable if it exists
                         Interactable ixable = initialFocusedObject.GetComponent<Interactable>();
                         if (ixable != null)
                         {
                            ixable.ResetInputTrackingStates();
                         }
 
-                        //TODO: Reset the state of PressableButton, when possible. 
-
-                        //reset initialHandPos to prevent the scroller from jumping
+                        // Reset initialHandPos to prevent the scroller from jumping
                         initialScrollerPos = workingScrollerPos = scrollContainer.transform.localPosition;
                         initialPointerPos = currentPointerPos;
                     }
                 }
 
                 var thresholdPoint = transform.TransformPoint((Vector3.forward * -1.0f) * releaseDistance);
-                //Make sure we're actually (near) touched and not a pointer event, do a dot product check            
+                // Make sure we're actually (near) touched and not a pointer event, do a dot product check            
                 bool scrollRelease = UseNearScrollBoundary ? DetectScrollRelease(transform.forward * -1.0f, thresholdPoint, currentPointerPos, clippingObject.transform, transform.worldToLocalMatrix, scrollDirection)
                                                            : DetectScrollRelease(transform.forward * -1.0f, thresholdPoint, currentPointerPos, null, null, null);
 
                 if (isTouched && scrollRelease)
                 {
-                    //We're on the other side of the original touch position. This is a release.
+                    // We're on the other side of the original touch position. This is a release.
                     if (isDragging)
                     {
-                        //Its a drag release
+                        // Its a drag release
                         initialScrollerPos = workingScrollerPos;
                         velocityState = VelocityState.Calculating;
                     }
                     else
                     {
-                        //Its a click release
+                        // Its a click release
                         Collider[] c = NodeList.Find(x => x.Transform.gameObject == initialFocusedObject).Colliders;
                         bool isColliderActive = false;
                         foreach (Collider col in c)
@@ -991,7 +989,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         }
                         if (isColliderActive)
                         {
-                            //Fire the UnityEvent
+                            // Fire the UnityEvent
                             ClickEvent?.Invoke(initialFocusedObject);
                         }
                     }
@@ -1004,45 +1002,45 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                     if (scrollDirection == ScrollDirectionType.UpAndDown)
                     {
-                        //Lock X, clamp Y
+                        // Lock X, clamp Y
                         workingScrollerPos.y = MathUtilities.CLampLerp(initialScrollerPos.y - handDelta.y, minY, maxY, 0.5f);
                         workingScrollerPos.x = 0.0f;
                     }
                     else
                     {
-                        //Lock Y, clamp X
+                        // Lock Y, clamp X
                         workingScrollerPos.x = MathUtilities.CLampLerp(initialScrollerPos.x - handDelta.x, minX, maxX, 0.5f);
                         workingScrollerPos.y = 0.0f;
                     }
 
-                    //Update the scrollContainer Position
+                    // Update the scrollContainer Position
                     ApplyPosition(workingScrollerPos);
 
                     CalculateVelocity();
 
-                    //Update the prev val for velocity
+                    // Update the prev val for velocity
                     lastPointerPos = currentPointerPos;
                 }
             }
             else if (animateScroller == null && nodeLengthCheck)// Prevent the Animation coroutine from being overridden
             {
-                //We're not engaged, so handle any not touching behavior
+                // We're not engaged, so handle any not touching behavior
                 HandleVelocityFalloff();
 
-                //Apply our position
+                // Apply our position
                 ApplyPosition(workingScrollerPos);
             }
         }
 
         private void LateUpdate()
         {
-            //Hide the items not in view
+            // Hide the items not in view
             HideItems();
         }
 
         private void OnDisable()
         {
-            //Unregister global input events
+            // Unregister global input events
             if (CoreServices.InputSystem != null)
             {
                 CoreServices.InputSystem.UnregisterHandler<IMixedRealityInputHandler>(this);
@@ -1068,21 +1066,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <param name="router">The active <see cref="CameraEventRouter"/> on the camera.</param>
         private void OnCameraPreRender(CameraEventRouter router)
         {
-            //clip any new items that may have shown up
+            // Clip any new items that may have shown up
             if (nodesToClip.Count > 0)
             {
                 AddItemsToClippingObject(nodesToClip);
 
-                //reset the list for next time
+                // Reset the list for next time
                 nodesToClip.Clear();
             }
 
-            //unclip any new items that may have shown up
+            // Unclip any new items that may have shown up
             if (nodesToUnclip.Count > 0)
             {
                 RemoveItemsFromClippingObject(nodesToUnclip);
 
-                //reset the list for next time
+                // Reset the list for next time
                 nodesToUnclip.Clear();
             }
 
@@ -1141,7 +1139,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                     avgVelocity = 0.0f;
 
-                    //Round to the nearest list item
+                    // Round to the nearest list item
                     if (scrollDirection == ScrollDirectionType.UpAndDown)
                     {
                         workingScrollerPos.y = Mathf.Round(scrollContainer.transform.localPosition.y / CellHeight) * CellHeight;
@@ -1188,12 +1186,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     {
                         if (avgVelocity == 0.0f)
                         {
-                            //velocity was cleared out so we should just snap
+                            // Velocity was cleared out so we should just snap
                             newPosAfterVelocity = scrollContainer.transform.localPosition.y;
                         }
                         else
                         {
-                            //Precalculate where the velocity falloff WOULD land our scrollContainer, then round it to the nearest item so it feels "natural"
+                            // Precalculate where the velocity falloff WOULD land our scrollContainer, then round it to the nearest item so it feels "natural"
                             velocitySnapshot = IterateFalloff(avgVelocity, out numSteps);
                             newPosAfterVelocity = initialScrollerPos.y - velocitySnapshot;
                         }
@@ -1206,12 +1204,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     {
                         if (avgVelocity == 0.0f)
                         {
-                            //velocity was cleared out so we should just snap
+                            // Velocity was cleared out so we should just snap
                             newPosAfterVelocity = scrollContainer.transform.localPosition.x;
                         }
                         else
                         {
-                            //Precalculate where the velocity falloff WOULD land our scrollContainer, then round it to the nearest item so it feels "natural"
+                            // Precalculate where the velocity falloff WOULD land our scrollContainer, then round it to the nearest item so it feels "natural"
                             velocitySnapshot = IterateFalloff(avgVelocity, out numSteps);
                             newPosAfterVelocity = initialScrollerPos.x + velocitySnapshot;
                         }
@@ -1223,7 +1221,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                     workingScrollerPos = Solver.SmoothTo(scrollContainer.transform.localPosition, velocityDestinationPos, Time.deltaTime, 0.9275f);
 
-                    //Clear the velocity now that we've applied a new position
+                    // Clear the velocity now that we've applied a new position
                     avgVelocity = 0.0f;
                     break;
 
@@ -1387,7 +1385,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             {
                 if (scrollDirection == ScrollDirectionType.UpAndDown)
                 {
-                    //Ensure we've actually snapped the position to prevent an extreme in-between state
+                    // Ensure we've actually snapped the position to prevent an extreme in-between state
                     workingScrollerPos.y = (Mathf.Round(scrollContainer.transform.localPosition.y / CellHeight)) * CellHeight;
                 }
                 else
@@ -1410,14 +1408,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// </summary>
         private void CalculateVelocity()
         {
-            //update simple velocity
+            // Update simple velocity
             TryGetPointerPositionOnPlane(out Vector3 newPos);
 
                 scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
                                  ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
                                  : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
 
-            //And filter it...
+            // And filter it...
             avgVelocity = (avgVelocity * (1.0f - velocityFilterWeight)) + (scrollVelocity * velocityFilterWeight);
         }
 
@@ -1454,8 +1452,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 yield return null;
             }
 
-            //update our values so they stick
-
+            // Update our values so they stick
             if (scrollDirection == ScrollDirectionType.UpAndDown)
             {
                 workingScrollerPos.y = initialScrollerPos.y = finalPos.y;
@@ -1518,7 +1515,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// </summary>
         private void AddAllItemsToClippingObject()
         {
-            //Register all of the renderers to be clipped by the clippingBox
+            // Register all of the renderers to be clipped by the clippingBox
             foreach (ObjectCollectionNode node in NodeList)
             {
                 Renderer[] childRends = node.Transform.gameObject.transform.GetComponentsInChildren<Renderer>(true);
@@ -1536,7 +1533,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             foreach (ObjectCollectionNode node in nodes)
             {
-                //Register all of the renderers to be clipped by the clippingBox
+                // Register all of the renderers to be clipped by the clippingBox
                 Renderer[] childRends = node.Transform.gameObject.transform.GetComponentsInChildren<Renderer>(true);
                 for (int i = 0; i < childRends.Length; i++)
                 {
@@ -1550,7 +1547,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// </summary>
         private void RemoveAllItemsFromClippingObject()
         {
-            //Register all of the renderers to be clipped by the clippingBox
+            // Register all of the renderers to be clipped by the clippingBox
             foreach (ObjectCollectionNode node in NodeList)
             {
                 Renderer[] childRends = node.Transform.gameObject.transform.GetComponentsInChildren<Renderer>(true);
@@ -1568,7 +1565,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             foreach (ObjectCollectionNode node in nodes)
             {
-                //Register all of the renderers to be clipped by the clippingBox
+                // Register all of the renderers to be clipped by the clippingBox
                 Renderer[] childRends = node.Transform.gameObject.transform.GetComponentsInChildren<Renderer>(true);
                 for (int i = 0; i < childRends.Length; i++)
                 {
@@ -1587,7 +1584,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <returns>The remainder from the divisor</returns>
         public static int ModuloCheck(int itemIndex, int divisor)
         {
-            //prevent divide by 0
+            // Prevent divide by 0
             return (divisor > 0) ? itemIndex % divisor : 0;
         }
 
@@ -1599,7 +1596,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <returns>The multiplier to get the row / column index the item is in</returns>
         public static int StepMultiplier(int itemIndex, int divisor)
         {
-            //prevent divide by 0
+            // Prevent divide by 0
             return (divisor != 0) ? itemIndex / divisor : 0;
         }
 
@@ -1611,10 +1608,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// to be added to the <see cref="ClipBox"/>.</remarks>
         private void HideItems()
         {
-            //Early Bail - our list is empty
+            // Early Bail - our list is empty
             if (NodeList.Count == 0) { return; }
 
-            //Stash the values from numItems to cut down on redundant calculations
+            // Stash the values from numItems to cut down on redundant calculations
             int prevItems = numItemsPrevView;
             int postItems = numItemsPostView;
 
@@ -1625,21 +1622,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 ScrollingObjectCollectionNode node = NodeList[i] as ScrollingObjectCollectionNode;
                 if (node == null)
                 {
-                    //The object we grabbed isn't a ScrollingObjectCollectionNode
+                    // The object we grabbed isn't a ScrollingObjectCollectionNode
                     NodeList[i] = new ScrollingObjectCollectionNode(NodeList[i]);
                     node = NodeList[i] as ScrollingObjectCollectionNode;
                 }
 
-                //hide the items that have no chance of being seen
+                // Hide the items that have no chance of being seen
                 if (i < prevItems - Tiers || i > postItems + Tiers)
                 {
-                    //quick check to cut down on the redundant calls
+                    // Quick check to cut down on the redundant calls
                     if (node.Transform.gameObject.activeSelf)
                     {
                         node.Transform.gameObject.SetActive(false);
                     }
 
-                    //the node is inactive, and has been previously clipped, make sure we remove it from the rendering list, this keeps the calls in ClippingBox as small as possible
+                    // The node is inactive, and has been previously clipped, make sure we remove it from the rendering list, this keeps the calls in ClippingBox as small as possible
                     if (node.isClipped)
                     {
                         nodesToUnclip.Add(NodeList[i]);
@@ -1652,7 +1649,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         i < prevItems || i > postItems :
                         i < prevItems - Tiers || i > postItems + Tiers;
 
-                    //Disable colliders on items that will be scrolling in and out of view
+                    // Disable colliders on items that will be scrolling in and out of view
                     if (disableNode)
                     {
                         foreach (Collider c in node.Colliders)
@@ -1668,13 +1665,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         }
                     }
 
-                    //Otherwise show the item
+                    // Otherwise show the item
                     if (!node.Transform.gameObject.activeSelf)
                     {
                         node.Transform.gameObject.SetActive(true);
                     }
 
-                    //the node has a new item, send it to the clipping box and see if its a renderer
+                    // The node has a new item, send it to the clipping box and see if its a renderer
                     if (!node.isClipped)
                     {
                         nodesToClip.Add(node);
@@ -1691,8 +1688,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <returns>The total distance the <see cref="avgVelocity"/> with <see cref="velocityDampen"/> as drag would travel.</returns>
         private float IterateFalloff(float vel, out int steps)
         {
-            //Some day this should be a falloff formula, below is the number of steps. Just can't figure out how to get the right velocity.
-            //float numSteps = (Mathf.Log(0.00001f)  - Mathf.Log(Mathf.Abs(avgVelocity))) / Mathf.Log(velocityFalloff);
+            // Some day this should be a falloff formula, below is the number of steps. Just can't figure out how to get the right velocity.
+            // float numSteps = (Mathf.Log(0.00001f)  - Mathf.Log(Mathf.Abs(avgVelocity))) / Mathf.Log(velocityFalloff);
 
             float newVal = 0.0f;
             float v = vel;
@@ -1740,11 +1737,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             TouchEnded?.Invoke(initialFocusedObject);
 
-            //Release the pointer
+            // Release the pointer
             currentPointer = null;
             initialFocusedObject = null;
 
-            //Clear our states
+            // Clear our states
             isTouched = false;
             isEngaged = false;
             isDragging = false;
@@ -1765,12 +1762,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             if (indexOfItem < numItemsPrevView)
             {
-                //its above the visible area
+                // Its above the visible area
                 itemLoc = false;
             }
             else if (indexOfItem > numItemsPostView)
             {
-                //its below the visible area
+                // Its below the visible area
                 itemLoc = false;
             }
             return itemLoc;
@@ -1828,20 +1825,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             {
                 workingScrollerPos.y = (FirstItemInViewIndex + StepMultiplier(numberOfItemsToMove, Tiers)) * CellHeight;
 
-                //clamp the working pos since we already have calculated it
+                // Clamp the working pos since we already have calculated it
                 workingScrollerPos.y = Mathf.Clamp(workingScrollerPos.y, minY, maxY);
 
-                //zero out the other axes
+                // Zero out the other axes
                 workingScrollerPos = workingScrollerPos.Mul(Vector3.up);
             }
             else
             {
                 workingScrollerPos.x = ((FirstItemInViewIndex + StepMultiplier(numberOfItemsToMove, Tiers)) * CellWidth) * -1.0f;
 
-                //clamp the working pos since we already have calculated it
+                // Clamp the working pos since we already have calculated it
                 workingScrollerPos.x = Mathf.Clamp(workingScrollerPos.x, minX, maxX);
 
-                //zero out the other axes
+                // Zero out the other axes
                 workingScrollerPos = workingScrollerPos.Mul(Vector3.right);
             }
 
@@ -1875,20 +1872,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             {
                 workingScrollerPos.y = (FirstItemInViewIndex + numberOfLinesToMove) * CellHeight;
 
-                //clamp the working pos since we already have calculated it
+                // Clamp the working pos since we already have calculated it
                 workingScrollerPos.y = Mathf.Clamp(workingScrollerPos.y, minY, maxY);
 
-                //zero out the other axes
+                // Zero out the other axes
                 workingScrollerPos = workingScrollerPos.Mul(Vector3.up);
             }
             else
             {
                 workingScrollerPos.x = ((FirstItemInViewIndex + numberOfLinesToMove) * CellWidth) * -1.0f;
 
-                //clamp the working pos since we already have calculated it
+                // Clamp the working pos since we already have calculated it
                 workingScrollerPos.x = Mathf.Clamp(workingScrollerPos.x, minX, maxX);
 
-                //zero out the other axes
+                // Zero out the other axes
                 workingScrollerPos = workingScrollerPos.Mul(Vector3.right);
             }
 
@@ -1925,20 +1922,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             {
                 workingScrollerPos.y = StepMultiplier(indexOfItem, Tiers) * CellHeight;
 
-                //clamp the working pos since we already have calculated it
+                // Clamp the working pos since we already have calculated it
                 workingScrollerPos.y = Mathf.Clamp(workingScrollerPos.y, minY, maxY);
 
-                //zero out the other axes
+                // Zero out the other axes
                 workingScrollerPos = workingScrollerPos.Mul(Vector3.up);
             }
             else
             {
                 workingScrollerPos.x = (StepMultiplier(indexOfItem, Tiers) * CellWidth) * -1.0f;
 
-                //clamp the working pos since we already have calculated it
+                // Clamp the working pos since we already have calculated it
                 workingScrollerPos.x = Mathf.Clamp(workingScrollerPos.x, minX, maxX);
 
-                //zero out the other axes
+                // Zero out the other axes
                 workingScrollerPos = workingScrollerPos.Mul(Vector3.right);
             }
 
@@ -1985,7 +1982,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             Collider c = obj.GetComponentInChildren<Collider>();
             alignedSize = Vector3.zero;
 
-            //store and clear the original rotation
+            // Store and clear the original rotation
             Quaternion origRot = obj.rotation;
             obj.rotation = Quaternion.identity;
 
@@ -2050,7 +2047,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 canGetSize = false;
             }
 
-            //reapply our rotation
+            // Reapply our rotation
             obj.rotation = origRot;
 
             return (canGetSize) ? true : false;
@@ -2060,10 +2057,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         #region IMixedRealityPointerHandler implementation
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void IMixedRealityPointerHandler.OnPointerUp(MixedRealityPointerEventData eventData)
         {
-            //Quick check for the global listener to bail if the object is not in the list
+            // Quick check for the global listener to bail if the object is not in the list
             if (currentPointer == null || eventData.Pointer.PointerId != currentPointer.PointerId)
             {
                 return;
@@ -2075,25 +2072,25 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 {
                     eventData.Use();
                     shouldSwallowEvents = true;
-                    //Its a drag release
+                    // Its a drag release
                     initialScrollerPos = workingScrollerPos;
                     velocityState = VelocityState.Calculating;
                 }
 
-                //Release the pointer
+                // Release the pointer
                 currentPointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
 
                 ResetState();
             }
         }
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
         {
             currentPointer = eventData.Pointer;
             oldIsTargetPositionLockedOnFocusLock = currentPointer.IsTargetPositionLockedOnFocusLock;
 
-            //Quick check for the global listener to bail if the object is not in the list
+            // Quick check for the global listener to bail if the object is not in the list
             if (currentPointer?.Result?.CurrentPointerTarget == null
                 || !ContainsNode(currentPointer.Result.CurrentPointerTarget.transform) || initialFocusedObject != null)
             {
@@ -2110,7 +2107,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
 
-            //Reset the scroll state
+            // Reset the scroll state
             scrollVelocity = 0.0f;
 
             if (TryGetPointerPositionOnPlane(out initialPointerPos))
@@ -2127,17 +2124,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
         {
-            //we ignore this event and calculate click in the Update() loop;
+            // We ignore this event and calculate click in the Update() loop;
         }
 
         #endregion IMixedRealityPointerHandler implementation
 
         #region IMixedRealityTouchHandler implementation
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchStarted(HandTrackingInputEventData eventData)
         {
             if (isDragging || initialFocusedObject)
@@ -2149,7 +2146,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             currentPointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
             if (currentPointer != null)
             {
-                //Quick check for the global listener to bail if the object is not in the list
+                // Quick check for the global listener to bail if the object is not in the list
                 if (currentPointer.Result?.CurrentPointerTarget == null ||
                     !ContainsNode(currentPointer.Result?.CurrentPointerTarget.transform))
                 {
@@ -2178,10 +2175,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         }
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            //Quick check for the global listener to bail if the object is not in the list
+            // Quick check for the global listener to bail if the object is not in the list
             if (currentPointer != null && currentPointer.Result?.CurrentPointerTarget != null 
                 && ContainsNode(currentPointer.Result.CurrentPointerTarget.transform))
             {
@@ -2193,14 +2190,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData)
         {
             IMixedRealityPointer p = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
 
             if (p != null)
             {
-                //Quick check for the global listener to bail if the object is not in the list
+                // Quick check for the global listener to bail if the object is not in the list
                 if (currentPointer == null || 
                     currentPointer.Result?.CurrentPointerTarget == null ||
                     !ContainsNode(p.Result.CurrentPointerTarget.transform) || initialFocusedObject != p.Result.CurrentPointerTarget)
@@ -2223,12 +2220,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
-            //We'll consider this a drag release
+            // We'll consider this a drag release
             if (isEngaged && animateScroller == null && currentPointer != null && currentPointer.InputSourceParent.SourceId == eventData.SourceId)
             {
                 if (isTouched || isDragging)
                 {
-                    //Its a drag release
+                    // Its a drag release
                     initialScrollerPos = workingScrollerPos;
                 }
 
@@ -2244,7 +2241,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             if (shouldSwallowEvents)
             {
-                //Prevents the handled event from PointerUp to continue propagating
+                // Prevents the handled event from PointerUp to continue propagating
                 eventData.Use();
                 shouldSwallowEvents = false;
             }

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -1762,12 +1762,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             if (indexOfItem < numItemsPrevView)
             {
-                // Its above the visible area
+                // It's above the visible area
                 itemLoc = false;
             }
             else if (indexOfItem > numItemsPostView)
             {
-                // Its below the visible area
+                // It's below the visible area
                 itemLoc = false;
             }
             return itemLoc;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1237,7 +1237,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else if (activation == BoundingBoxActivationType.ActivateManually)
             {
-                //activate to create handles etc. then deactivate. 
+                // Activate to create handles etc. then deactivate. 
                 Active = true;
                 Active = false;
             }
@@ -1679,7 +1679,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         link.transform.localScale = new Vector3(wireframeEdgeRadius, linkDimensions.z, wireframeEdgeRadius);
                         link.transform.Rotate(new Vector3(90.0f, 0.0f, 0.0f));
                     }
-                    else//X
+                    else // edgeAxes[i] == CardinalAxisType.X
                     {
                         link.transform.localScale = new Vector3(wireframeEdgeRadius, linkDimensions.x, wireframeEdgeRadius);
                         link.transform.Rotate(new Vector3(0.0f, 0.0f, 90.0f));
@@ -1921,7 +1921,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void SetMaterials()
         {
-            //ensure materials
+            // Ensure materials
             if (wireframeMaterial == null)
             {
                 float[] color = { 1.0f, 1.0f, 1.0f, 0.75f };
@@ -2049,7 +2049,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             bool isVisible;
 
-            //set balls visibility
+            // Set balls visibility
             if (balls != null)
             {
                 isVisible = (active == true && wireframeOnly == false);
@@ -2060,7 +2060,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            //set link visibility
+            // Set link visibility
             if (links != null)
             {
                 isVisible = active == true;
@@ -2073,14 +2073,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            //set box display visibility
+            // Set box display visibility
             if (boxDisplay != null)
             {
                 boxDisplay.SetActive(active);
                 ApplyMaterialToAllRenderers(boxDisplay, boxMaterial);
             }
 
-            //set corner visibility
+            // Set corner visibility
             if (corners != null)
             {
                 isVisible = (active == true && wireframeOnly == false && showScaleHandles == true);
@@ -2097,7 +2097,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void SetHighlighted(Transform activeHandle)
         {
-            //turn off all balls
+            // Turn off all balls
             if (balls != null)
             {
                 for (int i = 0; i < balls.Count; ++i)
@@ -2113,7 +2113,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            //turn off all corners
+            // Turn off all corners
             if (corners != null)
             {
                 for (int i = 0; i < corners.Count; ++i)
@@ -2129,7 +2129,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            //update the box material to the grabbed material
+            // Update the box material to the grabbed material
             if (boxDisplay != null)
             {
                 ApplyMaterialToAllRenderers(boxDisplay, boxGrabbedMaterial);
@@ -2211,7 +2211,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         {
                             links[i].localScale = new Vector3(wireframeEdgeRadius, linkDimensions.y, wireframeEdgeRadius);
                         }
-                        else//Z
+                        else // edgeAxes[i] == CardinalAxisType.Z
                         {
                             links[i].localScale = new Vector3(wireframeEdgeRadius, linkDimensions.z, wireframeEdgeRadius);
                         }
@@ -2233,7 +2233,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void HandleProximityScaling()
         {
-            //only use proximity effect if nothing is being dragged or grabbed
+            // Only use proximity effect if nothing is being dragged or grabbed
             if (currentPointer == null)
             {
                 proximityPointers.Clear();

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Loader/LoaderController.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Loader/LoaderController.cs
@@ -269,7 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void AnimateDotTransforms()
         {
-            //Set dot groups' scale
+            // Set dot groups' scale
             float sinScaleCalc = dotSetScale + Mathf.Sin(Cycles * tau / 2) * dotScaleMultipler;
             float cosScaleCalc = dotSetScale + Mathf.Cos(Cycles * tau / 2) * dotScaleMultipler;
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorOrbsRotator.cs
@@ -186,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     Color orbColor = propertyBlocks[index].GetColor("_Color");
 
-                    //fade in
+                    // Fade in
                     if (!stopRequested && orbColor.a < 1.0f)
                     {
                         orbColor.a += (1.0f * timeSlice);
@@ -194,7 +194,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         propertyBlocks[index].SetColor("_Color", orbColor);
                         dots[index].SetPropertyBlock(propertyBlocks[index]);
                     }
-                    //fade out
+                    // Fade out
                     else if (stopRequested && angles[index] > rotationWhenStopped)
                     {
                         orbColor.a -= (1.0f * timeSlice);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -285,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             SetAffordancesActive(false);
 
-            //check for boxcollider
+            // Check for boxcollider
             boxCollider = GetComponent<BoxCollider>();
             if (boxCollider == null)
             {
@@ -301,7 +301,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
 
-            //get material
+            // Get material
             currentMaterial = this.gameObject.GetComponent<Renderer>().material;
             proximityLightCenterColorID = Shader.PropertyToID("_ProximityLightCenterColorOverride");
             bool materialValid = currentMaterial != null && currentMaterial.HasProperty(proximityLightCenterColorID);
@@ -309,7 +309,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 currentMaterial.GetColor(proximityLightCenterColorID) :
                 new Color(0.0f, 0.0f, 0.0f, 0.0f);
 
-            //precache references
+            // Precache references
             meshFilter = gameObject.GetComponent<MeshFilter>();
             if (meshFilter == null)
             {
@@ -357,20 +357,20 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 currentScale = totalUVScale.x / scaleUVDelta;
 
-                //test for scale limits
+                // Test for scale limits
                 if (currentScale > minScale && currentScale < maxScale)
                 {
-                    //track total scale
+                    // Track total scale
                     totalUVScale /= scaleUVDelta;
                     for (int i = 0; i < uvs.Count; ++i)
                     {
-                        //this is where zoom is applied if Active
+                        // This is where zoom is applied if Active
                         uvs[i] = ((uvs[i] - scaleUVCentroid) / scaleUVDelta) + scaleUVCentroid;
                     }
                 }
             }
 
-            //test for pan limits
+            // Test for pan limits
             Vector2 uvDelta = new Vector2(totalUVOffset.x, -totalUVOffset.y);
             if (!unlimitedPan)
             {
@@ -412,8 +412,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
 
             float uvScaleFromTouches = GetContactDistance() / initialTouchDistance;
-            //uvScaleFromTouches = Mathf.Clamp(uvScaleFromTouches, 0.5f, 2.0f);
-
             return uvScaleFromTouches;
         }
         private void UpdateTouchUVOffset(uint sourceId)
@@ -605,7 +603,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 Vector3 verticalEdgeNorm = (lowerLeft - upperLeft) / magVertical;
                 Vector3 horizontalEdgeNorm = (upperRight - upperLeft) / magHorizontal;
-                //get dotproduct to determine distance ->then divide by length to get quad coord 0 to 1
+                // Get dotproduct to determine distance ->then divide by length to get quad coord 0 to 1
                 float v = Vector3.Dot(point - upperLeft, verticalEdgeNorm) / magVertical;
                 float h = Vector3.Dot(point - upperLeft, horizontalEdgeNorm) / magHorizontal;
                 quadCoord = new Vector2(h, v);
@@ -640,7 +638,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     data.touchingPoint = data.touchingInitialPt;
                 }
             }
-            else//is far
+            else // Is far
             {
                 if (data.currentPointer is GGVPointer)
                 {
@@ -660,7 +658,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }              
             }
 
-            //store value in case of MRController
+            // Store value in case of MRController
             if (data.currentPointer != null)
             {
                 Vector3 pt = data.currentPointer.Position;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundBlob.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundBlob.cs
@@ -204,7 +204,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             localContentSize.y /= meshBounds.size.y;
             localContentSize.z = 1;
 
-            localContentBounds.size = Vector3.one; //localContentSize;
+            localContentBounds.size = Vector3.one; // localContentSize;
             localContentBounds.center = localContentOffset;
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundMesh.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundMesh.cs
@@ -57,8 +57,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (BackgroundRenderer == null)
                 return;
 
-            //Get the size of the mesh and use this to adjust the local content size on the x / y axis
-            //This will accommodate meshes that aren't built to 1,1 scale
+            // Get the size of the mesh and use this to adjust the local content size on the x / y axis
+            // This will accommodate meshes that aren't built to 1,1 scale
             Bounds meshBounds = BackgroundRenderer.GetComponent<MeshFilter>().sharedMesh.bounds;
             localContentSize.x /= meshBounds.size.x;
             localContentSize.y /= meshBounds.size.y;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs
@@ -268,7 +268,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                 }
 
-                //check whether we're suppose to disappear
+                // Check whether we're suppose to disappear
                 switch (vanishType)
                 {
                     case VanishType.VanishOnFocusExit:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipUtility.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipUtility.cs
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 pivotPositions = new Vector3[NumPivotLocations];
             }
 
-            //Get the extents of our content size
+            // Get the extents of our content size
             localContentSize *= 0.5f;
 
             pivotPositions[(int)ToolTipAttachPoint.BottomMiddle] = new Vector3(0f, -localContentSize.y, 0f);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/GazeHandHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/GazeHandHelper.cs
@@ -93,14 +93,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     positionAvailableMap[id] = true;
                 }
 
-                //handPositionMap[id] = handPosition;
-
                 if (true == TryGetPointerPosition(id, out Vector3 currentGazePoint))
                 {
                     handPositionMap[id] = handPosition + (currentGazePoint - gazePointMap[id]);
                 }
-
-                //handPositionMap[eventData.SourceId] = handStartPositionMap[eventData.SourceId] + (gazePoint - gazePointMap[id]);
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/ThemeDefinition.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/ThemeDefinition.cs
@@ -139,10 +139,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region ISerializationCallbackReceiver implementation
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
-            //backward compatibility at runtime in case some custom properties have been added in code after first serialization
+            // Backward compatibility at runtime in case some custom properties have been added in code after first serialization
             ThemeDefinition defaultDefinition = GetDefaultThemeDefinition(ThemeType).Value;
 
             if (defaultDefinition.CustomProperties.Count > CustomProperties.Count)
@@ -163,7 +163,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
-        ///<inheritdoc/>
+        /// <inheritdoc/>
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
         }

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -309,7 +309,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             if (UpdateSolvers)
             {
-                //Before calling solvers, update goal to be the transform so that working and transform will match
+                // Before calling solvers, update goal to be the transform so that working and transform will match
                 GoalPosition = transform.position;
                 GoalRotation = transform.rotation;
                 GoalScale = transform.localScale;

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                                 if (themeItem.objectReferenceValue != null)
                                 {
                                     // TODO: Odd bug where themeStates below is null when it shouldn't be. Use instance object as workaround atm
-                                    //SerializedProperty themeStates = themeItem.FindPropertyRelative("States");
+                                    // SerializedProperty themeStates = themeItem.FindPropertyRelative("States");
                                     var themeInstance = themeItem.objectReferenceValue as Theme;
                                     if (statesProperty.objectReferenceValue != themeInstance.States)
                                     {

--- a/Assets/MRTK/Tests/EditModeTests/InputSystem/InteractionDefinitionTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/InputSystem/InteractionDefinitionTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
             // Make sure if we set the same value it's false
             Assert.IsFalse(interaction.Changed);
 
-            //Check setting the value twice with the same value produces no change
+            // Check setting the value twice with the same value produces no change
             var newValue = interaction.RawData;
 
             // Make sure if we set the same value it's false

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Vector3 endRotation = new Vector3(-0.18f, -0.109f, 0.504f); // end position for far interaction scaling
 
             TestHand hand = new TestHand(Handedness.Left);
-            yield return hand.Show(pointOnCube); //initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return hand.Show(pointOnCube); // Initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
             // grab front right rotation point
             yield return hand.MoveTo(rightFrontRotationHandlePoint);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
@@ -307,7 +307,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Vector3 scalePoint = new Vector3(0.165f, 0.267f, 0.794f); // end position for far interaction scaling
 
             TestHand hand = new TestHand(Handedness.Left);
-            yield return hand.Show(pointOnCube); //initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return hand.Show(pointOnCube); // Initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
             yield return hand.MoveTo(rightCornerInteractionPoint);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return hand.MoveTo(scalePoint);
@@ -697,7 +697,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // first test to interact with the cube without activating the app bar
             // this shouldn't scale the cube
             TestHand hand = new TestHand(Handedness.Left);
-            yield return hand.Show(pointOnCube); //initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
+            yield return hand.Show(pointOnCube); // Initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
             yield return hand.MoveTo(rightCornerInteractionPoint);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return hand.MoveTo(scalePoint);

--- a/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InteractableTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.True(wasClicked, "Interactable was not clicked.");
 
-            //Cleanup
+            // Cleanup
             GameObject.Destroy(interactable.gameObject);
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private const float DistanceThreshold = 1.5f;
         private const float HandDistanceThreshold = 0.5f;
-        private const float SolverUpdateWaitTime = 1.0f; //seconds
+        private const float SolverUpdateWaitTime = 1.0f; // Seconds
 
         /// <summary>
         /// Internal class used to store data for setup

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(pointer.IsNearObject);
             Assert.False(pointer.IsInteractionEnabled);
 
-            //Initialize overlapRect
+            // Initialize overlapRect
             overlapRect.SetActive(true);
 
             // Set the cube's layer to spatial mesh, which sphere pointer should be ignoring

--- a/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
@@ -299,7 +299,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                     new ThemePropertyValue() { Vector3 = state0Offset },
                     new ThemePropertyValue() { Vector3 = state1Offset },
                 },
-                new List<ThemePropertyValue>() //Color
+                new List<ThemePropertyValue>() // Color
                 {
                     new ThemePropertyValue() { Color = state0Color },
                     new ThemePropertyValue() { Color = state1Color },

--- a/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/PlayModeTestUtilities.cs
@@ -129,12 +129,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 foreach (GameObject gameObject in playModeTestScene.GetRootGameObjects())
                 {
-                    //Delete the MixedRealityToolkit and MixedRealityPlayspace gameobjects are managed by the ShutdownMixedRealityToolkit() function
+                    // Delete the MixedRealityToolkit and MixedRealityPlayspace gameobjects are managed by the ShutdownMixedRealityToolkit() function
                     if (gameObject != MixedRealityToolkit.Instance && gameObject.transform != MixedRealityPlayspace.Transform)
                         GameObject.Destroy(gameObject);
                 }
             }
-            //Delete the MixedRealityToolkit and MixedRealityPlayspace after other objects to allow handlers to get cleaned up
+            // Delete the MixedRealityToolkit and MixedRealityPlayspace after other objects to allow handlers to get cleaned up
             TestUtilities.ShutdownMixedRealityToolkit();
 
             // If we created a temporary untitled scene in edit mode to get us started, unload that now

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssetScriptReferenceRetargeter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         private static readonly HashSet<string> ExcludedYamlAssetExtensions = new HashSet<string> { ".jpg", ".csv", ".meta", ".pfx", ".txt", ".nuspec", ".asmdef", ".yml", ".cs", ".md", ".json", ".ttf", ".png", ".shader", ".wav", ".bin", ".gltf", ".glb", ".fbx", ".pdf", ".cginc", ".rsp", ".xml", ".targets", ".props", ".template", ".csproj", ".sln", ".psd", ".room" };
         private static readonly HashSet<string> ExcludedSuffixFromCopy = new HashSet<string>() { ".cs", ".cs.meta", ".asmdef", ".asmdef.meta" };
 
-        private static Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); //Guid, FileName
+        private static Dictionary<string, string> nonClassDictionary = new Dictionary<string, string>(); // Guid, FileName
 
         // This is the known Unity-defined script fileId
         private const string ScriptFileIdConstant = "11500000";
@@ -253,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     {
                         throw new InvalidDataException($"Line in file {filePath} contains script type but not m_Script: {line.Trim()}");
                     }
-                    //{ fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
+                    // { fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
 
                     await writer.WriteLineAsync(line);
                 }
@@ -307,7 +307,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                                 nonClassDictionary.Add(guid, Path.GetFileName(filePath));
                                 // anborod: This warning is very noisy, and often is correct due to "interface", "abstract", "enum" classes that won't return type with call to GetClass above.
                                 // To turn it on, we should do extra checking, but removing for now.
-                                //Debug.LogWarning($"Found script that we can't get type from: {monoScript.name}");
+                                // Debug.LogWarning($"Found script that we can't get type from: {monoScript.name}");
                             }
                         }
                     }
@@ -567,16 +567,16 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
 
             foreach (KeyValuePair<AssemblyInformation, FileInfo[]> mapping in mappings)
             {
-                //Editor is guid + 1; which has done when we processed Editor DLLs
-                //Standalone is guid + 2
-                //UAP is guid + 3
-                //Editor PDB is + 4
-                //Standalone PDB is +5
-                //UAP PDB is +6
-                //Android is guid + 7
-                //iOS is guid + 8
-                //Android PDB is +9
-                //iOS  PDB is +10
+                // Editor is guid + 1; which has done when we processed Editor DLLs
+                // Standalone is guid + 2
+                // UAP is guid + 3
+                // Editor PDB is + 4
+                // Standalone PDB is +5
+                // UAP PDB is +6
+                // Android is guid + 7
+                // iOS is guid + 8
+                // Android PDB is +9
+                // iOS  PDB is +10
                 string templateToUse = editorMetaFileTemplate;
                 foreach (FileInfo file in mapping.Value)
                 {
@@ -675,7 +675,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
             StringBuilder guidBuilder = new StringBuilder();
             guid = guid.ToLower();
 
-            //Add one to each hexit in the guid to make it unique, but also reproducible
+            // Add one to each hexit in the guid to make it unique, but also reproducible
             foreach (char hexit in guid)
             {
                 switch (hexit)

--- a/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/Utilities.cs
@@ -261,7 +261,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                     return false;
                 }
 
-                //PE Header starts @ 0x3C (60). Its a 4 byte header.
+                // PE Header starts @ 0x3C (60). Its a 4 byte header.
                 fileStream.Position = 0x3C;
                 uint peHeaderPointer = binaryReader.ReadUInt32();
                 if (peHeaderPointer == 0)
@@ -348,7 +348,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
                 Directory.CreateDirectory(dirPath.Replace(sourcePath, destinationPath));
             }
 
-            //Copy all the files & Replaces any files with the same name
+            // Copy all the files & Replaces any files with the same name
             foreach (string newPath in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
             {
                 File.Copy(newPath, newPath.Replace(sourcePath, destinationPath), true);


### PR DESCRIPTION
Some of our comments don't have a space between // and the comment (i.e. //thisisthecomment instead of // this is the comment).

It's somewhat tedious to call this out on each review manually, but the inconsistency was triggering some OCD (i.e. seeing some places in the same file that were good about this, and some that weren't). This should add an automatic way of catching it so that folks can just fix their nit level changes by seeing them explicitly in the CI logs.

See a sane coding style for why there should be some consistency and professionalism in how we do this:

https://google.github.io/styleguide/cppguide.html#Comments