### PR TITLE
Update WMR XR SDK assemblies to include Windows standalone

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/Microsoft.MixedReality.Toolkit.Providers.WindowsMixedReality.Shared.asmdef
@@ -6,7 +6,9 @@
     "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor",
-        "WSA"
+        "WSA",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Microsoft.MixedReality.Toolkit.Providers.XRSDK.WMR.asmdef
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Microsoft.MixedReality.Toolkit.Providers.XRSDK.WMR.asmdef
@@ -8,7 +8,9 @@
     "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor",
-        "WSA"
+        "WSA",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,


### PR DESCRIPTION
## Overview

 Although the WMR XR SDK data provider is already marked to work on Windows Standalone, the assemblies aren't actually included in the build. This fixes that, to unblock controller input on a WMR Windows Standalone build.

## Changes
- Part of #7905 