### PR TITLE
Add additional profiler markers and update from begin/endsample to using(marker)

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private static readonly ProfilerMarker UpdateHandJointsPerfMarker = new ProfilerMarker("[MRTK] ArticulatedHandDefinition.UpdateHandPoints");
+        private static readonly ProfilerMarker UpdateHandJointsPerfMarker = new ProfilerMarker("[MRTK] ArticulatedHandDefinition.UpdateHandJoints");
 
         /// <summary>
         /// Updates the current hand joints with new data.

--- a/Assets/MRTK/Core/Providers/UnityInput/MouseController.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/MouseController.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UInput = UnityEngine.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
@@ -47,60 +47,101 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
         private IMixedRealityMouseDeviceManager mouseDeviceManager = null;
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] MouseController.Update");
+
         /// <summary>
         /// Update controller.
         /// </summary>
         public void Update()
         {
-            if (!UInput.mousePresent) { return; }
-
-            Profiler.BeginSample("[MRTK] MouseController.Update");
-
-            if (mouseDeviceManager == null)
+            using (UpdatePerfMarker.Auto())
             {
-                mouseDeviceManager = CoreServices.GetInputSystemDataProvider<IMixedRealityMouseDeviceManager>();
-            }
+                if (!UInput.mousePresent) { return; }
 
-            // Bail early if our mouse isn't in our game window.
-            if (UInput.mousePosition.x < 0 ||
-                UInput.mousePosition.y < 0 ||
-                UInput.mousePosition.x > Screen.width ||
-                UInput.mousePosition.y > Screen.height)
-            {
-                Profiler.EndSample(); // Update - not in window
-                return;
-            }
-
-            for (int i = 0; i < Interactions.Length; i++)
-            {
-                if ((Interactions[i].InputType == DeviceInputType.SpatialPointer) ||
-                    (Interactions[i].InputType == DeviceInputType.PointerPosition))
+                if (mouseDeviceManager == null)
                 {
-                    Vector3 mouseDelta = Vector3.zero;
-                    mouseDelta.x = -UInput.GetAxis("Mouse Y");
-                    mouseDelta.y = UInput.GetAxis("Mouse X");
-                    if (mouseDeviceManager != null)
-                    {
-                        // Apply cursor speed.
-                        mouseDelta *= mouseDeviceManager.CursorSpeed;
-                    }
+                    mouseDeviceManager = CoreServices.GetInputSystemDataProvider<IMixedRealityMouseDeviceManager>();
+                }
 
-                    if (Interactions[i].InputType == DeviceInputType.SpatialPointer)
-                    {
-                        // Spatial pointer raises Pose events
-                        controllerPose = MixedRealityPose.ZeroIdentity;
-                        controllerPose.Rotation = Quaternion.Euler(mouseDelta);
-                        Interactions[i].PoseData = controllerPose;
+                // Bail early if our mouse isn't in our game window.
+                if (UInput.mousePosition.x < 0 ||
+                    UInput.mousePosition.y < 0 ||
+                    UInput.mousePosition.x > Screen.width ||
+                    UInput.mousePosition.y > Screen.height)
+                {
+                    return;
+                }
 
-                        if (Interactions[i].Changed)
+                for (int i = 0; i < Interactions.Length; i++)
+                {
+                    if ((Interactions[i].InputType == DeviceInputType.SpatialPointer) ||
+                        (Interactions[i].InputType == DeviceInputType.PointerPosition))
+                    {
+                        Vector3 mouseDelta = Vector3.zero;
+                        mouseDelta.x = -UInput.GetAxis("Mouse Y");
+                        mouseDelta.y = UInput.GetAxis("Mouse X");
+                        if (mouseDeviceManager != null)
                         {
-                            CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].PoseData);
+                            // Apply cursor speed.
+                            mouseDelta *= mouseDeviceManager.CursorSpeed;
+                        }
+
+                        if (Interactions[i].InputType == DeviceInputType.SpatialPointer)
+                        {
+                            // Spatial pointer raises Pose events
+                            controllerPose = MixedRealityPose.ZeroIdentity;
+                            controllerPose.Rotation = Quaternion.Euler(mouseDelta);
+                            Interactions[i].PoseData = controllerPose;
+
+                            if (Interactions[i].Changed)
+                            {
+                                CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].PoseData);
+                            }
+                        }
+                        else
+                        {
+                            // Pointer position raises position events
+                            Interactions[i].Vector2Data = mouseDelta;
+
+                            if (Interactions[i].Changed)
+                            {
+                                CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].Vector2Data);
+                            }
                         }
                     }
-                    else
+
+                    if (Interactions[i].AxisType == AxisType.Digital)
                     {
-                        // Pointer position raises position events
-                        Interactions[i].Vector2Data = mouseDelta;
+                        var keyButton = UInput.GetKey(Interactions[i].KeyCode);
+
+                        // Update the interaction data source
+                        Interactions[i].BoolData = keyButton;
+
+                        // If our value changed raise it.
+                        if (Interactions[i].Changed)
+                        {
+                            // Raise input system event if it's enabled
+                            if (Interactions[i].BoolData)
+                            {
+                                CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
+                            }
+                            else
+                            {
+                                CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
+                            }
+                        }
+                    }
+
+                    if (Interactions[i].InputType == DeviceInputType.Scroll)
+                    {
+                        Vector2 wheelDelta = UInput.mouseScrollDelta;
+                        if (mouseDeviceManager != null)
+                        {
+                            // Apply wheel speed.
+                            wheelDelta *= mouseDeviceManager.WheelSpeed;
+                        }
+
+                        Interactions[i].Vector2Data = wheelDelta;
 
                         if (Interactions[i].Changed)
                         {
@@ -108,48 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                         }
                     }
                 }
-
-                if (Interactions[i].AxisType == AxisType.Digital)
-                {
-                    var keyButton = UInput.GetKey(Interactions[i].KeyCode);
-
-                    // Update the interaction data source
-                    Interactions[i].BoolData = keyButton;
-
-                    // If our value changed raise it.
-                    if (Interactions[i].Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (Interactions[i].BoolData)
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
-                        }
-                        else
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction);
-                        }
-                    }
-                }
-
-                if (Interactions[i].InputType == DeviceInputType.Scroll)
-                {
-                    Vector2 wheelDelta = UInput.mouseScrollDelta;
-                    if (mouseDeviceManager != null)
-                    {
-                        // Apply wheel speed.
-                        wheelDelta *= mouseDeviceManager.WheelSpeed;
-                    }
-
-                    Interactions[i].Vector2Data = wheelDelta;
-
-                    if (Interactions[i].Changed)
-                    {
-                        CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[i].MixedRealityInputAction, Interactions[i].Vector2Data);
-                    }
-                }
             }
-
-            Profiler.EndSample(); // Update
         }
     }
 }

--- a/Assets/MRTK/Core/Providers/UnityInput/MouseDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/MouseDeviceManager.cs
@@ -3,8 +3,8 @@
 
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UInput = UnityEngine.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
@@ -154,18 +154,19 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             Service?.RaiseSourceDetected(Controller.InputSource, Controller);
         }
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] MouseDeviceManager.Update");
+
         /// <inheritdoc />
         public override void Update()
         {
-            Profiler.BeginSample("[MRTK] MouseDeviceManager.Update");
+            using (UpdatePerfMarker.Auto())
+            {
+                base.Update();
 
-            base.Update();
+                if (UInput.mousePresent && Controller == null) { Enable(); }
 
-            if (UInput.mousePresent && Controller == null) { Enable(); }
-
-            Controller?.Update();
-
-            Profiler.EndSample(); // Update
+                Controller?.Update();
+            }
         }
 
         /// <inheritdoc />

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -112,6 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                 return controllers;
             }
         }
+
         private static readonly ProfilerMarker RefreshDevicesPerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.Update");
 
         private void RefreshDevices()

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -113,7 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             }
         }
 
-        private static readonly ProfilerMarker RefreshDevicesPerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.Update");
+        private static readonly ProfilerMarker RefreshDevicesPerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.RefreshDevices");
 
         private void RefreshDevices()
         {

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -5,8 +5,8 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UInput = UnityEngine.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
@@ -59,27 +59,28 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         private float deviceRefreshTimer;
         private string[] lastDeviceList;
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.Update");
+
         /// <inheritdoc />
         public override void Update()
         {
-            Profiler.BeginSample("[MRTK] UnityJoystickManager.Update");
-
-            base.Update();
-
-            deviceRefreshTimer += Time.unscaledDeltaTime;
-
-            if (deviceRefreshTimer >= DeviceRefreshInterval)
+            using (UpdatePerfMarker.Auto())
             {
-                deviceRefreshTimer = 0.0f;
-                RefreshDevices();
-            }
+                base.Update();
 
-            foreach (var controller in ActiveControllers)
-            {
-                controller.Value?.UpdateController();
-            }
+                deviceRefreshTimer += Time.unscaledDeltaTime;
 
-            Profiler.EndSample(); // Update
+                if (deviceRefreshTimer >= DeviceRefreshInterval)
+                {
+                    deviceRefreshTimer = 0.0f;
+                    RefreshDevices();
+                }
+
+                foreach (var controller in ActiveControllers)
+                {
+                    controller.Value?.UpdateController();
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -100,74 +101,75 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             ActiveControllers.Clear();
         }
 
+        private static readonly ProfilerMarker GetActiveControllersPerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.GetActiveControllers");
+
         /// <inheritdoc/>
         public override IMixedRealityController[] GetActiveControllers()
         {
-            Profiler.BeginSample("[MRTK] UnityJoystickManager.GetActiveControllers");
-
-            IMixedRealityController[] controllers = ActiveControllers.Values.ToArray<IMixedRealityController>();
-
-            Profiler.EndSample(); // GetActiveControllers
-
-            return controllers;
+            using (GetActiveControllersPerfMarker.Auto())
+            {
+                IMixedRealityController[] controllers = ActiveControllers.Values.ToArray<IMixedRealityController>();
+                return controllers;
+            }
         }
+        private static readonly ProfilerMarker RefreshDevicesPerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.Update");
 
         private void RefreshDevices()
         {
-            Profiler.BeginSample("[MRTK] UnityJoystickManager.RefreshDevices");
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-            var joystickNames = UInput.GetJoystickNames();
-
-            if (joystickNames.Length <= 0)
+            using (RefreshDevicesPerfMarker.Auto())
             {
-                Profiler.EndSample(); // RefreshDevices - no devices
-                return;
-            }
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
-            if (lastDeviceList != null && joystickNames.Length == lastDeviceList.Length)
-            {
-                for (int i = 0; i < lastDeviceList.Length; i++)
+                var joystickNames = UInput.GetJoystickNames();
+
+                if (joystickNames.Length <= 0)
                 {
-                    if (joystickNames[i].Equals(lastDeviceList[i])) { continue; }
+                    return;
+                }
 
-                    if (ActiveControllers.ContainsKey(lastDeviceList[i]))
+                if (lastDeviceList != null && joystickNames.Length == lastDeviceList.Length)
+                {
+                    for (int i = 0; i < lastDeviceList.Length; i++)
                     {
-                        var controller = GetOrAddController(lastDeviceList[i]);
+                        if (joystickNames[i].Equals(lastDeviceList[i])) { continue; }
+
+                        if (ActiveControllers.ContainsKey(lastDeviceList[i]))
+                        {
+                            var controller = GetOrAddController(lastDeviceList[i]);
+
+                            if (controller != null)
+                            {
+                                inputSystem?.RaiseSourceLost(controller.InputSource, controller);
+                            }
+
+                            RemoveController(lastDeviceList[i]);
+                        }
+                    }
+                }
+
+                for (var i = 0; i < joystickNames.Length; i++)
+                {
+                    if (string.IsNullOrEmpty(joystickNames[i]))
+                    {
+                        continue;
+                    }
+
+                    if (!ActiveControllers.ContainsKey(joystickNames[i]))
+                    {
+                        var controller = GetOrAddController(joystickNames[i]);
 
                         if (controller != null)
                         {
-                            inputSystem?.RaiseSourceLost(controller.InputSource, controller);
+                            inputSystem?.RaiseSourceDetected(controller.InputSource, controller);
                         }
-
-                        RemoveController(lastDeviceList[i]);
                     }
                 }
+
+                lastDeviceList = joystickNames;
             }
-
-            for (var i = 0; i < joystickNames.Length; i++)
-            {
-                if (string.IsNullOrEmpty(joystickNames[i]))
-                {
-                    continue;
-                }
-
-                if (!ActiveControllers.ContainsKey(joystickNames[i]))
-                {
-                    var controller = GetOrAddController(joystickNames[i]);
-
-                    if (controller != null)
-                    {
-                        inputSystem?.RaiseSourceDetected(controller.InputSource, controller);
-                    }
-                }
-            }
-
-            lastDeviceList = joystickNames;
-
-            Profiler.EndSample(); // RefreshDevices
         }
+
+        private static readonly ProfilerMarker GetOrAddControllerPerfMarker = new ProfilerMarker("[MRTK] UnityJoystickManager.GetOrAddController");
 
         /// <summary>
         /// Gets or adds a controller using the joystick name provided.
@@ -176,54 +178,47 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         /// <returns>A new controller reference.</returns>
         protected virtual GenericJoystickController GetOrAddController(string joystickName)
         {
-            Profiler.BeginSample("[MRTK] UnityJoystickManager.GetOrAddController");
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-            if (ActiveControllers.ContainsKey(joystickName))
+            using (GetOrAddControllerPerfMarker.Auto())
             {
-                var controller = ActiveControllers[joystickName];
-                Debug.Assert(controller != null);
-                
-                Profiler.EndSample(); // GetOrAddController - already registered
-                
-                return controller;
-            }
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
-            Type controllerType;
+                if (ActiveControllers.ContainsKey(joystickName))
+                {
+                    var controller = ActiveControllers[joystickName];
+                    Debug.Assert(controller != null);
+                    return controller;
+                }
 
-            switch (GetCurrentControllerType(joystickName))
-            {
-                default:
-                    Profiler.EndSample(); // GetOrAddController - unknown type
+                Type controllerType;
+
+                switch (GetCurrentControllerType(joystickName))
+                {
+                    default:
+                        return null;
+                    case SupportedControllerType.GenericUnity:
+                        controllerType = typeof(GenericJoystickController);
+                        break;
+                    case SupportedControllerType.Xbox:
+                        controllerType = typeof(XboxController);
+                        break;
+                }
+
+                var inputSource = inputSystem?.RequestNewGenericInputSource($"{controllerType.Name} Controller", sourceType: InputSourceType.Controller);
+                var detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, Handedness.None, inputSource, null) as GenericJoystickController;
+
+                if (detectedController == null || !detectedController.Enabled)
+                {
+                    // Controller failed to be setup correctly.
+                    Debug.LogError($"Failed to create {controllerType.Name} controller");
+
+                    // Return null so we don't raise the source detected.
                     return null;
-                case SupportedControllerType.GenericUnity:
-                    controllerType = typeof(GenericJoystickController);
-                    break;
-                case SupportedControllerType.Xbox:
-                    controllerType = typeof(XboxController);
-                    break;
+                }
+
+                ActiveControllers.Add(joystickName, detectedController);
+
+                return detectedController;
             }
-
-            var inputSource = inputSystem?.RequestNewGenericInputSource($"{controllerType.Name} Controller", sourceType: InputSourceType.Controller);
-            var detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, Handedness.None, inputSource, null) as GenericJoystickController;
-
-            if (detectedController == null || !detectedController.Enabled)
-            {
-                // Controller failed to be setup correctly.
-                Debug.LogError($"Failed to create {controllerType.Name} controller");
-
-                Profiler.EndSample(); // GetOrAddController - failure
-
-                // Return null so we don't raise the source detected.
-                return null;
-            }
-
-            ActiveControllers.Add(joystickName, detectedController);
-
-            Profiler.EndSample(); // GetOrAddController
-
-            return detectedController;
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityTouchController.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityTouchController.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 {
@@ -93,113 +93,128 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             isNewController = true;
         }
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] UnityTouchController.Update");
+
         /// <summary>
         /// Update the touch data.
         /// </summary>
         public void Update()
         {
-            var inputSystem = CoreServices.InputSystem;
-            if (inputSystem == null)
+            using (UpdatePerfMarker.Auto())
             {
-                return;
-            }
-
-            Profiler.BeginSample("[MRTK] UnityTouchController.Update");
-
-            if (isNewController)
-            {
-                isNewController = false;
-
-                inputSystem.RaiseOnInputDown(InputSource, Handedness.None, Interactions[2].MixedRealityInputAction);
-                inputSystem.RaisePointerDown(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction);
-                isTouched = true;
-                inputSystem.RaiseGestureStarted(this, holdingAction);
-                isHolding = true;
-            }
-
-            if (!isTouched) 
-            {
-                Profiler.EndSample(); // Update - not touched
-                return;
-            }
-
-            Lifetime += Time.deltaTime;
-
-            if (TouchData.phase == TouchPhase.Moved)
-            {
-                Interactions[0].Vector2Data = TouchData.deltaPosition;
-
-                if (Interactions[0].Changed)
+                var inputSystem = CoreServices.InputSystem;
+                if (inputSystem == null)
                 {
-                    inputSystem.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[0].MixedRealityInputAction, TouchData.deltaPosition);
+                    return;
                 }
 
-                lastPose.Position = InputSource.Pointers[0].Position;
-                lastPose.Rotation = InputSource.Pointers[0].Rotation;
-                inputSystem.RaiseSourcePoseChanged(InputSource, this, lastPose);
-
-                Interactions[1].PoseData = lastPose;
-
-                if (Interactions[1].Changed)
+                if (isNewController)
                 {
-                    inputSystem.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[1].MixedRealityInputAction, lastPose);
+                    isNewController = false;
+
+                    inputSystem.RaiseOnInputDown(InputSource, Handedness.None, Interactions[2].MixedRealityInputAction);
+                    inputSystem.RaisePointerDown(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction);
+                    isTouched = true;
+                    inputSystem.RaiseGestureStarted(this, holdingAction);
+                    isHolding = true;
                 }
 
-                if (!isManipulating)
+                if (!isTouched)
                 {
-                    if (Mathf.Abs(TouchData.deltaPosition.x) > ManipulationThreshold ||
-                        Mathf.Abs(TouchData.deltaPosition.y) > ManipulationThreshold)
+                    return;
+                }
+
+                Lifetime += Time.deltaTime;
+
+                if (TouchData.phase == TouchPhase.Moved)
+                {
+                    Interactions[0].Vector2Data = TouchData.deltaPosition;
+
+                    if (Interactions[0].Changed)
                     {
-                        inputSystem?.RaiseGestureCanceled(this, holdingAction);
-                        isHolding = false;
-
-                        inputSystem?.RaiseGestureStarted(this, manipulationAction);
-                        isManipulating = true;
+                        inputSystem.RaisePositionInputChanged(InputSource, ControllerHandedness, Interactions[0].MixedRealityInputAction, TouchData.deltaPosition);
                     }
-                }
-                else
-                {
-                    inputSystem.RaiseGestureUpdated(this, manipulationAction, TouchData.deltaPosition);
-                }
 
-                // Send dragged event, to inform manipulation handlers.
-                inputSystem.RaisePointerDragged(InputSource.Pointers[0], Interactions[1].MixedRealityInputAction);
+                    lastPose.Position = InputSource.Pointers[0].Position;
+                    lastPose.Rotation = InputSource.Pointers[0].Rotation;
+                    inputSystem.RaiseSourcePoseChanged(InputSource, this, lastPose);
+
+                    Interactions[1].PoseData = lastPose;
+
+                    if (Interactions[1].Changed)
+                    {
+                        inputSystem.RaisePoseInputChanged(InputSource, ControllerHandedness, Interactions[1].MixedRealityInputAction, lastPose);
+                    }
+
+                    if (!isManipulating)
+                    {
+                        if (Mathf.Abs(TouchData.deltaPosition.x) > ManipulationThreshold ||
+                            Mathf.Abs(TouchData.deltaPosition.y) > ManipulationThreshold)
+                        {
+                            inputSystem?.RaiseGestureCanceled(this, holdingAction);
+                            isHolding = false;
+
+                            inputSystem?.RaiseGestureStarted(this, manipulationAction);
+                            isManipulating = true;
+                        }
+                    }
+                    else
+                    {
+                        inputSystem.RaiseGestureUpdated(this, manipulationAction, TouchData.deltaPosition);
+                    }
+
+                    // Send dragged event, to inform manipulation handlers.
+                    inputSystem.RaisePointerDragged(InputSource.Pointers[0], Interactions[1].MixedRealityInputAction);
+                }
             }
-
-            Profiler.EndSample(); // Update
         }
+
+        private static readonly ProfilerMarker EndTouchPerfMarker = new ProfilerMarker("[MRTK] UnityTouchController.EndTouch");
 
         /// <summary>
         /// End the touch.
         /// </summary>
         public void EndTouch()
         {
-            var inputSystem = CoreServices.InputSystem;
-
-            if (inputSystem == null)
+            using (EndTouchPerfMarker.Auto())
             {
-                return;
-            }
+                var inputSystem = CoreServices.InputSystem;
 
-            Profiler.BeginSample("[MRTK] UnityTouchController.EndTouch");
-
-            if (TouchData.phase == TouchPhase.Ended)
-            {
-                if (Lifetime < MaxTapContactTime)
+                if (inputSystem == null)
                 {
+                    return;
+                }
+
+                if (TouchData.phase == TouchPhase.Ended)
+                {
+                    if (Lifetime < MaxTapContactTime)
+                    {
+                        if (isHolding)
+                        {
+                            inputSystem.RaiseGestureCanceled(this, holdingAction);
+                            isHolding = false;
+                        }
+
+                        if (isManipulating)
+                        {
+                            inputSystem.RaiseGestureCanceled(this, manipulationAction);
+                            isManipulating = false;
+                        }
+
+                        inputSystem.RaisePointerClicked(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction, TouchData.tapCount);
+                    }
+
                     if (isHolding)
                     {
-                        inputSystem.RaiseGestureCanceled(this, holdingAction);
+                        inputSystem.RaiseGestureCompleted(this, holdingAction);
                         isHolding = false;
                     }
 
                     if (isManipulating)
                     {
-                        inputSystem.RaiseGestureCanceled(this, manipulationAction);
+                        inputSystem.RaiseGestureCompleted(this, manipulationAction, TouchData.deltaPosition);
                         isManipulating = false;
                     }
-
-                    inputSystem.RaisePointerClicked(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction, TouchData.tapCount);
                 }
 
                 if (isHolding)
@@ -208,38 +223,24 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                     isHolding = false;
                 }
 
+                Debug.Assert(!isHolding);
+
                 if (isManipulating)
                 {
                     inputSystem.RaiseGestureCompleted(this, manipulationAction, TouchData.deltaPosition);
                     isManipulating = false;
                 }
+
+                Debug.Assert(!isManipulating);
+
+                inputSystem.RaiseOnInputUp(InputSource, Handedness.None, Interactions[2].MixedRealityInputAction);
+                inputSystem.RaisePointerUp(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction);
+
+                Lifetime = 0.0f;
+                isTouched = false;
+                Interactions[1].PoseData = MixedRealityPose.ZeroIdentity;
+                Interactions[0].Vector2Data = Vector2.zero;
             }
-
-            if (isHolding)
-            {
-                inputSystem.RaiseGestureCompleted(this, holdingAction);
-                isHolding = false;
-            }
-
-            Debug.Assert(!isHolding);
-
-            if (isManipulating)
-            {
-                inputSystem.RaiseGestureCompleted(this, manipulationAction, TouchData.deltaPosition);
-                isManipulating = false;
-            }
-
-            Debug.Assert(!isManipulating);
-
-            inputSystem.RaiseOnInputUp(InputSource, Handedness.None, Interactions[2].MixedRealityInputAction);
-            inputSystem.RaisePointerUp(InputSource.Pointers[0], Interactions[2].MixedRealityInputAction);
-
-            Lifetime = 0.0f;
-            isTouched = false;
-            Interactions[1].PoseData = MixedRealityPose.ZeroIdentity;
-            Interactions[0].Vector2Data = Vector2.zero;
-
-            Profiler.EndSample(); // EndTouch
         }
     }
 }

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
         private List<UnityTouchController> touchesToRemove = new List<UnityTouchController>();
 
-        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.Update");
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] UnityTouchDeviceManager.Update");
 
         /// <inheritdoc />
         public override void Update()
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             ActiveTouches.Clear();
         }
 
-        private static readonly ProfilerMarker AddTouchControllerPerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.AddTouchController");
+        private static readonly ProfilerMarker AddTouchControllerPerfMarker = new ProfilerMarker("[MRTK] UnityTouchDeviceManager.AddTouchController");
 
         private void AddTouchController(Touch touch, Ray ray)
         {
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             }
         }
 
-        private static readonly ProfilerMarker UpdateTouchDataPerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.UpdateTouchData");
+        private static readonly ProfilerMarker UpdateTouchDataPerfMarker = new ProfilerMarker("[MRTK] UnityTouchDeviceManager.UpdateTouchData");
 
         private void UpdateTouchData(Touch touch, Ray ray)
         {
@@ -179,7 +179,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             }
         }
 
-        private static readonly ProfilerMarker RemoveTouchControllerPerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.RemoveTouchController");
+        private static readonly ProfilerMarker RemoveTouchControllerPerfMarker = new ProfilerMarker("[MRTK] UnityTouchDeviceManager.RemoveTouchController");
 
         private void RemoveTouchController(Touch touch)
         {

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -3,8 +3,8 @@
 
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UInput = UnityEngine.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
@@ -54,46 +54,47 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
         private List<UnityTouchController> touchesToRemove = new List<UnityTouchController>();
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.Update");
+
         /// <inheritdoc />
         public override void Update()
         {
-            Profiler.BeginSample("[MRTK] UnityTouchDeviceManager.Update");
-
-            base.Update();
-
-            // Ensure that touch up and source lost events are at least one frame apart.
-            for (int i = 0; i < touchesToRemove.Count; i++)
+            using (UpdatePerfMarker.Auto())
             {
-                IMixedRealityController controller = touchesToRemove[i];
-                Service?.RaiseSourceLost(controller.InputSource, controller);
-            }
-            touchesToRemove.Clear();
+                base.Update();
 
-            int touchCount = UInput.touchCount;
-            for (int i = 0; i < touchCount; i++)
-            {
-                Touch touch = UInput.touches[i];
-
-                // Construct a ray from the current touch coordinates
-                Ray ray = CameraCache.Main.ScreenPointToRay(touch.position);
-
-                switch (touch.phase)
+                // Ensure that touch up and source lost events are at least one frame apart.
+                for (int i = 0; i < touchesToRemove.Count; i++)
                 {
-                    case TouchPhase.Began:
-                        AddTouchController(touch, ray);
-                        break;
-                    case TouchPhase.Moved:
-                    case TouchPhase.Stationary:
-                        UpdateTouchData(touch, ray);
-                        break;
-                    case TouchPhase.Ended:
-                    case TouchPhase.Canceled:
-                        RemoveTouchController(touch);
-                        break;
+                    IMixedRealityController controller = touchesToRemove[i];
+                    Service?.RaiseSourceLost(controller.InputSource, controller);
+                }
+                touchesToRemove.Clear();
+
+                int touchCount = UInput.touchCount;
+                for (int i = 0; i < touchCount; i++)
+                {
+                    Touch touch = UInput.touches[i];
+
+                    // Construct a ray from the current touch coordinates
+                    Ray ray = CameraCache.Main.ScreenPointToRay(touch.position);
+
+                    switch (touch.phase)
+                    {
+                        case TouchPhase.Began:
+                            AddTouchController(touch, ray);
+                            break;
+                        case TouchPhase.Moved:
+                        case TouchPhase.Stationary:
+                            UpdateTouchData(touch, ray);
+                            break;
+                        case TouchPhase.Ended:
+                        case TouchPhase.Canceled:
+                            RemoveTouchController(touch);
+                            break;
+                    }
                 }
             }
-
-            Profiler.EndSample(); // Update
         }
 
         /// <inheritdoc />
@@ -117,88 +118,89 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             ActiveTouches.Clear();
         }
 
+        private static readonly ProfilerMarker AddTouchControllerPerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.AddTouchController");
+
         private void AddTouchController(Touch touch, Ray ray)
         {
-            Profiler.BeginSample("[MRTK] UnityTouchDeviceManager.AddTouchController");
-
-            UnityTouchController controller;
-
-            if (!ActiveTouches.TryGetValue(touch.fingerId, out controller))
+            using (AddTouchControllerPerfMarker.Auto())
             {
-                IMixedRealityInputSource inputSource = null;
+                UnityTouchController controller;
 
-                if (Service != null)
+                if (!ActiveTouches.TryGetValue(touch.fingerId, out controller))
                 {
-                    var pointers = RequestPointers(SupportedControllerType.TouchScreen, Handedness.Any);
-                    inputSource = Service.RequestNewGenericInputSource($"Touch {touch.fingerId}", pointers);
-                }
+                    IMixedRealityInputSource inputSource = null;
 
-                controller = new UnityTouchController(TrackingState.NotApplicable, Handedness.Any, inputSource);
-
-                if (inputSource != null)
-                {
-                    for (int i = 0; i < inputSource.Pointers.Length; i++)
+                    if (Service != null)
                     {
-                        inputSource.Pointers[i].Controller = controller;
-                        var touchPointer = (IMixedRealityTouchPointer)inputSource.Pointers[i];
-                        touchPointer.TouchRay = ray;
-                        touchPointer.FingerId = touch.fingerId;
+                        var pointers = RequestPointers(SupportedControllerType.TouchScreen, Handedness.Any);
+                        inputSource = Service.RequestNewGenericInputSource($"Touch {touch.fingerId}", pointers);
                     }
+
+                    controller = new UnityTouchController(TrackingState.NotApplicable, Handedness.Any, inputSource);
+
+                    if (inputSource != null)
+                    {
+                        for (int i = 0; i < inputSource.Pointers.Length; i++)
+                        {
+                            inputSource.Pointers[i].Controller = controller;
+                            var touchPointer = (IMixedRealityTouchPointer)inputSource.Pointers[i];
+                            touchPointer.TouchRay = ray;
+                            touchPointer.FingerId = touch.fingerId;
+                        }
+                    }
+
+                    ActiveTouches.Add(touch.fingerId, controller);
                 }
 
-                ActiveTouches.Add(touch.fingerId, controller);
+                Service?.RaiseSourceDetected(controller.InputSource, controller);
+
+                controller.TouchData = touch;
+                controller.StartTouch();
             }
-
-            Service?.RaiseSourceDetected(controller.InputSource, controller);
-
-            controller.TouchData = touch;
-            controller.StartTouch();
-
-            Profiler.EndSample(); // AddTouchController
         }
+
+        private static readonly ProfilerMarker UpdateTouchDataPerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.UpdateTouchData");
 
         private void UpdateTouchData(Touch touch, Ray ray)
         {
-            Profiler.BeginSample("[MRTK] UnityTouchDeviceManager.UpdateTouchData");
-
-            UnityTouchController controller;
-
-            if (!ActiveTouches.TryGetValue(touch.fingerId, out controller))
+            using (UpdateTouchDataPerfMarker.Auto())
             {
-                Profiler.EndSample(); // UpdateTouchData - no touches
-                return;
+                UnityTouchController controller;
+
+                if (!ActiveTouches.TryGetValue(touch.fingerId, out controller))
+                {
+                    return;
+                }
+
+                controller.TouchData = touch;
+                var pointer = (IMixedRealityTouchPointer)controller.InputSource.Pointers[0];
+                controller.ScreenPointRay = pointer.TouchRay = ray;
+                controller.Update();
             }
-
-            controller.TouchData = touch;
-            var pointer = (IMixedRealityTouchPointer)controller.InputSource.Pointers[0];
-            controller.ScreenPointRay = pointer.TouchRay = ray;
-            controller.Update();
-
-            Profiler.EndSample(); // UpdateTouchData
         }
+
+        private static readonly ProfilerMarker RemoveTouchControllerPerfMarker = new ProfilerMarker("[MRTK] UnityTouchManager.RemoveTouchController");
 
         private void RemoveTouchController(Touch touch)
         {
-            Profiler.BeginSample("[MRTK] UnityTouchDeviceManager.RemoveTouchController");
-
-            UnityTouchController controller;
-
-            if (!ActiveTouches.TryGetValue(touch.fingerId, out controller))
+            using (RemoveTouchControllerPerfMarker.Auto())
             {
-                Profiler.EndSample(); // RemoveTouchController - no touches
-                return;
+                UnityTouchController controller;
+
+                if (!ActiveTouches.TryGetValue(touch.fingerId, out controller))
+                {
+                    return;
+                }
+
+                RecyclePointers(controller.InputSource);
+
+                controller.TouchData = touch;
+                controller.EndTouch();
+                // Schedule the source lost event.
+                touchesToRemove.Add(controller);
+                // Remove from the active collection
+                ActiveTouches.Remove(touch.fingerId);
             }
-
-            RecyclePointers(controller.InputSource);
-
-            controller.TouchData = touch;
-            controller.EndTouch();
-            // Schedule the source lost event.
-            touchesToRemove.Add(controller);
-            // Remove from the active collection
-            ActiveTouches.Remove(touch.fingerId);
-
-            Profiler.EndSample(); // RemoveTouchController
         }
     }
 }

--- a/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
-using UnityEngine.Profiling;
+using Unity.Profiling;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -41,34 +41,36 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] BaseDataProviderAccessCoreSystem.Update");
+
         /// <inheritdoc />
         public override void Update()
         {
-            Profiler.BeginSample("[MRTK] BaseDataAccessCoreSystem.Update");
-
-            base.Update();
-
-            foreach (var provider in dataProviders)
+            using (UpdatePerfMarker.Auto())
             {
-                provider.Update();
-            }
+                base.Update();
 
-            Profiler.EndSample(); // Update
+                foreach (var provider in dataProviders)
+                {
+                    provider.Update();
+                }
+            }
         }
+
+        private static readonly ProfilerMarker LateUpdatePerfMarker = new ProfilerMarker("[MRTK] BaseDataProviderAccessCoreSystem.LateUpdate");
 
         /// <inheritdoc />
         public override void LateUpdate()
         {
-            Profiler.BeginSample("[MRTK] BaseDataAccessCoreSystem.LateUpdate");
-
-            base.LateUpdate();
-
-            foreach (var provider in dataProviders)
+            using (LateUpdatePerfMarker.Auto())
             {
-                provider.LateUpdate();
-            }
+                base.LateUpdate();
 
-            Profiler.EndSample(); // LateUpdate
+                foreach (var provider in dataProviders)
+                {
+                    provider.LateUpdate();
+                }
+            }
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Services/BaseEventSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseEventSystem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -390,9 +391,11 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-    #endregion Registration helpers
+        #endregion Registration helpers
 
-    #region Utilities
+        #region Utilities
+
+        private static readonly ProfilerMarker TraverseEventSystemHandlerHierarchyPerfMarker = new ProfilerMarker("[MRTK] BaseEventSystem.TraverseEventSystemHandlerHierarchy");
 
         /// <summary>
         /// Utility function for registering parent interfaces of a given handler.
@@ -409,16 +412,19 @@ namespace Microsoft.MixedReality.Toolkit
         /// </remarks>
         private void TraverseEventSystemHandlerHierarchy<T>(IEventSystemHandler handler, Action<Type, IEventSystemHandler> func) where T : IEventSystemHandler
         {
-            var handlerType = typeof(T);
-
-            // Need to call on handlerType first, because GetInterfaces below will only return parent types.
-            func(handlerType, handler);
-
-            foreach (var iface in handlerType.GetInterfaces())
+            using (TraverseEventSystemHandlerHierarchyPerfMarker.Auto())
             {
-                if (!iface.Equals(eventSystemHandlerType))
+                var handlerType = typeof(T);
+
+                // Need to call on handlerType first, because GetInterfaces below will only return parent types.
+                func(handlerType, handler);
+
+                foreach (var iface in handlerType.GetInterfaces())
                 {
-                    func(iface, handler);
+                    if (!iface.Equals(eventSystemHandlerType))
+                    {
+                        func(iface, handler);
+                    }
                 }
             }
         }
@@ -431,6 +437,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
     #endregion Utilities
+
         // Example Event Pattern #############################################################
 
         // public void RaiseGenericEvent(IEventSource eventSource)

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -10,8 +10,8 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UnityEngine.EventSystems;
 using Microsoft.MixedReality.Toolkit.SceneSystem;
 using Microsoft.MixedReality.Toolkit.CameraSystem;
@@ -936,30 +936,32 @@ namespace Microsoft.MixedReality.Toolkit
             ExecuteOnAllServicesInOrder(service => service.Enable());
         }
 
+        private static readonly ProfilerMarker UpdateAllServicesPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.UpdateAllServices");
+
         private void UpdateAllServices()
         {
-            Profiler.BeginSample("[MRTK] MixedRealityToolkit.UpdateAllServices");
-
-            // Update all systems
-            ExecuteOnAllServicesInOrder(service => service.Update());
-
-            Profiler.EndSample(); // UpdateAllServices
+            using (UpdateAllServicesPerfMarker.Auto())
+            {
+                // Update all systems
+                ExecuteOnAllServicesInOrder(service => service.Update());
+            }
         }
+
+        private static readonly ProfilerMarker LateUpdateAllServicesPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.LateUpdateAllServices");
 
         private void LateUpdateAllServices()
         {
-            // If the Mixed Reality Toolkit is not configured, stop.
-            if (activeProfile == null) { return; }
+            using (LateUpdateAllServicesPerfMarker.Auto())
+            {
+                // If the Mixed Reality Toolkit is not configured, stop.
+                if (activeProfile == null) { return; }
 
-            // If the Mixed Reality Toolkit is not initialized, stop.
-            if (!IsInitialized) { return; }
+                // If the Mixed Reality Toolkit is not initialized, stop.
+                if (!IsInitialized) { return; }
 
-            Profiler.BeginSample("[MRTK] MixedRealityToolkit.LateUpdateAllServices");
-
-            // Update all systems
-            ExecuteOnAllServicesInOrder(service => service.LateUpdate());
-
-            Profiler.EndSample(); // LateUpdateAllServices
+                // Update all systems
+                ExecuteOnAllServicesInOrder(service => service.LateUpdate());
+            }
         }
 
         private void DisableAllServices()
@@ -1014,47 +1016,49 @@ namespace Microsoft.MixedReality.Toolkit
             MixedRealityServiceRegistry.ClearAllServices();
         }
 
+        private static readonly ProfilerMarker ExecuteOnAllServicesInOrderPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesInOrder");
+
         private bool ExecuteOnAllServicesInOrder(Action<IMixedRealityService> execute)
         {
-            if (!HasProfileAndIsInitialized)
+            using (ExecuteOnAllServicesInOrderPerfMarker.Auto())
             {
-                return false;
+                if (!HasProfileAndIsInitialized)
+                {
+                    return false;
+                }
+
+                var services = MixedRealityServiceRegistry.GetAllServices();
+                int length = services.Count;
+                for (int i = 0; i < length; i++)
+                {
+                    execute(services[i]);
+                }
+
+                return true;
             }
-
-            Profiler.BeginSample("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesInOrder");
-
-            var services = MixedRealityServiceRegistry.GetAllServices();
-            int length = services.Count;
-            for (int i = 0; i < length; i++)
-            {
-                execute(services[i]);
-            }
-
-            Profiler.EndSample(); // ExecuteOnAllServicesInOrder
-
-            return true;
         }
+
+        private static readonly ProfilerMarker ExecuteOnAllServicesReverseOrderPerfMarker = new ProfilerMarker("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesReverseOrder");
 
         private bool ExecuteOnAllServicesReverseOrder(Action<IMixedRealityService> execute)
         {
-            if (!HasProfileAndIsInitialized)
+            using (ExecuteOnAllServicesReverseOrderPerfMarker.Auto())
             {
-                return false;
+                if (!HasProfileAndIsInitialized)
+                {
+                    return false;
+                }
+
+                var services = MixedRealityServiceRegistry.GetAllServices();
+                int length = services.Count;
+
+                for (int i = length - 1; i >= 0; i--)
+                {
+                    execute(services[i]);
+                }
+
+                return true;
             }
-
-            Profiler.BeginSample("[MRTK] MixedRealityToolkit.ExecuteOnAllServicesReverseOrder");
-
-            var services = MixedRealityServiceRegistry.GetAllServices();
-            int length = services.Count;
-
-            for (int i = length - 1; i >= 0; i--)
-            {
-                execute(services[i]);
-            }
-
-            Profiler.EndSample(); // ExecuteOnAllServicesReverseOrder
-
-            return true;
         }
 
         #endregion Multiple Service Management

--- a/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             new MixedRealityInteractionMapping(12, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip),
         };
 
-        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] GernericOpenVRController.UpdateController");
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] GenericOpenVRController.UpdateController");
 
         /// <inheritdoc />
         public override void UpdateController()

--- a/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
@@ -6,8 +6,8 @@ using Microsoft.MixedReality.Toolkit.Input.UnityInput;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
@@ -145,89 +145,91 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             new MixedRealityInteractionMapping(12, "Spatial Grip", AxisType.SixDof, DeviceInputType.SpatialGrip),
         };
 
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] GernericOpenVRController.UpdateController");
+
         /// <inheritdoc />
         public override void UpdateController()
         {
-            if (!Enabled) { return; }
-
-            Profiler.BeginSample("[MRTK] GenericOpenVRController.UpdateController");
-
-            InputTracking.GetNodeStates(nodeStates);
-
-            for (int i = 0; i < nodeStates.Count; i++)
+            using (UpdateControllerPerfMarker.Auto())
             {
-                if (nodeStates[i].nodeType == nodeType)
+                if (!Enabled) { return; }
+
+                InputTracking.GetNodeStates(nodeStates);
+
+                for (int i = 0; i < nodeStates.Count; i++)
                 {
-                    var xrNodeState = nodeStates[i];
-                    UpdateControllerData(xrNodeState);
-                    LastXrNodeStateReading = xrNodeState;
-                    break;
+                    if (nodeStates[i].nodeType == nodeType)
+                    {
+                        var xrNodeState = nodeStates[i];
+                        UpdateControllerData(xrNodeState);
+                        LastXrNodeStateReading = xrNodeState;
+                        break;
+                    }
                 }
+
+                base.UpdateController();
             }
-
-            base.UpdateController();
-
-            Profiler.EndSample(); // UpdateController
         }
+
+        private static readonly ProfilerMarker UpdateControllerDataPerfMarker = new ProfilerMarker("[MRTK] GernericOpenVRController.UpdateControllerData");
 
         /// <summary>
         /// Update the "Controller" input from the device
         /// </summary>
         protected void UpdateControllerData(XRNodeState state)
         {
-            Profiler.BeginSample("[MRTK] GenericOpenVRController.UpdateControllerData");
-
-            var lastState = TrackingState;
-
-            LastControllerPose = CurrentControllerPose;
-
-            if (nodeType == XRNode.LeftHand || nodeType == XRNode.RightHand)
+            using (UpdateControllerDataPerfMarker.Auto())
             {
-                // The source is either a hand or a controller that supports pointing.
-                // We can now check for position and rotation.
-                IsPositionAvailable = state.TryGetPosition(out CurrentControllerPosition);
-                IsPositionApproximate = false;
+                var lastState = TrackingState;
 
-                IsRotationAvailable = state.TryGetRotation(out CurrentControllerRotation);
+                LastControllerPose = CurrentControllerPose;
 
-                // Devices are considered tracked if we receive position OR rotation data from the sensors.
-                TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
-
-                CurrentControllerPosition = MixedRealityPlayspace.TransformPoint(CurrentControllerPosition);
-                CurrentControllerRotation = MixedRealityPlayspace.Rotation * CurrentControllerRotation;
-            }
-            else
-            {
-                // The input source does not support tracking.
-                TrackingState = TrackingState.NotApplicable;
-            }
-
-            CurrentControllerPose.Position = CurrentControllerPosition;
-            CurrentControllerPose.Rotation = CurrentControllerRotation;
-
-            // Raise input system events if it is enabled.
-            if (lastState != TrackingState)
-            {
-                CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
-            }
-
-            if (TrackingState == TrackingState.Tracked && LastControllerPose != CurrentControllerPose)
-            {
-                if (IsPositionAvailable && IsRotationAvailable)
+                if (nodeType == XRNode.LeftHand || nodeType == XRNode.RightHand)
                 {
-                    CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
+                    // The source is either a hand or a controller that supports pointing.
+                    // We can now check for position and rotation.
+                    IsPositionAvailable = state.TryGetPosition(out CurrentControllerPosition);
+                    IsPositionApproximate = false;
+
+                    IsRotationAvailable = state.TryGetRotation(out CurrentControllerRotation);
+
+                    // Devices are considered tracked if we receive position OR rotation data from the sensors.
+                    TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
+
+                    CurrentControllerPosition = MixedRealityPlayspace.TransformPoint(CurrentControllerPosition);
+                    CurrentControllerRotation = MixedRealityPlayspace.Rotation * CurrentControllerRotation;
                 }
-                else if (IsPositionAvailable && !IsRotationAvailable)
+                else
                 {
-                    CoreServices.InputSystem?.RaiseSourcePositionChanged(InputSource, this, CurrentControllerPosition);
+                    // The input source does not support tracking.
+                    TrackingState = TrackingState.NotApplicable;
                 }
-                else if (!IsPositionAvailable && IsRotationAvailable)
+
+                CurrentControllerPose.Position = CurrentControllerPosition;
+                CurrentControllerPose.Rotation = CurrentControllerRotation;
+
+                // Raise input system events if it is enabled.
+                if (lastState != TrackingState)
                 {
-                    CoreServices.InputSystem?.RaiseSourceRotationChanged(InputSource, this, CurrentControllerRotation);
+                    CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
+                }
+
+                if (TrackingState == TrackingState.Tracked && LastControllerPose != CurrentControllerPose)
+                {
+                    if (IsPositionAvailable && IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
+                    }
+                    else if (IsPositionAvailable && !IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourcePositionChanged(InputSource, this, CurrentControllerPosition);
+                    }
+                    else if (!IsPositionAvailable && IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourceRotationChanged(InputSource, this, CurrentControllerRotation);
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateControllerData
         }
 
         #region Controller model functions

--- a/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
+++ b/Assets/MRTK/Providers/OpenVR/GenericOpenVRController.cs
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
             }
         }
 
-        private static readonly ProfilerMarker UpdateControllerDataPerfMarker = new ProfilerMarker("[MRTK] GernericOpenVRController.UpdateControllerData");
+        private static readonly ProfilerMarker UpdateControllerDataPerfMarker = new ProfilerMarker("[MRTK] GenericOpenVRController.UpdateControllerData");
 
         /// <summary>
         /// Update the "Controller" input from the device

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -5,8 +5,8 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Threading.Tasks;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 #if WINDOWS_UWP
 using Windows.Perception.People;
@@ -76,112 +76,113 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
             }
         }
 
+        private static readonly ProfilerMarker UpdateHandMeshPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHandDefinition.UpdateHandMesh");
+
         /// <summary>
         /// Updates the current hand mesh based on the passed in state of the hand.
         /// </summary>
         /// <param name="sourceState">The current hand state.</param>
         public void UpdateHandMesh(SpatialInteractionSourceState sourceState)
         {
-            Profiler.BeginSample("[MRTK] WMRArticulatedHandDefinition.UpdateHandMesh");
-
-            MixedRealityHandTrackingProfile handTrackingProfile = null;
-            MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
-            if (inputSystemProfile != null)
+            using (UpdateHandMeshPerfMarker.Auto())
             {
-                handTrackingProfile = inputSystemProfile.HandTrackingProfile;
-            }
-
-            if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
-            {
-                // If hand mesh visualization is disabled make sure to destroy our hand mesh observer if it has already been created
-                if (handMeshObserver != null)
+                MixedRealityHandTrackingProfile handTrackingProfile = null;
+                MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+                if (inputSystemProfile != null)
                 {
-                    // Notify that hand mesh has been updated (cleared)
-                    HandMeshInfo handMeshInfo = new HandMeshInfo();
-                    CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
-                    hasRequestedHandMeshObserver = false;
-                    handMeshObserver = null;
+                    handTrackingProfile = inputSystemProfile.HandTrackingProfile;
                 }
-                return;
-            }
 
-            HandPose handPose = sourceState.TryGetHandPose();
-
-            // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
-            if (handMeshObserver == null && !hasRequestedHandMeshObserver)
-            {
-                SetHandMeshObserver(sourceState);
-                hasRequestedHandMeshObserver = true;
-            }
-
-            if (handMeshObserver != null && handPose != null)
-            {
-                if (handMeshTriangleIndices == null)
+                if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
                 {
-                    handMeshTriangleIndices = new ushort[handMeshObserver.TriangleIndexCount];
-                    handMeshTriangleIndicesUnity = new int[handMeshObserver.TriangleIndexCount];
-                    handMeshObserver.GetTriangleIndices(handMeshTriangleIndices);
-
-                    Array.Copy(handMeshTriangleIndices, handMeshTriangleIndicesUnity, (int)handMeshObserver.TriangleIndexCount);
-
-                    // Compute neutral pose
-                    Vector3[] neutralPoseVertices = new Vector3[handMeshObserver.VertexCount];
-                    HandPose neutralPose = handMeshObserver.NeutralPose;
-                    var neutralVertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
-                    HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
-                    handMeshVertexState.GetVertices(neutralVertexAndNormals);
-                    
-                    Parallel.For(0, handMeshObserver.VertexCount, i =>
+                    // If hand mesh visualization is disabled make sure to destroy our hand mesh observer if it has already been created
+                    if (handMeshObserver != null)
                     {
-                        neutralVertexAndNormals[i].Position.ConvertToUnityVector3(ref neutralPoseVertices[i]);
-                    });
-
-                    // Compute UV mapping
-                    InitializeUVs(neutralPoseVertices);
+                        // Notify that hand mesh has been updated (cleared)
+                        HandMeshInfo handMeshInfo = new HandMeshInfo();
+                        CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                        hasRequestedHandMeshObserver = false;
+                        handMeshObserver = null;
+                    }
+                    return;
                 }
 
-                if (vertexAndNormals == null)
+                HandPose handPose = sourceState.TryGetHandPose();
+
+                // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
+                if (handMeshObserver == null && !hasRequestedHandMeshObserver)
                 {
-                    vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
-                    handMeshVerticesUnity = new Vector3[handMeshObserver.VertexCount];
-                    handMeshNormalsUnity = new Vector3[handMeshObserver.VertexCount];
+                    SetHandMeshObserver(sourceState);
+                    hasRequestedHandMeshObserver = true;
                 }
 
-                if (vertexAndNormals != null && handMeshTriangleIndices != null)
+                if (handMeshObserver != null && handPose != null)
                 {
-                    var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
-                    handMeshVertexState.GetVertices(vertexAndNormals);
-
-                    var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);
-                    if (meshTransform.HasValue)
+                    if (handMeshTriangleIndices == null)
                     {
-                        System.Numerics.Matrix4x4.Decompose(meshTransform.Value, 
-                            out System.Numerics.Vector3 scale, 
-                            out System.Numerics.Quaternion rotation,
-                            out System.Numerics.Vector3 translation);
+                        handMeshTriangleIndices = new ushort[handMeshObserver.TriangleIndexCount];
+                        handMeshTriangleIndicesUnity = new int[handMeshObserver.TriangleIndexCount];
+                        handMeshObserver.GetTriangleIndices(handMeshTriangleIndices);
+
+                        Array.Copy(handMeshTriangleIndices, handMeshTriangleIndicesUnity, (int)handMeshObserver.TriangleIndexCount);
+
+                        // Compute neutral pose
+                        Vector3[] neutralPoseVertices = new Vector3[handMeshObserver.VertexCount];
+                        HandPose neutralPose = handMeshObserver.NeutralPose;
+                        var neutralVertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
+                        HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
+                        handMeshVertexState.GetVertices(neutralVertexAndNormals);
 
                         Parallel.For(0, handMeshObserver.VertexCount, i =>
                         {
-                            vertexAndNormals[i].Position.ConvertToUnityVector3(ref handMeshVerticesUnity[i]);
-                            vertexAndNormals[i].Normal.ConvertToUnityVector3(ref handMeshNormalsUnity[i]);
+                            neutralVertexAndNormals[i].Position.ConvertToUnityVector3(ref neutralPoseVertices[i]);
                         });
-                        
-                        HandMeshInfo handMeshInfo = new HandMeshInfo
-                        {
-                            vertices = handMeshVerticesUnity,
-                            normals = handMeshNormalsUnity,
-                            triangles = handMeshTriangleIndicesUnity,
-                            uvs = handMeshUVsUnity,
-                            position = translation.ToUnityVector3(),
-                            rotation = rotation.ToUnityQuaternion()
-                        };
 
-                        CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                        // Compute UV mapping
+                        InitializeUVs(neutralPoseVertices);
+                    }
+
+                    if (vertexAndNormals == null)
+                    {
+                        vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
+                        handMeshVerticesUnity = new Vector3[handMeshObserver.VertexCount];
+                        handMeshNormalsUnity = new Vector3[handMeshObserver.VertexCount];
+                    }
+
+                    if (vertexAndNormals != null && handMeshTriangleIndices != null)
+                    {
+                        var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
+                        handMeshVertexState.GetVertices(vertexAndNormals);
+
+                        var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);
+                        if (meshTransform.HasValue)
+                        {
+                            System.Numerics.Matrix4x4.Decompose(meshTransform.Value,
+                                out System.Numerics.Vector3 scale,
+                                out System.Numerics.Quaternion rotation,
+                                out System.Numerics.Vector3 translation);
+
+                            Parallel.For(0, handMeshObserver.VertexCount, i =>
+                            {
+                                vertexAndNormals[i].Position.ConvertToUnityVector3(ref handMeshVerticesUnity[i]);
+                                vertexAndNormals[i].Normal.ConvertToUnityVector3(ref handMeshNormalsUnity[i]);
+                            });
+
+                            HandMeshInfo handMeshInfo = new HandMeshInfo
+                            {
+                                vertices = handMeshVerticesUnity,
+                                normals = handMeshNormalsUnity,
+                                triangles = handMeshTriangleIndicesUnity,
+                                uvs = handMeshUVsUnity,
+                                position = translation.ToUnityVector3(),
+                                rotation = rotation.ToUnityQuaternion()
+                            };
+
+                            CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                        }
                     }
                 }
             }
-
-            Profiler.EndSample(); // UpdateHandMesh
         }
 #endif // WINDOWS_UWP
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
@@ -5,8 +5,8 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 
 #if UNITY_WSA
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UnityEngine.XR.WSA.Input;
 #endif
 
@@ -50,68 +50,72 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #region Update data functions
 
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateContoller");
+
         /// <summary>
         /// Update the source data from the provided platform state.
         /// </summary>
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         public virtual void UpdateController(InteractionSourceState interactionSourceState)
         {
-            if (!Enabled) { return; }
-
-            Profiler.BeginSample("[MRTK] BaseWindowsMixedRealitySource.UpdateController");
-
-            UpdateSourceData(interactionSourceState);
-            UpdateVelocity(interactionSourceState);
-
-            if (Interactions == null)
+            using (UpdateControllerPerfMarker.Auto())
             {
-                Debug.LogError($"No interaction configuration for Windows Mixed Reality {ControllerHandedness} Source");
-                Enabled = false;
-            }
+                if (!Enabled) { return; }
 
-            for (int i = 0; i < Interactions?.Length; i++)
-            {
-                switch (Interactions[i].InputType)
+                UpdateSourceData(interactionSourceState);
+                UpdateVelocity(interactionSourceState);
+
+                if (Interactions == null)
                 {
-                    case DeviceInputType.None:
-                        break;
-                    case DeviceInputType.SpatialPointer:
-                        UpdatePointerData(interactionSourceState, Interactions[i]);
-                        break;
-                    case DeviceInputType.Select:
-                    case DeviceInputType.Trigger:
-                    case DeviceInputType.TriggerTouch:
-                    case DeviceInputType.TriggerPress:
-                        UpdateTriggerData(interactionSourceState, Interactions[i]);
-                        break;
-                    case DeviceInputType.SpatialGrip:
-                        UpdateGripData(interactionSourceState, Interactions[i]);
-                        break;
+                    Debug.LogError($"No interaction configuration for Windows Mixed Reality {ControllerHandedness} Source");
+                    Enabled = false;
                 }
+
+                for (int i = 0; i < Interactions?.Length; i++)
+                {
+                    switch (Interactions[i].InputType)
+                    {
+                        case DeviceInputType.None:
+                            break;
+                        case DeviceInputType.SpatialPointer:
+                            UpdatePointerData(interactionSourceState, Interactions[i]);
+                            break;
+                        case DeviceInputType.Select:
+                        case DeviceInputType.Trigger:
+                        case DeviceInputType.TriggerTouch:
+                        case DeviceInputType.TriggerPress:
+                            UpdateTriggerData(interactionSourceState, Interactions[i]);
+                            break;
+                        case DeviceInputType.SpatialGrip:
+                            UpdateGripData(interactionSourceState, Interactions[i]);
+                            break;
+                    }
+                }
+
+                LastSourceStateReading = interactionSourceState;
             }
-
-            LastSourceStateReading = interactionSourceState;
-
-            Profiler.EndSample(); // UpdateController
         }
+
+        private static readonly ProfilerMarker UpdateVelocityPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateVelocity");
 
         public void UpdateVelocity(InteractionSourceState interactionSourceState)
         {
-            Profiler.BeginSample("[MRTK] BaseWindowsMixedRealitySource.UpdateVelocity");
-
-            Vector3 newVelocity;
-            if (interactionSourceState.sourcePose.TryGetVelocity(out newVelocity))
+            using (UpdateVelocityPerfMarker.Auto())
             {
-                Velocity = newVelocity;
+                Vector3 newVelocity;
+                if (interactionSourceState.sourcePose.TryGetVelocity(out newVelocity))
+                {
+                    Velocity = newVelocity;
+                }
+                Vector3 newAngularVelocity;
+                if (interactionSourceState.sourcePose.TryGetAngularVelocity(out newAngularVelocity))
+                {
+                    AngularVelocity = newAngularVelocity;
+                }
             }
-            Vector3 newAngularVelocity;
-            if (interactionSourceState.sourcePose.TryGetAngularVelocity(out newAngularVelocity))
-            {
-                AngularVelocity = newAngularVelocity;
-            }
-
-            Profiler.EndSample(); // UpdateVelocity
         }
+
+        private static readonly ProfilerMarker UpdateSourceDataPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateSourceData");
 
         /// <summary>
         /// Update the source input from the device.
@@ -119,72 +123,73 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateSourceData(InteractionSourceState interactionSourceState)
         {
-            Profiler.BeginSample("[MRTK] BaseWindowsMixedRealitySource.UpdateSourceData");
-
-            var lastState = TrackingState;
-            var sourceKind = interactionSourceState.source.kind;
-
-            lastSourcePose = currentSourcePose;
-
-            if (sourceKind == InteractionSourceKind.Hand ||
-               (sourceKind == InteractionSourceKind.Controller && interactionSourceState.source.supportsPointing))
+            using (UpdateSourceDataPerfMarker.Auto())
             {
-                // The source is either a hand or a controller that supports pointing.
-                // We can now check for position and rotation.
-                IsPositionAvailable = interactionSourceState.sourcePose.TryGetPosition(out currentSourcePosition);
+                var lastState = TrackingState;
+                var sourceKind = interactionSourceState.source.kind;
 
-                if (IsPositionAvailable)
+                lastSourcePose = currentSourcePose;
+
+                if (sourceKind == InteractionSourceKind.Hand ||
+                   (sourceKind == InteractionSourceKind.Controller && interactionSourceState.source.supportsPointing))
                 {
-                    IsPositionApproximate = (interactionSourceState.sourcePose.positionAccuracy == InteractionSourcePositionAccuracy.Approximate);
+                    // The source is either a hand or a controller that supports pointing.
+                    // We can now check for position and rotation.
+                    IsPositionAvailable = interactionSourceState.sourcePose.TryGetPosition(out currentSourcePosition);
+
+                    if (IsPositionAvailable)
+                    {
+                        IsPositionApproximate = (interactionSourceState.sourcePose.positionAccuracy == InteractionSourcePositionAccuracy.Approximate);
+                    }
+                    else
+                    {
+                        IsPositionApproximate = false;
+                    }
+
+                    IsRotationAvailable = interactionSourceState.sourcePose.TryGetRotation(out currentSourceRotation);
+
+                    // We want the source to follow the Playspace, so fold in the playspace transform here to 
+                    // put the source pose into world space.
+                    currentSourcePosition = MixedRealityPlayspace.TransformPoint(currentSourcePosition);
+                    currentSourceRotation = MixedRealityPlayspace.Rotation * currentSourceRotation;
+
+                    // Devices are considered tracked if we receive position OR rotation data from the sensors.
+                    TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
                 }
                 else
                 {
-                    IsPositionApproximate = false;
+                    // The input source does not support tracking.
+                    TrackingState = TrackingState.NotApplicable;
                 }
 
-                IsRotationAvailable = interactionSourceState.sourcePose.TryGetRotation(out currentSourceRotation);
+                currentSourcePose.Position = currentSourcePosition;
+                currentSourcePose.Rotation = currentSourceRotation;
 
-                // We want the source to follow the Playspace, so fold in the playspace transform here to 
-                // put the source pose into world space.
-                currentSourcePosition = MixedRealityPlayspace.TransformPoint(currentSourcePosition);
-                currentSourceRotation = MixedRealityPlayspace.Rotation * currentSourceRotation;
-
-                // Devices are considered tracked if we receive position OR rotation data from the sensors.
-                TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
-            }
-            else
-            {
-                // The input source does not support tracking.
-                TrackingState = TrackingState.NotApplicable;
-            }
-
-            currentSourcePose.Position = currentSourcePosition;
-            currentSourcePose.Rotation = currentSourceRotation;
-
-            // Raise input system events if it is enabled.
-            if (lastState != TrackingState)
-            {
-                CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
-            }
-
-            if (TrackingState == TrackingState.Tracked && lastSourcePose != currentSourcePose)
-            {
-                if (IsPositionAvailable && IsRotationAvailable)
+                // Raise input system events if it is enabled.
+                if (lastState != TrackingState)
                 {
-                    CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, currentSourcePose);
+                    CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
                 }
-                else if (IsPositionAvailable && !IsRotationAvailable)
+
+                if (TrackingState == TrackingState.Tracked && lastSourcePose != currentSourcePose)
                 {
-                    CoreServices.InputSystem?.RaiseSourcePositionChanged(InputSource, this, currentSourcePosition);
-                }
-                else if (!IsPositionAvailable && IsRotationAvailable)
-                {
-                    CoreServices.InputSystem?.RaiseSourceRotationChanged(InputSource, this, currentSourceRotation);
+                    if (IsPositionAvailable && IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, currentSourcePose);
+                    }
+                    else if (IsPositionAvailable && !IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourcePositionChanged(InputSource, this, currentSourcePosition);
+                    }
+                    else if (!IsPositionAvailable && IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourceRotationChanged(InputSource, this, currentSourceRotation);
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateSourceData
         }
+
+        private static readonly ProfilerMarker UpdatePointerDataPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdatePointerData");
 
         /// <summary>
         /// Update the spatial pointer input from the device.
@@ -192,31 +197,32 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdatePointerData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-            Profiler.BeginSample("[MRTK] BaseWindowsMixedRealitySource.UpdatePointerData");
-
-            if (interactionSourceState.source.supportsPointing)
+            using (UpdatePointerDataPerfMarker.Auto())
             {
-                interactionSourceState.sourcePose.TryGetPosition(out currentPointerPosition, InteractionSourceNode.Pointer);
-                interactionSourceState.sourcePose.TryGetRotation(out currentPointerRotation, InteractionSourceNode.Pointer);
+                if (interactionSourceState.source.supportsPointing)
+                {
+                    interactionSourceState.sourcePose.TryGetPosition(out currentPointerPosition, InteractionSourceNode.Pointer);
+                    interactionSourceState.sourcePose.TryGetRotation(out currentPointerRotation, InteractionSourceNode.Pointer);
 
-                // We want the source to follow the Playspace, so fold in the playspace transform here to 
-                // put the source pose into world space.
-                currentPointerPose.Position = MixedRealityPlayspace.TransformPoint(currentPointerPosition);
-                currentPointerPose.Rotation = MixedRealityPlayspace.Rotation * currentPointerRotation;
+                    // We want the source to follow the Playspace, so fold in the playspace transform here to 
+                    // put the source pose into world space.
+                    currentPointerPose.Position = MixedRealityPlayspace.TransformPoint(currentPointerPosition);
+                    currentPointerPose.Rotation = MixedRealityPlayspace.Rotation * currentPointerRotation;
+                }
+
+                // Update the interaction data source
+                interactionMapping.PoseData = currentPointerPose;
+
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentPointerPose);
+                }
             }
-
-            // Update the interaction data source
-            interactionMapping.PoseData = currentPointerPose;
-
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
-            {
-                // Raise input system event if it's enabled
-                CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentPointerPose);
-            }
-
-            Profiler.EndSample(); // UpdatePointerData
         }
+
+        private static readonly ProfilerMarker UpdateGripDataPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateGripData");
 
         /// <summary>
         /// Update the spatial grip input from the device.
@@ -224,32 +230,33 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateGripData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-            Profiler.BeginSample("[MRTK] BaseWindowsMixedRealitySource.UpdateSpatialGrip");
-
-            switch (interactionMapping.AxisType)
+            using (UpdateGripDataPerfMarker.Auto())
             {
-                case AxisType.SixDof:
+                switch (interactionMapping.AxisType)
                 {
-                    // The data queried in UpdateSourceData is the grip pose.
-                    // Reuse that data to save two method calls and transforms.
-                    currentGripPose.Position = currentSourcePosition;
-                    currentGripPose.Rotation = currentSourceRotation;
+                    case AxisType.SixDof:
+                        {
+                            // The data queried in UpdateSourceData is the grip pose.
+                            // Reuse that data to save two method calls and transforms.
+                            currentGripPose.Position = currentSourcePosition;
+                            currentGripPose.Rotation = currentSourceRotation;
 
-                    // Update the interaction data source
-                    interactionMapping.PoseData = currentGripPose;
+                            // Update the interaction data source
+                            interactionMapping.PoseData = currentGripPose;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentGripPose);
-                    }
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, currentGripPose);
+                            }
+                        }
+                        break;
                 }
-                break;
             }
-
-            Profiler.EndSample(); // UpdateSpatialGrip
         }
+
+        private static readonly ProfilerMarker UpdateTriggerDataPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateTriggerData");
 
         /// <summary>
         /// Update the trigger and grasped input from the device.
@@ -257,88 +264,87 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateTriggerData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-            Profiler.BeginSample("[MRTK] BaseWindowsMixedRealitySource.UpdateTriggerData");
-
-            switch (interactionMapping.InputType)
+            using (UpdateTriggerDataPerfMarker.Auto())
             {
-                case DeviceInputType.TriggerPress:
+                switch (interactionMapping.InputType)
                 {
-                    // Update the interaction data source
-                    interactionMapping.BoolData = interactionSourceState.grasped;
+                    case DeviceInputType.TriggerPress:
+                        {
+                            // Update the interaction data source
+                            interactionMapping.BoolData = interactionSourceState.grasped;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionMapping.BoolData)
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                if (interactionMapping.BoolData)
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                                else
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                            }
+                            break;
                         }
-                        else
+                    case DeviceInputType.Select:
                         {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                    }
-                    break;
-                }
-                case DeviceInputType.Select:
-                {
-                    // Get the select pressed state, factoring in a workaround for Unity issue #1033526.
-                    // When that issue is fixed, it should be possible change the line below to:
-                    // interactionMapping.BoolData = interactionSourceState.selectPressed;
-                    interactionMapping.BoolData = GetSelectPressedWorkaround(interactionSourceState);
+                            // Get the select pressed state, factoring in a workaround for Unity issue #1033526.
+                            // When that issue is fixed, it should be possible change the line below to:
+                            // interactionMapping.BoolData = interactionSourceState.selectPressed;
+                            interactionMapping.BoolData = GetSelectPressedWorkaround(interactionSourceState);
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionMapping.BoolData)
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                if (interactionMapping.BoolData)
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                                else
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                            }
+                            break;
                         }
-                        else
+                    case DeviceInputType.Trigger:
                         {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                    }
-                    break;
-                }
-                case DeviceInputType.Trigger:
-                {
-                    // Update the interaction data source
-                    interactionMapping.FloatData = interactionSourceState.selectPressedAmount;
+                            // Update the interaction data source
+                            interactionMapping.FloatData = interactionSourceState.selectPressedAmount;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        CoreServices.InputSystem?.RaiseFloatInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.selectPressedAmount);
-                    }
-                    break;
-                }
-                case DeviceInputType.TriggerTouch:
-                {
-                    // Update the interaction data source
-                    interactionMapping.BoolData = interactionSourceState.selectPressedAmount > 0;
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                CoreServices.InputSystem?.RaiseFloatInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.selectPressedAmount);
+                            }
+                            break;
+                        }
+                    case DeviceInputType.TriggerTouch:
+                        {
+                            // Update the interaction data source
+                            interactionMapping.BoolData = interactionSourceState.selectPressedAmount > 0;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionSourceState.selectPressedAmount > 0)
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                if (interactionSourceState.selectPressedAmount > 0)
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                                else
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                            }
+                            break;
                         }
-                        else
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                    }
-                    break;
                 }
             }
-
-            Profiler.EndSample(); // UpdateTriggerData
         }
 
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/BaseWindowsMixedRealitySource.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #region Update data functions
 
-        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateContoller");
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] BaseWindowsMixedRealitySource.UpdateController");
 
         /// <summary>
         /// Update the source data from the provided platform state.

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -7,7 +7,7 @@ using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System.Collections.Generic;
 
 #if UNITY_WSA
-using UnityEngine.Profiling;
+using Unity.Profiling;
 using UnityEngine.XR.WSA.Input;
 #if WINDOWS_UWP || DOTNETWINRT_PRESENT
 using System;
@@ -90,29 +90,32 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #region Update data functions
 
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHand.UpdateController");
+
         /// <inheritdoc />
         public override void UpdateController(InteractionSourceState interactionSourceState)
         {
-            if (!Enabled) { return; }
-
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityArticulatedHand.UpdateController");
-
-            base.UpdateController(interactionSourceState);
-
-            UpdateHandData(interactionSourceState);
-
-            for (int i = 0; i < Interactions?.Length; i++)
+            using (UpdateControllerPerfMarker.Auto())
             {
-                switch (Interactions[i].InputType)
+                if (!Enabled) { return; }
+
+                base.UpdateController(interactionSourceState);
+
+                UpdateHandData(interactionSourceState);
+
+                for (int i = 0; i < Interactions?.Length; i++)
                 {
-                    case DeviceInputType.IndexFinger:
-                        handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
-                        break;
+                    switch (Interactions[i].InputType)
+                    {
+                        case DeviceInputType.IndexFinger:
+                            handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
+                            break;
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateController
         }
+
+        private static readonly ProfilerMarker UpdateHandDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHand.UpdateHandData");
 
         /// <summary>
         /// Update the hand data from the device.
@@ -121,57 +124,56 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private void UpdateHandData(InteractionSourceState interactionSourceState)
         {
 #if WINDOWS_UWP || DOTNETWINRT_PRESENT
-            // Articulated hand support is only present in the 18362 version and beyond Windows
-            // SDK (which contains the V8 drop of the Universal API Contract). In particular,
-            // the HandPose related APIs are only present on this version and above.
-            if (!articulatedHandApiAvailable)
+            using (UpdateHandDataPerfMarker.Auto())
             {
-                return;
-            }
-
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityArticulatedHand.UpdateHandData");
-
-            PerceptionTimestamp perceptionTimestamp = PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now);
-            IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(perceptionTimestamp);
-            foreach (SpatialInteractionSourceState sourceState in sources)
-            {
-                if (sourceState.Source.Id.Equals(interactionSourceState.source.id))
+                // Articulated hand support is only present in the 18362 version and beyond Windows
+                // SDK (which contains the V8 drop of the Universal API Contract). In particular,
+                // the HandPose related APIs are only present on this version and above.
+                if (!articulatedHandApiAvailable)
                 {
+                    return;
+                }
+
+                PerceptionTimestamp perceptionTimestamp = PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now);
+                IReadOnlyList<SpatialInteractionSourceState> sources = SpatialInteractionManager?.GetDetectedSourcesAtTimestamp(perceptionTimestamp);
+                foreach (SpatialInteractionSourceState sourceState in sources)
+                {
+                    if (sourceState.Source.Id.Equals(interactionSourceState.source.id))
+                    {
 #if WINDOWS_UWP
-                    handDefinition?.UpdateHandMesh(sourceState);
+                        handDefinition?.UpdateHandMesh(sourceState);
 #endif // WINDOWS_UWP
 
-                    HandPose handPose = sourceState.TryGetHandPose();
+                        HandPose handPose = sourceState.TryGetHandPose();
 
-                    if (handPose != null && handPose.TryGetJoints(WindowsMixedRealityUtilities.SpatialCoordinateSystem, jointIndices, jointPoses))
-                    {
-                        for (int i = 0; i < jointPoses.Length; i++)
+                        if (handPose != null && handPose.TryGetJoints(WindowsMixedRealityUtilities.SpatialCoordinateSystem, jointIndices, jointPoses))
                         {
-                            Vector3 jointPosition = jointPoses[i].Position.ToUnityVector3();
-                            Quaternion jointOrientation = jointPoses[i].Orientation.ToUnityQuaternion();
-
-                            // We want the joints to follow the playspace, so fold in the playspace transform here to 
-                            // put the joint pose into world space.
-                            jointPosition = MixedRealityPlayspace.TransformPoint(jointPosition);
-                            jointOrientation = MixedRealityPlayspace.Rotation * jointOrientation;
-
-                            TrackedHandJoint handJoint = ConvertHandJointKindToTrackedHandJoint(jointIndices[i]);
-
-                            if (handJoint == TrackedHandJoint.IndexTip)
+                            for (int i = 0; i < jointPoses.Length; i++)
                             {
-                                lastIndexTipRadius = jointPoses[i].Radius;
+                                Vector3 jointPosition = jointPoses[i].Position.ToUnityVector3();
+                                Quaternion jointOrientation = jointPoses[i].Orientation.ToUnityQuaternion();
+
+                                // We want the joints to follow the playspace, so fold in the playspace transform here to 
+                                // put the joint pose into world space.
+                                jointPosition = MixedRealityPlayspace.TransformPoint(jointPosition);
+                                jointOrientation = MixedRealityPlayspace.Rotation * jointOrientation;
+
+                                TrackedHandJoint handJoint = ConvertHandJointKindToTrackedHandJoint(jointIndices[i]);
+
+                                if (handJoint == TrackedHandJoint.IndexTip)
+                                {
+                                    lastIndexTipRadius = jointPoses[i].Radius;
+                                }
+
+                                unityJointPoses[handJoint] = new MixedRealityPose(jointPosition, jointOrientation);
                             }
 
-                            unityJointPoses[handJoint] = new MixedRealityPose(jointPosition, jointOrientation);
+                            handDefinition?.UpdateHandJoints(unityJointPoses);
                         }
-
-                        handDefinition?.UpdateHandJoints(unityJointPoses);
+                        break;
                     }
-                    break;
                 }
             }
-
-            Profiler.EndSample(); // UpdateHandData
 #endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
         }
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -115,7 +115,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
         }
 
+#if WINDOWS_UWP || DOTNETWINRT_PRESENT
         private static readonly ProfilerMarker UpdateHandDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHand.UpdateHandData");
+#endif // WINDOWS_UWP || DOTNETWINRT_PRESENT
 
         /// <summary>
         /// Update the hand data from the device.

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -9,8 +9,8 @@ using System;
 #if UNITY_WSA
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UnityEngine.XR.WSA.Input;
 #endif
 
@@ -66,41 +66,44 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         #region Update data functions
 
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityController.UpdateController");
+
         /// <summary>
         /// Update the controller data from the provided platform state.
         /// </summary>
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform</param>
         public override void UpdateController(InteractionSourceState interactionSourceState)
         {
-            if (!Enabled) { return; }
-
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityController.UpdateContoller");
-
-            base.UpdateController(interactionSourceState);
-
-            for (int i = 0; i < Interactions?.Length; i++)
+            using (UpdateControllerPerfMarker.Auto())
             {
-                switch (Interactions[i].InputType)
+                if (!Enabled) { return; }
+
+                base.UpdateController(interactionSourceState);
+
+                for (int i = 0; i < Interactions?.Length; i++)
                 {
-                    case DeviceInputType.None:
-                        break;
-                    case DeviceInputType.ThumbStick:
-                    case DeviceInputType.ThumbStickPress:
-                        UpdateThumbstickData(interactionSourceState, Interactions[i]);
-                        break;
-                    case DeviceInputType.Touchpad:
-                    case DeviceInputType.TouchpadTouch:
-                    case DeviceInputType.TouchpadPress:
-                        UpdateTouchpadData(interactionSourceState, Interactions[i]);
-                        break;
-                    case DeviceInputType.Menu:
-                        UpdateMenuData(interactionSourceState, Interactions[i]);
-                        break;
+                    switch (Interactions[i].InputType)
+                    {
+                        case DeviceInputType.None:
+                            break;
+                        case DeviceInputType.ThumbStick:
+                        case DeviceInputType.ThumbStickPress:
+                            UpdateThumbstickData(interactionSourceState, Interactions[i]);
+                            break;
+                        case DeviceInputType.Touchpad:
+                        case DeviceInputType.TouchpadTouch:
+                        case DeviceInputType.TouchpadPress:
+                            UpdateTouchpadData(interactionSourceState, Interactions[i]);
+                            break;
+                        case DeviceInputType.Menu:
+                            UpdateMenuData(interactionSourceState, Interactions[i]);
+                            break;
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateController
         }
+
+        private static readonly ProfilerMarker UpdateTouchpadDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityController.UpdateTouchpadData");
 
         /// <summary>
         /// Update the touchpad input from the device.
@@ -108,67 +111,68 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateTouchpadData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityController.UpdateTouchpadData");
-
-            switch (interactionMapping.InputType)
+            using (UpdateTouchpadDataPerfMarker.Auto())
             {
-                case DeviceInputType.TouchpadTouch:
+                switch (interactionMapping.InputType)
                 {
-                    // Update the interaction data source
-                    interactionMapping.BoolData = interactionSourceState.touchpadTouched;
+                    case DeviceInputType.TouchpadTouch:
+                        {
+                            // Update the interaction data source
+                            interactionMapping.BoolData = interactionSourceState.touchpadTouched;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionSourceState.touchpadTouched)
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                if (interactionSourceState.touchpadTouched)
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                                else
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                            }
+                            break;
                         }
-                        else
+                    case DeviceInputType.TouchpadPress:
                         {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                    }
-                    break;
-                }
-                case DeviceInputType.TouchpadPress:
-                {
-                    // Update the interaction data source
-                    interactionMapping.BoolData = interactionSourceState.touchpadPressed;
+                            // Update the interaction data source
+                            interactionMapping.BoolData = interactionSourceState.touchpadPressed;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionSourceState.touchpadPressed)
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                if (interactionSourceState.touchpadPressed)
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                                else
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                            }
+                            break;
                         }
-                        else
+                    case DeviceInputType.Touchpad:
                         {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                    }
-                    break;
-                }
-                case DeviceInputType.Touchpad:
-                {
-                    // Update the interaction data source
-                    interactionMapping.Vector2Data = interactionSourceState.touchpadPosition;
+                            // Update the interaction data source
+                            interactionMapping.Vector2Data = interactionSourceState.touchpadPosition;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.touchpadPosition);
-                    }
-                    break;
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.touchpadPosition);
+                            }
+                            break;
+                        }
                 }
             }
-
-            Profiler.EndSample(); // UpdateTouchpadData
         }
+
+        private static readonly ProfilerMarker UpdateThumbstickDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityController.UpdateThumbstickData");
 
         /// <summary>
         /// Update the thumbstick input from the device.
@@ -176,47 +180,48 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateThumbstickData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityController.UpdateThumbstickData");
-
-            switch (interactionMapping.InputType)
+            using (UpdateThumbstickDataPerfMarker.Auto())
             {
-                case DeviceInputType.ThumbStickPress:
+                switch (interactionMapping.InputType)
                 {
-                    // Update the interaction data source
-                    interactionMapping.BoolData = interactionSourceState.thumbstickPressed;
-
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionSourceState.thumbstickPressed)
+                    case DeviceInputType.ThumbStickPress:
                         {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                        else
-                        {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                        }
-                    }
-                    break;
-                }
-                case DeviceInputType.ThumbStick:
-                {
-                    // Update the interaction data source
-                    interactionMapping.Vector2Data = interactionSourceState.thumbstickPosition;
+                            // Update the interaction data source
+                            interactionMapping.BoolData = interactionSourceState.thumbstickPressed;
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.thumbstickPosition);
-                    }
-                    break;
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                if (interactionSourceState.thumbstickPressed)
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                                else
+                                {
+                                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                                }
+                            }
+                            break;
+                        }
+                    case DeviceInputType.ThumbStick:
+                        {
+                            // Update the interaction data source
+                            interactionMapping.Vector2Data = interactionSourceState.thumbstickPosition;
+
+                            // If our value changed raise it.
+                            if (interactionMapping.Changed)
+                            {
+                                // Raise input system event if it's enabled
+                                CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionSourceState.thumbstickPosition);
+                            }
+                            break;
+                        }
                 }
             }
-
-            Profiler.EndSample(); // UpdateTouchpadData
         }
+
+        private static readonly ProfilerMarker UpdateMenuDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityController.UpdateMenuData");
 
         /// <summary>
         /// Update the menu button state.
@@ -224,26 +229,25 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateMenuData(InteractionSourceState interactionSourceState, MixedRealityInteractionMapping interactionMapping)
         {
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityController.UpdateMenuData");
-
-            // Update the interaction data source
-            interactionMapping.BoolData = interactionSourceState.menuPressed;
-
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
+            using (UpdateMenuDataPerfMarker.Auto())
             {
-                // Raise input system event if it's enabled
-                if (interactionSourceState.menuPressed)
+                // Update the interaction data source
+                interactionMapping.BoolData = interactionSourceState.menuPressed;
+
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
                 {
-                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
-                }
-                else
-                {
-                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    // Raise input system event if it's enabled
+                    if (interactionSourceState.menuPressed)
+                    {
+                        CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    }
+                    else
+                    {
+                        CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateMenuData
         }
 
         #endregion Update data functions

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -74,10 +74,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform</param>
         public override void UpdateController(InteractionSourceState interactionSourceState)
         {
+            if (!Enabled) { return; }
+
             using (UpdateControllerPerfMarker.Auto())
             {
-                if (!Enabled) { return; }
-
                 base.UpdateController(interactionSourceState);
 
                 for (int i = 0; i < Interactions?.Length; i++)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Windows.Utilities;
 using System;
 using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
 
 #if WINDOWS_UWP
@@ -119,7 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             Toolkit.Utilities.Editor.UWPCapabilityUtility.RequireCapability(
                     UnityEditor.PlayerSettings.WSACapability.GazeInput,
                     this.GetType());
-#endif
+#endif // UNITY_EDITOR && UNITY_WSA && UNITY_2019_3_OR_NEWER
 
             if (Application.isPlaying && eyesApiAvailable)
             {
@@ -130,33 +131,40 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
         }
 
+#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityEyeGazeDataProvider.Update");
+#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
+
         /// <inheritdoc />
         public override void Update()
         {
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-            if (WindowsMixedRealityUtilities.SpatialCoordinateSystem == null || !eyesApiAvailable)
+            using (UpdatePerfMarker.Auto())
             {
-                return;
-            }
-
-            SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(WindowsMixedRealityUtilities.SpatialCoordinateSystem, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-            if (pointerPose != null)
-            {
-                var eyes = pointerPose.Eyes;
-                if (eyes != null)
+                if (WindowsMixedRealityUtilities.SpatialCoordinateSystem == null || !eyesApiAvailable)
                 {
-                    Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
+                    return;
+                }
 
-                    if (eyes.Gaze.HasValue)
+                SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(WindowsMixedRealityUtilities.SpatialCoordinateSystem, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
+                if (pointerPose != null)
+                {
+                    var eyes = pointerPose.Eyes;
+                    if (eyes != null)
                     {
-                        Ray newGaze = new Ray(eyes.Gaze.Value.Origin.ToUnityVector3(), eyes.Gaze.Value.Direction.ToUnityVector3());
+                        Service?.EyeGazeProvider?.UpdateEyeTrackingStatus(this, eyes.IsCalibrationValid);
 
-                        if (SmoothEyeTracking)
+                        if (eyes.Gaze.HasValue)
                         {
-                            newGaze = SmoothGaze(newGaze);
-                        }
+                            Ray newGaze = new Ray(eyes.Gaze.Value.Origin.ToUnityVector3(), eyes.Gaze.Value.Direction.ToUnityVector3());
 
-                        Service?.EyeGazeProvider?.UpdateEyeGaze(this, newGaze, eyes.UpdateTimestamp.TargetTime.UtcDateTime);
+                            if (SmoothEyeTracking)
+                            {
+                                newGaze = SmoothGaze(newGaze);
+                            }
+
+                            Service?.EyeGazeProvider?.UpdateEyeGaze(this, newGaze, eyes.UpdateTimestamp.TargetTime.UtcDateTime);
+                        }
                     }
                 }
             }
@@ -195,104 +203,114 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         }
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
+        private static readonly ProfilerMarker SmoothGazePerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityEyeGazeDataProvider.SmoothGaze");
+
         private Ray SmoothGaze(Ray? newGaze)
         {
-            if (!oldGaze.HasValue)
+            using (SmoothGazePerfMarker.Auto())
             {
-                oldGaze = newGaze;
-                return newGaze.Value;
-            }
-
-            Ray smoothedGaze = new Ray();
-            bool isSaccading = false;
-
-            // Handle saccades vs. outliers: Instead of simply checking that two successive gaze points are sufficiently 
-            // apart, we check for clusters of gaze points instead.
-            // 1. If the user's gaze points are far enough apart, this may be a saccade, but also could be an outlier.
-            //    So, let's mark it as a potential saccade.
-            if ((IsSaccading(oldGaze.Value, newGaze.Value) && (confidenceOfSaccade == 0)))
-            {
-                confidenceOfSaccade++;
-                saccade_initialGazePoint = oldGaze.Value;
-                saccade_newGazeCluster.Clear();
-                saccade_newGazeCluster.Add(newGaze.Value);
-            }
-            // 2. If we have a potential saccade marked, let's check if the new points are within the proximity of 
-            //    the initial saccade point.
-            else if ((confidenceOfSaccade > 0) && (confidenceOfSaccade < confidenceOfSaccadeThreshold))
-            {
-                confidenceOfSaccade++;
-
-                // First, let's check that we don't just have a bunch of random outliers
-                // The assumption is that after a person saccades, they fixate for a certain 
-                // amount of time resulting in a cluster of gaze points.
-                for (int i = 0; i < saccade_newGazeCluster.Count; i++)
+                if (!oldGaze.HasValue)
                 {
-                    if (IsSaccading(saccade_newGazeCluster[i], newGaze.Value))
-                    {
-                        confidenceOfSaccade = 0;
-                    }
-
-                    // Meanwhile we want to make sure that we are still looking sufficiently far away from our 
-                    // original gaze point before saccading.
-                    if (!IsSaccading(saccade_initialGazePoint, newGaze.Value))
-                    {
-                        confidenceOfSaccade = 0;
-                    }
+                    oldGaze = newGaze;
+                    return newGaze.Value;
                 }
-                saccade_newGazeCluster.Add(newGaze.Value);
-            }
-            else if (confidenceOfSaccade == confidenceOfSaccadeThreshold)
-            {
-                isSaccading = true;
-            }
 
-            Vector3 v1 = oldGaze.Value.origin + oldGaze.Value.direction;
-            Vector3 v2 = newGaze.Value.origin + newGaze.Value.direction;
+                Ray smoothedGaze = new Ray();
+                bool isSaccading = false;
 
-            // Saccade-dependent local smoothing
-            if (isSaccading)
-            {
-                smoothedGaze.direction = newGaze.Value.direction;
-                smoothedGaze.origin = newGaze.Value.origin;
-                confidenceOfSaccade = 0;
-            }
-            else
-            {
-                smoothedGaze.direction = oldGaze.Value.direction * smoothFactorNormalized + newGaze.Value.direction * (1 - smoothFactorNormalized);
-                smoothedGaze.origin = oldGaze.Value.origin * smoothFactorNormalized + newGaze.Value.origin * (1 - smoothFactorNormalized);
-            }
+                // Handle saccades vs. outliers: Instead of simply checking that two successive gaze points are sufficiently 
+                // apart, we check for clusters of gaze points instead.
+                // 1. If the user's gaze points are far enough apart, this may be a saccade, but also could be an outlier.
+                //    So, let's mark it as a potential saccade.
+                if ((IsSaccading(oldGaze.Value, newGaze.Value) && (confidenceOfSaccade == 0)))
+                {
+                    confidenceOfSaccade++;
+                    saccade_initialGazePoint = oldGaze.Value;
+                    saccade_newGazeCluster.Clear();
+                    saccade_newGazeCluster.Add(newGaze.Value);
+                }
+                // 2. If we have a potential saccade marked, let's check if the new points are within the proximity of 
+                //    the initial saccade point.
+                else if ((confidenceOfSaccade > 0) && (confidenceOfSaccade < confidenceOfSaccadeThreshold))
+                {
+                    confidenceOfSaccade++;
 
-            oldGaze = smoothedGaze;
-            return smoothedGaze;
+                    // First, let's check that we don't just have a bunch of random outliers
+                    // The assumption is that after a person saccades, they fixate for a certain 
+                    // amount of time resulting in a cluster of gaze points.
+                    for (int i = 0; i < saccade_newGazeCluster.Count; i++)
+                    {
+                        if (IsSaccading(saccade_newGazeCluster[i], newGaze.Value))
+                        {
+                            confidenceOfSaccade = 0;
+                        }
+
+                        // Meanwhile we want to make sure that we are still looking sufficiently far away from our 
+                        // original gaze point before saccading.
+                        if (!IsSaccading(saccade_initialGazePoint, newGaze.Value))
+                        {
+                            confidenceOfSaccade = 0;
+                        }
+                    }
+                    saccade_newGazeCluster.Add(newGaze.Value);
+                }
+                else if (confidenceOfSaccade == confidenceOfSaccadeThreshold)
+                {
+                    isSaccading = true;
+                }
+
+                Vector3 v1 = oldGaze.Value.origin + oldGaze.Value.direction;
+                Vector3 v2 = newGaze.Value.origin + newGaze.Value.direction;
+
+                // Saccade-dependent local smoothing
+                if (isSaccading)
+                {
+                    smoothedGaze.direction = newGaze.Value.direction;
+                    smoothedGaze.origin = newGaze.Value.origin;
+                    confidenceOfSaccade = 0;
+                }
+                else
+                {
+                    smoothedGaze.direction = oldGaze.Value.direction * smoothFactorNormalized + newGaze.Value.direction * (1 - smoothFactorNormalized);
+                    smoothedGaze.origin = oldGaze.Value.origin * smoothFactorNormalized + newGaze.Value.origin * (1 - smoothFactorNormalized);
+                }
+
+                oldGaze = smoothedGaze;
+                return smoothedGaze;
+            }
         }
+
+        private static readonly ProfilerMarker IsSaccadingPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityEyeGazeDataProvider.IsSaccading");
 
         private bool IsSaccading(Ray rayOld, Ray rayNew)
         {
-            Vector3 v1 = rayOld.origin + rayOld.direction;
-            Vector3 v2 = rayNew.origin + rayNew.direction;
-
-            if (Vector3.Angle(v1, v2) > saccadeThreshInDegree)
+            using (IsSaccadingPerfMarker.Auto())
             {
-                Vector2 hv1 = new Vector2(v1.x, 0);
-                Vector2 hv2 = new Vector2(v2.x, 0);
-                if (Vector2.Angle(hv1, hv2) > saccadeThreshInDegree)
+                Vector3 v1 = rayOld.origin + rayOld.direction;
+                Vector3 v2 = rayNew.origin + rayNew.direction;
+
+                if (Vector3.Angle(v1, v2) > saccadeThreshInDegree)
                 {
-                    Post_OnSaccadeHorizontally();
+                    Vector2 hv1 = new Vector2(v1.x, 0);
+                    Vector2 hv2 = new Vector2(v2.x, 0);
+                    if (Vector2.Angle(hv1, hv2) > saccadeThreshInDegree)
+                    {
+                        Post_OnSaccadeHorizontally();
+                    }
+
+                    Vector2 vv1 = new Vector2(0, v1.y);
+                    Vector2 vv2 = new Vector2(0, v2.y);
+                    if (Vector2.Angle(vv1, vv2) > saccadeThreshInDegree)
+                    {
+                        Post_OnSaccadeVertically();
+                    }
+
+                    Post_OnSaccade();
+
+                    return true;
                 }
-
-                Vector2 vv1 = new Vector2(0, v1.y);
-                Vector2 vv2 = new Vector2(0, v2.y);
-                if (Vector2.Angle(vv1, vv2) > saccadeThreshInDegree)
-                {
-                    Post_OnSaccadeVertically();
-                }
-
-                Post_OnSaccade();
-
-                return true;
+                return false;
             }
-            return false;
         }
 
         private void Post_OnSaccade()

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -6,8 +6,8 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.WindowsMixedReality;
 using System;
 using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UnityEngine.XR;
 
 #if WINDOWS_UWP
@@ -66,29 +66,32 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 
         #region Update data functions
 
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityXRSDKArticulatedHand.UpdateController");
+
         /// <inheritdoc />
         public override void UpdateController(InputDevice inputDevice)
         {
-            if (!Enabled) { return; }
-
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityXRSDKArticulatdHand.UpdateController");
-
-            base.UpdateController(inputDevice);
-
-            UpdateHandData(inputDevice);
-
-            for (int i = 0; i < Interactions?.Length; i++)
+            using (UpdateControllerPerfMarker.Auto())
             {
-                switch (Interactions[i].InputType)
+                if (!Enabled) { return; }
+
+                base.UpdateController(inputDevice);
+
+                UpdateHandData(inputDevice);
+
+                for (int i = 0; i < Interactions?.Length; i++)
                 {
-                    case DeviceInputType.IndexFinger:
-                        handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
-                        break;
+                    switch (Interactions[i].InputType)
+                    {
+                        case DeviceInputType.IndexFinger:
+                            handDefinition?.UpdateCurrentIndexPose(Interactions[i]);
+                            break;
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateController
         }
+
+        private static readonly ProfilerMarker UpdateHandDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityXRSDKArticulatedHand.UpdateHandData");
 
         /// <summary>
         /// Update the hand data from the device.
@@ -96,8 +99,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
         private void UpdateHandData(InputDevice inputDevice)
         {
-            Profiler.BeginSample("[MRTK] WindowsMixedRealityXRSDKArticulatdHand.UpdateHandData");
-
+            using (UpdateHandDataPerfMarker.Auto())
+            {
 #if WINDOWS_UWP && WMR_ENABLED
             XRSDKSubsystemHelpers.InputSubsystem?.GetCurrentSourceStates(states);
 
@@ -111,43 +114,42 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             }
 #endif // WINDOWS_UWP && WMR_ENABLED
 
-            Hand hand;
-            if (inputDevice.TryGetFeatureValue(CommonUsages.handData, out hand))
-            {
-                foreach (HandFinger finger in handFingers)
+                Hand hand;
+                if (inputDevice.TryGetFeatureValue(CommonUsages.handData, out hand))
                 {
-                    if (hand.TryGetFingerBones(finger, fingerBones))
+                    foreach (HandFinger finger in handFingers)
                     {
-                        for (int i = 0; i < fingerBones.Count; i++)
+                        if (hand.TryGetFingerBones(finger, fingerBones))
                         {
-                            TrackedHandJoint trackedHandJoint = ConvertToTrackedHandJoint(finger, i);
-                            Bone bone = fingerBones[i];
-
-                            Vector3 position = Vector3.zero;
-                            Quaternion rotation = Quaternion.identity;
-
-                            if (bone.TryGetPosition(out position) || bone.TryGetRotation(out rotation))
+                            for (int i = 0; i < fingerBones.Count; i++)
                             {
-                                // We want input sources to follow the playspace, so fold in the playspace transform here to
-                                // put the controller pose into world space.
-                                position = MixedRealityPlayspace.TransformPoint(position);
-                                rotation = MixedRealityPlayspace.Rotation * rotation;
+                                TrackedHandJoint trackedHandJoint = ConvertToTrackedHandJoint(finger, i);
+                                Bone bone = fingerBones[i];
 
-                                unityJointPoses[trackedHandJoint] = new MixedRealityPose(position, rotation);
+                                Vector3 position = Vector3.zero;
+                                Quaternion rotation = Quaternion.identity;
+
+                                if (bone.TryGetPosition(out position) || bone.TryGetRotation(out rotation))
+                                {
+                                    // We want input sources to follow the playspace, so fold in the playspace transform here to
+                                    // put the controller pose into world space.
+                                    position = MixedRealityPlayspace.TransformPoint(position);
+                                    rotation = MixedRealityPlayspace.Rotation * rotation;
+
+                                    unityJointPoses[trackedHandJoint] = new MixedRealityPose(position, rotation);
+                                }
                             }
+
+                            // Unity doesn't provide a palm joint, so we synthesize one here
+                            MixedRealityPose palmPose = CurrentControllerPose;
+                            palmPose.Rotation *= (ControllerHandedness == Handedness.Left ? leftPalmOffset : rightPalmOffset);
+                            unityJointPoses[TrackedHandJoint.Palm] = palmPose;
                         }
-
-                        // Unity doesn't provide a palm joint, so we synthesize one here
-                        MixedRealityPose palmPose = CurrentControllerPose;
-                        palmPose.Rotation *= (ControllerHandedness == Handedness.Left ? leftPalmOffset : rightPalmOffset);
-                        unityJointPoses[TrackedHandJoint.Palm] = palmPose;
                     }
+
+                    handDefinition?.UpdateHandJoints(unityJointPoses);
                 }
-
-                handDefinition?.UpdateHandJoints(unityJointPoses);
             }
-
-            Profiler.EndSample(); // UpdateHandData
         }
 
         /// <summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -71,10 +71,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         /// <inheritdoc />
         public override void UpdateController(InputDevice inputDevice)
         {
+            if (!Enabled) { return; }
+
             using (UpdateControllerPerfMarker.Auto())
             {
-                if (!Enabled) { return; }
-
                 base.UpdateController(inputDevice);
 
                 UpdateHandData(inputDevice);

--- a/Assets/MRTK/Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MRTK/Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -4,8 +4,8 @@
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Threading.Tasks;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
 using System.Text;
@@ -78,125 +78,122 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             await StopRecordingAsync();
         }
 
+        private static readonly ProfilerMarker StartRecordingAsyncPerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.StartRecordingAsync");
+
         /// <inheritdoc />
         public async Task StartRecordingAsync(GameObject listener = null, float initialSilenceTimeout = 5f, float autoSilenceTimeout = 20f, int recordingTime = 10, string micDeviceName = "")
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.StartRecordingAsync");
-
+            using (StartRecordingAsyncPerfMarker.Auto())
+            {
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
-            if (IsListening || isTransitioning || inputSystem == null || !Application.isPlaying)
-            {
-                Debug.LogWarning("Unable to start recording");
-                return;
-            }
+                if (IsListening || isTransitioning || inputSystem == null || !Application.isPlaying)
+                {
+                    Debug.LogWarning("Unable to start recording");
+                    return;
+                }
 
-            if (dictationRecognizer == null && InputSystemProfile.SpeechCommandsProfile.SpeechRecognizerStartBehavior == AutoStartBehavior.ManualStart)
-            {
-                InitializeDictationRecognizer();
-            }
+                if (dictationRecognizer == null && InputSystemProfile.SpeechCommandsProfile.SpeechRecognizerStartBehavior == AutoStartBehavior.ManualStart)
+                {
+                    InitializeDictationRecognizer();
+                }
 
-            hasFailed = false;
-            IsListening = true;
-            isTransitioning = true;
+                hasFailed = false;
+                IsListening = true;
+                isTransitioning = true;
 
-            if (listener != null)
-            {
-                hasListener = true;
-                inputSystem.PushModalInputHandler(listener);
-            }
+                if (listener != null)
+                {
+                    hasListener = true;
+                    inputSystem.PushModalInputHandler(listener);
+                }
 
-            if (PhraseRecognitionSystem.Status == SpeechSystemStatus.Running)
-            {
-                PhraseRecognitionSystem.Shutdown();
-            }
+                if (PhraseRecognitionSystem.Status == SpeechSystemStatus.Running)
+                {
+                    PhraseRecognitionSystem.Shutdown();
+                }
 
-            await waitUntilPhraseRecognitionSystemHasStopped;
-            Debug.Assert(PhraseRecognitionSystem.Status == SpeechSystemStatus.Stopped);
+                await waitUntilPhraseRecognitionSystemHasStopped;
+                Debug.Assert(PhraseRecognitionSystem.Status == SpeechSystemStatus.Stopped);
 
-            // Query the maximum frequency of the default microphone.
-            int minSamplingRate; // Not used.
-            deviceName = micDeviceName;
-            Microphone.GetDeviceCaps(deviceName, out minSamplingRate, out samplingRate);
+                // Query the maximum frequency of the default microphone.
+                int minSamplingRate; // Not used.
+                deviceName = micDeviceName;
+                Microphone.GetDeviceCaps(deviceName, out minSamplingRate, out samplingRate);
 
-            dictationRecognizer.InitialSilenceTimeoutSeconds = initialSilenceTimeout;
-            dictationRecognizer.AutoSilenceTimeoutSeconds = autoSilenceTimeout;
-            dictationRecognizer.Start();
+                dictationRecognizer.InitialSilenceTimeoutSeconds = initialSilenceTimeout;
+                dictationRecognizer.AutoSilenceTimeoutSeconds = autoSilenceTimeout;
+                dictationRecognizer.Start();
 
-            await waitUntilDictationRecognizerHasStarted;
-            Debug.Assert(dictationRecognizer.Status == SpeechSystemStatus.Running);
+                await waitUntilDictationRecognizerHasStarted;
+                Debug.Assert(dictationRecognizer.Status == SpeechSystemStatus.Running);
 
-            if (dictationRecognizer.Status == SpeechSystemStatus.Failed)
-            {
-                inputSystem.RaiseDictationError(inputSource, "Dictation recognizer failed to start!");
+                if (dictationRecognizer.Status == SpeechSystemStatus.Failed)
+                {
+                    inputSystem.RaiseDictationError(inputSource, "Dictation recognizer failed to start!");
+                    return;
+                }
 
-                Profiler.EndSample(); // StartRecordingAsync - failure
-                return;
-            }
-
-            // Start recording from the microphone.
-            dictationAudioClip = Microphone.Start(deviceName, false, recordingTime, samplingRate);
-            textSoFar = new StringBuilder();
-            isTransitioning = false;
+                // Start recording from the microphone.
+                dictationAudioClip = Microphone.Start(deviceName, false, recordingTime, samplingRate);
+                textSoFar = new StringBuilder();
+                isTransitioning = false;
 #else
-            await Task.CompletedTask;
+                await Task.CompletedTask;
 #endif
-            Profiler.EndSample(); // StartRecordingAsync
+            }
         }
+
+        private static readonly ProfilerMarker StopRecordingAsyncPerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.StopRecordingAsync");
 
         /// <inheritdoc />
         public async Task<AudioClip> StopRecordingAsync()
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.StopRecordingAsync");
-
-#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-            if (!IsListening || isTransitioning || !Application.isPlaying)
+            using (StopRecordingAsyncPerfMarker.Auto())
             {
-                Debug.LogWarning("Unable to stop recording");
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+                if (!IsListening || isTransitioning || !Application.isPlaying)
+                {
+                    Debug.LogWarning("Unable to stop recording");
+                    return null;
+                }
 
-                Profiler.EndSample(); // StopRecordingAsync - failure
+                IsListening = false;
+                isTransitioning = true;
+
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
+
+                if (hasListener)
+                {
+                    inputSystem?.PopModalInputHandler();
+                    hasListener = false;
+                }
+
+                Microphone.End(deviceName);
+
+                if (dictationRecognizer.Status == SpeechSystemStatus.Running)
+                {
+                    dictationRecognizer.Stop();
+                }
+
+                await waitUntilDictationRecognizerHasStopped;
+                Debug.Assert(dictationRecognizer.Status == SpeechSystemStatus.Stopped);
+
+                PhraseRecognitionSystem.Restart();
+
+                await waitUntilPhraseRecognitionSystemHasStarted;
+                Debug.Assert(PhraseRecognitionSystem.Status == SpeechSystemStatus.Running);
+
+                isTransitioning = false;
+
+                return dictationAudioClip;
+#else
+                await Task.CompletedTask;
 
                 return null;
-            }
-
-            IsListening = false;
-            isTransitioning = true;
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-            if (hasListener)
-            {
-                inputSystem?.PopModalInputHandler();
-                hasListener = false;
-            }
-
-            Microphone.End(deviceName);
-
-            if (dictationRecognizer.Status == SpeechSystemStatus.Running)
-            {
-                dictationRecognizer.Stop();
-            }
-
-            await waitUntilDictationRecognizerHasStopped;
-            Debug.Assert(dictationRecognizer.Status == SpeechSystemStatus.Stopped);
-
-            PhraseRecognitionSystem.Restart();
-
-            await waitUntilPhraseRecognitionSystemHasStarted;
-            Debug.Assert(PhraseRecognitionSystem.Status == SpeechSystemStatus.Running);
-
-            isTransitioning = false;
-
-            Profiler.EndSample(); // StopRecordingAsync
-
-            return dictationAudioClip;
-#else
-            await Task.CompletedTask;
-
-            Profiler.EndSample(); // StopRecordingAsync
-            return null;
 #endif
+            }
         }
 
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
@@ -295,28 +292,29 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             }
         }
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.Update");
+
         /// <inheritdoc />
         public override void Update()
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.Update");
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-            if (!Application.isPlaying || inputSystem == null || dictationRecognizer == null) { return; }
-
-            if (!isTransitioning && IsListening && !Microphone.IsRecording(deviceName) && dictationRecognizer.Status == SpeechSystemStatus.Running)
+            using (UpdatePerfMarker.Auto())
             {
-                // If the microphone stops as a result of timing out, make sure to manually stop the dictation recognizer.
-                StopRecording();
-            }
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
 
-            if (!hasFailed && dictationRecognizer.Status == SpeechSystemStatus.Failed)
-            {
-                hasFailed = true;
-                inputSystem.RaiseDictationError(inputSource, "Dictation recognizer has failed!");
-            }
+                if (!Application.isPlaying || inputSystem == null || dictationRecognizer == null) { return; }
 
-            Profiler.EndSample(); // Update
+                if (!isTransitioning && IsListening && !Microphone.IsRecording(deviceName) && dictationRecognizer.Status == SpeechSystemStatus.Running)
+                {
+                    // If the microphone stops as a result of timing out, make sure to manually stop the dictation recognizer.
+                    StopRecording();
+                }
+
+                if (!hasFailed && dictationRecognizer.Status == SpeechSystemStatus.Failed)
+                {
+                    hasFailed = true;
+                    inputSystem.RaiseDictationError(inputSource, "Dictation recognizer has failed!");
+                }
+            }
         }
 
         /// <inheritdoc />
@@ -342,22 +340,25 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             }
         }
 
+        private static readonly ProfilerMarker DictationHypothesisPerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationHypothesis");
+
         /// <summary>
         /// This event is fired while the user is talking. As the recognizer listens, it provides text of what it's heard so far.
         /// </summary>
         /// <param name="text">The currently hypothesized recognition.</param>
         private void DictationRecognizer_DictationHypothesis(string text)
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationHypothesis");
+            using (DictationHypothesisPerfMarker.Auto())
+            {
+                // We don't want to append to textSoFar yet, because the hypothesis may have changed on the next event.
+                dictationResult = $"{textSoFar} {text}...";
 
-            // We don't want to append to textSoFar yet, because the hypothesis may have changed on the next event.
-            dictationResult = $"{textSoFar} {text}...";
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-            inputSystem?.RaiseDictationHypothesis(inputSource, dictationResult);
-
-            Profiler.EndSample(); // DictationHypothesis
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
+                inputSystem?.RaiseDictationHypothesis(inputSource, dictationResult);
+            }
         }
+
+        private static readonly ProfilerMarker DictationResultPerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationResult");
 
         /// <summary>
         /// This event is fired after the user pauses, typically at the end of a sentence. The full recognized string is returned here.
@@ -366,17 +367,18 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="confidence">A representation of how confident (rejected, low, medium, high) the recognizer is of this recognition.</param>
         private void DictationRecognizer_DictationResult(string text, ConfidenceLevel confidence)
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationResult");
+            using (DictationResultPerfMarker.Auto())
+            {
+                textSoFar.Append($"{text}. ");
 
-            textSoFar.Append($"{text}. ");
+                dictationResult = textSoFar.ToString();
 
-            dictationResult = textSoFar.ToString();
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-            inputSystem?.RaiseDictationResult(inputSource, dictationResult);
-
-            Profiler.EndSample(); // DictationResult
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
+                inputSystem?.RaiseDictationResult(inputSource, dictationResult);
+            }
         }
+
+        private static readonly ProfilerMarker DictationCompletePerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationComplete");
 
         /// <summary>
         /// This event is fired when the recognizer stops, whether from StartRecording() being called, a timeout occurring, or some other error.
@@ -385,23 +387,24 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="cause">An enumerated reason for the session completing.</param>
         private void DictationRecognizer_DictationComplete(DictationCompletionCause cause)
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationComplete");
-
-            // If Timeout occurs, the user has been silent for too long.
-            if (cause == DictationCompletionCause.TimeoutExceeded)
+            using (DictationCompletePerfMarker.Auto())
             {
-                Microphone.End(deviceName);
+                // If Timeout occurs, the user has been silent for too long.
+                if (cause == DictationCompletionCause.TimeoutExceeded)
+                {
+                    Microphone.End(deviceName);
 
-                dictationResult = "Dictation has timed out. Please try again.";
+                    dictationResult = "Dictation has timed out. Please try again.";
+                }
+
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
+                inputSystem?.RaiseDictationComplete(inputSource, dictationResult, dictationAudioClip);
+                textSoFar = null;
+                dictationResult = string.Empty;
             }
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-            inputSystem?.RaiseDictationComplete(inputSource, dictationResult, dictationAudioClip);
-            textSoFar = null;
-            dictationResult = string.Empty;
-
-            Profiler.EndSample(); // DictationComplete
         }
+
+        private static readonly ProfilerMarker DictationErrorPerfMarker = new ProfilerMarker("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationError");
 
         /// <summary>
         /// This event is fired when an error occurs.
@@ -410,16 +413,15 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         /// <param name="hresult">The int representation of the hresult.</param>
         private void DictationRecognizer_DictationError(string error, int hresult)
         {
-            Profiler.BeginSample("[MRTK] WindowsDictationInputProvider.DictationRecognizer_DictationError");
+            using (DictationErrorPerfMarker.Auto())
+            {
+                dictationResult = $"{error}\nHRESULT: {hresult}";
 
-            dictationResult = $"{error}\nHRESULT: {hresult}";
-
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-            inputSystem?.RaiseDictationError(inputSource, dictationResult);
-            textSoFar = null;
-            dictationResult = string.Empty;
-
-            Profiler.EndSample(); // DictationError
+                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
+                inputSystem?.RaiseDictationError(inputSource, dictationResult);
+                textSoFar = null;
+                dictationResult = string.Empty;
+            }
         }
 #endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
     }

--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -3,8 +3,8 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
@@ -46,84 +46,87 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
+        private static readonly ProfilerMarker UpdateControllerPerfMarker = new ProfilerMarker("[MRTK] GenericXRSDKController.UpdateController");
+
         /// <summary>
         /// Update the controller data from XR SDK.
         /// </summary>
         public virtual void UpdateController(InputDevice inputDevice)
         {
-            if (!Enabled) { return; }
-
-            Profiler.BeginSample("[MRTK] GenericXRSDKController.UpdateController");
-
-            if (Interactions == null)
+            using (UpdateControllerPerfMarker.Auto())
             {
-                Debug.LogError($"No interaction configuration for {GetType().Name}");
-                Enabled = false;
-            }
+                if (!Enabled) { return; }
 
-            var lastState = TrackingState;
-            LastControllerPose = CurrentControllerPose;
-
-            // Check for position and rotation.
-            IsPositionAvailable = inputDevice.TryGetFeatureValue(CommonUsages.devicePosition, out CurrentControllerPosition);
-            IsPositionApproximate = false;
-
-            IsRotationAvailable = inputDevice.TryGetFeatureValue(CommonUsages.deviceRotation, out CurrentControllerRotation);
-
-            // Devices are considered tracked if we receive position OR rotation data from the sensors.
-            TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
-
-            CurrentControllerPosition = MixedRealityPlayspace.TransformPoint(CurrentControllerPosition);
-            CurrentControllerRotation = MixedRealityPlayspace.Rotation * CurrentControllerRotation;
-
-            CurrentControllerPose.Position = CurrentControllerPosition;
-            CurrentControllerPose.Rotation = CurrentControllerRotation;
-
-            // Raise input system events if it is enabled.
-            if (lastState != TrackingState)
-            {
-                CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
-            }
-
-            if (TrackingState == TrackingState.Tracked && LastControllerPose != CurrentControllerPose)
-            {
-                if (IsPositionAvailable && IsRotationAvailable)
+                if (Interactions == null)
                 {
-                    CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
+                    Debug.LogError($"No interaction configuration for {GetType().Name}");
+                    Enabled = false;
                 }
-                else if (IsPositionAvailable && !IsRotationAvailable)
+
+                var lastState = TrackingState;
+                LastControllerPose = CurrentControllerPose;
+
+                // Check for position and rotation.
+                IsPositionAvailable = inputDevice.TryGetFeatureValue(CommonUsages.devicePosition, out CurrentControllerPosition);
+                IsPositionApproximate = false;
+
+                IsRotationAvailable = inputDevice.TryGetFeatureValue(CommonUsages.deviceRotation, out CurrentControllerRotation);
+
+                // Devices are considered tracked if we receive position OR rotation data from the sensors.
+                TrackingState = (IsPositionAvailable || IsRotationAvailable) ? TrackingState.Tracked : TrackingState.NotTracked;
+
+                CurrentControllerPosition = MixedRealityPlayspace.TransformPoint(CurrentControllerPosition);
+                CurrentControllerRotation = MixedRealityPlayspace.Rotation * CurrentControllerRotation;
+
+                CurrentControllerPose.Position = CurrentControllerPosition;
+                CurrentControllerPose.Rotation = CurrentControllerRotation;
+
+                // Raise input system events if it is enabled.
+                if (lastState != TrackingState)
                 {
-                    CoreServices.InputSystem?.RaiseSourcePositionChanged(InputSource, this, CurrentControllerPosition);
+                    CoreServices.InputSystem?.RaiseSourceTrackingStateChanged(InputSource, this, TrackingState);
                 }
-                else if (!IsPositionAvailable && IsRotationAvailable)
+
+                if (TrackingState == TrackingState.Tracked && LastControllerPose != CurrentControllerPose)
                 {
-                    CoreServices.InputSystem?.RaiseSourceRotationChanged(InputSource, this, CurrentControllerRotation);
+                    if (IsPositionAvailable && IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourcePoseChanged(InputSource, this, CurrentControllerPose);
+                    }
+                    else if (IsPositionAvailable && !IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourcePositionChanged(InputSource, this, CurrentControllerPosition);
+                    }
+                    else if (!IsPositionAvailable && IsRotationAvailable)
+                    {
+                        CoreServices.InputSystem?.RaiseSourceRotationChanged(InputSource, this, CurrentControllerRotation);
+                    }
+                }
+
+                for (int i = 0; i < Interactions?.Length; i++)
+                {
+                    switch (Interactions[i].AxisType)
+                    {
+                        case AxisType.None:
+                            break;
+                        case AxisType.Digital:
+                            UpdateButtonData(Interactions[i], inputDevice);
+                            break;
+                        case AxisType.SingleAxis:
+                            UpdateSingleAxisData(Interactions[i], inputDevice);
+                            break;
+                        case AxisType.DualAxis:
+                            UpdateDualAxisData(Interactions[i], inputDevice);
+                            break;
+                        case AxisType.SixDof:
+                            UpdatePoseData(Interactions[i], inputDevice);
+                            break;
+                    }
                 }
             }
-
-            for (int i = 0; i < Interactions?.Length; i++)
-            {
-                switch (Interactions[i].AxisType)
-                {
-                    case AxisType.None:
-                        break;
-                    case AxisType.Digital:
-                        UpdateButtonData(Interactions[i], inputDevice);
-                        break;
-                    case AxisType.SingleAxis:
-                        UpdateSingleAxisData(Interactions[i], inputDevice);
-                        break;
-                    case AxisType.DualAxis:
-                        UpdateDualAxisData(Interactions[i], inputDevice);
-                        break;
-                    case AxisType.SixDof:
-                        UpdatePoseData(Interactions[i], inputDevice);
-                        break;
-                }
-            }
-
-            Profiler.EndSample(); // UpdateController
         }
+
+        private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] GenericXRSDKController.UpdateButtonData");
 
         /// <summary>
         /// Update an interaction bool data type from a bool input
@@ -133,64 +136,65 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </remarks>
         protected virtual void UpdateButtonData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
         {
-            Profiler.BeginSample("[MRTK] GenericXRSDKController.UpdateButtonDatafs");
-
-            Debug.Assert(interactionMapping.AxisType == AxisType.Digital);
-
-            if (interactionMapping.InputType == DeviceInputType.TriggerTouch
-                && inputDevice.TryGetFeatureValue(CommonUsages.trigger, out float triggerData))
+            using (UpdateButtonDataPerfMarker.Auto())
             {
-                interactionMapping.BoolData = !Mathf.Approximately(triggerData, 0.0f);
-            }
-            else
-            {
-                InputFeatureUsage<bool> buttonUsage;
+                Debug.Assert(interactionMapping.AxisType == AxisType.Digital);
 
-                // Update the interaction data source
-                switch (interactionMapping.InputType)
+                if (interactionMapping.InputType == DeviceInputType.TriggerTouch
+                    && inputDevice.TryGetFeatureValue(CommonUsages.trigger, out float triggerData))
                 {
-                    case DeviceInputType.Select:
-                        buttonUsage = CommonUsages.triggerButton;
-                        break;
-                    case DeviceInputType.TouchpadTouch:
-                        buttonUsage = CommonUsages.primary2DAxisTouch;
-                        break;
-                    case DeviceInputType.TouchpadPress:
-                        buttonUsage = CommonUsages.primary2DAxisClick;
-                        break;
-                    case DeviceInputType.Menu:
-                        buttonUsage = CommonUsages.menuButton;
-                        break;
-                    case DeviceInputType.ThumbStickPress:
-                        buttonUsage = CommonUsages.secondary2DAxisClick;
-                        break;
-                    default:
-                        Profiler.EndSample(); // UpdateButtonData - non button
-                        return;
-                }
-
-                if (inputDevice.TryGetFeatureValue(buttonUsage, out bool buttonPressed))
-                {
-                    interactionMapping.BoolData = buttonPressed;
-                }
-            }
-
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
-            {
-                // Raise input system event if it's enabled
-                if (interactionMapping.BoolData)
-                {
-                    CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    interactionMapping.BoolData = !Mathf.Approximately(triggerData, 0.0f);
                 }
                 else
                 {
-                    CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    InputFeatureUsage<bool> buttonUsage;
+
+                    // Update the interaction data source
+                    switch (interactionMapping.InputType)
+                    {
+                        case DeviceInputType.Select:
+                            buttonUsage = CommonUsages.triggerButton;
+                            break;
+                        case DeviceInputType.TouchpadTouch:
+                            buttonUsage = CommonUsages.primary2DAxisTouch;
+                            break;
+                        case DeviceInputType.TouchpadPress:
+                            buttonUsage = CommonUsages.primary2DAxisClick;
+                            break;
+                        case DeviceInputType.Menu:
+                            buttonUsage = CommonUsages.menuButton;
+                            break;
+                        case DeviceInputType.ThumbStickPress:
+                            buttonUsage = CommonUsages.secondary2DAxisClick;
+                            break;
+                        default:
+                            Profiler.EndSample(); // UpdateButtonData - non button
+                            return;
+                    }
+
+                    if (inputDevice.TryGetFeatureValue(buttonUsage, out bool buttonPressed))
+                    {
+                        interactionMapping.BoolData = buttonPressed;
+                    }
+                }
+
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    if (interactionMapping.BoolData)
+                    {
+                        CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    }
+                    else
+                    {
+                        CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    }
                 }
             }
-
-            Profiler.EndSample(); // UpdateButtonData
         }
+
+        private static readonly ProfilerMarker UpdateSingleAxisDataPerfMarker = new ProfilerMarker("[MRTK] GenericXRSDKController.UpdateSingleAxisData");
 
         /// <summary>
         /// Update an interaction float data type from a SingleAxis (float) input
@@ -200,125 +204,126 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
         /// </remarks>
         protected virtual void UpdateSingleAxisData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
         {
-            Profiler.BeginSample("[MRTK] GenericXRSDKController.UpdateSingleAxisData");
-
-            Debug.Assert(interactionMapping.AxisType == AxisType.SingleAxis);
-
-            // Update the interaction data source
-            switch (interactionMapping.InputType)
+            using (UpdateSingleAxisDataPerfMarker.Auto())
             {
-                case DeviceInputType.TriggerPress:
-                    if (inputDevice.TryGetFeatureValue(CommonUsages.gripButton, out bool buttonPressed))
-                    {
-                        interactionMapping.BoolData = buttonPressed;
-                    }
+                Debug.Assert(interactionMapping.AxisType == AxisType.SingleAxis);
 
-                    // If our bool value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        if (interactionMapping.BoolData)
+                // Update the interaction data source
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.TriggerPress:
+                        if (inputDevice.TryGetFeatureValue(CommonUsages.gripButton, out bool buttonPressed))
                         {
-                            CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            interactionMapping.BoolData = buttonPressed;
                         }
-                        else
+
+                        // If our bool value changed raise it.
+                        if (interactionMapping.Changed)
                         {
-                            CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            // Raise input system event if it's enabled
+                            if (interactionMapping.BoolData)
+                            {
+                                CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            }
+                            else
+                            {
+                                CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                            }
                         }
-                    }
 
-                    if (inputDevice.TryGetFeatureValue(CommonUsages.grip, out float buttonData))
-                    {
-                        interactionMapping.FloatData = buttonData;
-                    }
-                    break;
-                case DeviceInputType.Trigger:
-                    if (inputDevice.TryGetFeatureValue(CommonUsages.trigger, out float triggerData))
-                    {
-                        interactionMapping.FloatData = triggerData;
-                    }
-                    break;
-                default:
-                    Profiler.EndSample(); // UpdateSingleAxisData - non single axis
-                    return;
+                        if (inputDevice.TryGetFeatureValue(CommonUsages.grip, out float buttonData))
+                        {
+                            interactionMapping.FloatData = buttonData;
+                        }
+                        break;
+                    case DeviceInputType.Trigger:
+                        if (inputDevice.TryGetFeatureValue(CommonUsages.trigger, out float triggerData))
+                        {
+                            interactionMapping.FloatData = triggerData;
+                        }
+                        break;
+                    default:
+                        Profiler.EndSample(); // UpdateSingleAxisData - non single axis
+                        return;
+                }
+
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    CoreServices.InputSystem?.RaiseFloatInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.FloatData);
+                }
             }
-
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
-            {
-                // Raise input system event if it's enabled
-                CoreServices.InputSystem?.RaiseFloatInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.FloatData);
-            }
-
-            Profiler.EndSample(); // UpdateSingleAxisData
         }
+
+        private static readonly ProfilerMarker UpdateDualAxisDataPerfMarker = new ProfilerMarker("[MRTK] GenericXRSDKController.UpdateDualAxisData");
 
         /// <summary>
         /// Update the touchpad / thumbstick input from the device
         /// </summary>
         protected virtual void UpdateDualAxisData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
         {
-            Profiler.BeginSample("[MRTK] GenericXRSDKController.UpdateDualAxisData");
-
-            Debug.Assert(interactionMapping.AxisType == AxisType.DualAxis);
-
-            InputFeatureUsage<Vector2> axisUsage;
-
-            // Update the interaction data source
-            switch (interactionMapping.InputType)
+            using (UpdateDualAxisDataPerfMarker.Auto())
             {
-                case DeviceInputType.ThumbStick:
-                    axisUsage = CommonUsages.secondary2DAxis;
-                    break;
-                case DeviceInputType.Touchpad:
-                    axisUsage = CommonUsages.primary2DAxis;
-                    break;
-                default:
-                    Profiler.EndSample(); // UpdateDualAxisData - non dual axis
-                    return;
-            }
+                Debug.Assert(interactionMapping.AxisType == AxisType.DualAxis);
 
-            if (inputDevice.TryGetFeatureValue(axisUsage, out Vector2 axisData))
-            {
+                InputFeatureUsage<Vector2> axisUsage;
+
                 // Update the interaction data source
-                interactionMapping.Vector2Data = axisData;
-            }
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.ThumbStick:
+                        axisUsage = CommonUsages.secondary2DAxis;
+                        break;
+                    case DeviceInputType.Touchpad:
+                        axisUsage = CommonUsages.primary2DAxis;
+                        break;
+                    default:
+                        Profiler.EndSample(); // UpdateDualAxisData - non dual axis
+                        return;
+                }
 
-            // If our value changed raise it.
-            if (interactionMapping.Changed)
-            {
-                // Raise input system event if it's enabled
-                CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.Vector2Data);
-            }
+                if (inputDevice.TryGetFeatureValue(axisUsage, out Vector2 axisData))
+                {
+                    // Update the interaction data source
+                    interactionMapping.Vector2Data = axisData;
+                }
 
-            Profiler.EndSample(); // UpdateDualAxisData
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.Vector2Data);
+                }
+            }
         }
+
+        private static readonly ProfilerMarker UpdatePoseDataPerfMarker = new ProfilerMarker("[MRTK] GenericXRSDKController.UpdatePoseData");
 
         /// <summary>
         /// Update spatial grip data.
         /// </summary>
         protected virtual void UpdatePoseData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
         {
-            Profiler.BeginSample("[MRTK] GenericXRSDKController.UpdatePoseData");
-
-            Debug.Assert(interactionMapping.AxisType == AxisType.SixDof);
-
-            // Update the interaction data source
-            switch (interactionMapping.InputType)
+            using (UpdatePoseDataPerfMarker.Auto())
             {
-                case DeviceInputType.SpatialGrip:
-                    interactionMapping.PoseData = CurrentControllerPose;
+                Debug.Assert(interactionMapping.AxisType == AxisType.SixDof);
 
-                    // If our value changed raise it.
-                    if (interactionMapping.Changed)
-                    {
-                        // Raise input system event if it's enabled
-                        CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.PoseData);
-                    }
-                    break;
+                // Update the interaction data source
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.SpatialGrip:
+                        interactionMapping.PoseData = CurrentControllerPose;
+
+                        // If our value changed raise it.
+                        if (interactionMapping.Changed)
+                        {
+                            // Raise input system event if it's enabled
+                            CoreServices.InputSystem?.RaisePoseInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.PoseData);
+                        }
+                        break;
+                }
             }
-
-            Profiler.EndSample(); // UpdatePoseData
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Physics;
 using System.Collections;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -61,6 +62,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private bool isCursorInstantiatedFromPrefab = false;
 
+        private static readonly ProfilerMarker SetCursorPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.SetCursor");
+
         /// <summary>
         /// Set a new cursor for this <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer"/>
         /// </summary>
@@ -68,11 +71,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="newCursor">The new cursor</param>
         public virtual void SetCursor(GameObject newCursor = null)
         {
-            if (cursorInstance != null)
-            {
-                DestroyCursorInstance();
-                cursorInstance = newCursor;
-            }
+            using (SetCursorPerfMarker.Auto())
+            { 
+                if (cursorInstance != null)
+                {
+                    DestroyCursorInstance();
+                    cursorInstance = newCursor;
+                }
 
             if (cursorInstance == null && cursorPrefab != null)
             {
@@ -80,38 +85,39 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 isCursorInstantiatedFromPrefab = true;
             }
 
-            if (cursorInstance != null)
-            {
-                cursorInstance.name = $"{Handedness}_{name}_Cursor";
-
-                BaseCursor oldC = BaseCursor as BaseCursor;
-                if (oldC != null && enabled)
+                if (cursorInstance != null)
                 {
-                    oldC.VisibleSourcesCount--;
-                }
+                    cursorInstance.name = $"{Handedness}_{name}_Cursor";
 
-                BaseCursor = cursorInstance.GetComponent<IMixedRealityCursor>();
-
-                BaseCursor newC = BaseCursor as BaseCursor;
-                if (newC != null && enabled)
-                {
-                    newC.VisibleSourcesCount++;
-                }
-
-                if (BaseCursor != null)
-                {
-                    BaseCursor.DefaultCursorDistance = DefaultPointerExtent;
-                    BaseCursor.Pointer = this;
-                    BaseCursor.SetVisibilityOnSourceDetected = setCursorVisibilityOnSourceDetected;
-
-                    if (disableCursorOnStart)
+                    BaseCursor oldC = BaseCursor as BaseCursor;
+                    if (oldC != null && enabled)
                     {
-                        BaseCursor.SetVisibility(false);
+                        oldC.VisibleSourcesCount--;
                     }
-                }
-                else
-                {
-                    Debug.LogError($"No IMixedRealityCursor component found on {cursorInstance.name}");
+
+                    BaseCursor = cursorInstance.GetComponent<IMixedRealityCursor>();
+
+                    BaseCursor newC = BaseCursor as BaseCursor;
+                    if (newC != null && enabled)
+                    {
+                        newC.VisibleSourcesCount++;
+                    }
+
+                    if (BaseCursor != null)
+                    {
+                        BaseCursor.DefaultCursorDistance = DefaultPointerExtent;
+                        BaseCursor.Pointer = this;
+                        BaseCursor.SetVisibilityOnSourceDetected = setCursorVisibilityOnSourceDetected;
+
+                        if (disableCursorOnStart)
+                        {
+                            BaseCursor.SetVisibility(false);
+                        }
+                    }
+                    else
+                    {
+                        Debug.LogError($"No IMixedRealityCursor component found on {cursorInstance.name}");
+                    }
                 }
             }
         }
@@ -380,12 +386,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public virtual void OnPreSceneQuery() { }
 
+        private static readonly ProfilerMarker OnPostSceneQueryPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnPostSceneQuery");
+
         /// <inheritdoc />
         public virtual void OnPostSceneQuery()
         {
-            if (IsSelectPressed)
+            using (OnPostSceneQueryPerfMarker.Auto())
             {
-                CoreServices.InputSystem.RaisePointerDragged(this, MixedRealityInputAction.None, Handedness);
+                if (IsSelectPressed)
+                {
+                    CoreServices.InputSystem.RaisePointerDragged(this, MixedRealityInputAction.None, Handedness);
+                }
             }
         }
 
@@ -452,24 +463,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IMixedRealitySourcePoseHandler Implementation
 
+        private static readonly ProfilerMarker OnSourceLostPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnSourceLost");
+
         /// <inheritdoc />
         public override void OnSourceLost(SourceStateEventData eventData)
         {
-            base.OnSourceLost(eventData);
-
-            if (eventData.SourceId == InputSourceParent.SourceId)
+            using (OnSourceLostPerfMarker.Auto())
             {
-                if (requiresHoldAction)
-                {
-                    IsHoldPressed = false;
-                }
+                base.OnSourceLost(eventData);
 
-                if (IsSelectPressed)
+                if (eventData.SourceId == InputSourceParent.SourceId)
                 {
-                    CoreServices.InputSystem.RaisePointerUp(this, pointerAction, Handedness);
-                }
+                    if (requiresHoldAction)
+                    {
+                        IsHoldPressed = false;
+                    }
 
-                IsSelectPressed = false;
+                    if (IsSelectPressed)
+                    {
+                        CoreServices.InputSystem.RaisePointerUp(this, pointerAction, Handedness);
+                    }
+
+                    IsSelectPressed = false;
+                }
             }
         }
 
@@ -477,52 +493,62 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IMixedRealityInputHandler Implementation
 
+        private static readonly ProfilerMarker OnInputUpPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnInputUp");
+
         /// <inheritdoc />
         public override void OnInputUp(InputEventData eventData)
         {
-            if(!IsInteractionEnabled) { return; }
-
-            base.OnInputUp(eventData);
-
-            if (eventData.SourceId == InputSourceParent.SourceId)
+            using (OnInputUpPerfMarker.Auto())
             {
-                if (requiresHoldAction && eventData.MixedRealityInputAction == activeHoldAction)
-                {
-                    IsHoldPressed = false;
-                }
+                if (!IsInteractionEnabled) { return; }
 
-                if (eventData.MixedRealityInputAction == pointerAction)
-                {
-                    IsSelectPressed = false;
+                base.OnInputUp(eventData);
 
-                    CoreServices.InputSystem.RaisePointerClicked(this, pointerAction, 0, Handedness);
-                    CoreServices.InputSystem.RaisePointerUp(this, pointerAction, Handedness);
+                if (eventData.SourceId == InputSourceParent.SourceId)
+                {
+                    if (requiresHoldAction && eventData.MixedRealityInputAction == activeHoldAction)
+                    {
+                        IsHoldPressed = false;
+                    }
+
+                    if (eventData.MixedRealityInputAction == pointerAction)
+                    {
+                        IsSelectPressed = false;
+
+                        CoreServices.InputSystem.RaisePointerClicked(this, pointerAction, 0, Handedness);
+                        CoreServices.InputSystem.RaisePointerUp(this, pointerAction, Handedness);
+                    }
                 }
             }
         }
 
+        private static readonly ProfilerMarker OnInputDownPerfMarker = new ProfilerMarker("[MRTK] BaseControllerPointer.OnInputDown");
+
         /// <inheritdoc />
         public override void OnInputDown(InputEventData eventData)
         {
-            if (!IsInteractionEnabled) { return; }
-
-            base.OnInputDown(eventData);
-
-            if (eventData.SourceId == InputSourceParent.SourceId)
+            using (OnInputDownPerfMarker.Auto())
             {
-                if (requiresHoldAction && eventData.MixedRealityInputAction == activeHoldAction)
-                {
-                    IsHoldPressed = true;
-                }
+                if (!IsInteractionEnabled) { return; }
 
-                if (eventData.MixedRealityInputAction == pointerAction)
-                {
-                    IsSelectPressed = true;
-                    HasSelectPressedOnce = true;
+                base.OnInputDown(eventData);
 
-                    if (IsInteractionEnabled)
+                if (eventData.SourceId == InputSourceParent.SourceId)
+                {
+                    if (requiresHoldAction && eventData.MixedRealityInputAction == activeHoldAction)
                     {
-                        CoreServices.InputSystem.RaisePointerDown(this, pointerAction, Handedness);
+                        IsHoldPressed = true;
+                    }
+
+                    if (eventData.MixedRealityInputAction == pointerAction)
+                    {
+                        IsSelectPressed = true;
+                        HasSelectPressedOnce = true;
+
+                        if (IsInteractionEnabled)
+                        {
+                            CoreServices.InputSystem.RaisePointerDown(this, pointerAction, Handedness);
+                        }
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -498,10 +498,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnInputUp(InputEventData eventData)
         {
+            if (!IsInteractionEnabled) { return; }
+
             using (OnInputUpPerfMarker.Auto())
             {
-                if (!IsInteractionEnabled) { return; }
-
                 base.OnInputUp(eventData);
 
                 if (eventData.SourceId == InputSourceParent.SourceId)
@@ -527,10 +527,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public override void OnInputDown(InputEventData eventData)
         {
+            if (!IsInteractionEnabled) { return; }
+
             using (OnInputDownPerfMarker.Auto())
             {
-                if (!IsInteractionEnabled) { return; }
-
                 base.OnInputDown(eventData);
 
                 if (eventData.SourceId == InputSourceParent.SourceId)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseMousePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseMousePointer.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -78,31 +79,41 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IMixedRealitySourcePoseHandler Implementation
 
+        private static readonly ProfilerMarker OnSourceDetectedPerfMarker = new ProfilerMarker("[MRTK] BaseMousePointer.OnSourceDetected");
+
         /// <inheritdoc />
         public override void OnSourceDetected(SourceStateEventData eventData)
         {
-            if (RayStabilizer != null)
+            using (OnSourceDetectedPerfMarker.Auto())
             {
-                RayStabilizer = null;
-            }
+                if (RayStabilizer != null)
+                {
+                    RayStabilizer = null;
+                }
 
-            base.OnSourceDetected(eventData);
+                base.OnSourceDetected(eventData);
 
-            if (eventData.SourceId == Controller?.InputSource.SourceId)
-            {
-                isInteractionEnabled = true;
+                if (eventData.SourceId == Controller?.InputSource.SourceId)
+                {
+                    isInteractionEnabled = true;
+                }
             }
         }
 
 
+        private static readonly ProfilerMarker OnSourceLostPerfMarker = new ProfilerMarker("[MRTK] BaseMousePointer.OnSourceLost");
+
         /// <inheritdoc />
         public override void OnSourceLost(SourceStateEventData eventData)
         {
-            base.OnSourceLost(eventData);
-
-            if (eventData.SourceId == Controller?.InputSource.SourceId)
+            using (OnSourceLostPerfMarker.Auto())
             {
-                isInteractionEnabled = false;
+                base.OnSourceLost(eventData);
+
+                if (eventData.SourceId == Controller?.InputSource.SourceId)
+                {
+                    isInteractionEnabled = false;
+                }
             }
         }
 
@@ -110,41 +121,56 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IMixedRealityInputHandler Implementation
 
+        private static readonly ProfilerMarker OnInputDownPerfMarker = new ProfilerMarker("[MRTK] BaseMousePointer.OnInputDown");
+
         /// <inheritdoc />
         public override void OnInputDown(InputEventData eventData)
         {
-            cursorWasDisabledOnDown = isDisabled;
+            using (OnInputDownPerfMarker.Auto())
+            {
+                cursorWasDisabledOnDown = isDisabled;
 
-            if (cursorWasDisabledOnDown)
-            {
-                ResetCursor();
-            }
-            else
-            {
-                base.OnInputDown(eventData);
+                if (cursorWasDisabledOnDown)
+                {
+                    ResetCursor();
+                }
+                else
+                {
+                    base.OnInputDown(eventData);
+                }
             }
         }
+
+        private static readonly ProfilerMarker OnInputUpPerfMarker = new ProfilerMarker("[MRTK] BaseMousePointer.OnInputUp");
 
         /// <inheritdoc />
         public override void OnInputUp(InputEventData eventData)
         {
-            if (!cursorWasDisabledOnDown)
-            {
-                base.OnInputUp(eventData);
-
-                if (isDisabled)
+            using (OnInputUpPerfMarker.Auto())
+            { 
+                if (!cursorWasDisabledOnDown)
                 {
-                    ResetCursor();
+                    base.OnInputUp(eventData);
+
+                    if (isDisabled)
+                    {
+                        ResetCursor();
+                    }
                 }
             }
         }
 
         #endregion IMixedRealityInputHandler Implementation
 
+        private static readonly ProfilerMarker ResetCursorPerfMarker = new ProfilerMarker("[MRTK] BaseMousePointer.ResetCursor");
+
         private void ResetCursor()
         {
-            SetVisibility(true);
-            transform.rotation = CameraCache.Main.transform.rotation;
+            using (ResetCursorPerfMarker.Auto())
+            {
+                SetVisibility(true);
+                transform.rotation = CameraCache.Main.transform.rotation;
+            }
         }
 
         #region MonoBehaviour Implementation
@@ -170,16 +196,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] BaseMousePointer.Update");
+
         private void Update()
         {
-            if (!hideCursorWhenInactive || isDisabled) { return; }
-
-            timeoutTimer += Time.unscaledDeltaTime;
-
-            if (timeoutTimer >= hideTimeout)
+            using (UpdatePerfMarker.Auto())
             {
-                timeoutTimer = 0.0f;
-                SetVisibility(false);
+                if (!hideCursorWhenInactive || isDisabled) { return; }
+
+                timeoutTimer += Time.unscaledDeltaTime;
+
+                if (timeoutTimer >= hideTimeout)
+                {
+                    timeoutTimer = 0.0f;
+                    SetVisibility(false);
+                }
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/CurvePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/CurvePointer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Physics;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -17,22 +18,27 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [Tooltip("Number of ray steps to utilize in raycast operation along curve defined in LineBase. This setting has a high performance cost. Values above 20 are not recommended.")]
         protected int LineCastResolution = 10;
 
+        private static readonly ProfilerMarker UpdateRaysPerfMarker = new ProfilerMarker("[MRTK] CurvePointer.UpdateRays");
+
         /// <inheritdoc />
         protected override void UpdateRays()
         {
-            // Make sure our array will hold
-            if (Rays == null || Rays.Length != LineCastResolution)
+            using (UpdateRaysPerfMarker.Auto())
             {
-                Rays = new RayStep[LineCastResolution];
-            }
+                // Make sure our array will hold
+                if (Rays == null || Rays.Length != LineCastResolution)
+                {
+                    Rays = new RayStep[LineCastResolution];
+                }
 
-            float stepSize = 1f / Rays.Length;
-            Vector3 lastPoint = LineBase.GetUnClampedPoint(0f);
-            for (int i = 0; i < Rays.Length; i++)
-            {
-                Vector3 currentPoint = LineBase.GetUnClampedPoint(stepSize * (i + 1));
-                Rays[i].UpdateRayStep(ref lastPoint, ref currentPoint);
-                lastPoint = currentPoint;
+                float stepSize = 1f / Rays.Length;
+                Vector3 lastPoint = LineBase.GetUnClampedPoint(0f);
+                for (int i = 0; i < Rays.Length; i++)
+                {
+                    Vector3 currentPoint = LineBase.GetUnClampedPoint(stepSize * (i + 1));
+                    Rays[i].UpdateRayStep(ref lastPoint, ref currentPoint);
+                    lastPoint = currentPoint;
+                }
             }
         }
     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Unity.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -32,189 +33,214 @@ namespace Microsoft.MixedReality.Toolkit.Input
             pointerPreferences = pointerPrefs;
         }
 
+        private static readonly ProfilerMarker RegisterPointersPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.RegisterPointers");
+
         public virtual void RegisterPointers(IMixedRealityPointer[] pointers)
         {
-            for (int i = 0; i < pointers.Length; i++)
+            using (RegisterPointersPerfMarker.Auto())
             {
-                IMixedRealityPointer pointer = pointers[i];
-
-                allPointers.Add(pointer);
-
-                pointer.IsActive = true;
-
-                if (pointer is IMixedRealityTeleportPointer)
+                for (int i = 0; i < pointers.Length; i++)
                 {
-                    teleportPointers.Add(pointer as IMixedRealityTeleportPointer);
-                }
-                else if (pointer is IMixedRealityNearPointer)
-                {
-                    nearInteractPointers.Add(pointer as IMixedRealityNearPointer);
-                }
-                else
-                {
-                    farInteractPointers.Add(pointer);
-                }
+                    IMixedRealityPointer pointer = pointers[i];
 
-                if (pointer.InputSourceParent != null)
-                {
-                    HashSet<IMixedRealityPointer> children;
-                    if (!pointerByInputSourceParent.TryGetValue(pointer.InputSourceParent, out children))
+                    allPointers.Add(pointer);
+
+                    pointer.IsActive = true;
+
+                    if (pointer is IMixedRealityTeleportPointer)
                     {
-                        children = new HashSet<IMixedRealityPointer>();
-                        pointerByInputSourceParent.Add(pointer.InputSourceParent, children);
+                        teleportPointers.Add(pointer as IMixedRealityTeleportPointer);
                     }
-                    children.Add(pointer);
+                    else if (pointer is IMixedRealityNearPointer)
+                    {
+                        nearInteractPointers.Add(pointer as IMixedRealityNearPointer);
+                    }
+                    else
+                    {
+                        farInteractPointers.Add(pointer);
+                    }
+
+                    if (pointer.InputSourceParent != null)
+                    {
+                        HashSet<IMixedRealityPointer> children;
+                        if (!pointerByInputSourceParent.TryGetValue(pointer.InputSourceParent, out children))
+                        {
+                            children = new HashSet<IMixedRealityPointer>();
+                            pointerByInputSourceParent.Add(pointer.InputSourceParent, children);
+                        }
+                        children.Add(pointer);
+                    }
                 }
             }
         }
+
+        private static readonly ProfilerMarker UnregisterPointersPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.UnregisterPointers");
 
         public virtual void UnregisterPointers(IMixedRealityPointer[] pointers)
         {
-            for (int i = 0; i < pointers.Length; i++)
+            using (UnregisterPointersPerfMarker.Auto())
             {
-                IMixedRealityPointer pointer = pointers[i];
-
-                allPointers.Remove(pointer);
-                farInteractPointers.Remove(pointer);
-                nearInteractPointers.Remove(pointer as IMixedRealityNearPointer);
-                teleportPointers.Remove(pointer as IMixedRealityTeleportPointer);
-
-                foreach (HashSet<IMixedRealityPointer> siblingPointers in pointerByInputSourceParent.Values)
+                for (int i = 0; i < pointers.Length; i++)
                 {
-                    siblingPointers.Remove(pointer);
+                    IMixedRealityPointer pointer = pointers[i];
+
+                    allPointers.Remove(pointer);
+                    farInteractPointers.Remove(pointer);
+                    nearInteractPointers.Remove(pointer as IMixedRealityNearPointer);
+                    teleportPointers.Remove(pointer as IMixedRealityTeleportPointer);
+
+                    foreach (HashSet<IMixedRealityPointer> siblingPointers in pointerByInputSourceParent.Values)
+                    {
+                        siblingPointers.Remove(pointer);
+                    }
                 }
             }
         }
+
+        private static readonly ProfilerMarker UpdatePointersPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.UpdatePointers");
 
         public virtual void UpdatePointers()
         {
-            // If there's any teleportation going on, disable all pointers except the teleporter
-            foreach (IMixedRealityTeleportPointer pointer in teleportPointers)
+            using (UpdatePointersPerfMarker.Auto())
             {
-                if (pointer.TeleportRequestRaised)
+                // If there's any teleportation going on, disable all pointers except the teleporter
+                foreach (IMixedRealityTeleportPointer pointer in teleportPointers)
                 {
-                    pointer.IsActive = true;
-
-                    foreach (IMixedRealityPointer otherPointer in allPointers)
+                    if (pointer.TeleportRequestRaised)
                     {
-                        if (otherPointer.PointerId == pointer.PointerId)
+                        pointer.IsActive = true;
+
+                        foreach (IMixedRealityPointer otherPointer in allPointers)
                         {
-                            continue;
-                        }
-
-                        otherPointer.IsActive = false;
-                    }
-                    // Don't do any further checks
-                    return;
-                }
-            }
-
-            // pointers whose active state has not yet been set this frame
-            unassignedPointers.Clear();
-            foreach (IMixedRealityPointer unassignedPointer in allPointers)
-            {
-                unassignedPointers.Add(unassignedPointer);
-            }
-
-            ApplyCustomPointerBehaviors();
-
-            // If any pointers are locked, they have priority. 
-            // Deactivate all other pointers that are on that input source
-            foreach (IMixedRealityPointer pointer in allPointers)
-            {
-                if (pointer.IsFocusLocked)
-                {
-                    pointer.IsActive = true;
-                    unassignedPointers.Remove(pointer);
-
-                    if (pointer.InputSourceParent != null)
-                    {
-                        foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
-                        {
-                            if (!unassignedPointers.Contains(otherPointer))
+                            if (otherPointer.PointerId == pointer.PointerId)
                             {
                                 continue;
                             }
 
                             otherPointer.IsActive = false;
-                            unassignedPointers.Remove(otherPointer);
                         }
+                        // Don't do any further checks
+                        return;
                     }
                 }
-            }
 
-            // Check for near and far interactions
-            // Any far interact pointers become disabled when a near pointer is near an object
-            foreach (IMixedRealityNearPointer pointer in nearInteractPointers)
-            {
-                if (!unassignedPointers.Contains(pointer))
+                // pointers whose active state has not yet been set this frame
+                unassignedPointers.Clear();
+                foreach (IMixedRealityPointer unassignedPointer in allPointers)
                 {
-                    continue;
+                    unassignedPointers.Add(unassignedPointer);
                 }
 
-                if (pointer.IsNearObject)
-                {
-                    pointer.IsActive = true;
-                    unassignedPointers.Remove(pointer);
+                ApplyCustomPointerBehaviors();
 
-                    if (pointer.InputSourceParent != null)
+                // If any pointers are locked, they have priority. 
+                // Deactivate all other pointers that are on that input source
+                foreach (IMixedRealityPointer pointer in allPointers)
+                {
+                    if (pointer.IsFocusLocked)
                     {
-                        foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
+                        pointer.IsActive = true;
+                        unassignedPointers.Remove(pointer);
+
+                        if (pointer.InputSourceParent != null)
                         {
-                            if (!unassignedPointers.Contains(otherPointer))
+                            foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
                             {
-                                continue;
-                            }
+                                if (!unassignedPointers.Contains(otherPointer))
+                                {
+                                    continue;
+                                }
 
-                            if (otherPointer is IMixedRealityNearPointer)
-                            {
-                                // Only disable far interaction pointers
-                                // It is okay for example to have two near pointers active on a single controller
-                                // like a poke pointer and a grab pointer
-                                continue;
+                                otherPointer.IsActive = false;
+                                unassignedPointers.Remove(otherPointer);
                             }
-
-                            otherPointer.IsActive = false;
-                            unassignedPointers.Remove(otherPointer);
                         }
                     }
                 }
-            }
 
-            // All other pointers that have not been assigned this frame
-            // have no reason to be disabled, so make sure they are active
-            foreach (IMixedRealityPointer unassignedPointer in unassignedPointers)
-            {
-                unassignedPointer.IsActive = true;
+                // Check for near and far interactions
+                // Any far interact pointers become disabled when a near pointer is near an object
+                foreach (IMixedRealityNearPointer pointer in nearInteractPointers)
+                {
+                    if (!unassignedPointers.Contains(pointer))
+                    {
+                        continue;
+                    }
+
+                    if (pointer.IsNearObject)
+                    {
+                        pointer.IsActive = true;
+                        unassignedPointers.Remove(pointer);
+
+                        if (pointer.InputSourceParent != null)
+                        {
+                            foreach (IMixedRealityPointer otherPointer in pointerByInputSourceParent[pointer.InputSourceParent])
+                            {
+                                if (!unassignedPointers.Contains(otherPointer))
+                                {
+                                    continue;
+                                }
+
+                                if (otherPointer is IMixedRealityNearPointer)
+                                {
+                                    // Only disable far interaction pointers
+                                    // It is okay for example to have two near pointers active on a single controller
+                                    // like a poke pointer and a grab pointer
+                                    continue;
+                                }
+
+                                otherPointer.IsActive = false;
+                                unassignedPointers.Remove(otherPointer);
+                            }
+                        }
+                    }
+                }
+
+                // All other pointers that have not been assigned this frame
+                // have no reason to be disabled, so make sure they are active
+                foreach (IMixedRealityPointer unassignedPointer in unassignedPointers)
+                {
+                    unassignedPointer.IsActive = true;
+                }
             }
         }
+
+        private static readonly ProfilerMarker ApplyCustomPointerBehaviorsPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.ApplyCustomPointerBehaviors");
 
         private void ApplyCustomPointerBehaviors()
         {
-            if (pointerPreferences != null)
+            using (ApplyCustomPointerBehaviorsPerfMarker.Auto())
             {
-                foreach (IMixedRealityPointer pointer in allPointers)
+                if (pointerPreferences != null)
                 {
-                    ApplyPointerBehavior(pointer, pointerPreferences.GetPointerBehavior(pointer));
+                    foreach (IMixedRealityPointer pointer in allPointers)
+                    {
+                        ApplyPointerBehavior(pointer, pointerPreferences.GetPointerBehavior(pointer));
+                    }
                 }
             }
         }
 
+        private static readonly ProfilerMarker ApplyCustomPointerBehaviorPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.ApplyCustomPointerBehavior");
+
         private void ApplyPointerBehavior(IMixedRealityPointer pointer, PointerBehavior behavior)
         {
-            if (behavior == PointerBehavior.Default)
+            using (ApplyCustomPointerBehaviorPerfMarker.Auto())
             {
-                return;
-            }
+                if (behavior == PointerBehavior.Default)
+                {
+                    return;
+                }
 
-            bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
-            pointer.IsActive = isPointerOn;
-            if (pointer is GenericPointer genericPtr)
-            {
-                genericPtr.IsInteractionEnabled = isPointerOn;
-            }
+                bool isPointerOn = behavior == PointerBehavior.AlwaysOn;
+                pointer.IsActive = isPointerOn;
+                if (pointer is GenericPointer genericPtr)
+                {
+                    genericPtr.IsInteractionEnabled = isPointerOn;
+                }
 
-            unassignedPointers.Remove(pointer);
+                unassignedPointers.Remove(pointer);
+            }
         }
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -221,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private static readonly ProfilerMarker ApplyCustomPointerBehaviorPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.ApplyCustomPointerBehavior");
+        private static readonly ProfilerMarker ApplyPointerBehaviorPerfMarker = new ProfilerMarker("[MRTK] DefaultPointerMediator.ApplyPointerBehavior");
 
         private void ApplyPointerBehavior(IMixedRealityPointer pointer, PointerBehavior behavior)
         {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPointerMediator.cs
@@ -225,7 +225,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void ApplyPointerBehavior(IMixedRealityPointer pointer, PointerBehavior behavior)
         {
-            using (ApplyCustomPointerBehaviorPerfMarker.Auto())
+            using (ApplyPointerBehaviorPerfMarker.Auto())
             {
                 if (behavior == PointerBehavior.Default)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -172,21 +173,31 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        private static readonly ProfilerMarker OnPostSceneQueryPerfMarker = new ProfilerMarker("[MRTK] GGVPointer.OnPostSceneQuery");
+
         /// <inheritdoc />
         public void OnPostSceneQuery()
         {
-            if (isSelectPressed && IsInteractionEnabled)
+            using (OnPostSceneQueryPerfMarker.Auto())
             {
-                CoreServices.InputSystem.RaisePointerDragged(this, MixedRealityInputAction.None, Controller.ControllerHandedness);
+                if (isSelectPressed && IsInteractionEnabled)
+                {
+                    CoreServices.InputSystem.RaisePointerDragged(this, MixedRealityInputAction.None, Controller.ControllerHandedness);
+                }
             }
         }
+
+        private static readonly ProfilerMarker OnPreSceneQueryPerfMarker = new ProfilerMarker("[MRTK] GGVPointer.OnPreSceneQuery");
 
         /// <inheritdoc />
         public void OnPreSceneQuery()
         {
-            Vector3 newGazeOrigin = gazeProvider.GazePointer.Rays[0].Origin;
-            Vector3 endPoint = newGazeOrigin + (gazeProvider.GazePointer.Rays[0].Direction * CoreServices.InputSystem.FocusProvider.GlobalPointingExtent);
-            Rays[0].UpdateRayStep(ref newGazeOrigin, ref endPoint);
+            using (OnPreSceneQueryPerfMarker.Auto())
+            {
+                Vector3 newGazeOrigin = gazeProvider.GazePointer.Rays[0].Origin;
+                Vector3 endPoint = newGazeOrigin + (gazeProvider.GazePointer.Rays[0].Direction * CoreServices.InputSystem.FocusProvider.GlobalPointingExtent);
+                Rays[0].UpdateRayStep(ref newGazeOrigin, ref endPoint);
+            }
         }
 
         /// <inheritdoc />
@@ -222,56 +233,66 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IMixedRealityInputHandler Implementation
 
+        private static readonly ProfilerMarker OnInputUpPerfMarker = new ProfilerMarker("[MRTK] GGVPointer.OnInputUp");
+
         /// <inheritdoc />
         public void OnInputUp(InputEventData eventData)
         {
-            if (eventData.SourceId == InputSourceParent.SourceId)
+            using (OnInputUpPerfMarker.Auto())
             {
-                if (eventData.MixedRealityInputAction == selectAction)
+                if (eventData.SourceId == InputSourceParent.SourceId)
                 {
-                    isSelectPressed = false;
-                    if (IsInteractionEnabled)
+                    if (eventData.MixedRealityInputAction == selectAction)
                     {
-                        BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
-                        if (c != null)
+                        isSelectPressed = false;
+                        if (IsInteractionEnabled)
                         {
-                            c.SourceDownIds.Remove(eventData.SourceId);
+                            BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                            if (c != null)
+                            {
+                                c.SourceDownIds.Remove(eventData.SourceId);
+                            }
+
+                            CoreServices.InputSystem.RaisePointerClicked(this, selectAction, 0, Controller.ControllerHandedness);
+                            CoreServices.InputSystem.RaisePointerUp(this, selectAction, Controller.ControllerHandedness);
+
+                            // For GGV, the gaze pointer does not set this value itself. 
+                            // See comment in OnInputDown for more details.
+                            gazeProvider.GazePointer.IsFocusLocked = false;
                         }
-
-                        CoreServices.InputSystem.RaisePointerClicked(this, selectAction, 0, Controller.ControllerHandedness);
-                        CoreServices.InputSystem.RaisePointerUp(this, selectAction, Controller.ControllerHandedness);
-
-                        // For GGV, the gaze pointer does not set this value itself. 
-                        // See comment in OnInputDown for more details.
-                        gazeProvider.GazePointer.IsFocusLocked = false;
                     }
                 }
             }
         }
 
+        private static readonly ProfilerMarker OnInputDownPerfMarker = new ProfilerMarker("[MRTK] GGVPointer.OnInputDown");
+
         /// <inheritdoc />
         public void OnInputDown(InputEventData eventData)
         {
-            if (eventData.SourceId == InputSourceParent.SourceId)
+            using (OnInputDownPerfMarker.Auto())
             {
-                if (eventData.MixedRealityInputAction == selectAction)
+                if (eventData.SourceId == InputSourceParent.SourceId)
                 {
-                    isSelectPressed = true;
-                    lastControllerHandedness = Controller.ControllerHandedness;
-                    if (IsInteractionEnabled)
+                    if (eventData.MixedRealityInputAction == selectAction)
                     {
-                        BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
-                        if (c != null)
+                        isSelectPressed = true;
+                        lastControllerHandedness = Controller.ControllerHandedness;
+                        if (IsInteractionEnabled)
                         {
-                            c.SourceDownIds.Add(eventData.SourceId);
+                            BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                            if (c != null)
+                            {
+                                c.SourceDownIds.Add(eventData.SourceId);
+                            }
+
+                            CoreServices.InputSystem.RaisePointerDown(this, selectAction, Controller.ControllerHandedness);
+
+                            // For GGV, the gaze pointer does not set this value itself as it does not receive input 
+                            // events from the hands. Because this value is important for certain gaze behavior, 
+                            // such as positioning the gaze cursor, it is necessary to set it here.
+                            gazeProvider.GazePointer.IsFocusLocked = (gazeProvider.GazePointer.Result?.Details.Object != null);
                         }
-
-                        CoreServices.InputSystem.RaisePointerDown(this, selectAction, Controller.ControllerHandedness);
-
-                        // For GGV, the gaze pointer does not set this value itself as it does not receive input 
-                        // events from the hands. Because this value is important for certain gaze behavior, 
-                        // such as positioning the gaze cursor, it is necessary to set it here.
-                        gazeProvider.GazePointer.IsFocusLocked = (gazeProvider.GazePointer.Result?.Details.Object != null);
                     }
                 }
             }
@@ -329,29 +350,34 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public void OnSourceDetected(SourceStateEventData eventData) { }
 
+        private static readonly ProfilerMarker OnSourceLostPerfMarker = new ProfilerMarker("[MRTK] GGVPointer.OnSourceLost");
+
         /// <inheritdoc />
         public void OnSourceLost(SourceStateEventData eventData)
         {
-            if (eventData.SourceId == InputSourceParent.SourceId)
+            using (OnSourceLostPerfMarker.Auto())
             {
-                BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
-                if (c != null)
+                if (eventData.SourceId == InputSourceParent.SourceId)
                 {
-                    c.SourceDownIds.Remove(eventData.SourceId);
+                    BaseCursor c = gazeProvider.GazePointer.BaseCursor as BaseCursor;
+                    if (c != null)
+                    {
+                        c.SourceDownIds.Remove(eventData.SourceId);
+                    }
+
+                    if (isSelectPressed)
+                    {
+                        // Raise OnInputUp if pointer is lost while select is pressed
+                        CoreServices.InputSystem.RaisePointerUp(this, selectAction, lastControllerHandedness);
+
+                        // For GGV, the gaze pointer does not set this value itself. 
+                        // See comment in OnInputDown for more details.
+                        gazeProvider.GazePointer.IsFocusLocked = false;
+                    }
+
+                    // Destroy the pointer since nobody else is destroying us
+                    GameObjectExtensions.DestroyGameObject(gameObject);
                 }
-
-                if (isSelectPressed)
-                {
-                    // Raise OnInputUp if pointer is lost while select is pressed
-                    CoreServices.InputSystem.RaisePointerUp(this, selectAction, lastControllerHandedness);
-
-                    // For GGV, the gaze pointer does not set this value itself. 
-                    // See comment in OnInputDown for more details.
-                    gazeProvider.GazePointer.IsFocusLocked = false;
-                }
-
-                // Destroy the pointer since nobody else is destroying us
-                GameObjectExtensions.DestroyGameObject(gameObject);
             }
         }
 
@@ -359,14 +385,19 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region IMixedRealityInputHandler<MixedRealityPose>
 
+        private static readonly ProfilerMarker OnInputChangedPerfMarker = new ProfilerMarker("[MRTK] GGVPointer.OnInputChanged");
+
         /// <inheritdoc />
         public void OnInputChanged(InputEventData<MixedRealityPose> eventData)
         {
-            if (eventData.SourceId == Controller?.InputSource.SourceId &&
-                eventData.Handedness == Controller?.ControllerHandedness &&
-                eventData.MixedRealityInputAction == poseAction)
+            using (OnInputChangedPerfMarker.Auto())
             {
-                sourcePosition = eventData.InputData.Position;
+                if (eventData.SourceId == Controller?.InputSource.SourceId &&
+                    eventData.Handedness == Controller?.ControllerHandedness &&
+                    eventData.MixedRealityInputAction == poseAction)
+                {
+                    sourcePosition = eventData.InputData.Position;
+                }
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ParabolicTeleportPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ParabolicTeleportPointer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Teleport
@@ -61,31 +62,36 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
 
         #region IMixedRealityPointer Implementation
 
+        private static readonly ProfilerMarker OnPreSceneQueryPerfMarker = new ProfilerMarker("[MRTK] ParabolicTeleportPointer.OnPreSceneQuery");
+
         /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
-            parabolicLineData.LineTransform.rotation = Quaternion.identity;
-            parabolicLineData.Direction = transform.forward;
-
-            // when pointing straight up, upDot should be close to 1.
-            // when pointing straight down, upDot should be close to -1.
-            // when pointing straight forward in any direction, upDot should be 0.
-            var upDot = Vector3.Dot(transform.forward, Vector3.up);
-
-            var velocity = minParabolaVelocity;
-            var distance = minDistanceModifier;
-
-            // If we're pointing below the horizon, always use the minimum modifiers.
-            if (upDot > 0f)
+            using (OnPreSceneQueryPerfMarker.Auto())
             {
-                // Increase the modifier multipliers the higher we point.
-                velocity = Mathf.Lerp(minParabolaVelocity, maxParabolaVelocity, upDot);
-                distance = Mathf.Lerp(minDistanceModifier, maxDistanceModifier, upDot);
-            }
+                parabolicLineData.LineTransform.rotation = Quaternion.identity;
+                parabolicLineData.Direction = transform.forward;
 
-            parabolicLineData.Velocity = velocity;
-            parabolicLineData.DistanceMultiplier = distance;
-            base.OnPreSceneQuery();
+                // when pointing straight up, upDot should be close to 1.
+                // when pointing straight down, upDot should be close to -1.
+                // when pointing straight forward in any direction, upDot should be 0.
+                var upDot = Vector3.Dot(transform.forward, Vector3.up);
+
+                var velocity = minParabolaVelocity;
+                var distance = minDistanceModifier;
+
+                // If we're pointing below the horizon, always use the minimum modifiers.
+                if (upDot > 0f)
+                {
+                    // Increase the modifier multipliers the higher we point.
+                    velocity = Mathf.Lerp(minParabolaVelocity, maxParabolaVelocity, upDot);
+                    distance = Mathf.Lerp(minDistanceModifier, maxDistanceModifier, upDot);
+                }
+
+                parabolicLineData.Velocity = velocity;
+                parabolicLineData.DistanceMultiplier = distance;
+                base.OnPreSceneQuery();
+            }
         }
 
         #endregion IMixedRealityPointer Implementation

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ScreenSpaceMousePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ScreenSpaceMousePointer.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
+using UnityEngine;
 using UInput = UnityEngine.Input;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -19,32 +20,37 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         protected override string ControllerName => "ScreenSpace Mouse Pointer";
 
+        private static readonly ProfilerMarker OnPreSceneQueryPerfMarker = new ProfilerMarker("[MRTK] ScreenSpaceMousePointer.OnPreSceneQuery");
+
         /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
-            if (UInput.mousePosition.x < 0 ||
-                UInput.mousePosition.y < 0 ||
-                UInput.mousePosition.x > Screen.width ||
-                UInput.mousePosition.y > Screen.height)
+            using (OnPreSceneQueryPerfMarker.Auto())
             {
-                return;
+                if (UInput.mousePosition.x < 0 ||
+                    UInput.mousePosition.y < 0 ||
+                    UInput.mousePosition.x > Screen.width ||
+                    UInput.mousePosition.y > Screen.height)
+                {
+                    return;
+                }
+
+                Vector3 currentMousePosition = UInput.mousePosition;
+
+                if ((lastMousePosition - (Vector2)currentMousePosition).magnitude >= MovementThresholdToUnHide)
+                {
+                    SetVisibility(true);
+                }
+
+                lastMousePosition = currentMousePosition;
+
+                Camera mainCamera = CameraCache.Main;
+                Ray ray = mainCamera.ScreenPointToRay(currentMousePosition);
+                Rays[0].CopyRay(ray, float.MaxValue);
+
+                transform.position = mainCamera.transform.position;
+                transform.rotation = Quaternion.LookRotation(ray.direction);
             }
-
-            Vector3 currentMousePosition = UInput.mousePosition;
-
-            if ((lastMousePosition - (Vector2)currentMousePosition).magnitude >= MovementThresholdToUnHide)
-            {
-                SetVisibility(true);
-            }
-
-            lastMousePosition = currentMousePosition;
-
-            Camera mainCamera = CameraCache.Main;
-            Ray ray = mainCamera.ScreenPointToRay(currentMousePosition);
-            Rays[0].CopyRay(ray, float.MaxValue);
-
-            transform.position = mainCamera.transform.position;
-            transform.rotation = Quaternion.LookRotation(ray.direction);
         }
 
         /// <inheritdoc />

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -4,8 +4,8 @@
 using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -122,42 +122,45 @@ namespace Microsoft.MixedReality.Toolkit.Input
             queryBufferInteractionRadius = new SpherePointerQueryInfo(sceneQueryBufferSize, SphereCastRadius);
         }
 
+        private static readonly ProfilerMarker OnPreSceneQueryPerfMarker = new ProfilerMarker("[MRTK] SpherePointer.OnPreSceneQuery");
+
         /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
-            Profiler.BeginSample("[MRTK] SpherePointer.OnPreSceneQuery");
-
-            if (Rays == null)
+            using (OnPreSceneQueryPerfMarker.Auto())
             {
-                Rays = new RayStep[1];
-            }
-
-            Vector3 pointerPosition;
-            if (TryGetNearGraspPoint(out pointerPosition))
-            {
-                Vector3 endPoint = Vector3.forward * SphereCastRadius;
-                Rays[0].UpdateRayStep(ref pointerPosition, ref endPoint);
-                PrioritizedLayerMasksOverride = PrioritizedLayerMasksOverride ?? GrabLayerMasks;
-
-                for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
+                if (Rays == null)
                 {
-                    if (queryBufferNearObjectRadius.TryUpdateQueryBufferForLayerMask(PrioritizedLayerMasksOverride[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
-                    {
-                        break;
-                    }
+                    Rays = new RayStep[1];
                 }
 
-                for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
+                Vector3 pointerPosition;
+                if (TryGetNearGraspPoint(out pointerPosition))
                 {
-                    if (queryBufferInteractionRadius.TryUpdateQueryBufferForLayerMask(PrioritizedLayerMasksOverride[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                    Vector3 endPoint = Vector3.forward * SphereCastRadius;
+                    Rays[0].UpdateRayStep(ref pointerPosition, ref endPoint);
+                    PrioritizedLayerMasksOverride = PrioritizedLayerMasksOverride ?? GrabLayerMasks;
+
+                    for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
                     {
-                        break;
+                        if (queryBufferNearObjectRadius.TryUpdateQueryBufferForLayerMask(PrioritizedLayerMasksOverride[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                        {
+                            break;
+                        }
+                    }
+
+                    for (int i = 0; i < PrioritizedLayerMasksOverride.Length; i++)
+                    {
+                        if (queryBufferInteractionRadius.TryUpdateQueryBufferForLayerMask(PrioritizedLayerMasksOverride[i], pointerPosition, triggerInteraction, ignoreCollidersNotInFOV))
+                        {
+                            break;
+                        }
                     }
                 }
             }
-
-            Profiler.EndSample(); // OnPreSceneQuery
         }
+
+        private static readonly ProfilerMarker TryGetNearGraspPointPerfMarker = new ProfilerMarker("[MRTK] SpherePointer.TryGetNearGraspPoint");
 
         /// <summary>
         /// Gets the position of where grasp happens
@@ -166,78 +169,78 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool TryGetNearGraspPoint(out Vector3 result)
         {
-            Profiler.BeginSample("[MRTK] SpherePointer.TryGetNearGraspPoint");
-
-            // If controller is of kind IMixedRealityHand, return average of index and thumb
-            if (Controller != null && Controller is IMixedRealityHand)
+            using (TryGetNearGraspPointPerfMarker.Auto())
             {
-                var hand = Controller as IMixedRealityHand;
-                hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index);
-                if (index != null)
+                // If controller is of kind IMixedRealityHand, return average of index and thumb
+                if (Controller != null && Controller is IMixedRealityHand)
                 {
-                    hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb);
-                    if (thumb != null)
+                    var hand = Controller as IMixedRealityHand;
+                    hand.TryGetJoint(TrackedHandJoint.IndexTip, out MixedRealityPose index);
+                    if (index != null)
                     {
-                        result = 0.5f * (index.Position + thumb.Position);
-                        Profiler.EndSample(); // TryGetNearGraspPoint - success
-                        return true;
+                        hand.TryGetJoint(TrackedHandJoint.ThumbTip, out MixedRealityPose thumb);
+                        if (thumb != null)
+                        {
+                            result = 0.5f * (index.Position + thumb.Position);
+                            return true;
+                        }
                     }
                 }
-            }
-            else
-            {
-                result = Position;
-                Profiler.EndSample(); // TryGetNearGraspPoint - success
-                return true;
-            }
+                else
+                {
+                    result = Position;
+                    return true;
+                }
 
-            result = Vector3.zero;
-            Profiler.EndSample(); // TryGetNearGraspPoint
-            return false;
+                result = Vector3.zero;
+                return false;
+            }
         }
+
+        private static readonly ProfilerMarker TryGetDistanceToNearestSurfacePerfMarker = new ProfilerMarker("[MRTK] SpherePointer.TryDistanceToNearestSurface");
 
         /// <inheritdoc />
         public bool TryGetDistanceToNearestSurface(out float distance)
         {
-            Profiler.BeginSample("[MRTK] SpherePointer.TryGetDistanceToNearestSurface");
-
-            var focusProvider = CoreServices.InputSystem?.FocusProvider;
-            if (focusProvider != null)
+            using (TryGetDistanceToNearestSurfacePerfMarker.Auto())
             {
-                FocusDetails focusDetails;
-                if (focusProvider.TryGetFocusDetails(this, out focusDetails))
+                var focusProvider = CoreServices.InputSystem?.FocusProvider;
+                if (focusProvider != null)
                 {
-                    distance = focusDetails.RayDistance;
-                    Profiler.EndSample(); // TryGetDistanceToNearestSurface - success
-                    return true;
+                    FocusDetails focusDetails;
+                    if (focusProvider.TryGetFocusDetails(this, out focusDetails))
+                    {
+                        distance = focusDetails.RayDistance;
+                        return true;
+                    }
                 }
-            }
 
-            distance = 0.0f;
-            Profiler.EndSample(); // TryGetDistanceToNearestSurface
-            return false;
+                distance = 0.0f;
+                return false;
+            }
         }
+
+        private static readonly ProfilerMarker TryGetNormalToNearestSurfacePerfMarker = new ProfilerMarker("[MRTK] SpherePointer.TryDistanceToNearestSurface");
 
         /// <inheritdoc />
         public bool TryGetNormalToNearestSurface(out Vector3 normal)
         {
-            Profiler.BeginSample("[MRTK] SpherePointer.TryGetNormalToNearestSurface");
-
-            var focusProvider = CoreServices.InputSystem?.FocusProvider;
-            if (focusProvider != null)
+            using (TryGetNormalToNearestSurfacePerfMarker.Auto())
             {
-                FocusDetails focusDetails;
-                if (focusProvider.TryGetFocusDetails(this, out focusDetails))
+                var focusProvider = CoreServices.InputSystem?.FocusProvider;
+                if (focusProvider != null)
                 {
-                    normal = focusDetails.Normal;
-                    Profiler.EndSample(); // TryGetNormalToNearestSurface - success
-                    return true;
+                    FocusDetails focusDetails;
+                    if (focusProvider.TryGetFocusDetails(this, out focusDetails))
+                    {
+                        normal = focusDetails.Normal;
+                        return true;
+                    }
                 }
-            }
 
-            normal = Vector3.forward;
-            Profiler.EndSample(); // TryGetNormalToNearestSurface
-            return false;
+                normal = Vector3.forward;
+                return false;
+            }
         }
 
         /// <summary>
@@ -272,6 +275,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 queryRadius = radius;
             }
 
+            private static readonly ProfilerMarker TryUpdateQueryBufferForLayerMaskPerfMarker = new ProfilerMarker("[MRTK] SpherePointer.TryUpdateQueryBufferForLayerMask");
+
             /// <summary>
             /// Intended to be called once per frame, this method performs a sphere intersection test against
             /// all colliders in the layers defined by layerMask at the given pointer position.
@@ -285,49 +290,48 @@ namespace Microsoft.MixedReality.Toolkit.Input
             /// <param name="ignoreCollidersNotInFOV">Whether to ignore colliders that are not visible.</param>
             public bool TryUpdateQueryBufferForLayerMask(LayerMask layerMask, Vector3 pointerPosition, QueryTriggerInteraction triggerInteraction, bool ignoreCollidersNotInFOV)
             {
-                Profiler.BeginSample("[MRTK] SpherePointerQueryInfo.TryUpdateQueryBufferForLayerMask");
-
-                grabbable = null;
-                numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(
-                    pointerPosition,
-                    queryRadius,
-                    queryBuffer,
-                    layerMask,
-                    triggerInteraction);
-
-                if (numColliders == queryBuffer.Length)
+                using (TryUpdateQueryBufferForLayerMaskPerfMarker.Auto())
                 {
-                    Debug.LogWarning($"Maximum number of {numColliders} colliders found in SpherePointer overlap query. Consider increasing the query buffer size in the pointer profile.");
-                }
+                    grabbable = null;
+                    numColliders = UnityEngine.Physics.OverlapSphereNonAlloc(
+                        pointerPosition,
+                        queryRadius,
+                        queryBuffer,
+                        layerMask,
+                        triggerInteraction);
 
-                Camera mainCam = CameraCache.Main;
-                for (int i = 0; i < numColliders; i++)
-                {
-                    Collider collider = queryBuffer[i];
-                    grabbable = collider.GetComponent<NearInteractionGrabbable>();
-                    if (grabbable != null)
+                    if (numColliders == queryBuffer.Length)
                     {
-                        if (ignoreCollidersNotInFOV)
+                        Debug.LogWarning($"Maximum number of {numColliders} colliders found in SpherePointer overlap query. Consider increasing the query buffer size in the pointer profile.");
+                    }
+
+                    Camera mainCam = CameraCache.Main;
+                    for (int i = 0; i < numColliders; i++)
+                    {
+                        Collider collider = queryBuffer[i];
+                        grabbable = collider.GetComponent<NearInteractionGrabbable>();
+                        if (grabbable != null)
                         {
-                            if (!mainCam.IsInFOVCached(collider))
+                            if (ignoreCollidersNotInFOV)
                             {
-                                // Additional check: is grabbable in the camera frustrum
-                                // We do this so that if grabbable is not visible it is not accidentally grabbed
-                                // Also to not turn off the hand ray if hand is near a grabbable that's not actually visible
-                                grabbable = null;
+                                if (!mainCam.IsInFOVCached(collider))
+                                {
+                                    // Additional check: is grabbable in the camera frustrum
+                                    // We do this so that if grabbable is not visible it is not accidentally grabbed
+                                    // Also to not turn off the hand ray if hand is near a grabbable that's not actually visible
+                                    grabbable = null;
+                                }
                             }
+                        }
+
+                        if (grabbable != null)
+                        {
+                            return true;
                         }
                     }
 
-                    if (grabbable != null)
-                    {
-                        Profiler.EndSample(); // TryUpdateQueryBufferForLayerMask
-                        return true;
-                    }
+                    return false;
                 }
-
-                Profiler.EndSample(); // TryUpdateQueryBufferForLayerMask
-                return false;
             }
 
             /// <summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointerGrabPoint.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointerGrabPoint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -31,12 +32,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        private static readonly ProfilerMarker LateUpdatePerfMarker = new ProfilerMarker("[MRTK] SpherePointerGrabPoint.LateUpdate");
+
         private void LateUpdate()
         {
-            if (pointerVisual.TetherVisualsEnabled)
+            using (LateUpdatePerfMarker.Auto())
             {
-                pointMatrix = Matrix4x4.TRS(pointerVisual.TetherEndPoint.position, pointerVisual.TetherEndPoint.rotation, Vector3.one * scale);
-                Graphics.DrawMesh(grabPointMesh, pointMatrix, grabPointMaterial, pointerVisual.gameObject.layer);
+                if (pointerVisual.TetherVisualsEnabled)
+                {
+                    pointMatrix = Matrix4x4.TRS(pointerVisual.TetherEndPoint.position, pointerVisual.TetherEndPoint.rotation, Vector3.one * scale);
+                    Graphics.DrawMesh(grabPointMesh, pointMatrix, grabPointMaterial, pointerVisual.gameObject.layer);
+                }
             }
         }
     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TouchPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/TouchPointer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Physics;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -35,24 +36,29 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public Ray TouchRay { get; set; } = default(Ray);
 
+        private static readonly ProfilerMarker OnPreSceneQueryPerfMarker = new ProfilerMarker("[MRTK] TouchPointer.OnPreSceneQuery");
+
         /// <inheritdoc />
         public override void OnPreSceneQuery()
         {
-            Rays[0].CopyRay(TouchRay, PointerExtent);
-
-            if (RayStabilizer != null)
+            using (OnPreSceneQueryPerfMarker.Auto())
             {
-                RayStabilizer.UpdateStability(Rays[0].Origin, Rays[0].Direction);
-                Rays[0].CopyRay(RayStabilizer.StableRay, PointerExtent);
+                Rays[0].CopyRay(TouchRay, PointerExtent);
 
-                if (MixedRealityRaycaster.DebugEnabled)
+                if (RayStabilizer != null)
                 {
-                    Debug.DrawRay(RayStabilizer.StableRay.origin, RayStabilizer.StableRay.direction * PointerExtent, Color.green);
+                    RayStabilizer.UpdateStability(Rays[0].Origin, Rays[0].Direction);
+                    Rays[0].CopyRay(RayStabilizer.StableRay, PointerExtent);
+
+                    if (MixedRealityRaycaster.DebugEnabled)
+                    {
+                        Debug.DrawRay(RayStabilizer.StableRay.origin, RayStabilizer.StableRay.direction * PointerExtent, Color.green);
+                    }
                 }
-            }
-            else if (MixedRealityRaycaster.DebugEnabled)
-            {
-                Debug.DrawRay(TouchRay.origin, TouchRay.direction * PointerExtent, Color.yellow);
+                else if (MixedRealityRaycaster.DebugEnabled)
+                {
+                    Debug.DrawRay(TouchRay.origin, TouchRay.direction * PointerExtent, Color.yellow);
+                }
             }
         }
 
@@ -74,27 +80,37 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
+        private static readonly ProfilerMarker OnSourceDetectedPerfMarker = new ProfilerMarker("[MRTK] TouchPointer.OnSourceDetected");
+
         /// <inheritdoc />
         public override void OnSourceDetected(SourceStateEventData eventData)
         {
-            base.OnSourceDetected(eventData);
-
-            if (eventData.InputSource.SourceId == Controller.InputSource.SourceId)
+            using (OnSourceDetectedPerfMarker.Auto())
             {
-                isInteractionEnabled = true;
+                base.OnSourceDetected(eventData);
+
+                if (eventData.InputSource.SourceId == Controller.InputSource.SourceId)
+                {
+                    isInteractionEnabled = true;
+                }
             }
         }
+
+        private static readonly ProfilerMarker OnSourceLostPerfMarker = new ProfilerMarker("[MRTK] TouchPointer.OnSourceLost");
 
         /// <inheritdoc />
         public override void OnSourceLost(SourceStateEventData eventData)
         {
-            base.OnSourceLost(eventData);
-
-            if (Controller != null &&
-                eventData.Controller != null &&
-                eventData.Controller.InputSource.SourceId == Controller.InputSource.SourceId)
+            using (OnSourceLostPerfMarker.Auto())
             {
-                isInteractionEnabled = false;
+                base.OnSourceLost(eventData);
+
+                if (Controller != null &&
+                    eventData.Controller != null &&
+                    eventData.Controller.InputSource.SourceId == Controller.InputSource.SourceId)
+                {
+                    isInteractionEnabled = false;
+                }
             }
         }
     }


### PR DESCRIPTION
This change refines the input system profiler markers by replacing begin/endsample calls to the preferred scoped using(marker.auto) syntax.

At the same time, additional markers were added that rounds out the suite of input markers.

As a part of this change, one HashSet was replaced with a Dictionary to eliminate some collection iterations. It has not been formally measured, though, anecdotally, it has been reported to have improved a partner application's performance.