### PR TITLE
Update coding guidelines to match current state of the repo

### DIFF
--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -108,7 +108,7 @@ public class MyNewComponent : MonoBehaviour
 
 ### Adding new Unity inspector scripts
 
-In general, try to avoid creating custom inspector scripts for MRTK components. It adds additional overhead and management of the codebase that could be handled by the Unity engine. 
+In general, try to avoid creating custom inspector scripts for MRTK components. It adds additional overhead and management of the codebase that could be handled by the Unity engine.
 
 If an inspector class is necessary, try to use Unity's [`DrawDefaultInspector()`](https://docs.unity3d.com/ScriptReference/Editor.DrawDefaultInspector.html). This again simplifies the inspector class and leaves much of the work to Unity.
 
@@ -121,9 +121,9 @@ public override void OnInspectorGUI()
 }
 ```
 
-If custom rendering is required in the inspector class, try to utilize [`SerializedProperty`](https://docs.unity3d.com/ScriptReference/SerializedProperty.html) and [`EditorGUILayout.PropertyField`](https://docs.unity3d.com/ScriptReference/EditorGUILayout.PropertyField.html). This will ensure Unity correctly handles rendering nested prefabs and modified values. 
+If custom rendering is required in the inspector class, try to utilize [`SerializedProperty`](https://docs.unity3d.com/ScriptReference/SerializedProperty.html) and [`EditorGUILayout.PropertyField`](https://docs.unity3d.com/ScriptReference/EditorGUILayout.PropertyField.html). This will ensure Unity correctly handles rendering nested prefabs and modified values.
 
-If [`EditorGUILayout.PropertyField`](https://docs.unity3d.com/ScriptReference/EditorGUILayout.PropertyField.html) cannot be used due to a requirement in custom logic, ensure all usage is wrapped around a [`EditorGUI.PropertyScope`](https://docs.unity3d.com/ScriptReference/EditorGUI.PropertyScope.html). This will ensure Unity renders the inspector correctly for nested prefabs and modified values with the given property. 
+If [`EditorGUILayout.PropertyField`](https://docs.unity3d.com/ScriptReference/EditorGUILayout.PropertyField.html) cannot be used due to a requirement in custom logic, ensure all usage is wrapped around a [`EditorGUI.PropertyScope`](https://docs.unity3d.com/ScriptReference/EditorGUI.PropertyScope.html). This will ensure Unity renders the inspector correctly for nested prefabs and modified values with the given property.
 
 Furthermore, try to decorate the custom inspector class with a [`CanEditMultipleObjects`](https://docs.unity3d.com/ScriptReference/CanEditMultipleObjects.html). This tag ensure multiple objects with this component in the scene can be selected and modified together. Any new inspector classes should test that their code works in this situation in the scene.
 
@@ -153,15 +153,15 @@ Furthermore, try to decorate the custom inspector class with a [`CanEditMultiple
                 var currentHandedness = (Handedness)handedness.enumValueIndex;
 
                 handedness.enumValueIndex = (int)(Handedness)EditorGUI.EnumPopup(
-                    position, 
-                    label, 
+                    position,
+                    label,
                     currentHandedness,
-                    (value) => { 
+                    (value) => {
                         // This function is executed by Unity to determine if a possible enum value
                         // is valid for selection in the editor view
                         // In this case, only Handedness.Left and Handedness.Right can be selected
-                        return (Handedness)value == Handedness.Left 
-                        || (Handedness)value == Handedness.Right; 
+                        return (Handedness)value == Handedness.Left
+                        || (Handedness)value == Handedness.Right;
                     });
             }
         }
@@ -481,8 +481,8 @@ These steps ensure that MRTK works on both Windows and Unix-based systems.
 ### Don't
 
 ```c#
-private const string Filepath = "Mypath\\to\\a\\file.txt";
-private const string OtherFilePath = "Mypath\to\a\file.txt";
+private const string FilePath = "MyPath\\to\\a\\file.txt";
+private const string OtherFilePath = "MyPath\to\a\file.txt";
 
 string filePath = myVarRootPath + myRelativePath;
 ```
@@ -490,7 +490,7 @@ string filePath = myVarRootPath + myRelativePath;
 ### Do
 
 ```c#
-private const string Filepath = "Mypath/to/a/file.txt";
+private const string FilePath = "MyPath/to/a/file.txt";
 private const string OtherFilePath = "folder{Path.DirectorySeparatorChar}file.txt";
 
 string filePath = Path.Combine(myVarRootPath,myRelativePath);

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -212,13 +212,13 @@ private Foo()
 
 ### Naming conventions
 
-Always use `PascalCase` for public / protected / virtual properties, and `camelCase` for private properties and fields. The only exception to this is for data structures that require the fields to be serialized by the `JsonUtility`.
+Always use `PascalCase` for properties. Use `camelCase` for most fields, except use `PascalCase` for `static readonly` and `const` fields. The only exception to this is for data structures that require the fields to be serialized by the `JsonUtility`.
 
 #### Don't
 
 ```c#
-public string myProperty; // <- Starts with a lower case letter
-private string MyProperty; // <- Starts with an uppercase case letter
+public string myProperty; // <- Starts with a lowercase letter
+private string MyField; // <- Starts with an uppercase letter
 ```
 
 #### Do
@@ -226,7 +226,8 @@ private string MyProperty; // <- Starts with an uppercase case letter
 ```c#
 public string MyProperty;
 protected string MyProperty;
-private string myProperty;
+private static readonly string MyField;
+private string myField;
 ```
 
 ### Access modifiers

--- a/Documentation/Contributing/CodingGuidelines.md
+++ b/Documentation/Contributing/CodingGuidelines.md
@@ -473,8 +473,8 @@ public enum Handedness
 
 When generating string file paths, and in particular writing hard-coded string paths, do the following:
 
-1. Use C#'s [`Path` APIs](https://docs.microsoft.com/en-us/dotnet/api/system.io.path?view=netframework-4.8) whenever possible such as `Path.Combine` or `Path.GetFullPath`.
-1. Use / or [`Path.DirectorySeparatorChar`](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.directoryseparatorchar?view=netframework-4.8) instead of \ or \\\\.
+1. Use C#'s [`Path` APIs](https://docs.microsoft.com/dotnet/api/system.io.path?view=netframework-4.8) whenever possible such as `Path.Combine` or `Path.GetFullPath`.
+1. Use / or [`Path.DirectorySeparatorChar`](https://docs.microsoft.com/dotnet/api/system.io.path.directoryseparatorchar?view=netframework-4.8) instead of \ or \\\\.
 
 These steps ensure that MRTK works on both Windows and Unix-based systems.
 


### PR DESCRIPTION
## Overview

I noticed, when reviewing our naming conventions during some PR reviews, that we have some older guidance that doesn't really match the current state of the repo.

From my best attempt at regexing as many syntaxes as I could think of:

Examples of PascalCase `private static readonly` fields: 611
Examples of camelCase `private static readonly` fields: 104
Examples of UPPER_SNAKE_CASE `private static readonly` fields: 7

Examples of PascalCase `private` properties: 95
Examples of camelCase `private` properties: 11

Recommended while reviewing:
![image](https://user-images.githubusercontent.com/3580640/79604622-468ea700-80a3-11ea-8c13-663dbdefac96.png)

Or press this link:
https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7684/files?diff=unified&w=1