### PR TITLE
Unity freezing when changing to UWP

### DIFF
--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1463,7 +1463,8 @@ namespace Microsoft.MixedReality.Toolkit
         /// Used to register newly created instances in edit mode.
         /// Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play mode, which is disruptive to services.
         /// </summary>
-        private void OnValidate()
+        [UnityEditor.Callbacks.DidReloadScripts] // This is workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
+        private static void OnDidReloadScripts()
         {
             // This check is only necessary in edit mode. This can also get called during player builds as well,
             // and shouldn't be run during that time.
@@ -1474,7 +1475,7 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            RegisterInstance(this);
+            RegisterInstance(Instance);
         }
 #endif // UNITY_EDITOR
 

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1481,7 +1481,7 @@ namespace Microsoft.MixedReality.Toolkit
                 return;
             }
 
-            RegisterInstance(Instance);
+            RegisterInstance(this);
         }
 #endif // UNITY_EDITOR
 

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1459,13 +1459,19 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
+        private void OnValidate()
+        {
+            EditorApplication.delayCall += DelayOnValidate; // This is a workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
+        }
+
         /// <summary>
         /// Used to register newly created instances in edit mode.
         /// Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play mode, which is disruptive to services.
         /// </summary>
-        [UnityEditor.Callbacks.DidReloadScripts] // This is workaround for a known unity issue when calling refresh assetdatabase from inside a on validate scope.
-        private static void OnDidReloadScripts()
+        private void DelayOnValidate() 
         {
+            EditorApplication.delayCall -= DelayOnValidate;
+
             // This check is only necessary in edit mode. This can also get called during player builds as well,
             // and shouldn't be run during that time.
             if (EditorApplication.isPlayingOrWillChangePlaymode ||


### PR DESCRIPTION

## Overview
Unity 2019.3.8f1 does not respond after attempting to switch to UWP from Standalone.

![80549722-d7eafc80-8972-11ea-9c0a-fa4d8785b1c5](https://user-images.githubusercontent.com/16922045/81423437-56525600-914c-11ea-93a2-70c85fa9c9dc.png)

## Log Files:
Destroying GameObjects immediately is not permitted during physics trigger/contact, animation event callbacks or OnValidate. You must use Destroy instead.
UnityEditor.SceneManagement.EditorSceneManager:ClosePreviewScene_Injected(Scene&)
UnityEditor.SceneManagement.EditorSceneManager:ClosePreviewScene(Scene)
UnityEditor.PreviewScene:Dispose()
UnityEditor.PreviewRenderUtility:Cleanup()
UnityEditor.MaterialEditor:OnDisable()
UnityEngine.Object:DestroyImmediate(Object, Boolean)
UnityEngine.Object:DestroyImmediate(Object)
UnityEditor.AssetPreviewUpdater:CreatePreviewForAsset(Object, Object[], String)
UnityEditor.AssetDatabase:Refresh(ImportAssetOptions)
UnityEditor.AssetDatabase:Refresh()
Microsoft.MixedReality.Toolkit.Utilities.Editor.ProjectPreferences:get_Instance() (at Assets\MRTK\Core\Utilities\Editor\Preferences\ProjectPreferences.cs:69)
Microsoft.MixedReality.Toolkit.Utilities.Editor.ProjectPreferences:Get(String, Boolean) (at Assets\MRTK\Core\Utilities\Editor\Preferences\ProjectPreferences.cs:119)
Microsoft.MixedReality.Toolkit.Editor.MixedRealityProjectPreferences:get_AutoEnableUWPCapabilities() (at Assets\MRTK\Core\Utilities\Editor\Preferences\MixedRealityProjectPreferences.cs:87)
Microsoft.MixedReality.Toolkit.Utilities.Editor.UWPCapabilityUtility:RequireCapability(WSACapability, Type) (at Assets\MRTK\Core\Utilities\UWPCapabilityUtility.cs:27)
Microsoft.MixedReality.Toolkit.Windows.Input.WindowsSpeechInputProvider:Initialize() (at Assets\MRTK\Providers\WindowsVoiceInput\WindowsSpeechInputProvider.cs:123)
Microsoft.MixedReality.Toolkit.BaseDataProviderAccessCoreSystem:RegisterDataProvider(IMixedRealityInputDeviceManager) (at Assets\MRTK\Core\Services\BaseDataProviderAccessCoreSystem.cs:254)
Microsoft.MixedReality.Toolkit.BaseDataProviderAccessCoreSystem:RegisterDataProviderInternal(Boolean, Type, SupportedPlatforms, Object[]) (at Assets\MRTK\Core\Services\BaseDataProviderAccessCoreSystem.cs:237)
Microsoft.MixedReality.Toolkit.BaseDataProviderAccessCoreSystem:RegisterDataProvider(Type, SupportedPlatforms, Object[]) (at Assets\MRTK\Core\Services\BaseDataProviderAccessCoreSystem.cs:162)
Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem:CreateDataProviders() (at Assets\MRTK\Services\InputSystem\MixedRealityInputSystem.cs:268)
Microsoft.MixedReality.Toolkit.Input.MixedRealityInputSystem:Initialize() (at Assets\MRTK\Services\InputSystem\MixedRealityInputSystem.cs:235)
Microsoft.MixedReality.Toolkit.<>c:b__60_0(IMixedRealityService) (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:924)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit:ExecuteOnAllServicesInOrder(Action`1) (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:1034)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit:InitializeAllServices() (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:924)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit:InitializeServiceLocator() (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:469)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit:InitializeInstance() (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:583)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit:RegisterInstance(MixedRealityToolkit, Boolean) (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:721)
Microsoft.MixedReality.Toolkit.MixedRealityToolkit:OnValidate() (at Assets\MRTK\Core\Services\MixedRealityToolkit.cs:1477)


## Changes
Proposed solution: Substituting OnValidate method inside MixedRealityToolkit to a callback method marked with DidReloadScrip atribute.

- Fixes: #7737 .
