### PR TITLE
Fix grasp point on hands without joints in SpherePointer

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -11,19 +11,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [AddComponentMenu("Scripts/MRTK/SDK/SpherePointer")]
     public class SpherePointer : BaseControllerPointer, IMixedRealityNearPointer
     {
-        private SceneQueryType raycastMode = SceneQueryType.SphereOverlap;
-
         /// <inheritdoc />
-        public override SceneQueryType SceneQueryType 
-        { 
-            get => raycastMode; 
-            set => raycastMode = value;
-        }
+        public override SceneQueryType SceneQueryType { get; set; } = SceneQueryType.SphereOverlap;
 
         [SerializeField]
         [Min(0.0f)]
         [Tooltip("Additional distance on top of sphere cast radius when pointer is considered 'near' an object and far interaction will turn off")]
         private float nearObjectMargin = 0.2f;
+
         /// <summary>
         /// Additional distance on top of<see cref="BaseControllerPointer.SphereCastRadius"/> when pointer is considered 'near' an object and far interaction will turn off.
         /// </summary>
@@ -43,6 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         [Tooltip("The LayerMasks, in prioritized order, that are used to determine the grabbable objects. Remember to also add NearInteractionGrabbable! Only collidables with NearInteractionGrabbable will raise events.")]
         private LayerMask[] grabLayerMasks = { UnityEngine.Physics.DefaultRaycastLayers };
+
         /// <summary>
         /// The LayerMasks, in prioritized order, that are used to determine the touchable objects.
         /// </summary>
@@ -54,16 +50,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         [Tooltip("Specify whether queries for grabbable objects hit triggers.")]
         protected QueryTriggerInteraction triggerInteraction = QueryTriggerInteraction.UseGlobal;
+
         /// <summary>
         /// Specify whether queries for grabbable objects hit triggers.
         /// </summary>
         public QueryTriggerInteraction TriggerInteraction => triggerInteraction;
 
-
         [SerializeField]
         [Tooltip("Maximum number of colliders that can be detected in a scene query.")]
         [Min(1)]
         private int sceneQueryBufferSize = 64;
+
         /// <summary>
         /// Maximum number of colliders that can be detected in a scene query.
         /// </summary>
@@ -72,6 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         [Tooltip("Whether to ignore colliders that may be near the pointer, but not actually in the visual FOV. This can prevent accidental grabs, and will allow hand rays to turn on when you may be near a grabbable but cannot see it. Visual FOV is defined by cone centered about display center, radius equal to half display height.")]
         private bool ignoreCollidersNotInFOV = true;
+
         /// <summary>
         /// Whether to ignore colliders that may be near the pointer, but not actually in the visual FOV.
         /// This can prevent accidental grabs, and will allow hand rays to turn on when you may be near 
@@ -92,10 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Uses SphereCastRadius + NearObjectMargin to determine if near an object.
         /// </summary>
         /// <returns>True if the pointer is near any collider that's both on a grabbable layer mask, and has a NearInteractionGrabbable.</returns>
-        public bool IsNearObject
-        {
-            get => queryBufferNearObjectRadius.ContainsGrabbable();
-        }
+        public bool IsNearObject => queryBufferNearObjectRadius.ContainsGrabbable;
 
         /// <summary>
         /// Test if the pointer is within the grabbable radius of collider that's both on a grabbable layer mask, and has a NearInteractionGrabbable.
@@ -103,17 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Note: if focus on pointer is locked, will always return true.
         /// </summary>
         /// <returns>True if the pointer is within the grabbable radius of collider that's both on a grabbable layer mask, and has a NearInteractionGrabbable.</returns>
-        public override bool IsInteractionEnabled
-        {
-            get
-            {
-                if (IsFocusLocked)
-                {
-                    return true;
-                }
-                return base.IsInteractionEnabled && queryBufferInteractionRadius.ContainsGrabbable();
-            }
-        }
+        public override bool IsInteractionEnabled => IsFocusLocked || (base.IsInteractionEnabled && queryBufferInteractionRadius.ContainsGrabbable);
 
         private void Awake()
         {
@@ -334,10 +319,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <summary>
             /// Returns true if any of the objects inside QueryBuffer contain a grabbable
             /// </summary>
-            public bool ContainsGrabbable()
-            {
-                return grabbable != null;
-            }
+            public bool ContainsGrabbable => grabbable != null;
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -169,14 +169,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Profiler.BeginSample("[MRTK] SpherePointer.TryGetNearGraspPoint");
 
             // If controller is of kind IMixedRealityHand, return average of index and thumb
-            if (Controller != null && Controller is IMixedRealityHand)
+            if (Controller != null && Controller is IMixedRealityHand hand)
             {
-                var hand = Controller as IMixedRealityHand;
-                hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index);
-                if (index != null)
+                if (hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index) && index != null)
                 {
-                    hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb);
-                    if (thumb != null)
+                    if (hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb) && thumb != null)
                     {
                         result = 0.5f * (index.Position + thumb.Position);
                         Profiler.EndSample(); // TryGetNearGraspPoint - success
@@ -184,7 +181,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     }
                 }
             }
-            else
+
+            if (Controller.IsPositionAvailable)
             {
                 result = Position;
                 Profiler.EndSample(); // TryGetNearGraspPoint - success

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -155,23 +155,27 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (TryGetNearGraspPointPerfMarker.Auto())
             {
-                // If controller is of kind IMixedRealityHand, return average of index and thumb
-                if (Controller != null && Controller is IMixedRealityHand hand)
+                if (Controller != null)
                 {
-                    if (hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index) && index != null)
+                    // If controller is of kind IMixedRealityHand, return average of index and thumb
+                    if (Controller is IMixedRealityHand hand)
                     {
-                        if (hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb) && thumb != null)
+                        if (hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index) && index != null)
                         {
-                            result = 0.5f * (index.Position + thumb.Position);
-                            return true;
+                            if (hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb) && thumb != null)
+                            {
+                                result = 0.5f * (index.Position + thumb.Position);
+                                return true;
+                            }
                         }
                     }
-                }
 
-                if (Controller.IsPositionAvailable)
-                {
-                    result = Position;
-                    return true;
+                    // If controller isn't an IMixedRealityHand or one of the required joints isn't available, check for position
+                    if (Controller.IsPositionAvailable)
+                    {
+                        result = Position;
+                        return true;
+                    }
                 }
 
                 result = Vector3.zero;


### PR DESCRIPTION
## Overview

When testing remoting without the DotNetWinRT adapter, I noticed that grab interactions weren't working, since I didn't have joints. Looking through the code, I realized we fall back to the pointer's position in all cases except if the controller is a hand.

With this change, we now try to get the hand joints if a controller is a hand, but, if that fails plus in all other cases, if the controller provides a position, we use that instead. Grab interactions now work even without hand joints, as long as a position is reported.

I also made updates to the profiler markers to fit the new `Auto()` style we've been using. Due to this, I recommend [hiding whitespace changes when reviewing](https://github.blog/2018-05-01-ignore-white-space-in-code-review/).

I also updated some formatting and spacing.

## Validation

The main scenario this affects is holographic remoting from the Unity editor to a HoloLens 2 without the DotNetWinRT adapter imported or enabled.
Before this change, grab interactions will fail. The grab pointer is never activated because hand joints aren't found.
After this change, the grab pointer uses the hand's grip pose when joints aren't found.