### PR TITLE
Fixed bounding box handlers not growing and added unit tests

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -633,7 +633,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 // also only use proximity effect if nothing is being dragged or grabbed
                 if (!wireframeOnly && currentPointer == null)
                 {
-                    proximityEffect.UpdateScaling(transform.position, currentBoundsExtents);
+                    proximityEffect.UpdateScaling(Vector3.Scale(TargetBounds.center, TargetBounds.gameObject.transform.lossyScale) + transform.position, currentBoundsExtents);
                 }
             }
         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -2338,19 +2338,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Determine if passed point is within sphere of radius around this GameObject
-        /// To avoid function overhead, request compiler to inline this function since repeatedly called every Update() for every pointer position and result
-        /// </summary>
-        /// <param name="point">world space position</param>
-        /// <param name="radiusSqr">radius of sphere in distance squared for faster comparison</param>
-        /// <returns>true if point is within sphere</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool IsPointWithinBounds(Vector3 point, float radiusSqr)
-        {
-            return (Vector3.Scale(TargetBounds.center, TargetBounds.gameObject.transform.lossyScale) + transform.position - point).sqrMagnitude < radiusSqr;
-        }
-
-        /// <summary>
         /// Get the ProximityState value based on the distanced provided
         /// </summary>
         /// <param name="sqrDistance">distance squared in proximity in meters</param>
@@ -2394,6 +2381,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             float newLocalScale = (handle.HandleVisual.localScale.x * (1.0f - weight)) + (handleSize * targetScale * weight);
             handle.HandleVisual.localScale = new Vector3(newLocalScale, newLocalScale, newLocalScale);
+        }
+
+        /// <summary>
+        /// Determine if passed point is within sphere of radius around this GameObject
+        /// To avoid function overhead, request compiler to inline this function since repeatedly called every Update() for every pointer position and result
+        /// </summary>
+        /// <param name="point">world space position</param>
+        /// <param name="radiusSqr">radius of sphere in distance squared for faster comparison</param>
+        /// <returns>true if point is within sphere</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsPointWithinBounds(Vector3 point, float radiusSqr)
+        {
+            return (Vector3.Scale(TargetBounds.center, TargetBounds.gameObject.transform.lossyScale) + transform.position - point).sqrMagnitude < radiusSqr;
         }
 
         /// <summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -253,22 +253,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [SerializeField]
-        [Obsolete("Use a TransformScaleHandler script rather than setting minimum on BoundingBox directly", false)]
+        [Obsolete("Use a MinMaxScaleConstraint script rather than setting minimum on BoundingBox directly", false)]
         [Tooltip("Minimum scaling allowed relative to the initial size")]
         private float scaleMinimum = 0.2f;
 
         [SerializeField]
-        [Obsolete("Use a TransformScaleHandler script rather than setting maximum on BoundingBox directly")]
+        [Obsolete("Use a MinMaxScaleConstraint script rather than setting maximum on BoundingBox directly")]
         [Tooltip("Maximum scaling allowed relative to the initial size")]
         private float scaleMaximum = 2.0f;
 
 
         /// <summary>
-        /// Deprecated: Use TransformScaleHandler component instead.
+        /// Deprecated: Use <see cref="Microsoft.MixedReality.Toolkit.UI.MinMaxScaleConstraint"/> component instead.
         /// Public property for the scale minimum, in the target's local scale.
         /// Set this value with SetScaleLimits.
         /// </summary>
-        [Obsolete("Use a TransformScaleHandler.ScaleMinimum as it is the authoritative value for min scale")]
+        [Obsolete("Use a MinMaxScaleConstraint. ScaleMinimum as it is the authoritative value for min scale")]
         public float ScaleMinimum
         {
             get
@@ -282,11 +282,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Deprecated: Use TransformScaleHandler component instead.
+        /// Deprecated: Use <see cref="Microsoft.MixedReality.Toolkit.UI.MinMaxScaleConstraint"/> component instead.
         /// Public property for the scale maximum, in the target's local scale.
         /// Set this value with SetScaleLimits.
         /// </summary>
-        [Obsolete("Use a TransformScaleHandler.ScaleMinimum as it is the authoritative value for max scale")]
+        [Obsolete("Use a MinMaxScaleConstraint component instead. ScaleMinimum as it is the authoritative value for max scale")]
         public float ScaleMaximum
         {
             get
@@ -1185,7 +1185,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <param name="min">Minimum scale</param>
         /// <param name="max">Maximum scale</param>
         /// <param name="relativeToInitialState">If true the values will be multiplied by scale of target at startup. If false they will be in absolute local scale.</param>
-        [Obsolete("Use a TransformScaleHandler script rather than setting min/max scale on BoundingBox directly")]
+        [Obsolete("Use a MinMaxScaleConstraint script rather than setting min/max scale on BoundingBox directly")]
         public void SetScaleLimits(float min, float max, bool relativeToInitialState = true)
         {
             scaleMinimum = min;
@@ -1502,7 +1502,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 ApplyMaterialToAllRenderers(cornerVisual, handleMaterial);
 
                 AddComponentsToAffordance(corner, new Bounds(cornerbounds.center * invScale, cornerbounds.size * invScale), RotationHandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, scaleHandleColliderPadding);
-                corners.Add(corner.transform);
+                corners.Add(cornerVisual.transform);
 
                 handles.Add(new Handle()
                 {
@@ -1634,8 +1634,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
 
                 AddComponentsToAffordance(midpoint, bounds, rotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, rotateHandleColliderPadding);
-
-                balls.Add(midpoint.transform);
+                balls.Add(midpointVisual.transform);
 
                 handles.Add(new Handle()
                 {
@@ -2259,14 +2258,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // Grab points within sphere of influence from valid pointers
                 foreach (var pointer in proximityPointers)
                 {
-                    if (IsPointWithinBounds(pointer.Position, maxRadius))
-                    {
-                        proximityPoints.Add(pointer.Position);
-                    }
+                    proximityPoints.Add(pointer.Position);
 
                     Vector3? point = pointer.Result?.Details.Point;
-
-                    if (point.HasValue && IsPointWithinBounds(point.Value, maxRadius))
+                    if (point.HasValue)
                     {
                         proximityPoints.Add(pointer.Result.Details.Point);
                     }
@@ -2364,19 +2359,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
-        /// Determine if passed point is within sphere of radius around this GameObject
-        /// To avoid function overhead, request compiler to inline this function since repeatedly called every Update() for every pointer position and result
-        /// </summary>
-        /// <param name="point">world space position</param>
-        /// <param name="radiusSqr">radius of sphere in distance squared for faster comparison</param>
-        /// <returns>true if point is within sphere</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool IsPointWithinBounds(Vector3 point, float radiusSqr)
-        {
-            return (transform.position - point).sqrMagnitude < radiusSqr;
-        }
-
-        /// <summary>
         /// Helper method to check if handle type may be visible based on configuration
         /// </summary>
         /// <param name="h">handle reference to check</param>
@@ -2410,14 +2392,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             for (int i = 0; i < balls.Count; ++i)
             {
-                if (handle == balls[i])
+                if (handle.position == balls[i].position && handle.rotation == balls[i].rotation)
                 {
                     return HandleType.Rotation;
                 }
             }
             for (int i = 0; i < corners.Count; ++i)
             {
-                if (handle == corners[i])
+                if (handle.position == corners[i].position && handle.rotation == corners[i].rotation)
                 {
                     return HandleType.Scale;
                 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1139,7 +1139,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private List<Handle> handles;
 
         private List<Transform> corners;
-        private List<Transform> cornersVisuals;
         /// <summary>
         /// Returns list of transforms pointing to the scale handles of the bounding box.
         /// </summary>
@@ -1148,18 +1147,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get { return corners; }
         }
 
-        /// <summary>
-        /// Returns list of transforms pointing to the scale handle visuals of the bounding box.
-        /// </summary>
-        public IReadOnlyList<Transform> ScaleCornerVisuals
-        {
-            get { return cornersVisuals; }
-        }
-
-
-
         private List<Transform> balls;
-        private List<Transform> ballVisuals;
 
         /// <summary>
         /// Returns list of transforms pointing to the rotation handles of the bounding box.
@@ -1167,14 +1155,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public IReadOnlyList<Transform> RotateMidpoints
         {
             get { return balls; }
-        }
-
-        /// <summary>
-        /// Returns list of transforms pointing to the rotation handle visuals of the bounding box.
-        /// </summary>
-        public IReadOnlyList<Transform> RotateMidpointVisuals
-        {
-            get { return ballVisuals; }
         }
 
         #endregion Public Properties
@@ -1522,7 +1502,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 AddComponentsToAffordance(corner, new Bounds(cornerbounds.center * invScale, cornerbounds.size * invScale), RotationHandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, scaleHandleColliderPadding);
                 corners.Add(corner.transform);
-                cornersVisuals.Add(cornerVisual.transform);
 
                 handles.Add(new Handle()
                 {
@@ -1655,7 +1634,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 AddComponentsToAffordance(midpoint, bounds, rotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, rotateHandleColliderPadding);
                 balls.Add(midpoint.transform);
-                ballVisuals.Add(midpointVisual.transform);
 
                 handles.Add(new Handle()
                 {
@@ -1991,9 +1969,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             boundsCorners = new Vector3[8];
 
             corners = new List<Transform>();
-            cornersVisuals = new List<Transform>();
             balls = new List<Transform>();
-            ballVisuals = new List<Transform>();
 
             handles = new List<Handle>();
 
@@ -2272,10 +2248,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         }
                     }
                 }
-
-                // Get the max radius possible of our current bounds plus the proximity
-                float maxRadius = currentBoundsExtents.sqrMagnitude;
-                maxRadius += 3 * handleMediumProximity * handleMediumProximity;
+                
+                // Get the max radius possible of our current bounds and extent the range to include proximity scaled objects. This is done by adjusting the original bounds to include the ObjectMediumProximity range in x, y and z axis
+                float maxRadius = currentBoundsExtents.sqrMagnitude + (3 * handleMediumProximity * handleMediumProximity);
 
                 // Grab points within sphere of influence from valid pointers
                 foreach (var pointer in proximityPointers)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -148,6 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private class Handle
         {
+            public GameObject HandleGameObject;
             public Transform HandleVisual;
             public Renderer HandleVisualRenderer;
             public HandleType Type = HandleType.None;
@@ -1139,7 +1140,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private List<Handle> handles;
 
         private List<Transform> corners;
-
+        private List<Transform> cornersVisuals;
         /// <summary>
         /// Returns list of transforms pointing to the scale handles of the bounding box.
         /// </summary>
@@ -1148,7 +1149,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get { return corners; }
         }
 
+        /// <summary>
+        /// Returns list of transforms pointing to the scale handle visuals of the bounding box.
+        /// </summary>
+        public IReadOnlyList<Transform> ScaleCornerVisuals
+        {
+            get { return cornersVisuals; }
+        }
+
+
+
         private List<Transform> balls;
+        private List<Transform> ballVisuals;
 
         /// <summary>
         /// Returns list of transforms pointing to the rotation handles of the bounding box.
@@ -1156,6 +1168,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public IReadOnlyList<Transform> RotateMidpoints
         {
             get { return balls; }
+        }
+
+        /// <summary>
+        /// Returns list of transforms pointing to the rotation handle visuals of the bounding box.
+        /// </summary>
+        public IReadOnlyList<Transform> RotateMidpointVisuals
+        {
+            get { return ballVisuals; }
         }
 
         #endregion Public Properties
@@ -1502,10 +1522,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 ApplyMaterialToAllRenderers(cornerVisual, handleMaterial);
 
                 AddComponentsToAffordance(corner, new Bounds(cornerbounds.center * invScale, cornerbounds.size * invScale), RotationHandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, scaleHandleColliderPadding);
-                corners.Add(cornerVisual.transform);
+                corners.Add(corner.transform);
+                cornersVisuals.Add(cornerVisual.transform);
 
                 handles.Add(new Handle()
                 {
+                    HandleGameObject = corner,
                     Type = HandleType.Scale,
                     HandleVisual = cornerVisual.transform,
                     HandleVisualRenderer = cornerVisual.GetComponentInChildren<Renderer>(),
@@ -1634,10 +1656,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
 
                 AddComponentsToAffordance(midpoint, bounds, rotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, rotateHandleColliderPadding);
-                balls.Add(midpointVisual.transform);
+                balls.Add(midpoint.transform);
+                ballVisuals.Add(midpointVisual.transform);
 
                 handles.Add(new Handle()
                 {
+                    HandleGameObject = midpoint,
                     Type = HandleType.Rotation,
                     HandleVisual = midpointVisual.transform,
                     HandleVisualRenderer = midpointVisual.GetComponent<Renderer>(),
@@ -1970,7 +1994,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             boundsCorners = new Vector3[8];
 
             corners = new List<Transform>();
+            cornersVisuals = new List<Transform>();
             balls = new List<Transform>();
+            ballVisuals = new List<Transform>();
 
             handles = new List<Handle>();
 
@@ -2392,14 +2418,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             for (int i = 0; i < balls.Count; ++i)
             {
-                if (handle.position == balls[i].position && handle.rotation == balls[i].rotation)
+                if (handle == balls[i])
                 {
                     return HandleType.Rotation;
                 }
             }
             for (int i = 0; i < corners.Count; ++i)
             {
-                if (handle.position == corners[i].position && handle.rotation == corners[i].rotation)
+                if (handle == corners[i])
                 {
                     return HandleType.Scale;
                 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -148,7 +148,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private class Handle
         {
-            public GameObject HandleGameObject;
             public Transform HandleVisual;
             public Renderer HandleVisualRenderer;
             public HandleType Type = HandleType.None;
@@ -1527,7 +1526,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 handles.Add(new Handle()
                 {
-                    HandleGameObject = corner,
                     Type = HandleType.Scale,
                     HandleVisual = cornerVisual.transform,
                     HandleVisualRenderer = cornerVisual.GetComponentInChildren<Renderer>(),
@@ -1661,7 +1659,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                 handles.Add(new Handle()
                 {
-                    HandleGameObject = midpoint,
                     Type = HandleType.Rotation,
                     HandleVisual = midpointVisual.transform,
                     HandleVisualRenderer = midpointVisual.GetComponent<Renderer>(),
@@ -2341,6 +2338,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
+        /// Determine if passed point is within sphere of radius around this GameObject
+        /// To avoid function overhead, request compiler to inline this function since repeatedly called every Update() for every pointer position and result
+        /// </summary>
+        /// <param name="point">world space position</param>
+        /// <param name="radiusSqr">radius of sphere in distance squared for faster comparison</param>
+        /// <returns>true if point is within sphere</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsPointWithinBounds(Vector3 point, float radiusSqr)
+        {
+            return (Vector3.Scale(TargetBounds.center, TargetBounds.gameObject.transform.lossyScale) + transform.position - point).sqrMagnitude < radiusSqr;
+        }
+
+        /// <summary>
         /// Get the ProximityState value based on the distanced provided
         /// </summary>
         /// <param name="sqrDistance">distance squared in proximity in meters</param>
@@ -2359,19 +2369,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 return HandleProximityState.FullsizeNoProximity;
             }
-        }
-
-        /// <summary>
-        /// Determine if passed point is within sphere of radius around this GameObject
-        /// To avoid function overhead, request compiler to inline this function since repeatedly called every Update() for every pointer position and result
-        /// </summary>
-        /// <param name="point">world space position</param>
-        /// <param name="radiusSqr">radius of sphere in distance squared for faster comparison</param>
-        /// <returns>true if point is within sphere</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool IsPointWithinBounds(Vector3 point, float radiusSqr)
-        {
-            return (Vector3.Scale(TargetBounds.center, TargetBounds.gameObject.transform.lossyScale) + transform.position - point).sqrMagnitude < radiusSqr;
         }
 
         private void ScaleHandle(Handle handle, bool lerp = false)

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var originalEdgeHandlerScale = bbox.RotateMidpoints[0].transform.localScale;
             var edgeHandlerPosition = bbox.RotateMidpoints[0].transform.position;
 
-            //Wait for the scaling/unscaling animation to finish
+            // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.2f);
 
             // Move the hand to a handler on the corner 
@@ -149,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var delta = new Vector3(0.1f, 0.1f, 0f);
             yield return rightHand.MoveTo(cornerHandlerPosition, numSteps);
 
-            //Wait for the scaling/unscaling animation to finish
+            // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.4f);
 
             TestUtilities.AssertAboutEqual(bbox.RotateMidpoints[0].localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
@@ -158,7 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Move the hand to a handler on the edge
             yield return rightHand.MoveTo(edgeHandlerPosition, numSteps);
-            //Wait for the scaling/unscaling animation to finish
+            // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.4f);
 
             TestUtilities.AssertAboutEqual(bbox.ScaleCorners[0].localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 p.LookAt(cube.transform.position);
             });
 
+            bbox.Target = cube;
             bbox.transform.localScale = boundingBoxStartScale;
             bbox.Active = true;
 
@@ -135,10 +136,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
             // Definining the edge and corner handlers that will be used
-            var originalCornerHandlerScale = bbox.ScaleCornerVisuals[0].transform.localScale;
-            var cornerHandlerPosition = bbox.ScaleCorners[0].transform.position;
-            var originalEdgeHandlerScale = bbox.RotateMidpointVisuals[0].transform.localScale;
-            var edgeHandlerPosition = bbox.RotateMidpoints[0].transform.position;
+            Debug.Log(bbox.transform.Find("rigRoot/midpoint_0").GetChild(0));
+            var originalCornerHandlerScale = bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale;
+            var cornerHandlerPosition = bbox.transform.Find("rigRoot/corner_0").transform.position;
+            var originalEdgeHandlerScale = bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale;
+            var edgeHandlerPosition = bbox.transform.Find("rigRoot/midpoint_0").transform.position;
 
             // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.2f);
@@ -152,18 +154,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.4f);
 
-            TestUtilities.AssertAboutEqual(bbox.RotateMidpointVisuals[0].localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
-            TestUtilities.AssertAboutEqual(bbox.ScaleCornerVisuals[0].localScale.normalized, originalCornerHandlerScale.normalized, "The corner handler scale has changed");
-            Assert.AreApproximatelyEqual(bbox.ScaleCornerVisuals[0].localScale.x/originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
+            TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
+            TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale.normalized, originalCornerHandlerScale.normalized, "The corner handler scale has changed");
+            Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale.x/originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
 
             // Move the hand to a handler on the edge
             yield return rightHand.MoveTo(edgeHandlerPosition, numSteps);
             // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.4f);
 
-            TestUtilities.AssertAboutEqual(bbox.ScaleCornerVisuals[0].localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");
-            TestUtilities.AssertAboutEqual(bbox.RotateMidpointVisuals[0].localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
-            Assert.AreApproximatelyEqual(bbox.RotateMidpointVisuals[0].localScale.x/originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
+            TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");
+            TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
+            Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.x/originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
 
             GameObject.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -110,6 +110,67 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Tests to see that the handlers grow in size when a pointer is near them
+        /// </summary>
+        [UnityTest]
+        public IEnumerator BBoxHandlerUI()
+        {
+            const int numSteps = 2;
+            var bbox = InstantiateSceneAndDefaultBbox();
+            bbox.ShowRotationHandleForX = true;
+            bbox.ShowRotationHandleForY = true;
+            bbox.ShowRotationHandleForZ = true;
+            bbox.ShowScaleHandles = true;
+            bbox.ProximityEffectActive = true;
+            bbox.ScaleHandleSize = 0.1f;
+            bbox.RotationHandleSize = 0.1f;
+            bbox.FarScale = 1.0f;
+            bbox.MediumScale = 1.5f;
+            bbox.CloseScale = 1.5f;
+            yield return null;
+            var bounds = bbox.GetComponent<BoxCollider>().bounds;
+            Assert.AreEqual(new Vector3(0, 0, 1.5f), bounds.center);
+            Assert.AreEqual(new Vector3(.5f, .5f, .5f), bounds.size);
+
+            var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
+
+            // Definining the edge and corner handlers that will be used
+            var originalCornerHandlerScale = bbox.ScaleCorners[0].transform.localScale;
+            var cornerHandlerPosition = bbox.ScaleCorners[0].transform.position;
+            var originalEdgeHandlerScale = bbox.RotateMidpoints[0].transform.localScale;
+            var edgeHandlerPosition = bbox.RotateMidpoints[0].transform.position;
+
+            //Wait for the scaling/unscaling animation to finish
+            yield return new WaitForSeconds(0.2f);
+
+            // Move the hand to a handler on the corner 
+            TestHand rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(new Vector3(0, 0, 0.5f));
+            var delta = new Vector3(0.1f, 0.1f, 0f);
+            yield return rightHand.MoveTo(cornerHandlerPosition, numSteps);
+
+            //Wait for the scaling/unscaling animation to finish
+            yield return new WaitForSeconds(0.4f);
+
+            TestUtilities.AssertAboutEqual(bbox.RotateMidpoints[0].localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
+            TestUtilities.AssertAboutEqual(bbox.ScaleCorners[0].localScale.normalized, originalCornerHandlerScale.normalized, "The corner handler scale has changed");
+            Assert.AreApproximatelyEqual(bbox.ScaleCorners[0].localScale.x/originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
+
+            // Move the hand to a handler on the edge
+            yield return rightHand.MoveTo(edgeHandlerPosition, numSteps);
+            //Wait for the scaling/unscaling animation to finish
+            yield return new WaitForSeconds(0.4f);
+
+            TestUtilities.AssertAboutEqual(bbox.ScaleCorners[0].localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");
+            TestUtilities.AssertAboutEqual(bbox.RotateMidpoints[0].localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
+            Assert.AreApproximatelyEqual(bbox.RotateMidpoints[0].localScale.x/originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
+
+            GameObject.Destroy(bbox.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+        }
+
+        /// <summary>
         /// Uses near interaction to scale the bounding box by directly grabbing corner
         /// </summary>
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -135,9 +135,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
             // Definining the edge and corner handlers that will be used
-            var originalCornerHandlerScale = bbox.ScaleCorners[0].transform.localScale;
+            var originalCornerHandlerScale = bbox.ScaleCornerVisuals[0].transform.localScale;
             var cornerHandlerPosition = bbox.ScaleCorners[0].transform.position;
-            var originalEdgeHandlerScale = bbox.RotateMidpoints[0].transform.localScale;
+            var originalEdgeHandlerScale = bbox.RotateMidpointVisuals[0].transform.localScale;
             var edgeHandlerPosition = bbox.RotateMidpoints[0].transform.position;
 
             // Wait for the scaling/unscaling animation to finish
@@ -152,18 +152,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.4f);
 
-            TestUtilities.AssertAboutEqual(bbox.RotateMidpoints[0].localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
-            TestUtilities.AssertAboutEqual(bbox.ScaleCorners[0].localScale.normalized, originalCornerHandlerScale.normalized, "The corner handler scale has changed");
-            Assert.AreApproximatelyEqual(bbox.ScaleCorners[0].localScale.x/originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
+            TestUtilities.AssertAboutEqual(bbox.RotateMidpointVisuals[0].localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
+            TestUtilities.AssertAboutEqual(bbox.ScaleCornerVisuals[0].localScale.normalized, originalCornerHandlerScale.normalized, "The corner handler scale has changed");
+            Assert.AreApproximatelyEqual(bbox.ScaleCornerVisuals[0].localScale.x/originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
 
             // Move the hand to a handler on the edge
             yield return rightHand.MoveTo(edgeHandlerPosition, numSteps);
             // Wait for the scaling/unscaling animation to finish
             yield return new WaitForSeconds(0.4f);
 
-            TestUtilities.AssertAboutEqual(bbox.ScaleCorners[0].localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");
-            TestUtilities.AssertAboutEqual(bbox.RotateMidpoints[0].localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
-            Assert.AreApproximatelyEqual(bbox.RotateMidpoints[0].localScale.x/originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
+            TestUtilities.AssertAboutEqual(bbox.ScaleCornerVisuals[0].localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");
+            TestUtilities.AssertAboutEqual(bbox.RotateMidpointVisuals[0].localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
+            Assert.AreApproximatelyEqual(bbox.RotateMidpointVisuals[0].localScale.x/originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
 
             GameObject.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object


### PR DESCRIPTION
## Overview
Incorporates suggestion from #7395 to fix bounding box handlers not growing to when the cursor was near them. Also includes refactoring out of date code comments and makes the corners and balls transforms correspond to the actual transforms of the in-editor objects

## Changes
- Fixes: #7395
