### PR TITLE
Remove priority from Leap Motion menu

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
@@ -325,7 +325,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// the MRTK source is from the repo, warnings are converted to errors. Warnings are not converted to errors if the MRTK source is from the unity packages.
         /// Warning 618 and 649 are logged when the Leap Motion Core Assets are imported into the project, 618 is the obsolete warning and 649 is a null on start warning.
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Configure CSC File for Leap Motion", false, 0)]
+        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Configure CSC File for Leap Motion")]
         static void UpdateCSC()
         {
             // The csc file will always be in the root of assets
@@ -401,7 +401,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         /// Leap Motion Core Assets import, this case only occurs if the MRTK source is from the unity packages. If the integration of leap and MRTK has not occurred, users can 
         /// select the Configure Leap Motion menu option to force integration. 
         /// </summary>
-        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Configure Leap Motion", false, 0)]
+        [MenuItem("Mixed Reality Toolkit/Utilities/Leap Motion/Configure Leap Motion")]
         static void ForceLeapMotionConfiguration()
         {
             // Check if leap core is in the project


### PR DESCRIPTION
## Overview
The Leap Motion menu always appeared a the top under the Mixed Reality Toolkit > Utilities menu.  It was always at the top because the priority was 0, this pr removes the priority from the MenuItem.

BEFORE:

![image](https://user-images.githubusercontent.com/53493796/81866448-12809780-9524-11ea-8e9a-74e22309f4a0.png)

AFTER:
![image](https://user-images.githubusercontent.com/53493796/81866225-bfa6e000-9523-11ea-9e19-9e43a5c0a80f.png)

