### PR TITLE
Add profiler instrumentation to spatial awareness paths

### DIFF
--- a/Assets/MRTK/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MRTK/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
@@ -123,22 +124,27 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
 
         #region IMixedRealitySpatialAwarenessObserver Implementation
 
+        private static readonly ProfilerMarker ClearObservationsPerfMarker = new ProfilerMarker("[MRTK] SpatialObjectMeshObserver.ClearObservations");
+
         /// <inheritdoc />
         public override void ClearObservations()
         {
-            if (IsRunning)
+            using (ClearObservationsPerfMarker.Auto())
             {
-                Debug.Log("Cannot clear observations while the observer is running. Suspending this observer.");
-                Suspend();
-            }
+                if (IsRunning)
+                {
+                    Debug.Log("Cannot clear observations while the observer is running. Suspending this observer.");
+                    Suspend();
+                }
 
-            foreach (int id in Meshes.Keys)
-            {
-                RemoveMeshObject(id);
-            }
+                foreach (int id in Meshes.Keys)
+                {
+                    RemoveMeshObject(id);
+                }
 
-            // Resend file observations when resumed.
-            sendObservations = true;
+                // Resend file observations when resumed.
+                sendObservations = true;
+            }
         }
 
         /// <inheritdoc />
@@ -161,6 +167,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         
         private int currentMeshId = 0;
 
+        private static readonly ProfilerMarker SendMeshObjectsPerfMarker = new ProfilerMarker("[MRTK] SpatialObjectMeshObserver.SendMeshObjects");
+
         /// <summary>
         /// Sends the observations using the mesh data contained within the configured 3D model.
         /// </summary>
@@ -168,52 +176,60 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         {
             if (!sendObservations) { return; }
 
-            if (spatialMeshObject != null)
+            using (SendMeshObjectsPerfMarker.Auto())
             {
-                MeshFilter[] meshFilters = spatialMeshObject.GetComponentsInChildren<MeshFilter>();
-                for (int i = 0; i < meshFilters.Length; i++)
+                if (spatialMeshObject != null)
                 {
-                    SpatialAwarenessMeshObject meshObject = SpatialAwarenessMeshObject.Create(
-                        meshFilters[i].sharedMesh,
-                        MeshPhysicsLayer,
-                        $"Spatial Object Mesh {currentMeshId}",
-                        currentMeshId,
-                        ObservedObjectParent);
+                    MeshFilter[] meshFilters = spatialMeshObject.GetComponentsInChildren<MeshFilter>();
+                    for (int i = 0; i < meshFilters.Length; i++)
+                    {
+                        SpatialAwarenessMeshObject meshObject = SpatialAwarenessMeshObject.Create(
+                            meshFilters[i].sharedMesh,
+                            MeshPhysicsLayer,
+                            $"Spatial Object Mesh {currentMeshId}",
+                            currentMeshId,
+                            ObservedObjectParent);
 
-                    meshObject.GameObject.transform.localPosition = meshFilters[i].transform.position;
-                    meshObject.GameObject.transform.localRotation = meshFilters[i].transform.rotation;
+                        meshObject.GameObject.transform.localPosition = meshFilters[i].transform.position;
+                        meshObject.GameObject.transform.localRotation = meshFilters[i].transform.rotation;
 
-                    ApplyMeshMaterial(meshObject);
+                        ApplyMeshMaterial(meshObject);
 
-                    meshes.Add(currentMeshId, meshObject);
+                        meshes.Add(currentMeshId, meshObject);
 
-                    meshEventData.Initialize(this, currentMeshId, meshObject);
-                    SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshAdded);
+                        meshEventData.Initialize(this, currentMeshId, meshObject);
+                        SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshAdded);
 
-                    currentMeshId++;
+                        currentMeshId++;
+                    }
                 }
-            }
 
-            sendObservations = false;
+                sendObservations = false;
+            }
         }
+
+        private static readonly ProfilerMarker RemoveMeshObjectPerfMarker = new ProfilerMarker("[MRTK] SpatialObjectMeshObserver.RemoveMeshObject");
 
         /// <summary>
         /// Removes an observation.
         /// </summary>
         private void RemoveMeshObject(int meshId)
         {
-            if (meshes.TryGetValue(meshId, out SpatialAwarenessMeshObject meshObject))
+            using (RemoveMeshObjectPerfMarker.Auto())
             {
-                // Remove the mesh object from the collection.
-                meshes.Remove(meshId);
-                if (meshObject != null)
+                if (meshes.TryGetValue(meshId, out SpatialAwarenessMeshObject meshObject))
                 {
-                    SpatialAwarenessMeshObject.Cleanup(meshObject);
-                }
+                    // Remove the mesh object from the collection.
+                    meshes.Remove(meshId);
+                    if (meshObject != null)
+                    {
+                        SpatialAwarenessMeshObject.Cleanup(meshObject);
+                    }
 
-                // Send the mesh removed event
-                meshEventData.Initialize(this, meshId, null);
-                SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshRemoved);
+                    // Send the mesh removed event
+                    meshEventData.Initialize(this, meshId, null);
+                    SpatialAwarenessSystem?.HandleEvent(meshEventData, OnMeshRemoved);
+                }
             }
         }
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealitySpatialMeshObserver.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.SpatialAwareness;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
 using UnityEngine;
 
 #if WMR_ENABLED
@@ -36,6 +37,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             BaseMixedRealityProfile profile = null) : base(spatialAwarenessSystem, name, priority, profile)
         { }
 
+        private static readonly ProfilerMarker ConfigureObserverVolumePerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealitySpatialMeshObserver.ConfigureObserverVolume");
+
         /// <inheritdoc/>
         protected override void ConfigureObserverVolume()
         {
@@ -44,25 +47,28 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 return;
             }
 
-            // Update the observer
-            switch (ObserverVolumeType)
+            using (ConfigureObserverVolumePerfMarker.Auto())
             {
-                case VolumeType.AxisAlignedCube:
-                    XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
-                    break;
+                // Update the observer
+                switch (ObserverVolumeType)
+                {
+                    case VolumeType.AxisAlignedCube:
+                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolume(ObserverOrigin, ObservationExtents);
+                        break;
 #if WMR_ENABLED
-                case VolumeType.Sphere:
-                    // We use the x value of the extents as the sphere radius
-                    XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolumeSphere(ObserverOrigin, ObservationExtents.x);
-                    break;
+                    case VolumeType.Sphere:
+                        // We use the x value of the extents as the sphere radius
+                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolumeSphere(ObserverOrigin, ObservationExtents.x);
+                        break;
 
-                case VolumeType.UserAlignedCube:
-                    XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolumeOrientedBox(ObserverOrigin, ObservationExtents, ObserverRotation);
-                    break;
+                    case VolumeType.UserAlignedCube:
+                        XRSDKSubsystemHelpers.MeshSubsystem.SetBoundingVolumeOrientedBox(ObserverOrigin, ObservationExtents, ObserverRotation);
+                        break;
 #endif // WMR_ENABLED
-                default:
-                    Debug.LogError($"Unsupported ObserverVolumeType value {ObserverVolumeType}");
-                    break;
+                    default:
+                        Debug.LogError($"Unsupported ObserverVolumeType value {ObserverVolumeType}");
+                        break;
+                }
             }
         }
     }

--- a/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -217,138 +218,208 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
             }
         }
 
+        private static readonly ProfilerMarker GetObserversPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.GetObservers");
+
         /// <inheritdoc />
         public IReadOnlyList<IMixedRealitySpatialAwarenessObserver> GetObservers()
         {
-            return GetDataProviders() as IReadOnlyList<IMixedRealitySpatialAwarenessObserver>;
+            using (GetObserversPerfMarker.Auto())
+            {
+                return GetDataProviders() as IReadOnlyList<IMixedRealitySpatialAwarenessObserver>;
+            }
         }
+
+        private static readonly ProfilerMarker GetObserversTPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.GetObservers<T>");
 
         /// <inheritdoc />
         public IReadOnlyList<T> GetObservers<T>() where T : IMixedRealitySpatialAwarenessObserver
         {
-            return GetDataProviders<T>();
+            using (GetObserversTPerfMarker.Auto())
+            {
+                return GetDataProviders<T>();
+            }
         }
+
+        private static readonly ProfilerMarker GetObserverPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.GetObserver");
 
         /// <inheritdoc />
         public IMixedRealitySpatialAwarenessObserver GetObserver(string name)
         {
-            return GetDataProvider(name) as IMixedRealitySpatialAwarenessObserver;
+            using (GetObserverPerfMarker.Auto())
+            {
+                return GetDataProvider(name) as IMixedRealitySpatialAwarenessObserver;
+            }
         }
+
+        private static readonly ProfilerMarker GetObserverTPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.GetObserver<T>");
 
         /// <inheritdoc />
         public T GetObserver<T>(string name = null) where T : IMixedRealitySpatialAwarenessObserver
         {
-            return GetDataProvider<T>(name);
+            using (GetObserverTPerfMarker.Auto())
+            {
+                return GetDataProvider<T>(name);
+            }
         }
 
         #region IMixedRealityDataProviderAccess Implementation
 
+        private static readonly ProfilerMarker GetDataProvidersPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.GetDataProviders");
+
         /// <inheritdoc />
         public override IReadOnlyList<T> GetDataProviders<T>()
         {
-            if (!typeof(IMixedRealitySpatialAwarenessObserver).IsAssignableFrom(typeof(T)))
+            using (GetDataProvidersPerfMarker.Auto())
             {
-                return null;
-            }
+                if (!typeof(IMixedRealitySpatialAwarenessObserver).IsAssignableFrom(typeof(T)))
+                {
+                    return null;
+                }
 
-            return base.GetDataProviders<T>();
+                return base.GetDataProviders<T>();
+            }
         }
+
+        private static readonly ProfilerMarker GetDataProviderPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.GetDataProvider");
 
         /// <inheritdoc />
         public override T GetDataProvider<T>(string name = null)
         {
-            if (!typeof(IMixedRealitySpatialAwarenessObserver).IsAssignableFrom(typeof(T)))
+            using (GetDataProviderPerfMarker.Auto())
             {
-                return default(T);
-            }
+                if (!typeof(IMixedRealitySpatialAwarenessObserver).IsAssignableFrom(typeof(T)))
+                {
+                    return default(T);
+                }
 
-            return base.GetDataProvider<T>(name);
+                return base.GetDataProvider<T>(name);
+            }
         }
 
         #endregion IMixedRealityDataProviderAccess Implementation
 
+        private static readonly ProfilerMarker ResumeObserversPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.ResumeObservers");
+
         /// <inheritdoc />
         public void ResumeObservers()
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (ResumeObserversPerfMarker.Auto())
             {
-                observer.Resume();
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+                {
+                    observer.Resume();
+                }
             }
         }
+
+        private static readonly ProfilerMarker ResumeObserversTPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.ResumeObservers<T>");
 
         /// <inheritdoc />
         public void ResumeObservers<T>() where T : IMixedRealitySpatialAwarenessObserver
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (ResumeObserversTPerfMarker.Auto())
             {
-                if (observer is T)
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
                 {
-                    observer.Resume();
+                    if (observer is T)
+                    {
+                        observer.Resume();
+                    }
                 }
             }
         }
+
+        private static readonly ProfilerMarker ResumeObserverPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.ResumeObserver");
 
         /// <inheritdoc />
         public void ResumeObserver<T>(string name) where T : IMixedRealitySpatialAwarenessObserver
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (ResumeObserverPerfMarker.Auto())
             {
-                if (observer is T && observer.Name == name)
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
                 {
-                    observer.Resume();
-                    break;
+                    if (observer is T && observer.Name == name)
+                    {
+                        observer.Resume();
+                        break;
+                    }
                 }
             }
         }
+
+        private static readonly ProfilerMarker SuspendObserversPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.SuspendObservers");
 
         /// <inheritdoc />
         public void SuspendObservers()
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (SuspendObserversPerfMarker.Auto())
             {
-                observer.Suspend();
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+                {
+                    observer.Suspend();
+                }
             }
         }
+
+        private static readonly ProfilerMarker SuspendObserversTPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.SuspendObservers<T>");
 
         /// <inheritdoc />
         public void SuspendObservers<T>() where T : IMixedRealitySpatialAwarenessObserver
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (SuspendObserversTPerfMarker.Auto())
             {
-                if (observer is T)
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
                 {
-                    observer.Suspend();
+                    if (observer is T)
+                    {
+                        observer.Suspend();
+                    }
                 }
             }
         }
+
+        private static readonly ProfilerMarker SuspendObserverPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.SuspendObserver");
 
         /// <inheritdoc />
         public void SuspendObserver<T>(string name) where T : IMixedRealitySpatialAwarenessObserver
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (SuspendObserverPerfMarker.Auto())
             {
-                if (observer is T && observer.Name == name)
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
                 {
-                    observer.Suspend();
-                    break;
+                    if (observer is T && observer.Name == name)
+                    {
+                        observer.Suspend();
+                        break;
+                    }
                 }
             }
         }
 
+        private static readonly ProfilerMarker ClearObservationsPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.ClearObservations");
+
         /// <inheritdoc />
         public void ClearObservations()
         {
-            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            using (ClearObservationsPerfMarker.Auto())
             {
-                observer.ClearObservations();
+                foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+                {
+                    observer.ClearObservations();
+                }
             }
         }
+
+        private static readonly ProfilerMarker ClearObservationsTPerfMarker = new ProfilerMarker("[MRTK] MixedRealitySpatialAwarenessSystem.ClearObservations<T>");
 
         /// <inheritdoc />
         public void ClearObservations<T>(string name) where T : IMixedRealitySpatialAwarenessObserver
         {
-            T observer = GetObserver<T>(name);
-            observer?.ClearObservations();
+            using (ClearObservationsTPerfMarker.Auto())
+            {
+                T observer = GetObserver<T>(name);
+                observer?.ClearObservations();
+            }
         }
 
         #endregion IMixedRealitySpatialAwarenessSystem Implementation


### PR DESCRIPTION
This change adds unity profiler markers to the spatial awareness system and its data providers.

This is a part of #7565