### PR TITLE
Properly handle user selecting None for the spatializer

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -67,10 +67,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void SaveSettings(string spatializer)
         {
-            if (!InstalledSpatializers.Contains(spatializer))
+            if ((spatializer != null) &&
+                !InstalledSpatializers.Contains(spatializer))
             {
                 Debug.LogError($"{spatializer} is not an installed spatializer.");
                 return;
+            }
+
+            if (spatializer == null)
+            {
+                Debug.LogWarning("No spatializer was specified. The application will not support Spatial Sound.");
             }
 
             SerializedObject audioMgrSettings = MixedRealityOptimizeUtils.GetSettingsObject("AudioManager");


### PR DESCRIPTION
This change fixes #7782 and now correctly configures the project to not use an audio spatializer.

When selecting None in the configurator, the following message is now logged to the console and the appropriate value of null is configured as the audio spatializer.

"No spatializer was specified. The application will not support Spatial Sound."