### PR TITLE
Fixing Build Window access of Response Data 

### DIFF
--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
@@ -56,8 +56,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="downloadHandler">Optional DownloadHandler for the request.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> GetAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, DownloadHandler downloadHandler = null)
+        public static async Task<Response> GetAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, DownloadHandler downloadHandler = null, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Get(query))
             {
@@ -66,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     webRequest.downloadHandler = downloadHandler;
                 }
 
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -80,12 +81,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="query">Finalized Endpoint Query with parameters.</param>
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> PostAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Post(query, null as string))
             {
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -96,12 +98,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="formData">Form Data.</param>
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, WWWForm formData, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> PostAsync(string query, WWWForm formData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Post(query, formData))
             {
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -112,8 +115,9 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="jsonData">JSON data for the request.</param>
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> PostAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Post(query, "POST"))
             {
@@ -122,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 webRequest.downloadHandler = new DownloadHandlerBuffer();
                 webRequest.SetRequestHeader("Content-Type", "application/json");
                 webRequest.SetRequestHeader("Accept", "application/json");
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -133,15 +137,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="bodyData">The raw data to post.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> PostAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Post(query, "POST"))
             {
                 webRequest.uploadHandler = new UploadHandlerRaw(bodyData);
                 webRequest.downloadHandler = new DownloadHandlerBuffer();
                 webRequest.SetRequestHeader("Content-Type", "application/octet-stream");
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -156,13 +161,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="jsonData">Data to be submitted.</param>
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PutAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> PutAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Put(query, jsonData))
             {
                 webRequest.SetRequestHeader("Content-Type", "application/json");
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -173,13 +179,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="bodyData">Data to be submitted.</param>
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PutAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> PutAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Put(query, bodyData))
             {
                 webRequest.SetRequestHeader("Content-Type", "application/octet-stream");
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
@@ -193,18 +200,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="query">Finalized Endpoint Query with parameters.</param>
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
+        /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> DeleteAsync(string query, Dictionary<string, string> headers = null, int timeout = -1)
+        public static async Task<Response> DeleteAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
         {
             using (var webRequest = UnityWebRequest.Delete(query))
             {
-                return await ProcessRequestAsync(webRequest, timeout, headers);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
             }
         }
 
         #endregion DELETE
 
-        private static async Task<Response> ProcessRequestAsync(UnityWebRequest webRequest, int timeout, Dictionary<string, string> headers = null)
+        private static async Task<Response> ProcessRequestAsync(UnityWebRequest webRequest, int timeout, Dictionary<string, string> headers = null, bool readResponseData = false)
         {
             if (timeout > 0)
             {
@@ -247,8 +255,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 Debug.LogError($"REST Error: {webRequest.responseCode}\n{downloadHandlerText}{responseHeaders}");
                 return new Response(false, $"{responseHeaders}\n{downloadHandlerText}", webRequest.downloadHandler?.data, webRequest.responseCode);
             }
-
-            return new Response(true, () => webRequest.downloadHandler?.text, () => webRequest.downloadHandler?.data, webRequest.responseCode);
+            if (readResponseData)
+            {
+                return new Response(true, webRequest.downloadHandler?.text, webRequest.downloadHandler?.data, webRequest.responseCode);
+            }
+            else // This option can be used only if action will be triggered in the same scope as the webrequest
+            {
+                return new Response(true, () => webRequest.downloadHandler?.text, () => webRequest.downloadHandler?.data, webRequest.responseCode);
+            }
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -65,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetDeviceOsInfoQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetMachineNameQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -117,7 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetBatteryQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -143,7 +143,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetPowerStateQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
             if (!isAuth) { return false; }
 
-            var response = await Rest.PostAsync(string.Format(RestartDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization);
+            var response = await Rest.PostAsync(string.Format(RestartDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
 
             if (response.Successful)
             {
@@ -175,7 +175,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
                 while (!hasRestarted)
                 {
-                    response = await Rest.GetAsync(query, targetDevice.Authorization);
+                    response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
                     if (!response.Successful)
                     {
@@ -212,7 +212,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
             if (!isAuth) { return false; }
 
-            var response = await Rest.PostAsync(string.Format(ShutdownDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization);
+            var response = await Rest.PostAsync(string.Format(ShutdownDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -258,7 +258,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 return false;
             }
 
-            var response = await Rest.GetAsync(string.Format(ProcessQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization);
+            var response = await Rest.GetAsync(string.Format(ProcessQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
 
             if (response.Successful)
             {
@@ -313,7 +313,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
             if (!isAuth) { return null; }
 
-            var response = await Rest.GetAsync(string.Format(PackagesQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization);
+            var response = await Rest.GetAsync(string.Format(PackagesQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -445,7 +445,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
         private static async Task<AppInstallStatus> GetInstallStatusAsync(DeviceInfo targetDevice)
         {
-            var response = await Rest.GetAsync(string.Format(InstallStatusQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization);
+            var response = await Rest.GetAsync(string.Format(InstallStatusQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
 
             if (response.Successful)
             {
@@ -494,7 +494,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             Debug.Log($"Attempting to uninstall {packageName} on {targetDevice.ToString()}...");
 
             string query = $"{string.Format(InstallQuery, FinalizeUrl(targetDevice.IP))}?package={UnityWebRequest.EscapeURL(appInfo.PackageFullName)}";
-            var response = await Rest.DeleteAsync(query, targetDevice.Authorization);
+            var response = await Rest.DeleteAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (response.Successful)
             {
@@ -537,7 +537,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             }
 
             string query = $"{string.Format(AppQuery, FinalizeUrl(targetDevice.IP))}?appid={UnityWebRequest.EscapeURL(appInfo.PackageRelativeId.EncodeTo64())}&package={UnityWebRequest.EscapeURL(appInfo.PackageFullName)}";
-            var response = await Rest.PostAsync(query, targetDevice.Authorization);
+            var response = await Rest.PostAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -579,7 +579,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             }
 
             string query = $"{string.Format(AppQuery, FinalizeUrl(targetDevice.IP))}?package={UnityWebRequest.EscapeURL(appInfo.PackageFullName.EncodeTo64())}";
-            Response response = await Rest.DeleteAsync(query, targetDevice.Authorization);
+            Response response = await Rest.DeleteAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -621,7 +621,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             }
 
             string logFile = $"{Application.temporaryCachePath}/{targetDevice.MachineName}_{DateTime.Now.Year}{DateTime.Now.Month}{DateTime.Now.Day}{DateTime.Now.Hour}{DateTime.Now.Minute}{DateTime.Now.Second}_player.txt";
-            var response = await Rest.GetAsync(string.Format(FileQuery, FinalizeUrl(targetDevice.IP), appInfo.PackageFullName), targetDevice.Authorization);
+            var response = await Rest.GetAsync(string.Format(FileQuery, FinalizeUrl(targetDevice.IP), appInfo.PackageFullName), targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -649,7 +649,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(IpConfigQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -676,7 +676,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(WiFiNetworkQuery, FinalizeUrl(targetDevice.IP), $"s?interface={interfaceInfo.GUID}");
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {
@@ -721,7 +721,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(WiFiInterfacesQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
 
             if (!response.Successful)
             {

--- a/Assets/MRTK/Examples/Demos/Gltf/Scripts/TestGlbLoading.cs
+++ b/Assets/MRTK/Examples/Demos/Gltf/Scripts/TestGlbLoading.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf
 
             try
             {
-                response = await Rest.GetAsync(uri);
+                response = await Rest.GetAsync(uri, readResponseData: true);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Overview
This [PR](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7527) has moved the access to DownloadHandler text and data to the Response object, adding an action that can be executed only when text from response is really needed (saving performance cost of unecessary DownloadHandler data conversion).

Most of methods inside DevicePortal.cs (used bu Build Window buttons ) use the text property from rest calls Response Data but most UnityWebRequests objects are initialized inside a using scope from Rest.cs. DevicePortal.cs methods cannot access delegated methods from download handler destroyed when out of the initialization using scope.

This regression Issue can be seen when trying to communicate with Hololens device through Build Window or when playing the Glb Loading Demo. 

![80339267-d77a3500-8890-11ea-83b6-404f3c72c402](https://user-images.githubusercontent.com/16922045/81316513-94377780-9083-11ea-825f-6dc94fc253a5.png)

## Changes

The proposed solution, keeps Response constructor option with delegate methods, but adds a flag in case ResponseData will have its download handler text property used by the caller method.

- Fixes: #7734 .
