### PR TITLE
Add WindowsMixedRealityUtilities.SpatialCoordinateSystem null checks

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -441,18 +441,18 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 base.Update();
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
-            if (mixedRealityGazeProviderHeadOverride != null && mixedRealityGazeProviderHeadOverride.UseHeadGazeOverride)
-            {
-                SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(WindowsMixedRealityUtilities.SpatialCoordinateSystem, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
-                if (pointerPose != null)
+                if (mixedRealityGazeProviderHeadOverride != null && mixedRealityGazeProviderHeadOverride.UseHeadGazeOverride && WindowsMixedRealityUtilities.SpatialCoordinateSystem != null)
                 {
-                    HeadPose head = pointerPose.Head;
-                    if (head != null)
+                    SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(WindowsMixedRealityUtilities.SpatialCoordinateSystem, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
+                    if (pointerPose != null)
                     {
-                        mixedRealityGazeProviderHeadOverride.OverrideHeadGaze(head.Position.ToUnityVector3(), head.ForwardDirection.ToUnityVector3());
+                        HeadPose head = pointerPose.Head;
+                        if (head != null)
+                        {
+                            mixedRealityGazeProviderHeadOverride.OverrideHeadGaze(head.Position.ToUnityVector3(), head.ForwardDirection.ToUnityVector3());
+                        }
                     }
                 }
-            }
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
                 UpdateInteractionManagerReading();

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/WindowsMixedRealityDeviceManager.cs
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         public override void Update()
         {
             // Override gaze before base.Update() updates the controllers
-            if (mixedRealityGazeProviderHeadOverride != null && mixedRealityGazeProviderHeadOverride.UseHeadGazeOverride)
+            if (mixedRealityGazeProviderHeadOverride != null && mixedRealityGazeProviderHeadOverride.UseHeadGazeOverride && WindowsMixedRealityUtilities.SpatialCoordinateSystem != null)
             {
                 SpatialPointerPose pointerPose = SpatialPointerPose.TryGetAtTimestamp(WindowsMixedRealityUtilities.SpatialCoordinateSystem, PerceptionTimestampHelper.FromHistoricalTargetTime(DateTimeOffset.Now));
                 if (pointerPose != null)


### PR DESCRIPTION
## Overview

Adds a `WindowsMixedRealityUtilities.SpatialCoordinateSystem != null` check before passing it into `SpatialPointerPose.TryGetAtTimestamp`. In certain scenarios, like running in the editor without a headset attached, the app won't launch into the full holographic view and we won't have a valid spatial coordinate system.

## Changes
- Fixes: #7698