### PR TITLE
Update the configurator to detect an appropriate audio spatializer and respond to changes

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -16,6 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public class MixedRealityEditorSettings : IActiveBuildTargetChanged, IPreprocessBuildWithReport
     {
         private const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
+        // todo: remove
         private const string MSFT_AudioSpatializerPlugin = "MS HRTF Spatializer";
 #if UNITY_ANDROID
         const string RenderingMode = "Single Pass Stereo";
@@ -123,6 +124,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     Debug.LogWarning("<b>Depth Buffer Sharing</b> has 24-bit depth format selected. Consider using 16-bit for performance. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
                 }
 
+                // todo: change this to check for no spatializer instead of a specific value
                 if (!AudioSettings.GetSpatializerPluginName().Equals(MSFT_AudioSpatializerPlugin))
                 {
                     // If using UWP, developers should use the Microsoft Audio Spatializer plugin

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Editor;
+using System.Linq;
+using System.Text;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
@@ -16,8 +18,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
     public class MixedRealityEditorSettings : IActiveBuildTargetChanged, IPreprocessBuildWithReport
     {
         private const string SessionKey = "_MixedRealityToolkit_Editor_ShownSettingsPrompts";
-        // todo: remove
-        private const string MSFT_AudioSpatializerPlugin = "MS HRTF Spatializer";
+        private static readonly string[] UwpRecommendedAudioSpatializers = { "MS HRTF Spatializer", "Microsoft Spatializer" };
+
 #if UNITY_ANDROID
         const string RenderingMode = "Single Pass Stereo";
 #else
@@ -124,11 +126,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     Debug.LogWarning("<b>Depth Buffer Sharing</b> has 24-bit depth format selected. Consider using 16-bit for performance. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
                 }
 
-                // todo: change this to check for no spatializer instead of a specific value
-                if (!AudioSettings.GetSpatializerPluginName().Equals(MSFT_AudioSpatializerPlugin))
+                if (!UwpRecommendedAudioSpatializers.Contains<string>(SpatializerUtilities.CurrentSpatializer))
                 {
-                    // If using UWP, developers should use the Microsoft Audio Spatializer plugin
-                    Debug.LogWarning("<b>Audio Spatializer Plugin</b> not currently set to <i>" + MSFT_AudioSpatializerPlugin + "</i>. Switch to <i>" + MSFT_AudioSpatializerPlugin + "</i> under <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i>");
+                    Debug.LogWarning($"This application is not using the recommended <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the following: {string.Join(", ", UwpRecommendedAudioSpatializers)}.");
+                }
+            }
+            else
+            {
+                if (SpatializerUtilities.CurrentSpatializer == null)
+                {
+                    Debug.LogWarning($"This application is not using an <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the available options.");
                 }
             }
         }

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityEditorSettings.cs
@@ -126,17 +126,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     Debug.LogWarning("<b>Depth Buffer Sharing</b> has 24-bit depth format selected. Consider using 16-bit for performance. See <i>Mixed Reality Toolkit</i> > <i>Utilities</i> > <i>Optimize Window</i> tool for more information to improve performance");
                 }
 
-                if (!UwpRecommendedAudioSpatializers.Contains<string>(SpatializerUtilities.CurrentSpatializer))
+                if (!UwpRecommendedAudioSpatializers.Contains(SpatializerUtilities.CurrentSpatializer))
                 {
                     Debug.LogWarning($"This application is not using the recommended <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the following: {string.Join(", ", UwpRecommendedAudioSpatializers)}.");
                 }
             }
-            else
+            else if (SpatializerUtilities.CurrentSpatializer == null)
             {
-                if (SpatializerUtilities.CurrentSpatializer == null)
-                {
-                    Debug.LogWarning($"This application is not using an <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the available options.");
-                }
+                Debug.LogWarning($"This application is not using an <b>Audio Spatializer Plugin</b>. Go to <i>Project Settings</i> > <i>Audio</i> > <i>Spatializer Plugin</i> and select one of the available options.");
             }
         }
 

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -269,7 +269,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 if (configured)
                 {
                     EditorGUILayout.LabelField(new GUIContent($"{title} {selection}", InspectorUIUtility.SuccessIcon));
-
                 }
                 else
                 {

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             { MRConfig.EnableMSBuildForUnity, true },
 #endif // !UNITY_2019_3_OR_NEWER
+            { MRConfig.AudioSpatializer, true },
+
             // UWP Capabilities
             { MRConfig.MicrophoneCapability, true },
             { MRConfig.InternetClientCapability, true },
@@ -79,6 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             Instance = this;
 
             CompilationPipeline.assemblyCompilationStarted += CompilationPipeline_assemblyCompilationStarted;
+            MixedRealityProjectConfigurator.SelectedSpatializer = SpatializerUtilities.CurrentSpatializer;
         }
 
         private void CompilationPipeline_assemblyCompilationStarted(string obj)
@@ -183,6 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #endif
 #endif // UNITY_2019_3_OR_NEWER
                 RenderToggle(MRConfig.SpatialAwarenessLayer, "Set default Spatial Awareness layer");
+                PromptForAudioSpatializer();
                 EditorGUILayout.Space();
 
                 if (MixedRealityOptimizeUtils.IsBuildTargetUWP())
@@ -242,6 +246,39 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             MixedRealityProjectConfigurator.ConfigureProject(configurationFilter);
+        }
+
+        /// <summary>
+        /// Provide the user with the list of spatializers that can be selected.
+        /// </summary>
+        private void PromptForAudioSpatializer()
+        {
+            string selectedSpatializer = MixedRealityProjectConfigurator.SelectedSpatializer;
+            List<string> spatializers = new List<string>();
+            spatializers.Add("None");
+            spatializers.AddRange(SpatializerUtilities.InstalledSpatializers);
+            RenderDropDown(MRConfig.AudioSpatializer, "Audio spatializer:", spatializers.ToArray(), ref selectedSpatializer);
+            MixedRealityProjectConfigurator.SelectedSpatializer = selectedSpatializer;
+        }
+
+        private void RenderDropDown(MRConfig configKey, string title, string[] collection, ref string selection)
+        {
+            int index = 0;
+            for (int i = 0; i < collection.Length; i++)
+            {
+                if (collection[i] != selection) { continue; }
+
+                index = i;
+            }
+            index = EditorGUILayout.Popup(title, index, collection, EditorStyles.popup);
+
+            selection = collection[index];
+            if (selection == "None") 
+            {
+                // The uer selected "None", return null. Unity uses this string where null
+                // is the underlying value.
+                selection = null; 
+            }
         }
 
         private void RenderToggle(MRConfig configKey, string title)

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -263,21 +263,33 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private void RenderDropDown(MRConfig configKey, string title, string[] collection, ref string selection)
         {
-            int index = 0;
-            for (int i = 0; i < collection.Length; i++)
+            bool configured = MixedRealityProjectConfigurator.IsConfigured(configKey);
+            using (new EditorGUI.DisabledGroupScope(configured))
             {
-                if (collection[i] != selection) { continue; }
+                if (configured)
+                {
+                    EditorGUILayout.LabelField(new GUIContent($"{title} {selection}", InspectorUIUtility.SuccessIcon));
 
-                index = i;
-            }
-            index = EditorGUILayout.Popup(title, index, collection, EditorStyles.popup);
+                }
+                else
+                {
+                    int index = 0;
+                    for (int i = 0; i < collection.Length; i++)
+                    {
+                        if (collection[i] != selection) { continue; }
 
-            selection = collection[index];
-            if (selection == "None") 
-            {
-                // The uer selected "None", return null. Unity uses this string where null
-                // is the underlying value.
-                selection = null; 
+                        index = i;
+                    }
+                    index = EditorGUILayout.Popup(title, index, collection, EditorStyles.popup);
+
+                    selection = collection[index];
+                    if (selection == "None")
+                    {
+                        // The uer selected "None", return null. Unity uses this string where null
+                        // is the underlying value.
+                        selection = null;
+                    }
+                }
             }
         }
 

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -285,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     selection = collection[index];
                     if (selection == "None")
                     {
-                        // The uer selected "None", return null. Unity uses this string where null
+                        // The user selected "None", return null. Unity uses this string where null
                         // is the underlying value.
                         selection = null;
                     }

--- a/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
+++ b/Assets/MRTK/Core/Inspectors/Setup/MixedRealityProjectConfiguratorWindow.cs
@@ -45,6 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
         private const float Default_Window_Height = 640.0f;
         private const float Default_Window_Width = 400.0f;
+        private const string None = "None";
 
         private readonly GUIContent ApplyButtonContent = new GUIContent("Apply", "Apply configurations to this Unity Project");
         private readonly GUIContent LaterButtonContent = new GUIContent("Later", "Do not show this pop-up notification until next session");
@@ -254,8 +255,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private void PromptForAudioSpatializer()
         {
             string selectedSpatializer = MixedRealityProjectConfigurator.SelectedSpatializer;
-            List<string> spatializers = new List<string>();
-            spatializers.Add("None");
+            List<string> spatializers = new List<string>
+            {
+                None
+            };
             spatializers.AddRange(SpatializerUtilities.InstalledSpatializers);
             RenderDropDown(MRConfig.AudioSpatializer, "Audio spatializer:", spatializers.ToArray(), ref selectedSpatializer);
             MixedRealityProjectConfigurator.SelectedSpatializer = selectedSpatializer;
@@ -282,7 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                     index = EditorGUILayout.Popup(title, index, collection, EditorStyles.popup);
 
                     selection = collection[index];
-                    if (selection == "None")
+                    if (selection == None)
                     {
                         // The user selected "None", return null. Unity uses this string where null
                         // is the underlying value.

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -122,6 +122,36 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         #endregion Run optimal configuration analysis on Play
 
+        #region Project configuration cache
+
+        // This section contains data that gets cached for future reference to help detect configuration
+        // changes that may result in a need to alert the application developer (ex: count of installed
+        // plugins of a specific type). There is no UI in the project settings dialog for these properties.
+
+        private const string AUDIO_SPATIALIZER_COUNT_KEY = "MixedRealityToolkit_Editor_AudioSpatializerCount";
+        private static bool audioSpatializerCountLoaded;
+        private static int audioSpatializerCount;
+
+        /// <summary>
+        /// Should configuration analysis be run and warnings logged when settings don't match MRTK's recommendations?
+        /// </summary>
+        public static int AudioSpatializerCount
+        {
+            get
+            {
+                if (!audioSpatializerCountLoaded)
+                {
+                    audioSpatializerCount = ProjectPreferences.Get(AUDIO_SPATIALIZER_COUNT_KEY, 0);
+                    audioSpatializerCountLoaded = true;
+                }
+
+                return audioSpatializerCount;
+            }
+            set => ProjectPreferences.Set(AUDIO_SPATIALIZER_COUNT_KEY, audioSpatializerCount = value);
+        }
+
+        #endregion Project configuration cache
+
         [SettingsProvider]
         private static SettingsProvider Preferences()
         {

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -147,7 +147,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 return audioSpatializerCount;
             }
-            set => ProjectPreferences.Set(AUDIO_SPATIALIZER_COUNT_KEY, audioSpatializerCount = value);
+            set
+            {
+                audioSpatializerCount = value;
+                ProjectPreferences.Set(AUDIO_SPATIALIZER_COUNT_KEY, audioSpatializerCount);
+            }
         }
 
         #endregion Project configuration cache

--- a/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Preferences/MixedRealityProjectPreferences.cs
@@ -133,8 +133,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static int audioSpatializerCount;
 
         /// <summary>
-        /// Should configuration analysis be run and warnings logged when settings don't match MRTK's recommendations?
+        /// The cached number of audio spatializers that were most recently detected.
         /// </summary>
+        /// <remarks>Used to track when the number of installed spatializers changes.</remarks>
         public static int AudioSpatializerCount
         {
             get

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityProjectConfigurator.cs
@@ -25,6 +25,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         private const string iOSCameraUsageDescription = "Required for augmented reality support.";
 
         /// <summary>
+        /// Property used to indicate the currently selected audio spatializer when
+        /// preparing to configure a Mixed Reality Toolkit project.
+        /// </summary>
+        public static string SelectedSpatializer { get; set; }
+
+        /// <summary>
         /// List of available configurations to check and configure with this utility
         /// </summary>
         public enum Configurations
@@ -38,6 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             OptimalRenderingPath = 5, // using the same value of SinglePassInstancing as a replacement
             SpatialAwarenessLayer,
             EnableMSBuildForUnity,
+            AudioSpatializer,
 
             // WSA Capabilities
             SpatialPerceptionCapability = 1000,
@@ -110,6 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             { Configurations.EnableMSBuildForUnity, new ConfigGetter(PackageManifestUpdater.IsMSBuildForUnityEnabled, BuildTarget.WSAPlayer) },
 #endif // !UNITY_2019_3_OR_NEWER
+            { Configurations.AudioSpatializer, new ConfigGetter(SpatializerUtilities.CheckSettings) },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability, new ConfigGetter(() => GetCapability(PlayerSettings.WSACapability.SpatialPerception), BuildTarget.WSAPlayer) },
@@ -141,6 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 #if !UNITY_2019_3_OR_NEWER
             { Configurations.EnableMSBuildForUnity, PackageManifestUpdater.EnsureMSBuildForUnity },
 #endif // !UNITY_2019_3_OR_NEWER
+            { Configurations.AudioSpatializer, SetAudioSpatializer },
 
             // UWP Capabilities
             { Configurations.SpatialPerceptionCapability,  () => PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true) },
@@ -299,6 +308,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public static bool HasSpatialAwarenessLayer()
         {
             return !string.IsNullOrEmpty(LayerMask.LayerToName(SpatialAwarenessDefaultLayer));
+        }
+
+        /// <summary>
+        /// Configures current Unity project to use the audio spatializer specified by the <see cref="SelectedSpatializer"/> property.
+        /// </summary>
+        public static void SetAudioSpatializer()
+        {
+            SpatializerUtilities.SaveSettings(SelectedSpatializer);
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
@@ -73,8 +74,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return;
             }
 
+            SerializedObject audioMgrSettings = MixedRealityOptimizeUtils.GetSettingsObject("AudioManager");
+            SerializedProperty spatializerPlugin = audioMgrSettings.FindProperty("m_SpatializerPlugin");
+            if (spatializerPlugin == null)
+            {
+                Debug.LogError("Unable to save the spatializer settings. The field could not be located into the Audio Manager settings object.");
+                return;
+            }
+
             AudioSettings.SetSpatializerPluginName(spatializer);
-        }
+            spatializerPlugin.stringValue = spatializer;
+            audioMgrSettings.ApplyModifiedProperties();
+    }
 
         /// <summary>
         /// 

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -28,24 +28,24 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// not the spatializer collection has changed.
         /// </summary>
         /// <returns>
-        /// True if; the selected spatializer is installed and no changes have been made to the collection of installed spatializers.
-        /// False if; There is no selected spatializer, the selected spatializer is no longer installed or the collection of installed spatializers has been changed.
+        /// True if the selected spatializer is installed and no changes have been made to the collection of installed spatializers.
+        /// False if there is no selected spatializer, the selected spatializer is no longer installed or the collection of installed spatializers has been changed.
         /// </returns>
         public static bool CheckSettings()
         {
             string spatializerName = CurrentSpatializer;
 
             // Check to see if an audio spatializer is configured.
-            if (string.IsNullOrWhiteSpace(spatializerName)) 
+            if (string.IsNullOrWhiteSpace(spatializerName))
             {
                 // A spatializer has not been configured.
-                return false; 
+                return false;
             }
 
             string[] installedSpatializers = AudioSettings.GetSpatializerPluginNames();
 
             // Check to see if the configured spatializer is installed.
-            if (!installedSpatializers.Contains<string>(spatializerName))
+            if (!installedSpatializers.Contains(spatializerName))
             {
                 // The current spatializer has been uninstalled.
                 return false;
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void SaveSettings(string spatializer)
         {
-            if (!InstalledSpatializers.Contains<string>(spatializer))
+            if (!InstalledSpatializers.Contains(spatializer))
             {
                 Debug.LogError($"{spatializer} is not an installed spatializer.");
                 return;

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -85,6 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             spatializerPlugin.stringValue = spatializer;
             audioMgrSettings.ApplyModifiedProperties();
 
+            // Cache the count of installed spatializers
             MixedRealityProjectPreferences.AudioSpatializerCount = InstalledSpatializers.Length;
         }
 

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class SpatializerUtilities
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public static string CurrentSpatializer => AudioSettings.GetSpatializerPluginName();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static string[] InstalledSpatializers => AudioSettings.GetSpatializerPluginNames();
+
+        /// <summary>
+        /// Checks to see if the audio spatializer is configured and/or whether or
+        /// not the spatializer collection has changed.
+        /// </summary>
+        /// <returns>
+        /// True if; the selected spatializer is installed and no changes have been made to the collection of installed spatializers.
+        /// False if; There is no selected spatializer, the selected spatializer is no longer installed or the collection of installed spatializers has been changed.
+        /// </returns>
+        public static bool CheckSettings()
+        {
+            string spatializerName = CurrentSpatializer;
+
+            // Check to see if an audio spatializer is configured.
+            if (string.IsNullOrWhiteSpace(spatializerName)) 
+            {
+                // A spatializer has not been configured.
+                return false; 
+            }
+
+            string[] installedSpatializers = AudioSettings.GetSpatializerPluginNames();
+
+            // Check to see if the configured spatializer is installed.
+            if (!installedSpatializers.Contains<string>(spatializerName))
+            {
+                // The current spatializer has been uninstalled.
+                return false;
+            }
+
+            // Next, check to see if the cached collection matches the current install
+            bool collectionIsSmaller = false;
+            if (SpatializerCollectionChanged(out collectionIsSmaller) && 
+                !collectionIsSmaller)
+            {
+                // A new spatializer has been installed.
+                return false;
+            }
+
+            // A spatializer is correctly confiugured.
+            return true;
+        }
+
+        /// <summary>
+        /// Saves the specified spatializer to the audio settings.
+        /// </summary>
+        public static void SaveSettings(string spatializer)
+        {
+            if (!InstalledSpatializers.Contains<string>(spatializer))
+            {
+                Debug.LogError($"{spatializer} is not an installed spatializer.");
+                return;
+            }
+
+            AudioSettings.SetSpatializerPluginName(spatializer);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        private static bool SpatializerCollectionChanged(out bool isSmaller)
+        {
+            isSmaller = false;
+
+            // todo
+
+            return false;
+        }
+    }
+}

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.Toolkit.Editor;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -8,17 +9,17 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
     /// <summary>
-    /// 
+    /// Collection of utilities to manage the configured audio spatializer.
     /// </summary>
     public static class SpatializerUtilities
     {
         /// <summary>
-        /// 
+        /// Returns the name of the currently selected spatializer plugin.
         /// </summary>
         public static string CurrentSpatializer => AudioSettings.GetSpatializerPluginName();
 
         /// <summary>
-        /// 
+        /// Returns the names of installed spatializer plugins.
         /// </summary>
         public static string[] InstalledSpatializers => AudioSettings.GetSpatializerPluginNames();
 
@@ -50,12 +51,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return false;
             }
 
-            // Next, check to see if the cached collection matches the current install
-            bool collectionIsSmaller = false;
-            if (SpatializerCollectionChanged(out collectionIsSmaller) && 
-                !collectionIsSmaller)
+            // Next, check to see if the count of installed spatializers has changed
+            if (!CheckSpatializerCount())
             {
-                // A new spatializer has been installed.
+                // A spatializer has been added or removed.
                 return false;
             }
 
@@ -85,19 +84,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             AudioSettings.SetSpatializerPluginName(spatializer);
             spatializerPlugin.stringValue = spatializer;
             audioMgrSettings.ApplyModifiedProperties();
-    }
+
+            MixedRealityProjectPreferences.AudioSpatializerCount = InstalledSpatializers.Length;
+        }
 
         /// <summary>
-        /// 
+        /// Compares the previous and current count of installed spatializer plugins.
         /// </summary>
-        /// <returns></returns>
-        private static bool SpatializerCollectionChanged(out bool isSmaller)
+        /// <returns>True if the count of installed spatializers is unchanged, false otherwise.</returns>
+        private static bool CheckSpatializerCount()
         {
-            isSmaller = false;
+            int previousCount = MixedRealityProjectPreferences.AudioSpatializerCount;
+            int currentCount = InstalledSpatializers.Length;
 
-            // todo
-
-            return false;
+            return (previousCount == currentCount);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return false;
             }
 
-            string[] installedSpatializers = AudioSettings.GetSpatializerPluginNames();
+            string[] installedSpatializers = InstalledSpatializers;
 
             // Check to see if the configured spatializer is installed.
             if (!installedSpatializers.Contains(spatializerName))

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs.meta
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7cd426f29fe95d43b1549b2a6e6cd92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change enables easy configuration of newly installed audio spatializers, for example https://www.nuget.org/packages/Microsoft.SpatialAudio.Spatializer.Unity, by doing the following

1. Check to see if a spatializer is configured
2. Check to see if the configured spatializer is currently installed
3. Check to see if the count of installed spatializers has changed since the last time the project loaded

In the case of 3, it is possible, in some cases, for the collection to have the same count, yet contain different values. Other than scenario 2 failing, this is outside of the current change scope.

Fixes #6897

Opening to the  branch as this is a frequent request from audio focused customers and makes it easy for non-audio focused customers to select the best spatializer for their scenario.

![image](https://user-images.githubusercontent.com/13281406/80264143-f639bb00-8647-11ea-9d4c-bee035cc3bd1.png)
