### PR TITLE
Update XR assets for XR Management 3.0

### DIFF
--- a/Assets/XR/Loaders/AR Core Loader.asset
+++ b/Assets/XR/Loaders/AR Core Loader.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06042c85f885b4d1886f3ca5a1074eca, type: 3}
+  m_Name: AR Core Loader
+  m_EditorClassIdentifier: 

--- a/Assets/XR/Loaders/AR Core Loader.asset.meta
+++ b/Assets/XR/Loaders/AR Core Loader.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e0a6da15c9d4bf2499d9c227d90bd8e7
+guid: f9ea5ada27dd36e45aa326aa65c71d50
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/XR/Loaders/AR Kit Loader.asset
+++ b/Assets/XR/Loaders/AR Kit Loader.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a18c4d6661b404073b154020b9e2d993, type: 3}
+  m_Name: AR Kit Loader
+  m_EditorClassIdentifier: 

--- a/Assets/XR/Loaders/AR Kit Loader.asset.meta
+++ b/Assets/XR/Loaders/AR Kit Loader.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e0a6da15c9d4bf2499d9c227d90bd8e7
+guid: f9b902a6081c7cb40bf0902de1518edf
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/XR/Settings/AR Core Loader Settings.asset
+++ b/Assets/XR/Settings/AR Core Loader Settings.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00cb13c61b2744fd786f9f969ce96149, type: 3}
+  m_Name: AR Core Loader Settings
+  m_EditorClassIdentifier: 
+  m_StartAndStopSubsystems: 0

--- a/Assets/XR/Settings/AR Core Loader Settings.asset.meta
+++ b/Assets/XR/Settings/AR Core Loader Settings.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e0a6da15c9d4bf2499d9c227d90bd8e7
+guid: 846dad373d6245c44ab24a2bb488cd00
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/XR/Settings/AR Kit Loader Settings.asset
+++ b/Assets/XR/Settings/AR Kit Loader Settings.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9cac560dd573c4c5088432b9d202f3e7, type: 3}
+  m_Name: AR Kit Loader Settings
+  m_EditorClassIdentifier: 
+  m_StartAndStopSubsystems: 0

--- a/Assets/XR/Settings/AR Kit Loader Settings.asset.meta
+++ b/Assets/XR/Settings/AR Kit Loader Settings.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e0a6da15c9d4bf2499d9c227d90bd8e7
+guid: 77640f1464920cb439f52079cbc103bb
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/XR/Settings/Windows MR Package Settings.asset
+++ b/Assets/XR/Settings/Windows MR Package Settings.asset
@@ -1,6 +1,34 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-9138172715340701070
+--- !u!114 &-1973919941960493343
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed912223f7b3af74d8e196b2a4e662b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DepthBufferFormat: 1
+  UseSharedDepthBuffer: 1
+--- !u!114 &-1895190840245289411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed912223f7b3af74d8e196b2a4e662b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DepthBufferFormat: 1
+  UseSharedDepthBuffer: 1
+--- !u!114 &-243325751501137724
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13,6 +41,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   UsePrimaryWindowForDisplay: 1
+  HolographicRemoting: 0
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -27,25 +56,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Keys: 0e00000001000000
   Values:
-  - {fileID: 8764183953860033900}
-  - {fileID: 3955096188411757935}
+  - {fileID: -1973919941960493343}
+  - {fileID: -1895190840245289411}
   BuildValues:
-  - {fileID: -9138172715340701070}
---- !u!114 &3955096188411757935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ed912223f7b3af74d8e196b2a4e662b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  DepthBufferFormat: 1
-  UseSharedDepthBuffer: 1
---- !u!114 &8764183953860033900
+  - {fileID: -243325751501137724}
+--- !u!114 &4104368139223955297
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/XR/XRGeneralSettings.asset
+++ b/Assets/XR/XRGeneralSettings.asset
@@ -1,6 +1,82 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-5796463592960687092
+--- !u!114 &-7812372066190229872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Standalone Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 8061498436382382255}
+  m_InitManagerOnStart: 1
+--- !u!114 &-7021520664427642206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: Android Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders:
+  - {fileID: 11400000, guid: f9ea5ada27dd36e45aa326aa65c71d50, type: 2}
+--- !u!114 &-4208678248568432793
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Metro Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 21087034884932355}
+  m_InitManagerOnStart: 1
+--- !u!114 &-1106129008331555982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: Android Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: -7021520664427642206}
+  m_InitManagerOnStart: 1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
+  m_Name: XRGeneralSettings
+  m_EditorClassIdentifier: 
+  Keys: 0e0000000100000007000000
+  Values:
+  - {fileID: -4208678248568432793}
+  - {fileID: -7812372066190229872}
+  - {fileID: -1106129008331555982}
+--- !u!114 &21087034884932355
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -17,21 +93,7 @@ MonoBehaviour:
   m_AutomaticRunning: 0
   m_Loaders:
   - {fileID: 11400000, guid: f71156c4b70809f4a8542fa1ca99fe9f, type: 2}
---- !u!114 &-2196315355675890184
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
-  m_Name: Standalone Settings
-  m_EditorClassIdentifier: 
-  m_LoaderManagerInstance: {fileID: -689958956425743848}
-  m_InitManagerOnStart: 1
---- !u!114 &-689958956425743848
+--- !u!114 &8061498436382382255
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -48,33 +110,3 @@ MonoBehaviour:
   m_AutomaticRunning: 0
   m_Loaders:
   - {fileID: 11400000, guid: f71156c4b70809f4a8542fa1ca99fe9f, type: 2}
---- !u!114 &11400000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
-  m_Name: XRGeneralSettings
-  m_EditorClassIdentifier: 
-  Keys: 0e00000001000000
-  Values:
-  - {fileID: 8889006692710314719}
-  - {fileID: -2196315355675890184}
---- !u!114 &8889006692710314719
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
-  m_Name: Metro Settings
-  m_EditorClassIdentifier: 
-  m_LoaderManagerInstance: {fileID: -5796463592960687092}
-  m_InitManagerOnStart: 1

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -9,7 +9,11 @@ EditorBuildSettings:
     path: Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
     guid: 3dd4a396b5225f8469b9a1eb608bfa57
   m_configObjects:
-    Unity.XR.WindowsMR.Settings: {fileID: 11400000, guid: b473d8d1ff820a242915cc3633363b8d,
+    Unity.XR.WindowsMR.Settings: {fileID: 11400000, guid: e0a6da15c9d4bf2499d9c227d90bd8e7,
+      type: 2}
+    com.unity.xr.arcore.PlayerSettings: {fileID: 11400000, guid: e62a87a58e0855440bf3675f4e3eac18,
+      type: 2}
+    com.unity.xr.arkit.PlayerSettings: {fileID: 11400000, guid: d96734d10d0040248bbb79519bb034b7,
       type: 2}
     com.unity.xr.management.loader_settings: {fileID: 11400000, guid: 68d3f4682465e9244a94c51343bb7c4c,
       type: 2}

--- a/ProjectSettings/XRPackageSettings.asset
+++ b/ProjectSettings/XRPackageSettings.asset
@@ -1,5 +1,7 @@
 {
     "m_Settings": [
-        "Windows MR Package Initialization"
+        "Windows MR Package Initialization",
+        "RemoveLegacyInputHelpersForReload",
+        "ShouldQueryLegacyPackageRemoval"
     ]
 }


### PR DESCRIPTION
## Overview

Unity's XR Plugin Management package had a pretty large update for version 3.0, and all previous versions were unpublished. As a result, ARCore and ARKit are now managed via XR Management, so I'm adding those assets. I also recreated the WMR assets from scratch.

For these assets, since they don't exist in 2018.4, they simply state that fact and don't cause issues:

![image](https://user-images.githubusercontent.com/3580640/82497636-73b7e600-9aa3-11ea-9aa8-c22ca73cec43.png)

These files are only included in the repo to facilitate XR SDK work on MRTK. They are not distributed in any MRTK package or intended to be used by others, but exist as repo scaffolding.