### PR TITLE
Allow Spatializer to be set to None for the MRTK Project Configurator

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         /// <returns>
         /// True if the selected spatializer is installed and no changes have been made to the collection of installed spatializers.
-        /// False if there is no selected spatializer, the selected spatializer is no longer installed or the collection of installed spatializers has been changed.
+        /// False if the selected spatializer is no longer installed or the collection of installed spatializers has been changed.
         /// </returns>
         public static bool CheckSettings()
         {
@@ -38,8 +38,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // Check to see if an audio spatializer is configured.
             if (string.IsNullOrWhiteSpace(spatializerName))
             {
-                // A spatializer has not been configured.
-                return false;
+                // The user chose to not initialize a spatializer so we are set correctly
+                return true;
             }
 
             string[] installedSpatializers = InstalledSpatializers;

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -33,6 +33,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </returns>
         public static bool CheckSettings()
         {
+            // Check to see if the count of installed spatializers has changed
+            if (!CheckSpatializerCount())
+            {
+                // A spatializer has been added or removed.
+                return false;
+            }
+
             string spatializerName = CurrentSpatializer;
 
             // Check to see if an audio spatializer is configured.
@@ -48,13 +55,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             if (!installedSpatializers.Contains(spatializerName))
             {
                 // The current spatializer has been uninstalled.
-                return false;
-            }
-
-            // Next, check to see if the count of installed spatializers has changed
-            if (!CheckSpatializerCount())
-            {
-                // A spatializer has been added or removed.
                 return false;
             }
 

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -67,16 +67,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// </summary>
         public static void SaveSettings(string spatializer)
         {
-            if ((spatializer != null) &&
-                !InstalledSpatializers.Contains(spatializer))
+            if (string.IsNullOrWhiteSpace(spatializer))
+            {
+                Debug.LogWarning("No spatializer was specified. The application will not support Spatial Sound.");
+            }
+            else if (!InstalledSpatializers.Contains(spatializer))
             {
                 Debug.LogError($"{spatializer} is not an installed spatializer.");
                 return;
-            }
-
-            if (spatializer == null)
-            {
-                Debug.LogWarning("No spatializer was specified. The application will not support Spatial Sound.");
             }
 
             SerializedObject audioMgrSettings = MixedRealityOptimizeUtils.GetSettingsObject("AudioManager");


### PR DESCRIPTION
## Overview
Allowed spatializer to be unset when checking settings, preventing the configurator from opening every time

## Changes
- Fixes: #7332

Tested by creating new c# scripts and ensuring that the dialog didn't come up again and that the particular code path was hit.