### PR TITLE
Update config checker to be aware of XR SDK

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -23,7 +23,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         const string RenderingMode = "Single Pass Instanced";
 #endif
 
-
         public MixedRealityEditorSettings()
         {
             callbackOrder = 0;

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
                 RenderToggle(MRConfig.ForceTextSerialization, "Enable Force Text Serialization");
                 RenderToggle(MRConfig.VisibleMetaFiles, "Enable Visible meta files");
-                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS())
+                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && !XRSettingsUtilities.ShouldLegacyVrBeDisabled)
                 {
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.VirtualRealitySupported, "Enable Legacy XR");

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -164,14 +164,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {
                 scrollPosition = scrollView.scrollPosition;
                 EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
-                RenderToggle(MRConfig.ForceTextSerialization, "Enable Force Text Serialization");
-                RenderToggle(MRConfig.VisibleMetaFiles, "Enable Visible meta files");
+                RenderToggle(MRConfig.ForceTextSerialization, "Force text asset serialization");
+                RenderToggle(MRConfig.VisibleMetaFiles, "Enable visible meta files");
                 if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && !XRSettingsUtilities.ShouldLegacyVrBeDisabled)
                 {
 #if UNITY_2019_3_OR_NEWER
-                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable Legacy XR");
+                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable legacy XR");
 #else
-                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR Supported");
+                    RenderToggle(MRConfig.VirtualRealitySupported, "Enable VR supported");
 #endif // UNITY_2019_3_OR_NEWER
                 }
 #if UNITY_2019_3_OR_NEWER

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
                 RenderToggle(MRConfig.ForceTextSerialization, "Force text asset serialization");
                 RenderToggle(MRConfig.VisibleMetaFiles, "Enable visible meta files");
-                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && !XRSettingsUtilities.ShouldLegacyVRBeDisabled)
+                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && XRSettingsUtilities.IsLegacyXRActive)
                 {
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.VirtualRealitySupported, "Enable legacy XR");

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.LabelField("Project Settings", EditorStyles.boldLabel);
                 RenderToggle(MRConfig.ForceTextSerialization, "Force text asset serialization");
                 RenderToggle(MRConfig.VisibleMetaFiles, "Enable visible meta files");
-                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && !XRSettingsUtilities.ShouldLegacyVrBeDisabled)
+                if (!MixedRealityOptimizeUtils.IsBuildTargetAndroid() && !MixedRealityOptimizeUtils.IsBuildTargetIOS() && !XRSettingsUtilities.ShouldLegacyVRBeDisabled)
                 {
 #if UNITY_2019_3_OR_NEWER
                     RenderToggle(MRConfig.VirtualRealitySupported, "Enable legacy XR");

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -4,9 +4,12 @@
 using Microsoft.MixedReality.Toolkit.Editor;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
+
+#if !UNITY_2019_3_OR_NEWER
+using System.IO;
+#endif // !UNITY_2019_3_OR_NEWER
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         // The configure functions for each type of setting
         private static readonly Dictionary<Configurations, Action> ConfigurationSetters = new Dictionary<Configurations, Action>()
         {
-            { Configurations.LatestScriptingRuntime,SetLatestScriptingRuntime },
+            { Configurations.LatestScriptingRuntime, SetLatestScriptingRuntime },
             { Configurations.ForceTextSerialization, SetForceTextSerialization },
             { Configurations.VisibleMetaFiles, SetVisibleMetaFiles },
             { Configurations.VirtualRealitySupported, () => XRSettingsUtilities.LegacyXREnabled = true },
@@ -246,7 +246,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             return PlayerSettings.scriptingRuntimeVersion == ScriptingRuntimeVersion.Latest;
 #else
-        return true;
+            return true;
 #endif // UNITY_2019_3_OR_NEWER
         }
 

--- a/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
@@ -28,14 +28,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Gets or sets the legacy virtual reality supported property in the player settings.
         /// </summary>
+        /// <remarks>Returns true if legacy XR is disabled due to XR SDK in Unity 2019.3+.</remarks>
         public static bool LegacyXREnabled
         {
             get
             {
                 // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
-                // with legacy requirements.
+                // with legacy requirements. Returns true if legacy XR is disabled due to XR SDK.
 #pragma warning disable 0618
-                return ShouldLegacyVRBeDisabled || PlayerSettings.virtualRealitySupported;
+                return !IsLegacyXRActive || PlayerSettings.virtualRealitySupported;
 #pragma warning restore 0618
             }
 
@@ -50,20 +51,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         }
 
 #if UNITY_2019_3_OR_NEWER
-        private static bool? shouldLegacyVRBeDisabled = null;
+        private static bool? isLegacyXRActive = null;
 #endif // UNITY_2019_3_OR_NEWER
 
         /// <summary>
-        /// Checks if an XR SDK plug-in is installed that disables legacy VR.
+        /// Checks if an XR SDK plug-in is installed that disables legacy VR. Returns false if so.
         /// </summary>
-        public static bool ShouldLegacyVRBeDisabled
+        public static bool IsLegacyXRActive
         {
             get
             {
 #if UNITY_2019_3_OR_NEWER
-                if (!shouldLegacyVRBeDisabled.HasValue)
+                if (!isLegacyXRActive.HasValue)
                 {
-                    shouldLegacyVRBeDisabled = false;
+                    isLegacyXRActive = true;
 
                     List<ISubsystemDescriptor> descriptors = new List<ISubsystemDescriptor>();
                     SubsystemManager.GetAllSubsystemDescriptors(descriptors);
@@ -74,15 +75,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         {
                             if (displayDescriptor.disablesLegacyVr)
                             {
-                                shouldLegacyVRBeDisabled = true;
+                                isLegacyXRActive = false;
                             }
                         }
                     }
                 }
 
-                return shouldLegacyVRBeDisabled.HasValue && shouldLegacyVRBeDisabled.Value;
+                return isLegacyXRActive.HasValue && isLegacyXRActive.Value;
 #else
-                return false;
+                return true;
 #endif // UNITY_2019_3_OR_NEWER
             }
         }
@@ -91,7 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Called when packages are installed or uninstalled, to toggle a new check on XR SDK package installation status.
         /// </summary>
-        private static void EditorApplication_projectChanged() => shouldLegacyVRBeDisabled = null;
+        private static void EditorApplication_projectChanged() => isLegacyXRActive = null;
 #endif // UNITY_2019_3_OR_NEWER
     }
 }

--- a/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
@@ -76,6 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                             if (displayDescriptor.disablesLegacyVr)
                             {
                                 isLegacyXRActive = false;
+                                break;
                             }
                         }
                     }

--- a/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #endif // UNITY_2019_3_OR_NEWER
 
         /// <summary>
-        /// Gets or sets the legacy virtual reality supported property in the player settings object.
+        /// Gets or sets the legacy virtual reality supported property in the player settings.
         /// </summary>
         public static bool LegacyXREnabled
         {
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
                 // with legacy requirements.
 #pragma warning disable 0618
-                return ShouldLegacyVrBeDisabled || PlayerSettings.virtualRealitySupported;
+                return ShouldLegacyVRBeDisabled || PlayerSettings.virtualRealitySupported;
 #pragma warning restore 0618
             }
 
@@ -50,20 +50,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         }
 
 #if UNITY_2019_3_OR_NEWER
-        private static bool? shouldLegacyVrBeDisabled = null;
+        private static bool? shouldLegacyVRBeDisabled = null;
 #endif // UNITY_2019_3_OR_NEWER
 
         /// <summary>
         /// Checks if an XR SDK plug-in is installed that disables legacy VR.
         /// </summary>
-        public static bool ShouldLegacyVrBeDisabled
+        public static bool ShouldLegacyVRBeDisabled
         {
             get
             {
 #if UNITY_2019_3_OR_NEWER
-                if (!shouldLegacyVrBeDisabled.HasValue)
+                if (!shouldLegacyVRBeDisabled.HasValue)
                 {
-                    shouldLegacyVrBeDisabled = false;
+                    shouldLegacyVRBeDisabled = false;
 
                     List<ISubsystemDescriptor> descriptors = new List<ISubsystemDescriptor>();
                     SubsystemManager.GetAllSubsystemDescriptors(descriptors);
@@ -74,13 +74,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         {
                             if (displayDescriptor.disablesLegacyVr)
                             {
-                                shouldLegacyVrBeDisabled = true;
+                                shouldLegacyVRBeDisabled = true;
                             }
                         }
                     }
                 }
 
-                return shouldLegacyVrBeDisabled.HasValue && shouldLegacyVrBeDisabled.Value;
+                return shouldLegacyVRBeDisabled.HasValue && shouldLegacyVRBeDisabled.Value;
 #else
                 return false;
 #endif // UNITY_2019_3_OR_NEWER
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Called when packages are installed or uninstalled, to toggle a new check on XR SDK package installation status.
         /// </summary>
-        private static void EditorApplication_projectChanged() => shouldLegacyVrBeDisabled = null;
+        private static void EditorApplication_projectChanged() => shouldLegacyVRBeDisabled = null;
 #endif // UNITY_2019_3_OR_NEWER
     }
 }

--- a/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/XRSettingsUtilities.cs
@@ -3,6 +3,12 @@
 
 using UnityEditor;
 
+#if UNITY_2019_3_OR_NEWER
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.XR;
+#endif // UNITY_2019_3_OR_NEWER
+
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
     /// <summary>
@@ -11,6 +17,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     /// </summary>
     public static class XRSettingsUtilities
     {
+#if UNITY_2019_3_OR_NEWER
+        static XRSettingsUtilities()
+        {
+            // Called when packages are installed or uninstalled
+            EditorApplication.projectChanged += EditorApplication_projectChanged;
+        }
+#endif // UNITY_2019_3_OR_NEWER
+
         /// <summary>
         /// Gets or sets the legacy virtual reality supported property in the player settings object.
         /// </summary>
@@ -21,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // Ensure compatibility with the pre-2019.3 XR architecture for customers / platforms
                 // with legacy requirements.
 #pragma warning disable 0618
-                return PlayerSettings.virtualRealitySupported;
+                return ShouldLegacyVrBeDisabled || PlayerSettings.virtualRealitySupported;
 #pragma warning restore 0618
             }
 
@@ -34,5 +48,50 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #pragma warning restore 0618
             }
         }
+
+#if UNITY_2019_3_OR_NEWER
+        private static bool? shouldLegacyVrBeDisabled = null;
+#endif // UNITY_2019_3_OR_NEWER
+
+        /// <summary>
+        /// Checks if an XR SDK plug-in is installed that disables legacy VR.
+        /// </summary>
+        public static bool ShouldLegacyVrBeDisabled
+        {
+            get
+            {
+#if UNITY_2019_3_OR_NEWER
+                if (!shouldLegacyVrBeDisabled.HasValue)
+                {
+                    shouldLegacyVrBeDisabled = false;
+
+                    List<ISubsystemDescriptor> descriptors = new List<ISubsystemDescriptor>();
+                    SubsystemManager.GetAllSubsystemDescriptors(descriptors);
+
+                    foreach (ISubsystemDescriptor descriptor in descriptors)
+                    {
+                        if (descriptor is XRDisplaySubsystemDescriptor displayDescriptor)
+                        {
+                            if (displayDescriptor.disablesLegacyVr)
+                            {
+                                shouldLegacyVrBeDisabled = true;
+                            }
+                        }
+                    }
+                }
+
+                return shouldLegacyVrBeDisabled.HasValue && shouldLegacyVrBeDisabled.Value;
+#else
+                return false;
+#endif // UNITY_2019_3_OR_NEWER
+            }
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        /// <summary>
+        /// Called when packages are installed or uninstalled, to toggle a new check on XR SDK package installation status.
+        /// </summary>
+        private static void EditorApplication_projectChanged() => shouldLegacyVrBeDisabled = null;
+#endif // UNITY_2019_3_OR_NEWER
     }
 }


### PR DESCRIPTION
## Overview

First pass on making the configurator XR SDK aware. In this, a `bool` is added to `XRSettingsUtilities` which checks if an XR SDK plug-in is installed which disables legacy VR. In this PR, this stops the check for VR enabled from running, since the legacy API was always being checked against and returns false when an XR SDK package is installed. This was causing the configurator to pop-up on every asset reload when XR SDK is enabled.

Next pass would be to see if there's a way to configure the XR SDK loaders from code.

## Changes
- Part of https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7513
