### PR TITLE
Add a namespace validation check to our CI scripts

### DIFF
--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -338,7 +338,8 @@ function IsNamespace {
         [string]$Line
     )
     process {
-        if ($Line -match "^namespace\s[a-zA-Z.]+") {
+        if (($Line -match "^namespace\sMicrosoft\.MixedReality\.Toolkit") -or
+            ($Line -match "^namespace\sMicrosoft\.Windows\.MixedReality")) {
             $true;
         }
         $false;

--- a/scripts/ci/validatecode.ps1
+++ b/scripts/ci/validatecode.ps1
@@ -328,6 +328,23 @@ function CheckForAssemblyInfo {
     }
 }
 
+<#
+.SYNOPSIS
+    Returns true if the given line is a namespace declaration
+#>
+function IsNamespace {
+    [CmdletBinding()]
+    param(
+        [string]$Line
+    )
+    process {
+        if ($Line -match "^namespace\s[a-zA-Z.]+") {
+            $true;
+        }
+        $false;
+    }
+}
+
 function CheckScript {
     [CmdletBinding()]
     param(
@@ -339,6 +356,7 @@ function CheckScript {
         # repeatedly running this script, discovering a single issue, fixing it, and then
         # re-running the script
         $containsIssue = $false
+        $containsNamespaceDeclaration = $false;
         $fileContent = Get-Content $FileName
         for ($i = 0; $i -lt $fileContent.Length; $i++) {
             if (CheckBooLang $FileName $fileContent $i) {
@@ -353,6 +371,15 @@ function CheckScript {
             if (CheckSpacelessComments $FileName $fileContent $i) {
                 $containsIssue = $true
             }
+            $containsNamespaceDeclaration = $containsNamespaceDeclaration -or (IsNamespace $fileContent[$i])
+        }
+
+        # Only validate that there is a namespace declaration if it's not an AssemblyInfo.cs file.
+        # These do not contain namespace declarations.
+        if ((-not $containsNamespaceDeclaration) -and ($FileName -notmatch "AssemblyInfo.cs$"))
+        {
+            Write-Warning "$FileName is missing a namespace declaration (i.e. missing namespace Microsoft.MixedReality.Toolkit.*)"
+            $containsIssue = $true;
         }
 
         if (CheckHardcodedPath $FileName) {


### PR DESCRIPTION
## Overview
Our AssetRetargetting phase in our CI build depends on all of our code to have a namespace. This isn't checked anywhere during PR validation, which means it's really easy to check in an error like this and then have it fail in a very un-understandable way once things have already been checked in for a while. On particularly crazy days this means that the build will probably get hosed for a while as you don't find out the error until your change has gotten through the queue and has finally run the ongoing CI.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7699