### PR TITLE
Fix broken links that use incorrect absolute paths and prevent regressions going forward

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Dialog/README_Dialog.md
+++ b/Assets/MRTK/SDK/Experimental/Dialog/README_Dialog.md
@@ -5,7 +5,7 @@ Dialog controls are UI overlays that provide contextual app information. They of
 
 ## Example scene
 You can find examples in the **DialogExample** scene under:
-[MRTK/Examples/Experimental/Dialog](/Assets/MRTK/Examples/Experimental/Dialog/)
+[MRTK/Examples/Experimental/Dialog](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/SDK/Experimental/Dialog)
 
 ## How to use Dialog control
 MRTK provides three Dialog prefabs: 

--- a/Assets/MRTK/SDK/Experimental/HandCoach/README_HandCoach.md
+++ b/Assets/MRTK/SDK/Experimental/HandCoach/README_HandCoach.md
@@ -17,11 +17,11 @@ The current interaction model represents a wide variety of gesture controls such
 
 ## Example scene
 You can find examples in the **HandCoachExample** scene under:
-[MixedRealityToolkit.Examples/Experimental/HandCoach/Scenes](/Assets/MixedRealityToolkit.Examples/Experimental/HandCoach/Scenes)
+[MixedRealityToolkit.Examples/Experimental/HandCoach/Scenes](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_development/Assets/MRTK/Examples/Experimental/HandCoach/Scenes)
 
 ## Hand 3D Assets
 You can find the assets under:
-[MixedRealityToolkit.SDK/Experimental/HandCoach](/Assets/MixedRealityToolkit.SDK/Experimental/HandCoach/)
+[MixedRealityToolkit.SDK/Experimental/HandCoach](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/SDK/Experimental/HandCoach)
 
 ## Quality
 If you notice distortions on the skinned mesh, you need to make sure your project is using the proper amount of joints. 

--- a/Documentation/README_MRTKStandardShader.md
+++ b/Documentation/README_MRTKStandardShader.md
@@ -77,11 +77,11 @@ For static lighting, the shader will respect lightmaps built by Unity's [Lightma
 
 ### Hover light
 
-* See [Hover Light](/Rendering/HoverLight.md)
+* See [Hover Light](Rendering/HoverLight.md)
 
 ### Proximity light
 
-* See [Proximity Light](/Rendering/ProximityLight.md)
+* See [Proximity Light](Rendering/ProximityLight.md)
 
 ## Lightweight Scriptable Render Pipeline support
 
@@ -132,7 +132,7 @@ Below are extra details on a handful of feature details available with the MRTK/
 
 ![primitive clipping](../Documentation/Images/MRTKStandardShader/MRTK_PrimitiveClipping.gif)
 
-* See [Clipping Primitive](/Rendering/ClippingPrimitive.md)
+* See [Clipping Primitive](Rendering/ClippingPrimitive.md)
 
 ### Mesh outlines
 
@@ -196,6 +196,6 @@ Per pixel clipping textures, local edge based anti aliasing, and normal map scal
 ## See also
 
 - [Interactable](README_Interactable.md)
-- [Hover Light](/Rendering/HoverLight.md)
-- [Proximity Light](/Rendering/ProximityLight.md)
-- [Clipping Primitive](/Rendering/ClippingPrimitive.md)
+- [Hover Light](Rendering/HoverLight.md)
+- [Proximity Light](Rendering/ProximityLight.md)
+- [Clipping Primitive](Rendering/ClippingPrimitive.md)

--- a/Documentation/README_TextPrefab.md
+++ b/Documentation/README_TextPrefab.md
@@ -53,12 +53,12 @@ When adding a UI or canvas based Text element to a scene, the size disparity is 
 
 ![Font size with scaling factors](../Documentation/Images/TextPrefab/TextPrefabInstructions07.png)
 
-### [Text3DSelawik.mat](/Assets/MixedRealityToolkit/StandardAssets/Materials/)
+### [Text3DSelawik.mat](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Core/StandardAssets/Materials)
 
 Material for 3DTextPrefab with occlusion support. Requires 3DTextShader.shader
 
 ![Default Font material vs 3DTextSegoeUI material](../Documentation/Images/TextPrefab/TextPrefabInstructions06.png)
 
-### [Text3DShader.shader](/Assets/MixedRealityToolkit/StandardAssets/Shaders/)
+### [Text3DShader.shader](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Core/StandardAssets/Shaders)
 
 Shader for 3DTextPrefab with occlusion support.


### PR DESCRIPTION
https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7849

Our docs contain a few broken links, which are broken for a few reasons:

1. They are actually wrong (i.e. they are absolute relative to the root, rather than relative to the current folder).
1. There are some links that reference the Asset root (i.e. /Assets) which won't resolve correct on github.io - for the safety of ensuring that links will actually work on github.io we essentially have to ensure that we use relative paths for docs, forcing a check that you aren't using an absolute path.

Note that this allows the usage of "/Assets" because some of our docs (experimental ones) don't actually get published to github.io (and thus, these are valid from those locations)

This is kinda a workaround (i.e. ideally docfx would just catch this issue because it's non existent w/ an absolute path) but this works for our purposes