### PR TITLE
Improve MRTK project settings text

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -41,13 +41,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             { MRConfig.IOSCameraUsageDescription, true },
         };
 
-        private const string WindowKey = "_MixedRealityToolkit_Editor_MixedRealityProjectConfiguratorWindow";
         private const float Default_Window_Height = 640.0f;
         private const float Default_Window_Width = 400.0f;
 
         private readonly GUIContent ApplyButtonContent = new GUIContent("Apply", "Apply configurations to this Unity Project");
         private readonly GUIContent LaterButtonContent = new GUIContent("Later", "Do not show this pop-up notification until next session");
-        private readonly GUIContent IgnoreButtonContent = new GUIContent("Ignore", "Modify this preference under Edit > Project Settings > MRTK");
+        private readonly GUIContent IgnoreButtonContent = new GUIContent("Ignore", "Modify this preference under Edit > Project Settings > Mixed Reality Toolkit");
 
         private bool showConfigurations = true;
 

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static bool ignoreSettingsPrompt;
 
         /// <summary>
-        /// Should the settings prompt show on startup?
+        /// Should the project configurator show when the project isn't configured according to MRTK's recommendations?
         /// </summary>
         public static bool IgnoreSettingsPrompt
         {
@@ -75,8 +75,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static bool autoEnabledCapabilitiesSettingsPrompt;
 
         /// <summary>
-        /// Should the settings prompt show on startup?
+        /// Should the UWP capabilities required by MRTK services be auto-enabled in Publishing Settings?
         /// </summary>
+        /// <remarks>Only valid for UWP Build Target projects. UWP Capabilities can be viewed under Player Settings > Publishing Settings.</remarks>
         public static bool AutoEnableUWPCapabilities
         {
             get
@@ -102,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static bool runOptimalConfig;
 
         /// <summary>
-        /// Should the settings prompt show on startup?
+        /// Should configuration analysis be run and warnings logged when settings don't match MRTK's recommendations?
         /// </summary>
         public static bool RunOptimalConfiguration
         {

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -134,6 +134,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
             void GUIHandler(string searchContext)
             {
+                EditorGUILayout.HelpBox("These settings are serialized into ProjectPreferences.asset in the MixedRealityToolkit-Generated folder.\nThis file can be checked into source control to maintain consistent settings across collaborators.", MessageType.Info);
+
                 var prevLabelWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = 250f;
 

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
     {
         #region Lock Profile Preferences
 
-        private static readonly GUIContent LockContent = new GUIContent("Lock SDK profiles", "Locks the SDK profiles from being edited.\n\nThis setting only applies to the currently running project.");
+        private static readonly GUIContent LockContent = new GUIContent("Lock SDK profiles", "Locks the SDK profiles from being edited.");
         private const string LOCK_KEY = "_MixedRealityToolkit_Editor_LockProfiles";
         private static bool lockPrefLoaded;
         private static bool lockProfiles;
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region Ignore startup settings prompt
 
-        private static readonly GUIContent IgnoreContent = new GUIContent("Ignore settings prompt on startup", "Prevents settings dialog popup from showing on startup.\n\nThis setting applies to all projects using the Mixed Reality Toolkit.");
+        private static readonly GUIContent IgnoreContent = new GUIContent("Ignore MRTK project configurator", "Prevents settings dialog popup from showing.");
         private const string IGNORE_KEY = "_MixedRealityToolkit_Editor_IgnoreSettingsPrompts";
         private static bool ignorePrefLoaded;
         private static bool ignoreSettingsPrompt;
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region Run optimal configuration analysis on Play
 
-        private static readonly GUIContent RunOptimalConfigContent = new GUIContent("Run optimal configuration analysis", "Run optimal configuration analysis for current project and log warnings on entering play mode or building.\n\nThis setting applies to all projects using the Mixed Reality Toolkit.");
+        private static readonly GUIContent RunOptimalConfigContent = new GUIContent("Run optimal configuration analysis", "Run optimal configuration analysis for current project and log warnings on entering play mode or building.");
         private const string RUN_OPTIMAL_CONFIG_KEY = "MixedRealityToolkit_Editor_RunOptimalConfig";
         private static bool runOptimalConfigPrefLoaded;
         private static bool runOptimalConfig;

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #region Auto-Enable UWP Capabilities
 
-        private static readonly GUIContent AutoEnableCapabilitiesContent = new GUIContent("Auto-Enable UWP Capabilities", "When this setting is enabled, MRTK services requiring particular UWP capabilities will be auto-enabled in Publishing Settings.\n\nOnly valid for UWP Build Target projects.\n\nUWP Capabilities can be viewed under Player Settings > Publishing Settings.");
+        private static readonly GUIContent AutoEnableCapabilitiesContent = new GUIContent("Auto-enable UWP capabilities", "When this setting is enabled, MRTK services requiring particular UWP capabilities will be auto-enabled in Publishing Settings.\n\nOnly valid for UWP Build Target projects.\n\nUWP Capabilities can be viewed under Player Settings > Publishing Settings.");
         private const string AUTO_ENABLE_CAPABILITIES_KEY = "_MixedRealityToolkit_Editor_AutoEnableUWPCapabilities";
         private static bool autoEnabledCapabilitiesPrefLoaded;
         private static bool autoEnabledCapabilitiesSettingsPrompt;

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/ProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/ProjectPreferences.cs
@@ -57,7 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                         if (!string.IsNullOrEmpty(modulePath))
                         {
                             filePath = Path.Combine(modulePath, DEFAULT_FILE_NAME);
-                            _instance = ScriptableObject.CreateInstance<ProjectPreferences>();
+                            _instance = CreateInstance<ProjectPreferences>();
                             AssetDatabase.CreateAsset(_instance, filePath);
                             AssetDatabase.SaveAssets();
                         }
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <remarks>
         /// If forceSave is true (default), then will call AssetDatabase.SaveAssets which saves all assets after execution
         /// </remarks>
-        public static void Set(string key, bool value, bool forceSave = true) => Set<bool>(key, value, Instance?.boolPreferences, forceSave);
+        public static void Set(string key, bool value, bool forceSave = true) => Set(key, value, Instance != null ? Instance.boolPreferences : null, forceSave);
 
         /// <summary>
         /// Save float to preferences and save to ScriptableObject with key given.
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <remarks>
         /// If forceSave is true (default), then will call AssetDatabase.SaveAssets which saves all assets after execution
         /// </remarks>
-        public static void Set(string key, float value, bool forceSave = true) => Set<float>(key, value, Instance?.floatPreferences, forceSave);
+        public static void Set(string key, float value, bool forceSave = true) => Set(key, value, Instance != null ? Instance.floatPreferences : null, forceSave);
 
         /// <summary>
         /// Save int to preferences and save to ScriptableObject with key given.
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <remarks>
         /// If forceSave is true (default), then will call AssetDatabase.SaveAssets which saves all assets after execution
         /// </remarks>
-        public static void Set(string key, int value, bool forceSave = true) => Set<int>(key, value, Instance?.intPreferences, forceSave);
+        public static void Set(string key, int value, bool forceSave = true) => Set(key, value, Instance != null ? Instance.intPreferences : null, forceSave);
 
         /// <summary>
         /// Save string to preferences and save to ScriptableObject with key given.
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <remarks>
         /// If forceSave is true (default), then will call AssetDatabase.SaveAssets which saves all assets after execution
         /// </remarks>
-        public static void Set(string key, string value, bool forceSave = true) => Set<string>(key, value, Instance?.stringPreferences, forceSave);
+        public static void Set(string key, string value, bool forceSave = true) => Set(key, value, Instance != null ? Instance.stringPreferences : null, forceSave);
 
         #endregion
 
@@ -116,22 +116,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Get bool from Project Preferences. If no entry found, then create new entry with provided defaultValue
         /// </summary>
-        public static bool Get(string key, bool defaultValue) => Get<bool>(key, defaultValue, Instance?.boolPreferences);
+        public static bool Get(string key, bool defaultValue) => Get(key, defaultValue, Instance != null ? Instance.boolPreferences : null);
 
         /// <summary>
         /// Get float from Project Preferences. If no entry found, then create new entry with provided defaultValue
         /// </summary>
-        public static float Get(string key, float defaultValue) => Get<float>(key, defaultValue, Instance?.floatPreferences);
+        public static float Get(string key, float defaultValue) => Get(key, defaultValue, Instance != null ? Instance.floatPreferences : null);
 
         /// <summary>
         /// Get int from Project Preferences. If no entry found, then create new entry with provided defaultValue
         /// </summary>
-        public static int Get(string key, int defaultValue) => Get<int>(key, defaultValue, Instance?.intPreferences);
+        public static int Get(string key, int defaultValue) => Get(key, defaultValue, Instance != null ? Instance.intPreferences : null);
 
         /// <summary>
         /// Get string from Project Preferences. If no entry found, then create new entry with provided defaultValue
         /// </summary>
-        public static string Get(string key, string defaultValue) => Get<string>(key, defaultValue, Instance?.stringPreferences);
+        public static string Get(string key, string defaultValue) => Get(key, defaultValue, Instance != null ? Instance.stringPreferences : null);
 
         #endregion
 
@@ -140,22 +140,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Remove key item from preferences if applicable
         /// </summary>
-        public static void RemoveBool(string key) => Remove(key, Instance?.boolPreferences);
+        public static void RemoveBool(string key) => Remove(key, Instance != null ? Instance.boolPreferences : null);
 
         /// <summary>
         /// Remove key item from preferences if applicable
         /// </summary>
-        public static void RemoveFloat(string key) => Remove<float>(key, Instance?.floatPreferences);
+        public static void RemoveFloat(string key) => Remove(key, Instance != null ? Instance.floatPreferences : null);
 
         /// <summary>
         /// Remove key item from preferences if applicable
         /// </summary>
-        public static void RemoveInt(string key) => Remove<int>(key, Instance?.intPreferences);
+        public static void RemoveInt(string key) => Remove(key, Instance != null ? Instance.intPreferences : null);
 
         /// <summary>
         /// Remove key item from preferences if applicable
         /// </summary>
-        public static void RemoveString(string key) => Remove<string>(key, Instance?.stringPreferences);
+        public static void RemoveString(string key) => Remove(key, Instance != null ? Instance.stringPreferences : null);
 
         #endregion
 


### PR DESCRIPTION
## Overview

After https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6315, all our MRTK settings are now on a per-project basis (some were previously global), serialized into a .asset file. Some of our settings descriptions still mentioned the previously global nature of things.
I also:

* updated some of the settings text, for example to explicitly call out the one that handles the project configurator
* updated some summary tags that were incorrect (copied and pasted from the first setting and not changed)
* added a note to the settings page about where these settings are serialized and how they can be shared
* Fixed some instances of incorrect Unity null propagation
    * `Instance?.` in `ProjectPreferences`, where `Instance` is a `UnityEngine.ScriptableObject`.
* Removed an unused key

![image](https://user-images.githubusercontent.com/3580640/79293064-8da05080-7e87-11ea-9dbc-687df0dd5266.png)
