### PR TITLE
BoundsControl is no longer recreating the rig on any of the configuration changes

### DIFF
--- a/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -156,13 +156,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
 
                 SetStatus("Scale X and update rig");
                 cube.transform.localScale = new Vector3(2, 1, 1);
-                //boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Rotate 20 degrees and update rig");
                 cube.transform.localRotation = Quaternion.Euler(0, 20, 0);
                 boundsControl.RotationHandles.ShowRotationHandleForY = true;
-                //boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Wireframe radius 0.1");

--- a/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -116,6 +116,14 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 SetStatus("ShowWireframe true");
                 boundsControl.LinksConfiguration.ShowWireFrame = true;
                 yield return WaitForSpeechCommand();
+               
+                SetStatus("Wireframe radius 0.1");
+                boundsControl.LinksConfiguration.WireframeEdgeRadius = 0.1f;
+                yield return WaitForSpeechCommand();
+
+                SetStatus("Wireframe shape cylinder");
+                boundsControl.LinksConfiguration.WireframeShape = WireframeType.Cylindrical;
+                yield return WaitForSpeechCommand();
 
                 SetStatus("BoxPadding 0.2f");
                 boundsControl.BoxPadding = new Vector3(0.2f, 0.2f, 0.2f);
@@ -165,13 +173,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
-                SetStatus("Wireframe radius 0.1");
-                boundsControl.LinksConfiguration.WireframeEdgeRadius = 0.1f;
-                yield return WaitForSpeechCommand();
-
-                SetStatus("Wireframe shape cylinder");
-                boundsControl.LinksConfiguration.WireframeShape = WireframeType.Cylindrical;
-                yield return WaitForSpeechCommand();
 
                 Destroy(cube);
             }

--- a/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -110,11 +110,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 yield return WaitForSpeechCommand();
 
                 SetStatus("ShowWireframe false");
-                boundsControl.LinksConfiguration.ShowWireFrame = false;
+                boundsControl.LinksConfig.ShowWireFrame = false;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("ShowWireframe true");
-                boundsControl.LinksConfiguration.ShowWireFrame = true;
+                boundsControl.LinksConfig.ShowWireFrame = true;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BoxPadding 0.2f");
@@ -126,32 +126,32 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Set scale handle size 0.3");
-                boundsControl.ScaleHandlesConfiguration.HandleSize = 0.3f;
+                boundsControl.ScaleHandlesConfig.HandleSize = 0.3f;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Set scale handle widget prefab");
                 Debug.Assert(scaleWidget != null);
-                boundsControl.ScaleHandlesConfiguration.HandlePrefab = scaleWidget;
+                boundsControl.ScaleHandlesConfig.HandlePrefab = scaleWidget;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Handles red");
-                boundsControl.ScaleHandlesConfiguration.HandleMaterial = redMaterial;
-                boundsControl.RotationHandles.HandleMaterial = redMaterial;
+                boundsControl.ScaleHandlesConfig.HandleMaterial = redMaterial;
+                boundsControl.RotationHandlesConfig.HandleMaterial = redMaterial;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BBox material cyan");
                 Debug.Assert(cyanMaterial != null);
-                boundsControl.BoxDisplayConfiguration.BoxMaterial = cyanMaterial;
+                boundsControl.BoxDisplayConfig.BoxMaterial = cyanMaterial;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BBox grabbed material red");
-                boundsControl.BoxDisplayConfiguration.BoxGrabbedMaterial = redMaterial;
+                boundsControl.BoxDisplayConfig.BoxGrabbedMaterial = redMaterial;
                 om.OnManipulationStarted.AddListener((med) => boundsControl.HighlightWires());
                 om.OnManipulationEnded.AddListener((med) => boundsControl.UnhighlightWires());
                 yield return WaitForSpeechCommand();
 
                 SetStatus("BBox material none");
-                boundsControl.BoxDisplayConfiguration.BoxMaterial = null;
+                boundsControl.BoxDisplayConfig.BoxMaterial = null;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Scale X and update rig");
@@ -160,15 +160,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
 
                 SetStatus("Rotate 20 degrees and update rig");
                 cube.transform.localRotation = Quaternion.Euler(0, 20, 0);
-                boundsControl.RotationHandles.ShowRotationHandleForY = true;
+                boundsControl.RotationHandlesConfig.ShowRotationHandleForY = true;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Wireframe radius 0.1");
-                boundsControl.LinksConfiguration.WireframeEdgeRadius = 0.1f;
+                boundsControl.LinksConfig.WireframeEdgeRadius = 0.1f;
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Wireframe shape cylinder");
-                boundsControl.LinksConfiguration.WireframeShape = WireframeType.Cylindrical;
+                boundsControl.LinksConfig.WireframeShape = WireframeType.Cylindrical;
                 yield return WaitForSpeechCommand();
 
                 Destroy(cube);
@@ -199,7 +199,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 boundsControl = multiRoot.AddComponent<BoundsControl>();
                 boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateOnStart;
                 boundsControl.HideElementsInInspector = false;
-                boundsControl.LinksConfiguration.WireframeEdgeRadius = .05f;
+                boundsControl.LinksConfig.WireframeEdgeRadius = .05f;
                 multiRoot.AddComponent<ObjectManipulator>();
 
                 SetStatus("Randomize Child Scale for skewing");
@@ -215,7 +215,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                     childTransform.transform.localScale = new Vector3(baseScale * Random.Range(.5f, 2f), baseScale * Random.Range(.5f, 2f), baseScale * Random.Range(.5f, 2f));
                 }
 
-                boundsControl.LinksConfiguration.WireframeEdgeRadius = 1f;
+                boundsControl.LinksConfig.WireframeEdgeRadius = 1f;
                 boundsControl.CreateRig();
                 SetStatus("Delete GameObject");
                 yield return WaitForSpeechCommand();

--- a/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
+++ b/Assets/MRTK/Examples/Experimental/Demos/UX/BoundsControl/Scripts/BoundsControlRuntimeExample.cs
@@ -116,14 +116,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
                 SetStatus("ShowWireframe true");
                 boundsControl.LinksConfiguration.ShowWireFrame = true;
                 yield return WaitForSpeechCommand();
-               
-                SetStatus("Wireframe radius 0.1");
-                boundsControl.LinksConfiguration.WireframeEdgeRadius = 0.1f;
-                yield return WaitForSpeechCommand();
-
-                SetStatus("Wireframe shape cylinder");
-                boundsControl.LinksConfiguration.WireframeShape = WireframeType.Cylindrical;
-                yield return WaitForSpeechCommand();
 
                 SetStatus("BoxPadding 0.2f");
                 boundsControl.BoxPadding = new Vector3(0.2f, 0.2f, 0.2f);
@@ -164,15 +156,22 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.Demos
 
                 SetStatus("Scale X and update rig");
                 cube.transform.localScale = new Vector3(2, 1, 1);
-                boundsControl.CreateRig();
+                //boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
                 SetStatus("Rotate 20 degrees and update rig");
                 cube.transform.localRotation = Quaternion.Euler(0, 20, 0);
                 boundsControl.RotationHandles.ShowRotationHandleForY = true;
-                boundsControl.CreateRig();
+                //boundsControl.CreateRig();
                 yield return WaitForSpeechCommand();
 
+                SetStatus("Wireframe radius 0.1");
+                boundsControl.LinksConfiguration.WireframeEdgeRadius = 0.1f;
+                yield return WaitForSpeechCommand();
+
+                SetStatus("Wireframe shape cylinder");
+                boundsControl.LinksConfiguration.WireframeShape = WireframeType.Cylindrical;
+                yield return WaitForSpeechCommand();
 
                 Destroy(cube);
             }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -133,18 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         [Header("Visuals")]
 
-        [SerializeField]
-        [Tooltip("Check to draw a tether point from the handles to the hand when manipulating.")]
-        private bool drawTetherWhenManipulating = true;
-
-        /// <summary>
-        /// Check to draw a tether point from the handles to the hand when manipulating.
-        /// </summary>
-        public bool DrawTetherWhenManipulating
-        {
-            get => drawTetherWhenManipulating;
-            set => drawTetherWhenManipulating = value;
-        }
+        
 
         [SerializeField]
         [Tooltip("Add a Collider here if you do not want the handle colliders to interact with another object's collider.")]
@@ -1217,11 +1206,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             // add corners
             bool isFlattened = flattenAxis != FlattenModeType.DoNotFlatten;
-            scaleHandles.Create(ref boundsCorners, rigRoot, drawTetherWhenManipulating, isFlattened);
+            scaleHandles.Create(ref boundsCorners, rigRoot, isFlattened);
             proximityEffect.RegisterObjectProvider(scaleHandles);
 
             // add links
-            rotationHandles.Create(ref boundsCorners, rigRoot, drawTetherWhenManipulating);
+            rotationHandles.Create(ref boundsCorners, rigRoot);
             proximityEffect.RegisterObjectProvider(rotationHandles);
             links.CreateLinks(rotationHandles, rigRoot, currentBoundsExtents);
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -404,7 +404,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     active = value;
                     rigRoot?.gameObject.SetActive(value);
-                    UpdateExtents();
                     ResetVisuals();
 
                     if (active)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿no// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
@@ -126,16 +126,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (activation != value)
                 {
                     activation = value;
+                    SetActivationFlags();
                     ResetVisuals();
                 }
             }
         }
 
         [Header("Visuals")]
-
-        
-
-        
 
         [SerializeField]
         [Tooltip("Flatten bounds in the specified axis or flatten the smallest one if 'auto' is selected")]
@@ -356,6 +353,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         private ProximityEffect proximityEffect;
 
         // Whether we should be displaying just the wireframe (if enabled) or the handles too
+        public bool WireframeOnly { get => wireframeOnly; }
         private bool wireframeOnly = false;
 
         // Pointer that is being used to manipulate the bounds control
@@ -552,6 +550,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             Flatten(flattenAxis);
             CreateRig();
             CaptureInitialState();
+            SetActivationFlags();
+        }
+
+        private void SetActivationFlags()
+        {
+            wireframeOnly = false;
 
             if (activation == BoundsControlActivationType.ActivateByProximityAndPointer ||
                 activation == BoundsControlActivationType.ActivateByProximity ||
@@ -566,8 +570,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
             else if (activation == BoundsControlActivationType.ActivateManually)
             {
-                // Activate to create handles etc. then deactivate. 
-                Active = true;
                 Active = false;
             }
         }
@@ -1170,9 +1172,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
             bool isVisible = (active == true && wireframeOnly == false);
             // Set corner visibility
-            scaleHandles.ResetHandleVisibility(isVisible);
+            scaleHandles.IsActive = isVisible;
             // Set rotation handle visibility
-            rotationHandles.ResetHandleVisibility(isVisible);
+            rotationHandles.IsActive = isVisible;
             rotationHandles.FlattenHandles(ref flattenedHandles);
         }
 
@@ -1186,7 +1188,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             links.ResetVisibility(active);
             links.Flatten(ref flattenedHandles);
             bool isVisible = (active == true && wireframeOnly == false);
-            rotationHandles.ResetHandleVisibility(isVisible);
+            rotationHandles.IsActive = isVisible;
             rotationHandles.FlattenHandles(ref flattenedHandles);
             scaleHandles.UpdateFlattenMode(flattenAxis != FlattenModeType.DoNotFlatten);
             boxDisplay.UpdateFlattenAxis(flattenAxis);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -51,7 +51,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (targetObject != value)
                 {
                     targetObject = value;
-                    CreateRig();
+                    isChildOfTarget = transform.IsChildOf(targetObject.transform);
+                    SetBoundsControlCollider();
+                    UpdateBounds();
+                    UpdateVisuals();
                 }
             }
         }
@@ -76,7 +79,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     {
                         prevBoundsOverride = new Bounds();
                     }
-                    CreateRig();
+                    SetBoundsControlCollider();
+                    UpdateBounds();
+                    UpdateVisuals();
                 }
             }
         }
@@ -96,7 +101,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (boundsCalculationMethod != value)
                 {
                     boundsCalculationMethod = value;
-                    CreateRig();
+                    SetBoundsControlCollider();
+                    UpdateBounds();
+                    UpdateVisuals();
                 }
             }
         }
@@ -208,7 +215,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (Vector3.Distance(boxPadding, value) > float.Epsilon)
                 {
                     boxPadding = value;
-                    CreateRig();
+                    SetBoundsControlCollider();
+                    UpdateBounds();
+                    UpdateVisuals();
                 }
             }
         }
@@ -546,22 +555,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             boxDisplay = new BoxDisplay(boxDisplayConfiguration);
             links = new Links(linksConfiguration);
             proximityEffect = new ProximityEffect(handleProximityEffectConfiguration);
-
-            // subscribe to visual changes
-           // scaleHandlesConfiguration.configurationChanged.AddListener(CreateRig);
-           // scaleHandlesConfiguration.visibilityChanged.AddListener(ResetVisuals);
-           // rotationHandlesConfiguration.configurationChanged.AddListener(CreateRig);
-            //boxDisplayConfiguration.configurationChanged.AddListener(CreateRig);
-            //linksConfiguration.configurationChanged.AddListener(CreateRig);          
-        }
-
-        private void OnDestroy()
-        {
-            //scaleHandlesConfiguration.configurationChanged.RemoveListener(CreateRig);
-            //scaleHandlesConfiguration.visibilityChanged.RemoveListener(ResetVisuals);
-            //rotationHandlesConfiguration.configurationChanged.RemoveListener(CreateRig);
-           // boxDisplayConfiguration.configurationChanged.RemoveListener(CreateRig);
-            //linksConfiguration.configurationChanged.RemoveListener(CreateRig);
         }
 
         private static T EnsureScriptable<T>(T instance) where T : ScriptableObject
@@ -669,6 +662,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
             else
             {
+                // first remove old collider if there is any so we don't accumulate any 
+                // box padding on consecutive calls of this method
+                if (TargetBounds != null)
+                {
+                    Destroy(TargetBounds);
+                }
                 Bounds bounds = GetTargetBounds();
                 TargetBounds = Target.AddComponent<BoxCollider>();
 
@@ -821,9 +820,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             if (Target != null)
             {
                 isChildOfTarget = transform.IsChildOf(Target.transform);
-
-                RegisterTransformScaleHandler(GetComponent<MinMaxScaleConstraint>());
             }
+            RegisterTransformScaleHandler(GetComponent<MinMaxScaleConstraint>());
         }
        
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -548,20 +548,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             proximityEffect = new ProximityEffect(handleProximityEffectConfiguration);
 
             // subscribe to visual changes
-            scaleHandlesConfiguration.configurationChanged.AddListener(CreateRig);
-            scaleHandlesConfiguration.visibilityChanged.AddListener(ResetVisuals);
-            rotationHandlesConfiguration.configurationChanged.AddListener(CreateRig);
-            boxDisplayConfiguration.configurationChanged.AddListener(CreateRig);
-            linksConfiguration.configurationChanged.AddListener(CreateRig);          
+           // scaleHandlesConfiguration.configurationChanged.AddListener(CreateRig);
+           // scaleHandlesConfiguration.visibilityChanged.AddListener(ResetVisuals);
+           // rotationHandlesConfiguration.configurationChanged.AddListener(CreateRig);
+            //boxDisplayConfiguration.configurationChanged.AddListener(CreateRig);
+            //linksConfiguration.configurationChanged.AddListener(CreateRig);          
         }
 
         private void OnDestroy()
         {
-            scaleHandlesConfiguration.configurationChanged.RemoveListener(CreateRig);
-            scaleHandlesConfiguration.visibilityChanged.RemoveListener(ResetVisuals);
-            rotationHandlesConfiguration.configurationChanged.RemoveListener(CreateRig);
-            boxDisplayConfiguration.configurationChanged.RemoveListener(CreateRig);
-            linksConfiguration.configurationChanged.RemoveListener(CreateRig);
+            //scaleHandlesConfiguration.configurationChanged.RemoveListener(CreateRig);
+            //scaleHandlesConfiguration.visibilityChanged.RemoveListener(ResetVisuals);
+            //rotationHandlesConfiguration.configurationChanged.RemoveListener(CreateRig);
+           // boxDisplayConfiguration.configurationChanged.RemoveListener(CreateRig);
+            //linksConfiguration.configurationChanged.RemoveListener(CreateRig);
         }
 
         private static T EnsureScriptable<T>(T instance) where T : ScriptableObject

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1,4 +1,4 @@
-﻿no// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Input;
@@ -53,8 +53,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     targetObject = value;
                     isChildOfTarget = transform.IsChildOf(targetObject.transform);
                     // reparent rigroot
-                    rigRoot.parent = targetObject.transform;
-                    OnTargetBoundsChanged();
+                    if (rigRoot != null)
+                    {
+                        rigRoot.parent = targetObject.transform;
+                        OnTargetBoundsChanged();
+                    }
                 }
             }
         }
@@ -408,7 +411,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                     if (active)
                     {
-                        proximityEffect.ResetProximityScale();
+                        proximityEffect?.ResetProximityScale();
                     }
                 }
             }
@@ -517,9 +520,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         private void OnEnable()
         {
+            SetActivationFlags();
             CreateRig();
             CaptureInitialState();
-            SetActivationFlags();
         }
 
         private void SetActivationFlags()

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -52,6 +52,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     targetObject = value;
                     isChildOfTarget = transform.IsChildOf(targetObject.transform);
+                    // reparent rigroot
+                    rigRoot.parent = targetObject.transform;
                     DetermineTargetBounds();
                     UpdateExtents();
                     UpdateVisuals();

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -173,7 +173,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     flattenAxis = value;
                     Flatten(flattenAxis);
-                    CreateRig();
+                    //CreateRig();
+                    UpdateFlattenAxis();
+                    UpdateBounds();
+                    UpdateVisuals();
                 }
             }
         }
@@ -1199,6 +1202,22 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             rotationHandles.FlattenHandles(ref flattenedHandles);
         }
 
+        private void UpdateFlattenAxis()
+        {
+            //CreateRig();
+            if (!IsInitialized)
+            {
+                return;
+            }
+            ResetVisuals();
+            links.ResetVisibility(active);
+            links.Flatten(ref flattenedHandles);
+            bool isVisible = (active == true && wireframeOnly == false);
+            rotationHandles.ResetHandleVisibility(isVisible);
+            rotationHandles.FlattenHandles(ref flattenedHandles);
+            scaleHandles.UpdateFlattenMode(flattenAxis != FlattenModeType.DoNotFlatten);
+            boxDisplay.UpdateFlattenAxis(flattenAxis);
+        }
         private void CreateVisuals()
         {
             // add corners

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1189,7 +1189,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
             // add box display
             boxDisplay.AddBoxDisplay(rigRoot.transform, currentBoundsExtents, flattenAxis);
-
             // update visuals
             UpdateVisuals();
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1189,6 +1189,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
             // add box display
             boxDisplay.AddBoxDisplay(rigRoot.transform, currentBoundsExtents, flattenAxis);
+
             // update visuals
             UpdateVisuals();
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -54,9 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     isChildOfTarget = transform.IsChildOf(targetObject.transform);
                     // reparent rigroot
                     rigRoot.parent = targetObject.transform;
-                    DetermineTargetBounds();
-                    UpdateExtents();
-                    UpdateVisuals();
+                    OnTargetBoundsChanged();
                 }
             }
         }
@@ -81,9 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     {
                         prevBoundsOverride = new Bounds();
                     }
-                    DetermineTargetBounds();
-                    UpdateExtents();
-                    UpdateVisuals();
+                    OnTargetBoundsChanged();
                 }
             }
         }
@@ -103,9 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (boundsCalculationMethod != value)
                 {
                     boundsCalculationMethod = value;
-                    DetermineTargetBounds();
-                    UpdateExtents();
-                    UpdateVisuals();
+                    OnTargetBoundsChanged();
                 }
             }
         }
@@ -149,34 +143,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (flattenAxis != value)
                 {
                     flattenAxis = value;
-                    Flatten(flattenAxis);
                     UpdateExtents();
                     UpdateVisuals();
                     ResetVisuals();
-
-                   // UpdateFlattenAxis();
                 }
-            }
-        }
-
-        private int[] flattenedHandles = null;
-        private void Flatten(FlattenModeType flattenAxis)
-        {
-            if (flattenAxis == FlattenModeType.FlattenX)
-            {
-                flattenedHandles = new int[] { 0, 4, 2, 6 };
-            }
-            else if (flattenAxis == FlattenModeType.FlattenY)
-            {
-                flattenedHandles = new int[] { 1, 3, 5, 7 };
-            }
-            else if (flattenAxis == FlattenModeType.FlattenZ)
-            {
-                flattenedHandles = new int[] { 9, 10, 8, 11 };
-            }
-            else
-            {
-                flattenedHandles = null;
             }
         }
 
@@ -195,9 +165,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (Vector3.Distance(boxPadding, value) > float.Epsilon)
                 {
                     boxPadding = value;
-                    DetermineTargetBounds();
-                    UpdateExtents();
-                    UpdateVisuals();
+                    OnTargetBoundsChanged();
                 }
             }
         }
@@ -498,8 +466,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             DetermineTargetBounds();
             UpdateExtents();
             CreateVisuals();
-            // UpdateFlattenAxis();
-           // UpdateVisuals();
             ResetVisuals();
             rigRoot.gameObject.SetActive(active);
             UpdateRigVisibilityInInspector();
@@ -552,7 +518,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         private void OnEnable()
         {
-            Flatten(flattenAxis);
             CreateRig();
             CaptureInitialState();
             SetActivationFlags();
@@ -1021,6 +986,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
+        private void OnTargetBoundsChanged()
+        {
+            DetermineTargetBounds();
+            UpdateExtents();
+            UpdateVisuals();
+        }
+
         #endregion Private Methods
 
         #region Used Event Handlers
@@ -1191,20 +1163,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 return;
             }
 
-            // Set link visibility
-            links.ResetVisibility(active);
-            links.Flatten(ref flattenedHandles);
-
-            boxDisplay.ResetVisibility(active);
+            links.Reset(active, flattenAxis);
+            
+            boxDisplay.Reset(active);
+            boxDisplay.UpdateFlattenAxis(flattenAxis);
 
             bool isVisible = (active == true && wireframeOnly == false);
-            // Set corner visibility
-            scaleHandles.IsActive = isVisible;
-            // Set rotation handle visibility
-            rotationHandles.IsActive = isVisible;
-            rotationHandles.FlattenHandles(ref flattenedHandles);
-            scaleHandles.UpdateFlattenMode(flattenAxis != FlattenModeType.DoNotFlatten);
-            boxDisplay.UpdateFlattenAxis(flattenAxis);
+            rotationHandles.Reset(isVisible, flattenAxis);
+            scaleHandles.Reset(isVisible, flattenAxis);
         }
 
         private void CreateVisuals()

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -202,7 +202,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         [SerializeField]
-        // [FormerlySerializedAs("wireframePadding")]
         [Tooltip("Extra padding added to the actual Target bounds")]
         private Vector3 boxPadding = Vector3.zero;
 
@@ -230,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Bounds control box display configuration section.
         /// </summary>
-        public BoxDisplayConfiguration BoxDisplayConfiguration
+        public BoxDisplayConfiguration BoxDisplayConfig
         {
             get => boxDisplayConfiguration;
             set => boxDisplayConfiguration = value;
@@ -242,7 +241,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// This section defines the links / lines that are drawn between the corners of the control.
         /// </summary>
-        public LinksConfiguration LinksConfiguration
+        public LinksConfiguration LinksConfig
         {
             get => linksConfiguration;
             set => linksConfiguration = value;
@@ -254,7 +253,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Configuration of the scale handles.
         /// </summary>
-        public ScaleHandlesConfiguration ScaleHandlesConfiguration
+        public ScaleHandlesConfiguration ScaleHandlesConfig
         {
             get => scaleHandlesConfiguration;
             set => scaleHandlesConfiguration = value;
@@ -266,7 +265,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Configuration of the rotation handles.
         /// </summary>
-        public RotationHandlesConfiguration RotationHandles
+        public RotationHandlesConfiguration RotationHandlesConfig
         {
             get => rotationHandlesConfiguration;
             set => rotationHandlesConfiguration = value;
@@ -278,7 +277,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Configuration for Proximity Effect to scale handles or change materials on proximity.
         /// </summary>
-        public ProximityEffectConfiguration HandleProximityEffectConfiguration
+        public ProximityEffectConfiguration HandleProximityEffectConfig
         {
             get => handleProximityEffectConfiguration;
             set => handleProximityEffectConfiguration = value;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -135,18 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         
 
-        [SerializeField]
-        [Tooltip("Add a Collider here if you do not want the handle colliders to interact with another object's collider.")]
-        private Collider handlesIgnoreCollider = null;
-
-        /// <summary>
-        /// Add a Collider here if you do not want the handle colliders to interact with another object's collider.
-        /// </summary>
-        public Collider HandlesIgnoreCollider
-        {
-            get => handlesIgnoreCollider;
-            set => handlesIgnoreCollider = value;
-        }
+        
 
         [SerializeField]
         [Tooltip("Flatten bounds in the specified axis or flatten the smallest one if 'auto' is selected")]
@@ -1216,11 +1205,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
             // add box display
             boxDisplay.AddBoxDisplay(rigRoot.transform, currentBoundsExtents, flattenAxis);
-
-            // setup colliders
-            // Make the handle colliders ignore specified collider. (e.g. spatial mapping's floor collider to avoid the object get lifted up)
-            scaleHandles.HandleIgnoreCollider(handlesIgnoreCollider);
-            rotationHandles.HandleIgnoreCollider(handlesIgnoreCollider);
 
             // update visuals
             UpdateVisuals();

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControlTypes.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControlTypes.cs
@@ -90,9 +90,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes
     }
 
     /// <summary>
-    /// This enum defines the type of collider in use when a rotation handle prefab is provided.
+    /// This enum defines the type of collider in use when no handle prefab is provided.
     /// </summary>
-    public enum RotationHandlePrefabCollider
+    public enum HandlePrefabCollider
     {
         Sphere,
         Box

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         private BoxDisplayConfiguration config;
 
         private Vector3 cachedExtents = Vector3.zero;
-        private FlattenModeType flattenMode;
+        private FlattenModeType cachedFlattenMode;
 
         private bool isVisible = true;
 
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube);
             Object.Destroy(boxDisplay.GetComponent<Collider>());
             boxDisplay.name = "box display";
-            flattenMode = flattenAxis;
+            cachedFlattenMode = flattenAxis;
             cachedExtents = currentBoundsExtents;
             Reset(isVisible);
             boxDisplay.transform.localScale = GetBoxDisplayScale(currentBoundsExtents, flattenAxis);
@@ -100,17 +100,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
 
             cachedExtents = boundsExtents;
-            flattenMode = flattenAxis;
+            cachedFlattenMode = flattenAxis;
         }
 
         internal void UpdateDisplayWithCache()
         {
-            UpdateDisplay(cachedExtents, flattenMode);
+            UpdateDisplay(cachedExtents, cachedFlattenMode);
         }
 
         internal void UpdateFlattenAxis(FlattenModeType flattenAxis)
         {
-            flattenMode = flattenAxis;
+            cachedFlattenMode = flattenAxis;
             UpdateDisplay(cachedExtents, flattenAxis);
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         private Vector3 cachedExtents;
         private FlattenModeType flattenMode;
 
+        private bool isVisible = true;
+
         internal BoxDisplay(BoxDisplayConfiguration configuration)
         {
             Debug.Assert(configuration != null, "Can't create BoundsControlBoxDisplay without valid configuration");
@@ -36,18 +38,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void AddBoxDisplay(Transform parent, Vector3 currentBoundsExtents, FlattenModeType flattenAxis)
         {
-            if (config.BoxMaterial != null)
-            {
-                // This has to be cube even in flattened mode as flattened box display can still have a thickness of flattenAxisDisplayScale
-                boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                GameObject.Destroy(boxDisplay.GetComponent<Collider>());
-                boxDisplay.name = "bounding box";
-                flattenMode = flattenAxis;
-                cachedExtents = currentBoundsExtents;
-                VisualUtils.ApplyMaterialToAllRenderers(boxDisplay, config.BoxMaterial);
-                boxDisplay.transform.localScale = GetBoxDisplayScale(currentBoundsExtents, flattenAxis);
-                boxDisplay.transform.parent = parent;
-            }
+            // This has to be cube even in flattened mode as flattened box display can still have a thickness of flattenAxisDisplayScale
+            boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject.Destroy(boxDisplay.GetComponent<Collider>());
+            boxDisplay.name = "bounding box";
+            flattenMode = flattenAxis;
+            cachedExtents = currentBoundsExtents;
+            ResetVisibility(isVisible);
+            boxDisplay.transform.localScale = GetBoxDisplayScale(currentBoundsExtents, flattenAxis);
+            boxDisplay.transform.parent = parent;
         }
 
         private Vector3 GetBoxDisplayScale(Vector3 currentBoundsExtents, FlattenModeType flattenAxis)
@@ -75,13 +74,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        internal void ResetVisibility(bool activate)
+        internal void ResetVisibility(bool visible)
         {
+            isVisible = visible;
             // Set box display visibility
             if (boxDisplay != null)
             {
+                bool activate = config.BoxMaterial != null && isVisible; // only set active if material is set
                 boxDisplay.SetActive(activate);
-                VisualUtils.ApplyMaterialToAllRenderers(boxDisplay, config.BoxMaterial);
+                if (activate)
+                {
+                    VisualUtils.ApplyMaterialToAllRenderers(boxDisplay, config.BoxMaterial);
+                }
             }
         }
 
@@ -99,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         internal void UpdateDisplayWithCache()
         {
             UpdateDisplay(cachedExtents, flattenMode);
-        }   
+        }
 
         internal void UpdateFlattenAxis(FlattenModeType flattenAxis)
         {
@@ -109,14 +113,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void UpdateBoxDisplayMaterial()
         {
-            if (boxDisplay)
-            {
-                ResetVisibility(boxDisplay.activeSelf);
-            }
-            else 
-            { 
-            // todo add box display
-            }
+            ResetVisibility(isVisible);
         }
 
     }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -114,12 +114,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             UpdateDisplay(cachedExtents, flattenAxis);
         }
 
-        internal void UpdateFlattenAxis(FlattenModeType flattenAxis)
-        {
-            cachedFlattenMode = flattenAxis;
-            UpdateDisplay(cachedExtents, flattenAxis);
-        }
-
         internal void UpdateBoxDisplayMaterial()
         {
             Reset(isVisible);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void UpdateFlattenAxis(FlattenModeType flattenAxis)
         {
-            flattenMode = flattenAxis;
+            cachedFlattenMode = flattenAxis;
             UpdateDisplay(cachedExtents, flattenAxis);
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -114,6 +114,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             UpdateDisplay(cachedExtents, flattenAxis);
         }
 
+        internal void UpdateFlattenAxis(FlattenModeType flattenAxis)
+        {
+            flattenMode = flattenAxis;
+            UpdateDisplay(cachedExtents, flattenAxis);
+        }
+
         internal void UpdateBoxDisplayMaterial()
         {
             Reset(isVisible);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         private BoxDisplayConfiguration config;
 
-        private Vector3 cachedExtents;
+        private Vector3 cachedExtents = Vector3.zero;
         private FlattenModeType flattenMode;
 
         private bool isVisible = true;
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             // This has to be cube even in flattened mode as flattened box display can still have a thickness of flattenAxisDisplayScale
             boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube);
             Object.Destroy(boxDisplay.GetComponent<Collider>());
-            boxDisplay.name = "bounding box";
+            boxDisplay.name = "box display";
             flattenMode = flattenAxis;
             cachedExtents = currentBoundsExtents;
             ResetVisibility(isVisible);
@@ -98,6 +98,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 boxDisplay.transform.localScale = GetBoxDisplayScale(boundsExtents, flattenAxis);
                 boxDisplay.transform.parent = parent;
             }
+
+            cachedExtents = boundsExtents;
+            flattenMode = flattenAxis;
         }
 
         internal void UpdateDisplayWithCache()

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             // This has to be cube even in flattened mode as flattened box display can still have a thickness of flattenAxisDisplayScale
             boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            GameObject.Destroy(boxDisplay.GetComponent<Collider>());
+            Object.Destroy(boxDisplay.GetComponent<Collider>());
             boxDisplay.name = "bounding box";
             flattenMode = flattenAxis;
             cachedExtents = currentBoundsExtents;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             boxDisplay.name = "box display";
             flattenMode = flattenAxis;
             cachedExtents = currentBoundsExtents;
-            ResetVisibility(isVisible);
+            Reset(isVisible);
             boxDisplay.transform.localScale = GetBoxDisplayScale(currentBoundsExtents, flattenAxis);
             boxDisplay.transform.parent = parent;
         }
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        internal void ResetVisibility(bool visible)
+        internal void Reset(bool visible)
         {
             isVisible = visible;
             // Set box display visibility
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void UpdateBoxDisplayMaterial()
         {
-            ResetVisibility(isVisible);
+            Reset(isVisible);
         }
 
     }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -17,10 +17,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         private BoxDisplayConfiguration config;
 
+        private Vector3 cachedExtents;
+        private FlattenModeType flattenMode;
+
         internal BoxDisplay(BoxDisplayConfiguration configuration)
         {
             Debug.Assert(configuration != null, "Can't create BoundsControlBoxDisplay without valid configuration");
             config = configuration;
+            config.flattenAxisScaleChanged.AddListener(UpdateDisplayWithCache);
+            config.materialChanged.AddListener(UpdateBoxDisplayMaterial);
+        }
+
+        ~BoxDisplay()
+        {
+            config.flattenAxisScaleChanged.RemoveListener(UpdateDisplayWithCache);
+            config.materialChanged.RemoveListener(UpdateBoxDisplayMaterial);
         }
 
         internal void AddBoxDisplay(Transform parent, Vector3 currentBoundsExtents, FlattenModeType flattenAxis)
@@ -28,10 +39,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             if (config.BoxMaterial != null)
             {
                 // This has to be cube even in flattened mode as flattened box display can still have a thickness of flattenAxisDisplayScale
-                boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube); 
+                boxDisplay = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 GameObject.Destroy(boxDisplay.GetComponent<Collider>());
                 boxDisplay.name = "bounding box";
-
+                flattenMode = flattenAxis;
+                cachedExtents = currentBoundsExtents;
                 VisualUtils.ApplyMaterialToAllRenderers(boxDisplay, config.BoxMaterial);
                 boxDisplay.transform.localScale = GetBoxDisplayScale(currentBoundsExtents, flattenAxis);
                 boxDisplay.transform.parent = parent;
@@ -83,5 +95,23 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 boxDisplay.transform.parent = parent;
             }
         }
+
+        internal void UpdateDisplayWithCache()
+        {
+            UpdateDisplay(cachedExtents, flattenMode);
+        }   
+
+        internal void UpdateBoxDisplayMaterial()
+        {
+            if (boxDisplay)
+            {
+                ResetVisibility(boxDisplay.activeSelf);
+            }
+            else 
+            { 
+            // todo add box display
+            }
+        }
+
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/BoxDisplay.cs
@@ -101,6 +101,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             UpdateDisplay(cachedExtents, flattenMode);
         }   
 
+        internal void UpdateFlattenAxis(FlattenModeType flattenAxis)
+        {
+            flattenMode = flattenAxis;
+            UpdateDisplay(cachedExtents, flattenAxis);
+        }
+
         internal void UpdateBoxDisplayMaterial()
         {
             if (boxDisplay)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/BoxDisplayConfiguration.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (boxMaterial != value)
                 {
                     boxMaterial = value;
-                    configurationChanged.Invoke();
+                    materialChanged.Invoke();
                 }
             }
         }
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (boxGrabbedMaterial != value)
                 {
                     boxGrabbedMaterial = value;
-                    configurationChanged.Invoke();
+                    materialChanged.Invoke();
                 }
             }
         }
@@ -68,11 +68,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (flattenAxisDisplayScale != value)
                 {
                     flattenAxisDisplayScale = value;
-                    configurationChanged.Invoke();
+                    flattenAxisScaleChanged.Invoke();
                 }
             }
         }
 
-        internal protected UnityEvent configurationChanged = new UnityEvent();
+        internal UnityEvent materialChanged = new UnityEvent();
+        internal UnityEvent flattenAxisScaleChanged = new UnityEvent();
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
@@ -27,7 +27,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handleMaterial = value;
                     TrySetDefaultMaterial();
-                    configurationChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.MATERIAL);
+                   // configurationChanged.Invoke();
                 }
             }
         }
@@ -48,7 +49,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handleGrabbedMaterial = value;
                     TrySetDefaultMaterial();
-                    configurationChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.MATERIAL_GRABBED);
+                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -68,7 +70,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (handlePrefab != value)
                 {
                     handlePrefab = value;
-                    configurationChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.PREFAB);
+                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -88,7 +91,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (handleSize != value)
                 {
                     handleSize = value;
-                    configurationChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.COLLIDER_SIZE);
+                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -108,13 +112,25 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (colliderPadding != value)
                 {
                     colliderPadding = value;
-                    configurationChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.COLLIDER_PADDING);
                 }
             }
         }
 
-        internal protected UnityEvent configurationChanged = new UnityEvent();
-        internal protected UnityEvent visibilityChanged = new UnityEvent();
+        //internal protected UnityEvent configurationChanged = new UnityEvent();
+        //internal protected UnityEvent visibilityChanged = new UnityEvent();
+
+        internal enum HandlesChangedEventType
+        {
+            MATERIAL,
+            MATERIAL_GRABBED,
+            PREFAB,
+            COLLIDER_SIZE,
+            COLLIDER_PADDING,
+            VISIBILITY
+        }
+        internal class HandlesChangedEvent : UnityEvent<HandlesChangedEventType> { }
+        internal HandlesChangedEvent handlesChanged = new HandlesChangedEvent();
 
         private void Awake()
         {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handleMaterial = value;
                     TrySetDefaultMaterial();
-                    handlesChanged.Invoke(HandlesChangedEventType.MATERIAL);
+                    handlesChanged.Invoke(HandlesChangedEventType.Material);
                 }
             }
         }
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handleGrabbedMaterial = value;
                     TrySetDefaultMaterial();
-                    handlesChanged.Invoke(HandlesChangedEventType.MATERIAL_GRABBED);
+                    handlesChanged.Invoke(HandlesChangedEventType.MaterialGrabbed);
                 }
             }
         }
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (handlePrefab != value)
                 {
                     handlePrefab = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.PREFAB);
+                    handlesChanged.Invoke(HandlesChangedEventType.Prefab);
                 }
             }
         }
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (handleSize != value)
                 {
                     handleSize = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.COLLIDER_SIZE);
+                    handlesChanged.Invoke(HandlesChangedEventType.ColliderSize);
                 }
             }
         }
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (colliderPadding != value)
                 {
                     colliderPadding = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.COLLIDER_PADDING);
+                    handlesChanged.Invoke(HandlesChangedEventType.ColliderPadding);
                 }
             }
         }
@@ -128,7 +128,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (value != drawTetherWhenManipulating)
                 {
                     drawTetherWhenManipulating = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.MANIPULATION_TETHER);
+                    handlesChanged.Invoke(HandlesChangedEventType.ManipulationTether);
                 }
             }   
         }
@@ -147,24 +147,24 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 if (value != handlesIgnoreCollider)
                 {
-                    handlesChanged.Invoke(HandlesChangedEventType.IGNORE_COLLIDER_REMOVE);
+                    handlesChanged.Invoke(HandlesChangedEventType.IgnoreColliderRemove);
                     handlesIgnoreCollider = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.IGNORE_COLLIDER_ADD);
+                    handlesChanged.Invoke(HandlesChangedEventType.IgnoreColliderAdd);
                 }
             }
         }
 
         internal enum HandlesChangedEventType
         {
-            MATERIAL,
-            MATERIAL_GRABBED,
-            PREFAB,
-            COLLIDER_SIZE,
-            COLLIDER_PADDING,
-            MANIPULATION_TETHER,
-            IGNORE_COLLIDER_REMOVE,
-            IGNORE_COLLIDER_ADD,
-            VISIBILITY
+            Material,
+            MaterialGrabbed,
+            Prefab,
+            ColliderSize,
+            ColliderPadding,
+            ManipulationTether,
+            IgnoreColliderRemove,
+            IgnoreColliderAdd,
+            Visibility
         }
         internal class HandlesChangedEvent : UnityEvent<HandlesChangedEventType> { }
         internal HandlesChangedEvent handlesChanged = new HandlesChangedEvent();

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
@@ -127,7 +127,36 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         public bool DrawTetherWhenManipulating
         {
             get => drawTetherWhenManipulating;
-            set => drawTetherWhenManipulating = value;
+            set
+            {
+                if (value != drawTetherWhenManipulating)
+                {
+                    drawTetherWhenManipulating = value;
+                    handlesChanged.Invoke(HandlesChangedEventType.MANIPULATION_TETHER);
+                }
+            }
+            
+        }
+
+        [SerializeField]
+        [Tooltip("Add a Collider here if you do not want the handle colliders to interact with another object's collider.")]
+        private Collider handlesIgnoreCollider = null;
+
+        /// <summary>
+        /// Add a Collider here if you do not want the handle colliders to interact with another object's collider.
+        /// </summary>
+        public Collider HandlesIgnoreCollider
+        {
+            get => handlesIgnoreCollider;
+            set
+            {
+                if (value != handlesIgnoreCollider)
+                {
+                    handlesChanged.Invoke(HandlesChangedEventType.IGNORE_COLLIDER_REMOVE);
+                    handlesIgnoreCollider = value;
+                    handlesChanged.Invoke(HandlesChangedEventType.IGNORE_COLLIDER_ADD);
+                }
+            }
         }
 
         //internal protected UnityEvent configurationChanged = new UnityEvent();
@@ -141,6 +170,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             COLLIDER_SIZE,
             COLLIDER_PADDING,
             MANIPULATION_TETHER,
+            IGNORE_COLLIDER_REMOVE,
+            IGNORE_COLLIDER_ADD,
             VISIBILITY
         }
         internal class HandlesChangedEvent : UnityEvent<HandlesChangedEventType> { }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
@@ -117,6 +117,19 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
+        [SerializeField]
+        [Tooltip("Check to draw a tether point from the handles to the hand when manipulating.")]
+        private bool drawTetherWhenManipulating = true;
+
+        /// <summary>
+        /// Check to draw a tether point from the handles to the hand when manipulating.
+        /// </summary>
+        public bool DrawTetherWhenManipulating
+        {
+            get => drawTetherWhenManipulating;
+            set => drawTetherWhenManipulating = value;
+        }
+
         //internal protected UnityEvent configurationChanged = new UnityEvent();
         //internal protected UnityEvent visibilityChanged = new UnityEvent();
 
@@ -127,6 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             PREFAB,
             COLLIDER_SIZE,
             COLLIDER_PADDING,
+            MANIPULATION_TETHER,
             VISIBILITY
         }
         internal class HandlesChangedEvent : UnityEvent<HandlesChangedEventType> { }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
@@ -28,7 +28,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     handleMaterial = value;
                     TrySetDefaultMaterial();
                     handlesChanged.Invoke(HandlesChangedEventType.MATERIAL);
-                   // configurationChanged.Invoke();
                 }
             }
         }
@@ -50,7 +49,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     handleGrabbedMaterial = value;
                     TrySetDefaultMaterial();
                     handlesChanged.Invoke(HandlesChangedEventType.MATERIAL_GRABBED);
-                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -71,7 +69,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handlePrefab = value;
                     handlesChanged.Invoke(HandlesChangedEventType.PREFAB);
-                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -92,7 +89,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handleSize = value;
                     handlesChanged.Invoke(HandlesChangedEventType.COLLIDER_SIZE);
-                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -134,8 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     drawTetherWhenManipulating = value;
                     handlesChanged.Invoke(HandlesChangedEventType.MANIPULATION_TETHER);
                 }
-            }
-            
+            }   
         }
 
         [SerializeField]
@@ -158,9 +153,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 }
             }
         }
-
-        //internal protected UnityEvent configurationChanged = new UnityEvent();
-        //internal protected UnityEvent visibilityChanged = new UnityEvent();
 
         internal enum HandlesChangedEventType
         {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         [SerializeField]
         [Tooltip("Radius for wireframe edges")]
-        private float wireframeEdgeRadius = 0.001f; 
+        private float wireframeEdgeRadius = 0.001f;
 
         /// <summary>
         /// Radius for wireframe edges

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -100,7 +100,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         #endregion Serialized Properties
 
-        //[System.Serializable]
         internal enum WireframeChangedEventType
         {
             VISIBILITY,
@@ -108,7 +107,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             SHAPE,
             MATERIAL
         }
-        //[System.Serializable]
         internal class WireFrameEvent : UnityEvent<WireframeChangedEventType> { }
         internal WireFrameEvent wireFrameChanged = new WireFrameEvent();
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -31,14 +31,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     wireframeMaterial = value;
                     TrySetDefaultMaterial();
-                    configurationChanged.Invoke();
+                    //configurationChanged.Invoke();
+                    // update materials
+                    wireFrameChanged.Invoke(WireframeChangedEventType.MATERIAL);
                 }
             }
         }
 
         [SerializeField]
         [Tooltip("Radius for wireframe edges")]
-        private float wireframeEdgeRadius = 0.001f;
+        private float wireframeEdgeRadius = 0.001f; 
 
         /// <summary>
         /// Radius for wireframe edges
@@ -51,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (wireframeEdgeRadius != value)
                 {
                     wireframeEdgeRadius = value;
-                    configurationChanged.Invoke();
+                    wireFrameChanged.Invoke(WireframeChangedEventType.RADIUS);
                 }
             }
         }
@@ -71,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (wireframeShape != value)
                 {
                     wireframeShape = value;
-                    configurationChanged.Invoke();
+                    wireFrameChanged.Invoke(WireframeChangedEventType.SHAPE);
                 }
             }
         }
@@ -91,14 +93,24 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showWireframe != value)
                 {
                     showWireframe = value;
-                    configurationChanged.Invoke();
+                    wireFrameChanged.Invoke(WireframeChangedEventType.VISIBILITY);
                 }
             }
         }
 
         #endregion Serialized Properties
 
-        internal protected UnityEvent configurationChanged = new UnityEvent();
+        //[System.Serializable]
+        internal enum WireframeChangedEventType
+        {
+            VISIBILITY,
+            RADIUS,
+            SHAPE,
+            MATERIAL
+        }
+        //[System.Serializable]
+        internal class WireFrameEvent : UnityEvent<WireframeChangedEventType> { }
+        internal WireFrameEvent wireFrameChanged = new WireFrameEvent();
 
         public void Awake()
         {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     wireframeMaterial = value;
                     TrySetDefaultMaterial();
-                    wireFrameChanged.Invoke(WireframeChangedEventType.MATERIAL);
+                    wireFrameChanged.Invoke(WireframeChangedEventType.Material);
                 }
             }
         }
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (wireframeEdgeRadius != value)
                 {
                     wireframeEdgeRadius = value;
-                    wireFrameChanged.Invoke(WireframeChangedEventType.RADIUS);
+                    wireFrameChanged.Invoke(WireframeChangedEventType.Radius);
                 }
             }
         }
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (wireframeShape != value)
                 {
                     wireframeShape = value;
-                    wireFrameChanged.Invoke(WireframeChangedEventType.SHAPE);
+                    wireFrameChanged.Invoke(WireframeChangedEventType.Shape);
                 }
             }
         }
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showWireframe != value)
                 {
                     showWireframe = value;
-                    wireFrameChanged.Invoke(WireframeChangedEventType.VISIBILITY);
+                    wireFrameChanged.Invoke(WireframeChangedEventType.Visibility);
                 }
             }
         }
@@ -100,10 +100,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal enum WireframeChangedEventType
         {
-            VISIBILITY,
-            RADIUS,
-            SHAPE,
-            MATERIAL
+            Visibility,
+            Radius,
+            Shape,
+            Material
         }
         internal class WireFrameEvent : UnityEvent<WireframeChangedEventType> { }
         internal WireFrameEvent wireFrameChanged = new WireFrameEvent();

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/LinksConfiguration.cs
@@ -31,8 +31,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     wireframeMaterial = value;
                     TrySetDefaultMaterial();
-                    //configurationChanged.Invoke();
-                    // update materials
                     wireFrameChanged.Invoke(WireframeChangedEventType.MATERIAL);
                 }
             }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showRotationHandleForX != value)
                 {
                     showRotationHandleForX = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    handlesChanged.Invoke(HandlesChangedEventType.Visibility);
                 }
             }
         }
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showRotationHandleForY != value)
                 {
                     showRotationHandleForY = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    handlesChanged.Invoke(HandlesChangedEventType.Visibility);
                 }
             }
         }
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showRotationHandleForZ != value)
                 {
                     showRotationHandleForZ = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    handlesChanged.Invoke(HandlesChangedEventType.Visibility);
                 }
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 {
@@ -16,12 +17,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         [SerializeField]
         [Tooltip("Determines the type of collider that will surround the rotation handle prefab.")]
-        private RotationHandlePrefabCollider rotationHandlePrefabColliderType = RotationHandlePrefabCollider.Box;
+        private HandlePrefabCollider rotationHandlePrefabColliderType = HandlePrefabCollider.Box;
 
         /// <summary>
         /// Determines the type of collider that will surround the rotation handle prefab.
         /// </summary>
-        public RotationHandlePrefabCollider RotationHandlePrefabColliderType
+        public HandlePrefabCollider RotationHandlePrefabColliderType
         {
             get
             {
@@ -32,7 +33,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (rotationHandlePrefabColliderType != value)
                 {
                     rotationHandlePrefabColliderType = value;
-                    configurationChanged.Invoke();
+                    colliderTypeChanged.Invoke();
+                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -55,7 +57,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showRotationHandleForX != value)
                 {
                     showRotationHandleForX = value;
-                    visibilityChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    //visibilityChanged.Invoke();
                 }
             }
         }
@@ -78,7 +81,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showRotationHandleForY != value)
                 {
                     showRotationHandleForY = value;
-                    visibilityChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    //visibilityChanged.Invoke();
                 }
             }
         }
@@ -101,9 +105,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showRotationHandleForZ != value)
                 {
                     showRotationHandleForZ = value;
-                    visibilityChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    //visibilityChanged.Invoke();
                 }
             }
         }
+
+        internal UnityEvent colliderTypeChanged = new UnityEvent();
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/RotationHandlesConfiguration.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     rotationHandlePrefabColliderType = value;
                     colliderTypeChanged.Invoke();
-                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -58,7 +57,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     showRotationHandleForX = value;
                     handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
-                    //visibilityChanged.Invoke();
                 }
             }
         }
@@ -82,7 +80,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     showRotationHandleForY = value;
                     handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
-                    //visibilityChanged.Invoke();
                 }
             }
         }
@@ -106,7 +103,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     showRotationHandleForZ = value;
                     handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
-                    //visibilityChanged.Invoke();
                 }
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -29,7 +29,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     handleSlatePrefab = value;
                     handlesChanged.Invoke(HandlesChangedEventType.PREFAB);
-                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -53,7 +52,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     showScaleHandles = value;
                     handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
-                    //visibilityChanged.Invoke();
                 }
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -28,7 +28,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (handleSlatePrefab != value)
                 {
                     handleSlatePrefab = value;
-                    configurationChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.PREFAB);
+                    //configurationChanged.Invoke();
                 }
             }
         }
@@ -51,7 +52,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showScaleHandles != value)
                 {
                     showScaleHandles = value;
-                    visibilityChanged.Invoke();
+                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    //visibilityChanged.Invoke();
                 }
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/ScaleHandlesConfiguration.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (handleSlatePrefab != value)
                 {
                     handleSlatePrefab = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.PREFAB);
+                    handlesChanged.Invoke(HandlesChangedEventType.Prefab);
                 }
             }
         }
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 if (showScaleHandles != value)
                 {
                     showScaleHandles = value;
-                    handlesChanged.Invoke(HandlesChangedEventType.VISIBILITY);
+                    handlesChanged.Invoke(HandlesChangedEventType.Visibility);
                 }
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     HandlesIgnoreConfigCollider(true);
                     break;
                 case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
-                    //TODO
+                    ResetHandles();
                     break;
             }
         }
@@ -84,14 +84,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         protected abstract void UpdateColliderBounds(Transform handle, Vector3 visualSize);
         protected abstract void RecreateVisuals();
 
-        internal void ResetHandleVisibility(bool isVisible)
+        private void ResetHandles()
         {
             if (handles != null)
             {
                 for (int i = 0; i < handles.Count; ++i)
                 {
-                    handles[i].gameObject.SetActive(isVisible && IsVisible(handles[i]));
-                    VisualUtils.ApplyMaterialToAllRenderers(handles[i].gameObject, BaseConfig.HandleMaterial);
+                    bool isVisible = IsVisible(handles[i]);
+                    handles[i].gameObject.SetActive(isVisible);
+                    if (isVisible)
+                    {
+                        VisualUtils.ApplyMaterialToAllRenderers(handles[i].gameObject, BaseConfig.HandleMaterial);
+                    }
                 }
             }
             highlightedHandle = null;
@@ -207,7 +211,20 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         //}
 
         #region IProximityScaleObjectProvider 
-        public abstract bool IsActive();
+
+        private bool isActive = true;
+        public virtual bool IsActive
+        {
+            get => isActive;
+            set
+            {
+                if (isActive != value)
+                {
+                    isActive = value;
+                    ResetHandles();
+                }
+            }
+        }
 
         public void ForEachProximityObject(Action<Transform> action)
         {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -25,29 +25,29 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             switch (changedType)
             {
-                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
+                case HandlesBaseConfiguration.HandlesChangedEventType.Material:
                     UpdateBaseMaterial();
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
+                case HandlesBaseConfiguration.HandlesChangedEventType.MaterialGrabbed:
                     UpdateGrabbedMaterial();
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
+                case HandlesBaseConfiguration.HandlesChangedEventType.Prefab:
                     RecreateVisuals();
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
-                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
+                case HandlesBaseConfiguration.HandlesChangedEventType.ColliderSize:
+                case HandlesBaseConfiguration.HandlesChangedEventType.ColliderPadding:
                     UpdateColliderBounds();
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.MANIPULATION_TETHER:
+                case HandlesBaseConfiguration.HandlesChangedEventType.ManipulationTether:
                     UpdateDrawTether();
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.IGNORE_COLLIDER_REMOVE:
+                case HandlesBaseConfiguration.HandlesChangedEventType.IgnoreColliderRemove:
                     HandlesIgnoreConfigCollider(false);
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.IGNORE_COLLIDER_ADD:
+                case HandlesBaseConfiguration.HandlesChangedEventType.IgnoreColliderAdd:
                     HandlesIgnoreConfigCollider(true);
                     break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
+                case HandlesBaseConfiguration.HandlesChangedEventType.Visibility:
                     ResetHandles();
                     break;
             }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -161,7 +161,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         protected void UpdateGrabbedMaterial()
         {
-            SetHighlighted(highlightedHandle);
+            if (highlightedHandle)
+            {
+                SetHighlighted(highlightedHandle);
+            }
         }
 
         //protected void UpdateColliderPadding(HandlePrefabCollider colliderType, Vector3 size)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControlTypes;
+using Microsoft.MixedReality.Toolkit.Input;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -41,9 +42,22 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
                     UpdateColliderBounds();
                     break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.MANIPULATION_TETHER:
+                    UpdateDrawTether();
+                    break;
                 case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
                     //TODO
                     break;
+            }
+        }
+
+        private void UpdateDrawTether()
+        {
+            // enable / disable tether in near interaction grabbable of handle
+            foreach (var handle in handles)
+            {
+                var grabbable = handle.gameObject.EnsureComponent<NearInteractionGrabbable>();
+                grabbable.ShowTetherWhenManipulating = BaseConfig.DrawTetherWhenManipulating;
             }
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -15,11 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     /// </summary>
     public abstract class HandlesBase : IProximityEffectObjectProvider
     {
-
-        internal HandlesBase()
-        {
-
-        }
+        internal HandlesBase() { }
         protected abstract HandlesBaseConfiguration BaseConfig
         {
             get;
@@ -84,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         protected abstract void UpdateColliderBounds(Transform handle, Vector3 visualSize);
         protected abstract void RecreateVisuals();
 
-        private void ResetHandles()
+        protected void ResetHandles()
         {
             if (handles != null)
             {
@@ -190,25 +186,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 SetHighlighted(highlightedHandle);
             }
         }
-
-        //protected void UpdateColliderPadding(HandlePrefabCollider colliderType, Vector3 size)
-        //{
-        //    foreach (var handle in handles)
-        //    {
-        //        if (colliderType == HandlePrefabCollider.Box)
-        //        {
-        //            BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
-        //            collider.size = size;
-        //            collider.size += BaseConfig.ColliderPadding;
-        //        }
-        //        else
-        //        {
-        //            SphereCollider sphere = handle.gameObject.GetComponent<SphereCollider>();
-        //            sphere.radius = size.x;
-        //            sphere.radius += Mathf.Max(Mathf.Max(BaseConfig.ColliderPadding.x, BaseConfig.ColliderPadding.y), BaseConfig.ColliderPadding.z);
-        //        }
-        //    }
-        //}
 
         #region IProximityScaleObjectProvider 
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -45,10 +45,21 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 case HandlesBaseConfiguration.HandlesChangedEventType.MANIPULATION_TETHER:
                     UpdateDrawTether();
                     break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.IGNORE_COLLIDER_REMOVE:
+                    HandlesIgnoreConfigCollider(false);
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.IGNORE_COLLIDER_ADD:
+                    HandlesIgnoreConfigCollider(true);
+                    break;
                 case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
                     //TODO
                     break;
             }
+        }
+
+        private void HandlesIgnoreConfigCollider(bool ignore)
+        {
+            VisualUtils.HandleIgnoreCollider(BaseConfig.HandlesIgnoreCollider, handles, ignore);
         }
 
         private void UpdateDrawTether()
@@ -118,11 +129,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     }
                 }
             }
-        }
-
-        internal void HandleIgnoreCollider(Collider handlesIgnoreCollider)
-        {
-            VisualUtils.HandleIgnoreCollider(handlesIgnoreCollider, handles);
         }
 
         internal void DestroyHandles()

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -14,10 +14,50 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     /// </summary>
     public abstract class HandlesBase : IProximityEffectObjectProvider
     {
+
+        internal HandlesBase()
+        {
+
+        }
         protected abstract HandlesBaseConfiguration BaseConfig
         {
             get;
         }
+
+        internal void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
+        {
+            switch (changedType)
+            {
+                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
+                    UpdateBaseMaterial();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
+                    UpdateGrabbedMaterial();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
+                    RecreateVisuals();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
+                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
+                    UpdateColliderBounds();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
+                    //TODO
+                    break;
+            }
+        }
+
+        protected void UpdateColliderBounds()
+        {
+            foreach (var handle in handles)
+            {
+                var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
+                UpdateColliderBounds(handle, handleBounds.size);
+            }
+        }
+
+        protected abstract void UpdateColliderBounds(Transform handle, Vector3 visualSize);
+        protected abstract void RecreateVisuals();
 
         internal void ResetHandleVisibility(bool isVisible)
         {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -29,12 +29,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     VisualUtils.ApplyMaterialToAllRenderers(handles[i].gameObject, BaseConfig.HandleMaterial);
                 }
             }
+            highlightedHandle = null;
         }
 
         internal abstract bool IsVisible(Transform handle);
         
 
         internal protected List<Transform> handles = new List<Transform>();
+        private Transform highlightedHandle = null;
+
+        
 
         public IReadOnlyList<Transform> Handles
         {
@@ -55,6 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     else
                     {
                         VisualUtils.ApplyMaterialToAllRenderers(handles[i].gameObject, BaseConfig.HandleGrabbedMaterial);
+                        highlightedHandle = handleToHighlight;
                     }
                 }
             }
@@ -99,6 +104,43 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         protected abstract Transform GetVisual(Transform handle);
 
+        protected void UpdateBaseMaterial()
+        {
+            if (handles != null)
+            {
+                for (int i = 0; i < handles.Count; ++i)
+                {
+                    if (handles[i] != highlightedHandle)
+                    {
+                        VisualUtils.ApplyMaterialToAllRenderers(handles[i].gameObject, BaseConfig.HandleMaterial);
+                    }
+                }
+            }
+        }
+
+        protected void UpdateGrabbedMaterial()
+        {
+            SetHighlighted(highlightedHandle);
+        }
+
+        //protected void UpdateColliderPadding(HandlePrefabCollider colliderType, Vector3 size)
+        //{
+        //    foreach (var handle in handles)
+        //    {
+        //        if (colliderType == HandlePrefabCollider.Box)
+        //        {
+        //            BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
+        //            collider.size = size;
+        //            collider.size += BaseConfig.ColliderPadding;
+        //        }
+        //        else
+        //        {
+        //            SphereCollider sphere = handle.gameObject.GetComponent<SphereCollider>();
+        //            sphere.radius = size.x;
+        //            sphere.radius += Mathf.Max(Mathf.Max(BaseConfig.ColliderPadding.x, BaseConfig.ColliderPadding.y), BaseConfig.ColliderPadding.z);
+        //        }
+        //    }
+        //}
 
         #region IProximityScaleObjectProvider 
         public abstract bool IsActive();

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -78,7 +78,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         internal protected List<Transform> handles = new List<Transform>();
         private Transform highlightedHandle = null;
 
-        
+        ProximityObjectsChangedEvent IProximityEffectObjectProvider.ProximityObjectsChanged => objectsChangedEvent;
+        protected ProximityObjectsChangedEvent objectsChangedEvent = new ProximityObjectsChangedEvent();
 
         public IReadOnlyList<Transform> Handles
         {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 for (int i = 0; i < links.Count; ++i)
                 {
-                    links[i].transform.gameObject.SetActive(isVisible);
+                    links[i].transform.gameObject.SetActive(isVisible && config.ShowWireFrame);
                 }
 
                 int[] flattenedHandles = VisualUtils.GetFlattenedIndices(cachedFlattenAxis);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -120,15 +120,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                         links[flattenedHandles[i]].transform.gameObject.SetActive(false);
                     }
                 }
-
-                int[] flattenedHandles = VisualUtils.GetFlattenedIndices(cachedFlattenAxis);
-                if (flattenedHandles != null)
-                {
-                    for (int i = 0; i < flattenedHandles.Length; ++i)
-                    {
-                        links[flattenedHandles[i]].transform.gameObject.SetActive(false);
-                    }
-                }
             }
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -31,6 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         private LinksConfiguration config;
         private Vector3 cachedExtents;
+        private FlattenModeType cachedFlattenAxis;
 
         internal Links(LinksConfiguration configuration)
         {
@@ -49,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             switch (changedType)
             {
                 case LinksConfiguration.WireframeChangedEventType.VISIBILITY:
-                    ResetVisibility(config.ShowWireFrame);
+                    Reset(config.ShowWireFrame, cachedFlattenAxis);
                     break;
                 case LinksConfiguration.WireframeChangedEventType.RADIUS:
                     UpdateLinkScales(cachedExtents);
@@ -75,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        internal void UpdateMaterial() // update call for wireframematerial update
+        internal void UpdateMaterial()
         {
             if (links != null && config.WireframeMaterial != null)
             {
@@ -101,13 +102,23 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        internal void ResetVisibility(bool isVisible)
+        internal void Reset(bool isVisible, FlattenModeType flattenAxis)
         {
+            cachedFlattenAxis = flattenAxis;
             if (links != null)
             {
                 for (int i = 0; i < links.Count; ++i)
                 {
                     links[i].transform.gameObject.SetActive(isVisible);
+                }
+
+                int[] flattenedHandles = VisualUtils.GetFlattenedIndices(cachedFlattenAxis);
+                if (flattenedHandles != null)
+                {
+                    for (int i = 0; i < flattenedHandles.Length; ++i)
+                    {
+                        links[flattenedHandles[i]].transform.gameObject.SetActive(false);
+                    }
                 }
             }
         }
@@ -157,17 +168,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     }
                 }
                 cachedExtents = currentBoundsExtents;
-            }
-        }
-
-        internal void Flatten(ref int[] flattenedHandles)
-        {
-            if (flattenedHandles != null)
-            {
-                for (int i = 0; i < flattenedHandles.Length; ++i)
-                {
-                    links[flattenedHandles[i]].transform.gameObject.SetActive(false);
-                }
             }
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -120,6 +120,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                         links[flattenedHandles[i]].transform.gameObject.SetActive(false);
                     }
                 }
+
+                int[] flattenedHandles = VisualUtils.GetFlattenedIndices(cachedFlattenAxis);
+                if (flattenedHandles != null)
+                {
+                    for (int i = 0; i < flattenedHandles.Length; ++i)
+                    {
+                        links[flattenedHandles[i]].transform.gameObject.SetActive(false);
+                    }
+                }
             }
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -49,18 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             switch (changedType)
             {
                 case LinksConfiguration.WireframeChangedEventType.VISIBILITY:
-                    if (links != null)
-                    {
-                        // todo
-                        // show links but links haven't been created yet -> create links
-                        if (config.ShowWireFrame && links.Count == 0)
-                        { 
-                        }
-                        else
-                        {
-                            ResetVisibility(config.ShowWireFrame);
-                        }
-                    }
+                    ResetVisibility(config.ShowWireFrame);
                     break;
                 case LinksConfiguration.WireframeChangedEventType.RADIUS:
                     UpdateLinkScales(cachedExtents);
@@ -118,11 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 for (int i = 0; i < links.Count; ++i)
                 {
-                    Renderer linkRenderer = links[i].transform.gameObject.GetComponent<Renderer>();
-                    if (linkRenderer != null)
-                    {
-                        linkRenderer.enabled = isVisible;
-                    }
+                    links[i].transform.gameObject.SetActive(isVisible);
                 }
             }
         }
@@ -181,11 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 for (int i = 0; i < flattenedHandles.Length; ++i)
                 {
-                    Renderer linkRenderer = links[flattenedHandles[i]].transform.gameObject.GetComponent<Renderer>();
-                    if (linkRenderer)
-                    {
-                        linkRenderer.enabled = false;
-                    }
+                    links[flattenedHandles[i]].transform.gameObject.SetActive(false);
                 }
             }
         }
@@ -219,7 +200,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         internal void CreateLinks(RotationHandles rotationHandles, Transform parent, Vector3 currentBoundsExtents)
         {
             // create links
-            if (links != null && config.ShowWireFrame)
+            if (links != null)
             {
                 GameObject link;
                 Vector3 linkDimensions = GetLinkDimensions(currentBoundsExtents);
@@ -264,6 +245,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                         linkRenderer.material = config.WireframeMaterial;
                     }
 
+                    link.SetActive(config.ShowWireFrame);
                     links.Add(new Link(link.transform, axisType));
                 }
             }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Links.cs
@@ -49,16 +49,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             switch (changedType)
             {
-                case LinksConfiguration.WireframeChangedEventType.VISIBILITY:
+                case LinksConfiguration.WireframeChangedEventType.Visibility:
                     Reset(config.ShowWireFrame, cachedFlattenAxis);
                     break;
-                case LinksConfiguration.WireframeChangedEventType.RADIUS:
+                case LinksConfiguration.WireframeChangedEventType.Radius:
                     UpdateLinkScales(cachedExtents);
                     break;
-                case LinksConfiguration.WireframeChangedEventType.SHAPE:
+                case LinksConfiguration.WireframeChangedEventType.Shape:
                     UpdateLinkPrimitive();
                     break;
-                case LinksConfiguration.WireframeChangedEventType.MATERIAL:
+                case LinksConfiguration.WireframeChangedEventType.Material:
                     UpdateMaterial();
                     break;
             }
@@ -193,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 }
             }
 
-            Object.DestroyImmediate(sharedMeshPrimitive);
+            Object.Destroy(sharedMeshPrimitive);
             UpdateLinkScales(cachedExtents);
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
@@ -43,6 +43,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// </summary>
         void ForEachProximityObject(Action<Transform> action);
 
+        /// <summary>
+        /// Allow for accessing / subscribing to the changed event for objects that show a proximity effect
+        /// </summary>
         ProximityObjectsChangedEvent ProximityObjectsChanged
         {
             get;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Returns true if the provider has any visible objects
         /// </summary>
-        bool IsActive();
+        bool IsActive { get; set; }
 
         /// <summary>
         /// Base Material is applied to any proximity scaled object whenever in medium or far/no proximity mode

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
@@ -3,9 +3,15 @@
 
 using System;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 {
+    /// <summary>
+    /// Event to inform subscribers that the proximity objects have changed
+    /// </summary>
+    public class ProximityObjectsChangedEvent : UnityEvent<IProximityEffectObjectProvider> { }
+
     /// <summary>
     /// Interface for defining a proximity object provider used in <see cref="ProximityEffect" /> of <see cref="BoundsControl" />
     /// ProximityEffectObjectProviders are responsible for providing gameobjects that are scaled / visually altered in ProximityEffect.
@@ -36,5 +42,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// This method allows iterating over the proximity scaled visuals. It should return the gameobject the scaling should be applied to.
         /// </summary>
         void ForEachProximityObject(Action<Transform> action);
+
+        ProximityObjectsChangedEvent ProximityObjectsChanged
+        {
+            get;
+        }
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/IProximityEffectObjectProvider.cs
@@ -46,9 +46,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Allow for accessing / subscribing to the changed event for objects that show a proximity effect
         /// </summary>
-        ProximityObjectsChangedEvent ProximityObjectsChanged
-        {
-            get;
-        }
+        ProximityObjectsChangedEvent ProximityObjectsChanged { get; }
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -194,7 +194,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     foreach (var item in keyValuePair.Value)
                     {
                         // If object can't be visible, skip calculations
-                        if (!keyValuePair.Key.IsActive())
+                        if (!keyValuePair.Key.IsActive)
                         {
                             continue;
                         }
@@ -243,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             foreach (var keyValuePair in registeredObjects)
             {
-                if (keyValuePair.Key.IsActive())
+                if (keyValuePair.Key.IsActive)
                 {
                     return true;
                 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Microsoft.MixedReality.Toolkit.Input;
 using System.Runtime.CompilerServices;
 
-
 namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 {
     /// <summary>
@@ -45,15 +44,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Container for registered object providers and their proximity infos
+        /// Dictionary that maps proximity object provider to list of objects that have proximity scaling applied
         /// </summary>
-        private class RegisteredObjects
-        {
-            public IProximityEffectObjectProvider objectProvider;
-            public List<ObjectProximityInfo> proximityInfos;
-        }
-
-        private List<RegisteredObjects> registeredObjects = new List<RegisteredObjects>();
+        
+        private Dictionary<IProximityEffectObjectProvider, List<ObjectProximityInfo>> registeredObjects = new Dictionary<IProximityEffectObjectProvider, List<ObjectProximityInfo>>();
 
 
         private HashSet<IMixedRealityPointer> proximityPointers = new HashSet<IMixedRealityPointer>();
@@ -63,18 +57,32 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// register objects for proximity effect via a <see cref="IProximityEffectObjectProvider"/>
         /// </summary>
-        public void AddObjects(IProximityEffectObjectProvider provider)
+        public void RegisterObjectProvider(IProximityEffectObjectProvider provider)
         {
-            RegisteredObjects registeredObject = new RegisteredObjects() { objectProvider = provider, proximityInfos = new List<ObjectProximityInfo>() };
+            registeredObjects.Add(provider, FetchObjects(provider));
+            // subscribe to object changes
+            provider.ProximityObjectsChanged.AddListener(RefreshObjects);
+        }
+
+        private List<ObjectProximityInfo> FetchObjects(IProximityEffectObjectProvider provider)
+        {
+            var registeredObjects = new List<ObjectProximityInfo>();
             provider.ForEachProximityObject(proximityObject =>
             {
-                registeredObject.proximityInfos.Add(new ObjectProximityInfo()
+                registeredObjects.Add(new ObjectProximityInfo()
                 {
                     ScaledObject = proximityObject,
                     ObjectVisualRenderer = proximityObject.gameObject.GetComponentInChildren<Renderer>()
                 });
             });
-            registeredObjects.Add(registeredObject);
+
+            return registeredObjects;
+        }
+
+        private void RefreshObjects(IProximityEffectObjectProvider provider)
+        {
+            // refetch object list
+            registeredObjects[provider] = FetchObjects(provider);
         }
 
         /// <summary>
@@ -84,6 +92,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             if (registeredObjects != null)
             {
+                foreach (var keyValuePair in registeredObjects)
+                {
+                    keyValuePair.Key.ProximityObjectsChanged.RemoveListener(RefreshObjects);
+                }
                 registeredObjects.Clear();
             }
         }
@@ -98,9 +110,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 return;
             }
 
-            foreach (var registeredObject in registeredObjects)
+            foreach (var keyValuePair in registeredObjects)
             {
-                foreach (var item in registeredObject.proximityInfos)
+                foreach (var item in keyValuePair.Value)
                 {
                     if (item.ProximityState != ProximityState.FullsizeNoProximity)
                     {
@@ -108,10 +120,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                        
                         if (item.ObjectVisualRenderer)
                         {
-                            item.ObjectVisualRenderer.material = registeredObject.objectProvider.GetBaseMaterial();
+                            item.ObjectVisualRenderer.material = keyValuePair.Key.GetBaseMaterial();
                         }
 
-                        ScaleObject(item.ProximityState, item.ScaledObject, registeredObject.objectProvider.GetObjectSize());
+                        ScaleObject(item.ProximityState, item.ScaledObject, keyValuePair.Key.GetObjectSize());
                     }
                 }
             }
@@ -176,13 +188,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             foreach (var point in proximityPoints)
             {
 
-                foreach (var provider in registeredObjects)
+                foreach (var keyValuePair in registeredObjects)
                 {
 
-                    foreach (var item in provider.proximityInfos)
+                    foreach (var item in keyValuePair.Value)
                     {
                         // If object can't be visible, skip calculations
-                        if (!provider.objectProvider.IsActive())
+                        if (!keyValuePair.Key.IsActive())
                         {
                             continue;
                         }
@@ -199,11 +211,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
 
             // Loop through all objects and update visual state based on closest point
-            foreach (var provider in registeredObjects)
+            foreach (var keyValuePair in registeredObjects)
             {
-                foreach (var item in provider.proximityInfos)
+                foreach (var item in keyValuePair.Value)
                 {
                     ProximityState newState = (closestObject == item.ScaledObject) ? GetProximityState(closestDistanceSqr) : ProximityState.FullsizeNoProximity;
+                    IProximityEffectObjectProvider provider = keyValuePair.Key;
 
                     // Only apply updates if object is in a new state or closest object needs to lerp scaling
                     if (item.ProximityState != newState)
@@ -213,11 +226,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                         if (item.ObjectVisualRenderer)
                         {
-                            item.ObjectVisualRenderer.material = newState == ProximityState.CloseProximity ? provider.objectProvider.GetHighlightedMaterial() : provider.objectProvider.GetBaseMaterial();
+                            item.ObjectVisualRenderer.material = newState == ProximityState.CloseProximity ? provider.GetHighlightedMaterial() : provider.GetBaseMaterial();
                         }
                     }
 
-                    ScaleObject(newState, item.ScaledObject, provider.objectProvider.GetObjectSize(), true);
+                    ScaleObject(newState, item.ScaledObject, provider.GetObjectSize(), true);
                 }
             }
         }
@@ -228,9 +241,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         private bool IsAnyRegisteredObjectVisible()
         {
-            foreach (var registeredObject in registeredObjects)
+            foreach (var keyValuePair in registeredObjects)
             {
-                if (registeredObject.objectProvider.IsActive())
+                if (keyValuePair.Key.IsActive())
                 {
                     return true;
                 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -179,8 +179,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     config.RotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, config.ColliderPadding, parent, drawManipulationTether);
 
                 handles.Add(midpoint.transform);
-
             }
+
+            objectsChangedEvent.Invoke(this);
         }
 
         protected override void RecreateVisuals()
@@ -206,6 +207,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 // update handle collider bounds
                 UpdateColliderBounds(handles[i], visualBounds.size);
             }
+
+            objectsChangedEvent.Invoke(this);
         }
 
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -181,6 +181,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 handles.Add(midpoint.transform);
             }
 
+            VisualUtils.HandleIgnoreCollider(config.HandlesIgnoreCollider, handles);
+
             objectsChangedEvent.Invoke(this);
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -155,15 +155,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        internal void Create(ref Vector3[] boundsCorners, Transform parent, bool drawManipulationTether)
+        internal void Create(ref Vector3[] boundsCorners, Transform parent)
         {
             edgeCenters = new Vector3[12];
             CalculateEdgeCenters(ref boundsCorners);
             InitEdgeAxis();
-            CreateHandles(parent, drawManipulationTether);
+            CreateHandles(parent);
         }
         
-        private void CreateHandles(Transform parent, bool drawManipulationTether)
+        private void CreateHandles(Transform parent)
         {
             for (int i = 0; i < edgeCenters.Length; ++i)
             {
@@ -176,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 float maxDim = VisualUtils.GetMaxComponent(midpointBounds.size);
                 float invScale = config.HandleSize / maxDim;
                 VisualUtils.AddComponentsToAffordance(midpoint, new Bounds(midpointBounds.center * invScale, midpointBounds.size * invScale),
-                    config.RotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, config.ColliderPadding, parent, drawManipulationTether);
+                    config.RotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, config.ColliderPadding, parent, config.DrawTetherWhenManipulating);
 
                 handles.Add(midpoint.transform);
             }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     // attach new collider
                     var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
-                    var invScale = config.HandleSize / handleBounds.size.x;
+                    var invScale = handleBounds.size.x == 0.0f ? 0.0f :config.HandleSize / handleBounds.size.x;
                     Vector3 colliderSizeScaled = handleBounds.size * invScale;
                     Vector3 colliderCenterScaled = handleBounds.center * invScale;
                     if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
@@ -189,7 +189,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                 Bounds midpointBounds = CreateVisual(i, midpoint);
                 float maxDim = VisualUtils.GetMaxComponent(midpointBounds.size);
-                float invScale = config.HandleSize / maxDim;
+                float invScale = maxDim == 0.0f ? 0.0f : config.HandleSize / maxDim;
                 VisualUtils.AddComponentsToAffordance(midpoint, new Bounds(midpointBounds.center * invScale, midpointBounds.size * invScale),
                     config.RotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, config.ColliderPadding, parent, config.DrawTetherWhenManipulating);
 
@@ -230,7 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
-            var invScale = config.HandleSize / visualSize.x;
+            var invScale = visualSize.x == 0.0f ? 0.0f : config.HandleSize / visualSize.x;
             GetVisual(handle).transform.localScale = new Vector3(invScale, invScale, invScale);
             Vector3 colliderSizeScaled = visualSize * invScale;
             if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
@@ -276,7 +276,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
             Bounds midpointBounds = VisualUtils.GetMaxBounds(midpointVisual);
             float maxDim = VisualUtils.GetMaxComponent(midpointBounds.size);
-            float invScale = config.HandleSize / maxDim;
+            float invScale = maxDim == 0.0f ? 0.0f : config.HandleSize / maxDim;
 
             midpointVisual.name = "visuals";
             midpointVisual.transform.parent = parent.transform;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -20,6 +20,86 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             Debug.Assert(configuration != null, "Can't create BoundsControlRotationHandles without valid configuration");
             config = configuration;
+            config.handlesChanged.AddListener(HandlesChanged);
+            config.colliderTypeChanged.AddListener(UpdateColliderType);
+        }
+
+        ~RotationHandles()
+        {
+            config.handlesChanged.RemoveListener(HandlesChanged);
+            config.colliderTypeChanged.RemoveListener(UpdateColliderType);
+        }
+
+        private void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
+        {
+            switch (changedType)
+            {
+                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
+                    UpdateBaseMaterial();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
+                    UpdateGrabbedMaterial();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
+                    RecreateVisuals();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
+                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
+                    UpdateColliderBounds();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
+                    //TODO
+                    break;
+            }
+        }
+
+       
+        void UpdateColliderBounds()
+        {
+            foreach (var handle in handles)
+            {
+                var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
+                UpdateColliderBounds(handle, handleBounds.size);
+            }
+        }
+
+        void UpdateColliderType()
+        {
+            foreach (var handle in handles)
+            {
+                // remove old colliders
+                var oldBoxCollider = handle.GetComponent<BoxCollider>();
+                if (oldBoxCollider != null)
+                {
+                    Object.Destroy(oldBoxCollider);
+                }
+
+                var oldSphereCollider = handle.GetComponent<SphereCollider>();
+                if (oldSphereCollider != null)
+                {
+                    Object.Destroy(oldSphereCollider);
+                }
+
+                // attach new collider
+                var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
+                var invScale = config.HandleSize / handleBounds.size.x;
+                Vector3 colliderSizeScaled = handleBounds.size * invScale;
+                Vector3 colliderCenterScaled = handleBounds.center * invScale;
+                if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
+                {
+                    BoxCollider collider = handle.gameObject.AddComponent<BoxCollider>();
+                    collider.size = colliderSizeScaled;
+                    collider.center = colliderCenterScaled;
+                    collider.size += config.ColliderPadding;
+                }
+                else
+                {
+                    SphereCollider sphere = handle.gameObject.AddComponent<SphereCollider>();
+                    sphere.center = colliderCenterScaled;
+                    sphere.radius = colliderSizeScaled.x * 0.5f;
+                    sphere.radius += GetMaxComponent(config.ColliderPadding);
+                }
+            }
         }
 
         internal const int NumEdges = 12;
@@ -125,51 +205,107 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 midpoint.transform.position = edgeCenters[i];
                 midpoint.transform.parent = parent;
 
-                GameObject midpointVisual;
-                GameObject prefabType = config.HandlePrefab;
-                if (prefabType != null)
-                {
-                    midpointVisual = GameObject.Instantiate(prefabType);
-                }
-                else
-                {
-                    midpointVisual = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                    GameObject.Destroy(midpointVisual.GetComponent<SphereCollider>());
-                }
-
-                // Align handle with its edge assuming that the prefab is initially aligned with the up direction 
-                if (edgeAxes[i] == CardinalAxisType.X)
-                {
-                    Quaternion realignment = Quaternion.FromToRotation(Vector3.up, Vector3.right);
-                    midpointVisual.transform.localRotation = realignment * midpointVisual.transform.localRotation;
-                }
-                else if (edgeAxes[i] == CardinalAxisType.Z)
-                {
-                    Quaternion realignment = Quaternion.FromToRotation(Vector3.up, Vector3.forward);
-                    midpointVisual.transform.localRotation = realignment * midpointVisual.transform.localRotation;
-                }
-
-                Bounds midpointBounds = VisualUtils.GetMaxBounds(midpointVisual);
-                float maxDim = Mathf.Max(
-                    Mathf.Max(midpointBounds.size.x, midpointBounds.size.y),
-                    midpointBounds.size.z);
+                Bounds midpointBounds = CreateVisual(i, midpoint);
+                float maxDim = GetMaxComponent(midpointBounds.size);
                 float invScale = config.HandleSize / maxDim;
-
-                midpointVisual.name = "visuals";
-                midpointVisual.transform.parent = midpoint.transform;
-                midpointVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
-                midpointVisual.transform.localPosition = Vector3.zero;
-
                 VisualUtils.AddComponentsToAffordance(midpoint, new Bounds(midpointBounds.center * invScale, midpointBounds.size * invScale),
                     config.RotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, config.ColliderPadding, parent, drawManipulationTether);
 
                 handles.Add(midpoint.transform);
 
-                if (config.HandleMaterial != null)
-                {
-                    VisualUtils.ApplyMaterialToAllRenderers(midpointVisual, config.HandleMaterial);
-                }
             }
+        }
+
+        private void RecreateVisuals()
+        {
+            for (int i = 0; i < handles.Count; ++i)
+            {
+                // get parent of visual
+                Transform obsoleteChild = handles[i].Find("visuals");
+                if (obsoleteChild)
+                {
+                    // get old child and remove it
+                    obsoleteChild.parent = null;
+                    Object.Destroy(obsoleteChild);
+                }
+                else
+                {
+                    Debug.LogError("couldn't find rotation visual on recreating visuals");
+                }
+
+                // create new visual
+                Bounds visualBounds = CreateVisual(i, handles[i].gameObject);
+
+                // update handle collider bounds
+                UpdateColliderBounds(handles[i], visualBounds.size);
+            }
+        }
+
+        private float GetMaxComponent(Vector3 vec)
+        {
+            return Mathf.Max(Mathf.Max(vec.x, vec.y), vec.z);
+        }
+
+        private void UpdateColliderBounds(Transform handle, Vector3 visualSize)
+        {
+            var invScale = config.HandleSize / visualSize.x;
+            Vector3 colliderSizeScaled = visualSize * invScale;
+            if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
+            {
+                BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
+                collider.size = colliderSizeScaled;
+                collider.size += BaseConfig.ColliderPadding;
+            }
+            else
+            {
+                SphereCollider collider = handle.gameObject.GetComponent<SphereCollider>();
+                collider.radius = colliderSizeScaled.x * 0.5f;
+                collider.radius += GetMaxComponent(config.ColliderPadding);
+            }
+        }
+
+
+        private Bounds CreateVisual(int handleIndex, GameObject parent)
+        {
+            GameObject midpointVisual;
+            GameObject prefabType = config.HandlePrefab;
+            if (prefabType != null)
+            {
+                midpointVisual = GameObject.Instantiate(prefabType);
+            }
+            else
+            {
+                midpointVisual = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                GameObject.Destroy(midpointVisual.GetComponent<SphereCollider>());
+            }
+
+            // Align handle with its edge assuming that the prefab is initially aligned with the up direction 
+            if (edgeAxes[handleIndex] == CardinalAxisType.X)
+            {
+                Quaternion realignment = Quaternion.FromToRotation(Vector3.up, Vector3.right);
+                midpointVisual.transform.localRotation = realignment * midpointVisual.transform.localRotation;
+            }
+            else if (edgeAxes[handleIndex] == CardinalAxisType.Z)
+            {
+                Quaternion realignment = Quaternion.FromToRotation(Vector3.up, Vector3.forward);
+                midpointVisual.transform.localRotation = realignment * midpointVisual.transform.localRotation;
+            }
+
+            Bounds midpointBounds = VisualUtils.GetMaxBounds(midpointVisual);
+            float maxDim = GetMaxComponent(midpointBounds.size);
+            float invScale = config.HandleSize / maxDim;
+
+            midpointVisual.name = "visuals";
+            midpointVisual.transform.parent = parent.transform;
+            midpointVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
+            midpointVisual.transform.localPosition = Vector3.zero;
+
+            if (config.HandleMaterial != null)
+            {
+                VisualUtils.ApplyMaterialToAllRenderers(midpointVisual, config.HandleMaterial);
+            }
+
+            return midpointBounds;
         }
 
         #region BoundsControlHandlerBase 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -216,6 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
             var invScale = config.HandleSize / visualSize.x;
+            handle.transform.localScale = new Vector3(invScale, invScale, invScale);
             Vector3 colliderSizeScaled = visualSize * invScale;
             if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
             {
@@ -279,10 +280,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         internal override bool IsVisible(Transform handle)
         {
             CardinalAxisType axisType = GetAxisType(handle);
-            return
-                (axisType == CardinalAxisType.X && config.ShowRotationHandleForX) ||
+            return IsActive && 
+                ((axisType == CardinalAxisType.X && config.ShowRotationHandleForX) ||
                 (axisType == CardinalAxisType.Y && config.ShowRotationHandleForY) ||
-                (axisType == CardinalAxisType.Z && config.ShowRotationHandleForZ);
+                (axisType == CardinalAxisType.Z && config.ShowRotationHandleForZ));
         }
 
         internal override HandleType GetHandleType()
@@ -304,9 +305,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         #endregion BoundsControlHandlerBase
 
         #region IProximityScaleObjectProvider 
-        public override bool IsActive()
+        public override bool IsActive
         {
-            return config.ShowRotationHandleForX || config.ShowRotationHandleForY || config.ShowRotationHandleForZ;
+            get
+            {
+                return (config.ShowRotationHandleForX || config.ShowRotationHandleForY || config.ShowRotationHandleForZ) && base.IsActive;
+            }
         }
 
         #endregion IProximityScaleObjectProvider

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -30,40 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             config.colliderTypeChanged.RemoveListener(UpdateColliderType);
         }
 
-        private void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
-        {
-            switch (changedType)
-            {
-                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
-                    UpdateBaseMaterial();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
-                    UpdateGrabbedMaterial();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
-                    RecreateVisuals();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
-                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
-                    UpdateColliderBounds();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
-                    //TODO
-                    break;
-            }
-        }
-
-       
-        void UpdateColliderBounds()
-        {
-            foreach (var handle in handles)
-            {
-                var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
-                UpdateColliderBounds(handle, handleBounds.size);
-            }
-        }
-
-        void UpdateColliderType()
+        private void UpdateColliderType()
         {
             foreach (var handle in handles)
             {
@@ -97,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     SphereCollider sphere = handle.gameObject.AddComponent<SphereCollider>();
                     sphere.center = colliderCenterScaled;
                     sphere.radius = colliderSizeScaled.x * 0.5f;
-                    sphere.radius += GetMaxComponent(config.ColliderPadding);
+                    sphere.radius += VisualUtils.GetMaxComponent(config.ColliderPadding);
                 }
             }
         }
@@ -206,7 +173,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 midpoint.transform.parent = parent;
 
                 Bounds midpointBounds = CreateVisual(i, midpoint);
-                float maxDim = GetMaxComponent(midpointBounds.size);
+                float maxDim = VisualUtils.GetMaxComponent(midpointBounds.size);
                 float invScale = config.HandleSize / maxDim;
                 VisualUtils.AddComponentsToAffordance(midpoint, new Bounds(midpointBounds.center * invScale, midpointBounds.size * invScale),
                     config.RotationHandlePrefabColliderType, CursorContextInfo.CursorAction.Rotate, config.ColliderPadding, parent, drawManipulationTether);
@@ -216,7 +183,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        private void RecreateVisuals()
+        protected override void RecreateVisuals()
         {
             for (int i = 0; i < handles.Count; ++i)
             {
@@ -226,7 +193,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     // get old child and remove it
                     obsoleteChild.parent = null;
-                    Object.Destroy(obsoleteChild);
+                    Object.Destroy(obsoleteChild.gameObject);
                 }
                 else
                 {
@@ -241,12 +208,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        private float GetMaxComponent(Vector3 vec)
-        {
-            return Mathf.Max(Mathf.Max(vec.x, vec.y), vec.z);
-        }
-
-        private void UpdateColliderBounds(Transform handle, Vector3 visualSize)
+        protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
             var invScale = config.HandleSize / visualSize.x;
             Vector3 colliderSizeScaled = visualSize * invScale;
@@ -260,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             {
                 SphereCollider collider = handle.gameObject.GetComponent<SphereCollider>();
                 collider.radius = colliderSizeScaled.x * 0.5f;
-                collider.radius += GetMaxComponent(config.ColliderPadding);
+                collider.radius += VisualUtils.GetMaxComponent(config.ColliderPadding);
             }
         }
 
@@ -292,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
 
             Bounds midpointBounds = VisualUtils.GetMaxBounds(midpointVisual);
-            float maxDim = GetMaxComponent(midpointBounds.size);
+            float maxDim = VisualUtils.GetMaxComponent(midpointBounds.size);
             float invScale = config.HandleSize / maxDim;
 
             midpointVisual.name = "visuals";

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -146,11 +146,19 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void FlattenHandles(ref int[] flattenedHandles)
         {
-            if (flattenedHandles != null)
+            if (IsActive)
             {
-                for (int i = 0; i < flattenedHandles.Length; ++i)
+                foreach (var handle in handles)
                 {
-                    handles[flattenedHandles[i]].gameObject.SetActive(false);
+                    handle.gameObject.SetActive(IsVisible(handle));
+                }
+
+                if (flattenedHandles != null)
+                {
+                    for (int i = 0; i < flattenedHandles.Length; ++i)
+                    {
+                        handles[flattenedHandles[i]].gameObject.SetActive(false);
+                    }
                 }
             }
         }
@@ -216,7 +224,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
             var invScale = config.HandleSize / visualSize.x;
-            handle.transform.localScale = new Vector3(invScale, invScale, invScale);
+            GetVisual(handle).transform.localScale = new Vector3(invScale, invScale, invScale);
             Vector3 colliderSizeScaled = visualSize * invScale;
             if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
             {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -222,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal override bool IsVisible(Transform handle)
         {
-            return config.ShowScaleHandles;
+            return IsActive;
         }
 
         internal override HandleType GetHandleType()
@@ -232,9 +232,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         #endregion BoundsControlHandlerBase
 
         #region IProximityScaleObjectProvider 
-        public override bool IsActive()
+        public override bool IsActive
         {
-            return config.ShowScaleHandles;
+            get
+            {
+                return config.ShowScaleHandles && base.IsActive;
+            }
         }
         #endregion IProximityScaleObjectProvider
     }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -71,8 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 }
 
                 Bounds visualBounds = CreateVisual(visualsScale, isFlattened);
-
-                var invScale = config.HandleSize / visualBounds.size.x;
+                var invScale = visualBounds.size.x == 0.0f ? 0.0f : config.HandleSize / visualBounds.size.x;
                 VisualUtils.AddComponentsToAffordance(corner, new Bounds(visualBounds.center * invScale, visualBounds.size * invScale), 
                     HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, config.DrawTetherWhenManipulating);
                 handles.Add(corner.transform);       
@@ -115,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
-            var invScale = config.HandleSize / visualSize.x;
+            var invScale = visualSize.x == 0.0f ? 0.0f : config.HandleSize / visualSize.x;
             GetVisual(handle).transform.localScale = new Vector3(invScale, invScale, invScale);
             BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
             Vector3 colliderSize = visualSize * invScale;
@@ -162,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             cornerbounds.size = maxDim * Vector3.one;
 
             // we need to multiply by this amount to get to desired scale handle size
-            var invScale = config.HandleSize / cornerbounds.size.x;
+            var invScale = cornerbounds.size.x == 0.0f ? 0.0f : config.HandleSize / cornerbounds.size.x;
             cornerVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
 
             VisualUtils.ApplyMaterialToAllRenderers(cornerVisual, config.HandleMaterial);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -170,8 +170,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             return cornerbounds;
         }
 
-        internal void UpdateFlattenMode(bool isFlattened)
+        internal void Reset(bool areHandlesActive, FlattenModeType flattenAxis)
         {
+            IsActive = areHandlesActive;
+            ResetHandles();
+            bool isFlattened = flattenAxis != FlattenModeType.DoNotFlatten;
             if (areHandlesFlattened != isFlattened)
             {
                 areHandlesFlattened = isFlattened;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -178,6 +178,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             if (areHandlesFlattened != isFlattened)
             {
                 areHandlesFlattened = isFlattened;
+                // we have to recreate visuals in this case as flattened scale handles will use a different prefab
                 RecreateVisuals();
             }
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -109,6 +109,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, drawManipulationTether);
                 handles.Add(corner.transform);       
             }
+
+            objectsChangedEvent.Invoke(this);
         }
 
         protected override void RecreateVisuals()
@@ -138,6 +140,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     UpdateColliderBounds(handles[i], cornerBounds.size);
                 }
             }
+
+            objectsChangedEvent.Invoke(this);
         }
 
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -28,38 +28,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             config.handlesChanged.RemoveListener(HandlesChanged);
         }
 
-        //private void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
-        //{
-        //    switch (changedType)
-        //    {
-        //        case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
-        //            UpdateBaseMaterial();
-        //            break;
-        //        case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
-        //            UpdateGrabbedMaterial();
-        //            break;
-        //        case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
-        //            RecreateVisuals();
-        //            break;
-        //        case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
-        //        case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
-        //            UpdateColliderBounds();
-        //            break;
-        //        case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
-        //            //TODO
-        //            break;
-        //    }
-        //}
-
-        //private void UpdateColliderBounds()
-        //{
-        //    foreach (var handle in handles)
-        //    {
-        //        var cornerbounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
-        //        UpdateColliderBounds(handle, cornerbounds.size);
-        //    }
-        //}
-
         internal void UpdateVisibilityInInspector(HideFlags flags)
         {
             if (handles != null)
@@ -204,8 +172,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
         internal void UpdateFlattenMode(bool isFlattened)
         {
-            areHandlesFlattened = isFlattened;
-            RecreateVisuals();
+            if (areHandlesFlattened != isFlattened)
+            {
+                areHandlesFlattened = isFlattened;
+                RecreateVisuals();
+            }
         }
 
         #region BoundsControlHandlerBase

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -27,37 +27,37 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             config.handlesChanged.RemoveListener(HandlesChanged);
         }
 
-        private void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
-        {
-            switch (changedType)
-            {
-                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
-                    UpdateBaseMaterial();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
-                    UpdateGrabbedMaterial();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
-                    RecreateVisuals();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
-                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
-                    UpdateColliderBounds();
-                    break;
-                case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
-                    //TODO
-                    break;
-            }
-        }
+        //private void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
+        //{
+        //    switch (changedType)
+        //    {
+        //        case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
+        //            UpdateBaseMaterial();
+        //            break;
+        //        case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
+        //            UpdateGrabbedMaterial();
+        //            break;
+        //        case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
+        //            RecreateVisuals();
+        //            break;
+        //        case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
+        //        case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
+        //            UpdateColliderBounds();
+        //            break;
+        //        case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
+        //            //TODO
+        //            break;
+        //    }
+        //}
 
-        private void UpdateColliderBounds()
-        {
-            foreach (var handle in handles)
-            {
-                var cornerbounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
-                UpdateColliderBounds(handle, cornerbounds);
-            }
-        }
+        //private void UpdateColliderBounds()
+        //{
+        //    foreach (var handle in handles)
+        //    {
+        //        var cornerbounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
+        //        UpdateColliderBounds(handle, cornerbounds.size);
+        //    }
+        //}
 
         internal void UpdateVisibilityInInspector(HideFlags flags)
         {
@@ -110,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        private void RecreateVisuals()
+        protected override void RecreateVisuals()
         {
             for (int i = 0; i < handles.Count; ++i)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     if (obsoleteChild)
                     {
                         obsoleteChild.parent = null;
-                        Object.Destroy(obsoleteChild);
+                        Object.Destroy(obsoleteChild.gameObject);
                     }
                     else
                     {
@@ -134,16 +134,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     Bounds cornerBounds = CreateVisual(visualsScaleParent.gameObject, true);
 
                     // update handle collider bounds
-                    UpdateColliderBounds(handles[i], cornerBounds);
+                    UpdateColliderBounds(handles[i], cornerBounds.size);
                 }
             }
         }
 
-        private void UpdateColliderBounds(Transform handle, Bounds cornerBounds)
+        protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
-            var invScale = config.HandleSize / cornerBounds.size.x;
+            var invScale = config.HandleSize / visualSize.x;
             BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
-            Vector3 colliderSize = cornerBounds.size * invScale;
+            Vector3 colliderSize = visualSize * invScale;
             collider.size = colliderSize;
             collider.size += BaseConfig.ColliderPadding;
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -19,6 +19,44 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             Debug.Assert(configuration != null, "Can't create BoundsControlScaleHandles without valid configuration");
             config = configuration;
+            config.handlesChanged.AddListener(HandlesChanged);
+        }
+
+        ~ScaleHandles()
+        {
+            config.handlesChanged.RemoveListener(HandlesChanged);
+        }
+
+        private void HandlesChanged(HandlesBaseConfiguration.HandlesChangedEventType changedType)
+        {
+            switch (changedType)
+            {
+                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL:
+                    UpdateBaseMaterial();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.MATERIAL_GRABBED:
+                    UpdateGrabbedMaterial();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.PREFAB:
+                    RecreateVisuals();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_SIZE:
+                case HandlesBaseConfiguration.HandlesChangedEventType.COLLIDER_PADDING:
+                    UpdateColliderBounds();
+                    break;
+                case HandlesBaseConfiguration.HandlesChangedEventType.VISIBILITY:
+                    //TODO
+                    break;
+            }
+        }
+
+        private void UpdateColliderBounds()
+        {
+            foreach (var handle in handles)
+            {
+                var cornerbounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
+                UpdateColliderBounds(handle, cornerbounds);
+            }
         }
 
         internal void UpdateVisibilityInInspector(HideFlags flags)
@@ -63,45 +101,97 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     visualsScale.transform.localScale = new Vector3(Mathf.Sign(p[0]), Mathf.Sign(p[1]), Mathf.Sign(p[2]));
                 }
 
-                // figure out which prefab to instantiate
-                GameObject cornerVisual = null;
-                GameObject prefabType = isFlattened ? config.HandleSlatePrefab : config.HandlePrefab;
-                if (prefabType == null)
-                {
-                    // instantiate default prefab, a cube. Remove the box collider from it
-                    cornerVisual = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                    cornerVisual.transform.parent = visualsScale.transform;
-                    cornerVisual.transform.localPosition = Vector3.zero;
-                    GameObject.Destroy(cornerVisual.GetComponent<BoxCollider>());
-                }
-                else
-                {
-                    cornerVisual = GameObject.Instantiate(prefabType, visualsScale.transform);
-                }
+                Bounds visualBounds = CreateVisual(visualsScale, isFlattened);
 
-                if (isFlattened)
-                {
-                    // Rotate 2D slate handle asset for proper orientation
-                    cornerVisual.transform.Rotate(0, 0, -90);
-                }
-
-                cornerVisual.name = "visuals";
-
-                // this is the size of the corner visuals
-                var cornerbounds = VisualUtils.GetMaxBounds(cornerVisual);
-                float maxDim = Mathf.Max(Mathf.Max(cornerbounds.size.x, cornerbounds.size.y), cornerbounds.size.z);
-                cornerbounds.size = maxDim * Vector3.one;
-
-                // we need to multiply by this amount to get to desired scale handle size
-                var invScale = config.HandleSize / cornerbounds.size.x;
-                cornerVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
-
-                VisualUtils.ApplyMaterialToAllRenderers(cornerVisual, config.HandleMaterial);
-
-                VisualUtils.AddComponentsToAffordance(corner, new Bounds(cornerbounds.center * invScale, cornerbounds.size * invScale), 
-                    RotationHandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, drawManipulationTether);
+                var invScale = config.HandleSize / visualBounds.size.x;
+                VisualUtils.AddComponentsToAffordance(corner, new Bounds(visualBounds.center * invScale, visualBounds.size * invScale), 
+                    HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, drawManipulationTether);
                 handles.Add(corner.transform);       
             }
+        }
+
+        private void RecreateVisuals()
+        {
+            for (int i = 0; i < handles.Count; ++i)
+            {
+                // get parent of visual
+                Transform visualsScaleParent = handles[i].Find("visualsScale");
+                if (visualsScaleParent)
+                {
+                    // get old child and remove it
+                    Transform obsoleteChild = visualsScaleParent.Find("visuals");
+                    if (obsoleteChild)
+                    {
+                        obsoleteChild.parent = null;
+                        Object.Destroy(obsoleteChild);
+                    }
+                    else
+                    {
+                        Debug.LogError("couldn't find corner visual on recreating visuals");
+                    }
+
+                    // create new visual
+                    Bounds cornerBounds = CreateVisual(visualsScaleParent.gameObject, true);
+
+                    // update handle collider bounds
+                    UpdateColliderBounds(handles[i], cornerBounds);
+                }
+            }
+        }
+
+        private void UpdateColliderBounds(Transform handle, Bounds cornerBounds)
+        {
+            var invScale = config.HandleSize / cornerBounds.size.x;
+            BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
+            Vector3 colliderSize = cornerBounds.size * invScale;
+            collider.size = colliderSize;
+            collider.size += BaseConfig.ColliderPadding;
+        }
+
+        /// <summary>
+        /// Creates the corner visual and returns the bounds of the created visual
+        /// </summary>
+        /// <param name="parent">parent of visual</param>
+        /// <param name="isFlattened">instantiate in flattened mode - slate</param>
+        /// <returns>bounds of the created visual</returns>
+        private Bounds CreateVisual(GameObject parent, bool isFlattened)
+        {
+            // figure out which prefab to instantiate
+            GameObject cornerVisual = null;
+            GameObject prefabType = isFlattened ? config.HandleSlatePrefab : config.HandlePrefab;
+            if (prefabType == null)
+            {
+                // instantiate default prefab, a cube. Remove the box collider from it
+                cornerVisual = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                cornerVisual.transform.parent = parent.transform;
+                cornerVisual.transform.localPosition = Vector3.zero;
+                GameObject.Destroy(cornerVisual.GetComponent<BoxCollider>());
+            }
+            else
+            {
+                cornerVisual = GameObject.Instantiate(prefabType, parent.transform);
+            }
+
+            if (isFlattened)
+            {
+                // Rotate 2D slate handle asset for proper orientation
+                cornerVisual.transform.Rotate(0, 0, -90);
+            }
+
+            cornerVisual.name = "visuals";
+
+            // this is the size of the corner visuals
+            var cornerbounds = VisualUtils.GetMaxBounds(cornerVisual);
+            float maxDim = Mathf.Max(Mathf.Max(cornerbounds.size.x, cornerbounds.size.y), cornerbounds.size.z);
+            cornerbounds.size = maxDim * Vector3.one;
+
+            // we need to multiply by this amount to get to desired scale handle size
+            var invScale = config.HandleSize / cornerbounds.size.x;
+            cornerVisual.transform.localScale = new Vector3(invScale, invScale, invScale);
+
+            VisualUtils.ApplyMaterialToAllRenderers(cornerVisual, config.HandleMaterial);
+
+            return cornerbounds;
         }
 
         #region BoundsControlHandlerBase

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
-        internal void Create(ref Vector3[] boundsCorners, Transform parent, bool drawManipulationTether, bool isFlattened)
+        internal void Create(ref Vector3[] boundsCorners, Transform parent, bool isFlattened)
         {
             // create corners
             for (int i = 0; i < boundsCorners.Length; ++i)
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                 var invScale = config.HandleSize / visualBounds.size.x;
                 VisualUtils.AddComponentsToAffordance(corner, new Bounds(visualBounds.center * invScale, visualBounds.size * invScale), 
-                    HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, drawManipulationTether);
+                    HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, config.DrawTetherWhenManipulating);
                 handles.Add(corner.transform);       
             }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -15,6 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     {
         protected override HandlesBaseConfiguration BaseConfig => config;
         private ScaleHandlesConfiguration config;
+        private bool areHandlesFlattened = false;
         internal ScaleHandles(ScaleHandlesConfiguration configuration)
         {
             Debug.Assert(configuration != null, "Can't create BoundsControlScaleHandles without valid configuration");
@@ -131,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     }
 
                     // create new visual
-                    Bounds cornerBounds = CreateVisual(visualsScaleParent.gameObject, true);
+                    Bounds cornerBounds = CreateVisual(visualsScaleParent.gameObject, areHandlesFlattened);
 
                     // update handle collider bounds
                     UpdateColliderBounds(handles[i], cornerBounds.size);
@@ -158,6 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         {
             // figure out which prefab to instantiate
             GameObject cornerVisual = null;
+            areHandlesFlattened = isFlattened;
             GameObject prefabType = isFlattened ? config.HandleSlatePrefab : config.HandlePrefab;
             if (prefabType == null)
             {
@@ -192,6 +194,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             VisualUtils.ApplyMaterialToAllRenderers(cornerVisual, config.HandleMaterial);
 
             return cornerbounds;
+        }
+
+        internal void UpdateFlattenMode(bool isFlattened)
+        {
+            areHandlesFlattened = isFlattened;
+            RecreateVisuals();
         }
 
         #region BoundsControlHandlerBase

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -110,6 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 handles.Add(corner.transform);       
             }
 
+            VisualUtils.HandleIgnoreCollider(config.HandlesIgnoreCollider, handles);
             objectsChangedEvent.Invoke(this);
         }
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -147,6 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         protected override void UpdateColliderBounds(Transform handle, Vector3 visualSize)
         {
             var invScale = config.HandleSize / visualSize.x;
+            GetVisual(handle).transform.localScale = new Vector3(invScale, invScale, invScale);
             BoxCollider collider = handle.gameObject.GetComponent<BoxCollider>();
             Vector3 colliderSize = visualSize * invScale;
             collider.size = colliderSize;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -29,6 +29,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
         }
 
+        internal static float GetMaxComponent(Vector3 vec)
+        {
+            return Mathf.Max(Mathf.Max(vec.x, vec.y), vec.z);
+        }
+
         internal static Bounds GetMaxBounds(GameObject g)
         {
             var b = new Bounds();
@@ -80,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 SphereCollider sphere = afford.AddComponent<SphereCollider>();
                 sphere.center = bounds.center;
                 sphere.radius = bounds.extents.x;
-                sphere.radius += Mathf.Max(Mathf.Max(colliderPadding.x, colliderPadding.y), colliderPadding.z);
+                sphere.radius += GetMaxComponent(colliderPadding);
             }
 
             // In order for the affordance to be grabbed using near interaction we need

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     internal class VisualUtils
     {
 
-        internal static void HandleIgnoreCollider(Collider handlesIgnoreCollider, List<Transform> handles)
+        internal static void HandleIgnoreCollider(Collider handlesIgnoreCollider, List<Transform> handles, bool ignore = true)
         {
             if (handlesIgnoreCollider != null)
             {
@@ -22,8 +22,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     Collider[] colliders = handle.gameObject.GetComponents<Collider>();
                     foreach (Collider collider in colliders)
-                    {
-                        UnityEngine.Physics.IgnoreCollision(collider, handlesIgnoreCollider);
+                    { 
+                        UnityEngine.Physics.IgnoreCollision(collider, handlesIgnoreCollider, ignore);
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     Collider[] colliders = handle.gameObject.GetComponents<Collider>();
                     foreach (Collider collider in colliders)
-                    { 
+                    {
                         UnityEngine.Physics.IgnoreCollision(collider, handlesIgnoreCollider, ignore);
                     }
                 }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -65,10 +65,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Add all common components to a corner or rotate affordance
         /// </summary>
-        internal static void AddComponentsToAffordance(GameObject afford, Bounds bounds, RotationHandlePrefabCollider colliderType, 
+        internal static void AddComponentsToAffordance(GameObject afford, Bounds bounds, HandlePrefabCollider colliderType, 
             CursorContextInfo.CursorAction cursorType, Vector3 colliderPadding, Transform parent, bool drawTetherWhenManipulating)
         {
-            if (colliderType == RotationHandlePrefabCollider.Box)
+            if (colliderType == HandlePrefabCollider.Box)
             {
                 BoxCollider collider = afford.AddComponent<BoxCollider>();
                 collider.size = bounds.size;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Add all common components to a corner or rotate affordance
+        /// Add all common components to a corner or rotate affordance.
         /// </summary>
         internal static void AddComponentsToAffordance(GameObject afford, Bounds bounds, HandlePrefabCollider colliderType, 
             CursorContextInfo.CursorAction cursorType, Vector3 colliderPadding, Transform parent, bool drawTetherWhenManipulating)
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Creates the default material for bounds control handles
+        /// Creates the default material for bounds control handles.
         /// </summary>
         internal static Material CreateDefaultMaterial()
         {
@@ -107,10 +107,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Calculates an array of corner points out of the given bounds
+        /// Calculates an array of corner points out of the given bounds.
         /// </summary>
-        /// <param name="bounds">bounds of the box</param>
-        /// <param name="positions">calculated corner points</param>
+        /// <param name="bounds">Bounds of the box.</param>
+        /// <param name="positions">Calculated corner points.</param>
         static internal void GetCornerPositionsFromBounds(Bounds bounds, ref Vector3[] positions)
         {
             const int numCorners = 1 << 3;
@@ -132,12 +132,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Flattens the given extents according to the passed flattenAxis. The flattenAxis value will be replaced by flattenValue
+        /// Flattens the given extents according to the passed flattenAxis. The flattenAxis value will be replaced by flattenValue.
         /// </summary>
-        /// <param name="extents">The original extents (unflattened)</param>
-        /// <param name="flattenAxis">The axis to flatten</param>
-        /// <param name="flattenValue">The value to flatten the flattenAxis to</param>
-        /// <returns>new extents with flattened axis</returns>
+        /// <param name="extents">The original extents (unflattened).</param>
+        /// <param name="flattenAxis">The axis to flatten.</param>
+        /// <param name="flattenValue">The value to flatten the flattenAxis to.</param>
+        /// <returns>New extents with flattened axis.</returns>
         static internal Vector3 FlattenBounds(Vector3 extents, FlattenModeType flattenAxis, float flattenValue = 0.0f)
         {
             Vector3 boundsExtents = extents;
@@ -168,12 +168,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         /// <summary>
-        /// Util function for retrieving a position for the given edge index of a box
-        /// This method makes sure all visual components are having the same definition of edges / corners
+        /// Util function for retrieving a position for the given edge index of a box.
+        /// This method makes sure all visual components are having the same definition of edges / corners.
         /// </summary>
-        /// <param name="linkIndex">Index of the edge the position is queried for</param>
-        /// <param name="cornerPoints">Corner points array of the box</param>
-        /// <returns>center position of link</returns>
+        /// <param name="linkIndex">Index of the edge the position is queried for.</param>
+        /// <param name="cornerPoints">Corner points array of the box.</param>
+        /// <returns>Center position of link.</returns>
         static internal Vector3 GetLinkPosition(int linkIndex, ref Vector3[] cornerPoints)
         {
             Debug.Assert(cornerPoints != null && cornerPoints.Length == 8, "Invalid corner points array passed");
@@ -210,24 +210,27 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             return Vector3.zero;
         }
 
+        static readonly int[] flattenedIndicesX = new int[] { 0, 4, 2, 6 };
+        static readonly int[] flattenedIndicesY = new int[] { 1, 3, 5, 7 };
+        static readonly int[] flattenedIndicesZ = new int[] { 9, 10, 8, 11 };
         /// <summary>
-        /// returns the flatten indices to the corresponding flattenAxis mode
+        /// Returns the flatten indices to the corresponding flattenAxis mode.
         /// </summary>
-        /// <param name="flattenAxis">flatten axis mode that should be converted to indices</param>
-        /// <returns>flattened indices</returns>
+        /// <param name="flattenAxis">Flatten axis mode that should be converted to indices.</param>
+        /// <returns>Flattened indices.</returns>
         internal static int[] GetFlattenedIndices(FlattenModeType flattenAxis)
         {
             if (flattenAxis == FlattenModeType.FlattenX)
             {
-                return new int[] { 0, 4, 2, 6 };
+                return flattenedIndicesX;
             }
             else if (flattenAxis == FlattenModeType.FlattenY)
             {
-                return new int[] { 1, 3, 5, 7 };
+                return flattenedIndicesY;
             }
             else if (flattenAxis == FlattenModeType.FlattenZ)
             {
-                return new int[] { 9, 10, 8, 11 };
+                return flattenedIndicesZ;
             }
 
             return null;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -210,5 +210,27 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             return Vector3.zero;
         }
 
+        /// <summary>
+        /// returns the flatten indices to the corresponding flattenAxis mode
+        /// </summary>
+        /// <param name="flattenAxis">flatten axis mode that should be converted to indices</param>
+        /// <returns>flattened indices</returns>
+        internal static int[] GetFlattenedIndices(FlattenModeType flattenAxis)
+        {
+            if (flattenAxis == FlattenModeType.FlattenX)
+            {
+                return new int[] { 0, 4, 2, 6 };
+            }
+            else if (flattenAxis == FlattenModeType.FlattenY)
+            {
+                return new int[] { 1, 3, 5, 7 };
+            }
+            else if (flattenAxis == FlattenModeType.FlattenZ)
+            {
+                return new int[] { 9, 10, 8, 11 };
+            }
+
+            return null;
+        }
     }
 }

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
@@ -52,7 +52,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 }
 
                 // migrate visuals
-                boundsControl.HandlesIgnoreCollider = boundingBox.HandlesIgnoreCollider;
                 boundsControl.FlattenAxis = MigrateFlattenAxis(boundingBox.FlattenAxis);
                 boundsControl.BoxPadding = boundingBox.BoxPadding;
                 string configDir = GetBoundsControlConfigDirectory(boundingBox);
@@ -244,6 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.HandleSize = box.ScaleHandleSize;
             config.ColliderPadding = box.ScaleHandleColliderPadding;
             config.DrawTetherWhenManipulating = box.DrawTetherWhenManipulating;
+            config.HandlesIgnoreCollider = box.HandlesIgnoreCollider;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "ScaleHandlesConfiguration"));
 
             control.ScaleHandlesConfig = config;
@@ -262,6 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.HandleSize = box.RotationHandleSize;
             config.ColliderPadding = box.RotateHandleColliderPadding;
             config.DrawTetherWhenManipulating = box.DrawTetherWhenManipulating;
+            config.HandlesIgnoreCollider = box.HandlesIgnoreCollider;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "RotationHandlesConfiguration"));
 
             control.RotationHandlesConfig = config;

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
@@ -52,7 +52,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 }
 
                 // migrate visuals
-                boundsControl.DrawTetherWhenManipulating = boundingBox.DrawTetherWhenManipulating;
                 boundsControl.HandlesIgnoreCollider = boundingBox.HandlesIgnoreCollider;
                 boundsControl.FlattenAxis = MigrateFlattenAxis(boundingBox.FlattenAxis);
                 boundsControl.BoxPadding = boundingBox.BoxPadding;
@@ -192,18 +191,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             return WireframeType.Cubic;
         }
 
-        private RotationHandlePrefabCollider MigrateRotationHandleColliderType(BoundingBox.RotationHandlePrefabCollider rotationHandlePrefabColliderType)
+        private HandlePrefabCollider MigrateRotationHandleColliderType(BoundingBox.RotationHandlePrefabCollider rotationHandlePrefabColliderType)
         {
             switch (rotationHandlePrefabColliderType)
             {
                 case BoundingBox.RotationHandlePrefabCollider.Sphere:
-                    return RotationHandlePrefabCollider.Sphere;
+                    return HandlePrefabCollider.Sphere;
                 case BoundingBox.RotationHandlePrefabCollider.Box:
-                    return RotationHandlePrefabCollider.Box;
+                    return HandlePrefabCollider.Box;
             }
 
             Debug.Assert(false, "Tried to migrate unsupported rotation handle collider type in bounding box / bounds control");
-            return RotationHandlePrefabCollider.Sphere;
+            return HandlePrefabCollider.Sphere;
         }
 
         #endregion Flags Migration
@@ -218,7 +217,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.FlattenAxisDisplayScale = box.FlattenAxisDisplayScale;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "BoxDisplayConfiguration"));
 
-            control.BoxDisplayConfiguration = config;
+            control.BoxDisplayConfig = config;
         }
 
         private void MigrateLinks(BoundsControl control, BoundingBox box, string configAssetDirectory)
@@ -230,7 +229,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.ShowWireFrame = box.ShowWireFrame;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "LinksConfiguration"));
 
-            control.LinksConfiguration = config;
+            control.LinksConfig = config;
 
         }
 
@@ -243,10 +242,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.HandleGrabbedMaterial = box.HandleGrabbedMaterial;
             config.HandlePrefab = box.ScaleHandlePrefab;
             config.HandleSize = box.ScaleHandleSize;
-            config.ColliderPadding = box.ScaleHandleColliderPadding;            
+            config.ColliderPadding = box.ScaleHandleColliderPadding;
+            config.DrawTetherWhenManipulating = box.DrawTetherWhenManipulating;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "ScaleHandlesConfiguration"));
 
-            control.ScaleHandlesConfiguration = config;
+            control.ScaleHandlesConfig = config;
         }
 
         private void MigrateRotationHandles(BoundsControl control, BoundingBox box, string configAssetDirectory)
@@ -261,9 +261,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.HandlePrefab = box.RotationHandlePrefab;
             config.HandleSize = box.RotationHandleSize;
             config.ColliderPadding = box.RotateHandleColliderPadding;
+            config.DrawTetherWhenManipulating = box.DrawTetherWhenManipulating;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "RotationHandlesConfiguration"));
 
-            control.RotationHandles = config;
+            control.RotationHandlesConfig = config;
         }
 
         private void MigrateProximityEffect(BoundsControl control, BoundingBox box, string configAssetDirectory)
@@ -280,7 +281,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.CloseGrowRate = box.CloseGrowRate;            
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "ProximityEffectConfiguration"));
 
-            control.HandleProximityEffectConfiguration = config;
+            control.HandleProximityEffectConfig = config;
         }
 
         #endregion Visuals Configuration Migration

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
@@ -70,13 +70,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
                 boundsControl.RotateStopped = boundingBox.RotateStopped;
                 boundsControl.ScaleStarted = boundingBox.ScaleStarted;
                 boundsControl.ScaleStopped = boundingBox.ScaleStopped;
-
-                // destroy obsolete component
-                Object.DestroyImmediate(boundingBox);
             }
 
             // look in the scene for app bars and upgrade them too to point to the new component
             MigrateAppBar(boundingBox, boundsControl);
+      
+            {
+                Undo.RecordObject(gameObject, "Removing obsolete BoundingBox component");
+                // destroy obsolete component
+                Object.DestroyImmediate(boundingBox);
+            }
 #endif
         }
 

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             boxDisplayConfig.BoxMaterial = testMaterial;
             boxDisplayConfig.BoxGrabbedMaterial = testMaterial;
             boxDisplayConfig.FlattenAxisDisplayScale = 5.0f;
-            boundsControl.BoxDisplayConfiguration = boxDisplayConfig;
+            boundsControl.BoxDisplayConfig = boxDisplayConfig;
 
             // links
             LinksConfiguration linksConfig = ScriptableObject.CreateInstance<LinksConfiguration>();
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             linksConfig.WireframeEdgeRadius = 1.0f;
             linksConfig.WireframeShape = WireframeType.Cylindrical;
             linksConfig.ShowWireFrame = false;
-            boundsControl.LinksConfiguration = linksConfig;
+            boundsControl.LinksConfig = linksConfig;
 
             // scale handles
             ScaleHandlesConfiguration scaleConfig = ScriptableObject.CreateInstance<ScaleHandlesConfiguration>();
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             scaleConfig.HandleSize = 0.05f ;
             scaleConfig.ColliderPadding = Vector3.one;
 
-            boundsControl.ScaleHandlesConfiguration = scaleConfig;
+            boundsControl.ScaleHandlesConfig = scaleConfig;
 
             // rotation handles
             RotationHandlesConfiguration rotationHandles = ScriptableObject.CreateInstance<RotationHandlesConfiguration>();
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             rotationHandles.HandleSize = 0.05f;
             rotationHandles.ColliderPadding = Vector3.zero;
 
-            boundsControl.RotationHandles = rotationHandles;
+            boundsControl.RotationHandlesConfig = rotationHandles;
 
             // proximity effect
             ProximityEffectConfiguration proximityConfig = ScriptableObject.CreateInstance<ProximityEffectConfiguration>();
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             proximityConfig.MediumGrowRate = 0.1f;
             proximityConfig.CloseGrowRate = 0.5f;
 
-            boundsControl.HandleProximityEffectConfiguration = proximityConfig;
+            boundsControl.HandleProximityEffectConfig = proximityConfig;
 
             // clean up created assets
             foreach (string assetPath in assetsToDestroy)

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             boundsControl.BoundsOverride = collider;
             boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
             boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateByProximityAndPointer;
-            boundsControl.DrawTetherWhenManipulating = false;
             boundsControl.HandlesIgnoreCollider = collider;
             boundsControl.FlattenAxis = FlattenModeType.FlattenAuto;
             boundsControl.BoxPadding = Vector3.one;
@@ -79,6 +78,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             scaleConfig.HandlePrefab = testCube;
             scaleConfig.HandleSize = 0.05f ;
             scaleConfig.ColliderPadding = Vector3.one;
+            scaleConfig.DrawTetherWhenManipulating = true;
 
             boundsControl.ScaleHandlesConfig = scaleConfig;
 
@@ -97,6 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             rotationHandles.HandlePrefab = childSphere;
             rotationHandles.HandleSize = 0.05f;
             rotationHandles.ColliderPadding = Vector3.zero;
+            rotationHandles.DrawTetherWhenManipulating = true;
 
             boundsControl.RotationHandlesConfig = rotationHandles;
 

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             boundsControl.BoundsOverride = collider;
             boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
             boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateByProximityAndPointer;
-            boundsControl.HandlesIgnoreCollider = collider;
             boundsControl.FlattenAxis = FlattenModeType.FlattenAuto;
             boundsControl.BoxPadding = Vector3.one;
 
@@ -78,7 +77,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             scaleConfig.HandlePrefab = testCube;
             scaleConfig.HandleSize = 0.05f ;
             scaleConfig.ColliderPadding = Vector3.one;
-            scaleConfig.DrawTetherWhenManipulating = true;
+            scaleConfig.DrawTetherWhenManipulating = false;
+            scaleConfig.HandlesIgnoreCollider = collider;
 
             boundsControl.ScaleHandlesConfig = scaleConfig;
 
@@ -97,7 +97,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             rotationHandles.HandlePrefab = childSphere;
             rotationHandles.HandleSize = 0.05f;
             rotationHandles.ColliderPadding = Vector3.zero;
-            rotationHandles.DrawTetherWhenManipulating = true;
+            rotationHandles.DrawTetherWhenManipulating = false;
+            rotationHandles.HandlesIgnoreCollider = collider;
 
             boundsControl.RotationHandlesConfig = rotationHandles;
 

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             assetsToDestroy.Add(path);
             AssetDatabase.CreateAsset(rotationHandles, path);
 
-            rotationHandles.RotationHandlePrefabColliderType = RotationHandlePrefabCollider.Box;
+            rotationHandles.RotationHandlePrefabColliderType = HandlePrefabCollider.Box;
             rotationHandles.ShowRotationHandleForX = false;
             rotationHandles.ShowRotationHandleForY = true;
             rotationHandles.ShowRotationHandleForZ = true;

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -542,7 +542,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             proximityConfig.CloseGrowRate = 1.0f;
             proximityConfig.MediumGrowRate = 1.0f;
             proximityConfig.FarGrowRate = 1.0f;
-            boundsControl.CreateRig();
             yield return null; // wait so rig gameobjects get recreated
             yield return TestCurrentProximityConfiguration(boundsControl, hand, "Defaults");
 
@@ -557,7 +556,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             proximityConfig.ObjectMediumProximity = 0.2f;
             proximityConfig.ObjectCloseProximity = 0.1f;
 
-            boundsControl.CreateRig();
             yield return null; // wait so rig gameobjects get recreated
             yield return TestCurrentProximityConfiguration(boundsControl, hand, "Custom runtime config max");
         }

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -715,7 +715,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         private IEnumerator TestDrawManipulationTetherFlag(HandlesBaseConfiguration config, GameObject rigRoot, string handleName)
         {
-            Assert.IsFalse(config.DrawTetherWhenManipulating, "tether drawing should be off as default");
+            Assert.IsTrue(config.DrawTetherWhenManipulating, "tether drawing should be on as default");
 
             // cache rig root for verifying that we're not recreating the rig on config changes
             Transform handle = rigRoot.transform.Find(handleName);
@@ -723,10 +723,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var grabbable = handle.gameObject.GetComponent<NearInteractionGrabbable>();
             Assert.AreEqual(config.DrawTetherWhenManipulating, grabbable.ShowTetherWhenManipulating, "draw tether wasn't propagated to handle NearInteractionGrabbable component");
 
-            config.DrawTetherWhenManipulating = true;
+            config.DrawTetherWhenManipulating = false;
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(handle, "handle was destroyed when changing tether visibility");
-            Assert.IsTrue(grabbable.ShowTetherWhenManipulating, "show tether wasn't applied to nearinteractiongrabbable of handle");
+            Assert.IsFalse(grabbable.ShowTetherWhenManipulating, "show tether wasn't applied to nearinteractiongrabbable of handle");
 
             yield return null;
         }

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         /// Test that if we update the bounds of a box collider, that the corners will move correctly
         /// </summary>
         [UnityTest]
-        public IEnumerator BBoxOverride()
+        public IEnumerator BoundsOverrideTest()
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
@@ -670,28 +670,56 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         }
 
-        /// <summary>
-        /// Tests instantiating the default bounds control and then configuring the control during runtime
-        /// Making sure settings are applied correctly and rig isn't recreated.
-        /// </summary>
-        /// <returns></returns>
+       
+        //[UnityTest] - todo: don't think we need that after the other flatten test but leaving here for checking later that we cover all handles / visuals
+        //public IEnumerator FlattenTest()
+        //{ 
+        //    //boundsControl.FlattenAxis = FlattenModeType.FlattenAuto;
+        //    yield return null;
+        //}
+
         [UnityTest]
-        public IEnumerator RuntimeConfigurationTest()
+        public IEnumerator HandlesIgnoreColliderTest()
         {
-            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
-            yield return VerifyInitialBoundsCorrect(boundsControl);
-
-           
-            //boundsControl.Target = childSphere;
-            //boundsControl.BoundsOverride = collider;
-            //boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
-            //boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateByProximityAndPointer;
-            //boundsControl.DrawTetherWhenManipulating = false;
             //boundsControl.HandlesIgnoreCollider = collider;
-            //boundsControl.FlattenAxis = FlattenModeType.FlattenAuto;
+            yield return null;
+        }
+
+
+        [UnityTest]
+        public IEnumerator ManipulationTetherTest()
+        {
+            //boundsControl.DrawTetherWhenManipulating = false;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ActivationTypeTest()
+        {
+            //boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateByProximityAndPointer;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator CalculationMethodTest()
+        {
+            //boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator SetTargetRuntimeTest()
+        {
+            // maybe unify with existing settarget test
+            //boundsControl.Target = childSphere;
+            yield return null;
+        }
+
+
+        [UnityTest]
+        public IEnumerator BoundsControlPaddingTest()
+        {
             //boundsControl.BoxPadding = Vector3.one;
-
-
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -786,11 +786,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsNotNull(rigRoot, "rigRoot was destroyed on hiding handles");
             Assert.IsNotNull(scaleHandle, "handle was destroyed on hide");
             Assert.IsFalse(scaleHandle.gameObject.activeSelf, "handle wasn't disabled on hide");
-            yield return new WaitForEndOfFrame();
 
             scaleHandleConfig.ShowScaleHandles = true;
             Assert.IsTrue(scaleHandle.gameObject.activeSelf, "handle wasn't enabled on show");
-            yield return new WaitForEndOfFrame();
 
             // test rotation handle behavior
             Transform rotationHandleAxisX = rigRoot.transform.Find("midpoint_0");
@@ -808,13 +806,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsFalse(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x not hidden");
             Assert.IsTrue(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not active");
             Assert.IsTrue(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not active");
-            yield return new WaitForEndOfFrame();
 
             rotationHandlesConfig.ShowRotationHandleForY = false;
             Assert.IsFalse(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x not hidden");
             Assert.IsFalse(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not hidden");
             Assert.IsTrue(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not active");
-            yield return new WaitForEndOfFrame();
 
             rotationHandlesConfig.ShowRotationHandleForX = true;
             rotationHandlesConfig.ShowRotationHandleForY = true;
@@ -823,8 +819,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsTrue(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not active");
             Assert.IsFalse(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not hidden");
 
-            yield return new WaitForEndOfFrame();
-
             // make sure handles are disabled and enabled when bounds control is deactived / activated
             boundsControl.Active = false;
             Assert.IsNotNull(rigRoot, "rigRoot was destroyed on disabling bounds control");
@@ -832,7 +826,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsFalse(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x not hidden");
             Assert.IsFalse(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not hidden");
             Assert.IsFalse(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not hidden");
-            yield return new WaitForEndOfFrame();
 
             // set active again and make sure internal states have been restored
             boundsControl.Active = true;
@@ -841,14 +834,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsTrue(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x not active");
             Assert.IsTrue(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not active");
             Assert.IsFalse(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not hidden");
-            yield return new WaitForEndOfFrame();
 
             // enable z axis again and verify
             rotationHandlesConfig.ShowRotationHandleForZ = true;
             Assert.IsTrue(rotationHandleAxisX.gameObject.activeSelf, "rotation handle x not active");
             Assert.IsTrue(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not active");
             Assert.IsTrue(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not active");
-            yield return new WaitForEndOfFrame();
 
             yield return null;
         }

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -33,7 +33,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         private Material testMaterialGrabbed;
 
         #region Utilities
-
         [SetUp]
         public void Setup()
         {
@@ -93,7 +92,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             TestUtilities.AssertAboutEqual(bounds.size, boundsControlStartScale, "bounds control incorrect size at start");
             yield return null;
         }
-
         #endregion
 
         /// <summary>
@@ -156,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            // This particular test is sensitive to the number of test frames and is run at a slower pace.
+            // This particular test is sensitive to the number of test frames, and is run at at slower pace.
             int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, initialHandPosition);
@@ -258,7 +256,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Test bounds control rotation via HoloLens 1 interaction / GGV
+        /// Test bounds control rotation via hololens 1 interaction / GGV
         /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
         /// </summary>
         [UnityTest]
@@ -542,7 +540,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(frontRightCornerPos);
             yield return null;
 
-            // we're in proximity scaling range - check if proximity scaling wasn't applied
+            // we're in poximity scaling range - check if proximity scaling wasn't applied
             Assert.AreEqual(proximityScaledVisual.localScale, defaultHandleSize, "Handle was scaled even though proximity effect wasn't active");
 
             //// reset hand
@@ -683,7 +681,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         }
 
-       
         //[UnityTest] - todo: don't think we need that after the other flatten test but leaving here for checking later that we cover all handles / visuals
         //public IEnumerator FlattenTest()
         //{ 
@@ -713,7 +710,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // test default and runtime changing draw tether flag of both handle types
             yield return TestDrawManipulationTetherFlag(boundsControl.ScaleHandlesConfig, rigRoot, "corner_3");
             yield return TestDrawManipulationTetherFlag(boundsControl.RotationHandlesConfig, rigRoot, "midpoint_2");
-         
             yield return null;
         }
 
@@ -836,7 +832,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             LinksConfiguration linkConfiguration = boundsControl.LinksConfig;
             // verify default radius
             Assert.AreEqual(linkVisual.localScale.x, linkConfiguration.WireframeEdgeRadius, "Wireframe default edge radius wasn't applied to link local scale");
-            
             // change radius
             linkConfiguration.WireframeEdgeRadius = 0.5f;
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
@@ -895,13 +890,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             Transform linkVisual = rigRoot.transform.Find("link_0");
             Assert.IsNotNull(linkVisual, "link visual couldn't be found");
-            
             LinksConfiguration linkConfiguration = boundsControl.LinksConfig;
             // set material and make sure rig root and link isn't destroyed while doing so
             linkConfiguration.WireframeMaterial = testMaterial;
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(linkVisual, "link visual was recreated on setting material");
-            
             // make sure color changed on visual
             Assert.AreEqual(linkVisual.GetComponent<Renderer>().material.color, testMaterial.color, "wireframe material wasn't applied to visual");
 
@@ -1100,7 +1093,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return VerifyInitialBoundsCorrect(boundsControl);
             GameObject childSphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             var sharedMeshFilter = childSphere.GetComponent<MeshFilter>();
-            
             // cache rig root for verifying that we're not recreating the rig on config changes
             GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
@@ -1129,7 +1121,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
             Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
             cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
-            
             // check if new mesh filter was applied
             Assert.IsTrue(sharedMeshFilter.mesh.name == cornerMeshFilter.mesh.name, "sphere scale handle wasn't applied");
 
@@ -1165,7 +1156,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             // check if new mesh filter was applied
             Assert.IsTrue(cornerMeshFilter.mesh.name.StartsWith(sharedMeshFilter.mesh.name), "sphere scale handle wasn't applied");
-            
             yield return null; 
         }
 
@@ -1313,7 +1303,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
             Transform cornerVisual = rigRoot.transform.Find(handleVisualName);
             Assert.IsNotNull(cornerVisual, "couldn't find visual" + handleVisualName);
-           
             // init test hand
             TestHand hand = new TestHand(Handedness.Right);
             yield return hand.Show(Vector3.zero);
@@ -1326,7 +1315,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             // move hand to edge of rotation handle
             yield return hand.MoveTo(cornerVisual.position + Vector3.one * handleConfig.HandleSize * 0.5f);
-            
             // test runtime collider padding configuration
             Vector3 colliderPaddingDelta = Vector3.one * 0.3f;
             yield return PlayModeTestUtilities.WaitForEnterKey();

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -638,13 +638,24 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // create another gameobject with boundscontrol attached 
             var emptyGameObject = new GameObject("empty");
             BoundsControl boundsControl = emptyGameObject.AddComponent<BoundsControl>();
+            yield return new WaitForFixedUpdate();
+
+            // fetch root and scale handle
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+            var scaleHandle = boundsControl.transform.Find("rigRoot/corner_3");
+            Assert.IsNotNull(scaleHandle, "scale handle couldn't be found");
+
+            // verify root is parented to bounds control gameobject
+            Assert.AreEqual(boundsControl.gameObject, rigRoot.transform.parent.gameObject);
 
             // set target to cube
             boundsControl.Target = cube;
-            boundsControl.Active = true;
+            Assert.IsNotNull(rigRoot, "rigRoot was destroyed on setting a new target");
+            Assert.IsNotNull(scaleHandle, "scale handle was destroyed on setting a new target");
 
-            // front right corner is corner 3
-            var frontRightCornerPos = cube.transform.Find("rigRoot/corner_3").position;
+            // verify root is parented to target gameobject
+            Assert.AreEqual(cube, rigRoot.transform.parent.gameObject);
 
             // grab corner and scale object
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
@@ -653,9 +664,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             TestHand hand = new TestHand(Handedness.Right);
             yield return hand.Show(initialHandPosition);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
-            yield return hand.MoveTo(frontRightCornerPos, numSteps);
+            var scaleHandlePos = scaleHandle.position;
+            yield return hand.MoveTo(scaleHandlePos, numSteps);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return hand.MoveTo(frontRightCornerPos + delta, numSteps);
+            yield return hand.MoveTo(scaleHandlePos + delta, numSteps);
 
             var endBounds = cube.GetComponent<BoxCollider>().bounds;
             Vector3 expectedCenter = new Vector3(0.033f, 0.033f, 1.467f);
@@ -706,15 +718,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             //boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
             yield return null;
         }
-
-        [UnityTest]
-        public IEnumerator SetTargetRuntimeTest()
-        {
-            // maybe unify with existing settarget test
-            //boundsControl.Target = childSphere;
-            yield return null;
-        }
-
 
         [UnityTest]
         public IEnumerator BoundsControlPaddingTest()

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -681,7 +681,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         /// <summary>
         /// Tests the different activation flags bounding box handles can be activated with
         /// </summary>
-        /// <returns></returns>
         [UnityTest]
         public IEnumerator ActivationTypeTest()
         {
@@ -1025,7 +1024,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(linkVisual, "link visual shouldn't be destroyed when changing edge radius");
 
-            //check if radius was applied
+            // check if radius was applied
             Assert.AreEqual(linkVisual.localScale.x, linkConfiguration.WireframeEdgeRadius, "Wireframe edge radius wasn't applied to link local scale");
 
             yield return null;
@@ -1061,7 +1060,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(linkVisual, "link visual shouldn't be destroyed when switching mesh");
 
-            //check if shape was applied
+            // check if shape was applied
             Assert.IsTrue(linkMeshFilter.mesh.name == "Cylinder Instance", "Link shape wasn't switched to cylinder");
 
             yield return null;
@@ -1097,7 +1096,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         /// Tests changing the box display default and grabbed material during runtime,
         /// making sure neither box display nor rig get recreated.
         /// </summary>
-        /// <returns></returns>
         [UnityTest]
         public IEnumerator BoxDisplayMaterialTest()
         {
@@ -1492,7 +1490,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // set test materials so we know if we're interacting with the handle later in the test
             handleConfig.HandleMaterial = testMaterial;
             handleConfig.HandleGrabbedMaterial = testMaterialGrabbed;
-            //handleConfig.HandleSize = 0.1f;
             yield return new WaitForFixedUpdate();
 
             // move hand to edge of rotation handle collider

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -698,7 +698,40 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         [UnityTest]
         public IEnumerator LinksVisibilityTest()
         {
-            //linksConfig.ShowWireFrame = false;
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            // fetch rigroot, corner visual and rotation handle config
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            Transform linkVisual = rigRoot.transform.Find("link_0");
+            Assert.IsNotNull(linkVisual, "link visual couldn't be found");
+            Assert.IsTrue(linkVisual.gameObject.activeSelf, "links not visible by default");
+            yield return new WaitForFixedUpdate();
+
+            // disable wireframe and make sure we're not recreating anything
+            LinksConfiguration linkConfiguration = boundsControl.LinksConfig;
+            linkConfiguration.ShowWireFrame = false;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(linkVisual, "link visual was recreated on changing visibility");
+            Assert.IsFalse(linkVisual.gameObject.activeSelf, "links did not get deactivated on hide");
+            yield return new WaitForFixedUpdate();
+
+            // enable links again
+            linkConfiguration.ShowWireFrame = true;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(linkVisual, "link visual was recreated on changing visibility");
+            Assert.IsTrue(linkVisual.gameObject.activeSelf, "links did not get activated on show");
+            yield return new WaitForFixedUpdate();
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator LinksFlattenTest()
+        {
+            // test flatten and unflatten for links
             yield return null;
         }
 
@@ -723,7 +756,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         [UnityTest]
         public IEnumerator LinksMaterialTest()
         {
-            //linksConfig.WireframeMaterial = testMaterial;
             var boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
@@ -745,7 +777,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             yield return null;
         }
-
 
         /// <summary>
         /// Tests changing the box display default and grabbed material during runtime,

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         /// Verify that we can instantiate bounds control at runtime
         /// </summary>
         [UnityTest]
-        public IEnumerator BBoxInstantiate()
+        public IEnumerator BoundsControlInstantiate()
         {
             BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
@@ -695,6 +695,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         public IEnumerator HandlesIgnoreColliderTest()
         {
             //boundsControl.HandlesIgnoreCollider = collider;
+            Assert.IsTrue(false, "not implemented");
             yield return null;
         }
 
@@ -702,13 +703,42 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         [UnityTest]
         public IEnumerator ManipulationTetherTest()
         {
-            //boundsControl.DrawTetherWhenManipulating = false;
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            // cache rig root for verifying that we're not recreating the rig on config changes
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            // test default and runtime changing draw tether flag of both handle types
+            yield return TestDrawManipulationTetherFlag(boundsControl.ScaleHandlesConfig, rigRoot, "corner_3");
+            yield return TestDrawManipulationTetherFlag(boundsControl.RotationHandlesConfig, rigRoot, "midpoint_2");
+         
+            yield return null;
+        }
+
+        private IEnumerator TestDrawManipulationTetherFlag(HandlesBaseConfiguration config, GameObject rigRoot, string handleName)
+        {
+            Assert.IsFalse(config.DrawTetherWhenManipulating, "tether drawing should be off as default");
+
+            // cache rig root for verifying that we're not recreating the rig on config changes
+            Transform handle = rigRoot.transform.Find(handleName);
+            Assert.IsNotNull(handle, "couldn't find handle");
+            var grabbable = handle.gameObject.GetComponent<NearInteractionGrabbable>();
+            Assert.AreEqual(config.DrawTetherWhenManipulating, grabbable.ShowTetherWhenManipulating, "draw tether wasn't propagated to handle NearInteractionGrabbable component");
+
+            config.DrawTetherWhenManipulating = true;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(handle, "handle was destroyed when changing tether visibility");
+            Assert.IsTrue(grabbable.ShowTetherWhenManipulating, "show tether wasn't applied to nearinteractiongrabbable of handle");
+
             yield return null;
         }
 
         [UnityTest]
         public IEnumerator ActivationTypeTest()
         {
+            Assert.IsTrue(false, "not implemented");
             //boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateByProximityAndPointer;
             yield return null;
         }
@@ -716,6 +746,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         [UnityTest]
         public IEnumerator CalculationMethodTest()
         {
+            Assert.IsTrue(false, "not implemented");
             //boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
             yield return null;
         }
@@ -723,6 +754,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         [UnityTest]
         public IEnumerator BoundsControlPaddingTest()
         {
+            Assert.IsTrue(false, "not implemented");
             //boundsControl.BoxPadding = Vector3.one;
             yield return null;
         }
@@ -1180,7 +1212,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // make sure color changed on visual
             Assert.AreEqual(cornerVisual.GetComponent<Renderer>().material.color, testMaterial.color, "handle material wasn't applied to visual");
 
-            yield return PlayModeTestUtilities.WaitForEnterKey();
             // grab handle and make sure grabbed material is applied
             var frontRightCornerPos = cornerVisual.position;
             TestHand hand = new TestHand(Handedness.Right);
@@ -1189,7 +1220,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(frontRightCornerPos);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return new WaitForFixedUpdate();
-            yield return PlayModeTestUtilities.WaitForEnterKey();
             Assert.AreEqual(cornerVisual.GetComponent<Renderer>().material.color, testMaterialGrabbed.color, "handle grabbed material wasn't applied to visual");
             // release handle
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
@@ -1237,13 +1267,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             handleConfig.HandleGrabbedMaterial = testMaterialGrabbed;
 
             // test runtime handle size configuration
-            yield return PlayModeTestUtilities.WaitForEnterKey();
             handleConfig.HandleSize = 0.1f;
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(handleVisual, "visual got destroyed when setting material");
             yield return hand.MoveTo(handleVisual.position + Vector3.one * handleConfig.HandleSize * 0.5f);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
-            yield return PlayModeTestUtilities.WaitForEnterKey();
             Assert.AreEqual(handleVisual.GetComponent<Renderer>().material.color, testMaterialGrabbed.color, "handle wasn't grabbed");
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
         }
@@ -1300,8 +1328,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(cornerVisual.position + Vector3.one * handleConfig.HandleSize * 0.5f);
             
             // test runtime collider padding configuration
-            yield return PlayModeTestUtilities.WaitForEnterKey();
             Vector3 colliderPaddingDelta = Vector3.one * 0.3f;
+            yield return PlayModeTestUtilities.WaitForEnterKey();
 
             // move hand to new collider bounds edge before setting the new value in the config
             yield return hand.Move(colliderPaddingDelta * 0.5f);
@@ -1329,6 +1357,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         [UnityTest]
         public IEnumerator ScaleHandleVisibilityTest()
         {
+            Assert.IsTrue(false, "not implemented");
             /// TODO:
             // check if visual gameobject has been switched off  TODO THIS IS NOT IMPLEMENTED
             //scaleHandleConfig.ShowScaleHandles = true;
@@ -1341,7 +1370,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         public IEnumerator RotationHandleVisibilityTest()
         {
             //TODO
-            
+            Assert.IsTrue(false, "not implemented");
             //rotationHandles.ShowRotationHandleForX = false;
             //rotationHandles.ShowRotationHandleForY = true;
             //rotationHandles.ShowRotationHandleForZ = true;

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
-            // This particular test is sensitive to the number of test frames, and is run at at slower pace.
+            // This particular test is sensitive to the number of test frames, and is run at a slower pace.
             int numSteps = 30;
             var delta = new Vector3(0.1f, 0.1f, 0f);
             yield return PlayModeTestUtilities.ShowHand(Handedness.Right, inputSimulationService, ArticulatedHandPose.GestureId.OpenSteadyGrabPoint, initialHandPosition);

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -720,11 +720,29 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         /// <summary>
         /// Tests changing the links material during runtime and making sure links and rig are not recreated.
         /// </summary>
-        /// <returns></returns>
         [UnityTest]
         public IEnumerator LinksMaterialTest()
         {
             //linksConfig.WireframeMaterial = testMaterial;
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            // fetch rigroot, corner visual and rotation handle config
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            Transform linkVisual = rigRoot.transform.Find("link_0");
+            Assert.IsNotNull(linkVisual, "link visual couldn't be found");
+            
+            LinksConfiguration linkConfiguration = boundsControl.LinksConfig;
+            // set material and make sure rig root and link isn't destroyed while doing so
+            linkConfiguration.WireframeMaterial = testMaterial;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(linkVisual, "link visual was recreated on setting material");
+            
+            // make sure color changed on visual
+            Assert.AreEqual(linkVisual.GetComponent<Renderer>().material.color, testMaterial.color, "wireframe material wasn't applied to visual");
+
             yield return null;
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -764,13 +764,55 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         public IEnumerator LinksFlattenTest()
         {
             // test flatten and unflatten for links
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            // fetch rigroot, and one of the link visuals
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            Transform linkVisual = rigRoot.transform.Find("link_0");
+            Assert.IsNotNull(linkVisual, "link visual couldn't be found");
+
+            Assert.IsTrue(linkVisual.gameObject.activeSelf, "link with index 0 wasn't enabled by default");
+
+            // flatten x axis and make sure link gets deactivated
+            boundsControl.FlattenAxis = FlattenModeType.FlattenX;
+            Assert.IsFalse(linkVisual.gameObject.activeSelf, "link with index 0 wasn't disabled when control was flattened in X axis");
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+
+            // unflatten the control again and make sure link gets activated accordingly
+            boundsControl.FlattenAxis = FlattenModeType.DoNotFlatten;
+            Assert.IsTrue(linkVisual.gameObject.activeSelf, "link with index 0 wasn't enabled on unflatten");
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             yield return null;
         }
 
         [UnityTest]
         public IEnumerator LinksRadiusTest()
-        {
-            //linksConfig.WireframeEdgeRadius = 1.0f;
+        { 
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            // fetch rigroot, and one of the link visuals
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            Transform linkVisual = rigRoot.transform.Find("link_0");
+            Assert.IsNotNull(linkVisual, "link visual couldn't be found");
+
+            LinksConfiguration linkConfiguration = boundsControl.LinksConfig;
+            // verify default radius
+            Assert.AreEqual(linkVisual.localScale.x, linkConfiguration.WireframeEdgeRadius, "Wireframe default edge radius wasn't applied to link local scale");
+            
+            // change radius
+            linkConfiguration.WireframeEdgeRadius = 0.5f;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(linkVisual, "link visual shouldn't be destroyed when changing edge radius");
+
+            //check if radius was applied
+            Assert.AreEqual(linkVisual.localScale.x, linkConfiguration.WireframeEdgeRadius, "Wireframe edge radius wasn't applied to link local scale");
+
             yield return null;
         }
 
@@ -800,7 +842,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(linkVisual, "link visual shouldn't be destroyed when switching mesh");
 
-            //refetch link and check if shape was applied
+            //check if shape was applied
             Assert.IsTrue(linkMeshFilter.mesh.name == "Cylinder Instance", "Link shape wasn't switched to cylinder");
 
             yield return null;

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -28,12 +28,23 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
     /// </summary>
     public class BoundsControlTests
     {
+        private Material testMaterial;
+        private Material testMaterialGrabbed;
+
         #region Utilities
 
         [SetUp]
         public void Setup()
         {
             PlayModeTestUtilities.Setup();
+
+            // create shared test materials
+            var shader = StandardShaderUtility.MrtkStandardShader;
+            testMaterial = new Material(shader);
+            testMaterial.color = Color.yellow;
+
+            testMaterialGrabbed = new Material(shader);
+            testMaterialGrabbed.color = Color.green;
         }
 
         [TearDown]
@@ -507,7 +518,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
             // 1. test no proximity scaling active per default
-            ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfiguration;
+            ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfig;
             Vector3 defaultHandleSize = Vector3.one * scaleHandleConfig.HandleSize;
 
             Vector3 initialHandPosition = new Vector3(0, 0, 0f);
@@ -537,7 +548,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(initialHandPosition);
 
             // 2. enable proximity scaling and test defaults
-            ProximityEffectConfiguration proximityConfig = boundsControl.HandleProximityEffectConfiguration;
+            ProximityEffectConfiguration proximityConfig = boundsControl.HandleProximityEffectConfig;
             proximityConfig.ProximityEffectActive = true;
             proximityConfig.CloseGrowRate = 1.0f;
             proximityConfig.MediumGrowRate = 1.0f;
@@ -568,13 +579,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         private IEnumerator TestCurrentProximityConfiguration(BoundsControl boundsControl, TestHand hand, string testDescription)
         {
             // get config and scaling handle
-            ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfiguration;
+            ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfig;
             Vector3 defaultHandleSize = Vector3.one * scaleHandleConfig.HandleSize;
             Transform scaleHandle = boundsControl.gameObject.transform.Find("rigRoot/corner_3");
             Transform proximityScaledVisual = scaleHandle.GetChild(0)?.GetChild(0);
             var frontRightCornerPos = scaleHandle.position;
             // check far scale applied
-            ProximityEffectConfiguration proximityConfig = boundsControl.HandleProximityEffectConfiguration;
+            ProximityEffectConfiguration proximityConfig = boundsControl.HandleProximityEffectConfig;
             Vector3 expectedFarScale = defaultHandleSize * proximityConfig.FarScale;
             Assert.AreEqual(proximityScaledVisual.localScale, expectedFarScale, testDescription + " - Proximity far scale wasn't applied to handle");
 
@@ -657,6 +668,437 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             // Wait for a frame to give Unity a change to actually destroy the object
             yield return null;
 
+        }
+
+        /// <summary>
+        /// Tests instantiating the default bounds control and then configuring the control during runtime
+        /// Making sure settings are applied correctly and rig isn't recreated.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator RuntimeConfigurationTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+           
+            //boundsControl.Target = childSphere;
+            //boundsControl.BoundsOverride = collider;
+            //boundsControl.CalculationMethod = BoundsCalculationMethod.ColliderOverRenderer;
+            //boundsControl.BoundsControlActivation = BoundsControlActivationType.ActivateByProximityAndPointer;
+            //boundsControl.DrawTetherWhenManipulating = false;
+            //boundsControl.HandlesIgnoreCollider = collider;
+            //boundsControl.FlattenAxis = FlattenModeType.FlattenAuto;
+            //boundsControl.BoxPadding = Vector3.one;
+
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator LinksVisibilityTest()
+        {
+            //linksConfig.ShowWireFrame = false;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator LinksRadiusTest()
+        {
+            //linksConfig.WireframeEdgeRadius = 1.0f;
+            yield return null;
+        }
+
+
+        [UnityTest]
+        public IEnumerator LinksShapeTest()
+        {
+            //linksConfig.WireframeShape = WireframeType.Cylindrical;
+            yield return null;
+        }
+
+        /// <summary>
+        /// Tests changing the links material during runtime and making sure links and rig are not recreated.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator LinksMaterialTest()
+        {
+            //linksConfig.WireframeMaterial = testMaterial;
+            yield return null;
+        }
+
+
+        /// <summary>
+        /// Tests changing the box display default and grabbed material during runtime,
+        /// making sure neither box display nor rig get recreated.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator BoxDisplayMaterialTest()
+        {
+            //var testMaterial = new Material(Shader.Find("Specular"));
+            //boxDisplayConfig.BoxMaterial = testMaterial;
+            //boxDisplayConfig.BoxGrabbedMaterial = testMaterial;
+            yield return null;
+        }
+
+        /// <summary>
+        /// Tests scaling of box display after flattening bounds control during runtime
+        /// and making sure neither box display nor rig get recreated.
+        /// </summary>
+        /// <returns></returns>
+        [UnityTest]
+        public IEnumerator BoxDisplayFlattenAxisScaleTest()
+        {
+            //boxDisplayConfig.FlattenAxisDisplayScale = 5.0f;
+            yield return null;
+        }
+
+
+        [UnityTest]
+        public IEnumerator RotationHandleFlattenTest()
+        {
+            // test flatten mode of rotation handle
+            yield return null;
+        }
+
+        /// <summary>
+        /// Test for verifying changing the handle prefabs during runtime 
+        /// and making sure the the entire rig won't be recreated
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotationHandlePrefabTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            GameObject childBox = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var sharedMeshFilter = childBox.GetComponent<MeshFilter>();
+
+            // cache rig root for verifying that we're not recreating the rig on config changes
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            // check default mesh filter
+            Transform rotationHandleVisual = rigRoot.transform.Find("midpoint_2/visuals");
+            Transform cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Assert.IsNotNull(rotationHandleVisual, "couldn't find rotation handle visual");
+            Assert.IsNotNull(cornerVisual, "couldn't find scale handle visual");
+            var handleVisualMeshFilter = rotationHandleVisual.GetComponent<MeshFilter>();
+
+            Assert.IsTrue(handleVisualMeshFilter.mesh.name == "Sphere Instance", "Rotation handles weren't created with default sphere");
+
+            // change mesh
+            RotationHandlesConfiguration rotationHandlesConfig = boundsControl.RotationHandlesConfig;
+            rotationHandlesConfig.HandlePrefab = childBox;
+            yield return null;
+            yield return new WaitForFixedUpdate();
+
+            // make sure only the visuals have been destroyed but not the rig root
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(cornerVisual, "scale handle got destroyed while replacing prefab for rotation handle");
+            Assert.IsNull(rotationHandleVisual, "corner visual wasn't destroyed when swapping the prefab");
+
+            // fetch new rotation handle visual
+            rotationHandleVisual = rigRoot.transform.Find("midpoint_2/visuals");
+            Assert.IsNotNull(rotationHandleVisual, "couldn't find rotation handle visual");
+            handleVisualMeshFilter = rotationHandleVisual.GetComponent<MeshFilter>();
+
+            // check if new mesh filter was applied
+            Assert.IsTrue(sharedMeshFilter.mesh.name == handleVisualMeshFilter.mesh.name, "box rotation handle wasn't applied");
+
+            yield return null;
+        }
+
+        /// <summary>
+        /// Test for verifying changing the handle prefabs during runtime 
+        /// in regular and flatten mode and making sure the the entire rig won't be recreated
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleHandlePrefabTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            GameObject childSphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            var sharedMeshFilter = childSphere.GetComponent<MeshFilter>();
+            
+            // cache rig root for verifying that we're not recreating the rig on config changes
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+
+            // check default mesh filter
+            Transform cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
+            Transform rotationHandleVisual = rigRoot.transform.Find("midpoint_2/visuals");
+            Assert.IsNotNull(rotationHandleVisual, "couldn't find rotation handle visual");
+            var cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
+
+            Assert.IsTrue(cornerMeshFilter.mesh.name == "Cube Instance", "Scale handles weren't created with default cube");
+
+            // change mesh
+            ScaleHandlesConfiguration scaleHandleConfig = boundsControl.ScaleHandlesConfig;
+            scaleHandleConfig.HandlePrefab = childSphere;
+            yield return null;
+            yield return new WaitForFixedUpdate();
+
+            // make sure only the visuals have been destroyed but not the rig root
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(rotationHandleVisual, "rotation handle visual got destroyed while replacing the scale handle");
+            Assert.IsNull(cornerVisual, "corner visual wasn't destroyed when swapping the prefab");
+
+            // fetch new corner visual
+            cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
+            cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
+            
+            // check if new mesh filter was applied
+            Assert.IsTrue(sharedMeshFilter.mesh.name == cornerMeshFilter.mesh.name, "sphere scale handle wasn't applied");
+
+            // set flatten mode
+            boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.FlattenX;
+            yield return null;
+            yield return new WaitForFixedUpdate();
+
+            // make sure only the visuals have been destroyed but not the rig root
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNull(cornerVisual, "corner visual wasn't destroyed when swapping the prefab");
+
+            // mesh should be cube again
+            cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
+            cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
+            Assert.IsTrue(cornerMeshFilter.mesh.name == "Cube Instance", "Flattened scale handles weren't created with default cube");
+            // reset flatten mode
+            boundsControl.FlattenAxis = Toolkit.Experimental.UI.BoundsControlTypes.FlattenModeType.DoNotFlatten;
+
+            scaleHandleConfig.HandleSlatePrefab = childSphere;
+            yield return null;
+            yield return new WaitForFixedUpdate();
+
+            // make sure only the visuals have been destroyed but not the rig root
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNull(cornerVisual, "corner visual wasn't destroyed when swapping the prefab");
+
+            // fetch new corner visual
+            cornerVisual = rigRoot.transform.Find("corner_3/visualsScale/visuals");
+            Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
+            cornerMeshFilter = cornerVisual.GetComponent<MeshFilter>();
+
+            // check if new mesh filter was applied
+            Assert.IsTrue(cornerMeshFilter.mesh.name.StartsWith(sharedMeshFilter.mesh.name), "sphere scale handle wasn't applied");
+            
+            yield return null; 
+        }
+
+        /// <summary>
+        /// Tests runtime configuration of scale handle materials.
+        /// Verifies scale handle default and grabbed material are properly replaced in all visuals when 
+        /// setting the material in the config as well as validating that neither the rig nor the visuals get recreated.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleHandleMaterialTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            yield return HandleMaterialTest("corner_3/visualsScale/visuals", boundsControl.ScaleHandlesConfig, boundsControl);
+        }
+
+        /// <summary>
+        /// Tests runtime configuration of rotation handle materials.
+        /// Verifies rotation handle default and grabbed material are properly replaced in all visuals when 
+        /// setting the material in the config as well as validating that neither the rig nor the visuals get recreated.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotationHandleMaterialTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            yield return HandleMaterialTest("midpoint_2/visuals", boundsControl.RotationHandlesConfig, boundsControl);
+        }
+
+        private IEnumerator HandleMaterialTest(string handleVisualName, HandlesBaseConfiguration handleConfig, BoundsControl boundsControl)
+        { 
+            // fetch rigroot, corner visual and rotation handle config
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+            Transform cornerVisual = rigRoot.transform.Find(handleVisualName);
+            Assert.IsNotNull(cornerVisual, "couldn't find corner visual");
+
+            // set materials and make sure rig root and visuals haven't been destroyed while doing so
+            handleConfig.HandleMaterial = testMaterial;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            handleConfig.HandleGrabbedMaterial = testMaterialGrabbed;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(cornerVisual, "corner visual got destroyed when setting material");
+            // make sure color changed on visual
+            Assert.AreEqual(cornerVisual.GetComponent<Renderer>().material.color, testMaterial.color, "handle material wasn't applied to visual");
+
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            // grab handle and make sure grabbed material is applied
+            var frontRightCornerPos = cornerVisual.position;
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(Vector3.zero);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            yield return hand.MoveTo(frontRightCornerPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return new WaitForFixedUpdate();
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            Assert.AreEqual(cornerVisual.GetComponent<Renderer>().material.color, testMaterialGrabbed.color, "handle grabbed material wasn't applied to visual");
+            // release handle
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+        }
+
+        /// <summary>
+        /// Tests runtime configuration of scale handle size.
+        /// Verifies scale handles are scaled according to new size value without recreating the visual or the rig
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleHandleSizeTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            yield return HandleSizeTest("corner_3/visualsScale/visuals", boundsControl.ScaleHandlesConfig, boundsControl);
+        }
+
+        /// <summary>
+        /// Tests runtime configuration of rotation handle size.
+        /// Verifies rotation handles are scaled according to new size value without recreating the visual or the rig
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotationHandleSizeTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            yield return HandleSizeTest("midpoint_2/visuals", boundsControl.RotationHandlesConfig, boundsControl);
+        }
+
+        private IEnumerator HandleSizeTest(string handleVisualName, HandlesBaseConfiguration handleConfig, BoundsControl boundsControl)
+        {
+            // fetch rigroot, corner visual and rotation handle config
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+            Transform handleVisual = rigRoot.transform.Find(handleVisualName);
+            Assert.IsNotNull(handleVisual, "couldn't find visual " + handleVisualName);
+
+            // test hand setup
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(Vector3.zero);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+
+            // set test materials so we know if we're interacting with the handle later in the test
+            handleConfig.HandleMaterial = testMaterial;
+            handleConfig.HandleGrabbedMaterial = testMaterialGrabbed;
+
+            // test runtime handle size configuration
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            handleConfig.HandleSize = 0.1f;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(handleVisual, "visual got destroyed when setting material");
+            yield return hand.MoveTo(handleVisual.position + Vector3.one * handleConfig.HandleSize * 0.5f);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            Assert.AreEqual(handleVisual.GetComponent<Renderer>().material.color, testMaterialGrabbed.color, "handle wasn't grabbed");
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+        }
+
+        /// <summary>
+        /// Tests runtime configuration of scale handle collider padding.
+        /// Verifies collider of scale handles are scaled according to new size value 
+        /// without recreating the visual or the rig
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScaleHandleColliderPaddingTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            yield return HandleColliderPaddingTest("corner_3/visualsScale/visuals", boundsControl.ScaleHandlesConfig, boundsControl);
+        }
+
+        /// <summary>
+        /// Tests runtime configuration of rotation handle collider padding.
+        /// Verifies collider of rotation handles are scaled according to new size value 
+        /// without recreating the visual or the rig
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotationHandleColliderPaddingTest()
+        {
+            var boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+            yield return HandleColliderPaddingTest("midpoint_2/visuals", boundsControl.RotationHandlesConfig, boundsControl);
+            //rotationHandles.RotationHandlePrefabColliderType = HandlePrefabCollider.Box;
+            // TODO check if visual or rigroot gets recreated
+            boundsControl.RotationHandlesConfig.RotationHandlePrefabColliderType = Toolkit.Experimental.UI.BoundsControlTypes.HandlePrefabCollider.Box;
+            yield return HandleColliderPaddingTest("midpoint_2/visuals", boundsControl.RotationHandlesConfig, boundsControl);
+        }
+
+        private IEnumerator HandleColliderPaddingTest(string handleVisualName, HandlesBaseConfiguration handleConfig, BoundsControl boundsControl)
+        { 
+            // fetch rigroot, corner visual and rotation handle config
+            GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
+            Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
+            Transform cornerVisual = rigRoot.transform.Find(handleVisualName);
+            Assert.IsNotNull(cornerVisual, "couldn't find visual" + handleVisualName);
+           
+            // init test hand
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(Vector3.zero);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+
+            // set test materials so we know if we're interacting with the handle later in the test
+            handleConfig.HandleMaterial = testMaterial;
+            handleConfig.HandleGrabbedMaterial = testMaterialGrabbed;
+            handleConfig.HandleSize = 0.1f;
+
+            // move hand to edge of rotation handle
+            yield return hand.MoveTo(cornerVisual.position + Vector3.one * handleConfig.HandleSize * 0.5f);
+            
+            // test runtime collider padding configuration
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            Vector3 colliderPaddingDelta = Vector3.one * 0.3f;
+
+            // move hand to new collider bounds edge before setting the new value in the config
+            yield return hand.Move(colliderPaddingDelta * 0.5f);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            // handle shouldn't be in grabbed state
+            Assert.AreEqual(cornerVisual.GetComponent<Renderer>().material.color, testMaterial.color, "handle was grabbed outside collider padding area");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            // now adjust collider bounds and try grabbing the handle again
+            handleConfig.ColliderPadding = handleConfig.ColliderPadding + colliderPaddingDelta;
+            Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+            Assert.IsNotNull(cornerVisual, "corner visual got destroyed when setting material");
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+            // handle should be grabbed now
+            Assert.AreEqual(cornerVisual.GetComponent<Renderer>().material.color, testMaterialGrabbed.color, "handle wasn't grabbed");
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+
+            yield return PlayModeTestUtilities.WaitForEnterKey();
+        }
+
+
+        [UnityTest]
+        public IEnumerator ScaleHandleVisibilityTest()
+        {
+            /// TODO:
+            // check if visual gameobject has been switched off  TODO THIS IS NOT IMPLEMENTED
+            //scaleHandleConfig.ShowScaleHandles = true;
+            //Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator RotationHandleVisibilityTest()
+        {
+            //TODO
+            
+            //rotationHandles.ShowRotationHandleForX = false;
+            //rotationHandles.ShowRotationHandleForY = true;
+            //rotationHandles.ShowRotationHandleForZ = true;
+            yield return null;
         }
 
         /// <summary>

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 95d57d7bcb7915c42acd392846e1bc9d
+guid: ff02a98d791261145984b46211b4b601
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/web/version.js
+++ b/web/version.js
@@ -2,7 +2,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; // title in the dropdown for the root version of the docs
-	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "releases/2.3.0"]; // list of all versions in the version folder
+	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "releases/2.3.0", "prerelease/2.4.0_stabilization"]; // list of all versions in the version folder
 	
 	//--------------------------------------
 	

--- a/web/version.js
+++ b/web/version.js
@@ -2,7 +2,7 @@ function createDropdown()
 {
 	// configurable values:
 	var defaultTitle = "mrtk_development"; // title in the dropdown for the root version of the docs
-	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "releases/2.3.0", "prerelease/2.4.0_stabilization"]; // list of all versions in the version folder
+	var versionArray = ["releases/2.0.0", "releases/2.1.0", "releases/2.2.0", "releases/2.3.0"]; // list of all versions in the version folder
 	
 	//--------------------------------------
 	


### PR DESCRIPTION
## Overview
Old BoundingBox is recreating it's rig / handles / boxdisplay / links on every configuration change.
This PR is addressing this problem in BoundsControl.
Every configuration change will now only reload what is absolutely necessary (there's only a few cases where we actually have to recreate gameobjects eg. when we change the prefab of a handle during runtime)

Changes in detail:
- ProximityEffect
  - added event to IProximityEffectObjectProvider to inform ProximityEffect whenever objects that the effect is applied to change.
- Visuals
  - every configuration change has an event that the corresponding visual logic class subscribes to, handling every configuration change individually and only reloading necessary parts
  - DrawTetherWhenManipulating and HandlesIgnoreCollider settings are now part of the HandlesBaseConfiguration as they apply to the handle visuals only (used to be part of BoundsControl main class). They can be set per handle type now.
- BoundsControl main class
  - moved flattenedhandles array into internal util class as it's a shared resource between main bounds control and the visual classes
  - renamed configuration properties, so there's no name clash with the type name
  - fixed wireframe flag not being set correctly (needed for handle activation through pointer proximity)
  - removed subscriptions to configuration changes, as those are handled independently now by the visuals logic classes
  - ported over bounds calculation fix from bounding box - https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7301/files
 - MigrationHandler
   - fixed too early destruction of boundingbox when app bar still needs to be migrated 


And created tests for all of the configuration changes, to not only verify that they're still doing the right thing but also to verify that any of the visuals won't be recreated if not necessary.
Tests added:

- ActivationTypeTest
- HandleVisibilityTest
- ManipulationTetherTest
- BoundsControlPaddingTest
- LinksVisibilityTest
- LinksFlattenTest
- LinksRadiusTest
- LinksShapeTest
- LinksMaterialTest
- BoxDisplayMaterialTest
- BoxDisplayFlattenAxisScaleTest
- RotationHandleFlattenTest
- RotationHandlePrefabTest
- ScaleHandlePrefabTest
- ScaleHandleMaterialTest
- RotationHandleMaterialTest
- ScaleHandleSizeTest
- RotationHandleSizeTest
- ScaleHandleColliderPaddingTest
- RotationHandleColliderPaddingTest


## Changes
- Fixes: #6260 


## Verification
- added tests 
- tested existing scenes
- tested migration scenarios and run existing unit tests