### PR TITLE
removed debug menu entries

### DIFF
--- a/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
@@ -14,7 +14,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Finds the first Renderer type component on the selected GameObject in scene and returns it's world space bounds size.
         /// </summary>
-        [MenuItem("GameObject/MRTK/Renderer Size", false, 0)]
         public static void RendererSize()
         {
             if (Selection.activeGameObject == null)
@@ -37,7 +36,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Finds all Collider type components on the selected GameObject in scene and returns their world space bounds size.
         /// </summary>
-        [MenuItem("GameObject/MRTK/Collider Size", false, 0)]
         public static void ColliderSize()
         {
             if (Selection.activeGameObject == null)

--- a/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
@@ -14,6 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <summary>
         /// Finds the first Renderer type component on the selected GameObject in scene and returns it's world space bounds size.
         /// </summary>
+        [MenuItem("GameObject/MRTK Debug Utilities/Print Renderer Size", false, 40)]
         public static void RendererSize()
         {
             if (Selection.activeGameObject == null)
@@ -33,9 +34,22 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
         }
 
+        [MenuItem("GameObject/MRTK Debug Utilities/Print Renderer Size", true, 41)]
+        private static bool ValidateRendererSize()
+        {
+            if (Selection.activeGameObject == null)
+            {
+                return false;
+            }
+
+            var renderers = Selection.activeGameObject.GetComponent<Renderer>();
+            return (renderers != null);
+        }
+
         /// <summary>
         /// Finds all Collider type components on the selected GameObject in scene and returns their world space bounds size.
         /// </summary>
+        [MenuItem("GameObject/MRTK Debug Utilities/Print Collider Size", false, 41)]
         public static void ColliderSize()
         {
             if (Selection.activeGameObject == null)
@@ -45,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
 
             var colliders = Selection.activeGameObject.GetComponents<Collider>();
-            if (colliders != null)
+            if (colliders != null && colliders.Length != 0)
             {
                 Debug.Log($"Following Collider components found on \"{Selection.activeGameObject}\"");
                 foreach (var c in colliders)
@@ -57,6 +71,18 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             {
                 Debug.Log($"No Collider components found on {Selection.activeGameObject}");
             }
+        }
+
+        [MenuItem("GameObject/MRTK Debug Utilities/Print Collider Size", true, 41)]
+        private static bool ValidateColliderSize()
+        {
+            if (Selection.activeGameObject == null)
+            {
+                return false;
+            }
+
+            var colliders = Selection.activeGameObject.GetComponents<Collider>();
+            return (colliders != null && colliders.Length != 0);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SizeUtilities.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
         }
 
-        [MenuItem("GameObject/MRTK Debug Utilities/Print Renderer Size", true, 41)]
+        [MenuItem("GameObject/MRTK Debug Utilities/Print Renderer Size", true, 40)]
         private static bool ValidateRendererSize()
         {
             if (Selection.activeGameObject == null)


### PR DESCRIPTION
removed debug menu entries from GameObject top menu (MRTK > Renderer Size , MRTK > Collider Size)
fixes https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7864