### PR TITLE
Remove leftover Profiler.EndSample() code in GenericXRSDKController

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -168,7 +168,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                             buttonUsage = CommonUsages.secondary2DAxisClick;
                             break;
                         default:
-                            Profiler.EndSample(); // UpdateButtonData - non button
                             return;
                     }
 
@@ -243,7 +242,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                         }
                         break;
                     default:
-                        Profiler.EndSample(); // UpdateSingleAxisData - non single axis
                         return;
                 }
 
@@ -279,7 +277,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                         axisUsage = CommonUsages.primary2DAxis;
                         break;
                     default:
-                        Profiler.EndSample(); // UpdateDualAxisData - non dual axis
                         return;
                 }
 


### PR DESCRIPTION
## Overview

Some profiler code was left in GenericXRSDKController, which causes a compilation error in Unity 2019.3 due to the removed `using`.