### PR TITLE
reverted hand mesh change so it reappears on toggle

### DIFF
--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -189,7 +189,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 mesh.normals = eventData.InputData.normals;
                 lastHandMeshVertices = eventData.InputData.vertices;
 
-                if (newMesh || meshChanged)
+                if (eventData.InputData.uvs != null && eventData.InputData.uvs.Length > 0)
                 {                    
                     mesh.triangles = eventData.InputData.triangles;
 

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -177,9 +177,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // In order to update the vertices when the array sizes change, the mesh
                 // must be cleared per instructions here:
                 // https://docs.unity3d.com/ScriptReference/Mesh.html
-                if (lastHandMeshVertices != null &&
+                if ((lastHandMeshVertices == null && eventData.InputData.vertices != null) ||
+                    (lastHandMeshVertices != null &&
                     lastHandMeshVertices.Length != 0 &&
-                    lastHandMeshVertices.Length != eventData.InputData.vertices?.Length)
+                    lastHandMeshVertices.Length != eventData.InputData.vertices?.Length))
                 {
                     meshChanged = true;
                     mesh.Clear();
@@ -189,7 +190,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 mesh.normals = eventData.InputData.normals;
                 lastHandMeshVertices = eventData.InputData.vertices;
 
-                if (eventData.InputData.uvs != null && eventData.InputData.uvs.Length > 0)
+                if (newMesh || meshChanged)
                 {                    
                     mesh.triangles = eventData.InputData.triangles;
 


### PR DESCRIPTION
## Overview
Reverted a change that prevented the hand mesh from updating and reappearing after being toggled

## Changes
- Fixes: #7871

Verified by manually deploying to HoloLens 2 and testing that the hand mesh would reappear