### PR TITLE
Migration Tool: Only list files in migration tool project option that actually can be migrated

### DIFF
--- a/Assets/MRTK/SDK/Features/Utilities/Migration/Tools/MigrationTool.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Migration/Tools/MigrationTool.cs
@@ -178,19 +178,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             if(migrationObjects.Count == 0)
             {
-                Debug.LogError($"{e.Message}: List of objects for migration is empty.");
+                Debug.LogError($"List of objects for migration is empty.");
                 return false;
             }
 
              if(migrationHandlerInstanceType == null)
             {
-                Debug.LogError($"{e.Message}: Please select type of migration handler.");
+                Debug.LogError($"Please select type for migration.");
                 return false;
             }
             
             if (type == null || migrationHandlerInstanceType != type)
             {
-                Debug.LogError($"{e.Message}: Selected objects should be migrated with type: {migrationHandlerInstanceType}");
+                Debug.LogError($"Selected objects should be migrated with type: {migrationHandlerInstanceType}");
                 return false;
             }
 

--- a/Assets/MRTK/SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
@@ -203,7 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 var component = (ManipulationHandler)target;
 
-                migrationTool.TryAddObjectForMigration((GameObject)component.gameObject);
+                migrationTool.TryAddObjectForMigration(typeof(ObjectManipulatorMigrationHandler),(GameObject)component.gameObject);
                 migrationTool.MigrateSelection(typeof(ObjectManipulatorMigrationHandler), true);
 #endif
             }

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/MigrationToolTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/MigrationToolTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
 
                 GameObject gameObject = SetUpGameObjectWithComponentOfType(oldType);
 
-                migrationTool.TryAddObjectForMigration(gameObject);
+                migrationTool.TryAddObjectForMigration(migrationHandlerType,gameObject);
                 migrationTool.MigrateSelection(migrationHandlerType, false);
 
                 Assert.IsNull(gameObject.GetComponent(oldType), $"Migrated Component of type {oldType.Name} could not be removed");
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
                 PrefabUtility.SaveAsPrefabAsset(gameObject, prefabPath);
                 assetsForDeletion.Add(prefabPath);
 
-                migrationTool.TryAddObjectForMigration(AssetDatabase.LoadAssetAtPath(prefabPath, typeof(GameObject)));
+                migrationTool.TryAddObjectForMigration(migrationHandlerType, AssetDatabase.LoadAssetAtPath(prefabPath, typeof(GameObject)));
                 migrationTool.MigrateSelection(migrationHandlerType, false);
 
                 GameObject prefabGameObject = PrefabUtility.LoadPrefabContents(prefabPath);
@@ -164,7 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
                 EditorSceneManager.SaveScene(scene, scenePath);
                 assetsForDeletion.Add(scenePath);
 
-                migrationTool.TryAddObjectForMigration(AssetDatabase.LoadAssetAtPath(scenePath, typeof(SceneAsset)));
+                migrationTool.TryAddObjectForMigration(migrationHandlerType, AssetDatabase.LoadAssetAtPath(scenePath, typeof(SceneAsset)));
                 migrationTool.MigrateSelection(migrationHandlerType, false);
 
                 var openScene = EditorSceneManager.OpenScene(scenePath);

--- a/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
+++ b/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
@@ -115,6 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 selectedMigrationHandlerIndex = EditorGUILayout.Popup(selectedMigrationHandlerIndex, migrationHandlerTypeNames, GUILayout.Width(500));
                 if (EditorGUI.EndChangeCheck())
                 {
+                    migrationTool.ClearMigrationList();
                     SetMigrationHandlerType();
                 }
             }
@@ -148,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 {
                     if (GUILayout.Button("Add full project for migration"))
                     {
-                        migrationTool.TryAddProjectForMigration();
+                        migrationTool.TryAddProjectForMigration(selectedMigrationHandlerType);
                     }
                     return;
                 }
@@ -166,7 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
                         if (check.changed && selection)
                         {
-                            migrationTool.TryAddObjectForMigration(selection);
+                            migrationTool.TryAddObjectForMigration(selectedMigrationHandlerType,selection);
                         }
                     }
                 }


### PR DESCRIPTION
## Overview
On Migration Window, when trying to migrate entire project using the "Add Full Project for Migration" button, Migration tool lists all files of the project which is not a great user experience, as it's uncertain to the user if all their files will be affected by the upgrade.
It would be better to just list the files that actually contain the components we're planning to upgrade. That would also make the list shorter, make it easier to filter files and give a better overview before pressing the migration button.

This is part of Migration Tool graduation.

## Changes
Tool goes through object hierarchy checking if migration is supported on any of the hierarchy objects. Only show upgradeable files in that list.

Before:
![Screenshot (15)](https://user-images.githubusercontent.com/16922045/79974050-8503d780-8490-11ea-9df4-bffbde8dce27.png)

After:
![Screenshot (14)](https://user-images.githubusercontent.com/16922045/79974057-892ff500-8490-11ea-98ce-d41c6d914ce1.png)


- Fixes: #7690 .

