### PR TITLE
Filter abstract classes (eg. TransformConstraint) to be added to the …

### DIFF
--- a/Assets/MRTK/SDK/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     var type = typeof(TransformConstraint);
                     var types = AppDomain.CurrentDomain.GetAssemblies()
                         .SelectMany(s => s.GetLoadableTypes())
-                        .Where(p => type.IsAssignableFrom(p));
+                        .Where(p => type.IsAssignableFrom(p) && !p.IsAbstract);
 
                     foreach (var derivedType in types)
                     {


### PR DESCRIPTION
Filter abstract classes so they are not added to the ObjectManipulator inspector "Add Constraint" dropdown menu

## Changes
- Fixes: #7891 
