### PR TITLE
Add gaze capability to PrefabSpawner/ToolTipSpawner

### DIFF
--- a/Assets/MRTK/Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity
+++ b/Assets/MRTK/Examples/Demos/UX/Tooltips/Scenes/TooltipExamples.unity
@@ -118,6 +118,85 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 576226217}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &89302871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1902218674}
+    m_Modifications:
+    - target: {fileID: 100000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_Name
+      value: Platonic
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 00665e2a669d4b0fab1965843b4c914b, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f9b1acc0404b53f45bffb480fefa205a, type: 3}
+--- !u!4 &89302872 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400000, guid: f9b1acc0404b53f45bffb480fefa205a,
+    type: 3}
+  m_PrefabInstance: {fileID: 89302871}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &92468369
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -461,13 +540,13 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 120013085}
-    characterCount: 0
+    characterCount: 38
     spriteCount: 0
-    spaceCount: 0
-    wordCount: 0
+    spaceCount: 4
+    wordCount: 6
     linkCount: 0
-    lineCount: 0
-    pageCount: 0
+    lineCount: 2
+    pageCount: 1
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
@@ -547,6 +626,92 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 85b0e186e2c82324b83f3696c29cf697, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &146519439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 146519440}
+  - component: {fileID: 146519441}
+  m_Layer: 0
+  m_Name: MixedRealityDiagnosticsSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &146519440
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146519439}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &146519441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146519439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &146661720
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 146661721}
+  - component: {fileID: 146661722}
+  m_Layer: 0
+  m_Name: MixedRealityTeleportSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &146661721
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146661720}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &146661722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146661720}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &161574831
@@ -979,6 +1144,49 @@ Transform:
   m_Father: {fileID: 92468370}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &313510053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 313510054}
+  - component: {fileID: 313510055}
+  m_Layer: 0
+  m_Name: InputSimulationService
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &313510054
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313510053}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &313510055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313510053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &343206303
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2213,7 +2421,7 @@ Transform:
   - {fileID: 161574832}
   - {fileID: 688873602}
   m_Father: {fileID: 1595493452}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 35.739002, z: 0}
 --- !u!82 &532207852
 AudioSource:
@@ -2430,6 +2638,49 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &545864619
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 545864620}
+  - component: {fileID: 545864621}
+  m_Layer: 0
+  m_Name: FocusProvider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &545864620
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545864619}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &545864621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545864619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &576226217
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2515,7 +2766,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4649356724422132, guid: 4e88d209b9ebe8b42a4d4748bd9b7141, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4649356724422132, guid: 4e88d209b9ebe8b42a4d4748bd9b7141, type: 3}
       propertyPath: m_LocalScale.x
@@ -3652,7 +3903,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400048, guid: 9b8d622e06b5ddc47bfd77b86d50527c, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 400048, guid: 9b8d622e06b5ddc47bfd77b86d50527c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3899,7 +4150,24 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1261765661}
+  - {fileID: 545864620}
+  - {fileID: 2092383791}
+  - {fileID: 1523301256}
+  - {fileID: 1374208021}
+  - {fileID: 313510054}
+  - {fileID: 1099708313}
+  - {fileID: 1797888893}
+  - {fileID: 146519440}
+  - {fileID: 1976123746}
+  - {fileID: 1612957417}
+  - {fileID: 146661721}
+  - {fileID: 2077265904}
+  - {fileID: 1548197172}
+  - {fileID: 1186942241}
+  - {fileID: 1480493860}
+  - {fileID: 1807852522}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4182,13 +4450,13 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 870272563}
-    characterCount: 0
+    characterCount: 13
     spriteCount: 0
-    spaceCount: 0
-    wordCount: 0
+    spaceCount: 2
+    wordCount: 3
     linkCount: 0
-    lineCount: 0
-    pageCount: 0
+    lineCount: 1
+    pageCount: 1
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
@@ -4229,6 +4497,16 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 463960672768484199, guid: c0931c4da6d91ea429abedb10290dd16,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1713571739358940556, guid: c0931c4da6d91ea429abedb10290dd16,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204069622047818202, guid: c0931c4da6d91ea429abedb10290dd16,
         type: 3}
       propertyPath: m_Mesh
       value: 
@@ -4860,6 +5138,92 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1003583354}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1099708312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1099708313}
+  - component: {fileID: 1099708314}
+  m_Layer: 0
+  m_Name: MixedRealityBoundarySystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1099708313
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1099708312}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1099708314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1099708312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1186942240
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1186942241}
+  - component: {fileID: 1186942242}
+  m_Layer: 0
+  m_Name: UnityTouchDeviceManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1186942241
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1186942240}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1186942242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1186942240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1192552200
 GameObject:
   m_ObjectHideFlags: 0
@@ -4960,7 +5324,7 @@ Transform:
   m_Children:
   - {fileID: 1606036650}
   m_Father: {fileID: 1595493452}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1220608072
 MonoBehaviour:
@@ -4975,8 +5339,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   focusEnabled: 1
-  toolTipPrefab: {fileID: 1083549605185280, guid: afaef0108a478c44a9eac26658bc29bf,
-    type: 3}
+  gazeEnabled: 0
+  prefab: {fileID: 1083549605185280, guid: afaef0108a478c44a9eac26658bc29bf, type: 3}
   tooltipToggleAction:
     id: 1
     description: Select
@@ -4987,6 +5351,7 @@ MonoBehaviour:
   appearDelay: 0
   vanishDelay: 5
   lifetime: 10
+  keepWorldRotation: 1
   settingsMode: 1
   showBackground: 1
   showOutline: 0
@@ -5013,6 +5378,49 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1261765660
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1261765661}
+  - component: {fileID: 1261765662}
+  m_Layer: 0
+  m_Name: DefaultRaycastProvider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1261765661
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1261765660}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1261765662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1261765660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1286762432
 GameObject:
   m_ObjectHideFlags: 0
@@ -5046,7 +5454,7 @@ Transform:
   m_Children:
   - {fileID: 365752474}
   m_Father: {fileID: 1595493452}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1286762434
 MonoBehaviour:
@@ -5061,8 +5469,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   focusEnabled: 1
-  toolTipPrefab: {fileID: 1379707608131922, guid: 44ac04f8e1e21474991e4b59809859f4,
-    type: 3}
+  gazeEnabled: 0
+  prefab: {fileID: 1379707608131922, guid: 44ac04f8e1e21474991e4b59809859f4, type: 3}
   tooltipToggleAction:
     id: 1
     description: None
@@ -5073,6 +5481,7 @@ MonoBehaviour:
   appearDelay: 0
   vanishDelay: 1
   lifetime: 2.5
+  keepWorldRotation: 1
   settingsMode: 1
   showBackground: 1
   showOutline: 0
@@ -5140,7 +5549,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: c72691f7b364d264abdb41ef2f01c706, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: c72691f7b364d264abdb41ef2f01c706, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6010,6 +6419,295 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   pivotAxis: 6
   targetTransform: {fileID: 0}
+--- !u!1 &1374208020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1374208021}
+  - component: {fileID: 1374208022}
+  m_Layer: 0
+  m_Name: InputRecordingService
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1374208021
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1374208020}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1374208022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1374208020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1461205041
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1461205042}
+  - component: {fileID: 1461205046}
+  - component: {fileID: 1461205045}
+  - component: {fileID: 1461205044}
+  - component: {fileID: 1461205043}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1461205042
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461205041}
+  m_LocalRotation: {x: -0, y: 0.000000059604645, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.9392002}
+  m_LocalScale: {x: 0.004, y: 0.004, z: 0.004}
+  m_Children: []
+  m_Father: {fileID: 1595493452}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.475, y: 3.4138}
+  m_SizeDelta: {x: 60, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1461205043
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461205041}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Show on Gaze
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: afc8299d5d5bbd440a0616c8ecbc7217, type: 2}
+  m_sharedMaterial: {fileID: 21340371490990018, guid: afc8299d5d5bbd440a0616c8ecbc7217,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 70
+  m_fontSizeBase: 70
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_textAlignment: 257
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 1
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_firstOverflowCharacterIndex: 0
+  m_linkedTextComponent: {fileID: 0}
+  m_isLinkedTextComponent: 0
+  m_isTextTruncated: 0
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 1
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_firstVisibleCharacter: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_textInfo:
+    textComponent: {fileID: 1461205043}
+    characterCount: 12
+    spriteCount: 0
+    spaceCount: 2
+    wordCount: 3
+    linkCount: 0
+    lineCount: 1
+    pageCount: 1
+    materialCount: 1
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_spriteAnimator: {fileID: 0}
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 1461205046}
+  m_subTextObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  m_maskType: 0
+--- !u!222 &1461205044
+CanvasRenderer:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461205041}
+  m_CullTransparentMesh: 0
+--- !u!33 &1461205045
+MeshFilter:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461205041}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1461205046
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461205041}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 21340371490990018, guid: afc8299d5d5bbd440a0616c8ecbc7217, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &1480493859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1480493860}
+  - component: {fileID: 1480493861}
+  m_Layer: 0
+  m_Name: WindowsDictationInputProvider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1480493860
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480493859}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1480493861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480493859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1494250749
 GameObject:
   m_ObjectHideFlags: 0
@@ -6184,6 +6882,49 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1506663989}
   m_CullTransparentMesh: 0
+--- !u!1 &1523301255
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1523301256}
+  - component: {fileID: 1523301257}
+  m_Layer: 0
+  m_Name: InputPlaybackService
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1523301256
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523301255}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1523301257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523301255}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1542015560
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6703,7 +7444,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4505063462395242, guid: 44ac04f8e1e21474991e4b59809859f4, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4505063462395242, guid: 44ac04f8e1e21474991e4b59809859f4, type: 3}
       propertyPath: m_LocalScale.x
@@ -7322,6 +8063,49 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 44ac04f8e1e21474991e4b59809859f4, type: 3}
+--- !u!1 &1548197171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1548197172}
+  - component: {fileID: 1548197173}
+  m_Layer: 0
+  m_Name: UnityJoystickManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1548197172
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548197171}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1548197173
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548197171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1595493450
 GameObject:
   m_ObjectHideFlags: 0
@@ -7353,8 +8137,10 @@ Transform:
   - {fileID: 120013084}
   - {fileID: 1849891555}
   - {fileID: 870272561}
+  - {fileID: 1461205042}
   - {fileID: 1220608071}
   - {fileID: 1286762433}
+  - {fileID: 1902218674}
   - {fileID: 532207851}
   - {fileID: 2071898284}
   - {fileID: 38932431}
@@ -7440,6 +8226,49 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1606036649}
   m_Mesh: {fileID: 4300000, guid: 40bb9772594a93140a43a9a4f5cf9356, type: 3}
+--- !u!1 &1612957416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1612957417}
+  - component: {fileID: 1612957418}
+  m_Layer: 0
+  m_Name: MixedRealitySpatialAwarenessSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1612957417
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1612957416}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1612957418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1612957416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1626314867
 GameObject:
   m_ObjectHideFlags: 0
@@ -7863,6 +8692,92 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 1c8a9561fb418d140bd508ccf24fe2a5, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 902b4366116e1184aaee744612f65d77, type: 3}
+--- !u!1 &1797888892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1797888893}
+  - component: {fileID: 1797888894}
+  m_Layer: 0
+  m_Name: MixedRealityCameraSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1797888893
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1797888892}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1797888894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1797888892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1807852521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807852522}
+  - component: {fileID: 1807852523}
+  m_Layer: 0
+  m_Name: WindowsSpeechInputProvider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1807852522
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807852521}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1807852523
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807852521}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1808134389
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8739,13 +9654,13 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1849891557}
-    characterCount: 0
+    characterCount: 13
     spriteCount: 0
-    spaceCount: 0
-    wordCount: 0
+    spaceCount: 2
+    wordCount: 3
     linkCount: 0
-    lineCount: 0
-    pageCount: 0
+    lineCount: 1
+    pageCount: 1
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
@@ -8778,6 +9693,134 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1849891554}
   m_Mesh: {fileID: 0}
+--- !u!1 &1902218673
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1902218674}
+  - component: {fileID: 1902218676}
+  - component: {fileID: 1902218675}
+  m_Layer: 0
+  m_Name: Object_ToolTipOnGaze
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1902218674
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1902218673}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.475, y: 3.5299997, z: 3.04}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_Children:
+  - {fileID: 89302872}
+  m_Father: {fileID: 1595493452}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &1902218675
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1902218673}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1902218676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1902218673}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 193c362eb02741c43b31788b51c83d73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  focusEnabled: 0
+  gazeEnabled: 1
+  prefab: {fileID: 1083549605185280, guid: afaef0108a478c44a9eac26658bc29bf, type: 3}
+  tooltipToggleAction:
+    id: 1
+    description: Select
+    axisConstraint: 2
+  appearType: 2
+  vanishType: 2
+  remainType: 1
+  appearDelay: 0
+  vanishDelay: 5
+  lifetime: 10
+  keepWorldRotation: 1
+  settingsMode: 1
+  showBackground: 1
+  showOutline: 0
+  showConnector: 1
+  followType: 2
+  pivotMode: 1
+  pivotDirection: 2
+  pivotDirectionOrient: 1
+  manualPivotDirection: {x: 0, y: 1, z: 0}
+  manualPivotLocalPosition: {x: 0, y: 0.55, z: 0}
+  pivotDistance: 0.35
+  toolTipText: New Tooltip
+  anchor: {fileID: 0}
+--- !u!1 &1976123745
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1976123746}
+  - component: {fileID: 1976123747}
+  m_Layer: 0
+  m_Name: MixedRealityInputSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1976123746
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976123745}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1976123747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976123745}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1978387418
 GameObject:
   m_ObjectHideFlags: 0
@@ -8906,3 +9949,89 @@ Transform:
   m_Father: {fileID: 92468370}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2077265903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2077265904}
+  - component: {fileID: 2077265905}
+  m_Layer: 0
+  m_Name: OpenVRDeviceManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2077265904
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2077265903}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2077265905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2077265903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2092383790
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2092383791}
+  - component: {fileID: 2092383792}
+  m_Layer: 0
+  m_Name: HandJointService
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2092383791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2092383790}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 785226068}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2092383792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2092383790}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09c04dafcb77c1e4195a36bd131cbdec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/BaseFocusHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/BaseFocusHandler.cs
@@ -30,6 +30,24 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public virtual bool HasFocus => FocusEnabled && Focusers.Count > 0;
 
+        [SerializeField]
+        [Tooltip("Is gaze enabled for this component?")]
+        private bool gazeEnabled = false;
+
+        /// <summary>
+        /// Is gaze enabled for this <see href="https://docs.unity3d.com/ScriptReference/Component.html">Component</see>?
+        /// </summary>
+        public virtual bool GazeEnabled
+        {
+            get { return gazeEnabled; }
+            set { gazeEnabled = value; }
+        }
+
+        /// <summary>
+        /// Does this object currently have gaze by any <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer"/>?
+        /// </summary>
+        public virtual bool HasGaze => GazeEnabled && CoreServices.InputSystem?.GazeProvider.GazeTarget == gameObject;
+
         /// <summary>
         /// The list of <see cref="Microsoft.MixedReality.Toolkit.Input.IMixedRealityPointer"/>s that are currently focused on this <see href="https://docs.unity3d.com/ScriptReference/GameObject.html">GameObject</see>
         /// </summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipSpawner.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI
@@ -13,59 +11,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// Applies its follow settings to the spawned ToolTip's ToolTipConnector component
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ToolTipSpawner")]
-    public class ToolTipSpawner :
-        BaseFocusHandler,
-        IMixedRealityInputHandler,
-        IMixedRealityInputHandler<float>
+    public class ToolTipSpawner : PrefabSpawner
     {
         private enum SettingsMode
         {
             UseDefaults = 0,
             Override
         }
-
-        private enum VanishType
-        {
-            VanishOnFocusExit = 0,
-            VanishOnTap,
-        }
-
-        private enum AppearType
-        {
-            AppearOnFocusEnter = 0,
-            AppearOnTap,
-        }
-
-        public enum RemainType
-        {
-            Indefinite = 0,
-            Timeout,
-        }
-
-        [SerializeField]
-        private GameObject toolTipPrefab = null;
-
-        [Header("Input Settings")]
-        [SerializeField]
-        [Tooltip("The action that will be used for when to spawn or toggle the tooltip.")]
-        private MixedRealityInputAction tooltipToggleAction = MixedRealityInputAction.None;
-
-        [Header("Appear / Vanish Behavior Settings")]
-        [SerializeField]
-        private AppearType appearType = AppearType.AppearOnFocusEnter;
-        [SerializeField]
-        private VanishType vanishType = VanishType.VanishOnFocusExit;
-        [SerializeField]
-        private RemainType remainType = RemainType.Timeout;
-        [SerializeField]
-        [Range(0f, 5f)]
-        private float appearDelay = 0.0f;
-        [SerializeField]
-        [Range(0f, 5f)]
-        private float vanishDelay = 2.0f;
-        [SerializeField]
-        [Range(0.5f, 10.0f)]
-        private float lifetime = 1.0f;
 
         [Header("ToolTip Override Settings")]
         [Tooltip("Prefab's settings will be used unless this is set to Override")]
@@ -99,122 +51,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         private Transform anchor = null;
 
-        private float focusEnterTime = 0f;
-        private float focusExitTime = 0f;
-        private float tappedTime = 0f;
-        private ToolTip toolTip;
-
-        /// <inheritdoc />
-        public override void OnFocusEnter(FocusEventData eventData)
+        protected override void SpawnableActivated(GameObject spawnable)
         {
-            base.OnFocusEnter(eventData);
-
-            HandleFocusEnter();
-        }
-
-        /// <inheritdoc />
-        public override void OnFocusExit(FocusEventData eventData)
-        {
-            base.OnFocusExit(eventData);
-
-            HandleFocusExit();
-        }
-
-        /// <inheritdoc />
-        void IMixedRealityInputHandler<float>.OnInputChanged(InputEventData<float> eventData)
-        {
-            if (eventData.InputData > .95f) 
-            {
-                HandleTap();
-            }
-        }
-
-        /// <inheritdoc />
-        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
-        {
-            if (tooltipToggleAction.Id == eventData.MixedRealityInputAction.Id)
-            {
-                HandleTap();
-            }
-        }
-
-        /// <inheritdoc />
-        void IMixedRealityInputHandler.OnInputUp(InputEventData eventData) { }
-
-        private void HandleTap()
-        {
-            tappedTime = Time.unscaledTime;
-
-            if (toolTip == null || !toolTip.gameObject.activeSelf)
-            {
-                switch (appearType)
-                {
-                    case AppearType.AppearOnTap:
-                        ShowToolTip();
-                        break;
-                }
-            }
-            else
-            {
-                switch (vanishType)
-                {
-                    case VanishType.VanishOnTap:
-                        toolTip.gameObject.SetActive(false);
-                        break;
-                }
-            }
-        }
-
-        private void HandleFocusEnter()
-        {
-            focusEnterTime = Time.unscaledTime;
-
-            if (toolTip == null || !toolTip.gameObject.activeSelf)
-            {
-                switch (appearType)
-                {
-                    case AppearType.AppearOnFocusEnter:
-                        ShowToolTip();
-                        break;
-                }
-            }
-        }
-
-        private void HandleFocusExit()
-        {
-            focusExitTime = Time.unscaledTime;
-        }
-
-        private async void ShowToolTip()
-        {
-            await UpdateTooltip(focusEnterTime, tappedTime);
-        }
-
-        private async Task UpdateTooltip(float focusEnterTimeOnStart, float tappedTimeOnStart)
-        {
-            if (toolTip == null)
-            {
-                var toolTipGo = Instantiate(toolTipPrefab);
-                toolTip = toolTipGo.GetComponent<ToolTip>();
-                toolTip.gameObject.SetActive(false);
-                toolTip.transform.position = transform.position;
-                toolTip.transform.parent = transform;
-            }
-
-            if (appearType == AppearType.AppearOnFocusEnter)
-            {
-                // Wait for the appear delay
-                await new WaitForSeconds(appearDelay);
-                // If we don't have focus any more, get out of here
-
-                if (!HasFocus)
-                {
-                    return;
-                }
-            }
+            var toolTip = spawnable.GetComponent<ToolTip>();
 
             toolTip.ToolTipText = toolTipText;
-            toolTip.gameObject.SetActive(true);
             var connector = toolTip.GetComponent<ToolTipConnector>();
             connector.Target = (anchor != null) ? anchor.gameObject : gameObject;
 
@@ -242,64 +83,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                     break;
             }
-
-            while (toolTip.gameObject.activeSelf)
-            {
-                if (remainType == RemainType.Timeout)
-                {
-                    switch (appearType)
-                    {
-                        case AppearType.AppearOnTap:
-                            if (Time.unscaledTime - tappedTime >= lifetime)
-                            {
-                                toolTip.gameObject.SetActive(false);
-                                return;
-                            }
-
-                            break;
-                        case AppearType.AppearOnFocusEnter:
-                            if (Time.unscaledTime - focusEnterTime >= lifetime)
-                            {
-                                toolTip.gameObject.SetActive(false);
-                                return;
-                            }
-
-                            break;
-                    }
-                }
-
-                // Check whether we're suppose to disappear
-                switch (vanishType)
-                {
-                    case VanishType.VanishOnFocusExit:
-                        if (!HasFocus)
-                        {
-                            toolTip.gameObject.SetActive(false);
-                        }
-
-                        break;
-
-                    case VanishType.VanishOnTap:
-                        if (!tappedTime.Equals(tappedTimeOnStart))
-                        {
-                            toolTip.gameObject.SetActive(false);
-                        }
-
-                        break;
-
-                    default:
-                        if (!HasFocus)
-                        {
-                            if (Time.time - focusExitTime > vanishDelay)
-                            {
-                                toolTip.gameObject.SetActive(false);
-                            }
-                        }
-                        break;
-                }
-
-                await new WaitForUpdate();
-            }
         }
 
 #if UNITY_EDITOR
@@ -307,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (Application.isPlaying) { return; }
 
-            if (toolTipPrefab == null) { return; }
+            if (prefab == null) { return; }
 
             if (gameObject == UnityEditor.Selection.activeGameObject)
             {
@@ -325,14 +108,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 switch (settingsMode)
                 {
                     case SettingsMode.UseDefaults:
-                        ToolTipConnector connector = toolTipPrefab.GetComponent<ToolTipConnector>();
+                        ToolTipConnector connector = prefab.GetComponent<ToolTipConnector>();
                         followType = connector.ConnectorFollowingType;
                         pivotDirectionOrient = connector.PivotDirectionOrient;
                         pivotDirection = connector.PivotDirection;
                         pivotMode = connector.PivotMode;
                         manualPivotDirection = connector.ManualPivotDirection;
                         manualPivotLocalPosition = connector.ManualPivotLocalPosition;
-                        pivotDistance = connector.PivotDistance; 
+                        pivotDistance = connector.PivotDistance;
                         break;
                 }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -191,8 +191,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         protected virtual void SpawnableActivated(GameObject spawnable) { }
 
-    private bool HasGaze => CoreServices.InputSystem.GazeProvider.GazeTarget == gameObject;
-
     /// <inheritdoc />
     public override void OnFocusEnter(FocusEventData eventData)
     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -1,0 +1,243 @@
+﻿using Microsoft.MixedReality.Toolkit.Input;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Serialization;
+using Microsoft.MixedReality.Toolkit.Utilities;
+
+public class PrefabSpawner :
+    BaseFocusHandler,
+    IMixedRealityInputHandler,
+    IMixedRealityInputHandler<float>
+{
+    private enum VanishType
+    {
+        VanishOnFocusExit = 0,
+        VanishOnTap,
+    }
+
+    private enum AppearType
+    {
+        AppearOnFocusEnter = 0,
+        AppearOnTap,
+    }
+
+    public enum RemainType
+    {
+        Indefinite = 0,
+        Timeout,
+    }
+
+    [SerializeField, FormerlySerializedAs("toolTipPrefab")]
+    protected GameObject prefab = null;
+
+    [Header("Input Settings")]
+    [SerializeField]
+    [Tooltip("The action that will be used for when to spawn or toggle the tooltip.")]
+    private MixedRealityInputAction tooltipToggleAction = MixedRealityInputAction.None;
+
+    [Header("Appear / Vanish Behavior Settings")]
+    [SerializeField]
+    private AppearType appearType = AppearType.AppearOnFocusEnter;
+    [SerializeField]
+    private VanishType vanishType = VanishType.VanishOnFocusExit;
+    [SerializeField]
+    private RemainType remainType = RemainType.Timeout;
+    [SerializeField]
+    [Range(0f, 5f)]
+    private float appearDelay = 0.0f;
+    [SerializeField]
+    [Range(0f, 5f)]
+    private float vanishDelay = 2.0f;
+    [SerializeField]
+    [Range(0.5f, 10.0f)]
+    private float lifetime = 1.0f;
+
+    private float focusEnterTime = 0f;
+    private float focusExitTime = 0f;
+    private float tappedTime = 0f;
+
+    private GameObject spawnable;
+
+    private async void ShowSpawnable()
+    {
+        await UpdateSpawnable(focusEnterTime, tappedTime);
+    }
+
+    protected void TryCreateSpawnable()
+    {
+        if (spawnable == null)
+        {
+            spawnable = Instantiate(prefab);
+            spawnable.gameObject.SetActive(false);
+            spawnable.transform.position = transform.position;
+            spawnable.transform.parent = transform;
+        }
+    }
+
+    private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
+    {
+        if (appearType == AppearType.AppearOnFocusEnter)
+        {
+            if (spawnable == null)
+            {
+                spawnable = Instantiate(prefab);
+                spawnable.gameObject.SetActive(false);
+                spawnable.transform.position = transform.position;
+                spawnable.transform.parent = transform;
+            }
+            // Wait for the appear delay
+            await new WaitForSeconds(appearDelay);
+            // If we don't have focus any more, get out of here
+
+            if (!HasFocus)
+            {
+                return;
+            }
+        }
+
+        spawnable.gameObject.SetActive(true);
+
+        SpawnableActivated(spawnable);
+
+        while (spawnable.gameObject.activeSelf)
+        {
+            if (remainType == RemainType.Timeout)
+            {
+                switch (appearType)
+                {
+                    case AppearType.AppearOnTap:
+                        if (Time.unscaledTime - tappedTime >= lifetime)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                            return;
+                        }
+
+                        break;
+                    case AppearType.AppearOnFocusEnter:
+                        if (Time.unscaledTime - focusEnterTime >= lifetime)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                            return;
+                        }
+
+                        break;
+                }
+            }
+
+            //check whether we're suppose to disappear
+            switch (vanishType)
+            {
+                case VanishType.VanishOnFocusExit:
+                    if (!HasFocus)
+                    {
+                        spawnable.gameObject.SetActive(false);
+                    }
+
+                    break;
+
+                case VanishType.VanishOnTap:
+                    if (!tappedTime.Equals(tappedTimeOnStart))
+                    {
+                        spawnable.gameObject.SetActive(false);
+                    }
+
+                    break;
+
+                default:
+                    if (!HasFocus)
+                    {
+                        if (Time.time - focusExitTime > vanishDelay)
+                        {
+                            spawnable.gameObject.SetActive(false);
+                        }
+                    }
+                    break;
+            }
+
+            await new WaitForUpdate();
+        }
+    }
+
+    protected virtual void SpawnableActivated(GameObject spawnable) { }
+
+    /// <inheritdoc />
+    public override void OnFocusEnter(FocusEventData eventData)
+    {
+        base.OnFocusEnter(eventData);
+
+        HandleFocusEnter();
+    }
+
+    /// <inheritdoc />
+    public override void OnFocusExit(FocusEventData eventData)
+    {
+        base.OnFocusExit(eventData);
+
+        HandleFocusExit();
+    }
+
+    /// <inheritdoc />
+    void IMixedRealityInputHandler<float>.OnInputChanged(InputEventData<float> eventData)
+    {
+        if (eventData.InputData > .95f)
+        {
+            HandleTap();
+        }
+    }
+
+    /// <inheritdoc />
+    void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
+    {
+        if (tooltipToggleAction.Id == eventData.MixedRealityInputAction.Id)
+        {
+            HandleTap();
+        }
+    }
+
+    /// <inheritdoc />
+    void IMixedRealityInputHandler.OnInputUp(InputEventData eventData) { }
+
+    protected virtual void HandleTap()
+    {
+        tappedTime = Time.unscaledTime;
+
+        if (spawnable == null || !spawnable.gameObject.activeSelf)
+        {
+            switch (appearType)
+            {
+                case AppearType.AppearOnTap:
+                    ShowSpawnable();
+                    break;
+            }
+        }
+        else
+        {
+            switch (vanishType)
+            {
+                case VanishType.VanishOnTap:
+                    spawnable.gameObject.SetActive(false);
+                    break;
+            }
+        }
+    }
+
+    private void HandleFocusEnter()
+    {
+        focusEnterTime = Time.unscaledTime;
+
+        if (spawnable == null || !spawnable.gameObject.activeSelf)
+        {
+            switch (appearType)
+            {
+                case AppearType.AppearOnFocusEnter:
+                    ShowSpawnable();
+                    break;
+            }
+        }
+    }
+
+    private void HandleFocusExit()
+    {
+        focusExitTime = Time.unscaledTime;
+    }
+}

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs
@@ -63,17 +63,6 @@ public class PrefabSpawner :
         await UpdateSpawnable(focusEnterTime, tappedTime);
     }
 
-    protected void TryCreateSpawnable()
-    {
-        if (spawnable == null)
-        {
-            spawnable = Instantiate(prefab);
-            spawnable.gameObject.SetActive(false);
-            spawnable.transform.position = transform.position;
-            spawnable.transform.parent = transform;
-        }
-    }
-
     private async Task UpdateSpawnable(float focusEnterTimeOnStart, float tappedTimeOnStart)
     {
         if (appearType == AppearType.AppearOnFocusEnter)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs.meta
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PrefabSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e1f252b96e3ab44289db8312629b4a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Now that the cool stuff from ToolTipSpawner works for any gameobject with PrefabSpawner it would be nice to also have the ability to use gazing.
This PR adds an additional enum entry to pick for gaze activation. You can now choose between 3 ways ob activating either a prefab in the case of the PrefabSpawner, or a ToolTip in case of the TooltipSpawner:

- OnTab
- OnFocus
- OnGaze

## Changes
- **Relies on**: #7770
