### PR TITLE
IsNull check for interfaces

### DIFF
--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -61,6 +61,6 @@ namespace Microsoft.MixedReality.Toolkit
         /// Properly checks an interface for null and returns the MonoBehaviour implementing it
         /// </summary>
         /// <returns> True if the implementer of the interface is not a MonoBehaviour or the MonoBehaviour is null</returns>
-        public static bool IsNull<T>(this T @interface, out MonoBehaviour monoBehaviour) where T : class => (monoBehaviour = @interface as MonoBehaviour) == null;
+        public static bool TryGetMonoBehaviour<T>(this T @interface, out MonoBehaviour monoBehaviour) where T : class => (monoBehaviour = @interface as MonoBehaviour) != null;
     }
 }

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -51,12 +51,9 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Tests if the Unity object is null. Checks both the managed object and the underly Unity-managed native object
+        /// Tests interfaces for null even when they are implemented by a UnityEngine.Object derived class, which overrides the Equals operator
         /// </summary>
         /// <returns>True if either the managed or native object is null, false otherwise</returns>
-        public static bool IsNull(Object obj)
-        {
-            return obj == null || obj.Equals(null);
-        }
+        public static bool IsNull<T>(T obj) where T : class => obj == null || obj.Equals(null);
     }
 }

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Tests interfaces for null even when they are implemented by a UnityEngine.Object derived class, which overrides the Equals operator
+        /// Tests if an interfaces is null taking potential UnityEngine.Object derived class implementers into account
         /// </summary>
         /// <returns>True if either the managed or native object is null, false otherwise</returns>
         public static bool IsNull<T>(T obj) where T : class => obj == null || obj.Equals(null);

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -55,6 +55,6 @@ namespace Microsoft.MixedReality.Toolkit
         /// which require their overridden operators to be called
         /// </summary>
         /// <returns>True if either the managed or native object is null, false otherwise</returns>
-        public static bool IsNull<T>(T obj) where T : class => obj == null || obj.Equals(null);
+        public static bool IsNull<T>(this T obj) where T : class => obj == null || obj.Equals(null);
     }
 }

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -51,7 +51,8 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Tests if an interfaces is null taking potential UnityEngine.Object derived class implementers into account
+        /// Tests if an interface is null, taking potential UnityEngine.Object derived class implementers into account
+        /// which require their overridden operators to be called
         /// </summary>
         /// <returns>True if either the managed or native object is null, false otherwise</returns>
         public static bool IsNull<T>(T obj) where T : class => obj == null || obj.Equals(null);

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -55,6 +55,12 @@ namespace Microsoft.MixedReality.Toolkit
         /// which require their overridden operators to be called
         /// </summary>
         /// <returns>True if either the managed or native object is null, false otherwise</returns>
-        public static bool IsNull<T>(this T obj) where T : class => obj == null || obj.Equals(null);
+        public static bool IsNull<T>(this T @interface) where T : class => @interface == null || @interface.Equals(null);
+        
+        /// <summary>
+        /// Properly checks an interface for null and returns the MonoBehaviour implementing it
+        /// </summary>
+        /// <returns> True if the implementer of the interface is not a MonoBehaviour or the MonoBehaviour is null</returns>
+        public static bool IsNull<T>(this T @interface, out MonoBehaviour monoBehaviour) where T : class => (monoBehaviour = @interface as MonoBehaviour) == null;
     }
 }

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -327,7 +327,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 while (enumerator.MoveNext())
                 {
                     var pointer = enumerator.Current.Key;
-                    if (!pointer.IsNull())
+                    if (pointer.IsNull())
                     {
                         removal.Add(pointer);
                     }

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -161,8 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Loop through active pointers in scene, destroy all gameobjects and clear our tracking dictionary
             foreach (var pointer in activePointersToConfig.Keys)
             {
-                var pointerComponent = pointer as MonoBehaviour;
-                if (pointerComponent != null)
+                if (!pointer.IsNull(out MonoBehaviour pointerComponent))
                 {
                     GameObjectExtensions.DestroyGameObject(pointerComponent.gameObject);
                 }
@@ -203,8 +202,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             while (pointerCache.Count > 0)
                             {
                                 var p = pointerCache.Pop();
-                                var pointerComponent = p as MonoBehaviour;
-                                if (pointerComponent != null)
+                                if (!p.IsNull(out MonoBehaviour pointerComponent))
                                 {
                                     pointerComponent.gameObject.SetActive(true);
 
@@ -253,8 +251,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     for (int i = 0; i < pointers.Length; i++)
                     {
                         var pointer = pointers[i];
-                        var pointerComponent = pointer as MonoBehaviour;
-                        if (pointerComponent != null)
+                        if (!pointers[i].IsNull(out MonoBehaviour pointerComponent))
                         {
                             // Unfortunately, it's possible the gameobject source is *being* destroyed so we are not null now but will be soon.
                             // At least if this is a controller we know about and we expect it to be destroyed, skip
@@ -329,10 +326,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var enumerator = activePointersToConfig.GetEnumerator();
                 while (enumerator.MoveNext())
                 {
-                    var pointerComponent = enumerator.Current.Key as MonoBehaviour;
-                    if (pointerComponent == null)
+                    var pointer = enumerator.Current.Key;
+                    if (!pointer.IsNull())
                     {
-                        removal.Add(enumerator.Current.Key);
+                        removal.Add(pointer);
                     }
                 }
 
@@ -352,8 +349,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 while (pointerConfigurations[i].cache.Count > 0)
                 {
-                    var pointerComponent = pointerConfigurations[i].cache.Pop() as MonoBehaviour;
-                    if (pointerComponent != null)
+                    if (!pointerConfigurations[i].cache.Pop().IsNull(out MonoBehaviour pointerComponent))
                     {
                         GameObjectExtensions.DestroyGameObject(pointerComponent.gameObject);
                     }

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -161,7 +161,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // Loop through active pointers in scene, destroy all gameobjects and clear our tracking dictionary
             foreach (var pointer in activePointersToConfig.Keys)
             {
-                if (!pointer.IsNull(out MonoBehaviour pointerComponent))
+                if (pointer.TryGetMonoBehaviour(out MonoBehaviour pointerComponent))
                 {
                     GameObjectExtensions.DestroyGameObject(pointerComponent.gameObject);
                 }
@@ -202,7 +202,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             while (pointerCache.Count > 0)
                             {
                                 var p = pointerCache.Pop();
-                                if (!p.IsNull(out MonoBehaviour pointerComponent))
+                                if (p.TryGetMonoBehaviour(out MonoBehaviour pointerComponent))
                                 {
                                     pointerComponent.gameObject.SetActive(true);
 
@@ -251,7 +251,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     for (int i = 0; i < pointers.Length; i++)
                     {
                         var pointer = pointers[i];
-                        if (!pointers[i].IsNull(out MonoBehaviour pointerComponent))
+                        if (pointers[i].TryGetMonoBehaviour(out MonoBehaviour pointerComponent))
                         {
                             // Unfortunately, it's possible the gameobject source is *being* destroyed so we are not null now but will be soon.
                             // At least if this is a controller we know about and we expect it to be destroyed, skip
@@ -349,7 +349,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 while (pointerConfigurations[i].cache.Count > 0)
                 {
-                    if (!pointerConfigurations[i].cache.Pop().IsNull(out MonoBehaviour pointerComponent))
+                    if (pointerConfigurations[i].cache.Pop().TryGetMonoBehaviour(out MonoBehaviour pointerComponent))
                     {
                         GameObjectExtensions.DestroyGameObject(pointerComponent.gameObject);
                     }

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             foreach (var pointer in activePointersToConfig.Keys)
             {
                 var pointerComponent = pointer as MonoBehaviour;
-                if (!UnityObjectExtensions.IsNull(pointerComponent))
+                if (pointerComponent != null)
                 {
                     GameObjectExtensions.DestroyGameObject(pointerComponent.gameObject);
                 }
@@ -204,7 +204,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                             {
                                 var p = pointerCache.Pop();
                                 var pointerComponent = p as MonoBehaviour;
-                                if (!UnityObjectExtensions.IsNull(pointerComponent))
+                                if (pointerComponent != null)
                                 {
                                     pointerComponent.gameObject.SetActive(true);
 
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         var pointer = pointers[i];
                         var pointerComponent = pointer as MonoBehaviour;
-                        if (!UnityObjectExtensions.IsNull(pointerComponent))
+                        if (pointerComponent != null)
                         {
                             // Unfortunately, it's possible the gameobject source is *being* destroyed so we are not null now but will be soon.
                             // At least if this is a controller we know about and we expect it to be destroyed, skip
@@ -329,8 +329,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 var enumerator = activePointersToConfig.GetEnumerator();
                 while (enumerator.MoveNext())
                 {
-                    var pointer = enumerator.Current.Key as MonoBehaviour;
-                    if (UnityObjectExtensions.IsNull(pointer))
+                    var pointerComponent = enumerator.Current.Key as MonoBehaviour;
+                    if (pointerComponent != null)
                     {
                         removal.Add(enumerator.Current.Key);
                     }
@@ -353,7 +353,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 while (pointerConfigurations[i].cache.Count > 0)
                 {
                     var pointerComponent = pointerConfigurations[i].cache.Pop() as MonoBehaviour;
-                    if (!UnityObjectExtensions.IsNull(pointerComponent))
+                    if (pointerComponent != null)
                     {
                         GameObjectExtensions.DestroyGameObject(pointerComponent.gameObject);
                     }

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -330,7 +330,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 while (enumerator.MoveNext())
                 {
                     var pointerComponent = enumerator.Current.Key as MonoBehaviour;
-                    if (pointerComponent != null)
+                    if (pointerComponent == null)
                     {
                         removal.Add(enumerator.Current.Key);
                     }

--- a/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
+++ b/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
@@ -193,11 +193,13 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 {
                     var audioInfluencer = previousInfluencers[i];
 
-                    // Remove influencers that are no longer in line of sight
-                    // OR
-                    // Have been disabled
+                    // Remove influencers that are
+                    // no longer in line of sight,
+                    // have been destroyed,
+                    // or have been disabled
                     if (!influencers.Contains(audioInfluencer) ||
-                        (!audioInfluencer.IsNull(out MonoBehaviour mbPrev) && !mbPrev.isActiveAndEnabled))
+                        !audioInfluencer.TryGetMonoBehaviour(out MonoBehaviour mbPrev) ||
+                        !mbPrev.isActiveAndEnabled)
                     {
                         influencersToRemove.Add(audioInfluencer);
                     }

--- a/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
+++ b/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
@@ -191,15 +191,15 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                 List<IAudioInfluencer> influencersToRemove = new List<IAudioInfluencer>();
                 for (int i = 0; i < previousInfluencers.Count; i++)
                 {
-                    MonoBehaviour mbPrev = previousInfluencers[i] as MonoBehaviour;
+                    var audioInfluencer = previousInfluencers[i];
 
                     // Remove influencers that are no longer in line of sight
                     // OR
                     // Have been disabled
-                    if (!influencers.Contains(previousInfluencers[i]) ||
-                        ((mbPrev != null) && !mbPrev.isActiveAndEnabled))
+                    if (!influencers.Contains(audioInfluencer) ||
+                        (!audioInfluencer.IsNull(out MonoBehaviour mbPrev) && !mbPrev.isActiveAndEnabled))
                     {
-                        influencersToRemove.Add(previousInfluencers[i]);
+                        influencersToRemove.Add(audioInfluencer);
                     }
                 }
                 RemoveInfluencers(influencersToRemove);

--- a/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
@@ -283,7 +283,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return TestButtonUtilities.TestClickPushButton(interactable.transform, targetStartPosition, translateTargetObject);
 
             Assert.IsTrue(wasClicked);
-            Assert.IsTrue(UnityObjectExtensions.IsNull(rightPokePointer));
+            Assert.IsTrue(rightPokePointer == null);
             Assert.IsNull(PlayModeTestUtilities.GetPointer<PokePointer>(Handedness.Right));
 
             wasClicked = false;
@@ -320,7 +320,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return TestButtonUtilities.TestClickPushButton(interactable.transform, targetStartPosition, translateTargetObject);
 
             Assert.IsTrue(wasClicked);
-            Assert.IsTrue(UnityObjectExtensions.IsNull(rightPokePointer));
+            Assert.IsTrue(rightPokePointer == null);
             Assert.IsNull(PlayModeTestUtilities.GetPointer<PokePointer>(Handedness.Right));
 
             wasClicked = false;


### PR DESCRIPTION
## Overview
Unity overrides a couple of operators to deal with the managed and native situation of objects. This is problematic when checking an interface for null as it does not take the implementer operators into account.
This PR adds a convenient way to check interfaces for null that have potentially been implemented by MonoBehaviours

I addition, it removes unnecessarily complicated null checks in locations where MonoBehaviours are used anyways

## Changes
- Fixes: #5981


## Verification
 ```
IEnumerator Start()
    {
        GameObject test = new GameObject("tester", typeof(Test));
        ICollection @interface = test.GetComponent<ICollection>();
        Destroy(test);
        yield return null;
        Debug.Log(@interface == null);
        Debug.Log(@interface.Equals(null));
        Debug.Log(IsNull(@interface));
    }
```