### PR TITLE
Resolved issue with NaN propagation from zero-scale PressableButtons

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -245,7 +245,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// The position from where the button starts to move.  Projected into world space based on the button's current world space position.
         /// </summary>
-        private Vector3 InitialPosition
+        private Vector3 InitialWorldPosition
         {
             get
             {
@@ -271,9 +271,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 if (Application.isPlaying && movingButtonVisuals) // we're using a cached position in play mode as the moving visuals will be moved during button interaction
                 {
-
-                    var localPosition = movingVisualsInitialLocalPosition;
-                    return localPosition;
+                    return movingVisualsInitialLocalPosition;
                 }
                 else
                 {
@@ -466,7 +464,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public Vector3 GetWorldPositionAlongPushDirection(float localDistance)
         {
             float distance = (distanceSpaceMode == SpaceMode.Local) ? localDistance * LocalToWorldScale : localDistance;
-            return InitialPosition + WorldSpacePressDirection.normalized * distance;
+            return InitialWorldPosition + WorldSpacePressDirection.normalized * distance;
         }
 
         /// <summary>
@@ -483,7 +481,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public float GetDistanceAlongPushDirection(Vector3 positionWorldSpace)
         {
-            Vector3 localPosition = positionWorldSpace - InitialPosition;
+            Vector3 localPosition = positionWorldSpace - InitialWorldPosition;
             float distance = Vector3.Dot(localPosition, WorldSpacePressDirection.normalized);
             return (distanceSpaceMode == SpaceMode.Local) ? distance / LocalToWorldScale : distance;
         }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -204,7 +204,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     return nearInteractionTouchable.transform.TransformDirection(nearInteractionTouchable.LocalPressDirection);
                 }
                 
-                return -transform.forward;
+                return transform.forward;
             }
         }
 
@@ -216,7 +216,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                GetComponent<NearInteractionTouchableSurface>();
                 var nearInteractionTouchable = GetComponent<NearInteractionTouchableSurface>();
                 if (nearInteractionTouchable != null)
                 {
@@ -499,7 +498,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 // Always move relative to startPushDistance
                 movingButtonVisuals.transform.localPosition = GetLocalPositionAlongPushDirection(currentPushDistance - startPushDistance);
-                //movingButtonVisuals.transform.position = GetWorldPositionAlongPushDirection(currentPushDistance - startPushDistance);
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -425,8 +425,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         /// 
         public Vector3 GetWorldPositionAlongPushDirection(float localDistance)
-        {
-            float distance = (distanceSpaceMode == SpaceMode.Local) ? localDistance * LocalToWorldScale : localDistance;
+        {   
+            // We clamp the calculated local distance to the maxPushDistance,
+            // because LocalToWorldScale may return NaNs when object scale is zero.
+            float distance = Mathf.Clamp(0f, maxPushDistance, (distanceSpaceMode == SpaceMode.Local) ? localDistance * LocalToWorldScale : localDistance);
             return InitialPosition + WorldSpacePressDirection.normalized * distance;
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
@@ -124,7 +124,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (movingButtonIconText != null)
             {
                 // Always move relative to startPushDistance
-                movingButtonIconText.transform.position = GetWorldPositionAlongPushDirection((CurrentPushDistance - startPushDistance) / 2);
+                //movingButtonIconText.transform.position = GetWorldPositionAlongPushDirection((CurrentPushDistance - startPushDistance) / 2);
+                movingButtonIconText.transform.localPosition = GetLocalPositionAlongPushDirection((CurrentPushDistance - startPushDistance)/2.0f);
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
@@ -124,7 +124,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             if (movingButtonIconText != null)
             {
                 // Always move relative to startPushDistance
-                //movingButtonIconText.transform.position = GetWorldPositionAlongPushDirection((CurrentPushDistance - startPushDistance) / 2);
                 movingButtonIconText.transform.localPosition = GetLocalPositionAlongPushDirection((CurrentPushDistance - startPushDistance)/2.0f);
             }
         }

--- a/Assets/MRTK/Tests/PlayModeTests/PressableButtonTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PressableButtonTests.cs
@@ -566,8 +566,44 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.IsTrue(AreApproximatelyEqual(maxPushDistanceWorld * zScale.z, maxPushDistanceWorld_Scaled, tolerance), "Max push distance plane did not scale correctly");
             Assert.IsTrue(AreApproximatelyEqual(pressDistanceWorld * zScale.z, pressDistanceWorld_Scaled, tolerance), "Press distance plane did not scale correctly");
             Assert.IsTrue(AreApproximatelyEqual(releaseDistanceWorld * zScale.z, releaseDistanceWorld_Scaled, tolerance), "Release distance plane did not scale correctly");
+            Object.Destroy(testButton);
+            // Wait for a frame to give Unity a chance to actually destroy the object
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TestParentZeroScale([ValueSource(nameof(PressableButtonsTestPrefabPaths))] string prefabFilename)
+        {
+            // instantiate scene and button
+            GameObject testButton = InstantiateDefaultPressableButton(prefabFilename);
+            yield return null;
+
+            PressableButton button = testButton.GetComponent<PressableButton>();
+            Assert.IsNotNull(button);
+
+            // check default value -> default must be using local space in order for the button to scale and function correctly
+            Assert.IsTrue(button.DistanceSpaceMode == PressableButton.SpaceMode.Local);
+
+            // make sure there's no scale on our button and non-zero to start push distance
+            testButton.transform.localScale = Vector3.one;
+            button.StartPushDistance = 0.00003f;
+
+            // Create an empty GameObject for our parent.
+            GameObject emptyParent = new GameObject();
+            emptyParent.transform.position = testButton.transform.position;
+
+            // Parent our button to the empty object.
+            testButton.transform.parent = emptyParent.transform;
+            yield return null;
+
+            // This should not cause any NaN errors, as per resolution to #7874
+            testButton.transform.localScale = Vector3.zero; 
+            yield return null;
 
             Object.Destroy(testButton);
+            yield return null;
+
+            Object.Destroy(emptyParent);
             // Wait for a frame to give Unity a chance to actually destroy the object
             yield return null;
         }


### PR DESCRIPTION
## Overview
An issue was reported (#7874) that when a PressableButton was scaled to zero, NaN values were propagated to a `transform.position` assign attempt. I analyzed this issue, and saw that the particular way that `PressableButton` calculates the visible button content offset uses a local-to-world scaling that is susceptible to NaN propagation when object scale is zero.

Testing this bug is difficult. The original issue (#7874) reported that these NaN issues occurred whenever the object was scaled near zero; I attempted to reproduce this error, but the error only occurred on my machine when _exiting play mode_; when setting the scale to zero, it did not occur until I exited play mode. Therefore, the included test may not fully cover all reproduceable cases (but it should cover the case that was originally reported in #7874.) That is to say, the unit test covers the _runtime_ case, but I was only personally able to observe this bug when leaving play and returning to edit mode.

Therefore, this PR resolves #7874.

## Changes

Adds a clamping to `GetWorldPositionAlongPushDirection`. This prevents a NaN `LocalToWorldScale` value from breaking the `UpdateMovingVisualsPosition` method, which uses `GetWorldPositionAlongPushDirection` to adjust the `movingButtonVisuals`.


## Verification
Unit test was added to verify that zero-scaling the parent of a `PressableButton` does not throw exceptions.
