### PR TITLE
Update min version of DotNetWinRT to latest (0.5.1049)

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
@@ -19,7 +19,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" Version="1.0.85" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.1045" />
+    <PackageReference Include="Microsoft.Windows.MixedReality.DotNetWinRT" Version="0.5.1049" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" Version="1.0.85" />

--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -14,7 +14,7 @@
     <releaseNotes>$releaseNotes$</releaseNotes>
     <tags>Unity MixedReality MixedRealityToolkit MRTK</tags>
     <dependencies>
-      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1045" />
+      <dependency id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1049" />
     </dependencies>
     <contentFiles>
       <files include="any\any\.PkgSrc\**" buildAction="None" copyToOutput="false" />


### PR DESCRIPTION
This change instructs MSBuild for Unity to the latest version, as of 2020-05-04. This version adds new functionality.