### PR TITLE
Configurable pinch/air tap thresholds for Leap Motion

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -28,9 +28,57 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
         private MixedRealityPose currentIndexPose = MixedRealityPose.ZeroIdentity;
 
-        // Pinch distance thresholds
-        private readonly float enterPinchDistance = 0.02f;
-        private readonly float exitPinchDistance = 0.05f;
+        // Minimum distance between the index and the thumb tip required to enter a pinch
+        private readonly float minimumPinchDistance = 0.015f;
+
+        // Maximum distance between the index and thumb tip required to exit the pinch gesture
+        private readonly float maximumPinchDistance = 0.1f;
+
+        // Default enterPinchDistance value
+        private float enterPinchDistance = 0.02f;
+
+        /// <summary>
+        /// The distance between the index finger tip and the thumb tip required to enter the pinch/air tap selection gesture.
+        /// The pinch gesture enter will be registered for all values less than the EnterPinchDistance. The default EnterPinchDistance value is 0.02 and must be between 0.015 and 0.1. 
+        /// </summary>
+        public float EnterPinchDistance 
+        {
+            get => enterPinchDistance;
+            set
+            {
+                if (value >= minimumPinchDistance && value <= maximumPinchDistance)
+                {
+                    enterPinchDistance = value;
+                }
+                else
+                {
+                    Debug.LogWarning("EnterPinchDistance must be be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
+                }   
+            }
+        }
+
+        // Default exitPinchDistance value
+        private float exitPinchDistance = 0.05f;
+
+        /// <summary>
+        /// The distance between the index finger tip and the thumb tip required to exit the pinch/air tap gesture.
+        /// The pinch gesture exit will be registered for all values greater than the ExitPinchDistance. The default ExitPinchDistance value is 0.05 and must be between 0.015 and 0.1. 
+        /// </summary>
+        public float ExitPinchDistance
+        {
+            get => exitPinchDistance;
+            set
+            {
+                if (value >= minimumPinchDistance && value <= maximumPinchDistance)
+                {
+                    exitPinchDistance = value;
+                }
+                else
+                {
+                    Debug.LogWarning("ExitPinchDistance must be be between 0.015 and 0.1, please change Exit Pinch Distance in the Leap Motion Device Manager Profile");
+                }
+            }
+        }
 
         private bool isPinching = false;
 
@@ -93,11 +141,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     float distance = Vector3.Distance(thumbTip.Position, indexTip.Position);
 
-                    if (isPinching && distance > exitPinchDistance)
+                    if (isPinching && distance > ExitPinchDistance)
                     {
                         isPinching = false;
                     }
-                    else if (!isPinching && distance < enterPinchDistance)
+                    else if (!isPinching && distance < EnterPinchDistance)
                     {
                         isPinching = true;
                     }

--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    Debug.LogWarning("EnterPinchDistance must be be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
+                    Debug.LogError("EnterPinchDistance must be be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
                 }   
             }
         }
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    Debug.LogWarning("ExitPinchDistance must be be between 0.015 and 0.1, please change Exit Pinch Distance in the Leap Motion Device Manager Profile");
+                    Debug.LogError("ExitPinchDistance must be be between 0.015 and 0.1, please change Exit Pinch Distance in the Leap Motion Device Manager Profile");
                 }
             }
         }

--- a/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionDeviceManagerProfileInspector.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/LeapMotionDeviceManagerProfileInspector.cs
@@ -22,6 +22,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Inspectors
         protected LeapMotionDeviceManagerProfile instance;
         protected SerializedProperty leapControllerOrientation;
         protected SerializedProperty leapControllerOffset;
+        protected SerializedProperty enterPinchDistance;
+        protected SerializedProperty exitPinchDistance;
 
         private const string leapDocURL = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/CrossPlatform/LeapMotionMRTK.html";
 
@@ -32,6 +34,8 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Inspectors
             instance = (LeapMotionDeviceManagerProfile)target;
             leapControllerOrientation = serializedObject.FindProperty("leapControllerOrientation");
             leapControllerOffset = serializedObject.FindProperty("leapControllerOffset");
+            enterPinchDistance = serializedObject.FindProperty("enterPinchDistance");
+            exitPinchDistance = serializedObject.FindProperty("exitPinchDistance");
         }
 
         /// <summary>
@@ -75,6 +79,10 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Inspectors
                     {
                         EditorGUILayout.PropertyField(leapControllerOffset);
                     }
+
+                    EditorGUILayout.PropertyField(enterPinchDistance);
+
+                    EditorGUILayout.PropertyField(exitPinchDistance);
 
                     serializedObject.ApplyModifiedProperties();
                 }

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
             handDefinition = new ArticulatedHandDefinition(inputSource, controllerHandedness);
         }
 
-        private readonly ArticulatedHandDefinition handDefinition;
+        internal ArticulatedHandDefinition handDefinition;
 
         // Set the interations for each hand to the Default interactions of the hand definition
         public override MixedRealityInteractionMapping[] DefaultInteractions => handDefinition?.DefaultInteractions;
@@ -76,8 +76,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         // The leap service provider contains the joint data for a hand.  The provider's CurrentFrame.Hands is used to retrieve 
         // metacarpal joint poses each frame.
         private LeapServiceProvider leapServiceProvider = null;
-
-        private Hand trackedLeapHand;
 
         private List<TrackedHandJoint> metacarpals = new List<TrackedHandJoint>
         {
@@ -246,7 +244,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
             MixedRealityPose indexPose = jointPoses[TrackedHandJoint.IndexTip];
 
             // Only update the hand ray if the hand is in pointing pose
-            if (handDefinition.IsInPointingPose)
+            if (IsInPointingPose)
             {
                 HandRay.Update(pointerPose.Position, GetPalmNormal(), CameraCache.Main.transform, ControllerHandedness);
                 Ray ray = HandRay.Ray;
@@ -276,7 +274,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
                     case DeviceInputType.Select:
                     case DeviceInputType.TriggerPress:
                         Interactions[i].BoolData = IsPinching;
-
                         if (Interactions[i].Changed)
                         {
                             if (Interactions[i].BoolData)

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
@@ -63,14 +63,26 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         public LeapMotionDeviceManagerProfile SettingsProfile => ConfigurationProfile as LeapMotionDeviceManagerProfile;
 
         /// <summary>
-        /// If true, the leap motion controller is connected and detected.
-        /// </summary>
-        private bool IsLeapConnected => LeapMotionServiceProvider.IsConnected();
-
-        /// <summary>
         /// The LeapServiceProvider is added to the scene at runtime in OnEnable. 
         /// </summary>
         public LeapServiceProvider LeapMotionServiceProvider { get; protected set; }
+
+        /// <summary>
+        /// The distance between the index finger tip and the thumb tip required to enter the pinch/air tap selection gesture.
+        /// The pinch gesture enter will be registered for all values less than the EnterPinchDistance. The default EnterPinchDistance value is 0.02 and must be between 0.015 and 0.1. 
+        /// </summary>
+        private float enterPinchDistance => SettingsProfile.EnterPinchDistance;
+
+        /// <summary>
+        /// The distance between the index finger tip and the thumb tip required to exit the pinch/air tap gesture.
+        /// The pinch gesture exit will be registered for all values greater than the ExitPinchDistance. The default ExitPinchDistance value is 0.05 and must be between 0.015 and 0.1. 
+        /// </summary>
+        private float exitPinchDistance => SettingsProfile.ExitPinchDistance;
+
+        /// <summary>
+        /// If true, the leap motion controller is connected and detected.
+        /// </summary>
+        private bool IsLeapConnected => LeapMotionServiceProvider.IsConnected();
 
         /// <summary>
         /// The Leap attachment hands, used to determine which hand is currently tracked by leap.
@@ -189,6 +201,10 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
                 var pointers = RequestPointers(SupportedControllerType.ArticulatedHand, handedness);
                 var inputSource = CoreServices.InputSystem?.RequestNewGenericInputSource($"Leap {handedness} Controller", pointers, InputSourceType.Hand);
                 var leapHand = new LeapMotionArticulatedHand(TrackingState.Tracked, handedness, inputSource);
+
+                // Set pinch thresholds
+                leapHand.handDefinition.EnterPinchDistance = enterPinchDistance;
+                leapHand.handDefinition.ExitPinchDistance = exitPinchDistance;
 
                 // Set the leap attachment hand to the corresponding handedness
                 if (handedness == Handedness.Left)

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
@@ -25,7 +25,6 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         /// </summary>
         public LeapControllerOrientation LeapControllerOrientation => leapControllerOrientation;
 
-
         [SerializeField]
         [Tooltip("Adds an offset to the game object with LeapServiceProvider attached.  This offset is only applied if the leapControllerOrientation" +
         "is LeapControllerOrientation.Desk and is necessary for the hand to appear in front of the main camera. If the leap controller is on the " +
@@ -39,7 +38,41 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         /// desk, the LeapServiceProvider is added to the scene instead of the LeapXRServiceProvider. The anchor point for the hands is the position of the 
         /// game object with the LeapServiceProvider attached.
         /// </summary>
-        public Vector3 LeapControllerOffset => leapControllerOffset;
+        public Vector3 LeapControllerOffset
+        {
+            get => leapControllerOffset;
+            set => leapControllerOffset = value;
+        }
+
+        [SerializeField]
+        [Tooltip("The distance between the index finger tip and the thumb tip required to enter the pinch/air tap selection gesture. " +
+            "The pinch gesture enter will be registered for all values less than the EnterPinchDistance. The default EnterPinchDistance value is 0.02 and must be between 0.015 and 0.1. ")]
+        private float enterPinchDistance = 0.02f;
+
+        /// <summary>
+        /// The distance between the index finger tip and the thumb tip required to enter the pinch/air tap selection gesture.
+        /// The pinch gesture enter will be registered for all values less than the EnterPinchDistance. The default EnterPinchDistance value is 0.02 and must be between 0.015 and 0.1. 
+        /// </summary>
+        public float EnterPinchDistance
+        {
+            get => enterPinchDistance;
+            set => enterPinchDistance = value;
+        }
+
+        [SerializeField]
+        [Tooltip("The minimum distance between the index finger tip and the thumb tip required to exit the pinch/air tap gesture to deselect.  The distance between the thumb and  " +
+            "the index tip must be greater than than the ExitPinchDistance to raise the OnInputUp event")]
+        private float exitPinchDistance = 0.05f;
+
+        /// <summary>
+        /// The minimum distance between the index finger tip and the thumb tip required to exit the pinch/air tap gesture to deselect.  The distance between the thumb and 
+        /// the index tip must be greater than than the ExitPinchDistance to raise the OnInputUp event
+        /// </summary>
+        public float ExitPinchDistance
+        {        
+            get => exitPinchDistance;
+            set => exitPinchDistance = value;
+        }
     }
 
 }


### PR DESCRIPTION
## Overview

Added configurable pinch thresholds for a Leap Motion hand. 

| New Inspector | Current Value Appearance |  
|--------|-------|
|    ![PinchConfigure](https://user-images.githubusercontent.com/53493796/80049001-a41d5c00-84c6-11ea-9f43-c1508b374aab.png) | ![LeapPinchAfter](https://user-images.githubusercontent.com/53493796/80048917-720bfa00-84c6-11ea-98a9-8ead7271dd28.gif) |  

## Changes
- Fixes: #7689 


## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
