### PR TITLE
Getting started gizmos notice

### DIFF
--- a/Documentation/Contributing/DocumentationGuide.md
+++ b/Documentation/Contributing/DocumentationGuide.md
@@ -158,6 +158,7 @@ When adding a link, consider whether it should also be listed in the [See also](
 
 Some other aspects:
 
+* The editor UI for screenshots should use light gray theme editor as not all users have access to the dark them and we'd like to keep things as consistent as possible.
 * Default image width is 500 pixels, as this displays well on most monitors. Try not to deviate too much from it. 800 pixels width should be the maximum.
 * Use PNGs for screenshots of UI.
 * Use PNGs or JPGs for 3D viewport screenshots. Prefer quality over compression ratio.

--- a/Documentation/Contributing/DocumentationGuide.md
+++ b/Documentation/Contributing/DocumentationGuide.md
@@ -158,7 +158,7 @@ When adding a link, consider whether it should also be listed in the [See also](
 
 Some other aspects:
 
-* The editor UI for screenshots should use light gray theme editor as not all users have access to the dark them and we'd like to keep things as consistent as possible.
+* The editor UI for screenshots should use light gray theme editor as not all users have access to the dark theme and we'd like to keep things as consistent as possible.
 * Default image width is 500 pixels, as this displays well on most monitors. Try not to deviate too much from it. 800 pixels width should be the maximum.
 * Use PNGs for screenshots of UI.
 * Use PNGs or JPGs for 3D viewport screenshots. Prefer quality over compression ratio.

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -148,7 +148,7 @@ To try the hand interaction scene, do the following steps.
 
 1. Uncheck or shrink the size of the 3d icons under the Gizmos tab in the Scene view to make the scene easier to look at
 
-  [Insert image here]
+  ![Gizmos](https://user-images.githubusercontent.com/39840334/80771381-2978c000-8b08-11ea-8fd0-149b0c06fc6a.png)
 
 1. Press the Play button.
 

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -146,6 +146,10 @@ To try the hand interaction scene, do the following steps.
 
 1. Close the TMP dialog. After this you need to reload the scene. You can do this by double-clicking the scene in the Project tab.
 
+1. Uncheck or shrink the size of the 3d icons under the Gizmos tab in the Scene view to make the scene easier to look at
+
+  [Insert image here]
+
 1. Press the Play button.
 
 ## Using the in-editor hand input simulation to test a scene

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -148,7 +148,7 @@ To try the hand interaction scene, do the following steps.
 
 1. Uncheck or shrink the size of the 3d icons under the Gizmos tab in the Scene view to make the scene easier to look at
 
-     ![Gizmos](https://user-images.githubusercontent.com/39840334/80771381-2978c000-8b08-11ea-8fd0-149b0c06fc6a.png)
+     ![Gizmos](https://user-images.githubusercontent.com/13754172/80819866-a8aed800-8b8a-11ea-8d7b-a3822fdfc907.png)
 
 1. Press the Play button.
 

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -146,7 +146,7 @@ To try the hand interaction scene, do the following steps.
 
 1. Close the TMP dialog. After this you need to reload the scene. You can do this by double-clicking the scene in the Project tab.
 
-1. Uncheck or shrink the size of the 3d icons under the Gizmos tab in the Scene view to make the scene easier to look at
+1. Uncheck or shrink the size of the 3d icons under the Gizmos tab in the Scene view to reduce scene clutter
 
      ![Gizmos](https://user-images.githubusercontent.com/13754172/80819866-a8aed800-8b8a-11ea-8d7b-a3822fdfc907.png)
 

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -148,7 +148,7 @@ To try the hand interaction scene, do the following steps.
 
 1. Uncheck or shrink the size of the 3d icons under the Gizmos tab in the Scene view to make the scene easier to look at
 
-  ![Gizmos](https://user-images.githubusercontent.com/39840334/80771381-2978c000-8b08-11ea-8fd0-149b0c06fc6a.png)
+     ![Gizmos](https://user-images.githubusercontent.com/39840334/80771381-2978c000-8b08-11ea-8fd0-149b0c06fc6a.png)
 
 1. Press the Play button.
 


### PR DESCRIPTION
## Overview
Adds helpful notice in the tutorial to lower the gizmos size for the HandInteractionExamples.unity scene
![Gizmos](https://user-images.githubusercontent.com/13754172/80819866-a8aed800-8b8a-11ea-8d7b-a3822fdfc907.png)

Duplicate of this misconfigured PR: https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7755
