### PR TITLE
Fix XR SDK boundary on-device

### DIFF
--- a/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
+++ b/Assets/MRTK/Core/Services/BaseBoundarySystem.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.Boundary
 {
@@ -22,9 +21,12 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             ExperienceScale scale) : base(profile)
         {
             Scale = scale;
+            BoundaryProfile = profile;
         }
 
         #region IMixedRealityService Implementation
+
+        private MixedRealityBoundaryVisualizationProfile BoundaryProfile { get; }
 
         private BoundaryEventData boundaryEventData = null;
 
@@ -34,49 +36,25 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <inheritdoc/>
         public override void Initialize()
         {
-            if (!Application.isPlaying || !XRDevice.isPresent) { return; }
-
-            MixedRealityBoundaryVisualizationProfile profile = ConfigurationProfile as MixedRealityBoundaryVisualizationProfile;
-            if (profile == null) { return; }
+            if (!Application.isPlaying || BoundaryProfile == null) { return; }
 
             boundaryEventData = new BoundaryEventData(EventSystem.current);
 
-            BoundaryHeight = profile.BoundaryHeight;
+            BoundaryHeight = BoundaryProfile.BoundaryHeight;
 
             SetTrackingSpace();
             CalculateBoundaryBounds();
 
-            ShowFloor = profile.ShowFloor;
-            FloorPhysicsLayer = profile.FloorPhysicsLayer;
-            ShowPlayArea = profile.ShowPlayArea;
-            PlayAreaPhysicsLayer = profile.PlayAreaPhysicsLayer;
-            ShowTrackedArea = profile.ShowTrackedArea;
-            TrackedAreaPhysicsLayer = profile.TrackedAreaPhysicsLayer;
-            ShowBoundaryWalls = profile.ShowBoundaryWalls;
-            BoundaryWallsPhysicsLayer = profile.BoundaryWallsPhysicsLayer;
-            ShowBoundaryCeiling = profile.ShowBoundaryCeiling;
-            CeilingPhysicsLayer = profile.CeilingPhysicsLayer;
-
-            if (ShowFloor)
-            {
-                GetFloorVisualization();
-            }
-            if (ShowPlayArea)
-            {
-                GetPlayAreaVisualization();
-            }
-            if (ShowTrackedArea)
-            {
-                GetTrackedAreaVisualization();
-            }
-            if (ShowBoundaryWalls)
-            {
-                GetBoundaryWallVisualization();
-            }
-            if (ShowBoundaryCeiling)
-            {
-                GetBoundaryCeilingVisualization();
-            }
+            ShowFloor = BoundaryProfile.ShowFloor;
+            FloorPhysicsLayer = BoundaryProfile.FloorPhysicsLayer;
+            ShowPlayArea = BoundaryProfile.ShowPlayArea;
+            PlayAreaPhysicsLayer = BoundaryProfile.PlayAreaPhysicsLayer;
+            ShowTrackedArea = BoundaryProfile.ShowTrackedArea;
+            TrackedAreaPhysicsLayer = BoundaryProfile.TrackedAreaPhysicsLayer;
+            ShowBoundaryWalls = BoundaryProfile.ShowBoundaryWalls;
+            BoundaryWallsPhysicsLayer = BoundaryProfile.BoundaryWallsPhysicsLayer;
+            ShowBoundaryCeiling = BoundaryProfile.ShowBoundaryCeiling;
+            CeilingPhysicsLayer = BoundaryProfile.CeilingPhysicsLayer;
 
             RaiseBoundaryVisualizationChanged();
         }

--- a/Assets/MRTK/Core/Services/BaseEventSystem.cs
+++ b/Assets/MRTK/Core/Services/BaseEventSystem.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public Dictionary<Type, List<EventHandlerEntry>> EventHandlersByType { get; } = new Dictionary<Type, List<EventHandlerEntry>>();
 
-    #region IMixedRealityEventSystem Implementation
+        #region IMixedRealityEventSystem Implementation
 
         /// <inheritdoc />
         public List<GameObject> EventListeners { get; } = new List<GameObject>();
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit
                     var handlerEntry = handlers[i];
 
                     // If handler's parent is in object collection (traversed above), it has already received an event.
-                    if(handlerEntry.parentObjectIsInObjectCollection)
+                    if (handlerEntry.parentObjectIsInObjectCollection)
                     {
                         continue;
                     }
@@ -166,11 +166,11 @@ namespace Microsoft.MixedReality.Toolkit
             }
 
             // #if due to Microsoft.MixedReality.Toolkit.ReflectionExtensions overload of Type.IsInterface
-            #if WINDOWS_UWP && !ENABLE_IL2CPP
-                Debug.Assert(typeof(T).IsInterface(), "RegisterHandler must be called with an interface as a generic parameter.");
-            #else
-                Debug.Assert(typeof(T).IsInterface, "RegisterHandler must be called with an interface as a generic parameter.");
-            #endif
+#if WINDOWS_UWP && !ENABLE_IL2CPP
+            Debug.Assert(typeof(T).IsInterface(), "RegisterHandler must be called with an interface as a generic parameter.");
+#else
+            Debug.Assert(typeof(T).IsInterface, "RegisterHandler must be called with an interface as a generic parameter.");
+#endif
             Debug.Assert(typeof(T).IsAssignableFrom(handler.GetType()), "Handler passed to RegisterHandler doesn't implement a type given as generic parameter.");
 
             TraverseEventSystemHandlerHierarchy<T>(handler, RegisterHandler);
@@ -185,11 +185,11 @@ namespace Microsoft.MixedReality.Toolkit
             }
 
             // #if due to Microsoft.MixedReality.Toolkit.ReflectionExtensions overload of Type.IsInterface
-            #if WINDOWS_UWP && !ENABLE_IL2CPP
-                Debug.Assert(typeof(T).IsInterface(), "UnregisterHandler must be called with an interface as a generic parameter.");
-            #else
-                Debug.Assert(typeof(T).IsInterface, "UnregisterHandler must be called with an interface as a generic parameter.");
-            #endif
+#if WINDOWS_UWP && !ENABLE_IL2CPP
+            Debug.Assert(typeof(T).IsInterface(), "UnregisterHandler must be called with an interface as a generic parameter.");
+#else
+            Debug.Assert(typeof(T).IsInterface, "UnregisterHandler must be called with an interface as a generic parameter.");
+#endif
             Debug.Assert(typeof(T).IsAssignableFrom(handler.GetType()), "Handler passed to UnregisterHandler doesn't implement a type given as generic parameter.");
 
             TraverseEventSystemHandlerHierarchy<T>(handler, UnregisterHandler);
@@ -281,7 +281,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <inheritdoc />
         public override void Destroy()
         {
-            if(!enableDanglingHandlerDiagnostics)
+            if (!enableDanglingHandlerDiagnostics)
             {
                 return;
             }
@@ -305,9 +305,9 @@ namespace Microsoft.MixedReality.Toolkit
             }
         }
 
-    #endregion IMixedRealityEventSystem Implementation
+        #endregion IMixedRealityEventSystem Implementation
 
-    #region Registration helpers
+        #region Registration helpers
 
         private void UnregisterHandler(Type handlerType, IEventSystemHandler handler)
         {
@@ -436,7 +436,7 @@ namespace Microsoft.MixedReality.Toolkit
                 "cause performance issues. It is recommended to remove or replace usages of 'Register/Unregister' methods with 'RegisterHandler/UnregisterHandler'.");
         }
 
-    #endregion Utilities
+        #endregion Utilities
 
         // Example Event Pattern #############################################################
 

--- a/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKBoundarySystem.cs
@@ -31,6 +31,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK
         /// <inheritdoc/>
         public override string Name { get; protected set; } = "XR SDK Boundary System";
 
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            if (!Application.isPlaying) { return; }
+
+            List<InputDevice> devices = new List<InputDevice>();
+            InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.HeadMounted, devices);
+
+            if (devices.Count <= 0) { return; }
+
+            base.Initialize();
+        }
+
         #endregion IMixedRealityService Implementation
 
         /// <inheritdoc/>

--- a/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
+++ b/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
@@ -35,8 +35,6 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             if (!Application.isPlaying || !XRDevice.isPresent) { return; }
 
             base.Initialize();
-
-            UnityBoundary.visible = true;
         }
 
         #endregion IMixedRealityService Implementation


### PR DESCRIPTION
## Overview

Fixes the lack of floor and boundary when running an XR SDK app on-device.

The root issue was that the `XRDevice.isPresent` API is [not expected to work in XR SDK](https://forum.unity.com/threads/xrdevice-ispresent-with-xrmanagement-on-quest.817722/). This PR removes that call from the base class and replaces it with the corresponding XR SDK API call. The existing non-XR SDK service implementation already called this API, so it's left unchanged.

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/9359fd71bac5bbcfe8db0803f0083e6f012f31a6/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs#L35

I also removed the `UnityBoundary.visible = true;` call, which was causing issues on Oculus and is not configurable in MRTK. There is no corresponding API in XR SDK, so it's being removed without replacement, to allow platforms to control their boundary visibility instead of forcing them on.

Also removed a profile cast in the base class' `Initialize`, which wasn't needed since the correctly-typed profile is passed in the constructor.

Also removed some extra `Get*Visualzation();` calls, which are already called as-needed in the existing property setters.

## Changes
- Fixes: #7519, fixes: #7878 