### PR TITLE
Update asset name to match filename

### DIFF
--- a/Assets/MRTK/Core/StandardAssets/FontsSDFTextures/seguisb SDF zwriteOff.asset
+++ b/Assets/MRTK/Core/StandardAssets/FontsSDFTextures/seguisb SDF zwriteOff.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
-  m_Name: seguisb SDF - zwriteoff
+  m_Name: seguisb SDF zwriteOff
   m_EditorClassIdentifier: 
   hashCode: -137542453
   material: {fileID: 21202819797275496}


### PR DESCRIPTION
## Overview

Unity keeps updating this asset's serialized name to match the file name whenever I open the project.