### PR TITLE
Fixing MixedRealityToolkit null error on Register

### DIFF
--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -681,7 +681,7 @@ namespace Microsoft.MixedReality.Toolkit
 
         private static void RegisterInstance(MixedRealityToolkit toolkitInstance, bool setAsActiveInstance = false)
         {
-            if (MixedRealityToolkit.isApplicationQuitting)
+            if (MixedRealityToolkit.isApplicationQuitting || toolkitInstance == null)
             {   // Don't register instances while application is quitting
                 return;
             }


### PR DESCRIPTION
## Overview

MixedRealityToolkit is throwing error message when using Migration Window from a scene without MixedRealityToolkit instance.

The Migration tool opens and closes scenes in the project. during this process, OnValidate is called from MixedRealityToolkit.cs on every scene containing an instance. The function DelayOnValidate() is only called when scene is changed, sending null value with RegisterInstance(this).
 
![Screenshot (30)](https://user-images.githubusercontent.com/16922045/81834911-89745b00-9539-11ea-8e89-f44666b5d8dd.png)

## To reproduce

1. Open a new empty scene
2. Open Migration Window
3. Select "ObjectManipulatorMigrationHandler"  from dropdown list
4. Navigate to full project section
5. Click on "Add full project for migration"
6. An error message is displayed on the console

## Your setup (please complete the following information)

- Unity Version 2018.4.12f1
- MRTK Version 2.4

## Changes
- Fixes: #7867.
