### PR TITLE
Adding eye gaze changes to release and updating notes

### DIFF
--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using Unity.Profiling;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityPhysics = UnityEngine.Physics;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -590,8 +591,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public Ray LatestEyeGaze { get; private set; } = default(Ray);
 
+        [FormerlySerializedAs("useEyeTracking")]
+        private bool isEyeTrackingEnabled;
+
         /// <inheritdoc />
-        public bool IsEyeTrackingEnabled { get; set; }
+        public bool IsEyeTrackingEnabled 
+        {
+            get => isEyeTrackingEnabled;
+            set => isEyeTrackingEnabled = value;
+        }
 
         /// <inheritdoc />
         public DateTime Timestamp { get; private set; }

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -6,7 +6,6 @@ using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityPhysics = UnityEngine.Physics;
 
 namespace Microsoft.MixedReality.Toolkit.Input
@@ -591,15 +590,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public Ray LatestEyeGaze { get; private set; } = default(Ray);
 
-        [FormerlySerializedAs("useEyeTracking")]
-        private bool isEyeTrackingEnabled;
-
         /// <inheritdoc />
-        public bool IsEyeTrackingEnabled 
-        {
-            get => isEyeTrackingEnabled;
-            set => isEyeTrackingEnabled = value;
-        }
+        public bool IsEyeTrackingEnabled { get; set; }
 
         /// <inheritdoc />
         public DateTime Timestamp { get; private set; }

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -165,20 +165,24 @@ Note that BoundsControl is still in experimental phase and therefore API or prop
 
 **Eye Gaze API**
 
-The `UseEyeTracking` property from `GazeProvider` implementation of `IMixedRealityEyeGazeProvider`  was renamed to `IsEyeTrackingEnabled`.
+The `UseEyeTracking` property from `GazeProvider` implementation of `IMixedRealityEyeGazeProvider` was renamed to `IsEyeTrackingEnabled`.
 
 If you did this previously...
 
 ```csharp
-GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
-gazeProvider.UseEyeTracking = true;
+if (CoreServices.InputSystem.GazeProvider is GazeProvider gazeProvider)
+{
+    gazeProvider.UseEyeTracking = true;
+}
 ```
 
 Do this now...
 
 ```csharp
-GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
-gazeProvider.IsEyeTrackingEnabled = true;
+if (CoreServices.InputSystem.GazeProvider is GazeProvider gazeProvider)
+{
+    gazeProvider.IsEyeTrackingEnabled = true;
+}
 ```
 
 **Eye gaze setup**

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -163,7 +163,25 @@ Note that BoundsControl is still in experimental phase and therefore API or prop
 
 ### Breaking changes in 2.4.0
 
-**Eye gaze setup change**
+**Eye Gaze API**
+
+The `UseEyeTracking` property from `GazeProvider` implementation of `IMixedRealityEyeGazeProvider`  was renamed to `IsEyeTrackingEnabled`.
+
+If you did this previously...
+
+```csharp
+GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
+gazeProvider.UseEyeTracking = true;
+```
+
+Do this now...
+
+```csharp
+GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
+gazeProvider.IsEyeTrackingEnabled = true;
+```
+
+**Eye gaze setup**
 
 This version of MRTK modifies the steps required for eye gaze setup. The _'IsEyeTrackingEnabled'_ checkbox can be found in the gaze settings of the input pointer profile. Checking this box will enable eye based gaze, rather then the default head based gaze.
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -89,11 +89,35 @@ uses hard coded paths to MRTK resources, they will need to be updated per the fo
 > [!IMPORTANT]
 > The `MixedRealityToolkit.Generated` contains customer generated files and remains unchanged.
 
+### Eye gaze setup in 2.4.0
+
+This version of MRTK modifies the steps required for eye gaze setup. The _'IsEyeTrackingEnabled'_ checkbox can be found in the gaze settings of the input pointer profile. Checking this box will enable eye based gaze, rather then the default head based gaze.
+
+For more information on these changes and complete instructions for eye tracking setup, please see the [eye tracking](EyeTracking/EyeTracking_BasicSetup.md) article.
+
 ### API changes in 2.4.0
 
 **Custom controller classes**
 
 Custom controller classes previously had to define `SetupDefaultInteractions(Handedness)`. This method has been made obsolete in 2.4, as the handedness parameter was redundant with the controller class' own handedness. The new method has no parameters. Additionally, many controller classes defined this the same way (`AssignControllerMappings(DefaultInteractions);`), so the full call has been refactored down into `BaseController` and made an optional override instead of required.
+
+**Eye Gaze properties**
+
+The `UseEyeTracking` property from `GazeProvider` implementation of `IMixedRealityEyeGazeProvider`  was renamed to `IsEyeTrackingEnabled`.
+
+If you did this previously...
+
+```csharp
+GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
+gazeProvider.UseEyeTracking = true;
+```
+
+Do this now...
+
+```csharp
+GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
+gazeProvider.IsEyeTrackingEnabled = true;
+```
 
 **WindowsApiChecker properties**
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -103,20 +103,24 @@ Custom controller classes previously had to define `SetupDefaultInteractions(Han
 
 **Eye Gaze properties**
 
-The `UseEyeTracking` property from `GazeProvider` implementation of `IMixedRealityEyeGazeProvider`  was renamed to `IsEyeTrackingEnabled`.
+The `UseEyeTracking` property from `GazeProvider` implementation of `IMixedRealityEyeGazeProvider` was renamed to `IsEyeTrackingEnabled`.
 
 If you did this previously...
 
 ```csharp
-GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
-gazeProvider.UseEyeTracking = true;
+if (CoreServices.InputSystem.GazeProvider is GazeProvider gazeProvider)
+{
+    gazeProvider.UseEyeTracking = true;
+}
 ```
 
 Do this now...
 
 ```csharp
-GazeProvider gazeProvider = FindObjectOfType<GazeProvider>();
-gazeProvider.IsEyeTrackingEnabled = true;
+if (CoreServices.InputSystem.GazeProvider is GazeProvider gazeProvider)
+{
+    gazeProvider.IsEyeTrackingEnabled = true;
+}
 ```
 
 **WindowsApiChecker properties**


### PR DESCRIPTION
## Overview
Both the Release Notes and Updating guidance are missing info about how to upgrade old eye tracking api calls to new ones. There is also no updating guidance on changes of setup eye tracking.

This PR updates documentation about Eye gaze/ tracking setup and api for 2.4.

## Changes
- Fixes: #7808 .

