### PR TITLE
Fixed regression with the ggv pointer persisting when hands are up

### DIFF
--- a/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
@@ -340,7 +340,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     UpdateHandDevice(HandSimulationMode, Handedness.Right, HandDataRight);
 
                     // HandDataGaze is only enabled if the user is simulating via mouse and keyboard
-                    if (UserInputEnabled && !XRDevice.isPresent && !(HandDataLeft.IsTracked || HandDataRight.IsTracked))
+                    if (UserInputEnabled)
                         UpdateHandDevice(HandSimulationMode.Gestures, Handedness.None, HandDataGaze);
                     lastHandUpdateTimestamp = currentTime.Ticks;
                 }

--- a/Assets/MRTK/Services/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Services/InputSimulation/SimulatedHandDataProvider.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using UnityEngine;
+using UnityEngine.XR;
 
 /// <summary>
 /// Provides per-frame data access to simulated hand data
@@ -182,7 +183,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         // If true then hands are controlled by user input
         private bool isSimulatingLeft = false;
         private bool isSimulatingRight = false;
-        private bool isSimulatingGaze => !isSimulatingLeft && !isSimulatingRight && !IsAlwaysVisibleLeft && !IsAlwaysVisibleRight;
+        private bool isSimulatingGaze => !isSimulatingLeft && !isSimulatingRight && !IsAlwaysVisibleLeft && !IsAlwaysVisibleRight && !XRDevice.isPresent;
         /// <summary>
         /// Left hand is controlled by user input.
         /// </summary>

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1157,7 +1157,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     if (pointerData.Pointer is IMixedRealityNearPointer)
                     {
-                        if (pointerData.Pointer.IsInteractionEnabled)
+                        var nearPointer = (IMixedRealityNearPointer)pointerData.Pointer;
+                        if (nearPointer.IsInteractionEnabled || nearPointer.IsNearObject)
                         {
                             NumNearPointersActive++;
                         }

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 foreach (var pointerData in pointers.Values)
                 {
-                    if (pointerData.Pointer is IMixedRealityNearPointer)
+                    if (pointerData.Pointer is IMixedRealityNearPointer nearPointer)
                     {
                         var nearPointer = (IMixedRealityNearPointer)pointerData.Pointer;
                         if (nearPointer.IsInteractionEnabled || nearPointer.IsNearObject)

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -1157,7 +1157,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     if (pointerData.Pointer is IMixedRealityNearPointer nearPointer)
                     {
-                        var nearPointer = (IMixedRealityNearPointer)pointerData.Pointer;
                         if (nearPointer.IsInteractionEnabled || nearPointer.IsNearObject)
                         {
                             NumNearPointersActive++;

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -88,8 +88,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
 
             // No hands, default cursor should be visible
             Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Head gaze cursor should be visible");
-            //KeyInputSystem.StopKeyInputSimulation();
-            //yield return PlayModeTestUtilities.WaitForEnterKey();
 
             // Begin right hand manipulation
             KeyInputSystem.PressKey(iss.InputSimulationProfile.ToggleRightHandKey);
@@ -100,8 +98,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             // Make sure right hand is tracked
             Assert.True(iss.HandDataRight.IsTracked);
 
+            TestHand hand = new TestHand(Handedness.Right);
+
             // Head cursor invisible when hand is tracked
             Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Eye gaze cursor should not be visible");
+            // Hand ray visible
+            var handRayPointer = hand.GetPointer<ShellHandRayPointer>();
+            Assert.True(handRayPointer.IsActive, "Hand ray not active");
 
             // Create grabbable cube
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -110,14 +113,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             yield return null;
 
             // Grab pointer is near grabbable
-            TestHand hand = new TestHand(Handedness.Right);
             var grabPointer = hand.GetPointer<SpherePointer>();
+            Assert.IsTrue(grabPointer.isActiveAndEnabled, "grab pointer is enabled");
             Assert.IsTrue(grabPointer.IsNearObject, "Grab pointer should be near a grabbable");
 
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
             // Head cursor invisible when grab pointer is near grabbable
             Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Eye gaze cursor should not be visible");
+            // Hand ray invisible when grab pointer is near grabbable
+            Assert.True(!handRayPointer.IsActive, "Hand ray not active");
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -36,7 +36,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             Assert.IsNotNull(iss, "InputSimulationService is null!");
             iss.UserInputEnabled = true;
 
-
             cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.transform.localPosition = new Vector3(0, 0, 2);
             cube.transform.localScale = new Vector3(.2f, .2f, .2f);
@@ -54,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
         }
         
         [UnityTest]
-        public IEnumerator HandsFreeInteractionTest()
+        public IEnumerator InputSimulationHandsFreeInteraction()
         {
             var iss = PlayModeTestUtilities.GetInputSimulationService();
             TestUtilities.PlayspaceToOriginLookingForward();
@@ -81,7 +80,48 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
         }
 
         [UnityTest]
-        public IEnumerator ArticulatedHandGestureTest()
+        public IEnumerator InputSimulationArtictulatedHandNearGrabbable()
+        {
+            var iss = PlayModeTestUtilities.GetInputSimulationService();
+            TestUtilities.PlayspaceToOriginLookingForward();
+            yield return null;
+
+            // No hands, default cursor should be visible
+            Assert.IsTrue(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Head gaze cursor should be visible");
+            //KeyInputSystem.StopKeyInputSimulation();
+            //yield return PlayModeTestUtilities.WaitForEnterKey();
+
+            // Begin right hand manipulation
+            KeyInputSystem.PressKey(iss.InputSimulationProfile.ToggleRightHandKey);
+            yield return null;
+            KeyInputSystem.AdvanceSimulation();
+            yield return null;
+
+            // Make sure right hand is tracked
+            Assert.True(iss.HandDataRight.IsTracked);
+
+            // Head cursor invisible when hand is tracked
+            Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Eye gaze cursor should not be visible");
+
+            // Create grabbable cube
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.AddComponent<NearInteractionGrabbable>();
+            cube.transform.position = new Vector3(0, 0, 1.2f);
+            yield return null;
+
+            // Grab pointer is near grabbable
+            TestHand hand = new TestHand(Handedness.Right);
+            var grabPointer = hand.GetPointer<SpherePointer>();
+            Assert.IsTrue(grabPointer.IsNearObject, "Grab pointer should be near a grabbable");
+
+            yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
+
+            // Head cursor invisible when grab pointer is near grabbable
+            Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Eye gaze cursor should not be visible");
+        }
+
+        [UnityTest]
+        public IEnumerator InputSimulationArticulatedHandGesture()
         {
             var iss = PlayModeTestUtilities.GetInputSimulationService();
             TestUtilities.PlayspaceToOriginLookingForward();

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
         }
 
         [UnityTest]
-        public IEnumerator InputSimulationArtictulatedHandNearGrabbable()
+        public IEnumerator InputSimulationArticulatedHandNearGrabbable()
         {
             var iss = PlayModeTestUtilities.GetInputSimulationService();
             TestUtilities.PlayspaceToOriginLookingForward();


### PR DESCRIPTION
## Overview
Fixes regression where the gaze cursor could still show up with articulated hands present. Also fixed edge case where gaze cursor would remain on the screen if hands were spawned while near an interactable 

Old broken behavior
![GazeCursorOld](https://user-images.githubusercontent.com/39840334/81014021-ff2d4800-8e10-11ea-87c2-682c28c86628.gif)

New behavior
![GazeCursorFix](https://user-images.githubusercontent.com/39840334/81014016-fdfc1b00-8e10-11ea-8d76-8841dafcf1cd.gif)


## Changes
- Fixes: #7742
