### PR TITLE
Extension service creator tool defaults to a null path if Generated/Extensions does not previously exist

### DIFF
--- a/Assets/MRTK/Tests/EditModeTests/Tools.meta
+++ b/Assets/MRTK/Tests/EditModeTests/Tools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ffe3eb3c0c93944589e778215824c53
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/EditModeTests/Tools/ExtensionServiceCreatorTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Tools/ExtensionServiceCreatorTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Editor;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.Editor
+{
+    public class ExtensionServiceCreatorTests
+    {
+
+        private const string DefaultGeneratedFolder = "MixedRealityToolkit.Generated";
+        private const string DefaultExtensionFolder = "MixedRealityToolkit.Generated/ExtensionFolder";
+        private bool GeneratedFolderExisted = false;
+        private bool ExtensionFolderExisted = false;
+        
+        [TearDown]
+        public void TearDown()
+        {
+            // Only do extension folder cleanup if it hadn't already existed (i.e. to avoid
+            // destroying local contributor state).
+            if (!ExtensionFolderExisted)
+            {
+                // If the generated folder also didn't exist prior to the test running, then
+                // we need to clean it up (to fully clean up state created by the test)
+                if (!GeneratedFolderExisted)
+                {
+                    DeleteFolderAndMeta(DefaultGeneratedFolder);
+                }
+                else
+                {
+                    // Otherwise, the generated folder already existed, we just need to clean
+                    // up the extensions folder that we created.
+                    DeleteFolderAndMeta(DefaultExtensionFolder);
+                }
+
+                AssetDatabase.Refresh();
+            }
+        }
+
+        [Test]
+        public void TestCreateDefaultFolder()
+        {
+            GeneratedFolderExisted = AssetDatabase.IsValidFolder(Path.Combine("Assets", DefaultGeneratedFolder));
+            ExtensionFolderExisted = AssetDatabase.IsValidFolder(Path.Combine("Assets", DefaultExtensionFolder));
+            
+            // This test intentionally no-ops in the case that the extension folder already exists - we
+            // don't to destroy local state, or risk bugs in moving that temporarily. This test is designed
+            // to work on a fresh clone (i.e. on CI).
+            if (ExtensionFolderExisted)
+            {
+                return;
+            }
+            
+            ExtensionServiceCreator creator = new ExtensionServiceCreator();
+            creator.ValidateAssets(new List<string>());
+            Assert.IsNotNull(creator.ServiceFolderObject);
+        }
+
+        private static void DeleteFolderAndMeta(string folder)
+        {
+            string resolvedFolder = Path.Combine(Application.dataPath, folder);
+            string resolvedFolderMeta = resolvedFolder + ".meta";
+            Directory.Delete(resolvedFolder, true);
+            File.Delete(resolvedFolderMeta);
+        }
+    }
+}

--- a/Assets/MRTK/Tests/EditModeTests/Tools/ExtensionServiceCreatorTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Tools/ExtensionServiceCreatorTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Editor;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
@@ -65,8 +66,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Editor
         {
             string resolvedFolder = Path.Combine(Application.dataPath, folder);
             string resolvedFolderMeta = resolvedFolder + ".meta";
-            Directory.Delete(resolvedFolder, true);
-            File.Delete(resolvedFolderMeta);
+            try
+            {
+                Directory.Delete(resolvedFolder, true);
+                File.Delete(resolvedFolderMeta);
+            }
+            catch (Exception)
+            {
+                // It's possible that these things could have been deleted outside of the test
+                // process, so don't fail the test if that happened.
+            }
         }
     }
 }

--- a/Assets/MRTK/Tests/EditModeTests/Tools/ExtensionServiceCreatorTests.cs.meta
+++ b/Assets/MRTK/Tests/EditModeTests/Tools/ExtensionServiceCreatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fae73fd2bfc78d745a529c1fbd213a2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -435,6 +435,11 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 
                 AssetDatabase.CreateFolder(generatedFolder, DefaultExtensionsFolderName);
                 AssetDatabase.Refresh();
+
+                // Setting the default folders is necessary after the asset database refresh
+                // to ensure that the extension service creator's consumers will not need
+                // to manually set the location in a separate step.
+                SetAllFolders(ExtensionsFolder);
             }
 
             return errors.Count == 0;


### PR DESCRIPTION
## Overview
The extension service creator has an issue where the destination folder is null if the generated folder doesn't exist at the time of the wizard invocation. It turns out that the wizard is actually creating the folder, but it never re-sets its internal state after generating the default folder, which leads to this bug.

The fix here is to actually force a reconciliation of default folder state after creating the default extension folder.

This also adds a test to verify that it happens. Note that the test doesn't run in all cases - if you already have some local extension generated folder, it will no-op (to avoid blowing away local state). Still, this test should run on CI which will at least ensure that we have coverage of weird stuff happening.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7530