### PR TITLE
Allow user to customize alignment of objects in grid layout

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/CollectionEnums/LayoutAlignment.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/CollectionEnums/LayoutAlignment.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Describes how the layout should be arranged horizontally
+    /// </summary>
+    public enum LayoutHorizontalAlignment
+    {
+        Left,
+        Center,
+        Right
+    };
+
+    /// <summary>
+    /// Describes how the layout should be arranged vertically
+    /// </summary>
+    public enum LayoutVerticalAlignment
+    {
+        Top,
+        Middle,
+        Bottom
+    };
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/CollectionEnums/LayoutAlignment.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/CollectionEnums/LayoutAlignment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c724669b772785a449389352d1c6aa90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -69,15 +69,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         [SerializeField, Tooltip("How the columns are aligned in the grid")]
-        private LayoutHorizontalAlignment colAlignment = LayoutHorizontalAlignment.Left;
+        private LayoutHorizontalAlignment columnAlignment = LayoutHorizontalAlignment.Left;
 
         /// <summary>
         /// How the columns are aligned in the grid
         /// </summary>
-        public LayoutHorizontalAlignment ColAlignment 
+        public LayoutHorizontalAlignment ColumnAlignment 
         {
-            get { return colAlignment; }
-            set { colAlignment = value; }
+            get { return columnAlignment; }
+            set { columnAlignment = value; }
         }
 
         [SerializeField, Tooltip("How the rows are aligned in the grid")]
@@ -371,9 +371,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 {
                     for (int x = 0; x < xMax; x++)
                     {
-                        if(y == yMax - 1)
+                        if (y == yMax - 1)
                         {
-                            switch (ColAlignment)
+                            switch (ColumnAlignment)
                             {
                                 case LayoutHorizontalAlignment.Left:
                                     alignmentOffsetX = 0;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -63,6 +63,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { anchor = value; }
         }
 
+        [SerializeField, Tooltip("How the columns are aligned in the grid")]
+        private LayoutHorizontalAlignment colAlignment = LayoutHorizontalAlignment.Center;
+        public LayoutHorizontalAlignment ColAlignment 
+        {
+            get { return colAlignment; }
+            set { colAlignment = value; }
+        }
+
+        [SerializeField, Tooltip("How the rows are aligned in the gridn")]
+        private LayoutVerticalAlignment rowAlignment = LayoutVerticalAlignment.Top;
+        public LayoutVerticalAlignment RowAlignment
+        {
+            get { return rowAlignment; }
+            set { rowAlignment = value; }
+        }
+
         [Range(0.05f, 100.0f)]
         [Tooltip("Radius for the sphere or cylinder")]
         [SerializeField]
@@ -333,38 +349,70 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 startOffsetY = yMax * CellHeight;
             }
+            float alignmentOffsetX = 0;
+            float alignmentOffsetY = 0;
 
             if (layout == LayoutOrder.ColumnThenRow)
             {
                 for (int y = 0; y < yMax; y++)
+                {
                     for (int x = 0; x < xMax; x++)
                     {
+                        if(y == yMax - 1)
                         {
-                            if (cellCounter < NodeList.Count)
+                            switch (ColAlignment)
                             {
-                                grid[cellCounter].Set((-startOffsetX + (x * CellWidth) + HalfCell.x) + NodeList[cellCounter].Offset.x,
-                                                     (startOffsetY - (y * CellHeight) - HalfCell.y) + NodeList[cellCounter].Offset.y,
-                                                     0.0f);
+                                case LayoutHorizontalAlignment.Left:
+                                    alignmentOffsetX = 0;
+                                    break;
+                                case LayoutHorizontalAlignment.Center:
+                                    alignmentOffsetX = CellWidth *((xMax - (NodeList.Count % xMax)) % xMax) * 0.5f;
+                                    break;
+                                case LayoutHorizontalAlignment.Right:
+                                    alignmentOffsetX = CellWidth * ((xMax - (NodeList.Count % xMax)) % xMax);
+                                    break;
                             }
-                            cellCounter++;
                         }
-                    }
 
+                        if (cellCounter < NodeList.Count)
+                        {
+                            grid[cellCounter].Set((-startOffsetX + (x * CellWidth) + HalfCell.x) + NodeList[cellCounter].Offset.x + alignmentOffsetX,
+                                                 (startOffsetY - (y * CellHeight) - HalfCell.y) + NodeList[cellCounter].Offset.y + alignmentOffsetY,
+                                                 0.0f);
+                        }
+                        cellCounter++;
+                    }
+                }
             }
             else
             {
-
                 for (int x = 0; x < xMax; x++)
                 {
                     for (int y = 0; y < yMax; y++)
                     {
+                        if (x == xMax - 1)
+                        {
+                            switch (RowAlignment)
+                            {
+                                case LayoutVerticalAlignment.Top:
+                                    alignmentOffsetY = 0;
+                                    break;
+                                case LayoutVerticalAlignment.Middle:
+                                    alignmentOffsetY = -CellHeight * ((yMax - (NodeList.Count % yMax)) % yMax) * 0.5f;
+                                    break;
+                                case LayoutVerticalAlignment.Bottom:
+                                    alignmentOffsetY = -CellHeight * ((yMax - (NodeList.Count % yMax)) % yMax);
+                                    break;
+                            }
+                        }
+
                         if (cellCounter < NodeList.Count)
                         {
-                            grid[cellCounter].Set((-startOffsetX + (x * CellWidth) + HalfCell.x) + NodeList[cellCounter].Offset.x,
-                                                 (startOffsetY - (y * CellHeight) - HalfCell.y) + NodeList[cellCounter].Offset.y,
+                            grid[cellCounter].Set((-startOffsetX + (x * CellWidth) + HalfCell.x) + NodeList[cellCounter].Offset.x + alignmentOffsetX,
+                                                 (startOffsetY - (y * CellHeight) - HalfCell.y) + NodeList[cellCounter].Offset.y + alignmentOffsetY,
                                                  0.0f);
                         }
-                        cellCounter++;
+                    cellCounter++;
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -42,12 +42,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { orientType = value; }
         }
 
-        [Tooltip("Specify direction in which children are laid out.")]
+        [Tooltip("Specify direction in which children are laid out")]
         [SerializeField]
         private LayoutOrder layout = LayoutOrder.RowThenColumn;
 
         /// <summary>
-        /// Specify direction in which children are laid out.
+        /// Specify direction in which children are laid out
         /// </summary>
         public LayoutOrder Layout
         {
@@ -55,8 +55,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { layout = value; }
         }
 
+
         [SerializeField, Tooltip("Where the grid is anchored relative to local origin")]
         private LayoutAnchor anchor = LayoutAnchor.MiddleCenter;
+
+        /// <summary>
+        /// Where the grid is anchored relative to local origin
+        /// </summary>
         public LayoutAnchor Anchor
         {
             get { return anchor; }
@@ -64,15 +69,23 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         [SerializeField, Tooltip("How the columns are aligned in the grid")]
-        private LayoutHorizontalAlignment colAlignment = LayoutHorizontalAlignment.Center;
+        private LayoutHorizontalAlignment colAlignment = LayoutHorizontalAlignment.Left;
+
+        /// <summary>
+        /// How the columns are aligned in the grid
+        /// </summary>
         public LayoutHorizontalAlignment ColAlignment 
         {
             get { return colAlignment; }
             set { colAlignment = value; }
         }
 
-        [SerializeField, Tooltip("How the rows are aligned in the gridn")]
+        [SerializeField, Tooltip("How the rows are aligned in the grid")]
         private LayoutVerticalAlignment rowAlignment = LayoutVerticalAlignment.Top;
+
+        /// <summary>
+        /// How the rows are aligned in the grid
+        /// </summary>
         public LayoutVerticalAlignment RowAlignment
         {
             get { return rowAlignment; }

--- a/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private SerializedProperty cellWidth;
         private SerializedProperty cellHeight;
         private SerializedProperty anchor;
+        private SerializedProperty rowAlignment;
+        private SerializedProperty colAlignment;
 
 
         protected override void OnEnable()
@@ -36,6 +38,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             cellWidth = serializedObject.FindProperty("cellWidth");
             cellHeight = serializedObject.FindProperty("cellHeight");
             anchor = serializedObject.FindProperty("anchor");
+            rowAlignment = serializedObject.FindProperty("rowAlignment");
+            colAlignment = serializedObject.FindProperty("colAlignment");
         }
 
         protected override void OnInspectorGUIInsertion()
@@ -51,11 +55,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {
                 EditorGUILayout.HelpBox("ColumnThenRow will lay out content first horizontally (by column), then vertically (by row). NumColumns specifies number of columns per row.", MessageType.Info);
                 EditorGUILayout.PropertyField(cols, new GUIContent("Num Columns", "Number of columns per row."));
+                EditorGUILayout.PropertyField(colAlignment);
             }
             else if (layoutTypeIndex == LayoutOrder.RowThenColumn)
             {
                 EditorGUILayout.HelpBox("RowThenColumns will lay out content first vertically (by row), then horizontally (by column). NumRows specifies number of rows per column.", MessageType.Info);
                 EditorGUILayout.PropertyField(rows, new GUIContent("Num Rows", "Number of rows per column."));
+                EditorGUILayout.PropertyField(rowAlignment);
             }
             else
             {
@@ -87,7 +93,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // layout anchor has no effect on radial layout, it is always at center.
                 EditorGUILayout.PropertyField(anchor);
             }
-            
         }
     }
 }

--- a/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private SerializedProperty cellHeight;
         private SerializedProperty anchor;
         private SerializedProperty rowAlignment;
-        private SerializedProperty colAlignment;
+        private SerializedProperty columnAlignment;
 
 
         protected override void OnEnable()
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             cellHeight = serializedObject.FindProperty("cellHeight");
             anchor = serializedObject.FindProperty("anchor");
             rowAlignment = serializedObject.FindProperty("rowAlignment");
-            colAlignment = serializedObject.FindProperty("colAlignment");
+            columnAlignment = serializedObject.FindProperty("columnAlignment");
         }
 
         protected override void OnInspectorGUIInsertion()
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {
                 EditorGUILayout.HelpBox("ColumnThenRow will lay out content first horizontally (by column), then vertically (by row). NumColumns specifies number of columns per row.", MessageType.Info);
                 EditorGUILayout.PropertyField(cols, new GUIContent("Num Columns", "Number of columns per row."));
-                EditorGUILayout.PropertyField(colAlignment);
+                EditorGUILayout.PropertyField(columnAlignment);
             }
             else if (layoutTypeIndex == LayoutOrder.RowThenColumn)
             {

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -120,13 +120,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 child.transform.localScale = Vector3.one * 0.1f;
             }
 
-            grid.ColAlignment = LayoutHorizontalAlignment.Left;
+            grid.ColumnAlignment = LayoutHorizontalAlignment.Left;
             grid.UpdateCollection();
 
             int expectedIdx = 0;
             foreach (LayoutHorizontalAlignment alignment in Enum.GetValues(typeof(LayoutHorizontalAlignment)))
             {
-                grid.ColAlignment = alignment;
+                grid.ColumnAlignment = alignment;
                 grid.UpdateCollection();
                 int j = 0;
                 foreach (Transform child2 in go.transform)

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Tests that grid lays out object correctly for all different anchor types
         /// </summary>
         [UnityTest]
-        public IEnumerator TestAnchors()
+        public IEnumerator TestGridAnchors()
         {
             // Create a grid
             GameObject go = new GameObject();
@@ -93,40 +93,139 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
             yield return null;
         }
+        
+        /// <summary>
+        /// Tests that grid lays out object correctly for all different alignment options
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestGridAlignment()
+        {
+            // Create a grid
+            GameObject go = new GameObject();
+            go.name = "grid";
+            var grid = go.AddComponent<GridObjectCollection>();
+            grid.Distance = 0.75f;
+            grid.CellWidth = 0.15f;
+            grid.CellHeight = 0.15f;
 
-    #region Expected Values
-    // You can use GridObjectLayoutControl.cs in the examples package to
-    // quickly generate the expected positions used in these tests.
+            grid.Layout = LayoutOrder.ColumnThenRow;
+            grid.Columns = 2;
 
-    private Vector3[] anchorTestExpected = new Vector3[] {
-        new Vector3(0.08f, -0.08f, 0.75f), // UpperLeft index 0
-        new Vector3(0.23f, -0.08f, 0.75f), // UpperLeft index 1
-        new Vector3(0.38f, -0.08f, 0.75f), // UpperLeft index 2
-        new Vector3(-0.15f, -0.08f, 0.75f), // UpperCenter index 0
-        new Vector3(0.00f, -0.08f, 0.75f), // UpperCenter index 1
-        new Vector3(0.15f, -0.08f, 0.75f), // UpperCenter index 2
-        new Vector3(-0.38f, -0.08f, 0.75f), // UpperRight index 0
-        new Vector3(-0.23f, -0.08f, 0.75f), // UpperRight index 1
-        new Vector3(-0.08f, -0.08f, 0.75f), // UpperRight index 2
-        new Vector3(0.08f, 0.00f, 0.75f), // MiddleLeft index 0
-        new Vector3(0.23f, 0.00f, 0.75f), // MiddleLeft index 1
-        new Vector3(0.38f, 0.00f, 0.75f), // MiddleLeft index 2
-        new Vector3(-0.15f, 0.00f, 0.75f), // MiddleCenter index 0
-        new Vector3(0.00f, 0.00f, 0.75f), // MiddleCenter index 1
-        new Vector3(0.15f, 0.00f, 0.75f), // MiddleCenter index 2
-        new Vector3(-0.38f, 0.00f, 0.75f), // MiddleRight index 0
-        new Vector3(-0.23f, 0.00f, 0.75f), // MiddleRight index 1
-        new Vector3(-0.08f, 0.00f, 0.75f), // MiddleRight index 2
-        new Vector3(0.08f, 0.08f, 0.75f), // BottomLeft index 0
-        new Vector3(0.23f, 0.08f, 0.75f), // BottomLeft index 1
-        new Vector3(0.38f, 0.08f, 0.75f), // BottomLeft index 2
-        new Vector3(-0.15f, 0.08f, 0.75f), // BottomCenter index 0
-        new Vector3(0.00f, 0.08f, 0.75f), // BottomCenter index 1
-        new Vector3(0.15f, 0.08f, 0.75f), // BottomCenter index 2
-        new Vector3(-0.38f, 0.08f, 0.75f), // BottomRight index 0
-        new Vector3(-0.23f, 0.08f, 0.75f), // BottomRight index 1
-        new Vector3(-0.08f, 0.08f, 0.75f) // BottomRight index 2
-    };
+            grid.Anchor = LayoutAnchor.UpperCenter;
+
+            for (int i = 0; i < 3; i++)
+            {
+                var child = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                child.transform.parent = go.transform;
+                child.transform.localScale = Vector3.one * 0.1f;
+            }
+
+            grid.ColAlignment = LayoutHorizontalAlignment.Left;
+            grid.UpdateCollection();
+
+            int expectedIdx = 0;
+            foreach (LayoutHorizontalAlignment alignment in Enum.GetValues(typeof(LayoutHorizontalAlignment)))
+            {
+                grid.ColAlignment = alignment;
+                grid.UpdateCollection();
+                int j = 0;
+                foreach (Transform child2 in go.transform)
+                {
+                    var expected = alignmentTestExpected[expectedIdx];
+                    var actual = child2.transform.localPosition;
+                    TestUtilities.AssertAboutEqual(
+                        actual,
+                        expected,
+                        "Child object not in expected position, horizontal alignment " + alignment,
+                        0.01f);
+                    j++;
+                    expectedIdx++;
+                }
+                yield return null;
+
+            }
+            yield return null;
+
+            grid.Layout = LayoutOrder.RowThenColumn;
+            grid.Rows = 2;
+
+            foreach (LayoutVerticalAlignment alignment in Enum.GetValues(typeof(LayoutVerticalAlignment)))
+            {
+                grid.RowAlignment = alignment;
+                grid.UpdateCollection();
+                int j = 0;
+                foreach (Transform child2 in go.transform)
+                {
+                    var expected = alignmentTestExpected[expectedIdx];
+                    var actual = child2.transform.localPosition;
+                    TestUtilities.AssertAboutEqual(
+                        actual,
+                        expected,
+                        "Child object not in expected position, horizontal alignment " + alignment,
+                        0.01f);
+                    j++;
+                    expectedIdx++;
+                }
+                yield return null;
+
+            }
+            yield return null;
+        }
+
+
+        #region Expected Values
+        // You can use GridObjectLayoutControl.cs in the examples package to
+        // quickly generate the expected positions used in these tests.
+
+        private Vector3[] anchorTestExpected = new Vector3[] {
+            new Vector3(0.08f, -0.08f, 0.75f), // UpperLeft index 0
+            new Vector3(0.23f, -0.08f, 0.75f), // UpperLeft index 1
+            new Vector3(0.38f, -0.08f, 0.75f), // UpperLeft index 2
+            new Vector3(-0.15f, -0.08f, 0.75f), // UpperCenter index 0
+            new Vector3(0.00f, -0.08f, 0.75f), // UpperCenter index 1
+            new Vector3(0.15f, -0.08f, 0.75f), // UpperCenter index 2
+            new Vector3(-0.38f, -0.08f, 0.75f), // UpperRight index 0
+            new Vector3(-0.23f, -0.08f, 0.75f), // UpperRight index 1
+            new Vector3(-0.08f, -0.08f, 0.75f), // UpperRight index 2
+            new Vector3(0.08f, 0.00f, 0.75f), // MiddleLeft index 0
+            new Vector3(0.23f, 0.00f, 0.75f), // MiddleLeft index 1
+            new Vector3(0.38f, 0.00f, 0.75f), // MiddleLeft index 2
+            new Vector3(-0.15f, 0.00f, 0.75f), // MiddleCenter index 0
+            new Vector3(0.00f, 0.00f, 0.75f), // MiddleCenter index 1
+            new Vector3(0.15f, 0.00f, 0.75f), // MiddleCenter index 2
+            new Vector3(-0.38f, 0.00f, 0.75f), // MiddleRight index 0
+            new Vector3(-0.23f, 0.00f, 0.75f), // MiddleRight index 1
+            new Vector3(-0.08f, 0.00f, 0.75f), // MiddleRight index 2
+            new Vector3(0.08f, 0.08f, 0.75f), // BottomLeft index 0
+            new Vector3(0.23f, 0.08f, 0.75f), // BottomLeft index 1
+            new Vector3(0.38f, 0.08f, 0.75f), // BottomLeft index 2
+            new Vector3(-0.15f, 0.08f, 0.75f), // BottomCenter index 0
+            new Vector3(0.00f, 0.08f, 0.75f), // BottomCenter index 1
+            new Vector3(0.15f, 0.08f, 0.75f), // BottomCenter index 2
+            new Vector3(-0.38f, 0.08f, 0.75f), // BottomRight index 0
+            new Vector3(-0.23f, 0.08f, 0.75f), // BottomRight index 1
+            new Vector3(-0.08f, 0.08f, 0.75f) // BottomRight index 2
+        };
+        private Vector3[] alignmentTestExpected = new Vector3[] {
+            new Vector3(-0.075f, -0.075f, 0.75f), // Left Horizontal 0
+            new Vector3(0.075f, -0.075f, 0.75f), // Left Horizontal 1
+            new Vector3(-0.075f, -0.225f, 0.75f), // Left Horizontal 2
+            new Vector3(-0.075f, -0.075f, 0.75f), // Center Horizontal 0
+            new Vector3(0.075f, -0.075f, 0.75f), // Center Horizontal 1
+            new Vector3(0f, -0.225f, 0.75f), // Center Horizontal 2
+            new Vector3(-0.075f, -0.075f, 0.75f), // Right Horizontal 0
+            new Vector3(0.075f, -0.075f, 0.75f), // Right Horizontal 1
+            new Vector3(0.075f, -0.225f, 0.75f), // Right Horizontal 2
+            new Vector3(-0.075f, -0.075f, 0.75f), // Top Vertical 0
+            new Vector3(-0.075f, -0.225f, 0.75f), // Top Vertical 1
+            new Vector3(0.075f, -0.075f, 0.75f), // Top Vertical 2
+            new Vector3(-0.075f, -0.075f, 0.75f), // Middle Vertical 0
+            new Vector3(-0.075f, -0.225f, 0.75f), // Middle Vertical 1
+            new Vector3(0.075f, -0.150f, 0.75f), // Middle Vertical 2
+            new Vector3(-0.075f, -0.075f, 0.75f), // Bottom Vertical 0
+            new Vector3(-0.075f, -0.225f, 0.75f), // Middle Vertical 1
+            new Vector3(0.075f, -0.225f, 0.75f), // Top Vertical 2
+        };
     #endregion
     
     #endregion

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -75,17 +75,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 grid.Anchor = et;
                 grid.UpdateCollection();
-                int j = 0;
-                foreach(Transform child2 in go.transform)
+                foreach(Transform childTransform in go.transform)
                 {
                     var expected = anchorTestExpected[expectedIdx];
-                    var actual = child2.transform.localPosition;
+                    var actual = childTransform.transform.localPosition;
                     TestUtilities.AssertAboutEqual(
                         actual, 
                         expected, 
                         "Child object not in expected position, layout " + et, 
                         0.01f);
-                    j++;
                     expectedIdx++;
                 }
                 yield return null;
@@ -128,17 +126,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 grid.ColumnAlignment = alignment;
                 grid.UpdateCollection();
-                int j = 0;
-                foreach (Transform child2 in go.transform)
+                foreach (Transform childTransform in go.transform)
                 {
                     var expected = alignmentTestExpected[expectedIdx];
-                    var actual = child2.transform.localPosition;
+                    var actual = childTransform.transform.localPosition;
                     TestUtilities.AssertAboutEqual(
                         actual,
                         expected,
                         "Child object not in expected position, horizontal alignment " + alignment,
                         0.01f);
-                    j++;
                     expectedIdx++;
                 }
                 yield return null;
@@ -153,17 +149,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 grid.RowAlignment = alignment;
                 grid.UpdateCollection();
-                int j = 0;
-                foreach (Transform child2 in go.transform)
+                foreach (Transform childTransform in go.transform)
                 {
                     var expected = alignmentTestExpected[expectedIdx];
-                    var actual = child2.transform.localPosition;
+                    var actual = childTransform.transform.localPosition;
                     TestUtilities.AssertAboutEqual(
                         actual,
                         expected,
                         "Child object not in expected position, horizontal alignment " + alignment,
                         0.01f);
-                    j++;
                     expectedIdx++;
                 }
                 yield return null;

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -69,6 +69,11 @@ We have introduced two helper components, [`UI_KeyboardInputField`](xref:Microso
 
 For more information, see - [Mixed Reality Keyboard Helpers](../Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/README_MixedRealityKeyboard.md).
 
+**Grid Object Collection Alignment Options**
+
+<img src="https://user-images.githubusercontent.com/39840334/79289136-5c228780-7e7d-11ea-82b4-07959e42c3ed.gif" width="300" />
+
+We have added the ability to choose how the elements in the grid are aligned, whether they are aligned in the center or along the left/right axis (top/bottom axis when doing row then column layout)
 
 ### Breaking changes in 2.4.0
 


### PR DESCRIPTION
## Overview
Allow the user to customize the behavior of the grid layout so that they can choose how the elements in the grid are aligned, whether they are aligned in the center or along the left/right axis (top/bottom axis when doing row then column layout)

## Changes
- Fixes: #6813 

![GridAlignment](https://user-images.githubusercontent.com/39840334/79289136-5c228780-7e7d-11ea-82b4-07959e42c3ed.gif)
