### PR TITLE
Fix the remaining broken image links in the documentation

### DIFF
--- a/Assets/MRTK/SDK/Experimental/HandCoach/README_HandCoach.md
+++ b/Assets/MRTK/SDK/Experimental/HandCoach/README_HandCoach.md
@@ -26,7 +26,7 @@ You can find the assets under:
 ## Quality
 If you notice distortions on the skinned mesh, you need to make sure your project is using the proper amount of joints. 
 Go to Unity's Edit > Project Settings > Quality > Other > Blend Weights. Make sure "4 bones" are selected to see Smooth Joints. 
-![](/Documentation/Images/HandCoach/MRTK_ProjectSettings.png)
+![](../../../../../Documentation/Images/HandCoach/MRTK_ProjectSettings.png)
 
 
 

--- a/Assets/MRTK/SDK/Features/UX/Interactable/README.md
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/README.md
@@ -11,7 +11,7 @@ The Interactable is a base component for building interactive content, like butt
 - Checkbox - an example of a checkbox toggle control
 - Radial and Radial Set - an example of a button collection or tab system where only one button can be toggled at a time
 
-![Components of Interactables](/Documentation/Images/Interactable/Interactable_details.png)
+![Components of Interactables](../../../../../../Documentation/Images/Interactable/Interactable_details.png)
 
 
 


### PR DESCRIPTION
There are a couple last broken images in the docs, and I want to fix these up so that I can then enable broken image detection on the Assets/ folder as well.

For a little background, I added some build infra a while back to detect broken images which would check all markdown files under the Documentation/ folder - this was because we would keep getting messages (not OFTEN but still enough that it's not great) that we had broken image links. Unlike doc links, docfx doesn't actually check for validity of linked images.

However, this was only enabled on Documentation/ because we really only put docs there - since that work went in, folks have been taking the process of putting docs for experimental features next to the code in the Assets/ folder.

After this I can enable the Assets/ folder to also be checked.