### PR TITLE
Extract ToolTipSpawner timed/type visualization capabilities

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI
@@ -13,59 +11,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// Applies its follow settings to the spawned ToolTip's ToolTipConnector component
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ToolTipSpawner")]
-    public class ToolTipSpawner :
-        BaseFocusHandler,
-        IMixedRealityInputHandler,
-        IMixedRealityInputHandler<float>
+    public class ToolTipSpawner : PrefabSpawner
     {
         private enum SettingsMode
         {
             UseDefaults = 0,
             Override
         }
-
-        private enum VanishType
-        {
-            VanishOnFocusExit = 0,
-            VanishOnTap,
-        }
-
-        private enum AppearType
-        {
-            AppearOnFocusEnter = 0,
-            AppearOnTap,
-        }
-
-        public enum RemainType
-        {
-            Indefinite = 0,
-            Timeout,
-        }
-
-        [SerializeField]
-        private GameObject toolTipPrefab = null;
-
-        [Header("Input Settings")]
-        [SerializeField]
-        [Tooltip("The action that will be used for when to spawn or toggle the tooltip.")]
-        private MixedRealityInputAction tooltipToggleAction = MixedRealityInputAction.None;
-
-        [Header("Appear / Vanish Behavior Settings")]
-        [SerializeField]
-        private AppearType appearType = AppearType.AppearOnFocusEnter;
-        [SerializeField]
-        private VanishType vanishType = VanishType.VanishOnFocusExit;
-        [SerializeField]
-        private RemainType remainType = RemainType.Timeout;
-        [SerializeField]
-        [Range(0f, 5f)]
-        private float appearDelay = 0.0f;
-        [SerializeField]
-        [Range(0f, 5f)]
-        private float vanishDelay = 2.0f;
-        [SerializeField]
-        [Range(0.5f, 10.0f)]
-        private float lifetime = 1.0f;
 
         [Header("ToolTip Override Settings")]
         [Tooltip("Prefab's settings will be used unless this is set to Override")]
@@ -99,122 +51,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         private Transform anchor = null;
 
-        private float focusEnterTime = 0f;
-        private float focusExitTime = 0f;
-        private float tappedTime = 0f;
-        private ToolTip toolTip;
-
-        /// <inheritdoc />
-        public override void OnFocusEnter(FocusEventData eventData)
+        protected override void SpawnableActivated(GameObject spawnable)
         {
-            base.OnFocusEnter(eventData);
-
-            HandleFocusEnter();
-        }
-
-        /// <inheritdoc />
-        public override void OnFocusExit(FocusEventData eventData)
-        {
-            base.OnFocusExit(eventData);
-
-            HandleFocusExit();
-        }
-
-        /// <inheritdoc />
-        void IMixedRealityInputHandler<float>.OnInputChanged(InputEventData<float> eventData)
-        {
-            if (eventData.InputData > .95f) 
-            {
-                HandleTap();
-            }
-        }
-
-        /// <inheritdoc />
-        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
-        {
-            if (tooltipToggleAction.Id == eventData.MixedRealityInputAction.Id)
-            {
-                HandleTap();
-            }
-        }
-
-        /// <inheritdoc />
-        void IMixedRealityInputHandler.OnInputUp(InputEventData eventData) { }
-
-        private void HandleTap()
-        {
-            tappedTime = Time.unscaledTime;
-
-            if (toolTip == null || !toolTip.gameObject.activeSelf)
-            {
-                switch (appearType)
-                {
-                    case AppearType.AppearOnTap:
-                        ShowToolTip();
-                        break;
-                }
-            }
-            else
-            {
-                switch (vanishType)
-                {
-                    case VanishType.VanishOnTap:
-                        toolTip.gameObject.SetActive(false);
-                        break;
-                }
-            }
-        }
-
-        private void HandleFocusEnter()
-        {
-            focusEnterTime = Time.unscaledTime;
-
-            if (toolTip == null || !toolTip.gameObject.activeSelf)
-            {
-                switch (appearType)
-                {
-                    case AppearType.AppearOnFocusEnter:
-                        ShowToolTip();
-                        break;
-                }
-            }
-        }
-
-        private void HandleFocusExit()
-        {
-            focusExitTime = Time.unscaledTime;
-        }
-
-        private async void ShowToolTip()
-        {
-            await UpdateTooltip(focusEnterTime, tappedTime);
-        }
-
-        private async Task UpdateTooltip(float focusEnterTimeOnStart, float tappedTimeOnStart)
-        {
-            if (toolTip == null)
-            {
-                var toolTipGo = Instantiate(toolTipPrefab);
-                toolTip = toolTipGo.GetComponent<ToolTip>();
-                toolTip.gameObject.SetActive(false);
-                toolTip.transform.position = transform.position;
-                toolTip.transform.parent = transform;
-            }
-
-            if (appearType == AppearType.AppearOnFocusEnter)
-            {
-                // Wait for the appear delay
-                await new WaitForSeconds(appearDelay);
-                // If we don't have focus any more, get out of here
-
-                if (!HasFocus)
-                {
-                    return;
-                }
-            }
+            var toolTip = spawnable.GetComponent<ToolTip>();
 
             toolTip.ToolTipText = toolTipText;
-            toolTip.gameObject.SetActive(true);
             var connector = toolTip.GetComponent<ToolTipConnector>();
             connector.Target = (anchor != null) ? anchor.gameObject : gameObject;
 
@@ -242,64 +83,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                     break;
             }
-
-            while (toolTip.gameObject.activeSelf)
-            {
-                if (remainType == RemainType.Timeout)
-                {
-                    switch (appearType)
-                    {
-                        case AppearType.AppearOnTap:
-                            if (Time.unscaledTime - tappedTime >= lifetime)
-                            {
-                                toolTip.gameObject.SetActive(false);
-                                return;
-                            }
-
-                            break;
-                        case AppearType.AppearOnFocusEnter:
-                            if (Time.unscaledTime - focusEnterTime >= lifetime)
-                            {
-                                toolTip.gameObject.SetActive(false);
-                                return;
-                            }
-
-                            break;
-                    }
-                }
-
-                // Check whether we're suppose to disappear
-                switch (vanishType)
-                {
-                    case VanishType.VanishOnFocusExit:
-                        if (!HasFocus)
-                        {
-                            toolTip.gameObject.SetActive(false);
-                        }
-
-                        break;
-
-                    case VanishType.VanishOnTap:
-                        if (!tappedTime.Equals(tappedTimeOnStart))
-                        {
-                            toolTip.gameObject.SetActive(false);
-                        }
-
-                        break;
-
-                    default:
-                        if (!HasFocus)
-                        {
-                            if (Time.time - focusExitTime > vanishDelay)
-                            {
-                                toolTip.gameObject.SetActive(false);
-                            }
-                        }
-                        break;
-                }
-
-                await new WaitForUpdate();
-            }
         }
 
 #if UNITY_EDITOR
@@ -307,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (Application.isPlaying) { return; }
 
-            if (toolTipPrefab == null) { return; }
+            if (prefab == null) { return; }
 
             if (gameObject == UnityEditor.Selection.activeGameObject)
             {
@@ -325,14 +108,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 switch (settingsMode)
                 {
                     case SettingsMode.UseDefaults:
-                        ToolTipConnector connector = toolTipPrefab.GetComponent<ToolTipConnector>();
+                        ToolTipConnector connector = prefab.GetComponent<ToolTipConnector>();
                         followType = connector.ConnectorFollowingType;
                         pivotDirectionOrient = connector.PivotDirectionOrient;
                         pivotDirection = connector.PivotDirection;
                         pivotMode = connector.PivotMode;
                         manualPivotDirection = connector.ManualPivotDirection;
                         manualPivotLocalPosition = connector.ManualPivotLocalPosition;
-                        pivotDistance = connector.PivotDistance; 
+                        pivotDistance = connector.PivotDistance;
                         break;
                 }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -42,6 +42,7 @@ public class PrefabSpawner :
     private VanishType vanishType = VanishType.VanishOnFocusExit;
     [SerializeField]
     private RemainType remainType = RemainType.Timeout;
+    [Header("Timing")]
     [SerializeField]
     [Range(0f, 5f)]
     private float appearDelay = 0.0f;
@@ -51,6 +52,9 @@ public class PrefabSpawner :
     [SerializeField]
     [Range(0.5f, 10.0f)]
     private float lifetime = 1.0f;
+    [Header("Orientation")]
+    [SerializeField]
+    private bool keepWorldRotation = true;
 
     private float focusEnterTime = 0f;
     private float focusExitTime = 0f;
@@ -69,10 +73,13 @@ public class PrefabSpawner :
         {
             if (spawnable == null)
             {
-                spawnable = Instantiate(prefab);
+                spawnable = Instantiate(prefab, transform, false);
+                spawnable.transform.localPosition = Vector3.zero;
+                if (!keepWorldRotation)
+                {
+                    spawnable.transform.localRotation = Quaternion.identity;
+                }
                 spawnable.gameObject.SetActive(false);
-                spawnable.transform.position = transform.position;
-                spawnable.transform.parent = transform;
             }
             // Wait for the appear delay
             await new WaitForSeconds(appearDelay);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -1,239 +1,249 @@
-﻿using Microsoft.MixedReality.Toolkit.Input;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Input;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Serialization;
 using Microsoft.MixedReality.Toolkit.Utilities;
 
-public class PrefabSpawner :
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+    /// <summary>
+    /// Add to any Object to spawn a prefab to it, according to preference
+    /// </summary>
+    [AddComponentMenu("Scripts/MRTK/SDK/PrefabSpawner")]
+    public class PrefabSpawner :
     BaseFocusHandler,
     IMixedRealityInputHandler,
     IMixedRealityInputHandler<float>
-{
-    private enum VanishType
     {
-        VanishOnFocusExit = 0,
-        VanishOnTap,
-    }
-
-    private enum AppearType
-    {
-        AppearOnFocusEnter = 0,
-        AppearOnTap,
-    }
-
-    public enum RemainType
-    {
-        Indefinite = 0,
-        Timeout,
-    }
-
-    [SerializeField, FormerlySerializedAs("toolTipPrefab")]
-    protected GameObject prefab = null;
-
-    [Header("Input Settings")]
-    [SerializeField]
-    [Tooltip("The action that will be used for when to spawn or toggle the tooltip.")]
-    private MixedRealityInputAction tooltipToggleAction = MixedRealityInputAction.None;
-
-    [Header("Appear / Vanish Behavior Settings")]
-    [SerializeField]
-    private AppearType appearType = AppearType.AppearOnFocusEnter;
-    [SerializeField]
-    private VanishType vanishType = VanishType.VanishOnFocusExit;
-    [SerializeField]
-    private RemainType remainType = RemainType.Timeout;
-    [Header("Timing")]
-    [SerializeField]
-    [Range(0f, 5f)]
-    private float appearDelay = 0.0f;
-    [SerializeField]
-    [Range(0f, 5f)]
-    private float vanishDelay = 2.0f;
-    [SerializeField]
-    [Range(0.5f, 10.0f)]
-    private float lifetime = 1.0f;
-    [Header("Orientation")]
-    [SerializeField]
-    private bool keepWorldRotation = true;
-
-    private float focusEnterTime = 0f;
-    private float focusExitTime = 0f;
-    private float tappedTime = 0f;
-
-    private GameObject spawnable;
-
-    private async void ShowSpawnable()
-    {
-        await UpdateSpawnable(focusEnterTime, tappedTime);
-    }
-
-    private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
-    {
-        if (appearType == AppearType.AppearOnFocusEnter)
+        private enum VanishType
         {
-            if (spawnable == null)
-            {
-                spawnable = Instantiate(prefab, transform, false);
-                spawnable.transform.localPosition = Vector3.zero;
-                if (!keepWorldRotation)
-                {
-                    spawnable.transform.localRotation = Quaternion.identity;
-                }
-                spawnable.gameObject.SetActive(false);
-            }
-            // Wait for the appear delay
-            await new WaitForSeconds(appearDelay);
-            // If we don't have focus any more, get out of here
+            VanishOnFocusExit = 0,
+            VanishOnTap,
+        }
 
-            if (!HasFocus)
+        private enum AppearType
+        {
+            AppearOnFocusEnter = 0,
+            AppearOnTap,
+        }
+
+        public enum RemainType
+        {
+            Indefinite = 0,
+            Timeout,
+        }
+
+        [SerializeField, FormerlySerializedAs("toolTipPrefab")]
+        protected GameObject prefab = null;
+
+        [Header("Input Settings")]
+        [SerializeField]
+        [Tooltip("The action that will be used for when to spawn or toggle the tooltip.")]
+        private MixedRealityInputAction tooltipToggleAction = MixedRealityInputAction.None;
+
+        [Header("Appear / Vanish Behavior Settings")]
+        [SerializeField]
+        private AppearType appearType = AppearType.AppearOnFocusEnter;
+        [SerializeField]
+        private VanishType vanishType = VanishType.VanishOnFocusExit;
+        [SerializeField]
+        private RemainType remainType = RemainType.Timeout;
+        [Header("Timing")]
+        [SerializeField]
+        [Range(0f, 5f)]
+        private float appearDelay = 0.0f;
+        [SerializeField]
+        [Range(0f, 5f)]
+        private float vanishDelay = 2.0f;
+        [SerializeField]
+        [Range(0.5f, 10.0f)]
+        private float lifetime = 1.0f;
+        [Header("Orientation")]
+        [SerializeField]
+        private bool keepWorldRotation = true;
+
+        private float focusEnterTime = 0f;
+        private float focusExitTime = 0f;
+        private float tappedTime = 0f;
+
+        private GameObject spawnable;
+
+        private async void ShowSpawnable()
+        {
+            await UpdateSpawnable(focusEnterTime, tappedTime);
+        }
+
+        private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
+        {
+            if (appearType == AppearType.AppearOnFocusEnter)
             {
-                return;
+                if (spawnable == null)
+                {
+                    spawnable = Instantiate(prefab, transform, false);
+                    spawnable.transform.localPosition = Vector3.zero;
+                    if (!keepWorldRotation)
+                    {
+                        spawnable.transform.localRotation = Quaternion.identity;
+                    }
+                    spawnable.gameObject.SetActive(false);
+                }
+                // Wait for the appear delay
+                await new WaitForSeconds(appearDelay);
+                // If we don't have focus any more, get out of here
+
+                if (!HasFocus)
+                {
+                    return;
+                }
+            }
+
+            spawnable.gameObject.SetActive(true);
+
+            SpawnableActivated(spawnable);
+
+            while (spawnable.gameObject.activeSelf)
+            {
+                if (remainType == RemainType.Timeout)
+                {
+                    switch (appearType)
+                    {
+                        case AppearType.AppearOnTap:
+                            if (Time.unscaledTime - tappedTime >= lifetime)
+                            {
+                                spawnable.gameObject.SetActive(false);
+                                return;
+                            }
+
+                            break;
+                        case AppearType.AppearOnFocusEnter:
+                            if (Time.unscaledTime - focusEnterTime >= lifetime)
+                            {
+                                spawnable.gameObject.SetActive(false);
+                                return;
+                            }
+
+                            break;
+                    }
+                }
+
+                //check whether we're suppose to disappear
+                switch (vanishType)
+                {
+                    case VanishType.VanishOnFocusExit:
+                        if (!HasFocus)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                        }
+
+                        break;
+
+                    case VanishType.VanishOnTap:
+                        if (!tappedTime.Equals(tappedTimeOnStart))
+                        {
+                            spawnable.gameObject.SetActive(false);
+                        }
+
+                        break;
+
+                    default:
+                        if (!HasFocus)
+                        {
+                            if (Time.time - focusExitTime > vanishDelay)
+                            {
+                                spawnable.gameObject.SetActive(false);
+                            }
+                        }
+                        break;
+                }
+
+                await new WaitForUpdate();
             }
         }
 
-        spawnable.gameObject.SetActive(true);
+        protected virtual void SpawnableActivated(GameObject spawnable) { }
 
-        SpawnableActivated(spawnable);
-
-        while (spawnable.gameObject.activeSelf)
+        /// <inheritdoc />
+        public override void OnFocusEnter(FocusEventData eventData)
         {
-            if (remainType == RemainType.Timeout)
+            base.OnFocusEnter(eventData);
+
+            HandleFocusEnter();
+        }
+
+        /// <inheritdoc />
+        public override void OnFocusExit(FocusEventData eventData)
+        {
+            base.OnFocusExit(eventData);
+
+            HandleFocusExit();
+        }
+
+        /// <inheritdoc />
+        void IMixedRealityInputHandler<float>.OnInputChanged(InputEventData<float> eventData)
+        {
+            if (eventData.InputData > .95f)
+            {
+                HandleTap();
+            }
+        }
+
+        /// <inheritdoc />
+        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
+        {
+            if (tooltipToggleAction.Id == eventData.MixedRealityInputAction.Id)
+            {
+                HandleTap();
+            }
+        }
+
+        /// <inheritdoc />
+        void IMixedRealityInputHandler.OnInputUp(InputEventData eventData) { }
+
+        protected virtual void HandleTap()
+        {
+            tappedTime = Time.unscaledTime;
+
+            if (spawnable == null || !spawnable.gameObject.activeSelf)
             {
                 switch (appearType)
                 {
                     case AppearType.AppearOnTap:
-                        if (Time.unscaledTime - tappedTime >= lifetime)
-                        {
-                            spawnable.gameObject.SetActive(false);
-                            return;
-                        }
-
-                        break;
-                    case AppearType.AppearOnFocusEnter:
-                        if (Time.unscaledTime - focusEnterTime >= lifetime)
-                        {
-                            spawnable.gameObject.SetActive(false);
-                            return;
-                        }
-
+                        ShowSpawnable();
                         break;
                 }
             }
-
-            //check whether we're suppose to disappear
-            switch (vanishType)
+            else
             {
-                case VanishType.VanishOnFocusExit:
-                    if (!HasFocus)
-                    {
+                switch (vanishType)
+                {
+                    case VanishType.VanishOnTap:
                         spawnable.gameObject.SetActive(false);
-                    }
-
-                    break;
-
-                case VanishType.VanishOnTap:
-                    if (!tappedTime.Equals(tappedTimeOnStart))
-                    {
-                        spawnable.gameObject.SetActive(false);
-                    }
-
-                    break;
-
-                default:
-                    if (!HasFocus)
-                    {
-                        if (Time.time - focusExitTime > vanishDelay)
-                        {
-                            spawnable.gameObject.SetActive(false);
-                        }
-                    }
-                    break;
+                        break;
+                }
             }
-
-            await new WaitForUpdate();
         }
-    }
 
-    protected virtual void SpawnableActivated(GameObject spawnable) { }
-
-    /// <inheritdoc />
-    public override void OnFocusEnter(FocusEventData eventData)
-    {
-        base.OnFocusEnter(eventData);
-
-        HandleFocusEnter();
-    }
-
-    /// <inheritdoc />
-    public override void OnFocusExit(FocusEventData eventData)
-    {
-        base.OnFocusExit(eventData);
-
-        HandleFocusExit();
-    }
-
-    /// <inheritdoc />
-    void IMixedRealityInputHandler<float>.OnInputChanged(InputEventData<float> eventData)
-    {
-        if (eventData.InputData > .95f)
+        private void HandleFocusEnter()
         {
-            HandleTap();
-        }
-    }
+            focusEnterTime = Time.unscaledTime;
 
-    /// <inheritdoc />
-    void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
-    {
-        if (tooltipToggleAction.Id == eventData.MixedRealityInputAction.Id)
-        {
-            HandleTap();
-        }
-    }
-
-    /// <inheritdoc />
-    void IMixedRealityInputHandler.OnInputUp(InputEventData eventData) { }
-
-    protected virtual void HandleTap()
-    {
-        tappedTime = Time.unscaledTime;
-
-        if (spawnable == null || !spawnable.gameObject.activeSelf)
-        {
-            switch (appearType)
+            if (spawnable == null || !spawnable.gameObject.activeSelf)
             {
-                case AppearType.AppearOnTap:
-                    ShowSpawnable();
-                    break;
+                switch (appearType)
+                {
+                    case AppearType.AppearOnFocusEnter:
+                        ShowSpawnable();
+                        break;
+                }
             }
         }
-        else
+
+        private void HandleFocusExit()
         {
-            switch (vanishType)
-            {
-                case VanishType.VanishOnTap:
-                    spawnable.gameObject.SetActive(false);
-                    break;
-            }
+            focusExitTime = Time.unscaledTime;
         }
-    }
-
-    private void HandleFocusEnter()
-    {
-        focusEnterTime = Time.unscaledTime;
-
-        if (spawnable == null || !spawnable.gameObject.activeSelf)
-        {
-            switch (appearType)
-            {
-                case AppearType.AppearOnFocusEnter:
-                    ShowSpawnable();
-                    break;
-            }
-        }
-    }
-
-    private void HandleFocusExit()
-    {
-        focusExitTime = Time.unscaledTime;
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                 }
 
-                //check whether we're suppose to disappear
+                // Check whether we're supposed to disappear
                 switch (vanishType)
                 {
                     case VanishType.VanishOnFocusExit:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -1,0 +1,243 @@
+﻿using Microsoft.MixedReality.Toolkit.Input;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Serialization;
+using Microsoft.MixedReality.Toolkit.Utilities;
+
+public class PrefabSpawner :
+    BaseFocusHandler,
+    IMixedRealityInputHandler,
+    IMixedRealityInputHandler<float>
+{
+    private enum VanishType
+    {
+        VanishOnFocusExit = 0,
+        VanishOnTap,
+    }
+
+    private enum AppearType
+    {
+        AppearOnFocusEnter = 0,
+        AppearOnTap,
+    }
+
+    public enum RemainType
+    {
+        Indefinite = 0,
+        Timeout,
+    }
+
+    [SerializeField, FormerlySerializedAs("toolTipPrefab")]
+    protected GameObject prefab = null;
+
+    [Header("Input Settings")]
+    [SerializeField]
+    [Tooltip("The action that will be used for when to spawn or toggle the tooltip.")]
+    private MixedRealityInputAction tooltipToggleAction = MixedRealityInputAction.None;
+
+    [Header("Appear / Vanish Behavior Settings")]
+    [SerializeField]
+    private AppearType appearType = AppearType.AppearOnFocusEnter;
+    [SerializeField]
+    private VanishType vanishType = VanishType.VanishOnFocusExit;
+    [SerializeField]
+    private RemainType remainType = RemainType.Timeout;
+    [SerializeField]
+    [Range(0f, 5f)]
+    private float appearDelay = 0.0f;
+    [SerializeField]
+    [Range(0f, 5f)]
+    private float vanishDelay = 2.0f;
+    [SerializeField]
+    [Range(0.5f, 10.0f)]
+    private float lifetime = 1.0f;
+
+    private float focusEnterTime = 0f;
+    private float focusExitTime = 0f;
+    private float tappedTime = 0f;
+
+    private GameObject spawnable;
+
+    private async void ShowSpawnable()
+    {
+        await UpdateSpawnable(focusEnterTime, tappedTime);
+    }
+
+    protected void TryCreateSpawnable()
+    {
+        if (spawnable == null)
+        {
+            spawnable = Instantiate(prefab);
+            spawnable.gameObject.SetActive(false);
+            spawnable.transform.position = transform.position;
+            spawnable.transform.parent = transform;
+        }
+    }
+
+    private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
+    {
+        if (appearType == AppearType.AppearOnFocusEnter)
+        {
+            if (spawnable == null)
+            {
+                spawnable = Instantiate(prefab);
+                spawnable.gameObject.SetActive(false);
+                spawnable.transform.position = transform.position;
+                spawnable.transform.parent = transform;
+            }
+            // Wait for the appear delay
+            await new WaitForSeconds(appearDelay);
+            // If we don't have focus any more, get out of here
+
+            if (!HasFocus)
+            {
+                return;
+            }
+        }
+
+        spawnable.gameObject.SetActive(true);
+
+        SpawnableActivated(spawnable);
+
+        while (spawnable.gameObject.activeSelf)
+        {
+            if (remainType == RemainType.Timeout)
+            {
+                switch (appearType)
+                {
+                    case AppearType.AppearOnTap:
+                        if (Time.unscaledTime - tappedTime >= lifetime)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                            return;
+                        }
+
+                        break;
+                    case AppearType.AppearOnFocusEnter:
+                        if (Time.unscaledTime - focusEnterTime >= lifetime)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                            return;
+                        }
+
+                        break;
+                }
+            }
+
+            //check whether we're suppose to disappear
+            switch (vanishType)
+            {
+                case VanishType.VanishOnFocusExit:
+                    if (!HasFocus)
+                    {
+                        spawnable.gameObject.SetActive(false);
+                    }
+
+                    break;
+
+                case VanishType.VanishOnTap:
+                    if (!tappedTime.Equals(tappedTimeOnStart))
+                    {
+                        spawnable.gameObject.SetActive(false);
+                    }
+
+                    break;
+
+                default:
+                    if (!HasFocus)
+                    {
+                        if (Time.time - focusExitTime > vanishDelay)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                        }
+                    }
+                    break;
+            }
+
+            await new WaitForUpdate();
+        }
+    }
+
+    protected virtual void SpawnableActivated(GameObject spawnable) { }
+
+    /// <inheritdoc />
+    public override void OnFocusEnter(FocusEventData eventData)
+    {
+        base.OnFocusEnter(eventData);
+
+        HandleFocusEnter();
+    }
+
+    /// <inheritdoc />
+    public override void OnFocusExit(FocusEventData eventData)
+    {
+        base.OnFocusExit(eventData);
+
+        HandleFocusExit();
+    }
+
+    /// <inheritdoc />
+    void IMixedRealityInputHandler<float>.OnInputChanged(InputEventData<float> eventData)
+    {
+        if (eventData.InputData > .95f)
+        {
+            HandleTap();
+        }
+    }
+
+    /// <inheritdoc />
+    void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
+    {
+        if (tooltipToggleAction.Id == eventData.MixedRealityInputAction.Id)
+        {
+            HandleTap();
+        }
+    }
+
+    /// <inheritdoc />
+    void IMixedRealityInputHandler.OnInputUp(InputEventData eventData) { }
+
+    protected virtual void HandleTap()
+    {
+        tappedTime = Time.unscaledTime;
+
+        if (spawnable == null || !spawnable.gameObject.activeSelf)
+        {
+            switch (appearType)
+            {
+                case AppearType.AppearOnTap:
+                    ShowSpawnable();
+                    break;
+            }
+        }
+        else
+        {
+            switch (vanishType)
+            {
+                case VanishType.VanishOnTap:
+                    spawnable.gameObject.SetActive(false);
+                    break;
+            }
+        }
+    }
+
+    private void HandleFocusEnter()
+    {
+        focusEnterTime = Time.unscaledTime;
+
+        if (spawnable == null || !spawnable.gameObject.activeSelf)
+        {
+            switch (appearType)
+            {
+                case AppearType.AppearOnFocusEnter:
+                    ShowSpawnable();
+                    break;
+            }
+        }
+    }
+
+    private void HandleFocusExit()
+    {
+        focusExitTime = Time.unscaledTime;
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -63,17 +63,6 @@ public class PrefabSpawner :
         await UpdateSpawnable(focusEnterTime, tappedTime);
     }
 
-    protected void TryCreateSpawnable()
-    {
-        if (spawnable == null)
-        {
-            spawnable = Instantiate(prefab);
-            spawnable.gameObject.SetActive(false);
-            spawnable.transform.position = transform.position;
-            spawnable.transform.parent = transform;
-        }
-    }
-
     private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
     {
         if (appearType == AppearType.AppearOnFocusEnter)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e1f252b96e3ab44289db8312629b4a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
ToolTipSpawner has a lot of logic that's generally interesting for GameObjects in total. But it currently only allows to spawn ToolTips specifically.
This PR extracts the basics into its own class to make them reusable for anything.

## Changes
- Fixes: #7769