### PR TITLE
Re-add accidentally removed profiler marker

### DIFF
--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -696,7 +696,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     // Events with no propagation configuration
                     else
                     {
-                        ExecuteEvents.ExecuteHierarchy(focusedObject, baseInputEventData, eventHandler);
+                        using (ExecuteHierarchyPerfMarker.Auto())
+                        {
+                            ExecuteEvents.ExecuteHierarchy(focusedObject, baseInputEventData, eventHandler);
+                        }
                     }
                 }
                 return modalEventHandled;


### PR DESCRIPTION
This change restores a profiler marker that was accidentally removed during the merge of the development branch into the event_propagation branch.