### PR TITLE
Remove a section that has dead text/links

### DIFF
--- a/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
+++ b/Documentation/EyeTracking/EyeTracking_ExamplesOverview.md
@@ -41,14 +41,6 @@ For more precisely positioning your hologram, you can use additional input from 
 
 **Summary**: Positioning holograms using eyes, voice and hand input (*drag-and-drop*). Eye-supported sliders using eyes + hands.
 
-### **Visualization of visual attention**
-
-Data based on where users look makes an immensely powerful tool to assess usability of a design and to identify problems in efficient work streams.
-This tutorial discusses different eye tracking visualizations and how they fit different needs.
-We provide basic examples for logging and loading eye tracking data and examples for how to visualize them.
-
-**Summary**: Two-dimensional attention map (heatmaps) on slates. Recording & replaying eye tracking data.
-
 ## Setting up the MRTK eye tracking samples
 
 ### Prerequisites


### PR DESCRIPTION
## Overview
It looks like the eye tracking docs had an outline for a tutorial that was never written - it's possible that it exists somewhere but since it isn't in the rest of our docs, it would be better for us not to have broken links/getting folks' hopes up, so until that tutorial gets written, I'm removing that reference to a non-existent page.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7542