### PR TITLE
Update ManualCameraControl.cs summary doc

### DIFF
--- a/Assets/MRTK/Services/InputSimulation/ManualCameraControl.cs
+++ b/Assets/MRTK/Services/InputSimulation/ManualCameraControl.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Class for manually controlling the camera in the Unity editor. Attach to the MainCamera object.
+    /// Class for manually controlling the camera in the Unity editor. Used by the Input Simulation Service.
     /// </summary>
     public class ManualCameraControl
     {


### PR DESCRIPTION
## Overview

This summary tag still refers to adding this script to the camera. This is a holdover from the original script, ported from HTK. The MRTK version of the script isn't a MonoBehaviour and is used directly by the simulation service.