### PR TITLE
Fold in Playspace transform into hand mesh display

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -168,14 +168,18 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                                 vertexAndNormals[i].Normal.ConvertToUnityVector3(ref handMeshNormalsUnity[i]);
                             });
 
+                            /// Hands should follow the Playspace to accommodate teleporting, so fold in the Playspace transform.
+                            Vector3 positionUnity = MixedRealityPlayspace.TransformPoint(translation.ToUnityVector3());
+                            Quaternion rotationUnity = MixedRealityPlayspace.Rotation * rotation.ToUnityQuaternion(); 
+
                             HandMeshInfo handMeshInfo = new HandMeshInfo
                             {
                                 vertices = handMeshVerticesUnity,
                                 normals = handMeshNormalsUnity,
                                 triangles = handMeshTriangleIndicesUnity,
                                 uvs = handMeshUVsUnity,
-                                position = translation.ToUnityVector3(),
-                                rotation = rotation.ToUnityQuaternion()
+                                position = positionUnity,
+                                rotation = rotationUnity
                             };
 
                             CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);


### PR DESCRIPTION
Fold in Playspace transform into hand mesh display to accommodate teleport.

## Overview

The transforms for the hand meshes are missing the Playspace transform. Therefore, after teleport the hand meshes will appear in the wrong place. This fixes that.

## Changes
Folds in a missing transform in WindowsMixedRealityArticulatedHandDefinition, following the pattern elsewhere in the code (e.g. WindowsMixedRealityArticulatedHand).

- Fixes: #7697.


## Verification
Note that the performance cost is negligible, resulting in only a transform concatenation per mesh. This addition appears to just correct an easy to miss oversight. No architectural or otherwise significant changes are needed.

Note that I don't have context to know if this fix relates to new XR SDK surface, or whether it should. I've only tested and validated on the legacy API. Would be great if someone knowledgeable there could confirm or deny.

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
