### PR TITLE
Custom Button Icon Migration Tools

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Unplated.prefab
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2Unplated.prefab
@@ -371,6 +371,7 @@ MonoBehaviour:
       - Near and Far
       - Near Only
       - Far Only
+  resetOnDestroy: 0
   enabledOnStart: 1
 --- !u!82 &316800719
 AudioSource:
@@ -512,7 +513,10 @@ MonoBehaviour:
   iconQuadRenderer: {fileID: 1911902820}
   iconQuadTextureNameID: _MainTex
   iconQuadTexture: {fileID: 2800000, guid: bb1b4a9241fba2042a81428e917afd5d, type: 3}
+  defaultButtonQuadMaterial: {fileID: 2100000, guid: fa419ab56051229449e3b813df8f295f,
+    type: 2}
   iconSet: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683, type: 2}
+  defaultIconSet: {fileID: 11400000, guid: 8b386ef895f7c924f8c4b03d1d3ed683, type: 2}
 --- !u!1 &937783100
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
@@ -466,8 +466,18 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Upgrades a button using a custom icon material.
         /// </summary>
-        public void EditorUpgradeCustomIcon()
+        public void EditorUpgradeCustomIcon(ButtonIconSet defaultIconSet = null, string customIconsFolder = null)
         {
+            if (string.IsNullOrEmpty(customIconsFolder))
+            {
+                customIconsFolder = MixedRealityToolkitFiles.GetGeneratedFolder;
+            }
+
+            if (defaultIconSet == null)
+            {
+                defaultIconSet = this.defaultIconSet;
+            }
+
             SerializedObject configObject = new SerializedObject(this);
             SerializedProperty iconStyleProp = configObject.FindProperty("iconStyle");
             SerializedProperty iconSetProp = configObject.FindProperty("iconSet");
@@ -505,14 +515,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             ButtonIconSet targetIconSet = iconSet;
             bool createdIconSet = false;
-            string generatedIconSetFolder = System.IO.Path.Combine(MixedRealityToolkitFiles.GetGeneratedFolder, customIconSetsFolderName);
+            string generatedIconSetFolder = System.IO.Path.Combine(customIconsFolder, customIconSetsFolderName);
 
             // If this icon set doesn't have our icon in it, we need to either add it or create a new icon set
             if (!iconSet.TryGetQuadIcon(targetQuadIcon.name, out Texture2D quadIcon) && iconSet == defaultIconSet)
             {   // If we're using the default icon set, we have to create a new set to add the icon
                 if (!AssetDatabase.IsValidFolder(generatedIconSetFolder))
                 {   // Create the folder if it doesn't exist
-                    AssetDatabase.CreateFolder(MixedRealityToolkitFiles.GetGeneratedFolder, customIconSetsFolderName);
+                    AssetDatabase.CreateFolder(customIconsFolder, customIconSetsFolderName);
                 }
 
                 string generatedIconSetPath = System.IO.Path.Combine(generatedIconSetFolder, generatedIconSetName + ".asset");

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
@@ -4,13 +4,19 @@
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
+using System;
+#if UNITY_EDITOR
+using UnityEditor;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
+#endif
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
     /// <summary>
-    /// Helper component that gathers the most commonly modified button elemtents in one place.
+    /// Helper component that gathers the most commonly modified button elements in one place.
     /// </summary>
     [ExecuteAlways]
+    [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html#how-to-change-the-icon-and-text")]
     public partial class ButtonConfigHelper : MonoBehaviour
     {
         /// <summary>
@@ -120,55 +126,49 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private readonly static uint defaultIconChar = ButtonIconSet.ConvertCharStringToUInt32("\uEBD2");
         private const string defaultIconTextureNameID = "_MainTex";
 
-        [SerializeField]
-        [Tooltip("Optional main label used by the button.")]
+        [SerializeField, Tooltip("Optional main label used by the button.")]
         private TextMeshPro mainLabelText = null;
-        [SerializeField]
-        [Tooltip("Optional interactable component used by the button. Used for its OnClick event.")]
+        [SerializeField, Tooltip("Optional interactable component used by the button. Used for its OnClick event.")]
         private Interactable interactable = null;
-        [SerializeField]
-        [Tooltip("Optional see it / say it object.")]
+        [SerializeField, Tooltip("Optional see it / say it object.")]
         private GameObject seeItSayItLabel = null;
-        [SerializeField]
-        [Tooltip("Optional see it / say it label used by the button. Should be subsumed under the seeItSayItLabel object.")]
+        [SerializeField, Tooltip("Optional see it / say it label used by the button. Should be subsumed under the seeItSayItLabel object.")]
         private TextMeshPro seeItSatItLabelText = null;
         [SerializeField, Tooltip("How the button icon should be rendered.")]
         private ButtonIconStyle iconStyle = ButtonIconStyle.Quad;
 
         [Header("Font Icon")]
-        [SerializeField]
-        [Tooltip("Optional label used for font icon.")]
+        [SerializeField, Tooltip("Optional label used for font icon.")]
         private TextMeshPro iconCharLabel = null;
-        [SerializeField]
-        [Tooltip("Optional font used for font icon. This will be set by configuration actions using the icon set.")]
+        [SerializeField, Tooltip("Optional font used for font icon. This will be set by configuration actions using the icon set.")]
         private TMP_FontAsset iconCharFont = null;
-        [SerializeField]
-        [Tooltip("Optional unicode code for font icon. See Text Mesh Pro font asset for available unicode characters. This will be set by configuration actions.")]
+        [SerializeField, Tooltip("Optional unicode code for font icon. See Text Mesh Pro font asset for available unicode characters. This will be set by configuration actions.")]
         private uint iconChar = 0;
 
         [Header("Sprite Icon")]
-        [SerializeField]
-        [Tooltip("Optional sprite renderer used for sprite icon.")]
+        [SerializeField, Tooltip("Optional sprite renderer used for sprite icon.")]
         private SpriteRenderer iconSpriteRenderer = null;
-        [SerializeField]
-        [Tooltip("Optional sprite used for sprite icon. This will be set by configuration actions.")]
+        [SerializeField, Tooltip("Optional sprite used for sprite icon. This will be set by configuration actions.")]
         private Sprite iconSprite = null;
 
         [Header("Quad Icon")]
-        [SerializeField]
-        [Tooltip("Optional quad renderer used for texture icon.")]
+        [SerializeField, Tooltip("Optional quad renderer used for texture icon.")]
         private MeshRenderer iconQuadRenderer = null;
-        [SerializeField]
-        [Tooltip("The texture name ID. Set to " + defaultIconTextureNameID + " by default.")]
+        [SerializeField, Tooltip("The texture name ID. Set to " + defaultIconTextureNameID + " by default.")]
         private string iconQuadTextureNameID = defaultIconTextureNameID;
-        [SerializeField]
-        [Tooltip("Optional texture used for texture icon. This will be set by configuration actions.")]
+        [SerializeField, Tooltip("Optional texture used for texture icon. This will be set by configuration actions.")]
         private Texture iconQuadTexture = null;
+        // Disable 'assigned but never used' errors to avoid errors related to editor-only fields.
+        #pragma warning disable CS0414
+        [SerializeField, Tooltip("The default material used by quad button icons. Used to detect legacy custom buttons.")]
+        private Material defaultButtonQuadMaterial = null;
 
         [Header("Icon Set")]
-        [SerializeField]
-        [Tooltip("Optional icon set used to configure icon objects.")]
+        [SerializeField, Tooltip("Optional icon set used to configure icon objects.")]
         private ButtonIconSet iconSet = null;
+        [SerializeField, Tooltip("The default icon set.")]
+        private ButtonIconSet defaultIconSet = null;
+        #pragma warning restore CS0414
 
         private MaterialPropertyBlock iconTexturePropertyBlock;
 
@@ -414,7 +414,165 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void OnEnable()
         {
+#if UNITY_EDITOR
+            if (EditorCheckForCustomIcon())
+            {   // If we're using a custom icon, preserve it so it doesn't vanish
+                EditorPreserveCustomIcon();
+            }
+#else
+            // Set these to null to avoid build errors.
+            defaultIconSet = null;
+            defaultButtonQuadMaterial = null;
+#endif
+
             ForceRefresh();
         }
+
+#if UNITY_EDITOR
+
+        private static readonly string generatedIconSetName = "CustomIconSet";
+        private static readonly string customIconSetsFolderName = "CustomIconSets";
+        private static readonly string customIconSetCreatedMessage = "A new icon set has been created to hold your button's custom icons. This icon set will be used by your button's ButtonConfigHelper component. It has been saved to:\n\n{0}";
+        
+        /// <summary>
+        /// Returns true if the button is using a custom icon material.
+        /// </summary>
+        public bool EditorCheckForCustomIcon()
+        {
+            if (iconSet == null || iconQuadRenderer == null || iconStyle != ButtonIconStyle.Quad)
+            {   // Nothing to do here.
+                return false;
+            }
+
+            if (iconSet != defaultIconSet)
+            {   // This button is using a custom icon set, so we can't assume material differences mean it needs an upgrade.
+                return false;
+            }
+
+            if (iconQuadRenderer.sharedMaterial == defaultButtonQuadMaterial)
+            {   // This button is using the default material, so it's not a customized button.
+                return false;
+            }
+
+            string assetPath = AssetDatabase.GetAssetPath(iconQuadRenderer.sharedMaterial);
+            if (string.IsNullOrEmpty(assetPath))
+            {   // If the asset path is null, this material instance exists only in memory.
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Upgrades a button using a custom icon material.
+        /// </summary>
+        public void EditorUpgradeCustomIcon()
+        {
+            SerializedObject configObject = new SerializedObject(this);
+            SerializedProperty iconStyleProp = configObject.FindProperty("iconStyle");
+            SerializedProperty iconSetProp = configObject.FindProperty("iconSet");
+            SerializedProperty iconQuadTextureProp = configObject.FindProperty("iconQuadTexture");
+
+            if (iconQuadRenderer.gameObject.activeSelf && !iconQuadRenderer.enabled)
+            {   // If the quad renderer is disabled, enable it and disable the quad renderer game object instead.
+                // Disabling the quad renderer used to be the preferred way to disable icons but it's no longer consistent with our icon style.
+                iconQuadRenderer.enabled = true;
+                iconQuadRenderer.gameObject.SetActive(false);
+                EditorUtility.SetDirty(gameObject);
+            }
+
+            if (!iconQuadRenderer.gameObject.activeSelf && !iconSpriteRenderer.gameObject.activeSelf && !iconCharLabel.gameObject.activeSelf)
+            {   // If all the icon objects are disabled, set the icon style to none and do nothing else.
+                iconStyleProp.enumValueIndex = (int)ButtonIconStyle.None;
+                configObject.ApplyModifiedProperties();
+                EditorUtility.SetDirty(gameObject);
+                return;
+            }
+
+            string assetPath = AssetDatabase.GetAssetPath(iconQuadRenderer.sharedMaterial);
+            if (string.IsNullOrEmpty(assetPath))
+            {   // If the asset path is null, this material instance exists only in memory.
+                return;
+            }
+
+            Material targetQuadMaterial = iconQuadRenderer.sharedMaterial;
+            Texture targetQuadIcon = targetQuadMaterial.mainTexture;
+
+            if (targetQuadIcon == null)
+            {   // There is no icon to copy.
+                return;
+            }
+
+            ButtonIconSet targetIconSet = iconSet;
+            bool createdIconSet = false;
+            string generatedIconSetFolder = System.IO.Path.Combine(MixedRealityToolkitFiles.GetGeneratedFolder, customIconSetsFolderName);
+
+            // If this icon set doesn't have our icon in it, we need to either add it or create a new icon set
+            if (!iconSet.TryGetQuadIcon(targetQuadIcon.name, out Texture2D quadIcon) && iconSet == defaultIconSet)
+            {   // If we're using the default icon set, we have to create a new set to add the icon
+                if (!AssetDatabase.IsValidFolder(generatedIconSetFolder))
+                {   // Create the folder if it doesn't exist
+                    AssetDatabase.CreateFolder(MixedRealityToolkitFiles.GetGeneratedFolder, customIconSetsFolderName);
+                }
+
+                string generatedIconSetPath = System.IO.Path.Combine(generatedIconSetFolder, generatedIconSetName + ".asset");
+                targetIconSet = (ButtonIconSet)AssetDatabase.LoadAssetAtPath(generatedIconSetPath, typeof(ButtonIconSet));
+
+                if (targetIconSet == null)
+                {   // If the icon set doesn't already exist, duplicate the default
+                    ScriptableObject duplicateIconSet = Instantiate<ButtonIconSet>(defaultIconSet);
+                    duplicateIconSet.name = generatedIconSetName;
+
+                    AssetDatabase.CreateAsset(duplicateIconSet, generatedIconSetPath);
+                    AssetDatabase.SaveAssets();
+                    AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+                    targetIconSet = (ButtonIconSet)AssetDatabase.LoadAssetAtPath(generatedIconSetPath, typeof(ButtonIconSet));
+                    createdIconSet = true;
+                }
+            }
+
+            bool selectIconSet = false;
+            if (createdIconSet)
+            {
+                selectIconSet = EditorUtility.DisplayDialog("Custom Icon Set Created", string.Format(customIconSetCreatedMessage, generatedIconSetFolder), "View Asset", "OK");
+            }
+
+            // Set the icon set to the custom generated icon set
+            iconSetProp.objectReferenceValue = targetIconSet;
+            // Add the custom icon to the custom set
+            targetIconSet.EditorAddCustomQuadIcon(targetQuadIcon);
+            // Reset changes to the quad renderer
+            iconQuadTextureProp.objectReferenceValue = targetQuadIcon;
+            configObject.ApplyModifiedProperties();
+
+            // If the custom material shader is different from the default material, don't alter the material
+            if (targetQuadMaterial.shader.name == defaultButtonQuadMaterial.shader.name)
+            {   // If the custom material shader is the same, revert any prefab overrides
+                SerializedObject iconQuadRendererObject = new SerializedObject(iconQuadRenderer);
+                SerializedProperty materialsProp = iconQuadRendererObject.FindProperty("m_Materials");
+                PrefabUtility.RevertPropertyOverride(materialsProp, InteractionMode.AutomatedAction);
+            }
+
+            EditorUtility.SetDirty(gameObject);
+
+            ForceRefresh();
+
+            if (selectIconSet)
+            {
+                Selection.activeObject = targetIconSet;
+                EditorGUIUtility.PingObject(targetIconSet);
+            }
+        }
+
+        private void EditorPreserveCustomIcon()
+        {
+            SerializedObject configObject = new SerializedObject(this);
+            SerializedProperty iconQuadTextureProp = configObject.FindProperty("iconQuadTexture");
+
+            iconQuadTextureProp.objectReferenceValue = iconQuadRenderer.sharedMaterial.mainTexture;
+            configObject.ApplyModifiedProperties();
+        }
+#endif
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -53,8 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Sprite[] spriteIcons = new Sprite[0];
         [SerializeField]
         private TMP_FontAsset charIconFont = null;
-        [SerializeField]
-        [Tooltip("See TextMeshPro font assets for available unicode characters. Default characters are drawn from the HoloSymMDL2 font.")]
+        [SerializeField, Tooltip("See TextMeshPro font assets for available unicode characters. Default characters are drawn from the HoloSymMDL2 font.")]
         private CharIcon[] charIcons = new CharIcon[]
         {
             new CharIcon{ Character = ConvertCharStringToUInt32("\uEBD2"), Name = "AppBarAdjust" },
@@ -102,6 +101,15 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void InitializeLookups()
         {
+#if UNITY_EDITOR
+            if (quadIconLookup.Count != quadIcons.Length ||
+                spriteIconLookup.Count != spriteIcons.Length ||
+                charIconLookup.Count != charIcons.Length)
+            {   // Our lookups are stale
+                EditorResetCharIconLookups();
+            }
+#endif
+
             if (lookupsInitialized)
                 return;
 
@@ -191,9 +199,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
 #if UNITY_EDITOR
-
         private const int maxButtonSize = 75;
-        private const int charIconFontSize = 30;
         private const int maxButtonsPerColumn = 6;
 
         private Texture[] spriteIconTextures = null;
@@ -335,10 +341,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Draws a selectable grid of texture icons.
         /// </summary>
         /// <returns>True if a new icon was selected.</returns>
-        public bool EditorDrawQuadIconSelector(Texture currentTexture, out Texture newTexture, int indentLevel = 0)
+        public bool EditorDrawQuadIconSelector(Texture currentTexture, out bool foundTexture, out Texture newTexture, int indentLevel = 0)
         {
             newTexture = null;
             int currentSelection = -1;
+            foundTexture = false;
 
             for (int i = 0; i < quadIcons.Length; i++)
             {
@@ -359,9 +366,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 var maxWidth = GUILayout.MaxWidth(maxButtonSize * maxButtonsPerColumn);
                 int newSelection = GUILayout.SelectionGrid(currentSelection, quadIcons, maxButtonsPerColumn, maxHeight, maxWidth);
 #endif
-                if (newSelection >= 0 && newSelection != currentSelection)
+                if (newSelection >= 0)
                 {
-                    newTexture = quadIcons[newSelection];
+                    foundTexture = true;
+                    if (newSelection != currentSelection)
+                    {
+                        newTexture = quadIcons[newSelection];
+                    }
                 }
             }
 
@@ -446,6 +457,31 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 EditorGUILayout.LabelField("Couldn't draw character icon. Character may not be available in the font asset.");
             }
+        }
+
+        /// <summary>
+        /// Adds a custom quad icon to the quadIcons array. If quad icon already exists in set no action will be taken.
+        /// </summary>
+        public bool EditorAddCustomQuadIcon(Texture customQuadIcon)
+        {
+            foreach (Texture quadIcon in quadIcons)
+            {
+                if (quadIcon == customQuadIcon)
+                {   // Already exists!
+                    return false;
+                }
+            }
+
+            SerializedObject serializedObject = new SerializedObject(this);
+            SerializedProperty quadIconProp = serializedObject.FindProperty("quadIcons");
+            quadIconProp.InsertArrayElementAtIndex(0);
+            SerializedProperty quadIconElement = quadIconProp.GetArrayElementAtIndex(0);
+            quadIconElement.objectReferenceValue = customQuadIcon;
+            serializedObject.ApplyModifiedProperties();
+
+            EditorResetCharIconLookups();
+            InitializeLookups();
+            return true;
         }
 
         [CustomEditor(typeof(ButtonIconSet))]

--- a/Assets/MRTK/SDK/Features/Utilities/Migration/ButtonConfigHelperMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Migration/ButtonConfigHelperMigrationHandler.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.UI;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Migration handler for migrating buttons with custom icons to the button config helper.
+    /// </summary>
+    public class ButtonConfigHelperMigrationHandler : IMigrationHandler
+    {
+        public bool CanMigrate(GameObject gameObject)
+        {
+#if UNITY_EDITOR
+            ButtonConfigHelper bch = gameObject.GetComponent<ButtonConfigHelper>();
+            return bch != null && bch.EditorCheckForCustomIcon();
+#else
+            return false;
+#endif
+        }
+
+        public void Migrate(GameObject gameObject)
+        {
+#if UNITY_EDITOR
+            ButtonConfigHelper bch = gameObject.GetComponent<ButtonConfigHelper>();
+            bch.EditorUpgradeCustomIcon();
+#endif
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/Utilities/Migration/ButtonConfigHelperMigrationHandler.cs.meta
+++ b/Assets/MRTK/SDK/Features/Utilities/Migration/ButtonConfigHelperMigrationHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad1fba6d80f6189419309914256cbabb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -4,16 +4,25 @@
 using UnityEngine;
 using UnityEditor;
 using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities.Editor;
 
 namespace Microsoft.MixedReality.Toolkit.Inspectors
 {
-    [CustomEditor(typeof(ButtonConfigHelper))]
+    [CustomEditor(typeof(ButtonConfigHelper)), CanEditMultipleObjects]
     public class ButtonConfigHelperInspector : UnityEditor.Editor
     {
-        const string LabelFoldoutKey = "MRTK.ButtonConfigHelper.Label";
-        const string BasicEventsFoldoutKey = "MRTK.ButtonConfigHelper.BasicEvents";
-        const string IconFoldoutKey = "MRTK.ButtonConfigHelper.Icon";
-        const string ShowComponentsKey = "MRTK.ButtonConfigHelper.ShowComponents";
+        private const string LabelFoldoutKey = "MRTK.ButtonConfigHelper.Label";
+        private const string BasicEventsFoldoutKey = "MRTK.ButtonConfigHelper.BasicEvents";
+        private const string IconFoldoutKey = "MRTK.ButtonConfigHelper.Icon";
+        private const string ShowComponentsKey = "MRTK.ButtonConfigHelper.ShowComponents";
+
+        private const string generatedIconSetName = "CustomIconSet";
+        private const string customIconSetsFolderName = "CustomIconSets";
+        private const string customIconUpgradeMessage = "This button appears to have a custom icon material. This is no longer required for custom icons.\n\n" +
+            "We recommend upgrading the buttons in your project using the Migration Tool.";
+        private const string missingIconWarningMessage = "The icon used by this button's custom material was not found in the icon set.";
+        private const string customIconSetCreatedMessage = "A new icon set has been created to hold your button's custom icons. It has been saved to:\n\n{0}";
+        private const string upgradeDocUrl = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html#how-to-change-the-icon-and-text";
 
         private SerializedProperty mainLabelTextProp;
         private SerializedProperty seeItSayItLabelProp;
@@ -35,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private SerializedProperty iconQuadTextureNameIDProp;
         private SerializedProperty iconQuadTextureProp;
 
-        private ButtonConfigHelper cb;
+        private ButtonConfigHelper cb = null;
 
         private void OnEnable()
         {
@@ -68,6 +77,25 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
             bool basicEventsFoldout = SessionState.GetBool(BasicEventsFoldoutKey, true);
             bool iconFoldout = SessionState.GetBool(IconFoldoutKey, true);
             bool showComponents = SessionState.GetBool(ShowComponentsKey, false);
+
+            if (cb.EditorCheckForCustomIcon())
+            {
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                {
+                    EditorGUILayout.LabelField("Custom Icon Migration", EditorStyles.boldLabel);
+                    EditorGUILayout.HelpBox(customIconUpgradeMessage, MessageType.Error);
+
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        if (GUILayout.Button("Use migration tool to upgrade buttons"))
+                        {
+                            EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window");
+                        }
+
+                        InspectorUIUtility.RenderDocumentationButton(upgradeDocUrl);
+                    }
+                }
+            }
 
             showComponents = EditorGUILayout.Toggle("Show Component References", showComponents);
 
@@ -296,10 +324,16 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
             if (iconSet != null)
             {
                 Texture newIconTexture;
-                if (iconSet.EditorDrawQuadIconSelector(currentIconTexture, out newIconTexture, 1))
+                bool foundTexture;
+                if (iconSet.EditorDrawQuadIconSelector(currentIconTexture, out foundTexture, out newIconTexture, 1))
                 {
                     iconQuadTextureProp.objectReferenceValue = newIconTexture;
                     cb.SetQuadIcon(newIconTexture);
+                }
+
+                if (!foundTexture)
+                {
+                    EditorGUILayout.HelpBox(missingIconWarningMessage, MessageType.Warning);
                 }
             }
             else


### PR DESCRIPTION
## Overview

(New branch based on #7886 to ensure a clean merge.)

Provides tools to migrate from old material-based custom icons to icon sets. (This PR does not upgrade any buttons in example scenes.)

Previously custom button icons required assigning a new material to the button's quad renderer. This is no longer necessary and we recommend moving custom icon textures into an IconSet. The inspector lets developers know this option exists:

![ButtonConfigInspector](https://user-images.githubusercontent.com/9789716/82091775-d3318280-96ac-11ea-803b-7518f73cb3c1.PNG)

Existing custom materials and icons are preserved. However they will be less optimal until upgraded. An additional warning is shown in the icon selection foldout:

![ButtonConfigIconWarning](https://user-images.githubusercontent.com/9789716/82091888-0d9b1f80-96ad-11ea-896e-0400e11e74ee.PNG)

### Migration Window
The ButtonConfigHelperMigrationHandler type can migrate all button assets in the project.

![MigrationWindow](https://user-images.githubusercontent.com/9789716/81989712-9c973180-95f2-11ea-8387-6c80451d2157.PNG)

### Custom icon sets

If an icon is not found in the default icon set during migration, a custom icon set will be created in _MixedRealityToolkit.Generated/CustomIconSets._ A dialog lets people know this has taken place.

![ConfigHelperDialog](https://user-images.githubusercontent.com/9789716/82093856-c57dfc00-96b0-11ea-83ab-4df57446d661.PNG)

## Changes
- Fixes: #7810

## Verification
Looking for feedback on clarity and workflow. The example scenes provide good samples for migration.

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
