### PR TITLE
Reconcile some unneeded #if UNITY_EDITOR defines

### DIFF
--- a/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseDataProviderAccessCoreSystem.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
-using UnityEngine;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
+using System.Collections.Generic;
 using Unity.Profiling;
-
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
@@ -24,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit
         {
             base.Reset();
 
-            foreach(var provider in dataProviders)
+            foreach (var provider in dataProviders)
             {
                 provider.Reset();
             }

--- a/Assets/MRTK/Examples/Demos/Gltf/Scripts/Editor/TestGltfLoadingEditor.cs
+++ b/Assets/MRTK/Examples/Demos/Gltf/Scripts/Editor/TestGltfLoadingEditor.cs
@@ -14,11 +14,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf.Editor
     [CustomEditor(typeof(TestGltfLoading))]
     public class TestGltfLoadingEditor : UnityEditor.Editor
     {
-        private string GLTFModelsPath = $"Demos{Path.DirectorySeparatorChar}Gltf{Path.DirectorySeparatorChar}Models";
+        private static readonly string GLTFModelsPath = $"Demos{Path.DirectorySeparatorChar}Gltf{Path.DirectorySeparatorChar}Models";
 
         public override void OnInspectorGUI()
         {
-            var testGltfLoading = this.target as TestGltfLoading;
+            var testGltfLoading = target as TestGltfLoading;
 
             base.OnInspectorGUI();
 
@@ -33,9 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf.Editor
             {
                 string modelPath = MixedRealityToolkitFiles.MapRelativeFolderPathToAbsolutePath(MixedRealityToolkitModuleType.Examples, GLTFModelsPath);
                 DirectoryCopy(modelPath, Path.Combine(Application.streamingAssetsPath, "GltfModels"));
-#if UNITY_EDITOR
-                UnityEditor.AssetDatabase.Refresh(UnityEditor.ImportAssetOptions.ForceUpdate);
-#endif
+                AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
                 Debug.Log("Copied glTF model files to Streaming Assets folder");
             }
         }

--- a/Assets/MRTK/Extensions/LostTrackingService/Editor/LostTrackingServiceInspector.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/Editor/LostTrackingServiceInspector.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_EDITOR
 using Microsoft.MixedReality.Toolkit.Editor;
 using UnityEditor;
 using UnityEngine;
@@ -40,4 +39,3 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking.Editor
         }
     }
 }
-#endif

--- a/Assets/MRTK/SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/ManipulationHandler/ManipulationHandlerInspector.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -198,14 +196,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.HelpBox("This component is deprecated. Please migrate object to up to date version", MessageType.Warning);
             if (GUILayout.Button("Migrate Object"))
             {
-#if UNITY_EDITOR
                 MigrationTool migrationTool = new MigrationTool();
 
                 var component = (ManipulationHandler)target;
 
-                migrationTool.TryAddObjectForMigration(typeof(ObjectManipulatorMigrationHandler),(GameObject)component.gameObject);
+                migrationTool.TryAddObjectForMigration(typeof(ObjectManipulatorMigrationHandler), (GameObject)component.gameObject);
                 migrationTool.MigrateSelection(typeof(ObjectManipulatorMigrationHandler), true);
-#endif
             }
         }
     }

--- a/Assets/MRTK/SDK/Inspectors/UX/VisualThemes/StatesInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/VisualThemes/StatesInspector.cs
@@ -8,9 +8,8 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Microsoft.MixedReality.Toolkit.UI
+namespace Microsoft.MixedReality.Toolkit.UI.Editor
 {
-#if UNITY_EDITOR
     [CustomEditor(typeof(States))]
     public class StatesInspector : UnityEditor.Editor
     {
@@ -36,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             EditorGUILayout.HelpBox("Manage state configurations to drive Interactables or Transitions", MessageType.None);
 
             SerializedProperty stateModelClassName = serializedObject.FindProperty("StateModelClassName");
-            SerializedProperty assemblyQualifiedName  = serializedObject.FindProperty("AssemblyQualifiedName");
+            SerializedProperty assemblyQualifiedName = serializedObject.FindProperty("AssemblyQualifiedName");
 
             var stateModelTypes = TypeCacheUtility.GetSubClasses<BaseStateModel>();
             var stateModelClassNames = stateModelTypes.Select(t => t?.Name).ToArray();
@@ -103,5 +102,4 @@ namespace Microsoft.MixedReality.Toolkit.UI
             serializedObject.ApplyModifiedProperties();
         }
     }
-#endif
 }

--- a/Assets/MRTK/SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/VisualThemes/ThemeInspector.cs
@@ -11,7 +11,6 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.UI.Editor
 {
-#if UNITY_EDITOR
     /// <summary>
     /// Inspector for themes, and used by Interactable
     /// </summary>
@@ -628,5 +627,4 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
             return results;
         }
     }
-#endif
 }

--- a/Assets/MRTK/Services/InputSystem/Editor/NearInteractionTouchableVolumeInspector.cs
+++ b/Assets/MRTK/Services/InputSystem/Editor/NearInteractionTouchableVolumeInspector.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    [CustomEditor(typeof(NearInteractionTouchableVolume))]
+    public class NearInteractionTouchableVolumeInspector : UnityEditor.Editor
+    {
+        /// <inheritdoc />
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            NearInteractionTouchableVolume t = target as NearInteractionTouchableVolume;
+            Collider c = t.GetComponent<Collider>();
+            if (c == null)
+            {
+                EditorGUILayout.HelpBox("A collider is required in order to compute the touchable volume.", MessageType.Warning);
+            }
+        }
+    }
+}

--- a/Assets/MRTK/Services/InputSystem/Editor/NearInteractionTouchableVolumeInspector.cs.meta
+++ b/Assets/MRTK/Services/InputSystem/Editor/NearInteractionTouchableVolumeInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63252277b44134644992d368783d6ea8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Services/InputSystem/NearInteractionTouchableVolume.cs
+++ b/Assets/MRTK/Services/InputSystem/NearInteractionTouchableVolume.cs
@@ -13,26 +13,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
     [AddComponentMenu("Scripts/MRTK/Services/NearInteractionTouchableVolume")]
     public class NearInteractionTouchableVolume : BaseNearInteractionTouchable
     {
-#if UNITY_EDITOR
-        [UnityEditor.CustomEditor(typeof(NearInteractionTouchableVolume))]
-        public class Editor : UnityEditor.Editor
-        {
-            /// <inheritdoc />
-            public override void OnInspectorGUI()
-            {
-                base.OnInspectorGUI();
-
-                NearInteractionTouchableVolume t = (NearInteractionTouchableVolume)target;
-                Collider c = t.GetComponent<Collider>();
-                if (c == null)
-                {
-                    UnityEditor.EditorGUILayout.HelpBox("A collider is required in order to compute the touchable volume.", UnityEditor.MessageType.Warning);
-                }
-            }
-        }
-#endif
-
-        public bool ColliderEnabled { get { return touchableCollider.enabled && touchableCollider.gameObject.activeInHierarchy; } }
+        /// <summary>
+        /// Is the touchable collider enabled and active in the scene.
+        /// </summary>
+        public bool ColliderEnabled => touchableCollider.enabled && touchableCollider.gameObject.activeInHierarchy;
 
         /// <summary>
         /// The collider used by this touchable.


### PR DESCRIPTION
## Overview

While looking into the number of `#if` defines we have (which has a direct effect on the number of different assemblies we need to build and support), I realized we have some extraneous `#if UNITY_EDITOR` defines. I resolved least impact defines here. The three cases this PR fixes:

1. Remove editor defines in editor-only assemblies
1. Refactor out custom inspectors into editor-only assemblies
1. Remove an unused UnityEditor namespace

There will likely be a few follow up PRs in the coming weeks.