### PR TITLE
Gaze cursor now disabled when simulated articualted hands are in view

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef
@@ -3,7 +3,9 @@
     "references": [
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Gltf",
-        "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared"
+        "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared",
+        "Microsoft.MixedReality.Toolkit.Services.InputSimulation",
+        "Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.asmdef
@@ -3,9 +3,7 @@
     "references": [
         "Microsoft.MixedReality.Toolkit",
         "Microsoft.MixedReality.Toolkit.Gltf",
-        "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared",
-        "Microsoft.MixedReality.Toolkit.Services.InputSimulation",
-        "Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor"
+        "Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -393,13 +393,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 GestureRecognizerEnabled = true;
             }
-
-            // Disable the simulated gaze since it is no longer controlled by the input simulation service
-            InputSimulationService inputSimulationService = CoreServices.GetInputSystemDataProvider<InputSimulationService>();
-            if (inputSimulationService != null)
-            {
-                inputSimulationService.SimulateGaze = false;
-            }
         }
 
         private static readonly ProfilerMarker GetOrAddControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityDeviceManager.GetOrAddController");

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -393,6 +393,13 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             {
                 GestureRecognizerEnabled = true;
             }
+
+            // Disable the simulated gaze since it is no longer controlled by the input simulation service
+            InputSimulationService inputSimulationService = CoreServices.GetInputSystemDataProvider<InputSimulationService>();
+            if (inputSimulationService != null)
+            {
+                inputSimulationService.SimulateGaze = false;
+            }
         }
 
         private static readonly ProfilerMarker GetOrAddControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityDeviceManager.GetOrAddController");

--- a/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
@@ -136,10 +136,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool SimulateEyePosition { get; set; }
 
-        /// If true then the gaze data provider is always simulated.
-        /// </summary>
-        public bool SimulateGaze { get; set; }
-
         /// <summary>
         /// <summary>
         /// If true then keyboard and mouse input are used to simulate hands.
@@ -345,7 +341,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     UpdateHandDevice(HandSimulationMode, Handedness.Right, HandDataRight);
 
                     // HandDataGaze is only enabled if the user is simulating via mouse and keyboard
-                    if (UserInputEnabled && SimulateGaze && !(HandDataLeft.IsTracked || HandDataRight.IsTracked))
+                    if (UserInputEnabled && !XRDevice.isPresent && !(HandDataLeft.IsTracked || HandDataRight.IsTracked))
                         UpdateHandDevice(HandSimulationMode.Gestures, Handedness.None, HandDataGaze);
                     lastHandUpdateTimestamp = currentTime.Ticks;
                 }

--- a/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
@@ -137,7 +137,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public bool SimulateEyePosition { get; set; }
 
         /// <summary>
-        /// <summary>
         /// If true then keyboard and mouse input are used to simulate hands.
         /// </summary>
         public bool UserInputEnabled { get; set; } = true;

--- a/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
@@ -136,6 +136,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool SimulateEyePosition { get; set; }
 
+        /// If true then the gaze data provider is always simulated.
+        /// </summary>
+        public bool SimulateGaze { get; set; }
+
+        /// <summary>
         /// <summary>
         /// If true then keyboard and mouse input are used to simulate hands.
         /// </summary>
@@ -340,7 +345,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     UpdateHandDevice(HandSimulationMode, Handedness.Right, HandDataRight);
 
                     // HandDataGaze is only enabled if the user is simulating via mouse and keyboard
-                    if (UserInputEnabled)
+                    if (UserInputEnabled && SimulateGaze && !(HandDataLeft.IsTracked || HandDataRight.IsTracked))
                         UpdateHandDevice(HandSimulationMode.Gestures, Handedness.None, HandDataGaze);
                     lastHandUpdateTimestamp = currentTime.Ticks;
                 }

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -148,7 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(!iss.HandDataRight.IsTracked);
             Assert.True(iss.HandDataLeft.IsTracked);
 
-            //Make sure gaze cursor is not visible
+            // Make sure gaze cursor is not visible
             Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // start click

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -87,6 +87,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             TestUtilities.PlayspaceToOriginLookingForward();
             yield return null;
 
+            // Check that gaze cursor is initially visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
             // Begin right hand manipulation
             KeyInputSystem.PressKey(iss.InputSimulationProfile.RightHandManipulationKey);
             yield return null;
@@ -96,6 +99,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             // Make sure right hand is tracked
             Assert.True(iss.HandDataRight.IsTracked);
             Assert.True(!iss.HandDataLeft.IsTracked);
+
+            //Make sure gaze cursor is not visible
+            Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // start click
             KeyInputSystem.PressKey(iss.InputSimulationProfile.InteractionButton);
@@ -128,6 +134,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(!iss.HandDataRight.IsTracked);
             Assert.True(!iss.HandDataLeft.IsTracked);
 
+            // Check that gaze cursor is visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
             // Repeat with left hand
             // Begin left hand manipulation
             KeyInputSystem.PressKey(iss.InputSimulationProfile.LeftHandManipulationKey);
@@ -138,6 +147,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             // Make sure left hand is tracked
             Assert.True(!iss.HandDataRight.IsTracked);
             Assert.True(iss.HandDataLeft.IsTracked);
+
+            //Make sure gaze cursor is not visible
+            Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // start click
             KeyInputSystem.PressKey(iss.InputSimulationProfile.InteractionButton);
@@ -171,6 +183,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(!iss.HandDataRight.IsTracked);
             Assert.True(!iss.HandDataLeft.IsTracked);
 
+            // Check that gaze cursor is visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
+
             // Lastly with 2 hands
             // Begin hand manipulation
             KeyInputSystem.PressKey(iss.InputSimulationProfile.RightHandManipulationKey);
@@ -182,6 +197,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             // Make sure hands are tracked
             Assert.True(iss.HandDataRight.IsTracked);
             Assert.True(iss.HandDataLeft.IsTracked);
+
+            //Make sure gaze cursor is not visible
+            Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // start click
             KeyInputSystem.PressKey(iss.InputSimulationProfile.InteractionButton);
@@ -216,6 +234,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             // Make sure hands are not tracked
             Assert.True(!iss.HandDataRight.IsTracked);
             Assert.True(!iss.HandDataLeft.IsTracked);
+
+            // Check that gaze cursor is visible
+            Assert.True(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
         }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(iss.HandDataRight.IsTracked);
             Assert.True(!iss.HandDataLeft.IsTracked);
 
-            //Make sure gaze cursor is not visible
+            // Make sure gaze cursor is not visible
             Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // start click

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -198,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.True(iss.HandDataRight.IsTracked);
             Assert.True(iss.HandDataLeft.IsTracked);
 
-            //Make sure gaze cursor is not visible
+            // Make sure gaze cursor is not visible
             Assert.True(!CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible);
 
             // start click


### PR DESCRIPTION
##  Overview
Made it so the simulated gaze cursor will no longer appear if articulated hands are in view. Fix is specifically to address regression with holographic emulation in 2018.4

## Changes
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7715
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7742
