### PR TITLE
Update Build and Deploy HoloLens Guidance Doc

### DIFF
--- a/Documentation/BuildAndDeploy.md
+++ b/Documentation/BuildAndDeploy.md
@@ -9,7 +9,7 @@ Instructions on how to build and deploy for HoloLens 1 and HoloLens 2 (UWP) can 
 >[!IMPORTANT]
 > If using Unity 2019.3.x, select **ARM64** and not **ARM** as the build architecture in Visual Studio. By defalut in Unity 2019.3.x, a MRTK app will not deploy to a HoloLens if ARM is selected.  
 >
-> If the ARM architecture is required, navigate to **File > Player Settings**, under the **Other Settings** menu disable **Graphics Jobs**.  Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is reccomended.
+> If the ARM architecture is required, navigate to **Edit > Project Settings, Player**, under the **Other Settings** menu disable **Graphics Jobs**.  Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is reccomended.
 
 **Tip:** When building for WMR, HoloLens 1, or HoloLens 2, it is recommended that the build settings "Target SDK Version"
 and "Minimum Platform Version" look like they do in the picture below:

--- a/Documentation/BuildAndDeploy.md
+++ b/Documentation/BuildAndDeploy.md
@@ -4,7 +4,12 @@ To run an app on device as a standalone app (for HoloLens, Android, iOS, etc.), 
 
 ## Building and deploying MRTK to HoloLens 1 and HoloLens 2 (UWP)
 
-Instructions on how to build and deploy for HoloLens 1 and HoloLens 2 (UWP) can be found at [building your application to device](https://docs.microsoft.com/windows/mixed-reality/mrlearning-base-ch1#build-your-application-to-your-device) .
+Instructions on how to build and deploy for HoloLens 1 and HoloLens 2 (UWP) can be found at [building your application to device](https://docs.microsoft.com/windows/mixed-reality/mrlearning-base-ch1#build-your-application-to-your-device).
+
+>[!IMPORTANT]
+> If using Unity 2019.3.x, select **ARM64** and not **ARM** as the build architecture in Visual Studio. By defalut in Unity 2019.3.x, a MRTK app will not deploy to a HoloLens if ARM is selected.  
+>
+> If the ARM architecture is required, navigate to **File > Player Settings**, under the **Other Settings** menu disable **Graphics Jobs**.  Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is reccomended.
 
 **Tip:** When building for WMR, HoloLens 1, or HoloLens 2, it is recommended that the build settings "Target SDK Version"
 and "Minimum Platform Version" look like they do in the picture below:

--- a/Documentation/BuildAndDeploy.md
+++ b/Documentation/BuildAndDeploy.md
@@ -7,9 +7,9 @@ To run an app on device as a standalone app (for HoloLens, Android, iOS, etc.), 
 Instructions on how to build and deploy for HoloLens 1 and HoloLens 2 (UWP) can be found at [building your application to device](https://docs.microsoft.com/windows/mixed-reality/mrlearning-base-ch1#build-your-application-to-your-device).
 
 >[!IMPORTANT]
-> If using Unity 2019.3.x, select **ARM64** and not **ARM** as the build architecture in Visual Studio. By defalut in Unity 2019.3.x, a MRTK app will not deploy to a HoloLens if ARM is selected.  
+> If using Unity 2019.3.x, select **ARM64** and not **ARM** as the build architecture in Visual Studio. With the default Unity settings in Unity 2019.3.x, a Unity app will not deploy to a HoloLens if ARM is selected due to a Unity bug. This can be tracked on [Unity's issue tracker](https://issuetracker.unity3d.com/issues/enabling-graphics-jobs-in-2019-dot-3-x-results-in-a-crash-or-nothing-rendering-on-hololens-2).
 >
-> If the ARM architecture is required, navigate to **Edit > Project Settings, Player**, under the **Other Settings** menu disable **Graphics Jobs**.  Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is reccomended.
+> If the ARM architecture is required, navigate to **Edit > Project Settings, Player**, and under the **Other Settings** menu disable **Graphics Jobs**. Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is recommended.
 
 **Tip:** When building for WMR, HoloLens 1, or HoloLens 2, it is recommended that the build settings "Target SDK Version"
 and "Minimum Platform Version" look like they do in the picture below:


### PR DESCRIPTION
## Overview
Selecting ARM as the build architecture in Unity 2019.3.x results in a fails to deploy to a HoloLens device.  A note has been added to the Build and Deploy doc for HL and HL2 devices to use ARM64 instead of ARM for Unity 2019.

## Changes
- Fixes: #7858 
