### PR TITLE
Add support for Leap Motion Core Assets version 4.5.0

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
@@ -137,9 +137,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         }
 
         /// <summary>
-        /// Checks if the Leap Motion Core Assets are version 4.4.0 or 4.5.0.
+        /// Checks if the Leap Motion Core Assets version is supported.
         /// </summary>
-        /// <returns>True, if the Leap Motion Core Assets imported are version 4.4.0 or 4.5.0.</returns>
+        /// <returns>True, if the Leap Motion Core Assets version imported is supported</returns>
         private static bool LeapCoreAssetsVersionSupport()
         {
             string versionLeapPath = Path.Combine(Application.dataPath, pathDifference, "LeapMotion", "Core", "Version.txt");
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
 
                     foreach (string versionNumberSupported in leapCoreAssetsVersionsSupported)
                     {
-                        // If the leap core assets version number is 4.4.0 or 4.5.0
+                        // If the leap core assets version number is supported
                         if (line.Contains(versionNumberSupported))
                         {
                             currentLeapCoreAssetsVersion = versionNumberSupported;

--- a/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
@@ -278,6 +278,15 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                             IncludePlatforms = new string[] { "Editor" }
                         };
 
+#if !UNITY_2019_3_OR_NEWER
+                        // In Unity 2018.4, directories that contain tests need to have a test assembly.
+                        // An asmdef is added to a leap directory that contains tests for the leap core assets 4.5.0.
+                        if (leapEditorAsmDef.Name.Contains("Tests"))
+                        {
+                            leapEditorAsmDef.OptionalUnityReferences = new string[] { "TestAssemblies" };
+                        }
+#endif
+
                         leapEditorAsmDef.Save(fullLeapAsmDefFilePath);
                     }
                 }


### PR DESCRIPTION
## Overview

UltraLeap released a new version of the [Leap Motion Unity Core Assets](https://github.com/leapmotion/UnityModules/releases/tag/UM-4.5.0) recently.

The current MRTK Leap Motion Data Provider only supported the Leap Core Assets version 4.4.0, this PR adds support for 4.5.0 as well.

The largest difference between 4.4.0 and 4.5.0 is the location of the tests directory.  If the 4.5.0 core assets are imported into MRTK, a new test assembly definition is added.

Both 4.4.0 and 4.5.0 will be supported.

## Changes
- Fixes: #7764 

## Verification
1. Download the [Leap Motion Unity Core Assets 4.5.0](https://github.com/leapmotion/UnityModules/releases/tag/UM-4.5.0)
2. Import the package into either Unity 2019.3 or 2018.4
