### PR TITLE
Migration Window: Adding inactive objects to migration list

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
@@ -28,6 +28,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             var boundingBox = gameObject.GetComponent<BoundingBox>();
             var boundsControl = gameObject.AddComponent<BoundsControl>();
 
+            boundsControl.enabled = boundingBox.enabled;
+
             {
                 Undo.RecordObject(gameObject, "BoundsControl migration: swapping BoundingBox with BoundsControl.");
                 

--- a/Assets/MRTK/SDK/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Migration/ObjectManipulatorMigrationHandler.cs
@@ -25,6 +25,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             var manipHandler = gameObject.GetComponent<ManipulationHandler>();
             var objManip = gameObject.AddComponent<ObjectManipulator>();
 
+            objManip.enabled = manipHandler.enabled;
+
             objManip.HostTransform = manipHandler.HostTransform;
 
             switch (manipHandler.ManipulationType)

--- a/Assets/MRTK/SDK/Features/Utilities/Migration/Tools/MigrationTool.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Migration/Tools/MigrationTool.cs
@@ -119,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             if (IsSceneGameObject(selectedObject))
             {
-                var objectHierarchy = ((GameObject)selectedObject).GetComponentsInChildren<Transform>();
+                var objectHierarchy = ((GameObject)selectedObject).GetComponentsInChildren<Transform>(true);
                 for (int i = 0; i < objectHierarchy.Length; i++)
                 {
                     if (migrationHandlerInstance.CanMigrate(objectHierarchy[i].gameObject))
@@ -371,7 +371,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private bool MigrateGameObjectHierarchy(GameObject parent, MigrationStatus status)
         {
             bool changedAnyGameObject = false;
-            foreach (var child in parent.GetComponentsInChildren<Transform>())
+            foreach (var child in parent.GetComponentsInChildren<Transform>(true))
             {
                 try
                 {

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/MigrationToolTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/MigrationToolTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
     {
         private readonly MigrationTool migrationTool = new MigrationTool();
         private readonly HashSet<string> assetsForDeletion = new HashSet<string>();
+        private readonly string scenePath = "Assets/_migration.unity";
+        private readonly string prefabPath = "Assets/_migration.prefab";
 
         private struct MigrationTypes
         {
@@ -94,7 +96,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
         }
 
         /// <summary>
-        /// Checks if MigrationTool can process migration on a game object containing a deprecated ManipulationHandler component.
+        /// Checks if MigrationTool can process migration on a game object containing a deprecated component with a compatible migration handler.
         /// </summary>
         [Test]
         public void GameObjectCanBeMigrated()
@@ -107,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
 
                 GameObject gameObject = SetUpGameObjectWithComponentOfType(oldType);
 
-                migrationTool.TryAddObjectForMigration(migrationHandlerType,gameObject);
+                migrationTool.TryAddObjectForMigration(migrationHandlerType, gameObject);
                 migrationTool.MigrateSelection(migrationHandlerType, false);
 
                 Assert.IsNull(gameObject.GetComponent(oldType), $"Migrated Component of type {oldType.Name} could not be removed");
@@ -118,7 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
         }
 
         /// <summary>
-        /// Checks if MigrationTool can process migration on a prefab containing a deprecated ManipulationHandler component.
+        /// Checks if MigrationTool can process migration on a prefab containing a deprecated component with a compatible migration handler.
         /// </summary>
         [Test]
         public void PrefabCanBeMigrated()
@@ -128,7 +130,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
                 Type oldType = entry.oldType;
                 Type newType = entry.newType;
                 Type migrationHandlerType = entry.handler;
-                string prefabPath = "Assets/_migration.prefab";
 
                 GameObject gameObject = SetUpGameObjectWithComponentOfType(oldType);
                 PrefabUtility.SaveAsPrefabAsset(gameObject, prefabPath);
@@ -147,7 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
         }
 
         /// <summary>
-        /// Checks if MigrationTool can process migration on a scene root game object that contains a deprecated ManipulationHandler component.
+        /// Checks if MigrationTool can process migration on a scene root game object that contains a deprecated component with a compatible migration handler.
         /// </summary>
         [Test]
         public void SceneCanBeMigrated()
@@ -157,7 +158,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
                 Type oldType = entry.oldType;
                 Type newType = entry.newType;
                 Type migrationHandlerType = entry.handler;
-                string scenePath = "Assets/_migration.unity";
 
                 Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
                 GameObject gameObject = SetUpGameObjectWithComponentOfType(oldType);
@@ -179,6 +179,48 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
             }
         }
 
+        /// <summary>
+        /// Checks if MigrationTool can process migration on a inactive scene root game object that contains an inactive deprecated component with a compatible migration handler.
+        /// Active state of both game object and component must be kept.
+        /// </summary>
+        [Test]
+        public void MigrationKeepObjectAndComponentActiveState()
+        {
+            foreach (var entry in migrationList)
+            {
+                Type oldType = entry.oldType;
+                Type newType = entry.newType;
+                Type migrationHandlerType = entry.handler;
+
+                Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                GameObject gameObject = SetUpGameObjectWithComponentOfType(oldType);
+                MonoBehaviour oldTypeComponent = (MonoBehaviour)gameObject.GetComponent(oldType);
+
+                oldTypeComponent.enabled = false;
+                gameObject.SetActive(false);
+
+                EditorSceneManager.SaveScene(scene, scenePath);
+                assetsForDeletion.Add(scenePath);
+
+                migrationTool.TryAddObjectForMigration(migrationHandlerType, AssetDatabase.LoadAssetAtPath(scenePath, typeof(SceneAsset)));
+                migrationTool.MigrateSelection(migrationHandlerType, false);
+
+                var openScene = EditorSceneManager.OpenScene(scenePath);
+                foreach (var sceneGameObject in openScene.GetRootGameObjects())
+                {
+                    Assert.IsNull(sceneGameObject.GetComponent(oldType), $"Migrated component of type {oldType.Name} could not be removed");
+                    Assert.IsNotNull(sceneGameObject.GetComponent(newType), $"Migrated component of type {newType.Name} could not be added");
+
+                    // Active state of game object and component is kept
+                    Assert.IsFalse(sceneGameObject.activeSelf, $"Active state of migrated game object was not kept during migration with type {migrationHandlerType.Name}");
+                    Assert.IsFalse(((MonoBehaviour)sceneGameObject.GetComponent(newType)).enabled, $"Active state of migrated component was not kept during migration with type { migrationHandlerType.Name}");
+
+                    Object.DestroyImmediate(sceneGameObject);
+                }
+                Object.DestroyImmediate(gameObject);
+            }
+        }
+
         private static GameObject SetUpGameObjectWithComponentOfType(Type type)
         {
             GameObject go = new GameObject();
@@ -193,4 +235,3 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode
         }
     }
 }
-


### PR DESCRIPTION
## Overview
Migration Tool does not migrate inactive objects from selected scenes or prefabs.

## To reproduce

1. Open Migration Window
2. Select ObjectManipulator migration from the dropdown
3. Drag the HandInteractionExample.unity into the scene section
4. Press migrate

Observe that the gameobject node_id30 has not been upgraded

## Changes
 objects to list of objects to be migrated

- Fixes: #7863 .
