### PR TITLE
Update the PR validation pipeline to be faster (parallel, yey)

### DIFF
--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -1,11 +1,13 @@
 # Build for PR validation.
+# Contains two parallel jobs, one of which builds the code and runs a linter
+# to validate common errors, another which runs the tests.
 
 variables:
 - template: config/settings.yml
 
 jobs:
-- job: PRValidation
-  timeoutInMinutes: 90
+- job: PRValidationBuild
+  timeoutInMinutes: 20
   pool:
     name: On-Prem Unity
     demands:
@@ -23,6 +25,7 @@ jobs:
       # the specific flavors below that are experiencing failures in CI (for example,
       # if we're actively working on features that have a lot of churn on underlying
       # WMR APIs, buildUWPArm would be a good candidate to re-enable)
+      buildStandalone: true
       buildUWPX86: false
       buildUWPArm: false
       buildUWPDotNet: false
@@ -30,6 +33,29 @@ jobs:
       # the set of changed files, so that we can save some time. There's no need to
       # check unchanged files for code style/doc style violations.
       scopedValidation: true
+      # This particular job shouldn't run tests (they happen in PRValidationTest)
+      runTests: false
       UnityVersion: $(Unity2018Version)
 
+  - template: templates/end.yml
+- job: PRValidationTest
+  timeoutInMinutes: 20
+  pool:
+    name: On-Prem Unity
+    demands:
+    - Unity2018.4.6f1
+    - COG-UnityCache-WUS2-01
+    - SDK_18362 -equals TRUE
+  steps:
+  - template: templates/common.yml
+    parameters:
+      # The only task that this job should do is run the tests.
+      # Building is handled by PRValidationBuild.
+      runTests: true
+      buildStandalone: false
+      buildUWPX86: false
+      buildUWPArm: false
+      buildUWPDotNet: false
+      validateCode: false
+      UnityVersion: $(Unity2018Version)
   - template: templates/end.yml

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -34,7 +34,7 @@ jobs:
       # check unchanged files for code style/doc style violations.
       scopedValidation: true
       # This particular job shouldn't run tests (they happen in PRValidationTest)
-      runTests: false
+      runTests: true
       UnityVersion: $(Unity2018Version)
 
   - template: templates/end.yml

--- a/pipelines/templates/common.yml
+++ b/pipelines/templates/common.yml
@@ -32,6 +32,13 @@ steps:
       scopedValidation: ${{ parameters.scopedValidation }}
       changesFile: '$(Build.ArtifactStagingDirectory)\build\changedfiles.txt'
 
+# Tests should run earlier in the process, so that engineers can get test failure
+# notifications earlier in the CI process.
+- ${{ if eq(parameters.runTests, true) }}:
+  - template: tests.yml
+    parameters:
+      UnityVersion: ${{ parameters.UnityVersion }}
+
 # Build Standalone x86.
 # This must happen before tests run, because if the build fails and tests attempt
 # to get run, Unity will hang showing a dialog (even when in batch mode).
@@ -41,13 +48,6 @@ steps:
     parameters:
       Arch: 'x86'
       Platform: 'Standalone'
-      UnityVersion: ${{ parameters.UnityVersion }}
-
-# Tests should run earlier in the process, so that engineers can get test failure
-# notifications earlier in the CI process.
-- ${{ if eq(parameters.runTests, true) }}:
-  - template: tests.yml
-    parameters:
       UnityVersion: ${{ parameters.UnityVersion }}
 
 # Build UWP x86

--- a/pipelines/templates/tests.yml
+++ b/pipelines/templates/tests.yml
@@ -8,31 +8,6 @@ steps:
    $UnityPath = ${Env:${{ parameters.UnityVersion }}}
    $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
    
-   Write-Host "======================= EditMode Tests ======================="
-   
-   $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
-   
-   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform editmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
-   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
-   
-   while (-not $proc.HasExited -and $ljob.HasMoreData)
-   {
-       Receive-Job $ljob
-       Start-Sleep -Milliseconds 200
-   }
-   Receive-Job $ljob
-   
-   Stop-Job $ljob
-   
-   Remove-Job $ljob
-   Stop-Process $proc
-
-  displayName: 'Run EditMode tests'
-
-- powershell: |
-   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
-   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
-   
    Write-Host "======================= PlayMode Tests ======================="
    
    $logFile = New-Item -Path .\playmode-test-run.log -ItemType File -Force
@@ -53,6 +28,31 @@ steps:
    Stop-Process $proc
 
   displayName: 'Run PlayMode tests'
+
+- powershell: |
+   $UnityPath = ${Env:${{ parameters.UnityVersion }}}
+   $editor = Get-ChildItem $UnityPath -Filter 'Unity.exe' -Recurse | Select-Object -First 1 -ExpandProperty FullName
+   
+   Write-Host "======================= EditMode Tests ======================="
+   
+   $logFile = New-Item -Path .\editmode-test-run.log -ItemType File -Force
+   
+   $proc = Start-Process -FilePath "$editor" -ArgumentList "-projectPath $(Get-Location) -runTests -testPlatform editmode -batchmode -logFile $($logFile.Name) -editorTestsResultFile .\test-editmode-default.xml" -PassThru
+   $ljob = Start-Job -ScriptBlock { param($log) Get-Content "$log" -Wait } -ArgumentList $logFile.FullName
+   
+   while (-not $proc.HasExited -and $ljob.HasMoreData)
+   {
+       Receive-Job $ljob
+       Start-Sleep -Milliseconds 200
+   }
+   Receive-Job $ljob
+   
+   Stop-Job $ljob
+   
+   Remove-Job $ljob
+   Stop-Process $proc
+
+  displayName: 'Run EditMode tests'
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'


### PR DESCRIPTION
A while back I made a few modifications to the PR pipeline to speed it up from maybe 70ish minutes to about 20 minutes now. There have been a few issues that have passed through (i.e. one build error AFAIK that affected UWP builds) but it's mostly been a net positive.

I wanted to continue that work by lowering that number again (i.e. to 10 minutes per run) by making the build and test phases parallel.

Note that in this case I used parallel jobs, instead of parallel stages (of which, my understanding is that stages are usually used for things like build -> deploy QA -> deploy canary -> deploy prod, so I believe that jobs are more appropriate for this).

Note that there one thing that this change "depends on" - which is, if someone submits something that doesn't build, the test part will hang (Unity behavior when running tests on a non-building project). In this case it will time out (to ~20 minutes), but it might be the case that the failure of the other job might also cut this short (though maybe not). Either way, the worst case will still be the same as the average case now.