### PR TITLE
Update near interaction touchable default forward

### DIFF
--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/PressableButtonInspector.cs
@@ -113,11 +113,6 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         private ButtonInfo GatherCurrentInfo()
         {
-            ButtonInfo info = new ButtonInfo();
-
-            info.LocalCenter = touchable.LocalCenter;
-            info.PlaneExtents = touchable.Bounds;
-
             Vector3 pressDirLocal = (touchable != null) ? touchable.LocalPressDirection : Vector3.forward;
             Vector3 upDirLocal = Vector3.up;
 
@@ -126,14 +121,16 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 upDirLocal = touchableConcrete.LocalUp;
             }
 
-            info.PushRotationLocal = Quaternion.LookRotation(pressDirLocal, upDirLocal);
-            
-            info.StartPushDistance = startPushDistance.floatValue;
-            info.MaxPushDistance = maxPushDistance.floatValue;
-            info.PressDistance = pressDistance.floatValue;
-            info.ReleaseDistance = pressDistance.floatValue - releaseDistanceDelta.floatValue;
-
-            return info;
+            return new ButtonInfo
+            {
+                LocalCenter = touchable.LocalCenter,
+                PlaneExtents = touchable.Bounds,
+                PushRotationLocal = Quaternion.LookRotation(pressDirLocal, upDirLocal),
+                StartPushDistance = startPushDistance.floatValue,
+                MaxPushDistance = maxPushDistance.floatValue,
+                PressDistance = pressDistance.floatValue,
+                ReleaseDistance = pressDistance.floatValue - releaseDistanceDelta.floatValue
+            };
         }
 
         private void DrawButtonInfo(ButtonInfo info, bool editingEnabled)
@@ -189,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 Undo.RecordObject(target, string.Concat("Modify Button Planes of ", button.name));
 
                 startPushDistance.floatValue = info.StartPushDistance;
-                maxPushDistance.floatValue = info.MaxPushDistance; 
+                maxPushDistance.floatValue = info.MaxPushDistance;
                 pressDistance.floatValue = info.PressDistance;
                 releaseDistanceDelta.floatValue = info.PressDistance - info.ReleaseDistance;
 

--- a/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs
+++ b/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     public class NearInteractionTouchable : NearInteractionTouchableSurface
     {
         [SerializeField]
+        [Tooltip("Local space forward direction")]
         protected Vector3 localForward = Vector3.forward;
 
         /// <summary>
@@ -24,6 +25,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Vector3 LocalForward { get => localForward; }
 
         [SerializeField]
+        [Tooltip("Local space up direction")]
         protected Vector3 localUp = Vector3.up;
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public bool AreLocalVectorsOrthogonal => Vector3.Dot(localForward, localUp) == 0;
 
         [SerializeField]
+        [Tooltip("Local space object center")]
         protected Vector3 localCenter = Vector3.zero;
 
         /// <summary>
@@ -79,6 +82,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override Vector3 LocalPressDirection => -localForward;
 
         [SerializeField]
+        [Tooltip("Bounds or size of the 2D NearInteractionTouchablePlane")]
         protected Vector2 bounds = Vector2.zero;
 
         /// <summary>
@@ -194,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             Math.Abs(Vector3.Dot(newCollider.size, LocalUp)));
 
                 SetBounds(adjustedSize);
-                
+
                 // Set x and y center to match the newCollider but change the position of the
                 // z axis so the plane is always in front of the object
                 SetLocalCenter(newCollider.center + Vector3.Scale(newCollider.size / 2.0f, LocalForward));

--- a/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs
+++ b/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             bounds.y = Mathf.Max(bounds.y, 0);
         }
 
-        void OnEnable()
+        private void OnEnable()
         {
             if (touchableCollider == null)
             {

--- a/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs
+++ b/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     {
         [SerializeField]
         [Tooltip("Local space forward direction")]
-        protected Vector3 localForward = Vector3.forward;
+        protected Vector3 localForward = -Vector3.forward;
 
         /// <summary>
         /// Local space forward direction


### PR DESCRIPTION
## Overview

Currently, the default forward direction for near interaction touchable is `Vector3.forward`. This direction is into the scene, away from the camera. Since we use this direction as the assumed direction a user will be pressing the button from, this doesn't make sense in most cases, since they'll be pressing from the camera. This changes the default value to `-Vector3.forward`. This matches a case we have later in the code as well:

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/6340cf0d67071533fb6cb47fed7bdf899be6ef6b/Assets/MRTK/Services/InputSystem/NearInteractionTouchable.cs#L190

Before:
![image](https://user-images.githubusercontent.com/3580640/79366094-705b9880-7f00-11ea-8311-8879e5cb8839.png)

After:
![image](https://user-images.githubusercontent.com/3580640/79365411-78670880-7eff-11ea-9bcc-9d6599850a5b.png)

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/6319