### PR TITLE
Revert SceneQueryType rewrite

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -11,8 +11,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [AddComponentMenu("Scripts/MRTK/SDK/SpherePointer")]
     public class SpherePointer : BaseControllerPointer, IMixedRealityNearPointer
     {
+        private SceneQueryType raycastMode = SceneQueryType.SphereOverlap;
+
         /// <inheritdoc />
-        public override SceneQueryType SceneQueryType { get; set; } = SceneQueryType.SphereOverlap;
+        public override SceneQueryType SceneQueryType
+        {
+            get => raycastMode;
+            set => raycastMode = value;
+        }
 
         [SerializeField]
         [Min(0.0f)]


### PR DESCRIPTION
## Overview

Rewriting this overwritten auto-property with another auto-property seems to have introduced a serialization issue. This reverts that change.

## Changes
- Fixes: #7642 