### PR TITLE
Input Simulation camera movespeed and profile adjustment

### DIFF
--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputSimulationProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputSimulationProfile.asset
@@ -32,9 +32,9 @@ MonoBehaviour:
   currentControlMode: 0
   fastControlKey:
     bindingType: 2
-    code: 305
-  controlSlowSpeed: 0.1
-  controlFastSpeed: 1
+    code: 303
+  controlSlowSpeed: 1
+  controlFastSpeed: 5
   moveHorizontal: Horizontal
   moveVertical: Vertical
   moveUpDown: UpDown

--- a/Assets/MRTK/Services/InputSimulation/ManualCameraControl.cs
+++ b/Assets/MRTK/Services/InputSimulation/ManualCameraControl.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             deltaPosition += InputCurve(UnityEngine.Input.GetAxis(profile.MoveUpDown)) * up;
 
             float accel = KeyInputSystem.GetKey(profile.FastControlKey) ? profile.ControlFastSpeed : profile.ControlSlowSpeed;
-            return accel * deltaPosition;
+            return accel * deltaPosition * Time.deltaTime;
         }
 
         private Vector3 GetCameraControlRotation(MouseDelta mouseDelta)

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -81,6 +81,10 @@ We have added the ability to choose how the elements in the grid are aligned, wh
 
 We made changes to Grid Object Collection behavior to be more in line with Unity's layout group behaviors by aligning the anchor along an object's central axis. The old Grid Object Collection behavior can be toggled with the `AnchorAlongAxis` field.
 
+**Adjusted input simulation camera control**
+
+Camera control speed using in-editor input simulation is slower for a smoother experience and is now untied from framerate. Fast camera control now activated with Right Shift instead of Right Ctrl
+
 **Hands-free GGV input simulation**
 
 <img src="https://user-images.githubusercontent.com/39840334/79164615-40908180-7d96-11ea-8195-6be34d4df8d6.gif" width="300"/>


### PR DESCRIPTION
Untied the camera movespeed from the frame rate.
Adjusted the camera's movespeed accordingly
Changed the fast control key from Right Ctrl to Right Shift so the user can't accidentally call Ctrl + S

## Changes
- Fixes: #7692