### PR TITLE
Adjusted anchor behavior to match unity's layout group behavior

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -68,6 +68,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { anchor = value; }
         }
 
+        [SerializeField, Tooltip("Whether or not to use the legacy anchor layout")]
+        private bool useLegacyAnchor = true;
+
+        /// <summary>
+        /// Where the grid is anchored relative to local origin
+        /// </summary>
+        public bool UseLegacyAnchor
+        {
+            get { return useLegacyAnchor; }
+            set { useLegacyAnchor = value; }
+        }
+
+
         [SerializeField, Tooltip("How the columns are aligned in the grid")]
         private LayoutHorizontalAlignment columnAlignment = LayoutHorizontalAlignment.Left;
 
@@ -346,21 +359,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             float startOffsetX = (xMax * 0.5f) * CellWidth;
             if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.MiddleLeft)
             {
-                startOffsetX = 0.5f * CellWidth;
+                startOffsetX = useLegacyAnchor ? 0 :  0.5f * CellWidth;
             }
             else if (anchor == LayoutAnchor.BottomRight || anchor == LayoutAnchor.UpperRight || anchor == LayoutAnchor.MiddleRight)
             {
-                startOffsetX = (xMax - 0.5f) * CellWidth;
+                startOffsetX = useLegacyAnchor ? xMax * CellWidth : (xMax - 0.5f) * CellWidth;
             }
 
             float startOffsetY = (yMax * 0.5f) * CellHeight;
             if (anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.UpperCenter || anchor == LayoutAnchor.UpperRight)
             {
-                startOffsetY = 0.5f * CellHeight;
+                startOffsetY = useLegacyAnchor ? 0 : 0.5f * CellHeight;
             }
             else if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.BottomCenter || anchor == LayoutAnchor.BottomRight)
             {
-                startOffsetY = (yMax - 0.5f) * CellHeight;
+                startOffsetY = useLegacyAnchor ? yMax * CellHeight : (yMax - 0.5f) * CellHeight;
             }
             float alignmentOffsetX = 0;
             float alignmentOffsetY = 0;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -346,21 +346,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             float startOffsetX = (xMax * 0.5f) * CellWidth;
             if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.MiddleLeft)
             {
-                startOffsetX = 0;
+                startOffsetX = 0.5f * CellWidth;
             }
             else if (anchor == LayoutAnchor.BottomRight || anchor == LayoutAnchor.UpperRight || anchor == LayoutAnchor.MiddleRight)
             {
-                startOffsetX = xMax * CellWidth;
+                startOffsetX = (xMax - 0.5f) * CellWidth;
             }
 
             float startOffsetY = (yMax * 0.5f) * CellHeight;
             if (anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.UpperCenter || anchor == LayoutAnchor.UpperRight)
             {
-                startOffsetY = 0;
+                startOffsetY = 0.5f * CellHeight;
             }
             else if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.BottomCenter || anchor == LayoutAnchor.BottomRight)
             {
-                startOffsetY = yMax * CellHeight;
+                startOffsetY = (yMax - 0.5f) * CellHeight;
             }
             float alignmentOffsetX = 0;
             float alignmentOffsetY = 0;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -68,16 +68,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             set { anchor = value; }
         }
 
-        [SerializeField, Tooltip("Whether or not to use the legacy anchor layout")]
-        private bool useLegacyAnchor = true;
+        [SerializeField, Tooltip("Whether anchoring occurs along an objects axis or not")]
+        private bool anchorAlongAxis = false;
 
         /// <summary>
-        /// Where the grid is anchored relative to local origin
+        /// Whether anchoring occurs along an objects axis or not
         /// </summary>
-        public bool UseLegacyAnchor
+        public bool AnchorAlongAxis
         {
-            get { return useLegacyAnchor; }
-            set { useLegacyAnchor = value; }
+            get { return anchorAlongAxis; }
+            set { anchorAlongAxis = value; }
         }
 
 
@@ -359,21 +359,21 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             float startOffsetX = (xMax * 0.5f) * CellWidth;
             if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.MiddleLeft)
             {
-                startOffsetX = useLegacyAnchor ? 0 :  0.5f * CellWidth;
+                startOffsetX = anchorAlongAxis ? 0.5f * CellWidth : 0;
             }
             else if (anchor == LayoutAnchor.BottomRight || anchor == LayoutAnchor.UpperRight || anchor == LayoutAnchor.MiddleRight)
             {
-                startOffsetX = useLegacyAnchor ? xMax * CellWidth : (xMax - 0.5f) * CellWidth;
+                startOffsetX = anchorAlongAxis ? (xMax - 0.5f) * CellWidth : xMax * CellWidth;
             }
 
             float startOffsetY = (yMax * 0.5f) * CellHeight;
             if (anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.UpperCenter || anchor == LayoutAnchor.UpperRight)
             {
-                startOffsetY = useLegacyAnchor ? 0 : 0.5f * CellHeight;
+                startOffsetY = anchorAlongAxis ? 0.5f * CellHeight: 0;
             }
             else if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.BottomCenter || anchor == LayoutAnchor.BottomRight)
             {
-                startOffsetY = useLegacyAnchor ? yMax * CellHeight : (yMax - 0.5f) * CellHeight;
+                startOffsetY = anchorAlongAxis ? (yMax - 0.5f) * CellHeight : yMax * CellHeight;
             }
             float alignmentOffsetX = 0;
             float alignmentOffsetY = 0;

--- a/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
@@ -20,6 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private SerializedProperty cellWidth;
         private SerializedProperty cellHeight;
         private SerializedProperty anchor;
+        private SerializedProperty useLegacyAnchor;
         private SerializedProperty rowAlignment;
         private SerializedProperty columnAlignment;
 
@@ -38,6 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             cellWidth = serializedObject.FindProperty("cellWidth");
             cellHeight = serializedObject.FindProperty("cellHeight");
             anchor = serializedObject.FindProperty("anchor");
+            useLegacyAnchor = serializedObject.FindProperty("useLegacyAnchor");
             rowAlignment = serializedObject.FindProperty("rowAlignment");
             columnAlignment = serializedObject.FindProperty("columnAlignment");
         }
@@ -93,6 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // layout anchor has no effect on radial layout, it is always at center.
                 EditorGUILayout.PropertyField(anchor);
             }
+            EditorGUILayout.PropertyField(useLegacyAnchor);
         }
     }
 }

--- a/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private SerializedProperty cellWidth;
         private SerializedProperty cellHeight;
         private SerializedProperty anchor;
-        private SerializedProperty useLegacyAnchor;
+        private SerializedProperty anchorAlongAxis;
         private SerializedProperty rowAlignment;
         private SerializedProperty columnAlignment;
 
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             cellWidth = serializedObject.FindProperty("cellWidth");
             cellHeight = serializedObject.FindProperty("cellHeight");
             anchor = serializedObject.FindProperty("anchor");
-            useLegacyAnchor = serializedObject.FindProperty("useLegacyAnchor");
+            anchorAlongAxis = serializedObject.FindProperty("anchorAlongAxis");
             rowAlignment = serializedObject.FindProperty("rowAlignment");
             columnAlignment = serializedObject.FindProperty("columnAlignment");
         }
@@ -95,7 +95,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 // layout anchor has no effect on radial layout, it is always at center.
                 EditorGUILayout.PropertyField(anchor);
             }
-            EditorGUILayout.PropertyField(useLegacyAnchor);
+
+            LayoutAnchor layoutAnchor = (LayoutAnchor)anchor.enumValueIndex;
+            if (layoutAnchor != LayoutAnchor.MiddleCenter)
+            {
+                EditorGUILayout.PropertyField(anchorAlongAxis);
+            }
         }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -69,8 +69,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
             grid.Layout = LayoutOrder.Horizontal;
 
-            // Testing Legacy Anchors
-            grid.UseLegacyAnchor = true;
+            // Testing anchoring along axis
+            grid.AnchorAlongAxis = true;
             int expectedIdx = 0;
             foreach (LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
             {
@@ -78,7 +78,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 grid.UpdateCollection();
                 foreach (Transform childTransform in go.transform)
                 {
-                    var expected = legacyAnchorTestExpected[expectedIdx];
+                    var expected = axisAnchorTestExpected[expectedIdx];
                     var actual = childTransform.transform.localPosition;
                     TestUtilities.AssertAboutEqual(
                         actual,
@@ -90,8 +90,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return null;
             }
 
-            // Testing Anchors
-            grid.UseLegacyAnchor = false;
+            // Testing non-axis aligned anchors
+            grid.AnchorAlongAxis = false;
             expectedIdx = 0;
             foreach(LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
             {
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 grid.UpdateCollection();
                 foreach(Transform childTransform in go.transform)
                 {
-                    var expected = anchorTestExpected[expectedIdx];
+                    var expected = freeAnchorTestExpected[expectedIdx];
                     var actual = childTransform.transform.localPosition;
                     TestUtilities.AssertAboutEqual(
                         actual, 
@@ -131,7 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             grid.Columns = 2;
 
             grid.Anchor = LayoutAnchor.UpperCenter;
-            grid.UseLegacyAnchor = false;
+            grid.AnchorAlongAxis = true;
 
             for (int i = 0; i < 3; i++)
             {
@@ -192,7 +192,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Expected Values
         // You can use GridObjectLayoutControl.cs in the examples package to
         // quickly generate the expected positions used in these tests.
-        private Vector3[] legacyAnchorTestExpected = new Vector3[] {
+        private Vector3[] freeAnchorTestExpected = new Vector3[] {
             new Vector3(0.08f, -0.08f, 0.75f), // UpperLeft index 0
             new Vector3(0.23f, -0.08f, 0.75f), // UpperLeft index 1
             new Vector3(0.38f, -0.08f, 0.75f), // UpperLeft index 2
@@ -221,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             new Vector3(-0.23f, 0.08f, 0.75f), // BottomRight index 1
             new Vector3(-0.08f, 0.08f, 0.75f) // BottomRight index 2
         };
-        private Vector3[] anchorTestExpected = new Vector3[] {
+        private Vector3[] axisAnchorTestExpected = new Vector3[] {
             new Vector3(0.0f, -0.0f, 0.75f), // UpperLeft index 0
             new Vector3(0.15f, -0.0f, 0.75f), // UpperLeft index 1
             new Vector3(0.30f, -0.0f, 0.75f), // UpperLeft index 2

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
             grid.Layout = LayoutOrder.Horizontal;
 
-            //Testing Legacy Anchors
+            // Testing Legacy Anchors
             grid.UseLegacyAnchor = true;
             int expectedIdx = 0;
             foreach (LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return null;
             }
 
-            //Testing Anchors
+            // Testing Anchors
             grid.UseLegacyAnchor = false;
             expectedIdx = 0;
             foreach(LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -172,53 +172,53 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // quickly generate the expected positions used in these tests.
 
         private Vector3[] anchorTestExpected = new Vector3[] {
-            new Vector3(0.08f, -0.08f, 0.75f), // UpperLeft index 0
-            new Vector3(0.23f, -0.08f, 0.75f), // UpperLeft index 1
-            new Vector3(0.38f, -0.08f, 0.75f), // UpperLeft index 2
-            new Vector3(-0.15f, -0.08f, 0.75f), // UpperCenter index 0
-            new Vector3(0.00f, -0.08f, 0.75f), // UpperCenter index 1
-            new Vector3(0.15f, -0.08f, 0.75f), // UpperCenter index 2
-            new Vector3(-0.38f, -0.08f, 0.75f), // UpperRight index 0
-            new Vector3(-0.23f, -0.08f, 0.75f), // UpperRight index 1
-            new Vector3(-0.08f, -0.08f, 0.75f), // UpperRight index 2
-            new Vector3(0.08f, 0.00f, 0.75f), // MiddleLeft index 0
-            new Vector3(0.23f, 0.00f, 0.75f), // MiddleLeft index 1
-            new Vector3(0.38f, 0.00f, 0.75f), // MiddleLeft index 2
+            new Vector3(0.0f, -0.0f, 0.75f), // UpperLeft index 0
+            new Vector3(0.15f, -0.0f, 0.75f), // UpperLeft index 1
+            new Vector3(0.30f, -0.0f, 0.75f), // UpperLeft index 2
+            new Vector3(-0.15f, -0.0f, 0.75f), // UpperCenter index 0
+            new Vector3(0.00f, -0.0f, 0.75f), // UpperCenter index 1
+            new Vector3(0.15f, -0.0f, 0.75f), // UpperCenter index 2
+            new Vector3(-0.30f, -0.0f, 0.75f), // UpperRight index 0
+            new Vector3(-0.15f, -0.0f, 0.75f), // UpperRight index 1
+            new Vector3(-0.0f, -0.0f, 0.75f), // UpperRight index 2
+            new Vector3(0.0f, 0.00f, 0.75f), // MiddleLeft index 0
+            new Vector3(0.15f, 0.00f, 0.75f), // MiddleLeft index 1
+            new Vector3(0.30f, 0.00f, 0.75f), // MiddleLeft index 2
             new Vector3(-0.15f, 0.00f, 0.75f), // MiddleCenter index 0
             new Vector3(0.00f, 0.00f, 0.75f), // MiddleCenter index 1
             new Vector3(0.15f, 0.00f, 0.75f), // MiddleCenter index 2
-            new Vector3(-0.38f, 0.00f, 0.75f), // MiddleRight index 0
-            new Vector3(-0.23f, 0.00f, 0.75f), // MiddleRight index 1
-            new Vector3(-0.08f, 0.00f, 0.75f), // MiddleRight index 2
-            new Vector3(0.08f, 0.08f, 0.75f), // BottomLeft index 0
-            new Vector3(0.23f, 0.08f, 0.75f), // BottomLeft index 1
-            new Vector3(0.38f, 0.08f, 0.75f), // BottomLeft index 2
-            new Vector3(-0.15f, 0.08f, 0.75f), // BottomCenter index 0
-            new Vector3(0.00f, 0.08f, 0.75f), // BottomCenter index 1
-            new Vector3(0.15f, 0.08f, 0.75f), // BottomCenter index 2
-            new Vector3(-0.38f, 0.08f, 0.75f), // BottomRight index 0
-            new Vector3(-0.23f, 0.08f, 0.75f), // BottomRight index 1
-            new Vector3(-0.08f, 0.08f, 0.75f) // BottomRight index 2
+            new Vector3(-0.30f, 0.00f, 0.75f), // MiddleRight index 0
+            new Vector3(-0.15f, 0.00f, 0.75f), // MiddleRight index 1
+            new Vector3(-0.0f, 0.00f, 0.75f), // MiddleRight index 2
+            new Vector3(0.0f, 0.0f, 0.75f), // BottomLeft index 0
+            new Vector3(0.15f, 0.0f, 0.75f), // BottomLeft index 1
+            new Vector3(0.30f, 0.0f, 0.75f), // BottomLeft index 2
+            new Vector3(-0.15f, 0.0f, 0.75f), // BottomCenter index 0
+            new Vector3(0.00f, 0.0f, 0.75f), // BottomCenter index 1
+            new Vector3(0.15f, 0.0f, 0.75f), // BottomCenter index 2
+            new Vector3(-0.30f, 0.0f, 0.75f), // BottomRight index 0
+            new Vector3(-0.15f, 0.0f, 0.75f), // BottomRight index 1
+            new Vector3(-0.0f, 0.0f, 0.75f) // BottomRight index 2
         };
         private Vector3[] alignmentTestExpected = new Vector3[] {
-            new Vector3(-0.075f, -0.075f, 0.75f), // Left Horizontal 0
-            new Vector3(0.075f, -0.075f, 0.75f), // Left Horizontal 1
-            new Vector3(-0.075f, -0.225f, 0.75f), // Left Horizontal 2
-            new Vector3(-0.075f, -0.075f, 0.75f), // Center Horizontal 0
-            new Vector3(0.075f, -0.075f, 0.75f), // Center Horizontal 1
-            new Vector3(0f, -0.225f, 0.75f), // Center Horizontal 2
-            new Vector3(-0.075f, -0.075f, 0.75f), // Right Horizontal 0
-            new Vector3(0.075f, -0.075f, 0.75f), // Right Horizontal 1
-            new Vector3(0.075f, -0.225f, 0.75f), // Right Horizontal 2
-            new Vector3(-0.075f, -0.075f, 0.75f), // Top Vertical 0
-            new Vector3(-0.075f, -0.225f, 0.75f), // Top Vertical 1
-            new Vector3(0.075f, -0.075f, 0.75f), // Top Vertical 2
-            new Vector3(-0.075f, -0.075f, 0.75f), // Middle Vertical 0
-            new Vector3(-0.075f, -0.225f, 0.75f), // Middle Vertical 1
-            new Vector3(0.075f, -0.150f, 0.75f), // Middle Vertical 2
-            new Vector3(-0.075f, -0.075f, 0.75f), // Bottom Vertical 0
-            new Vector3(-0.075f, -0.225f, 0.75f), // Middle Vertical 1
-            new Vector3(0.075f, -0.225f, 0.75f), // Top Vertical 2
+            new Vector3(-0.075f, 0.0f, 0.75f), // Left Horizontal 0
+            new Vector3(0.075f, 0.0f, 0.75f), // Left Horizontal 1
+            new Vector3(-0.075f, -0.150f, 0.75f), // Left Horizontal 2
+            new Vector3(-0.075f, 0.0f, 0.75f), // Center Horizontal 0
+            new Vector3(0.075f, 0.0f, 0.75f), // Center Horizontal 1
+            new Vector3(0f, -0.150f, 0.75f), // Center Horizontal 2
+            new Vector3(-0.075f, 0.0f, 0.75f), // Right Horizontal 0
+            new Vector3(0.075f, 0.0f, 0.75f), // Right Horizontal 1
+            new Vector3(0.075f, -0.150f, 0.75f), // Right Horizontal 2
+            new Vector3(-0.075f, 0.0f, 0.75f), // Top Vertical 0
+            new Vector3(-0.075f, -0.150f, 0.75f), // Top Vertical 1
+            new Vector3(0.075f, 0.0f, 0.75f), // Top Vertical 2
+            new Vector3(-0.075f, 0.0f, 0.75f), // Middle Vertical 0
+            new Vector3(-0.075f, -0.150f, 0.75f), // Middle Vertical 1
+            new Vector3(0.075f, -0.075f, 0.75f), // Middle Vertical 2
+            new Vector3(-0.075f, 0.0f, 0.75f), // Bottom Vertical 0
+            new Vector3(-0.075f, -0.150f, 0.75f), // Middle Vertical 1
+            new Vector3(0.075f, -0.150f, 0.75f), // Top Vertical 2
         };
     #endregion
     

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -131,6 +131,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             grid.Columns = 2;
 
             grid.Anchor = LayoutAnchor.UpperCenter;
+            grid.UseLegacyAnchor = false;
 
             for (int i = 0; i < 3; i++)
             {

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -67,10 +67,32 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 child.transform.parent = go.transform;
                 child.transform.localScale = Vector3.one * 0.1f;
             }
-
             grid.Layout = LayoutOrder.Horizontal;
 
+            //Testing Legacy Anchors
+            grid.UseLegacyAnchor = true;
             int expectedIdx = 0;
+            foreach (LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
+            {
+                grid.Anchor = et;
+                grid.UpdateCollection();
+                foreach (Transform childTransform in go.transform)
+                {
+                    var expected = legacyAnchorTestExpected[expectedIdx];
+                    var actual = childTransform.transform.localPosition;
+                    TestUtilities.AssertAboutEqual(
+                        actual,
+                        expected,
+                        "Child object not in expected position, layout " + et,
+                        0.01f);
+                    expectedIdx++;
+                }
+                yield return null;
+            }
+
+            //Testing Anchors
+            grid.UseLegacyAnchor = false;
+            expectedIdx = 0;
             foreach(LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
             {
                 grid.Anchor = et;
@@ -87,7 +109,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                     expectedIdx++;
                 }
                 yield return null;
-
             }
             yield return null;
         }
@@ -170,7 +191,35 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Expected Values
         // You can use GridObjectLayoutControl.cs in the examples package to
         // quickly generate the expected positions used in these tests.
-
+        private Vector3[] legacyAnchorTestExpected = new Vector3[] {
+            new Vector3(0.08f, -0.08f, 0.75f), // UpperLeft index 0
+            new Vector3(0.23f, -0.08f, 0.75f), // UpperLeft index 1
+            new Vector3(0.38f, -0.08f, 0.75f), // UpperLeft index 2
+            new Vector3(-0.15f, -0.08f, 0.75f), // UpperCenter index 0
+            new Vector3(0.00f, -0.08f, 0.75f), // UpperCenter index 1
+            new Vector3(0.15f, -0.08f, 0.75f), // UpperCenter index 2
+            new Vector3(-0.38f, -0.08f, 0.75f), // UpperRight index 0
+            new Vector3(-0.23f, -0.08f, 0.75f), // UpperRight index 1
+            new Vector3(-0.08f, -0.08f, 0.75f), // UpperRight index 2
+            new Vector3(0.08f, 0.00f, 0.75f), // MiddleLeft index 0
+            new Vector3(0.23f, 0.00f, 0.75f), // MiddleLeft index 1
+            new Vector3(0.38f, 0.00f, 0.75f), // MiddleLeft index 2
+            new Vector3(-0.15f, 0.00f, 0.75f), // MiddleCenter index 0
+            new Vector3(0.00f, 0.00f, 0.75f), // MiddleCenter index 1
+            new Vector3(0.15f, 0.00f, 0.75f), // MiddleCenter index 2
+            new Vector3(-0.38f, 0.00f, 0.75f), // MiddleRight index 0
+            new Vector3(-0.23f, 0.00f, 0.75f), // MiddleRight index 1
+            new Vector3(-0.08f, 0.00f, 0.75f), // MiddleRight index 2
+            new Vector3(0.08f, 0.08f, 0.75f), // BottomLeft index 0
+            new Vector3(0.23f, 0.08f, 0.75f), // BottomLeft index 1
+            new Vector3(0.38f, 0.08f, 0.75f), // BottomLeft index 2
+            new Vector3(-0.15f, 0.08f, 0.75f), // BottomCenter index 0
+            new Vector3(0.00f, 0.08f, 0.75f), // BottomCenter index 1
+            new Vector3(0.15f, 0.08f, 0.75f), // BottomCenter index 2
+            new Vector3(-0.38f, 0.08f, 0.75f), // BottomRight index 0
+            new Vector3(-0.23f, 0.08f, 0.75f), // BottomRight index 1
+            new Vector3(-0.08f, 0.08f, 0.75f) // BottomRight index 2
+        };
         private Vector3[] anchorTestExpected = new Vector3[] {
             new Vector3(0.0f, -0.0f, 0.75f), // UpperLeft index 0
             new Vector3(0.15f, -0.0f, 0.75f), // UpperLeft index 1

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -77,9 +77,9 @@ We have added the ability to choose how the elements in the grid are aligned, wh
 
 **Grid Object Collection Anchor Changes**
 
-<img src="https://user-images.githubusercontent.com/39840334/79499692-33ff6980-7fe0-11ea-9b41-63b5d969a853.gif" width="300" />
+<img src="https://user-images.githubusercontent.com/39840334/79516745-17bff480-8001-11ea-8492-cfa953c451da.gif" width="300" />
 
-We made changes to Grid Object Collection behavior to more more in line with Unity's layout group behaviors. The legacy Grid Object Collection behavior can be toggled with the `UseLegacyAnchor` field.
+We made changes to Grid Object Collection behavior to be more in line with Unity's layout group behaviors by aligning the anchor along an object's central axis. The old Grid Object Collection behavior can be toggled with the `AnchorAlongAxis` field.
 
 ### Breaking changes in 2.4.0
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -75,6 +75,12 @@ For more information, see - [Mixed Reality Keyboard Helpers](../Assets/MRTK/SDK/
 
 We have added the ability to choose how the elements in the grid are aligned, whether they are aligned in the center or along the left/right axis (top/bottom axis when doing row then column layout)
 
+**Grid Object Collection Anchor Changes**
+
+<img src="https://user-images.githubusercontent.com/39840334/79499692-33ff6980-7fe0-11ea-9b41-63b5d969a853.gif" width="300" />
+
+We made changes to Grid Object Collection behavior to more more in line with Unity's layout group behaviors. The legacy Grid Object Collection behavior can be toggled with the `UseLegacyAnchor` field.
+
 ### Breaking changes in 2.4.0
 
 **Eye gaze setup change**


### PR DESCRIPTION
## Overview
Changed the grid object collection's behavior so that the collection is anchored at the center of the cell in the upper left/upper right/lower left/lower right when in the appropriate mode

Previously: 
![image](https://user-images.githubusercontent.com/39840334/79493707-b84cef00-7fd6-11ea-8716-ef7cf989c41d.png)

Now:
![image](https://user-images.githubusercontent.com/39840334/79493725-c1d65700-7fd6-11ea-9a83-316171b103eb.png)

You can also toggle between the old and new behaviors

![LegacyGridAnchor](https://user-images.githubusercontent.com/39840334/79516745-17bff480-8001-11ea-8492-cfa953c451da.gif)

## Changes
- Fixes: #7666

