### PR TITLE
Update docs to explain a bit more about what GGV is.

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityGGVHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityGGVHand.cs
@@ -7,7 +7,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 {
     /// <summary>
-    /// A Windows Mixed Reality GGV hand instance.
+    /// A Windows Mixed Reality GGV (Gaze, Gesture, and Voice) hand instance.
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.GGVHand,

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKGGVHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKGGVHand.cs
@@ -7,7 +7,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 {
     /// <summary>
-    /// A Windows Mixed Reality GGV hand instance for XR SDK.
+    /// A Windows Mixed Reality GGV (Gaze, Gesture, and Voice) hand instance for XR SDK.
     /// </summary>
     [MixedRealityController(
         SupportedControllerType.GGVHand,

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// for focus with hand and gesture-based input and interaction across it.
     /// </summary>
     /// <remarks>
+    /// GGV stands for gaze, gesture, and voice.
     /// This pointer's position is given by hand position (grip pose),
     /// and the input focus is given by head gaze.
     /// </remarks>

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
-        /// Test ggv zooming instantiated from prefab
+        /// Test ggv (gaze, gesture, and voice) zooming instantiated from prefab
         /// </summary>
         [UnityTest]
         public IEnumerator Prefab_GGVZoom()

--- a/Documentation/Input/InputProviders.md
+++ b/Documentation/Input/InputProviders.md
@@ -14,7 +14,7 @@ These are the input providers available out of the box, together with their corr
 | [`Unity Joystick Manager`](xref:Microsoft.MixedReality.Toolkit.Input.UnityInput.UnityJoystickManager) | Generic Joystick  |
 | [`Unity Touch Device Manager`](xref:Microsoft.MixedReality.Toolkit.Input.UnityInput.UnityTouchDeviceManager) | Unity Touch Controller  |
 | [`Windows Dictation Input Provider`](xref:Microsoft.MixedReality.Toolkit.Windows.Input.WindowsDictationInputProvider) | *None*  |
-| [`Windows Mixed Reality Device Manager`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityDeviceManager) | WMR Articulated Hand, WMR Controller, WMR GGV Hand |
+| [`Windows Mixed Reality Device Manager`](xref:Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input.WindowsMixedRealityDeviceManager) | WMR Articulated Hand, WMR Controller, WMR GGV (Gaze, Gesture, and Voice) Hand |
 | [`Windows Speech Input Provider`](xref:Microsoft.MixedReality.Toolkit.Windows.Input.WindowsSpeechInputProvider) | *None* |
 
 Dictation and Speech providers don't create any controllers, they raise their own specialized input events directly.

--- a/Documentation/InputSimulation/InputSimulationService.md
+++ b/Documentation/InputSimulation/InputSimulationService.md
@@ -149,7 +149,7 @@ For manipulating objects with two hands at the same time, the persistent hand mo
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Qol5OFNfN14" class="center" frameborder="0" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
 
-### GGV interaction
+### GGV (Gaze, Gesture, and Voice) interaction
 
 1. Enable GGV simulation by switching **Hand Simulation Mode** to *Gestures* in the [Input Simulation Profile](#enabling-the-input-simulation-service)
 1. Rotate the camera to point the gaze cursor at the interactable object (right mouse button)

--- a/Documentation/README_SystemKeyboard.md
+++ b/Documentation/README_SystemKeyboard.md
@@ -2,7 +2,7 @@
 
 ![System keyboard](../Documentation/Images/SystemKeyboard/MRTK_SystemKeyboard_Main.png)
 
-A Unity application can invoke the system keyboard at any time. Note that the system keyboard will behave according to the target platform's capabilities, for example the keyboard on HoloLens 2 would support direct hand interactions, while the keyboard on HoloLens (1st gen) would support GGV<sup>[1](https://docs.microsoft.com/windows/mixed-reality/gaze)</sup>. Additionally, the system keyboard will not show up when performing [Unity Remoting](Tools/HolographicRemoting.md) from the editor to a HoloLens.
+A Unity application can invoke the system keyboard at any time. Note that the system keyboard will behave according to the target platform's capabilities, for example the keyboard on HoloLens 2 would support direct hand interactions, while the keyboard on HoloLens (1st gen) would support GGV (Gaze, Gesture, and Voice)<sup>[1](https://docs.microsoft.com/windows/mixed-reality/gaze)</sup>. Additionally, the system keyboard will not show up when performing [Unity Remoting](Tools/HolographicRemoting.md) from the editor to a HoloLens.
 
 ## How to invoke the system keyboard
 


### PR DESCRIPTION
## Overview
There are a few locations that will use GGV (being the first location that people will often read) which don't expand the acronym. I ended up adding notes on what GGV stands for so that it's then at least searchable afterward (i.e. oh I should look for 'gaze gesture voice').

Note that I also could have introduced an acronym page for the docs but opted to not go that route because I don't think that the page would be super large and I don't think that people would necessarily read it (i.e. explaining what something is inline feels easier to the reader, at least within the scope of these changes)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7623
