### PR TITLE
Fix for controller and pointer errors in VR (#7796)

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityController.cs
@@ -8,7 +8,6 @@ using System;
 
 #if UNITY_WSA
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR.WSA.Input;
@@ -258,7 +257,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// Ensure that if a controller model was desired that we have attempted initialization.
         /// </summary>
         /// <param name="interactionSourceState">The InteractionSourceState retrieved from the platform.</param>
-        internal async Task EnsureControllerModel(InteractionSource interactionSource)
+        internal void EnsureControllerModel(InteractionSource interactionSource)
         {
             GameObject controllerModel;
 
@@ -278,7 +277,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
 
             controllerModelInitialized = true;
-            await CreateControllerModelFromPlatformSDK(interactionSource);
+            CreateControllerModelFromPlatformSDK(interactionSource);
         }
 
         /// <inheritdoc />
@@ -299,7 +298,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             return false;
         }
 
-        private async Task CreateControllerModelFromPlatformSDK(InteractionSource interactionSource)
+        private async void CreateControllerModelFromPlatformSDK(InteractionSource interactionSource)
         {
             Debug.Log("Trying to load controller model from platform SDK");
             byte[] fileBytes = null;

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -397,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         private static readonly ProfilerMarker GetOrAddControllerPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityDeviceManager.GetOrAddController");
 
-        private async void GetOrAddController(InteractionSourceState interactionSourceState)
+        private void GetOrAddController(InteractionSourceState interactionSourceState)
         {
             using (GetOrAddControllerPerfMarker.Auto())
             {
@@ -414,7 +414,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
                     if (mrtkController != null)
                     {
-                        await mrtkController.EnsureControllerModel(interactionSourceState.source);
+                        mrtkController.EnsureControllerModel(interactionSourceState.source);
                     }
 
                     // Does the controller still exist after we loaded the controller model?

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
@@ -26,9 +26,8 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
             get { return pointer; }
             set
             {
-                Debug.Assert(value.GetType() == typeof(TeleportPointer) ||
-                             value.GetType() == typeof(ParabolicTeleportPointer),
-                    "Teleport Cursor's Pointer must derive from a TeleportPointer type.");
+                Debug.Assert(value is TeleportPointer,
+                    "Teleport Cursor's Pointer must derive from TeleportPointer.");
 
                 pointer = value as TeleportPointer;
                 pointer.BaseCursor = this;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/TeleportCursor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.Teleport
                              value.GetType() == typeof(ParabolicTeleportPointer),
                     "Teleport Cursor's Pointer must derive from a TeleportPointer type.");
 
-                pointer = (TeleportPointer)value;
+                pointer = value as TeleportPointer;
                 pointer.BaseCursor = this;
                 RegisterManagers();
             }

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -840,10 +840,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (RaiseSourceDetectedPerfMarker.Auto())
             {
+                if (DetectedInputSources.Contains(source)) 
+                { 
+                    Debug.LogError($"{source.SourceName} has already been registered with the Input Manager!");
+                    return;
+                }
+
                 // Create input event
                 sourceStateEventData.Initialize(source, controller);
-
-                if (DetectedInputSources.Contains(source)) { Debug.LogError($"{source.SourceName} has already been registered with the Input Manager!"); }
 
                 DetectedInputSources.Add(source);
 
@@ -873,10 +877,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (RaiseSourceLostPerfMarker.Auto())
             {
+                if (!DetectedInputSources.Contains(source)) 
+                { 
+                    Debug.LogError($"{source.SourceName} was never registered with the Input Manager!");
+                    return;
+                }
+
                 // Create input event
                 sourceStateEventData.Initialize(source, controller);
-
-                if (!DetectedInputSources.Contains(source)) { Debug.LogError($"{source.SourceName} was never registered with the Input Manager!"); }
 
                 DetectedInputSources.Remove(source);
 

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -842,7 +842,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (DetectedInputSources.Contains(source)) 
                 { 
-                    Debug.LogError($"{source.SourceName} has already been registered with the Input Manager!");
+                    Debug.LogWarning($"[MRTK Issue] {source.SourceName} has already been registered with the Input Manager!");
                     return;
                 }
 
@@ -879,7 +879,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 if (!DetectedInputSources.Contains(source)) 
                 { 
-                    Debug.LogError($"{source.SourceName} was never registered with the Input Manager!");
+                    Debug.LogWarning($"[MRTK Issue] {source.SourceName} was never registered with the Input Manager!");
                     return;
                 }
 


### PR DESCRIPTION
This change fixes the controller and pointer errors reported in #7796 by partially reverting #6939.

It also prevents duplicate source detected/lost events from attempting to modify the controllers collection, which would result in errors / exceptions from the runtime.

Details on what was happening before this change.
The timing changes caused by awaiting the controller model was resulting in the following failure path:
1. The platform raises a source detected event
2. Pointer and cursor MonoBehaviours are instantiated
3. Input source is created
4. Controller object is created
5. Controller waits for the model to load
6. Update is called on the MonoBehaviours
7. Teleport cursor checks for the teleport pointer and fails to find it,
8. Teleport cursor deletes itself
9. The focus provider receives the source detected event from MRTK and registers the pointer.
10. The pointer cannot locate the cursor, since it deleted itself.

Issue #7856 covers restoring the behavior removed by this change and improving the flow described above.