### PR TITLE
Update HL2 holographic reprojection docs

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityCameraSettingsProfile.cs
@@ -27,11 +27,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         public bool RenderFromPVCameraForMixedRealityCapture => renderFromPVCameraForMixedRealityCapture;
 
         [SerializeField]
-        [Tooltip("Specifies the default depth reprojection method for HoloLens 2. Note: AutoPlanar requires the DotNetWinRT adapter. DepthReprojection is the default if the adapter isn't present.")]
+        [Tooltip("Specifies the default reprojection method for HoloLens 2. Note: AutoPlanar requires the DotNetWinRT adapter. DepthReprojection is the default if the adapter isn't present.")]
         private HolographicDepthReprojectionMethod reprojectionMethod = HolographicDepthReprojectionMethod.DepthReprojection;
 
         /// <summary>
-        /// Specifies the default depth reprojection method for HoloLens 2.
+        /// Specifies the default reprojection method for HoloLens 2.
         /// </summary>
         /// <remarks>AutoPlanar requires the DotNetWinRT adapter. DepthReprojection is the default if the adapter isn't present.</remarks>
         public HolographicDepthReprojectionMethod ReprojectionMethod => reprojectionMethod;

--- a/Documentation/CameraSystem/WindowsMixedRealityCameraSettings.md
+++ b/Documentation/CameraSystem/WindowsMixedRealityCameraSettings.md
@@ -37,7 +37,9 @@ With this setting on HoloLens 2, you can enable hologram alignment in your mixed
 
 ### HoloLens 2 reprojection method
 
-Set the initial method for HoloLens 2 reprojection here. To update the reprojection method at runtime, access the `WindowsMixedRealityReprojectionUpdater` like so:
+Sets the initial method for HoloLens 2 reprojection. The default recommendation is to use depth reprojection, as all parts of the scene will be independently stabilized based on their distance from the user. If holograms still appear unstable, try ensuring all objects are properly submitted their depth to the depth buffer. This is sometimes a shader setting. If depth appears to be properly submitted and instability is still present, try autoplanar stabilization, which uses the depth buffer to calculate a stabilization plane. If an app is unable to submit enough depth data for either of those options to be usable, planar reprojection is provided as a fallback. This method will be based on an app's provided focus point data via [SetFocusPointForFrame](https://docs.unity3d.com/ScriptReference/XR.WSA.HolographicSettings.SetFocusPointForFrame.html).
+
+To update the reprojection method at runtime, access the `WindowsMixedRealityReprojectionUpdater` like so:
 
 ```c#
 var reprojectionUpdater = CameraCache.Main.EnsureComponent<WindowsMixedRealityReprojectionUpdater>();

--- a/Documentation/CameraSystem/WindowsMixedRealityCameraSettings.md
+++ b/Documentation/CameraSystem/WindowsMixedRealityCameraSettings.md
@@ -35,8 +35,20 @@ The Windows Mixed Reality Camera Settings also supports a profile. This profile 
 
 With this setting on HoloLens 2, you can enable hologram alignment in your mixed reality captures. If enabled, the platform will provide an additional HolographicCamera to the app when a mixed reality capture photo or video is taken. This HolographicCamera provides view matrices corresponding to the photo/video camera location, and it provides projection matrices using the photo/video camera field of view. This will ensure that holograms, such as hand meshes, remain visibly aligned in the video output.
 
+### HoloLens 2 reprojection method
+
+Set the initial method for HoloLens 2 reprojection here. To update the reprojection method at runtime, access the `WindowsMixedRealityReprojectionUpdater` like so:
+
+```c#
+var reprojectionUpdater = CameraCache.Main.EnsureComponent<WindowsMixedRealityReprojectionUpdater>();
+reprojectionUpdater.ReprojectionMethod = HolographicDepthReprojectionMethod.AutoPlanar;
+```
+
+This only needs to be updated once and the value is reused for all subsequent frames. If the method will be updated frequently, it's recommended to cache the result of `EnsureComponent` instead of calling it often.
+
 ## See also
 
 - [Camera System Overview](CameraSystemOverview.md)
 - [Creating a Camera Settings Provider](CreateSettingsProvider.md)
 - [Rendering Mixed Reality Capture from the PV camera](https://docs.microsoft.com/windows/mixed-reality/mixed-reality-capture-for-developers#render-from-the-pv-camera-opt-in)
+- [Holographic reprojection](https://docs.microsoft.com/windows/mixed-reality/hologram-stability#reprojection)


### PR DESCRIPTION
## Overview

Adds sample code and more information on the HL2 holographic reprojection method setting and how to change it at runtime.

Also removed a reference to "depth reprojection" in the setting, where the setting could be planar reprojection or autoplanar reprojection as well.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7718