### PR TITLE
Update table of contents to add the new configuration dialog page

### DIFF
--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -13,6 +13,8 @@
     href: BuildAndDeploy.md
   - name: NuGet Packages
     href: MRTKNuGetPackage.md
+  - name: MRTK configuration dialog
+    href: MRTK_Configuration_Dialog.md
   - name: Getting started with MRTK and XR SDK
     href: GettingStartedWithMRTKAndXRSDK.md
   - name: Performance


### PR DESCRIPTION
The push of the commit that added the new configuration dialog page to the table of contents failed due to a command line typeo.

This change adds in the missing contents link