### PR TITLE
Update Optimize Window UI to respect editor theme

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -42,11 +42,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public static readonly GUIStyle ControllerButtonStyle = new GUIStyle("LargeButton")
         {
             imagePosition = ImagePosition.ImageAbove,
-                    fontStyle = FontStyle.Bold,
-                    stretchHeight = true,
-                    stretchWidth = true,
-                    wordWrap = true,
-                    fontSize = 10,
+            fontStyle = FontStyle.Bold,
+            stretchHeight = true,
+            stretchWidth = true,
+            wordWrap = true,
+            fontSize = 10,
         };
 
         /// <summary>

--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Default style for bold large font size title
         /// </summary>
-        public static readonly GUIStyle BoldLargeTitleStyle = new GUIStyle()
+        public static readonly GUIStyle BoldLargeTitleStyle = new GUIStyle(EditorStyles.largeLabel)
         {
             fontSize = InspectorUIUtility.TitleFontSize,
             fontStyle = FontStyle.Bold,

--- a/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -180,7 +180,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             using (new GUILayout.VerticalScope("Box"))
             {
-                EditorGUILayout.LabelField(ToolbarTitles[(int)ToolbarSection.Shader], MixedRealityStylesUtility.BoldLargeTitleStyle);
+                GUILayout.Label(ToolbarTitles[(int)ToolbarSection.Shader], MixedRealityStylesUtility.BoldLargeTitleStyle);
                 using (new EditorGUI.IndentLevelScope())
                 {
                     EditorGUILayout.LabelField("The Unity standard shader is generally not performant or optimized for Mixed Reality development. The MRTK Standard shader can be a more performant option. "
@@ -274,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             using (new GUILayout.VerticalScope("Box"))
             {
-                EditorGUILayout.LabelField(ToolbarTitles[(int)ToolbarSection.Scene], MixedRealityStylesUtility.BoldLargeTitleStyle);
+                GUILayout.Label(ToolbarTitles[(int)ToolbarSection.Scene], MixedRealityStylesUtility.BoldLargeTitleStyle);
                 using (new EditorGUI.IndentLevelScope())
                 {
                     EditorGUILayout.LabelField("This section provides controls and performance information for the currently opened scene. Any optimizations performed are only for the active scene at any moment.", EditorStyles.wordWrappedLabel);

--- a/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
+++ b/Assets/MRTK/Tools/OptimizeWindow/MixedRealityOptimizeWindow.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             // Render Title
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.LabelField("Mixed Reality Toolkit Optimize Window", MixedRealityStylesUtility.BoldLargeTitleStyle);
+                GUILayout.Label("Mixed Reality Toolkit Optimize Window", MixedRealityStylesUtility.BoldLargeTitleStyle);
                 InspectorUIUtility.RenderDocumentationButton(OptimizeWindow_URL);
             }
 
@@ -405,7 +405,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             using (new GUILayout.VerticalScope("Box"))
             {
-                EditorGUILayout.LabelField(ToolbarTitles[(int)ToolbarSection.Settings], MixedRealityStylesUtility.BoldLargeTitleStyle);
+                GUILayout.Label(ToolbarTitles[(int)ToolbarSection.Settings], MixedRealityStylesUtility.BoldLargeTitleStyle);
                 using (new EditorGUI.IndentLevelScope())
                 {
                     RenderOptimalRenderingSection();


### PR DESCRIPTION
## Overview

Currently, the optimize window isn't respecting the editor theme with its titles:

![image](https://user-images.githubusercontent.com/3580640/81359648-918e4f80-908e-11ea-8131-a19e7822d837.png)

this updates it to use a built-in theme as its base, so the color is inherited and managed by the editor:

![image](https://user-images.githubusercontent.com/3580640/81359773-ee8a0580-908e-11ea-8cb3-ac9f2a4971c2.png)
