### PR TITLE
Scroll View Graduation - Reseting Child Interaction when dragging

### DIFF
--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -373,7 +373,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         public UnityEvent ListMomentumEnded = new UnityEvent();
 
         /// <summary>
-        /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity
+        /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.
         /// </summary>
         [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
         public UnityEvent ListMomentumBegin = new UnityEvent();

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
-using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System.Collections;
@@ -17,7 +16,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// A set of child objects organized in a series of Rows/Columns that can scroll in either the X or Y direction.
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ScrollingObjectCollection")]
-    public class ScrollingObjectCollection : BaseObjectCollection, IMixedRealityPointerHandler, IMixedRealityTouchHandler, IMixedRealitySourceStateHandler, IMixedRealityInputHandler
+    public class ScrollingObjectCollection : BaseObjectCollection,
+        IMixedRealityInputHandler,
+        IMixedRealityInputHandler<Vector2>,
+        IMixedRealityInputHandler<Vector3>,
+        IMixedRealityInputHandler<MixedRealityPose>,
+        IMixedRealityPointerHandler,
+        IMixedRealitySourceStateHandler,
+        IMixedRealityTouchHandler
     {
         /// <summary>
         /// How velocity is applied to a <see cref="ScrollingObjectCollection"/> when a scroll is released.
@@ -367,6 +373,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         public UnityEvent ListMomentumEnded = new UnityEvent();
 
         /// <summary>
+        /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity
+        /// </summary>
+        [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
+        public UnityEvent ListMomentumBegin = new UnityEvent();
+
+        /// <summary>
         /// First item (visible) in the <see cref="ViewableArea"/>. 
         /// </summary>
         public int FirstItemInViewIndex
@@ -516,9 +528,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         // The ray length of original pointer down
         private float pointerHitDistance;
 
-        // This flag is set by PointerUp to prevent InputUp from continuing to propagate. e.g. Interactables
-        private bool shouldSwallowEvents = false;
-
         #endregion scroll state variables
 
         #region drag position calculation variables
@@ -642,7 +651,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 if (!ContainsNode(child) && (child.gameObject.activeSelf || !IgnoreInactiveTransforms))
                 {
-                    NodeList.Add( new ScrollingObjectCollectionNode { Name = child.name, Transform = child, Colliders = child.GetComponentsInChildren<Collider>() });
+                    NodeList.Add(new ScrollingObjectCollectionNode { Name = child.name, Transform = child, Colliders = child.GetComponentsInChildren<Collider>() });
                 }
             }
 
@@ -877,13 +886,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnEnable()
         {
-            // Register for global input events
             if (CoreServices.InputSystem != null)
             {
-                CoreServices.InputSystem.RegisterHandler<IMixedRealityInputHandler>(this);
-                CoreServices.InputSystem.RegisterHandler<IMixedRealityTouchHandler>(this);
-                CoreServices.InputSystem.RegisterHandler<IMixedRealityPointerHandler>(this);
-                CoreServices.InputSystem.RegisterHandler<IMixedRealitySourceStateHandler>(this);
+                // Register for event propagation on trickle down phase in order to handle events before children
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<Vector2>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<Vector3>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<MixedRealityPose>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);               
+
+                // Register for global input events
+                CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
+                CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
             }
 
             if (useOnPreRender)
@@ -945,14 +959,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         avgVelocity = 0.0f;
 
                         isDragging = true;
+                        ListMomentumBegin.Invoke();
                         velocityState = VelocityState.None;
-
-                        // Now that we're dragging, reset the interacted with interactable if it exists
-                        Interactable ixable = initialFocusedObject.GetComponent<Interactable>();
-                        if (ixable != null)
-                        {
-                           ixable.ResetInputTrackingStates();
-                        }
 
                         // Reset initialHandPos to prevent the scroller from jumping
                         initialScrollerPos = workingScrollerPos = scrollContainer.transform.localPosition;
@@ -1040,13 +1048,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnDisable()
         {
-            // Unregister global input events
             if (CoreServices.InputSystem != null)
             {
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealityInputHandler>(this);
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealityTouchHandler>(this);
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealityPointerHandler>(this);
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+                // Unregister for event propagation on trickle down phase
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<Vector2>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<Vector3>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<MixedRealityPose>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
+
+                // Unregister global input events
+                CoreServices.InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+                CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
             }
 
             if (useOnPreRender && cameraMethods != null)
@@ -1411,9 +1424,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // Update simple velocity
             TryGetPointerPositionOnPlane(out Vector3 newPos);
 
-                scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
-                                 ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
-                                 : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
+            scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
+                             ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
+                             : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
 
             // And filter it...
             avgVelocity = (avgVelocity * (1.0f - velocityFilterWeight)) + (scrollVelocity * velocityFilterWeight);
@@ -2067,11 +2080,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
 
             if (!isTouched && isEngaged && animateScroller == null)
-            {   
+            {
                 if (isDragging)
                 {
                     eventData.Use();
-                    shouldSwallowEvents = true;
                     // Its a drag release
                     initialScrollerPos = workingScrollerPos;
                     velocityState = VelocityState.Calculating;
@@ -2130,6 +2142,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // We ignore this event and calculate click in the Update() loop;
         }
 
+        /// <inheritdoc/>
+        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData){}
+
         #endregion IMixedRealityPointerHandler implementation
 
         #region IMixedRealityTouchHandler implementation
@@ -2146,13 +2161,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             currentPointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
             if (currentPointer != null)
             {
-                // Quick check for the global listener to bail if the object is not in the list
-                if (currentPointer.Result?.CurrentPointerTarget == null ||
-                    !ContainsNode(currentPointer.Result?.CurrentPointerTarget.transform))
-                {
-                    return;
-                }
-
                 StopAllCoroutines();
                 animateScroller = null;
 
@@ -2162,53 +2170,31 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     initialPressTime = Time.time;
                     initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
                     initialScrollerPos = scrollContainer.transform.localPosition;
-                    shouldSwallowEvents = true;
 
                     isTouched = true;
                     isEngaged = true;
                     isDragging = false;
 
                     TouchStarted?.Invoke(initialFocusedObject);
-
                 }
             }
-
         }
 
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            // Quick check for the global listener to bail if the object is not in the list
-            if (currentPointer != null && currentPointer.Result?.CurrentPointerTarget != null 
-                && ContainsNode(currentPointer.Result.CurrentPointerTarget.transform))
+            if (isDragging)
             {
-                if (isDragging)
-                {
-                    eventData.Use();
-                }
-                return;
+                eventData.Use();
             }
         }
 
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData)
         {
-            IMixedRealityPointer p = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
-
-            if (p != null)
+            if (isDragging)
             {
-                // Quick check for the global listener to bail if the object is not in the list
-                if (currentPointer == null || 
-                    currentPointer.Result?.CurrentPointerTarget == null ||
-                    !ContainsNode(p.Result.CurrentPointerTarget.transform) || initialFocusedObject != p.Result.CurrentPointerTarget)
-                {
-                    return;
-                }
-
-                if (p == currentPointer && isDragging)
-                {
-                    eventData.Use();
-                }
+                eventData.Use();
             }
         }
 
@@ -2235,20 +2221,54 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData) { }
+        #endregion IMixedRealitySourceStateHandler implementation
 
+        #region IMixedRealityInputHandler implementation
+
+        /// <inheritdoc/>
         void IMixedRealityInputHandler.OnInputUp(InputEventData eventData)
         {
-            if (shouldSwallowEvents)
+            if (isDragging)
             {
-                // Prevents the handled event from PointerUp to continue propagating
                 eventData.Use();
-                shouldSwallowEvents = false;
             }
         }
 
-        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData) { }
+        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
+        {
+            if(isDragging)
+            {
+                eventData.StopPropagation();
+            }
+        }
 
-        #endregion IMixedRealitySourceStateHandler implementation
+        /// <inheritdoc/>
+        public void OnInputChanged(InputEventData<Vector2> eventData)
+        {
+            if (isDragging)
+            {
+                eventData.Use();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnInputChanged(InputEventData<Vector3> eventData)
+        {
+            if (isDragging)
+            {
+                eventData.Use();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnInputChanged(InputEventData<MixedRealityPose> eventData)
+        {
+            if (isDragging)
+            {
+                eventData.Use();
+            }
+        }
+
+        #endregion IMixedRealityInputHandler implementation
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1362,6 +1362,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToMoveEvent(eventData))
             {
+                if (eventData.used)
+                {
+                    ResetInputTrackingStates();
+                    return;
+                }
+
                 if (dragStartPosition == null)
                 {
                     dragStartPosition = inputPosition;
@@ -1546,7 +1552,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            if (!IsEnabled)
+            if (!IsEnabled || eventData.used)
             {
                 return;
             }
@@ -1558,7 +1564,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            if (!IsEnabled)
+            if (!IsEnabled || eventData.used)
             {
                 return;
             }
@@ -1568,7 +1574,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
             eventData.Use();
         }
 
-        public void OnTouchUpdated(HandTrackingInputEventData eventData) { }
+        public void OnTouchUpdated(HandTrackingInputEventData eventData)
+        {
+            if (IsEnabled && eventData.used && ShouldListenToMoveEvent(eventData))
+            {
+                ResetInputTrackingStates();
+                return;
+            }
+        }
 
         #endregion TouchHandlers
 
@@ -1584,6 +1597,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToUpDownEvent(eventData))
             {
+                if (eventData.used)
+                {
+                    ResetInputTrackingStates();
+                    return;
+                }
+
                 SetInputUp();
                 if (IsInputFromNearInteraction(eventData))
                 {
@@ -1605,6 +1624,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToUpDownEvent(eventData))
             {
+                if (eventData.used)
+                {
+                    ResetInputTrackingStates();
+                    return;
+                }
+
                 pressingInputSources.Add(eventData.InputSource);
                 SetInputDown();
                 HasGrab = IsInputFromNearInteraction(eventData);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -304,6 +304,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
             UpdatePressedState(currentPushDistance);
         }
 
+        private void ResetInteraction()
+        {
+            touchPoints.Clear();
+            currentInputSources.Clear();
+            IsTouching = false;
+            IsPressing = false;
+        }
+
         private void RetractButton()
         {
             float retractDistance = currentPushDistance - startPushDistance;
@@ -368,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         void IMixedRealityTouchHandler.OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            if (touchPoints.ContainsKey(eventData.Controller))
+            if (touchPoints.ContainsKey(eventData.Controller) || eventData.used)
             {
                 return;
             }
@@ -395,13 +403,26 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (touchPoints.ContainsKey(eventData.Controller))
             {
-                touchPoints[eventData.Controller] = eventData.InputData;
-                eventData.Use();
+                if (eventData.used)
+                {
+                    ResetInteraction();
+                }
+                else
+                {
+                    touchPoints[eventData.Controller] = eventData.InputData;
+                }
             }
+            eventData.Use();
+            return;
         }
 
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
+            if(eventData.used)
+            {
+                return;
+            }
+
             if (touchPoints.ContainsKey(eventData.Controller))
             {
                 // When focus is lost, before removing controller, update the respective touch point to give a last chance for checking if pressed occurred 

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Experimental.UI;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using System.Collections;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class ScrollViewTests : BasePlayModeTests
+    {
+        #region Tests
+
+        /// <summary>
+        /// Tests if interaction with a pressable button is reset after scroll drag is engaged
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollEngageResetsNearInteractionwithChildren()
+        {
+            // Setting up scroll view object with two pressable button children
+            GameObject scrollObject = new GameObject();
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.parent = scrollObject.transform;
+
+            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button3.transform.parent = scrollObject.transform;
+
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.Tiers = 1;
+            scrollView.ViewableArea = 2;
+            scrollView.HandDeltaMagThreshold = scrollView.CellHeight * 0.2f;
+            scrollView.UpdateCollection();
+
+            scrollObject.transform.position = Vector3.forward;
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            PressableButton buttonComponent = button1.GetComponentInChildren<PressableButton>();
+
+            Assert.IsNotNull(buttonComponent);
+
+            bool buttonTouchBegin = false;
+            buttonComponent.TouchBegin.AddListener(() =>
+            {
+                buttonTouchBegin = true;
+            });
+
+            bool buttonTouchEnd = false;
+            buttonComponent.TouchEnd.AddListener(() =>
+            {
+                buttonTouchEnd = true;
+            });
+
+            bool buttonPressBegin = false;
+            buttonComponent.ButtonPressed.AddListener(() =>
+            {
+                buttonPressBegin = true;
+            });
+
+            bool buttonPressCompleted = false;
+            buttonComponent.ButtonReleased.AddListener(() =>
+            {
+                buttonPressCompleted = true;
+            });
+
+            bool scrollDragBegin = false;
+            scrollView.ListMomentumBegin.AddListener(() =>
+            {
+                scrollDragBegin = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 buttonPos = buttonComponent.transform.position;
+            Vector3 startHandPos = buttonPos + new Vector3(0, 0, buttonComponent.StartPushDistance - offset); // Just before touch
+            Vector3 onPressPos = buttonPos + new Vector3(0, 0, buttonComponent.PressDistance + offset); // Past press plane         
+            Vector3 onScrollEngagedPos = onPressPos + new Vector3(0, -(scrollView.HandDeltaMagThreshold + offset), 0); // Engaging in scroll drag
+
+            // If scroll drag not yet engaged then child button interaction should behave normally
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(startHandPos);
+            yield return hand.MoveTo(onPressPos);
+            yield return hand.MoveTo(startHandPos);
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.IsTrue(buttonTouchBegin, "Button touch begin did not trigger.");
+            Assert.IsTrue(buttonPressBegin, "Button press begin did not trigger.");
+            Assert.IsTrue(buttonPressCompleted, "Button press release did not trigger.");
+
+            yield return hand.Hide();
+
+            Assert.IsTrue(buttonTouchEnd, "Button touch end did not trigger.");
+
+            // Reset values
+            buttonTouchBegin = false;
+            buttonTouchEnd = false;
+            buttonPressBegin = false;
+            buttonPressCompleted = false;
+            scrollDragBegin = false;
+
+            // Scroll drag engage should halt interaction with any child button            
+            yield return hand.Show(startHandPos);
+            yield return hand.MoveTo(onPressPos);
+            
+            Assert.IsTrue(buttonTouchBegin, "Button touch begin did not trigger.");
+            Assert.IsTrue(buttonPressBegin, "Button press begin did not trigger.");
+
+            yield return hand.MoveTo(onScrollEngagedPos);
+
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin dit not trigger.");
+            Assert.IsTrue(buttonTouchEnd, "Button touch end did not trigger.");
+            Assert.IsFalse(buttonPressCompleted, "Button press release did not trigger.");
+
+            yield return hand.Hide();
+        }
+
+        /// <summary>
+        /// Tests if interaction triggered by far pointer on interactable object is reset after scroll is engaged
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollEngageResetsFarInteractionwithChildren()
+        {          
+            // Setting up scroll view object with two pressable button children
+            GameObject scrollObject = new GameObject();
+            float scale = 10f;
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.localScale *= scale;
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.localScale *= scale;
+            button2.transform.parent = scrollObject.transform;
+
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
+            scrollView.Tiers = 1;
+            scrollView.ViewableArea = 1;
+            scrollView.HandDeltaMagThreshold = scrollView.CellHeight * 0.2f;
+            scrollView.UpdateCollection();
+
+            scrollObject.transform.position = Vector3.forward;
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            Interactable interactableComponent1 = button1.GetComponent<Interactable>();
+
+            Assert.IsNotNull(interactableComponent1);
+
+            bool scrollDragBegin = false;
+            scrollView.ListMomentumBegin.AddListener(() =>
+            {
+                scrollDragBegin = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 buttonPos = interactableComponent1.transform.position;
+            Vector3 startHandPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
+            Vector3 onScrollEngagedPos = startHandPos + new Vector3(0, -(scrollView.HandDeltaMagThreshold + offset), 0); // Engaging in scroll drag
+
+            // If scroll drag not yet engaged child button interaction should behave normally
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(startHandPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
+            Assert.IsTrue(interactableComponent1.HasPress, "Interactable did not get press from far interaction.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered");
+            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
+            Assert.IsFalse(interactableComponent1.HasPress, "Interactable still have press from far interaction.");
+
+            // Scroll drag engage should halt interaction with any child button 
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
+            Assert.IsTrue(interactableComponent1.HasPress, "Interactable did not get press from far interaction.");
+
+            yield return hand.MoveTo(onScrollEngagedPos);
+
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin was not triggered");
+            Assert.IsFalse(interactableComponent1.HasFocus, "Interactable still have far pointer focus.");
+            Assert.IsFalse(interactableComponent1.HasPress, "Interactable still have press from far interaction.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.Hide();
+        }
+
+        #endregion Tests
+
+        #region Utilities
+
+        private GameObject InstantiatePrefab(string path)
+        {
+            Object buttonPrefab = AssetDatabase.LoadAssetAtPath(path, typeof(Object));
+            GameObject button = Object.Instantiate(buttonPrefab) as GameObject;
+
+            return button;
+        }
+
+        #endregion Utilities
+    }
+}

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 521754bf45dc6e149978d1e7b7a907e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
This PR is part of Scroll View graduation and addresses issues related to interaction with children elements after scroll view is engaged into drag:

1. Pressable Buttons never trigger OnPressCompleted. 
When a collection of pressable buttons is added to ScrollingObjectCollection, OnPressCompleted event fire is insconsistent.

2. Pressable buttons do not reset their state after input is cancelled.
When a pressable button inside a ScrollingObjectCollection is pressed, button reset (retract) is not happening. This happens if user presses the button slowly, if user engages in a scroll right after button press, or if input is cancelled.

3. Scroll engage should stop any content interaction 

## Solution proposed

 Using the event propagation feature branch, scroll view can register for touch events on trickle down phase allowing it to catch touch events before its children. If scroll view is engaged in drag, it calls eventData.Use() allowing children to handle cancellation if event is used. On Propagation branch event propagation is only stopped by calling eventData.StopPropagation(), so we are using eventData.used as a flag for cancellation. 

 * More performant and clear option could be to create and use an interface for interactable cancellation and raise something like an ICancellable.CancelInteraction  and StopPropagation after cancellation sent. 

## Changes
The PR is based on Event Propagation feature branch.

Fixes #7444
Fixes #7445
Fixes #7446
