### PR TITLE
Fix bug #7805

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1101,6 +1101,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private HashSet<IMixedRealityPointer> proximityPointers = new HashSet<IMixedRealityPointer>();
         private List<Vector3> proximityPoints = new List<Vector3>();
 
+        // Set true to prevent CreateRig. When you need set multiple properties and do not want to CreateRig every time, use it.
+        // Use function SetPreventCreateRig
+        private bool preventCreateRig = false;
+
         #endregion
 
         #region public Properties
@@ -1192,10 +1196,24 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         /// <summary>
+        // Set true to prevent CreateRig. When you need set multiple properties and do not want to CreateRig every time, use it.
+        /// </summary>
+        /// <param name="b"></param>
+        public void SetPreventCreateRig(bool b)
+        {
+            preventCreateRig = b;
+        }
+
+        /// <summary>
         /// Destroys and re-creates the rig around the bounding box
         /// </summary>
         public void CreateRig()
         {
+            if (preventCreateRig)
+            {
+                return;
+            }
+
             DestroyRig();
             SetMaterials();
             InitializeRigRoot();


### PR DESCRIPTION
## Overview
Fix the lag when I add many BoundingBox (over 100) by coding and set all properties.

I add a bool variable to prevent "CreateRig", and also a function to set this bool. 

How to use: After you create BoundingBox by code, you can set this bool to true, then set all the properties. After that, you will set this bool to false, and call "CreateRig" manually at the end.

## Changes
- Fixes: #7805  .



