### PR TITLE
Create a baseline for using dotnet-format on MRTK C# code

### DIFF
--- a/Assets/MRTK/Core/Attributes/HelpAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/HelpAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// <summary>
     /// A PropertyAttribute for showing a collapsible Help section.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field|AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
     public class HelpAttribute : PropertyAttribute
     {
         /// <summary>
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="helpText">The help text to display</param>
         /// <param name="helpHeader">The help header foldout text</param>
         /// <param name="collapsible">If true, this help drawer will be collapsible</param>
-        public HelpAttribute(string helpText, string helpHeader="Help", bool collapsible = true)
+        public HelpAttribute(string helpText, string helpHeader = "Help", bool collapsible = true)
         {
             Text = helpText;
             Header = helpHeader;

--- a/Assets/MRTK/Core/Attributes/MixedRealityControllerAttribute.cs
+++ b/Assets/MRTK/Core/Attributes/MixedRealityControllerAttribute.cs
@@ -42,9 +42,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// 
         /// </summary>
         public MixedRealityControllerAttribute(
-            SupportedControllerType supportedControllerType, 
+            SupportedControllerType supportedControllerType,
             Handedness[] supportedHandedness,
-            string texturePath = "", 
+            string texturePath = "",
             MixedRealityControllerConfigurationFlags flags = 0)
         {
             SupportedControllerType = supportedControllerType;

--- a/Assets/MRTK/Core/Definitions/BoundarySystem/InscribedRectangle.cs
+++ b/Assets/MRTK/Core/Definitions/BoundarySystem/InscribedRectangle.cs
@@ -163,12 +163,12 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                     // Note, we are ignoring the return value as we are checking each point's validity
                     // individually.
                     FindSurroundingCollisionPoints(
-                        geometryEdges, 
-                        startingPoints[pointIndex], 
+                        geometryEdges,
+                        startingPoints[pointIndex],
                         angleRadians,
-                        out topCollisionPoint, 
-                        out bottomCollisionPoint, 
-                        out leftCollisionPoint, 
+                        out topCollisionPoint,
+                        out bottomCollisionPoint,
+                        out leftCollisionPoint,
                         out rightCollisionPoint);
 
                     float newWidth;
@@ -332,9 +332,9 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
             }
 
             // Each corner of the rectangle must intersect with the geometry.
-            if (!EdgeUtilities.IsValidPoint(topCollisionPoint) || 
+            if (!EdgeUtilities.IsValidPoint(topCollisionPoint) ||
                 !EdgeUtilities.IsValidPoint(bottomCollisionPoint) ||
-                !EdgeUtilities.IsValidPoint(leftCollisionPoint) || 
+                !EdgeUtilities.IsValidPoint(leftCollisionPoint) ||
                 !EdgeUtilities.IsValidPoint(rightCollisionPoint))
             {
                 return false;
@@ -521,7 +521,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
 
                 // If the lowest value needed to outperform the previous best is greater than our max, 
                 // this aspect ratio can't outperform what we've already calculated.
-                if ((searchHeightLowerBound > searchHeightUpperBound) || 
+                if ((searchHeightLowerBound > searchHeightUpperBound) ||
                     (searchHeightLowerBound * aspectRatios[i] > maxWidth))
                 {
                     continue;
@@ -533,10 +533,10 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
                 // Perform the binary search until continuing to search will not give us a significant win.
                 do
                 {
-                    if (CheckRectangleFit(geometryEdges, 
-                        centerPoint, 
-                        angleRadians, 
-                        aspectRatios[i] * currentTestingHeight, 
+                    if (CheckRectangleFit(geometryEdges,
+                        centerPoint,
+                        angleRadians,
+                        aspectRatios[i] * currentTestingHeight,
                         currentTestingHeight))
                     {
                         // Binary search up-ward

--- a/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
+++ b/Assets/MRTK/Core/Definitions/CameraSystem/MixedRealityCameraProfile.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public int TransparentQualityLevel => transparentQualityLevel;
 
-#region Obsolete properties
+        #region Obsolete properties
 
         /// <summary>
         /// Quality level for a HoloLens device.
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit
         [Obsolete("HoloLensQualityLevel is obsolete and will be removed in a future Mixed Reality Toolkit release. Please use TransparentQualityLevel.")]
         public int HoloLensQualityLevel => transparentQualityLevel;
 
-#endregion Obsolete properties
+        #endregion Obsolete properties
 
     }
 }

--- a/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/MixedRealityControllerVisualizationProfile.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         public bool RenderMotionControllers
         {
-            get =>  renderMotionControllers;
+            get => renderMotionControllers;
             private set => renderMotionControllers = value;
         }
 

--- a/Assets/MRTK/Core/Definitions/Devices/SupportedControllerType.cs
+++ b/Assets/MRTK/Core/Definitions/Devices/SupportedControllerType.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     // todo: remove this.... it requires customization to add new device types
-    
+
     /// <summary>
     /// The SDKType lists the XR SDKs that are supported by the Mixed Reality Toolkit.
     /// Initially, this lists proposed SDKs, not all may be implemented at this time (please see ReleaseNotes for more details)

--- a/Assets/MRTK/Core/Definitions/InputSystem/InputActionEventPair.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/InputActionEventPair.cs
@@ -5,7 +5,8 @@ using System;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace Microsoft.MixedReality.Toolkit.Input {
+namespace Microsoft.MixedReality.Toolkit.Input
+{
     /// <summary>
     /// Data class that maps <see cref="MixedRealityInputAction"/>s to <see cref="UnityEvent"/>s wired up in the inspector.
     /// </summary>

--- a/Assets/MRTK/Core/Definitions/Physics/RayStep.cs
+++ b/Assets/MRTK/Core/Definitions/Physics/RayStep.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
         public Vector3 Origin { get; private set; }
         public Vector3 Terminus { get; private set; }
         public Vector3 Direction { get; private set; }
-        
+
         public float Length { get; private set; }
 
         private readonly float epsilon;

--- a/Assets/MRTK/Core/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/MixedRealitySceneSystemProfile.cs
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         // CS414 is disabled during this section because these properties are being used in the editor
         // scenario - when this file is build for player scenario, these serialized fields still exist
         // but are not used.
-        #pragma warning disable 414
+#pragma warning disable 414
         [SerializeField]
         [Tooltip("If true, the service will update your build settings automatically, ensuring that all manager, lighting and content scenes are added. Disable this if you want total control over build settings.")]
         private bool editorManageBuildSettings = true;
@@ -135,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
         [SerializeField]
         private bool editorLightingCacheOutOfDate = false;
-        #pragma warning restore 414
+#pragma warning restore 414
 
         #endregion
 
@@ -230,7 +230,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                     newContentTags.Add(contentScene.Tag);
                 }
             }
-            
+
             // See if our content tags have changed
             if (!contentTags.SequenceEqual(newContentTags))
             {
@@ -239,7 +239,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
             }
 
             defaultLightingSceneIndex = Mathf.Clamp(defaultLightingSceneIndex, 0, lightingScenes.Count - 1);
-            
+
             if (saveChanges)
             {   // We need to tie this directly to lighting scenes somehow
                 editorLightingCacheOutOfDate = true;
@@ -344,7 +344,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         {
             bool changed = false;
 
-            for (int i = sceneList.Count -1; i >= 0; i--)
+            for (int i = sceneList.Count - 1; i >= 0; i--)
             {
                 if (sceneList[i].IsEmpty)
                 {
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                     changed = true;
                 }
             }
-           
+
             return changed;
         }
         #endregion

--- a/Assets/MRTK/Core/Definitions/SceneSystem/RuntimeLightingSettings.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/RuntimeLightingSettings.cs
@@ -27,13 +27,13 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <param name="t">Value from 0 to 1</param>
         public static RuntimeLightingSettings Lerp(RuntimeLightingSettings from, RuntimeLightingSettings to, float t)
         {
-            bool notStarted             = t <= 0;
-            to.AlbedoBoost              = Mathf.Lerp(from.AlbedoBoost, to.AlbedoBoost, t);
-            to.BounceScale              = Mathf.Lerp(from.BounceScale, to.BounceScale, t);
-            to.EnableBakedLightmaps     = notStarted ? from.EnableBakedLightmaps : to.EnableBakedLightmaps;
+            bool notStarted = t <= 0;
+            to.AlbedoBoost = Mathf.Lerp(from.AlbedoBoost, to.AlbedoBoost, t);
+            to.BounceScale = Mathf.Lerp(from.BounceScale, to.BounceScale, t);
+            to.EnableBakedLightmaps = notStarted ? from.EnableBakedLightmaps : to.EnableBakedLightmaps;
             to.EnabledRealtimeLightmaps = notStarted ? from.EnabledRealtimeLightmaps : to.EnabledRealtimeLightmaps;
-            to.EnvironmentLightingMode  = notStarted ? from.EnvironmentLightingMode : to.EnvironmentLightingMode;
-            to.IndirectOutputScale      = Mathf.Lerp(from.IndirectOutputScale, to.IndirectOutputScale, t);
+            to.EnvironmentLightingMode = notStarted ? from.EnvironmentLightingMode : to.EnvironmentLightingMode;
+            to.IndirectOutputScale = Mathf.Lerp(from.IndirectOutputScale, to.IndirectOutputScale, t);
             return to;
         }
 
@@ -42,9 +42,9 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// </summary>
         public static RuntimeLightingSettings Black(RuntimeLightingSettings source)
         {
-            source.AlbedoBoost          = 0;
-            source.BounceScale          = 0;
-            source.IndirectOutputScale  = 0;
+            source.AlbedoBoost = 0;
+            source.BounceScale = 0;
+            source.IndirectOutputScale = 0;
             return source;
         }
     }

--- a/Assets/MRTK/Core/Definitions/SceneSystem/RuntimeRenderSettings.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/RuntimeRenderSettings.cs
@@ -43,27 +43,27 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <param name="t">Value from 0 to 1</param>
         public static RuntimeRenderSettings Lerp(RuntimeRenderSettings from, RuntimeRenderSettings to, float t)
         {
-            bool notStarted                 = t <= 0;
-            to.AmbientEquatorColor          = Color.Lerp(from.AmbientEquatorColor, to.AmbientEquatorColor, t);
-            to.AmbientGroundColor           = Color.Lerp(from.AmbientGroundColor, to.AmbientGroundColor, t);
-            to.AmbientIntensity             = Mathf.Lerp(from.AmbientIntensity, to.AmbientIntensity, t);
-            to.AmbientLight                 = Color.Lerp(from.AmbientLight, to.AmbientLight, t);
-            to.AmbientMode                  = notStarted ? from.AmbientMode : to.AmbientMode;
-            to.AmbientSkyColor              = Color.Lerp(from.AmbientSkyColor, to.AmbientSkyColor, t);
-            to.CustomReflection             = notStarted ? from.CustomReflection : to.CustomReflection;
-            to.DefaultReflectionMode        = notStarted ? from.DefaultReflectionMode : to.DefaultReflectionMode;
-            to.DefaultReflectionResolution  = notStarted ? from.DefaultReflectionResolution : to.DefaultReflectionResolution;
-            to.Fog                          = notStarted ? from.Fog : to.Fog;
-            to.FogColor                     = Color.Lerp(from.FogColor, to.FogColor, t);
-            to.FogDensity                   = Mathf.Lerp(from.FogDensity, to.FogDensity, t);
-            to.FogMode                      = notStarted ? from.FogMode : to.FogMode;
-            to.LinearFogEnd                 = Mathf.Lerp(from.LinearFogEnd, to.LinearFogEnd, t);
-            to.LinearFogStart               = Mathf.Lerp(from.LinearFogStart, to.LinearFogStart, t);
-            to.ReflectionBounces            = notStarted ? from.ReflectionBounces : to.ReflectionBounces;
-            to.ReflectionIntensity          = Mathf.Lerp(from.ReflectionIntensity, to.ReflectionIntensity, t);
-            to.SkyboxMaterial               = notStarted ? from.SkyboxMaterial : to.SkyboxMaterial;
-            to.SubtractiveShadowColor       = Color.Lerp(from.SubtractiveShadowColor, to.SubtractiveShadowColor, t);
-            to.UseRadianceAmbientProbe      = notStarted ? from.UseRadianceAmbientProbe : to.UseRadianceAmbientProbe;
+            bool notStarted = t <= 0;
+            to.AmbientEquatorColor = Color.Lerp(from.AmbientEquatorColor, to.AmbientEquatorColor, t);
+            to.AmbientGroundColor = Color.Lerp(from.AmbientGroundColor, to.AmbientGroundColor, t);
+            to.AmbientIntensity = Mathf.Lerp(from.AmbientIntensity, to.AmbientIntensity, t);
+            to.AmbientLight = Color.Lerp(from.AmbientLight, to.AmbientLight, t);
+            to.AmbientMode = notStarted ? from.AmbientMode : to.AmbientMode;
+            to.AmbientSkyColor = Color.Lerp(from.AmbientSkyColor, to.AmbientSkyColor, t);
+            to.CustomReflection = notStarted ? from.CustomReflection : to.CustomReflection;
+            to.DefaultReflectionMode = notStarted ? from.DefaultReflectionMode : to.DefaultReflectionMode;
+            to.DefaultReflectionResolution = notStarted ? from.DefaultReflectionResolution : to.DefaultReflectionResolution;
+            to.Fog = notStarted ? from.Fog : to.Fog;
+            to.FogColor = Color.Lerp(from.FogColor, to.FogColor, t);
+            to.FogDensity = Mathf.Lerp(from.FogDensity, to.FogDensity, t);
+            to.FogMode = notStarted ? from.FogMode : to.FogMode;
+            to.LinearFogEnd = Mathf.Lerp(from.LinearFogEnd, to.LinearFogEnd, t);
+            to.LinearFogStart = Mathf.Lerp(from.LinearFogStart, to.LinearFogStart, t);
+            to.ReflectionBounces = notStarted ? from.ReflectionBounces : to.ReflectionBounces;
+            to.ReflectionIntensity = Mathf.Lerp(from.ReflectionIntensity, to.ReflectionIntensity, t);
+            to.SkyboxMaterial = notStarted ? from.SkyboxMaterial : to.SkyboxMaterial;
+            to.SubtractiveShadowColor = Color.Lerp(from.SubtractiveShadowColor, to.SubtractiveShadowColor, t);
+            to.UseRadianceAmbientProbe = notStarted ? from.UseRadianceAmbientProbe : to.UseRadianceAmbientProbe;
             return to;
         }
 
@@ -73,17 +73,17 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// </summary>
         public static RuntimeRenderSettings Black(RuntimeRenderSettings source)
         {
-            source.AmbientEquatorColor      = Color.clear;
-            source.AmbientGroundColor       = Color.clear;
-            source.AmbientIntensity         = 0;
-            source.AmbientLight             = Color.clear;
-            source.AmbientSkyColor          = Color.clear;
-            source.FogColor                 = Color.clear;
-            source.FogDensity               = 0;
-            source.LinearFogEnd             = 0;
-            source.LinearFogStart           = 0;
-            source.ReflectionIntensity      = 0;
-            source.SubtractiveShadowColor   = Color.clear;
+            source.AmbientEquatorColor = Color.clear;
+            source.AmbientGroundColor = Color.clear;
+            source.AmbientIntensity = 0;
+            source.AmbientLight = Color.clear;
+            source.AmbientSkyColor = Color.clear;
+            source.FogColor = Color.clear;
+            source.FogDensity = 0;
+            source.LinearFogEnd = 0;
+            source.LinearFogStart = 0;
+            source.ReflectionIntensity = 0;
+            source.SubtractiveShadowColor = Color.clear;
             return source;
         }
     }

--- a/Assets/MRTK/Core/Definitions/SceneSystem/RuntimeSunlightSettings.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/RuntimeSunlightSettings.cs
@@ -25,13 +25,13 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// <param name="t">Value from 0 to 1</param>
         public static RuntimeSunlightSettings Lerp(RuntimeSunlightSettings from, RuntimeSunlightSettings to, float t)
         {
-            bool notStarted     = t <= 0;
-            to.Color            = Color.Lerp(from.Color, to.Color, t);
-            to.Intensity        = Mathf.Lerp(from.Intensity, to.Intensity, t);
-            to.XRotation        = Mathf.Lerp(from.XRotation, to.XRotation, t);
-            to.YRotation        = Mathf.Lerp(from.YRotation, to.YRotation, t);
-            to.ZRotation        = Mathf.Lerp(from.ZRotation, to.ZRotation, t);
-            to.UseSunlight      = notStarted ? from.UseSunlight : to.UseSunlight;
+            bool notStarted = t <= 0;
+            to.Color = Color.Lerp(from.Color, to.Color, t);
+            to.Intensity = Mathf.Lerp(from.Intensity, to.Intensity, t);
+            to.XRotation = Mathf.Lerp(from.XRotation, to.XRotation, t);
+            to.YRotation = Mathf.Lerp(from.YRotation, to.YRotation, t);
+            to.ZRotation = Mathf.Lerp(from.ZRotation, to.ZRotation, t);
+            to.UseSunlight = notStarted ? from.UseSunlight : to.UseSunlight;
             return to;
         }
 
@@ -40,8 +40,8 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
         /// </summary>
         public static RuntimeSunlightSettings Black(RuntimeSunlightSettings source)
         {
-            source.Color        = Color.clear;
-            source.Intensity    = 0;
+            source.Color = Color.clear;
+            source.Intensity = 0;
 
             return source;
         }

--- a/Assets/MRTK/Core/Definitions/SceneSystem/SceneInfo.cs
+++ b/Assets/MRTK/Core/Definitions/SceneSystem/SceneInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 return IsInBuildSettings & BuildIndex >= 0;
             }
         }
-        
+
         /// <summary>
         /// Name of the scene. Set by the property drawer.
         /// </summary>

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/MixedRealitySpatialAwarenessMeshObserverProfile.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Spatial Awareness Mesh Observer Profile", fileName = "MixedRealitySpatialAwarenessMeshObserverProfile", order = (int)CreateProfileMenuItemIndices.SpatialAwarenessMeshObserver)]
     [MixedRealityServiceProfile(typeof(IMixedRealitySpatialAwarenessMeshObserver))]
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.html")]
-    public class MixedRealitySpatialAwarenessMeshObserverProfile : BaseSpatialAwarenessObserverProfile 
+    public class MixedRealitySpatialAwarenessMeshObserverProfile : BaseSpatialAwarenessObserverProfile
     {
         #region IMixedRealitySpatialAwarenessMeshObserver settings
 

--- a/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessPlanarObject.cs
+++ b/Assets/MRTK/Core/Definitions/SpatialAwareness/SpatialAwarenessPlanarObject.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         public static SpatialAwarenessPlanarObject CreateSpatialObject(Vector3 size, int layer, string name, int planeId)
         {
             SpatialAwarenessPlanarObject newMesh = new SpatialAwarenessPlanarObject();
-            
+
             newMesh.Id = planeId;
             newMesh.GameObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             newMesh.GameObject.layer = layer;

--- a/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/SupportedPlatforms.cs
@@ -11,16 +11,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     [Flags]
     public enum SupportedPlatforms
     {
-        WindowsStandalone   = 1 << 0,
-        MacStandalone       = 1 << 1,
-        LinuxStandalone     = 1 << 2,
-        WindowsUniversal    = 1 << 3,
-        WindowsEditor       = 1 << 4,
-        Android             = 1 << 5,
-        MacEditor           = 1 << 6,
-        LinuxEditor         = 1 << 7,
-        IOS                 = 1 << 8,
-        Web                 = 1 << 9,
-        Lumin               = 1 << 10
+        WindowsStandalone = 1 << 0,
+        MacStandalone = 1 << 1,
+        LinuxStandalone = 1 << 2,
+        WindowsUniversal = 1 << 3,
+        WindowsEditor = 1 << 4,
+        Android = 1 << 5,
+        MacEditor = 1 << 6,
+        LinuxEditor = 1 << 7,
+        IOS = 1 << 8,
+        Web = 1 << 9,
+        Lumin = 1 << 10
     }
 }

--- a/Assets/MRTK/Core/Definitions/Utilities/SystemType.cs
+++ b/Assets/MRTK/Core/Definitions/Utilities/SystemType.cs
@@ -137,10 +137,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         // Key == original reference string entry, value == new migrated placement
         // String values are broken into {namespace.classname, asmdef}
         private static Dictionary<string, string> ReferenceMappings = new Dictionary<string, string>()
-        { 
+        {
             { "Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor",
             "Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation" },
-            
+
             { "Microsoft.MixedReality.Toolkit.Input.InputPlaybackService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor",
             "Microsoft.MixedReality.Toolkit.Input.InputPlaybackService, Microsoft.MixedReality.Toolkit.Services.InputSimulation" },
         };

--- a/Assets/MRTK/Core/EventDatum/Boundary/BoundaryEventData.cs
+++ b/Assets/MRTK/Core/EventDatum/Boundary/BoundaryEventData.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         public BoundaryEventData(EventSystem eventSystem) : base(eventSystem) { }
 
         public void Initialize(
-            IMixedRealityBoundarySystem boundarySystem, 
+            IMixedRealityBoundarySystem boundarySystem,
             bool isFloorVisualized,
             bool isPlayAreaVisualized,
             bool isTrackedAreaVisualized,

--- a/Assets/MRTK/Core/EventDatum/GenericBaseEventData.cs
+++ b/Assets/MRTK/Core/EventDatum/GenericBaseEventData.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// Constructor.
         /// </summary>
         /// <param name="eventSystem">Usually <see href="https://docs.unity3d.com/ScriptReference/EventSystems.EventSystem-current.html">EventSystems.EventSystem.current</see></param>
-        public GenericBaseEventData(EventSystem eventSystem) : base(eventSystem) {}
+        public GenericBaseEventData(EventSystem eventSystem) : base(eventSystem) { }
 
         /// <summary>
         /// Used to initialize/reset the event and populate the data.

--- a/Assets/MRTK/Core/Extensions/BoundsExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/BoundsExtensions.cs
@@ -729,9 +729,9 @@ namespace Microsoft.MixedReality.Toolkit
             var x = bounds.extents.x;
             var y = bounds.extents.y;
             var z = bounds.extents.z;
-            var a = new Vector3(-x,  y, -z);
-            var b = new Vector3( x, -y, -z);
-            var c = new Vector3( x,  y, -z);
+            var a = new Vector3(-x, y, -z);
+            var b = new Vector3(x, -y, -z);
+            var c = new Vector3(x, y, -z);
 
             var verticies = new Vector3[]
             {

--- a/Assets/MRTK/Core/Extensions/CanvasExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/CanvasExtensions.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="hitChildObject">The child object that was hit or the canvas itself if it has no active children that were within the hit range.</param>
         public static bool Raycast(this Canvas canvas, Vector3 rayOrigin, Vector3 rayDirection, out float distance, out Vector3 hitPoint, out GameObject hitChildObject)
         {
-            hitChildObject =null;
+            hitChildObject = null;
             Plane plane = canvas.GetPlane();
             Ray ray = new Ray(rayOrigin, rayDirection);
 
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit
                     {
                         hitChildObject = canvas.gameObject;
                     }
-                    
+
                     return true;
                 }
             }
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit
             RectTransform rectTransform;
             bool shouldRaycast = false;
 
-            for (int i=rectTransformParent.childCount-1; i >= 0; i--)
+            for (int i = rectTransformParent.childCount - 1; i >= 0; i--)
             {
                 rectTransform = rectTransformParent.GetChild(i).GetComponent<RectTransform>();
                 Graphic graphic = rectTransform.GetComponent<Graphic>();
@@ -180,7 +180,7 @@ namespace Microsoft.MixedReality.Toolkit
                 {
                     rectTransform.GetLocalCorners(localCorners);
                     childLocalPoint = rectTransform.InverseTransformPoint(worldPoint);
-                    
+
                     if (recursive)
                     {
                         RectTransform childRect = GetChildRectTransformAtPoint(rectTransform, worldPoint, recursive, shouldReturnActive, shouldReturnRaycastable);

--- a/Assets/MRTK/Core/Extensions/ComparerExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/ComparerExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             public ReverseComparer(IComparer<TElement> originalComparer)
             {
-                 Debug.Assert(originalComparer != null, "originalComparer cannot be null.");
+                Debug.Assert(originalComparer != null, "originalComparer cannot be null.");
 
                 this.originalComparer = originalComparer;
             }

--- a/Assets/MRTK/Core/Extensions/EventSystemExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/EventSystemExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit
         private static readonly RaycastResultComparer RaycastResultComparer = new RaycastResultComparer();
 
         private static readonly ProfilerMarker RaycastPerfMarker = new ProfilerMarker("[MRTK] EventSystemExtensions.Raycast");
-        
+
         /// <summary>
         /// Executes a raycast all and returns the closest element.
         /// Fixes the current issue with Unity's raycast sorting which does not consider separate canvases.

--- a/Assets/MRTK/Core/Extensions/Texture2DExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/Texture2DExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit
 
             Color32 toColor = fillColor; // Implicit cast
             Color32[] colors = new Color32[width * height];
-            for (int i=0; i < colors.Length; i++)
+            for (int i = 0; i < colors.Length; i++)
             {
                 colors[i] = toColor;
             }

--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit
             }
             else
             {
-            #if UNITY_EDITOR
+#if UNITY_EDITOR
                 // Must use DestroyImmediate in edit mode but it is not allowed when called from 
                 // trigger/contact, animation event callbacks or OnValidate. Must use Destroy instead.
                 // Delay call to counter this issue in editor
@@ -44,9 +44,9 @@ namespace Microsoft.MixedReality.Toolkit
                 {
                     Object.DestroyImmediate(obj);
                 };
-            #else
+#else
                 Object.DestroyImmediate(obj);
-            #endif
+#endif
             }
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         /// <returns>True if either the managed or native object is null, false otherwise</returns>
         public static bool IsNull<T>(this T @interface) where T : class => @interface == null || @interface.Equals(null);
-        
+
         /// <summary>
         /// Properly checks an interface for null and returns the MonoBehaviour implementing it
         /// </summary>

--- a/Assets/MRTK/Core/Extensions/VectorExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/VectorExtensions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="radius">This is a <see cref="float"/> for the radius of the cylinder</param>
         public static Vector3 CylindricalMapping(Vector3 source, float radius)
         {
-            float circ  = 2f * Mathf.PI * radius;
+            float circ = 2f * Mathf.PI * radius;
 
             float xAngle = (source.x / circ) * 360f;
 

--- a/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityStandardShaderGUI.cs
@@ -419,7 +419,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
                 materialEditor.ShaderProperty(albedoAlphaMode, albedoAlphaMode.displayName);
 
-                if ((RenderingMode)renderingMode.floatValue == RenderingMode.Cutout || 
+                if ((RenderingMode)renderingMode.floatValue == RenderingMode.Cutout ||
                     (RenderingMode)renderingMode.floatValue == RenderingMode.Custom)
                 {
                     materialEditor.ShaderProperty(alphaCutoff, Styles.alphaCutoff.text);
@@ -593,7 +593,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 materialEditor.ShaderProperty(borderMinValue, Styles.borderMinValue, 2);
 
                 materialEditor.ShaderProperty(borderLightReplacesAlbedo, Styles.borderLightReplacesAlbedo, 2);
-                
+
                 if (PropertyEnabled(hoverLight) && PropertyEnabled(enableHoverColorOverride))
                 {
                     materialEditor.ShaderProperty(borderLightUsesHoverColor, Styles.borderLightUsesHoverColor, 2);
@@ -735,8 +735,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
 
         protected bool ScaleRequired()
         {
-            return PropertyEnabled(vertexExtrusion) || 
-                   PropertyEnabled(roundCorners) || 
+            return PropertyEnabled(vertexExtrusion) ||
+                   PropertyEnabled(roundCorners) ||
                    PropertyEnabled(borderLight) ||
                    (PropertyEnabled(enableTriplanarMapping) && PropertyEnabled(enableLocalSpaceTriplanarMapping));
         }
@@ -780,9 +780,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         [MenuItem("Mixed Reality Toolkit/Utilities/Upgrade MRTK Standard Shader for Lightweight Render Pipeline")]
         protected static void UpgradeShaderForLightweightRenderPipeline()
         {
-            if (EditorUtility.DisplayDialog("Upgrade MRTK Standard Shader?", 
-                                            "This will alter the MRTK Standard Shader for use with Unity's Lightweight Render Pipeline. You cannot undo this action.", 
-                                            "Ok", 
+            if (EditorUtility.DisplayDialog("Upgrade MRTK Standard Shader?",
+                                            "This will alter the MRTK Standard Shader for use with Unity's Lightweight Render Pipeline. You cannot undo this action.",
+                                            "Ok",
                                             "Cancel"))
             {
                 string path = AssetDatabase.GetAssetPath(StandardShaderUtility.MrtkStandardShader);

--- a/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityToolkitFacadeHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Facades
 
             // These are core systems that are likely out-of-box services and known to have register DataProviders
             // Search for any dataproviders that service facades can be created for
-            var dataProviderManagers = new IMixedRealityService[]{CoreServices.InputSystem, CoreServices.SpatialAwarenessSystem};
+            var dataProviderManagers = new IMixedRealityService[] { CoreServices.InputSystem, CoreServices.SpatialAwarenessSystem };
             foreach (var system in dataProviderManagers)
             {
                 var dataProviderAccess = system as IMixedRealityDataProviderAccess;

--- a/Assets/MRTK/Core/Inspectors/MixedRealityWireframeShaderGUI.cs
+++ b/Assets/MRTK/Core/Inspectors/MixedRealityWireframeShaderGUI.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             float? cullMode = GetFloatProperty(material, "_Cull");
 
             base.AssignNewShaderToMaterial(material, oldShader, newShader);
-   
+
             SetShaderFeatureActive(material, null, BaseStyles.cullModeName, cullMode);
 
             // Setup the rendering mode based on the old shader.

--- a/Assets/MRTK/Core/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/BaseMixedRealityToolkitConfigurationProfileInspector.cs
@@ -210,7 +210,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             Selection.activeObject = selectionObject;
                         }
                     }
-                    else if(!MixedRealityToolkit.Instance.HasActiveProfile)
+                    else if (!MixedRealityToolkit.Instance.HasActiveProfile)
                     {
                         EditorGUILayout.HelpBox("There is no active profile assigned in the current MRTK instance. Some properties may not be editable.", MessageType.Error);
                     }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityCameraProfileInspector.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty transparentQualityLevel;
 
         private const string DataProviderErrorMsg = "The Mixed Reality Camera System will use default settings.\nAdd a settings provider to customize the camera.";
-        private static readonly GUIContent AddProviderTitle  = new GUIContent("+ Add Camera Settings Provider", "Add Camera Settings Provider");
+        private static readonly GUIContent AddProviderTitle = new GUIContent("+ Add Camera Settings Provider", "Add Camera Settings Provider");
         private static readonly GUIContent RemoveProviderTitle = new GUIContent("-", "Remove Camera Settings Provider");
 
         private readonly GUIContent nearClipTitle = new GUIContent("Near Clip");

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerVisualizationProfileInspector.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
         public override void OnInspectorGUI()
         {
-           if (!RenderProfileHeader(ProfileTitle, ProfileDescription, target, true, BackProfileType.Input))
+            if (!RenderProfileHeader(ProfileTitle, ProfileDescription, target, true, BackProfileType.Input))
             {
                 return;
             }

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityGesturesProfileInspector.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
 
             UpdateGestureLabels();
 
-            if (!IsProfileInActiveInstance() 
+            if (!IsProfileInActiveInstance()
                 || MixedRealityToolkit.Instance.ActiveProfile.InputSystemProfile.InputActionsProfile == null)
             {
                 return;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityRegisteredServiceProviderProfileInspector.cs
@@ -134,9 +134,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                     // Try to assign default configuration profile when type changes.
                                     serializedObject.ApplyModifiedProperties();
                                     AssignDefaultConfigurationValues(
-                                        ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType, 
+                                        ((MixedRealityRegisteredServiceProvidersProfile)serializedObject.targetObject).Configurations[i].ComponentType,
                                         componentName,
-                                        configurationProfile, 
+                                        configurationProfile,
                                         runtimePlatform);
                                     changed = true;
                                     break;
@@ -154,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                             serializedObject.ApplyModifiedProperties();
                         }
 
-                        if (IsProfileRequired(serviceType) && 
+                        if (IsProfileRequired(serviceType) &&
                             (configurationProfile.objectReferenceValue == null))
                         {
                             EditorGUILayout.HelpBox($"{componentName} requires a Profile", MessageType.Warning);
@@ -173,7 +173,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private void AssignDefaultConfigurationValues(
             System.Type componentType,
             SerializedProperty componentName,
-            SerializedProperty configurationProfile, 
+            SerializedProperty configurationProfile,
             SerializedProperty runtimePlatform)
         {
             configurationProfile.objectReferenceValue = null;

--- a/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/Profiles/MixedRealitySceneSystemProfileInspector.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         const float DragAreaOffset = 10;
         const float LightingSceneTypesLabelWidth = 45;
 
-        private static string managerSceneContent = 
+        private static string managerSceneContent =
             "The Manager scene is loaded first and remains loaded for the duration of the app. Only one Manager scene is ever loaded, and no scene operation will ever unload it.";
 
         private static string lightingSceneContent =
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 return;
             }
-            
+
             if (!RenderProfileHeader(ProfileTitle, ProfileDescription, target))
             {
                 return;
@@ -270,7 +270,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                     arrayElement = arrayProperty.GetArrayElementAtIndex(i);
                                     assetProperty = arrayElement.FindPropertyRelative("Asset");
                                     if (assetProperty.objectReferenceValue != null && assetProperty.objectReferenceValue == draggedObject)
-                                    {   
+                                    {
                                         isDuplicate = true;
                                         break;
                                     }
@@ -281,7 +281,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                                     Debug.LogWarning("Skipping " + draggedObject.name + " - it's already in the " + arrayProperty.displayName + " list.");
                                     continue;
                                 }
-                                
+
                                 // Create the new element at 0
                                 arrayProperty.InsertArrayElementAtIndex(0);
                                 arrayProperty.serializedObject.ApplyModifiedProperties();

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoDrawer.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoDrawer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         /// We could add an enum or bool to the SceneInfo struct to control this, but that seemed like unnecessary clutter.
         /// </summary>
         public static bool DrawTagProperty { get; set; }
-        
+
         const float iconWidth = 20f;
         const float totalPropertyWidth = 410;
         const float assetPropertyWidth = 400;
@@ -88,7 +88,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             assetRect.width = position.width - iconWidth;
             assetRect.height = EditorGUIUtility.singleLineHeight;
             assetRect.x += iconWidth;
-           
+
             Rect buttonRect = position;
             buttonRect.height = EditorGUIUtility.singleLineHeight;
             buttonRect.y += (EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing);
@@ -186,12 +186,12 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
 
 
-            if (!string.IsNullOrEmpty (nameProperty.stringValue) && asset == null)
+            if (!string.IsNullOrEmpty(nameProperty.stringValue) && asset == null)
             {
                 // If we still can't find it, draw a button that lets people attempt to recover it
                 if (GUI.Button(buttonRect, "Search for missing scene", EditorStyles.toolbarButton))
                 {
-                   changed |= SceneInfoUtils.FindScene(nameProperty, pathProperty, ref asset);
+                    changed |= SceneInfoUtils.FindScene(nameProperty, pathProperty, ref asset);
                 }
             }
             else
@@ -260,7 +260,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 property.serializedObject.ApplyModifiedProperties();
             }
-            
+
             EditorGUIUtility.wideMode = lastMode;
             EditorGUI.indentLevel = lastIndentLevel;
             EditorGUI.EndProperty();

--- a/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
+++ b/Assets/MRTK/Core/Inspectors/PropertyDrawers/SceneInfoUtils.cs
@@ -158,7 +158,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                     changed = true;
                 }
 
-                
+
                 // The method is using scenes by path is not reliable (code included
                 // commented out here for reference).
                 // Cached scenes are used instead (see CachedScenes).

--- a/Assets/MRTK/Core/Inspectors/ServiceInspectors/SpatialAwarenessSystemInspector.cs
+++ b/Assets/MRTK/Core/Inspectors/ServiceInspectors/SpatialAwarenessSystemInspector.cs
@@ -21,9 +21,9 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private static readonly Color originColor = new Color(0.75f, 0.1f, 0.75f, 0.75f);
         private static readonly Color enabledColor = GUI.backgroundColor;
         private static readonly Color disabledColor = Color.Lerp(enabledColor, Color.clear, 0.5f);
-        
+
         public override bool AlwaysDrawSceneGUI { get { return false; } }
-        
+
         public override void DrawInspectorGUI(object target)
         {
             IMixedRealitySpatialAwarenessSystem spatial = (IMixedRealitySpatialAwarenessSystem)target;

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorFieldsUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorFieldsUtility.cs
@@ -107,7 +107,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 }
             }
         }
-        
+
         /// <summary>
         /// Update a property value in a serialized PropertySettings
         /// </summary>

--- a/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/InspectorUIUtility.cs
@@ -506,15 +506,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             return show;
         }
 
-    /// <summary>
-    /// Draws a popup UI with PropertyField type features.
-    /// Displays prefab pending updates
-    /// </summary>
-    /// <param name="prop">serialized property corresponding to Enum</param>
-    /// <param name="label">label for property</param>
-    /// <param name="propValue">Current enum value for property</param>
-    /// <returns>New enum value after draw</returns>
-    public static Enum DrawEnumSerializedProperty(SerializedProperty prop, GUIContent label, Enum propValue)
+        /// <summary>
+        /// Draws a popup UI with PropertyField type features.
+        /// Displays prefab pending updates
+        /// </summary>
+        /// <param name="prop">serialized property corresponding to Enum</param>
+        /// <param name="label">label for property</param>
+        /// <param name="propValue">Current enum value for property</param>
+        /// <returns>New enum value after draw</returns>
+        public static Enum DrawEnumSerializedProperty(SerializedProperty prop, GUIContent label, Enum propValue)
         {
             return DrawEnumSerializedProperty(EditorGUILayout.GetControlRect(), prop, label, propValue);
         }

--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -551,7 +551,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
                 int newIndex = EditorGUILayout.Popup(
                     new GUIContent(oldProfileObject != null ? "" : property.displayName),
-                    selectedIndex, 
+                    selectedIndex,
                     profileContent,
                     GUILayout.ExpandWidth(true));
 
@@ -563,7 +563,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 {
                     // The view asset button should always be enabled.
                     using (new GUIEnabledWrapper())
-                    { 
+                    {
                         if (GUILayout.Button("View Asset", EditorStyles.miniButton, GUILayout.Width(80)))
                         {
                             EditorGUIUtility.PingObject(property.objectReferenceValue);

--- a/Assets/MRTK/Core/Inspectors/Utilities/Search/MixedRealitySearchUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/Search/MixedRealitySearchUtility.cs
@@ -144,7 +144,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Search
                     CheckFieldForKeywords(property, config, result);
                 }
             }
-           
+
             if (result.Fields.Count > 0)
             {
                 result.Fields.Sort(delegate (FieldSearchResult r1, FieldSearchResult r2)
@@ -169,7 +169,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Search
             return isProfileField;
         }
 
-        private static IEnumerable<SerializedProperty> GatherProperties (UnityEngine.Object profile)
+        private static IEnumerable<SerializedProperty> GatherProperties(UnityEngine.Object profile)
         {
             List<SerializedProperty> properties = new List<SerializedProperty>();
             SerializedProperty iterator = new SerializedObject(profile).GetIterator();
@@ -239,7 +239,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Search
                             break;
 
                         case SerializedPropertyType.String:
-                            if(!string.IsNullOrEmpty(property.stringValue) && property.stringValue.ToLower().Contains(keyword))
+                            if (!string.IsNullOrEmpty(property.stringValue) && property.stringValue.ToLower().Contains(keyword))
                             {
                                 keywordMatch = true;
                                 numContentMatches++;

--- a/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityBaseInputHandler.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityBaseInputHandler.cs
@@ -11,5 +11,5 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// Base interface for all input handlers. This allows us to use ExecuteEvents.ExecuteHierarchy&lt;IMixedRealityBaseInputHandler&gt;
     /// to send an event to all input handling interfaces.
     /// </summary>
-    public interface IMixedRealityBaseInputHandler : IEventSystemHandler {}
+    public interface IMixedRealityBaseInputHandler : IEventSystemHandler { }
 }

--- a/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/Handlers/IMixedRealityHandMeshHandler.cs
@@ -50,4 +50,3 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Quaternion rotation;
     }
 }
- 

--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeSaccadeProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeSaccadeProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public interface IMixedRealityEyeSaccadeProvider : IMixedRealityDataProvider
     {
-         /// <summary>
+        /// <summary>
         /// Triggered when user is saccading across the view (jumping quickly with their eye gaze above a certain threshold in visual angles). 
         /// </summary>
         event Action OnSaccade;

--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityMouseDeviceManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         [ObsoleteAttribute("The MouseInputProfile property has been deprecated and will be removed in a future version of MRTK.")]
         MixedRealityMouseInputProfile MouseInputProfile { get; }
-        
+
         /// <summary>
         /// Gets or sets a multiplier value used to adjust the speed of the mouse cursor.
         /// </summary>

--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -120,7 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private static ProfilerMarker RequestPointersPerfMarker = new ProfilerMarker("[MRTK] BaseInputDeviceManager.RequestPointers");
 
         // Active pointers associated with the config index they were spawned from
-        private readonly Dictionary<IMixedRealityPointer, uint> activePointersToConfig 
+        private readonly Dictionary<IMixedRealityPointer, uint> activePointersToConfig
             = new Dictionary<IMixedRealityPointer, uint>(PointerEqualityComparer.Default);
 
         #endregion

--- a/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
+++ b/Assets/MRTK/Core/Providers/BaseSpatialObserver.cs
@@ -219,9 +219,9 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         }
 
         #endregion Helpers
-        
+
         #region Obsolete
-        
+
         /// <summary>
         /// Constructor.
         /// </summary>

--- a/Assets/MRTK/Core/Providers/GenericPointer.cs
+++ b/Assets/MRTK/Core/Providers/GenericPointer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <inheritdoc />
         public SceneQueryType SceneQueryType { get; set; } = SceneQueryType.SimpleRaycast;
-        
+
         /// <inheritdoc />
         public float SphereCastRadius { get; set; }
 

--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// The distance between the index finger tip and the thumb tip required to enter the pinch/air tap selection gesture.
         /// The pinch gesture enter will be registered for all values less than the EnterPinchDistance. The default EnterPinchDistance value is 0.02 and must be between 0.015 and 0.1. 
         /// </summary>
-        public float EnterPinchDistance 
+        public float EnterPinchDistance
         {
             get => enterPinchDistance;
             set
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 else
                 {
                     Debug.LogError("EnterPinchDistance must be be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
-                }   
+                }
             }
         }
 

--- a/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
+++ b/Assets/MRTK/Core/Providers/Hands/BaseHandVisualizer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 lastHandMeshVertices = eventData.InputData.vertices;
 
                 if (newMesh || meshChanged)
-                {                    
+                {
                     mesh.triangles = eventData.InputData.triangles;
 
                     if (eventData.InputData.uvs?.Length > 0)

--- a/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandBounds.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
                 foreach (var kvp in eventData.InputData)
                 {
-                    if (kvp.Key == TrackedHandJoint.None || 
+                    if (kvp.Key == TrackedHandJoint.None ||
                         kvp.Key == TrackedHandJoint.Palm)
                     {
                         continue;

--- a/Assets/MRTK/Core/Providers/Hands/HandJointService.cs
+++ b/Assets/MRTK/Core/Providers/Hands/HandJointService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IMixedRealityInputSystem inputSystem,
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : this(inputSystem, name, priority, profile) 
+            BaseMixedRealityProfile profile) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/Core/Providers/UnityInput/MixedRealityMouseInputProfile.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/MixedRealityMouseInputProfile.cs
@@ -9,8 +9,8 @@ using UnityEngine.Serialization;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     [CreateAssetMenu(
-        menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Mouse Input Profile", 
-        fileName = "MixedRealityMouseInputProfile", 
+        menuName = "Mixed Reality Toolkit/Profiles/Mixed Reality Mouse Input Profile",
+        fileName = "MixedRealityMouseInputProfile",
         order = (int)CreateProfileMenuItemIndices.MouseInput)]
     [MixedRealityServiceProfile(typeof(MouseDeviceManager))]
     public class MixedRealityMouseInputProfile : BaseMixedRealityProfile

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             IMixedRealityInputSystem inputSystem,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile) 
+            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityTouchDeviceManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
             IMixedRealityInputSystem inputSystem,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile) 
+            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/Core/Services/BaseExtensionService.cs
+++ b/Assets/MRTK/Core/Services/BaseExtensionService.cs
@@ -21,9 +21,9 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="profile">The configuration profile for the service.</param>
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
         protected BaseExtensionService(
-            IMixedRealityServiceRegistrar registrar, 
-            string name = null, 
-            uint priority = DefaultPriority, 
+            IMixedRealityServiceRegistrar registrar,
+            string name = null,
+            uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : this(name, priority, profile)
         {
             Registrar = registrar;

--- a/Assets/MRTK/Core/Services/BaseService.cs
+++ b/Assets/MRTK/Core/Services/BaseService.cs
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// True will release all managed resources, unmanaged resources are always released.
         /// </param>
         protected virtual void Dispose(bool disposing) { }
-    
+
         #endregion IDisposable Implementation
     }
 }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -1464,7 +1464,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// Used to register newly created instances in edit mode.
         /// Initially handled by using ExecuteAlways, but this attribute causes the instance to be destroyed as we enter play mode, which is disruptive to services.
         /// </summary>
-        private void DelayOnValidate() 
+        private void DelayOnValidate()
         {
             EditorApplication.delayCall -= DelayOnValidate;
 

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -154,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             Debug.Log($"Exiting build...");
             EditorApplication.Exit(success ? 0 : 1);
         }
-        
+
         public static async Task<bool> BuildUnityPlayerSimplified()
         {
             // We don't need stack traces on all our logs. Makes things a lot easier to read.

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             }
 
             // Now that NuGet packages have been restored, we can run the actual build process.
-            exitCode = await Run(msBuildPath, 
+            exitCode = await Run(msBuildPath,
                 $"\"{solutionProjectPath}\" {(buildInfo.Multicore ? "/m /nr:false" : "")} /t:{(buildInfo.RebuildAppx ? "Rebuild" : "Build")} /p:Configuration={buildInfo.Configuration} /p:Platform={buildInfo.BuildPlatform} {(string.IsNullOrEmpty(buildInfo.PlatformToolset) ? string.Empty : $"/p:PlatformToolset={buildInfo.PlatformToolset}")} {GetMSBuildLoggingCommand(buildInfo.LogDirectory, "buildAppx.log")}",
                 !Application.isBatchMode,
                 cancellationToken);
@@ -242,7 +242,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             var rootNode = XElement.Load(projectFilePath);
             var defaultNamespace = rootNode.GetDefaultNamespace();
             var propertyGroupNode = rootNode.Element(defaultNamespace + "PropertyGroup");
-            
+
             if (propertyGroupNode == null)
             {
                 propertyGroupNode = new XElement(defaultNamespace + "PropertyGroup", new XAttribute("Label", "Globals"));

--- a/Assets/MRTK/Core/Utilities/CameraFOVChecker.cs
+++ b/Assets/MRTK/Core/Utilities/CameraFOVChecker.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit
     /// </summary>
     public static class CameraFOVChecker
     {
-        
+
         // Help to clear caches when new frame runs
         static private int inFOVLastCalculatedFrame = -1;
         // Map from grabbable => is the grabbable in FOV for this frame. Cleared every frame

--- a/Assets/MRTK/Core/Utilities/DebugUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/DebugUtilities.cs
@@ -60,7 +60,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             DrawPoint(point, Quaternion.identity, color, size);
         }
-        
+
         /// <summary>
         /// Draws a point with a rotation in the Scene window.
         /// </summary>

--- a/Assets/MRTK/Core/Utilities/Editor/EditorProjectUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/EditorProjectUtilities.cs
@@ -229,19 +229,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             string fileName)
         {
             DirectoryInfo[] folders = root.GetDirectories(folderName);
-            if (folders.Length == 0) 
+            if (folders.Length == 0)
             {
-                return null; 
+                return null;
             }
-            if (folders.Length > 1) 
+            if (folders.Length > 1)
             {
                 Debug.LogWarning($"Too many instances of the {folderName} pattern, using the first one found.");
             }
 
             folders = folders[0].GetDirectories("Runtime");
-            if (folders.Length == 0) 
+            if (folders.Length == 0)
             {
-                return null; 
+                return null;
             }
 
             FileInfo[] files = folders[0].GetFiles(fileName);

--- a/Assets/MRTK/Core/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/PackageManifest/PackageManifestUpdater.cs
@@ -119,19 +119,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             // * (currentVersion == minVersion && minPrerelease != 0 && currentPrerelease >= minPrerelease)   return true;
             // * all other combinations                                                                       return false;
             if (currentVersion > minVersion)
-            { 
-                return true; 
+            {
+                return true;
             }
             else if (currentVersion == minVersion)
             {
                 // The current and minimum versions are the same, check the prerelease portion
-                if (currentPrerelease == minPrerelease) 
-                { 
-                    return true; 
+                if (currentPrerelease == minPrerelease)
+                {
+                    return true;
                 }
-                else if ((minPrerelease != 0f) && (currentPrerelease >= minPrerelease)) 
-                { 
-                    return true; 
+                else if ((minPrerelease != 0f) && (currentPrerelease >= minPrerelease))
+                {
+                    return true;
                 };
             }
 

--- a/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/Setup/MixedRealityToolkitFiles.cs
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// <param name="absolutePath">The absolute path to the project.</param>
         /// <returns>The project relative path.</returns>
         /// <remarks>This doesn't produce paths that contain step out '..' relative paths.</remarks>
-        public static string GetAssetDatabasePath(string absolutePath) 
+        public static string GetAssetDatabasePath(string absolutePath)
             // Use Path.GetFullPath to ensure proper Path.DirectorySeparatorChar is used depending on our editor platform
             => Path.GetFullPath(absolutePath)?.Replace(Path.GetFullPath(Application.dataPath), "Assets");
 

--- a/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Schema/GltfObject.cs
@@ -133,7 +133,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Schema
         public GltfAccessor GetAccessor(int index)
         {
             if (index < 0) return null;
-            
+
             var accessor = accessors[index];
             accessor.BufferView = bufferViews[accessor.bufferView];
             accessor.BufferView.Buffer = buffers[accessor.BufferView.buffer];

--- a/Assets/MRTK/Core/Utilities/InspectorFields/InspectorField.cs
+++ b/Assets/MRTK/Core/Utilities/InspectorFields/InspectorField.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         /// A string list of options for a pop-up list
         /// </summary>
         public string[] Options { get; set; }
-        
+
         /// <summary>
         /// An object to hold the actual value
         /// </summary>
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             }
             return setting;
         }
-        
+
         /// <summary>
         /// Get the propertySettings value
         /// </summary>
@@ -235,7 +235,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             return value;
         }
-        
+
         /// <summary>
         /// Get the index from a list of strings using string comparison
         /// </summary>

--- a/Assets/MRTK/Core/Utilities/InspectorFields/InspectorGenericFields.cs
+++ b/Assets/MRTK/Core/Utilities/InspectorFields/InspectorGenericFields.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 }
             }
         }
-        
+
         /// <summary>
         /// Searches through a class for InspectorField tags creates properties that can be serialized and
         /// automatically rendered in a custom inspector

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// Base class that provides data about a line.
     /// </summary>
     /// <remarks>Data to be consumed by other classes like the <see cref="BaseMixedRealityLineRenderer"/></remarks>
-    [ExecuteAlways] 
+    [ExecuteAlways]
     public abstract class BaseMixedRealityLineDataProvider : MonoBehaviour
     {
         #region Properties
@@ -164,7 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         public float VelocitySearchRange
         {
             get => velocitySearchRange;
-            set =>  velocitySearchRange = Mathf.Clamp(value, 0.001f, 0.1f);
+            set => velocitySearchRange = Mathf.Clamp(value, 0.001f, 0.1f);
         }
 
         [SerializeField]
@@ -471,7 +471,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 Debug.LogError("Invalid point index");
                 return Vector3.zero;
             }
-            
+
             Vector3 point = GetPointInternal(pointIndex);
             TransformPoint(ref point);
             return point;
@@ -611,8 +611,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             {
                 strength = distortionStrength.Evaluate(normalizedLength);
             }
-            
-            for (int i = 0; i <distorters.Count; i++)
+
+            for (int i = 0; i < distorters.Count; i++)
             {
                 Distorter distorter = distorters[i];
                 if (distorter.DistortionEnabled)

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierDataProvider.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierDataProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     break;
             }
         }
-        
+
         /// <inheritdoc />
         protected override Vector3 GetPointInternal(float normalizedDistance)
         {

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierInertia.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/BezierInertia.cs
@@ -4,7 +4,7 @@
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities
-{ 
+{
     [ExecuteAlways]
     [AddComponentMenu("Scripts/MRTK/Core/BezierInertia")]
     public class BezierInertia : MonoBehaviour
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             Vector3 p1WorldTarget = bezier.LineTransform.TransformPoint(p1Target);
             Vector3 p2WorldTarget = bezier.LineTransform.TransformPoint(p2Target);
-            
+
             p1Offset += p1WorldTarget - p1Position;
             p2Offset += p2WorldTarget - p2Position;
 
@@ -65,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             p2Position = Vector3.Lerp(p2Position, p2WorldTarget, seekTargetStrength * Time.deltaTime);
 
             bezier.SetPoint(1, p1Position);
-            bezier.SetPoint(2, p2Position);            
+            bezier.SetPoint(2, p2Position);
         }
     }
 }

--- a/Assets/MRTK/Core/Utilities/Lines/LineFollower.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/LineFollower.cs
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         private BaseMixedRealityLineDataProvider source = null;
 
         #region MonoBehaviour Implementation
-        
+
         private void OnEnable() => EnsureSetup();
 
         private void Update()

--- a/Assets/MRTK/Core/Utilities/Lines/Renderers/BaseMixedRealityLineRenderer.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/Renderers/BaseMixedRealityLineRenderer.cs
@@ -236,7 +236,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
         #region Gizmos
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
 
         protected virtual void OnDrawGizmos()
         {
@@ -332,7 +332,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
         }
 
-        #endif
+#endif
         #endregion
     }
 }

--- a/Assets/MRTK/Core/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/Renderers/StripMeshLineRenderer.cs
@@ -119,7 +119,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             forwards.Clear();
             colors.Clear();
             widths.Clear();
-            
+
             for (int i = 0; i <= LineStepCount; i++)
             {
                 float normalizedDistance = GetNormalizedPointAlongLine(i);

--- a/Assets/MRTK/Core/Utilities/MathUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/MathUtilities.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// </summary>
         public static float ScaleFromAngularSizeAndDistance(float angle, float distance)
         {
-            float scale = 2.0f * distance * Mathf.Tan(angle * Mathf.Deg2Rad * 0.5f);            
+            float scale = 2.0f * distance * Mathf.Tan(angle * Mathf.Deg2Rad * 0.5f);
             return scale;
         }
 
@@ -474,7 +474,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             return pos;
         }
-        
+
         /// <summary>
         /// Calculates the direction vector from a rotation.
         /// </summary>
@@ -493,8 +493,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <remarks>
         /// Field of view parameters are in degrees and plane distances are in meters 
         /// </remarks>
-        public static bool IsInFOV(Vector3 testPosition, Transform frameOfReference, 
-            float verticalFOV, float horizontalFOV, 
+        public static bool IsInFOV(Vector3 testPosition, Transform frameOfReference,
+            float verticalFOV, float horizontalFOV,
             float minPlaneDistance, float maxPlaneDistance)
         {
             Vector3 deltaPos = testPosition - frameOfReference.position;
@@ -528,7 +528,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <remarks>
         /// Field of view parameter is in degrees and distances are in meters.
         /// </remarks>
-        public static bool IsInFOVCone(Transform cone, 
+        public static bool IsInFOVCone(Transform cone,
             Vector3 point,
             float fieldOfView,
             float minDist = 0.05f,

--- a/Assets/MRTK/Core/Utilities/MixedRealityPlayspace.cs
+++ b/Assets/MRTK/Core/Utilities/MixedRealityPlayspace.cs
@@ -82,7 +82,7 @@ namespace Microsoft.MixedReality.Toolkit
         public static Quaternion Rotation
         {
             get { return Transform.rotation; }
-            set { Transform.rotation = value;  }
+            set { Transform.rotation = value; }
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Utilities/MixedRealityServiceRegistry.cs
+++ b/Assets/MRTK/Core/Utilities/MixedRealityServiceRegistry.cs
@@ -359,7 +359,7 @@ namespace Microsoft.MixedReality.Toolkit
         private static bool FindEntry(List<KeyValuePair<IMixedRealityService, IMixedRealityServiceRegistrar>> serviceList,
             Type interfaceType,
             string name,
-            out IMixedRealityService serviceInstance, 
+            out IMixedRealityService serviceInstance,
             out IMixedRealityServiceRegistrar registrar)
         {
             using (FindEntryPerfMarker.Auto())

--- a/Assets/MRTK/Core/Utilities/Rendering/DepthBufferRenderer.cs
+++ b/Assets/MRTK/Core/Utilities/Rendering/DepthBufferRenderer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Rendering
             RenderTexture renderTexture = new RenderTexture(textureWidth, textureHeight, 0);
 
             postProcessMaterial.SetTexture("_DepthTex", depthTexture);
-       
+
             cam.depthTextureMode = DepthTextureMode.Depth;
             cam.SetTargetBuffers(renderTexture.colorBuffer, depthTexture.depthBuffer);
         }

--- a/Assets/MRTK/Core/Utilities/Scenes/SerializedObjectUtils.cs
+++ b/Assets/MRTK/Core/Utilities/Scenes/SerializedObjectUtils.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             return madeChanges;
         }
-        
+
         /// <summary>
         /// Iterates through a serialized object's fields and sets any accompanying fields in the supplied struct.
         /// </summary>
@@ -74,7 +74,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
 
             return (T)targetObject;
         }
-        
+
         /// <summary>
         /// Sets the target field to the value from property based on property type.
         /// </summary>

--- a/Assets/MRTK/Core/Utilities/StandardShader/MeshOutline.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/MeshOutline.cs
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         {
             if (outlineMaterial != null && meshRenderer != null)
             {
-                Debug.AssertFormat(outlineMaterial.IsKeywordEnabled(vertexExtrusionKeyword), 
+                Debug.AssertFormat(outlineMaterial.IsKeywordEnabled(vertexExtrusionKeyword),
                                    "The material \"{0}\" does not have vertex extrusion enabled, no outline will be rendered.", outlineMaterial.name);
 
                 // Ensure that the outline material always renders before the default materials.

--- a/Assets/MRTK/Core/Utilities/StandardShader/MeshSmoother.cs
+++ b/Assets/MRTK/Core/Utilities/StandardShader/MeshSmoother.cs
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             MeshReference meshReference;
             var sharedMesh = meshFilter.sharedMesh;
 
-            if (sharedMesh != null && 
+            if (sharedMesh != null &&
                 processedMeshes.TryGetValue(sharedMesh, out meshReference))
             {
                 meshReference.Decrement();

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -338,9 +338,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
         {
             Debug.Assert(!string.IsNullOrEmpty(appFullPath));
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
-            if (!isAuth) 
-            { 
-                return false; 
+            if (!isAuth)
+            {
+                return false;
             }
 
             Debug.Log($"Starting app install on {targetDevice.ToString()}...");

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoBasicSetup/Scripts/FollowEyeGazeGazeProvider.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoBasicSetup/Scripts/FollowEyeGazeGazeProvider.cs
@@ -26,4 +26,4 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             }
         }
     }
-} 
+}

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBaseRectTransf.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoScrollPanZoom/Scripts/BaseClasses/PanZoomBaseRectTransf.cs
@@ -154,7 +154,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             Vector2 transfCursorPos = cursorPos - new Vector2(0.5f, 0.5f);
             pivot = transfCursorPos * navRectTransf.rect.size;
             offsetRate_Zoom = (oldScale - newScale) * pivot;
-            
+
             // Update the texture's scale to the computed value.
             scale = newScale;
         }
@@ -184,7 +184,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
                     // Rotate around the x axis
                     transfHitPnt = Quaternion.AngleAxis(gameObject.transform.rotation.eulerAngles.x, Vector3.right) * transfHitPnt;
-                    
+
                     // Normalize the transformed hit point to as UV coordinates are in [0,1].
                     float uvx = 1 - (Mathf.Clamp(transfHitPnt.x, -halfsize.x, halfsize.x) + halfsize.x) / (2 * halfsize.x);
                     float uvy = (Mathf.Clamp(transfHitPnt.y, -halfsize.y, halfsize.y) + halfsize.y) / (2 * halfsize.y);

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/TransportToRespawnLocation.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoTargetPositioning/Scripts/TransportToRespawnLocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
     /// <summary>
     /// The associated GameObject acts as a teleporter to a referenced respawn location.  
     /// </summary>
-    [RequireComponent (typeof(Collider))]
+    [RequireComponent(typeof(Collider))]
     [AddComponentMenu("Scripts/MRTK/Examples/TransportToRespawnLocation")]
     public class TransportToRespawnLocation : MonoBehaviour
     {
@@ -19,13 +19,13 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         [SerializeField]
         [Tooltip("Optional audio clip which is played when the target is respawned.")]
         private AudioClip AudioFX_OnRespawn = null;
-        
+
         void OnTriggerEnter(Collider other)
         {
             if (RespawnReference != null)
             {
                 other.gameObject.transform.position = RespawnReference.transform.position;
-                AudioFeedbackPlayer.Instance.PlaySound(AudioFX_OnRespawn); 
+                AudioFeedbackPlayer.Instance.PlaySound(AudioFX_OnRespawn);
             }
         }
     }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/BasicInputLogger.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/BasicInputLogger.cs
@@ -115,11 +115,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
                 string sec = AddLeadingZeroToSingleDigitIntegers(DateTime.Now.Second);
 
                 return string.Format("{0}{1}{2}-{3}{4}{5}",
-                    year, 
-                    month, 
-                    day, 
-                    hour, 
-                    minute, 
+                    year,
+                    month,
+                    day,
+                    hour,
+                    minute,
                     sec);
             }
         }
@@ -130,11 +130,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
         }
 
 
-#region Append log
+        #region Append log
         public bool Append(string msg)
         {
             CheckIfInitialized();
-            
+
             if (isLogging)
             {
                 // post IO to a separate thread.
@@ -201,7 +201,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
                 // Create new Stream writer
                 using (var writer = new StreamWriter(Filename))
                 {
-                    Debug.Log("SAVE LOGS to "+ Filename);
+                    Debug.Log("SAVE LOGS to " + Filename);
                     writer.Write(this.buffer.ToString());
                 }
             }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/CustomInputLogger.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/CustomInputLogger.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
         public void StopLoggingAndSave()
         {
-            Debug.Log(">> STOP LOGGING and save! ");       
+            Debug.Log(">> STOP LOGGING and save! ");
             SaveLogs();
             isLogging = false;
         }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/DrawOnTexture.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/DrawOnTexture.cs
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
             {
                 Debug.LogFormat("New draw point at ( {0}; {1} )", posUV.x, posUV.y);
                 MyDrawTexture.SetPixel(
-                    (int)(posUV.x * MyDrawTexture.width), 
+                    (int)(posUV.x * MyDrawTexture.width),
                     (int)(posUV.y * MyDrawTexture.height),
                     col);
 
@@ -97,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
                     {
                         for (int iy = 0; iy < MyDrawTexture.height; iy++)
                         {
-                            MyDrawTexture.SetPixel((int)(ix), (int)(iy), new Color(0, 0, 0, 0));   
+                            MyDrawTexture.SetPixel((int)(ix), (int)(iy), new Color(0, 0, 0, 0));
                         }
                     }
                     neverDrawnOn = false;
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
                         Vector2 currPnt = new Vector2(tx, ty);
 
                         float distCenterToCurrPnt = Vector2.Distance(center, currPnt);
-                        
+
                         if (distCenterToCurrPnt <= dynamicRadius / 2)
                         {
                             float normalizedDist = (distCenterToCurrPnt / dynamicRadius / 2); // [0.0, 1.0]
@@ -127,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
 
                             Color baseColor = MyDrawTexture.GetPixel((int)tx, (int)ty);
                             float delta = intensity * (1 - Mathf.Abs(localNormalizedInterest));
-           
+
                             float normalizedInterest = baseColor.a + delta;
                             Color col = Color.red;
                             // Get color from  given heatmap ramp
@@ -230,24 +230,24 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         {
             col = null;
 
-            
+
             float spread = drawBrushSize;
             float amplitude = drawIntensity;
             float distCenterToCurrPnt = Vector2.Distance(origPivot, currPnt) / spread;
 
             float B = 2f;
             float scaledInterest = 1 / (1 + Mathf.Pow(Mathf.Epsilon, -(B * distCenterToCurrPnt)));
-            float delta = scaledInterest / amplitude ;
+            float delta = scaledInterest / amplitude;
             if (delta < minThreshDeltaHeatMap)
                 return false;
 
             Color baseColor = MyDrawTexture.GetPixel((int)currPnt.x, (int)currPnt.y);
             float normalizedInterest = Mathf.Clamp(baseColor.a + delta, 0, 1);
-            
+
             // Get color from given heatmap ramp
             if (HeatmapLookUpTable != null)
             {
-                col = HeatmapLookUpTable.GetPixel((int)(normalizedInterest * (HeatmapLookUpTable.width-1)), 0);
+                col = HeatmapLookUpTable.GetPixel((int)(normalizedInterest * (HeatmapLookUpTable.width - 1)), 0);
                 col = new Color(col.Value.r, col.Value.g, col.Value.b, normalizedInterest);
             }
             else

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/LogStructureEyeGaze.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/LogStructureEyeGaze.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
         public override string[] GetHeaderColumns()
         {
-            return new string[] 
+            return new string[]
             {
                 // UserId
                 "UserId",
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
                 EyeTrackingProvider.IsEyeTrackingEnabledAndValid ? EyeTrackingProvider.GazeOrigin.x : 0,
                 EyeTrackingProvider.IsEyeTrackingEnabledAndValid ? EyeTrackingProvider.GazeOrigin.y : 0,
                 EyeTrackingProvider.IsEyeTrackingEnabledAndValid ? EyeTrackingProvider.GazeOrigin.z : 0,
-                                    
+
                 EyeTrackingProvider.IsEyeTrackingEnabledAndValid ? EyeTrackingProvider.GazeDirection.x : 0,
                 EyeTrackingProvider.IsEyeTrackingEnabledAndValid ? EyeTrackingProvider.GazeDirection.y : 0,
                 EyeTrackingProvider.IsEyeTrackingEnabledAndValid ? EyeTrackingProvider.GazeDirection.z : 0,

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorder.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorder.cs
@@ -78,7 +78,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             {
                 return FilenameToUse;
             }
-            
+
             return String.Format("{0}-{1}", sessionDescr, UserName);
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
                 return str.Substring(0, maxLength);
             }
         }
-        
+
         public static string GetStringFormat(object[] data)
         {
             string strFormat = "";
@@ -102,9 +102,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
             strFormat += ("{" + (data.Length - 1) + "}");
             return strFormat;
         }
-        
+
         public void UpdateLog(string inputType, string inputStatus, EyeTrackingTarget intendedTarget)
-        {            
+        {
             if ((Instance != null) && (isLogging))
             {
                 if (logStructure != null)

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderFeedback.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderFeedback.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
         [SerializeField]
         private AudioClip audio_LoadRecordedData = null;
-        
+
         private void PlayAudio(AudioClip audio)
         {
             if (AudioFeedbackPlayer.Instance != null)
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
 
         private void Update()
         {
-            if ((isShowingSomething)&&((DateTime.Now - startShowTime).TotalSeconds > maxShowDurationInSeconds))
+            if ((isShowingSomething) && ((DateTime.Now - startShowTime).TotalSeconds > maxShowDurationInSeconds))
             {
                 ResetStatusText();
             }

--- a/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderUIController.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/DemoVisualizer/Scripts/UserInputRecorderUIController.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking.Logging
         {
             RecordingUI_Reset(true);
         }
-        
+
         private void RecordingUI_Reset(bool reset)
         {
             if (btn_StopRecording != null)

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Scripts/TargetBehaviors/OnLoadStartScene.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.EyeTracking
         [SerializeField]
         [Tooltip("Name of the scene to be loaded when the button is selected.")]
         private string SceneToBeLoaded = "";
-        
+
         public void Start()
         {
             LoadNewScene();

--- a/Assets/MRTK/Examples/Demos/Gltf/Scripts/TestGltfLoading.cs
+++ b/Assets/MRTK/Examples/Demos/Gltf/Scripts/TestGltfLoading.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf
         /// <summary>
         /// Combines Streaming Assets folder path with RelativePath
         /// </summary>
-        public string AbsolutePath => Path.Combine(Path.GetFullPath(Application.streamingAssetsPath),RelativePath);
+        public string AbsolutePath => Path.Combine(Path.GetFullPath(Application.streamingAssetsPath), RelativePath);
 
         [SerializeField]
         [Tooltip("Scale factor to apply on load")]
@@ -74,6 +74,6 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Gltf
                 Debug.Log("Import successful");
             }
         }
-        
+
     }
 }

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scripts/GestureTester.cs
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scripts/GestureTester.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples
                 SetIndicator(NavigationIndicator, $"Navigation: started {Vector3.zero}", NavigationMaterial, Vector3.zero);
                 ShowRails(Vector3.zero);
             }
-            
+
             SetIndicator(SelectIndicator, "Select:", DefaultMaterial);
         }
 

--- a/Assets/MRTK/Examples/Demos/HandTracking/Scripts/LeapCoreAssetsDetector.cs
+++ b/Assets/MRTK/Examples/Demos/HandTracking/Scripts/LeapCoreAssetsDetector.cs
@@ -20,8 +20,8 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             text.text = "The Leap Data Provider can be used in this project";
             text.color = Color.green;
 #else
-        text.text = "This project has not met the requirements to use the Leap Data Provider. For more information, visit the MRTK Leap Motion Documentation";
-        text.color = Color.red;
+            text.text = "This project has not met the requirements to use the Leap Data Provider. For more information, visit the MRTK Leap Motion Documentation";
+            text.color = Color.red;
 #endif
         }
     }

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/InputData/InputDataExample.cs
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/InputData/InputDataExample.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         public TextMesh inputUtilsText;
         public TextMesh rawDataText;
 
-        private Tuple<InputSourceType, Handedness> [] inputSources = new Tuple<InputSourceType, Handedness>[]
+        private Tuple<InputSourceType, Handedness>[] inputSources = new Tuple<InputSourceType, Handedness>[]
         {
             new Tuple<InputSourceType, Handedness>(InputSourceType.Controller, Handedness.Right) ,
             new Tuple<InputSourceType, Handedness>(InputSourceType.Controller, Handedness.Left) ,
@@ -57,12 +57,12 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             // Iterate through all controllers output position, rotation, and other data from input 
             // mappings on a controller.
             sb.Clear();
-            foreach(var controller in CoreServices.InputSystem.DetectedControllers)
+            foreach (var controller in CoreServices.InputSystem.DetectedControllers)
             {
                 sb.AppendLine("Inputs for " + controller.InputSource.SourceName);
                 sb.AppendLine();
                 // Interactions for a controller is the list of inputs that this controller exposes
-                foreach(MixedRealityInteractionMapping inputMapping in controller.Interactions)
+                foreach (MixedRealityInteractionMapping inputMapping in controller.Interactions)
                 {
                     sb.AppendLine("\tDescription: " + inputMapping.Description);
                     sb.Append("\tAxisType: " + inputMapping.AxisType);
@@ -87,5 +87,5 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
             PointerUtils.SetHandRayPointerBehavior(PointerBehavior.AlwaysOff);
         }
 
-    } 
+    }
 }

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/InputData/InputDataExampleGizmo.cs
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/InputData/InputDataExampleGizmo.cs
@@ -30,9 +30,9 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         public void Update()
         {
             Ray myRay;
-            if(InputRayUtils.TryGetRay(sourceType, handedness, out myRay))
+            if (InputRayUtils.TryGetRay(sourceType, handedness, out myRay))
             {
-                transform.localPosition= myRay.origin;
+                transform.localPosition = myRay.origin;
                 transform.localRotation = Quaternion.LookRotation(myRay.direction, Vector3.up);
                 SetIsDataAvailable(true);
             }

--- a/Assets/MRTK/Examples/Demos/UX/Interactables/Scripts/CustomInteractablesReceiver.cs
+++ b/Assets/MRTK/Examples/Demos/UX/Interactables/Scripts/CustomInteractablesReceiver.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     outputString = statusString.Replace("%state%", lastState.Name);
 
-                    if(showClicked != null)
+                    if (showClicked != null)
                     {
                         outputString += "\n" + clickString + "(" + clickCount + ")";
                     }
@@ -139,7 +139,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             base.OnClick(state, source);
             if (Host != null)
             {
-                if(showClicked != null)
+                if (showClicked != null)
                 {
                     Host.StopCoroutine(showClicked);
                     showClicked = null;
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             base.OnVoiceCommand(state, source, command, index, length);
             lastVoiceCommand = command;
-            
+
             if (Host != null)
             {
                 if (showVoice != null)

--- a/Assets/MRTK/Examples/Demos/UX/ObjectManipulator/Scripts/ReturnToBounds.cs
+++ b/Assets/MRTK/Examples/Demos/UX/ObjectManipulator/Scripts/ReturnToBounds.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// </summary>
         [SerializeField]
         private Transform frontBounds = null;
-    
+
         public Transform FrontBounds
         {
             get => frontBounds;
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// </summary>
         [SerializeField]
         private Transform backBounds = null;
-    
+
         public Transform BackBounds
         {
             get => backBounds;
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// </summary>
         [SerializeField]
         private Transform leftBounds = null;
-    
+
         public Transform LeftBounds
         {
             get => leftBounds;
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// </summary>
         [SerializeField]
         private Transform rightBounds = null;
-    
+
         public Transform RightBounds
         {
             get => rightBounds;
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// </summary>
         [SerializeField]
         private Transform bottomBounds = null;
-    
+
         public Transform BottomBounds
         {
             get => bottomBounds;
@@ -75,15 +75,15 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// </summary>
         [SerializeField]
         private Transform topBounds = null;
-    
+
         public Transform TopBounds
         {
             get => topBounds;
             set => topBounds = value;
         }
-    
+
         private Vector3 positionAtStart;
-    
+
 
         /// <summary>
         /// Caches start position of gameobject this script is attached to

--- a/Assets/MRTK/Examples/Demos/UX/ProgressIndicator/Scripts/ProgressIndicatorDemo.cs
+++ b/Assets/MRTK/Examples/Demos/UX/ProgressIndicator/Scripts/ProgressIndicatorDemo.cs
@@ -27,11 +27,11 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         private KeyCode toggleOrbsKey = KeyCode.Alpha3;
 
         [SerializeField, Header("Settings")]
-        private string[] loadingMessages = new string[] { 
+        private string[] loadingMessages = new string[] {
             "First Loading Message",
-            "Loading Message 1", 
-            "Loading Message 2", 
-            "Loading Message 3", 
+            "Loading Message 1",
+            "Loading Message 2",
+            "Loading Message 3",
             "Final Loading Message" };
 
         [SerializeField, Range(1f, 10f)]

--- a/Assets/MRTK/Examples/Demos/Utilities/InspectorFields/Inspectors/InspectorFieldsExampleInspector.cs
+++ b/Assets/MRTK/Examples/Demos/Utilities/InspectorFields/Inspectors/InspectorFieldsExampleInspector.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 namespace Microsoft.MixedReality.Toolkit.Examples.Demos.Utilities.InspectorFields.Inspectors
 {
     [CustomEditor(typeof(InspectorFieldsExample))]
-    public class InspectorFieldsExampleInspector : UnityEditor.Editor 
+    public class InspectorFieldsExampleInspector : UnityEditor.Editor
     {
         private SerializedProperty settings;
         private InspectorFieldsExample example;

--- a/Assets/MRTK/Examples/Demos/Utilities/InspectorFields/Scripts/InspectorFieldsExample.cs
+++ b/Assets/MRTK/Examples/Demos/Utilities/InspectorFields/Scripts/InspectorFieldsExample.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         [InspectorField(Label = "Enabled", Tooltip = "Is the component enabled?", Type = InspectorField.FieldTypes.Bool)]
         public bool Enabled;
 
-        [InspectorField(Label = "Component Option", Tooltip = "Select an option", Type = InspectorField.FieldTypes.DropdownString, Options = new string[]{"Option 1", "Option 2", "Option 3", "Option 4" })]
+        [InspectorField(Label = "Component Option", Tooltip = "Select an option", Type = InspectorField.FieldTypes.DropdownString, Options = new string[] { "Option 1", "Option 2", "Option 3", "Option 4" })]
         public string ComponentOption = "Option 3";
 
         [InspectorField(Label = "Component Index", Tooltip = "A index value of the component", Type = InspectorField.FieldTypes.DropdownInt, Options = new string[] { "Index 0", "Index 1", "Index 2", "Index 3", "Index 4" })]

--- a/Assets/MRTK/Examples/Experimental/Dwell/BaseDwellSample.cs
+++ b/Assets/MRTK/Examples/Experimental/Dwell/BaseDwellSample.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dwell
         public virtual void DwellIntended(IMixedRealityPointer pointer) { }
 
         public virtual void DwellCanceled(IMixedRealityPointer pointer) { isDwelling = false; }
-        
+
         public virtual void DwellCompleted(IMixedRealityPointer pointer)
         {
             isDwelling = false;

--- a/Assets/MRTK/Examples/Experimental/Dwell/ToggleDwellSample.cs
+++ b/Assets/MRTK/Examples/Experimental/Dwell/ToggleDwellSample.cs
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dwell
         {
             isDwellEnabled = !isDwellEnabled;
             dwellStatus.text = isDwellEnabled ? "On" : "Off";
-            
+
             // swap the button background and dwell visuals overlay color
             buttonBackground.color = isDwellEnabled ? this.dwellOnColor : this.dwellOffColor;
             dwellVisualImage.color = isDwellEnabled ? this.dwellOffColor : this.dwellOnColor;

--- a/Assets/MRTK/Examples/Experimental/HandMenuLayout/Prefabs/HandMenuSliderAssets/Scripts/UpdateSliderTrackLine.cs
+++ b/Assets/MRTK/Examples/Experimental/HandMenuLayout/Prefabs/HandMenuSliderAssets/Scripts/UpdateSliderTrackLine.cs
@@ -13,10 +13,10 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Experimental.HandMenu
     {
         [SerializeField]
         private GameObject activeLine = null;
-        
+
         public void OnSliderUpdated(SliderEventData eventData)
         {
-            activeLine.transform.localScale = new Vector3 (transform.localScale.x, eventData.NewValue, transform.localScale.z);
+            activeLine.transform.localScale = new Vector3(transform.localScale.x, eventData.NewValue, transform.localScale.z);
         }
     }
 }

--- a/Assets/MRTK/Extensions/HandPhysicsService/Examples/PhysicsTriggerEventReadout.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/Examples/PhysicsTriggerEventReadout.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics.Examples
         [SerializeField]
         [Tooltip("TextMeshPro object that will write the events")]
         private TextMeshPro textField;
-    
+
         /// <summary>
         /// TextMeshPro object that will write the events 
         /// </summary>
@@ -42,7 +42,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics.Examples
             JointKinematicBody joint = other.GetComponent<JointKinematicBody>();
             if (joint == null) { return; }
 
-            if(currentJoints.Contains(joint))
+            if (currentJoints.Contains(joint))
             {
                 currentJoints.Remove(joint);
             }
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics.Examples
                 WriteText();
                 currentJoints.Remove(joint);
             }
-            if(currentJoints.Count <= 0)
+            if (currentJoints.Count <= 0)
             {
                 WriteText(true);
             }

--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
             handPhysicsServiceProfile = (HandPhysicsServiceProfile)profile;
         }
 
-        private IMixedRealityHandJointService HandJointService 
+        private IMixedRealityHandJointService HandJointService
             => handJointService ?? CoreServices.GetInputSystemDataProvider<IMixedRealityHandJointService>();
 
         /// <inheritdoc />

--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsServiceProfile.cs
@@ -9,9 +9,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
     /// Configuration profile for <see cref="HandPhysicsService"/> extension service.
     /// </summary>
 	[MixedRealityServiceProfile(typeof(IHandPhysicsService))]
-	[CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality Toolkit/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
-	public class HandPhysicsServiceProfile : BaseMixedRealityProfile
-	{
+    [CreateAssetMenu(fileName = "HandPhysicsServiceProfile", menuName = "Mixed Reality Toolkit/Extensions/Hand Physics Service/Hand Physics Service Configuration Profile")]
+    public class HandPhysicsServiceProfile : BaseMixedRealityProfile
+    {
         /// <summary>
         /// Whether make the Palm a physics joint
         /// </summary>
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
         [SerializeField]
         [Tooltip("Whether make the Palm a physics joint")]
         private bool usePalmKinematicBody = false;
-       
+
         [SerializeField]
         [Tooltip("The prefab to represent the palm physics joint")]
         private GameObject palmKinematicBodyPrefab = null;

--- a/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
+++ b/Assets/MRTK/Extensions/LostTrackingService/LostTrackingService.cs
@@ -47,9 +47,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
         /// <param name="profile">The service's configuration profile.</param>
         [Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
         public LostTrackingService(
-            IMixedRealityServiceRegistrar registrar, 
-            string name, 
-            uint priority, 
+            IMixedRealityServiceRegistrar registrar,
+            string name,
+            uint priority,
             BaseMixedRealityProfile profile) : this(name, priority, profile)
         {
             Registrar = registrar;
@@ -62,8 +62,8 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.Tracking
         /// <param name="priority">Service priority. Used to determine order of instantiation.</param>
         /// <param name="profile">The service's configuration profile.</param>
         public LostTrackingService(
-            string name, 
-            uint priority, 
+            string name,
+            uint priority,
             BaseMixedRealityProfile profile) : base(name, priority, profile)
         {
             this.profile = profile as LostTrackingServiceProfile;

--- a/Assets/MRTK/Extensions/SceneTransitionService/Interfaces/ISceneTransitionService.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/Interfaces/ISceneTransitionService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         /// The default time in seconds for fade in to complete.
         /// </summary>
         float FadeInTime { get; set; }
-        
+
         /// <summary>
         /// The default time in seconds for fade out to complete.
         /// </summary>
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         /// If FadeTargets is set to custom, you will need to provide a custom set of cameras for fading using this function PRIOR to calling DoSceneTransition.
         /// </summary>
         void SetCustomFadeTargetCameras(IEnumerable<Camera> customFadeTargetCameras);
-        
+
         /// <summary>
         /// Fades target cameras out to color. Can be used independently of scene transitions provided no transition is taking place. Uses default FadeOutTime.
         /// </summary>

--- a/Assets/MRTK/Extensions/SceneTransitionService/LoadContentScene.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/LoadContentScene.cs
@@ -47,5 +47,5 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
                 transitions.DoSceneTransition(() => CoreServices.SceneSystem.LoadContent(contentScene.Name, loadSceneMode));
             }
         }
-	}
+    }
 }

--- a/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionService.cs
+++ b/Assets/MRTK/Extensions/SceneTransitionService/SceneTransitionService.cs
@@ -30,9 +30,9 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.SceneTransitions
         /// <param name="profile">The service's configuration profile.</param>
         [Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
         public SceneTransitionService(
-            IMixedRealityServiceRegistrar registrar, 
-            string name, 
-            uint priority, 
+            IMixedRealityServiceRegistrar registrar,
+            string name,
+            uint priority,
             BaseMixedRealityProfile profile) : this(name, priority, profile)
         {
             Registrar = registrar;

--- a/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         private static bool isLeapInProject = false;
 
         // The current supported Leap Core Assets version numbers.
-        private static string[] leapCoreAssetsVersionsSupported = new string[] { "4.4.0", "4.5.0"};
+        private static string[] leapCoreAssetsVersionsSupported = new string[] { "4.4.0", "4.5.0" };
 
         // The current Leap Core Assets version in this project
         private static string currentLeapCoreAssetsVersion = "";
@@ -127,7 +127,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                     Debug.LogError("MRTK only supports the Leap Motion Core Assets Version 4.4.0 and 4.5.0, the Leap Motion Core Assets imported are not Version 4.4.0 or 4.5.0");
                 }
             }
-            
+
             if (!isLeapInProject && references.Contains("LeapMotion"))
             {
                 references.Remove("LeapMotion");
@@ -222,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                     Name = "LeapMotion",
                     AllowUnsafeCode = true,
                     References = new string[] { },
-                    IncludePlatforms = new string[] { "Editor", "WindowsStandalone32", "WindowsStandalone64"}
+                    IncludePlatforms = new string[] { "Editor", "WindowsStandalone32", "WindowsStandalone64" }
                 };
 
                 leapAsmDef.Save(leapCoreAsmDefPath);
@@ -234,7 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                 AssemblyDefinition leapDataProviderAsmDef = AssemblyDefinition.Load(leapDataProviderAsmDefFile[0].FullName);
 
                 List<string> references = leapDataProviderAsmDef.References.ToList();
-                
+
                 if (!references.Contains("LeapMotion"))
                 {
                     references.Add("LeapMotion");
@@ -388,7 +388,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
                     else
                     {
                         streamWriter.WriteLine(cscLine);
-                    } 
+                    }
                 }
             }
 

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManager.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
             BaseMixedRealityProfile profile = null) : base(inputSystem, name, priority, profile) { }
 
 
-#region IMixedRealityCapabilityCheck Implementation
+        #region IMixedRealityCapabilityCheck Implementation
 
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         }
 
 
-#endregion IMixedRealityCapabilityCheck Implementation
+        #endregion IMixedRealityCapabilityCheck Implementation
 #if LEAPMOTIONCORE_PRESENT
 
         /// <summary>

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         [SerializeField]
         [Tooltip("Adds an offset to the game object with LeapServiceProvider attached.  This offset is only applied if the leapControllerOrientation" +
         "is LeapControllerOrientation.Desk and is necessary for the hand to appear in front of the main camera. If the leap controller is on the " +
-        "desk, the LeapServiceProvider is added to the scene instead of the LeapXRServiceProvider. The anchor point for the hands is the position of the" + 
+        "desk, the LeapServiceProvider is added to the scene instead of the LeapXRServiceProvider. The anchor point for the hands is the position of the" +
         "game object with the LeapServiceProvider attached.")]
         private Vector3 leapControllerOffset = new Vector3(0, -0.2f, 0.2f);
 
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         /// the index tip must be greater than than the ExitPinchDistance to raise the OnInputUp event
         /// </summary>
         public float ExitPinchDistance
-        {        
+        {
             get => exitPinchDistance;
             set => exitPinchDistance = value;
         }

--- a/Assets/MRTK/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
+++ b/Assets/MRTK/Providers/ObjectMeshObserver/SpatialObjectMeshObserver.cs
@@ -90,7 +90,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         /// <inheritdoc />
         public override void Update()
         {
-            if (!IsRunning) 
+            if (!IsRunning)
             {
                 return;
             }
@@ -164,7 +164,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialObjectMeshObserver
         #endregion IMixedRealitySpatialAwarenessObserver Implementation
 
         #region Helpers
-        
+
         private int currentMeshId = 0;
 
         private static readonly ProfilerMarker SendMeshObjectsPerfMarker = new ProfilerMarker("[MRTK] SpatialObjectMeshObserver.SendMeshObjects");

--- a/Assets/MRTK/Providers/OpenVR/Headers/openvr_api.cs
+++ b/Assets/MRTK/Providers/OpenVR/Headers/openvr_api.cs
@@ -1894,18 +1894,18 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public bool PollNextEvent(ref VREvent_t pEvent, uint uncbVREvent)
         {
 #if !UNITY_METRO
-		if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
-				(System.Environment.OSVersion.Platform == System.PlatformID.Unix))
-		{
-			PollNextEventUnion u;
-			VREvent_t_Packed event_packed = new VREvent_t_Packed();
-			u.pPollNextEventPacked = null;
-			u.pPollNextEvent = FnTable.PollNextEvent;
-			bool packed_result = u.pPollNextEventPacked(ref event_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t_Packed)));
+            if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
+                    (System.Environment.OSVersion.Platform == System.PlatformID.Unix))
+            {
+                PollNextEventUnion u;
+                VREvent_t_Packed event_packed = new VREvent_t_Packed();
+                u.pPollNextEventPacked = null;
+                u.pPollNextEvent = FnTable.PollNextEvent;
+                bool packed_result = u.pPollNextEventPacked(ref event_packed, (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t_Packed)));
 
-			event_packed.Unpack(ref pEvent);
-			return packed_result;
-		}
+                event_packed.Unpack(ref pEvent);
+                return packed_result;
+            }
 #endif
             bool result = FnTable.PollNextEvent(ref pEvent, uncbVREvent);
             return result;
@@ -1940,18 +1940,18 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public bool GetControllerState(uint unControllerDeviceIndex, ref VRControllerState_t pControllerState, uint unControllerStateSize)
         {
 #if !UNITY_METRO
-		if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
-				(System.Environment.OSVersion.Platform == System.PlatformID.Unix))
-		{
-			GetControllerStateUnion u;
-			VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
-			u.pGetControllerStatePacked = null;
-			u.pGetControllerState = FnTable.GetControllerState;
-			bool packed_result = u.pGetControllerStatePacked(unControllerDeviceIndex,ref state_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VRControllerState_t_Packed)));
+            if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
+                    (System.Environment.OSVersion.Platform == System.PlatformID.Unix))
+            {
+                GetControllerStateUnion u;
+                VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
+                u.pGetControllerStatePacked = null;
+                u.pGetControllerState = FnTable.GetControllerState;
+                bool packed_result = u.pGetControllerStatePacked(unControllerDeviceIndex, ref state_packed, (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VRControllerState_t_Packed)));
 
-			state_packed.Unpack(ref pControllerState);
-			return packed_result;
-		}
+                state_packed.Unpack(ref pControllerState);
+                return packed_result;
+            }
 #endif
             bool result = FnTable.GetControllerState(unControllerDeviceIndex, ref pControllerState, unControllerStateSize);
             return result;
@@ -1971,18 +1971,18 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public bool GetControllerStateWithPose(ETrackingUniverseOrigin eOrigin, uint unControllerDeviceIndex, ref VRControllerState_t pControllerState, uint unControllerStateSize, ref TrackedDevicePose_t pTrackedDevicePose)
         {
 #if !UNITY_METRO
-		if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
-				(System.Environment.OSVersion.Platform == System.PlatformID.Unix))
-		{
-			GetControllerStateWithPoseUnion u;
-			VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
-			u.pGetControllerStateWithPosePacked = null;
-			u.pGetControllerStateWithPose = FnTable.GetControllerStateWithPose;
-			bool packed_result = u.pGetControllerStateWithPosePacked(eOrigin,unControllerDeviceIndex,ref state_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VRControllerState_t_Packed)),ref pTrackedDevicePose);
+            if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
+                    (System.Environment.OSVersion.Platform == System.PlatformID.Unix))
+            {
+                GetControllerStateWithPoseUnion u;
+                VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
+                u.pGetControllerStateWithPosePacked = null;
+                u.pGetControllerStateWithPose = FnTable.GetControllerStateWithPose;
+                bool packed_result = u.pGetControllerStateWithPosePacked(eOrigin, unControllerDeviceIndex, ref state_packed, (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VRControllerState_t_Packed)), ref pTrackedDevicePose);
 
-			state_packed.Unpack(ref pControllerState);
-			return packed_result;
-		}
+                state_packed.Unpack(ref pControllerState);
+                return packed_result;
+            }
 #endif
             bool result = FnTable.GetControllerStateWithPose(eOrigin, unControllerDeviceIndex, ref pControllerState, unControllerStateSize, ref pTrackedDevicePose);
             return result;
@@ -2945,18 +2945,18 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public bool PollNextOverlayEvent(ulong ulOverlayHandle, ref VREvent_t pEvent, uint uncbVREvent)
         {
 #if !UNITY_METRO
-		if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
-				(System.Environment.OSVersion.Platform == System.PlatformID.Unix))
-		{
-			PollNextOverlayEventUnion u;
-			VREvent_t_Packed event_packed = new VREvent_t_Packed();
-			u.pPollNextOverlayEventPacked = null;
-			u.pPollNextOverlayEvent = FnTable.PollNextOverlayEvent;
-			bool packed_result = u.pPollNextOverlayEventPacked(ulOverlayHandle,ref event_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t_Packed)));
+            if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
+                    (System.Environment.OSVersion.Platform == System.PlatformID.Unix))
+            {
+                PollNextOverlayEventUnion u;
+                VREvent_t_Packed event_packed = new VREvent_t_Packed();
+                u.pPollNextOverlayEventPacked = null;
+                u.pPollNextOverlayEvent = FnTable.PollNextOverlayEvent;
+                bool packed_result = u.pPollNextOverlayEventPacked(ulOverlayHandle, ref event_packed, (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t_Packed)));
 
-			event_packed.Unpack(ref pEvent);
-			return packed_result;
-		}
+                event_packed.Unpack(ref pEvent);
+                return packed_result;
+            }
 #endif
             bool result = FnTable.PollNextOverlayEvent(ulOverlayHandle, ref pEvent, uncbVREvent);
             return result;
@@ -3238,18 +3238,18 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Headers
         public bool GetComponentState(string pchRenderModelName, string pchComponentName, ref VRControllerState_t pControllerState, ref RenderModel_ControllerMode_State_t pState, ref RenderModel_ComponentState_t pComponentState)
         {
 #if !UNITY_METRO
-		if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
-				(System.Environment.OSVersion.Platform == System.PlatformID.Unix))
-		{
-			GetComponentStateUnion u;
-			VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
-			u.pGetComponentStatePacked = null;
-			u.pGetComponentState = FnTable.GetComponentState;
-			bool packed_result = u.pGetComponentStatePacked(pchRenderModelName,pchComponentName,ref state_packed,ref pState,ref pComponentState);
+            if ((System.Environment.OSVersion.Platform == System.PlatformID.MacOSX) ||
+                    (System.Environment.OSVersion.Platform == System.PlatformID.Unix))
+            {
+                GetComponentStateUnion u;
+                VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
+                u.pGetComponentStatePacked = null;
+                u.pGetComponentState = FnTable.GetComponentState;
+                bool packed_result = u.pGetComponentStatePacked(pchRenderModelName, pchComponentName, ref state_packed, ref pState, ref pComponentState);
 
-			state_packed.Unpack(ref pControllerState);
-			return packed_result;
-		}
+                state_packed.Unpack(ref pControllerState);
+                return packed_result;
+            }
 #endif
             bool result = FnTable.GetComponentState(pchRenderModelName, pchComponentName, ref pControllerState, ref pState, ref pComponentState);
             return result;

--- a/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
@@ -32,9 +32,9 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
         public OpenVRDeviceManager(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            string name = null, 
-            uint priority = DefaultPriority, 
-            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile) 
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/Providers/UnityAR/Editor/ConfigurationChecker/UnityARConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/UnityAR/Editor/ConfigurationChecker/UnityARConfigurationChecker.cs
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UnityAR
                 {
                     // Add a reference to the ARFoundation assembly
                     references.Add(arFoundationReference);
-                    changed = true; 
+                    changed = true;
                 }
 #endif
 #if UNITY_2019_1_OR_NEWER

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Definitions/HolographicFrameNativeData.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Definitions/HolographicFrameNativeData.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
         /// The current native root <see href="https://docs.microsoft.com/uwp/api/windows.perception.spatial.spatialcoordinatesystem">ISpatialCoordinateSystem</see>.
         /// </summary>
         public IntPtr ISpatialCoordinateSystemPtr;
-        
+
         /// <summary>
         /// The current native <see href="https://docs.microsoft.com/uwp/api/Windows.Graphics.Holographic.HolographicFrame">IHolographicFrame</see>.
         /// </summary>

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityUtilitiesProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityUtilitiesProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
     public class WindowsMixedRealityUtilitiesProvider : IWindowsMixedRealityUtilitiesProvider
     {
         /// <inheritdoc />
-        IntPtr IWindowsMixedRealityUtilitiesProvider.ISpatialCoordinateSystemPtr => 
+        IntPtr IWindowsMixedRealityUtilitiesProvider.ISpatialCoordinateSystemPtr =>
 #if UNITY_WSA
             WorldManager.GetNativeISpatialCoordinateSystemPtr();
 #else

--- a/Assets/MRTK/Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MRTK/Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             IMixedRealityInputSystem inputSystem,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile) 
+            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -33,9 +33,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         public WindowsSpeechInputProvider(
             IMixedRealityServiceRegistrar registrar,
             IMixedRealityInputSystem inputSystem,
-            string name = null, 
-            uint priority = DefaultPriority, 
-            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile) 
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -339,9 +339,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         private Vector3 currentBoundsExtents;
 
         private readonly List<IMixedRealityInputSource> touchingSources = new List<IMixedRealityInputSource>();
-      
+
         private List<IMixedRealityController> sourcesDetected;
-      
+
         // Current axis of rotation about the center of the rig root
         private Vector3 currentRotationAxis;
 
@@ -548,8 +548,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 Active = false;
             }
 
-            
-            
+
+
         }
 
         private void OnDisable()
@@ -796,7 +796,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
             RegisterTransformScaleHandler(GetComponent<MinMaxScaleConstraint>());
         }
-       
+
 
         private Vector3 CalculateBoundsExtents()
         {
@@ -1166,7 +1166,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
 
             links.Reset(active, flattenAxis);
-            
+
             boxDisplay.Reset(active);
             boxDisplay.UpdateFlattenAxis(flattenAxis);
 

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/Configuration/HandlesBaseConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
     /// Configuration base class for any <see cref="BoundsControl"/> handle type deriving from <see cref="HandlesBase"/>
     /// </summary>
     public abstract class HandlesBaseConfiguration : ScriptableObject
-    { 
+    {
         [SerializeField]
         [Tooltip("Material applied to handles when they are not in a grabbed state")]
         private Material handleMaterial;
@@ -130,7 +130,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     drawTetherWhenManipulating = value;
                     handlesChanged.Invoke(HandlesChangedEventType.ManipulationTether);
                 }
-            }   
+            }
         }
 
         [SerializeField]

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/HandlesBase.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         }
 
         internal abstract bool IsVisible(Transform handle);
-        
+
 
         internal protected List<Transform> handles = new List<Transform>();
         private Transform highlightedHandle = null;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ProximityEffect/ProximityEffect.cs
@@ -39,14 +39,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         private class ObjectProximityInfo
         {
             public Transform ScaledObject;
-            public Renderer ObjectVisualRenderer; 
+            public Renderer ObjectVisualRenderer;
             public ProximityState ProximityState = ProximityState.FullsizeNoProximity;
         }
 
         /// <summary>
         /// Dictionary that maps proximity object provider to list of objects that have proximity scaling applied
         /// </summary>
-        
+
         private Dictionary<IProximityEffectObjectProvider, List<ObjectProximityInfo>> registeredObjects = new Dictionary<IProximityEffectObjectProvider, List<ObjectProximityInfo>>();
 
 
@@ -117,7 +117,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     if (item.ProximityState != ProximityState.FullsizeNoProximity)
                     {
                         item.ProximityState = ProximityState.FullsizeNoProximity;
-                       
+
                         if (item.ObjectVisualRenderer)
                         {
                             item.ObjectVisualRenderer.material = keyValuePair.Key.GetBaseMaterial();
@@ -171,9 +171,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     proximityPoints.Add(pointer.Position);
                 }
-                
+
                 if (pointer.Result?.CurrentPointerTarget != null)
-                { 
+                {
                     Vector3? point = pointer.Result?.Details.Point;
                     if (point.HasValue && IsPointWithinBounds(boundsCenter, pointer.Result.Details.Point, squareMaxLength))
                     {

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/RotationHandles.cs
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     // attach new collider
                     var handleBounds = VisualUtils.GetMaxBounds(GetVisual(handle).gameObject);
-                    var invScale = handleBounds.size.x == 0.0f ? 0.0f :config.HandleSize / handleBounds.size.x;
+                    var invScale = handleBounds.size.x == 0.0f ? 0.0f : config.HandleSize / handleBounds.size.x;
                     Vector3 colliderSizeScaled = handleBounds.size * invScale;
                     Vector3 colliderCenterScaled = handleBounds.center * invScale;
                     if (config.RotationHandlePrefabColliderType == HandlePrefabCollider.Box)
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                         sphere.radius += VisualUtils.GetMaxComponent(config.ColliderPadding);
                     }
                 }
-               
+
             }
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
 
         internal void InitEdgeAxis()
-        { 
+        {
             edgeAxes = new CardinalAxisType[NumEdges];
             edgeAxes[0] = CardinalAxisType.X;
             edgeAxes[1] = CardinalAxisType.Y;
@@ -177,7 +177,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             InitEdgeAxis();
             CreateHandles(parent);
         }
-        
+
         private void CreateHandles(Transform parent)
         {
             for (int i = 0; i < edgeCenters.Length; ++i)
@@ -295,7 +295,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         internal override bool IsVisible(Transform handle)
         {
             CardinalAxisType axisType = GetAxisType(handle);
-            return IsActive && 
+            return IsActive &&
                 ((axisType == CardinalAxisType.X && config.ShowRotationHandleForX) ||
                 (axisType == CardinalAxisType.Y && config.ShowRotationHandleForY) ||
                 (axisType == CardinalAxisType.Z && config.ShowRotationHandleForZ));

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/ScaleHandles.cs
@@ -72,9 +72,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
 
                 Bounds visualBounds = CreateVisual(visualsScale, isFlattened);
                 var invScale = visualBounds.size.x == 0.0f ? 0.0f : config.HandleSize / visualBounds.size.x;
-                VisualUtils.AddComponentsToAffordance(corner, new Bounds(visualBounds.center * invScale, visualBounds.size * invScale), 
+                VisualUtils.AddComponentsToAffordance(corner, new Bounds(visualBounds.center * invScale, visualBounds.size * invScale),
                     HandlePrefabCollider.Box, CursorContextInfo.CursorAction.Scale, config.ColliderPadding, parent, config.DrawTetherWhenManipulating);
-                handles.Add(corner.transform);       
+                handles.Add(corner.transform);
             }
 
             VisualUtils.HandleIgnoreCollider(config.HandlesIgnoreCollider, handles);

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/Visuals/VisualUtils.cs
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         /// <summary>
         /// Add all common components to a corner or rotate affordance.
         /// </summary>
-        internal static void AddComponentsToAffordance(GameObject afford, Bounds bounds, HandlePrefabCollider colliderType, 
+        internal static void AddComponentsToAffordance(GameObject afford, Bounds bounds, HandlePrefabCollider colliderType,
             CursorContextInfo.CursorAction cursorType, Vector3 colliderPadding, Transform parent, bool drawTetherWhenManipulating)
         {
             if (colliderType == HandlePrefabCollider.Box)

--- a/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/Utilities/Migration/BoundsControlMigrationHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 
             {
                 Undo.RecordObject(gameObject, "BoundsControl migration: swapping BoundingBox with BoundsControl.");
-                
+
                 // migrate logic settings
                 boundsControl.Target = boundingBox.Target;
                 boundsControl.BoundsOverride = boundingBox.BoundsOverride;
@@ -76,7 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
 
             // look in the scene for app bars and upgrade them too to point to the new component
             MigrateAppBar(boundingBox, boundsControl);
-      
+
             {
                 Undo.RecordObject(gameObject, "Removing obsolete BoundingBox component");
                 // destroy obsolete component
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             var scene = boundingBox.gameObject.scene;
             if (scene != null)
             {
-                string scenePath = scene.path;             
+                string scenePath = scene.path;
                 string sceneDir = System.IO.Path.GetDirectoryName(scenePath);
                 // if empty we're creating the folder in the asset root.
                 // This should only happen if we're trying to migrate a dynamically created
@@ -284,7 +284,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             config.CloseScale = box.CloseScale;
             config.FarGrowRate = box.FarGrowRate;
             config.MediumGrowRate = box.MediumGrowRate;
-            config.CloseGrowRate = box.CloseGrowRate;            
+            config.CloseGrowRate = box.CloseGrowRate;
             AssetDatabase.CreateAsset(config, GenerateUniqueConfigName(configAssetDirectory, box.gameObject, "ProximityEffectConfiguration"));
 
             control.HandleProximityEffectConfig = config;
@@ -295,7 +295,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
         {
             // note: this might be expensive for larger scenes but we don't know where the appbar is 
             // placed in the hierarchy so we have to search the scene for it
-            AppBar[] appBars = Object.FindObjectsOfType<AppBar>(); 
+            AppBar[] appBars = Object.FindObjectsOfType<AppBar>();
             for (int i = 0; i < appBars.Length; ++i)
             {
                 AppBar appBar = appBars[i];

--- a/Assets/MRTK/SDK/Experimental/FollowSolver/Follow.cs
+++ b/Assets/MRTK/SDK/Experimental/FollowSolver/Follow.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
     /// </summary> 
     [AddComponentMenu("Scripts/MRTK/Experimental/Solver/Follow")]
     public class Follow : Solver
-    {        
+    {
         [SerializeField]
         [Tooltip("The desired orientation of this object")]
         private SolverOrientationType orientationType = SolverOrientationType.FaceTrackedObject;
@@ -664,7 +664,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Utilities
             {
                 defaultOrientationType = SolverOrientationType.FaceTrackedObject;
             }
-            
+
             switch (defaultOrientationType)
             {
                 case SolverOrientationType.YawOnly:

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -269,7 +269,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
 
                     if (!CheckForStandardShader(nodeTransform.GetComponentsInChildren<Renderer>()))
                     {
-                        Debug.LogWarning(nodeTransform.name + " has a renderer that is not using " +  StandardShaderUtility.MrtkStandardShaderName + ". This will result in unexpected results with ScrollingObjectCollection");
+                        Debug.LogWarning(nodeTransform.name + " has a renderer that is not using " + StandardShaderUtility.MrtkStandardShaderName + ". This will result in unexpected results with ScrollingObjectCollection");
                     }
                 }
             }
@@ -289,7 +289,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
                 DisplayTouchPlane(scrollContainer);
 
                 // Display the item number on the list items
-                for (int i = 0; i <= nodeList.arraySize-1; i++)
+                for (int i = 0; i <= nodeList.arraySize - 1; i++)
                 {
                     var node = nodeList.GetArrayElementAtIndex(i);
                     Transform nodeTransform = node.FindPropertyRelative("Transform").objectReferenceValue as Transform;
@@ -351,7 +351,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private bool CheckForStandardShader(Renderer[] rends)
         {
             foreach (Renderer rend in rends)
-            {                
+            {
                 if (!StandardShaderUtility.IsUsingMrtkStandardShader(rend.sharedMaterial) && rend.sharedMaterial.shader != MRTKtmp)
                 {
                     return false;

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs
@@ -167,7 +167,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             HideKeyboard();
         }
 
-#endregion MonoBehaviour Implementation
+        #endregion MonoBehaviour Implementation
 
         public abstract string Text { get; protected set; }
 

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/NonNativeKeyboardTouchAssistant.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// </summary>
     public class NonNativeKeyboardTouchAssistant : MonoBehaviour
     {
-        [SerializeField] 
+        [SerializeField]
         private AudioClip clickSound = null;
 
         private AudioSource clickSoundPlayer;
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         {
             var capabilityChecker = CoreServices.InputSystem as IMixedRealityCapabilityCheck;
 
-            if(capabilityChecker != null && capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand))
+            if (capabilityChecker != null && capabilityChecker.CheckCapability(MixedRealityCapability.ArticulatedHand))
             {
                 EnableTouch();
             }

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/UICollection.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/UICollection.cs
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         private void CollectItems()
-        { 
+        {
             Items.Clear();
 
             foreach (Transform childTransform in transform)

--- a/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/HandPulseLogic.cs
+++ b/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/HandPulseLogic.cs
@@ -5,120 +5,120 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Experimental.SurfacePulse
 {
     [AddComponentMenu("Scripts/MRTK/SDK/HandPulseLogic")]
-	public class HandPulseLogic : MonoBehaviour, IMixedRealityPointerHandler
-	{
-		public SurfacePulse Pulse;
+    public class HandPulseLogic : MonoBehaviour, IMixedRealityPointerHandler
+    {
+        public SurfacePulse Pulse;
 
-		public bool bPulseOnLookAtPalms;
-		public bool bPulseOnPinch;
+        public bool bPulseOnLookAtPalms;
+        public bool bPulseOnPinch;
 
-		public float PalmFacingTime = 0.25f;
-		float PalmFacingTimer = 0;
+        public float PalmFacingTime = 0.25f;
+        float PalmFacingTimer = 0;
 
-		public Vector3 PulseOriginPalms = new Vector3(0.5f, 0.5f, 0);
-		public Vector3 PulseOriginFingertips = new Vector3(0, 1f, 0);
+        public Vector3 PulseOriginPalms = new Vector3(0.5f, 0.5f, 0);
+        public Vector3 PulseOriginFingertips = new Vector3(0, 1f, 0);
 
-		private void Start()
-		{
-			MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>().RegisterHandler<IMixedRealityPointerHandler>(this);
-		}
+        private void Start()
+        {
+            MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>().RegisterHandler<IMixedRealityPointerHandler>(this);
+        }
 
-		private void OnDestroy()
-		{
-			MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>().UnregisterHandler<IMixedRealityPointerHandler>(this);
-		}
+        private void OnDestroy()
+        {
+            MixedRealityToolkit.Instance.GetService<IMixedRealityInputSystem>().UnregisterHandler<IMixedRealityPointerHandler>(this);
+        }
 
-		// Update is called once per frame
-		void Update()
-		{
-			if (bPulseOnLookAtPalms)
-			{
-				if (IsAPalmFacingCamera())
-				{
-					if (PalmFacingTimer >= 0)
-					{
-						PalmFacingTimer += Time.deltaTime;
-						if (PalmFacingTimer > PalmFacingTime)
-						{
-							PulsePalms();
-							PalmFacingTimer = -1;
-						}
-					}
-				}
-				else
-				{
-					PalmFacingTimer = 0;
-				}
+        // Update is called once per frame
+        void Update()
+        {
+            if (bPulseOnLookAtPalms)
+            {
+                if (IsAPalmFacingCamera())
+                {
+                    if (PalmFacingTimer >= 0)
+                    {
+                        PalmFacingTimer += Time.deltaTime;
+                        if (PalmFacingTimer > PalmFacingTime)
+                        {
+                            PulsePalms();
+                            PalmFacingTimer = -1;
+                        }
+                    }
+                }
+                else
+                {
+                    PalmFacingTimer = 0;
+                }
 
-			}
+            }
 
-		}
+        }
 
-		void PulsePalms()
-		{
-			Pulse.SetLocalOrigin(PulseOriginPalms);
-			Pulse.PulseOnce();
-		}
+        void PulsePalms()
+        {
+            Pulse.SetLocalOrigin(PulseOriginPalms);
+            Pulse.PulseOnce();
+        }
 
-		void PulseFingerTips()
-		{
-			Pulse.SetLocalOrigin(PulseOriginFingertips);
-			Pulse.PulseOnce();
-		}
+        void PulseFingerTips()
+        {
+            Pulse.SetLocalOrigin(PulseOriginFingertips);
+            Pulse.PulseOnce();
+        }
 
-		private static bool IsAPalmFacingCamera()
-		{
-			foreach (IMixedRealityController c in CoreServices.InputSystem.DetectedControllers)
-			{
-				if (c.ControllerHandedness.IsMatch(Handedness.Both))
-				{
-					MixedRealityPose palmPose;
-					var jointedHand = c as IMixedRealityHand;
+        private static bool IsAPalmFacingCamera()
+        {
+            foreach (IMixedRealityController c in CoreServices.InputSystem.DetectedControllers)
+            {
+                if (c.ControllerHandedness.IsMatch(Handedness.Both))
+                {
+                    MixedRealityPose palmPose;
+                    var jointedHand = c as IMixedRealityHand;
 
-					if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
-					{
-						if (Vector3.Dot(palmPose.Up, CameraCache.Main.transform.forward) > 0.0f)
-						{
-							return true;
-						}
-					}
-				}
-			}
+                    if ((jointedHand != null) && jointedHand.TryGetJoint(TrackedHandJoint.Palm, out palmPose))
+                    {
+                        if (Vector3.Dot(palmPose.Up, CameraCache.Main.transform.forward) > 0.0f)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
 
-			return false;
-		}
+            return false;
+        }
 
-		// IMixedRealityPointerHandler
-		/// <summary>
-		/// When a pointer down event is raised, this method is used to pass along the event data to the input handler.
-		/// </summary>
-		void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
-		{
-			if (bPulseOnPinch)
-			{
-				PulseFingerTips();
-			}
-		}
+        // IMixedRealityPointerHandler
+        /// <summary>
+        /// When a pointer down event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
+        {
+            if (bPulseOnPinch)
+            {
+                PulseFingerTips();
+            }
+        }
 
-		/// <summary>
-		/// Called every frame a pointer is down. Can be used to implement drag-like behaviors.
-		/// </summary>
-		void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData)
-		{
-		}
+        /// <summary>
+        /// Called every frame a pointer is down. Can be used to implement drag-like behaviors.
+        /// </summary>
+        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData)
+        {
+        }
 
-		/// <summary>
-		/// When a pointer up event is raised, this method is used to pass along the event data to the input handler.
-		/// </summary>
-		void IMixedRealityPointerHandler.OnPointerUp(MixedRealityPointerEventData eventData)
-		{
-		}
+        /// <summary>
+        /// When a pointer up event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        void IMixedRealityPointerHandler.OnPointerUp(MixedRealityPointerEventData eventData)
+        {
+        }
 
-		/// <summary>
-		/// When a pointer clicked event is raised, this method is used to pass along the event data to the input handler.
-		/// </summary>
-		void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
-		{
-		}
-	}
+        /// <summary>
+        /// When a pointer clicked event is raised, this method is used to pass along the event data to the input handler.
+        /// </summary>
+        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
+        {
+        }
+    }
 }

--- a/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/SurfacePulse.cs
+++ b/Assets/MRTK/SDK/Experimental/PulseShader/Scripts/SurfacePulse.cs
@@ -6,175 +6,175 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Experimental.SurfacePulse
 {
-	[AddComponentMenu("Scripts/MRTK/SDK/SurfacePulse")]
-	public class SurfacePulse : MonoBehaviour
-	{
-		[Tooltip("Shader parameter name to drive the pulse radius")]
-		public string ParamName = "_Pulse_";
+    [AddComponentMenu("Scripts/MRTK/SDK/SurfacePulse")]
+    public class SurfacePulse : MonoBehaviour
+    {
+        [Tooltip("Shader parameter name to drive the pulse radius")]
+        public string ParamName = "_Pulse_";
 
-		[Tooltip("Shader parameter name to set the pulse origin, in local space")]
-		public string OriginParamName = "_Pulse_Origin_";
+        [Tooltip("Shader parameter name to set the pulse origin, in local space")]
+        public string OriginParamName = "_Pulse_Origin_";
 
-		[Tooltip("How long in seconds the pulse should animate")]
-		public float PulseDuration = 5f;
+        [Tooltip("How long in seconds the pulse should animate")]
+        public float PulseDuration = 5f;
 
-		[Tooltip("How long to wait in seconds between pulses, when pulsing is active")]
-		public float PulseRepeatDelay = 5f;
+        [Tooltip("How long to wait in seconds between pulses, when pulsing is active")]
+        public float PulseRepeatDelay = 5f;
 
-		[Tooltip("Minimum time to wait between each pulse")]
-		public float PulseRepeatMinDelay = 1f;
+        [Tooltip("Minimum time to wait between each pulse")]
+        public float PulseRepeatMinDelay = 1f;
 
-		[Tooltip("Automatically begin repeated pulsing")]
-		public bool bAutoStart = false;
+        [Tooltip("Automatically begin repeated pulsing")]
+        public bool bAutoStart = false;
 
-		[Tooltip("Automatically set pulse origin to the main camera location")]
-		public bool bOriginFollowCamera = false;
+        [Tooltip("Automatically set pulse origin to the main camera location")]
+        public bool bOriginFollowCamera = false;
 
-		[Tooltip("The material to animate")]
-		public Material SurfaceMat;
+        [Tooltip("The material to animate")]
+        public Material SurfaceMat;
 
-		// Internal state
-		Coroutine RepeatPulseCoroutine;
+        // Internal state
+        Coroutine RepeatPulseCoroutine;
 
-		float pulseStartedTime;
-		bool repeatingPulse;
-		bool cancelPulse;
+        float pulseStartedTime;
+        bool repeatingPulse;
+        bool cancelPulse;
 
 
-		// Reset the material property when exiting play mode so it won't be changed on disk
+        // Reset the material property when exiting play mode so it won't be changed on disk
 #if UNITY_EDITOR
 
-		SurfacePulse()
-		{
-			EditorApplication.playModeStateChanged += HandleOnPlayModeChanged;
-		}
+        SurfacePulse()
+        {
+            EditorApplication.playModeStateChanged += HandleOnPlayModeChanged;
+        }
 
-		void HandleOnPlayModeChanged(PlayModeStateChange change)
-		{
-			// This method is run whenever the playmode state is changed.
-			if (!EditorApplication.isPlaying)
-			{
-				// do stuff when the editor is paused.
-				ResetPulseMaterial();
-			}
-		}
+        void HandleOnPlayModeChanged(PlayModeStateChange change)
+        {
+            // This method is run whenever the playmode state is changed.
+            if (!EditorApplication.isPlaying)
+            {
+                // do stuff when the editor is paused.
+                ResetPulseMaterial();
+            }
+        }
 
 #endif // UNITY_EDITOR
 
-		private void OnDestroy()
-		{
-			ResetPulseMaterial();
-		}
+        private void OnDestroy()
+        {
+            ResetPulseMaterial();
+        }
 
-		private void Start()
-		{
-			if (bAutoStart)
-			{
-				StartPulsing();
-			}
-		}
+        private void Start()
+        {
+            if (bAutoStart)
+            {
+                StartPulsing();
+            }
+        }
 
-		private void Update()
-		{
-			if (bOriginFollowCamera)
-			{
-				SetLocalOrigin(CameraCache.Main.transform.position);
-			}
-		}
+        private void Update()
+        {
+            if (bOriginFollowCamera)
+            {
+                SetLocalOrigin(CameraCache.Main.transform.position);
+            }
+        }
 
-		/////////////////////////////////////////////////////////////////////////////////////////
-		// Material control
-		/////////////////////////////////////////////////////////////////////////////////////////
-		public void SetLocalOrigin(Vector3 origin)
-		{
-			SurfaceMat.SetVector(OriginParamName, origin);
-		}
+        /////////////////////////////////////////////////////////////////////////////////////////
+        // Material control
+        /////////////////////////////////////////////////////////////////////////////////////////
+        public void SetLocalOrigin(Vector3 origin)
+        {
+            SurfaceMat.SetVector(OriginParamName, origin);
+        }
 
-		public void ResetPulseMaterial()
-		{
-			ApplyPulseRadiusToMaterial(0);
-		}
+        public void ResetPulseMaterial()
+        {
+            ApplyPulseRadiusToMaterial(0);
+        }
 
-		/////////////////////////////////////////////////////////////////////////////////////////
-		// Pulse control
-		/////////////////////////////////////////////////////////////////////////////////////////
-		public void PulseOnce()
-		{
-			cancelPulse = false;
-			StartCoroutine(CoSinglePulse());
-		}
+        /////////////////////////////////////////////////////////////////////////////////////////
+        // Pulse control
+        /////////////////////////////////////////////////////////////////////////////////////////
+        public void PulseOnce()
+        {
+            cancelPulse = false;
+            StartCoroutine(CoSinglePulse());
+        }
 
-		public void StartPulsing()
-		{
-			repeatingPulse = true;
-			cancelPulse = false;
-			if (RepeatPulseCoroutine == null)
-			{
-				RepeatPulseCoroutine = StartCoroutine(CoRepeatPulse());
-			}
-		}
+        public void StartPulsing()
+        {
+            repeatingPulse = true;
+            cancelPulse = false;
+            if (RepeatPulseCoroutine == null)
+            {
+                RepeatPulseCoroutine = StartCoroutine(CoRepeatPulse());
+            }
+        }
 
-		public void StopPulsing(bool bFinishCurrentPulse = true)
-		{
-			repeatingPulse = false;
-			if (!bFinishCurrentPulse)
-			{
-				cancelPulse = true;
-				ApplyPulseRadiusToMaterial(0);
-			}
-		}
+        public void StopPulsing(bool bFinishCurrentPulse = true)
+        {
+            repeatingPulse = false;
+            if (!bFinishCurrentPulse)
+            {
+                cancelPulse = true;
+                ApplyPulseRadiusToMaterial(0);
+            }
+        }
 
-		/////////////////////////////////////////////////////////////////////////////////////////
-		// Implementation
-		/////////////////////////////////////////////////////////////////////////////////////////
-		IEnumerator CoSinglePulse()
-		{
-			yield return CoWaitForRepeatDelay();
-			if (!cancelPulse)
-			{
-				yield return CoAnimatePulse();
-			}
-		}
+        /////////////////////////////////////////////////////////////////////////////////////////
+        // Implementation
+        /////////////////////////////////////////////////////////////////////////////////////////
+        IEnumerator CoSinglePulse()
+        {
+            yield return CoWaitForRepeatDelay();
+            if (!cancelPulse)
+            {
+                yield return CoAnimatePulse();
+            }
+        }
 
-		IEnumerator CoRepeatPulse()
-		{
-			while (repeatingPulse && !cancelPulse)
-			{
-				yield return CoSinglePulse();
-			}
+        IEnumerator CoRepeatPulse()
+        {
+            while (repeatingPulse && !cancelPulse)
+            {
+                yield return CoSinglePulse();
+            }
 
-			RepeatPulseCoroutine = null;
-		}
+            RepeatPulseCoroutine = null;
+        }
 
-		private IEnumerator CoAnimatePulse()
-		{
-			pulseStartedTime = Time.time;
-			float t = 0;
-			while (t < PulseDuration && !cancelPulse)
-			{
-				t += Time.deltaTime;
-				ApplyPulseRadiusToMaterial(t / PulseDuration);
-				yield return null;
-			}
-		}
+        private IEnumerator CoAnimatePulse()
+        {
+            pulseStartedTime = Time.time;
+            float t = 0;
+            while (t < PulseDuration && !cancelPulse)
+            {
+                t += Time.deltaTime;
+                ApplyPulseRadiusToMaterial(t / PulseDuration);
+                yield return null;
+            }
+        }
 
-		IEnumerator CoWaitForRepeatDelay()
-		{
-			// Wait for minimum time between pulses starting
-			if (pulseStartedTime > 0)
-			{
-				float timeSincePulseStarted = Time.time - pulseStartedTime;
-				float delayTime = PulseRepeatMinDelay - timeSincePulseStarted;
-				if (delayTime > 0)
-				{
-					yield return new WaitForSeconds(delayTime);
-				}
-			}
-		}
+        IEnumerator CoWaitForRepeatDelay()
+        {
+            // Wait for minimum time between pulses starting
+            if (pulseStartedTime > 0)
+            {
+                float timeSincePulseStarted = Time.time - pulseStartedTime;
+                float delayTime = PulseRepeatMinDelay - timeSincePulseStarted;
+                if (delayTime > 0)
+                {
+                    yield return new WaitForSeconds(delayTime);
+                }
+            }
+        }
 
-		void ApplyPulseRadiusToMaterial(float radius)
-		{
-			SurfaceMat.SetFloat(ParamName, radius);
-		}
-	}
+        void ApplyPulseRadiusToMaterial(float radius)
+        {
+            SurfaceMat.SetFloat(ParamName, radius);
+        }
+    }
 }

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -262,7 +262,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Tooltip("Whether items that are partially clipped are disabled for input hit testing")]
         [SerializeField]
         private bool disableClippedItems = true;
-        public bool DisableClippedItems {
+        public bool DisableClippedItems
+        {
             get => disableClippedItems;
             set => disableClippedItems = value;
         }
@@ -633,7 +634,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             for (int i = 0; i < scrollContainer.transform.childCount; i++)
             {
                 Transform child = scrollContainer.transform.GetChild(i);
-                
+
                 if (ContainsNode(child, out int nodeIndex) && NodeList[nodeIndex].GetType() != typeof(ScrollingObjectCollectionNode))
                 {
                     // This node is in the list, but of the wrong type
@@ -642,7 +643,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 if (!ContainsNode(child) && (child.gameObject.activeSelf || !IgnoreInactiveTransforms))
                 {
-                    NodeList.Add( new ScrollingObjectCollectionNode { Name = child.name, Transform = child, Colliders = child.GetComponentsInChildren<Collider>() });
+                    NodeList.Add(new ScrollingObjectCollectionNode { Name = child.name, Transform = child, Colliders = child.GetComponentsInChildren<Collider>() });
                 }
             }
 
@@ -951,7 +952,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         Interactable ixable = initialFocusedObject.GetComponent<Interactable>();
                         if (ixable != null)
                         {
-                           ixable.ResetInputTrackingStates();
+                            ixable.ResetInputTrackingStates();
                         }
 
                         // Reset initialHandPos to prevent the scroller from jumping
@@ -1411,9 +1412,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // Update simple velocity
             TryGetPointerPositionOnPlane(out Vector3 newPos);
 
-                scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
-                                 ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
-                                 : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
+            scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
+                             ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
+                             : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
 
             // And filter it...
             avgVelocity = (avgVelocity * (1.0f - velocityFilterWeight)) + (scrollVelocity * velocityFilterWeight);
@@ -2067,7 +2068,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
 
             if (!isTouched && isEngaged && animateScroller == null)
-            {   
+            {
                 if (isDragging)
                 {
                     eventData.Use();
@@ -2179,7 +2180,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
             // Quick check for the global listener to bail if the object is not in the list
-            if (currentPointer != null && currentPointer.Result?.CurrentPointerTarget != null 
+            if (currentPointer != null && currentPointer.Result?.CurrentPointerTarget != null
                 && ContainsNode(currentPointer.Result.CurrentPointerTarget.transform))
             {
                 if (isDragging)
@@ -2198,7 +2199,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             if (p != null)
             {
                 // Quick check for the global listener to bail if the object is not in the list
-                if (currentPointer == null || 
+                if (currentPointer == null ||
                     currentPointer.Result?.CurrentPointerTarget == null ||
                     !ContainsNode(p.Result.CurrentPointerTarget.transform) || initialFocusedObject != p.Result.CurrentPointerTarget)
                 {

--- a/Assets/MRTK/SDK/Experimental/ServiceManagers/Support/Scripts/BaseServiceManager.cs
+++ b/Assets/MRTK/SDK/Experimental/ServiceManagers/Support/Scripts/BaseServiceManager.cs
@@ -103,7 +103,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental
             Type interfaceType = typeof(T);
             List<T> matchingServices = new List<T>();
 
-            foreach(IMixedRealityService service in registeredServices.Values)
+            foreach (IMixedRealityService service in registeredServices.Values)
             {
                 if (!interfaceType.IsAssignableFrom(service.GetType())) { continue; }
 
@@ -264,9 +264,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental
             Type interfaceType = typeof(T);
             IMixedRealityService serviceInstance;
 
-            if (!registeredServices.TryGetValue(interfaceType, out serviceInstance)) { return default(T);  }
+            if (!registeredServices.TryGetValue(interfaceType, out serviceInstance)) { return default(T); }
 
             return (T)serviceInstance;
-         }
+        }
     }
 }

--- a/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
+++ b/Assets/MRTK/SDK/Features/Audio/Influencers/AudioInfluencerController.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             hits = new RaycastHit[maxObjects];
         }
 
-        private void Update() 
+        private void Update()
         {
             DateTime now = DateTime.UtcNow;
 
@@ -243,7 +243,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
                                                 distance,
                                                 UnityPhysics.DefaultRaycastLayers,
                                                 QueryTriggerInteraction.Ignore);
-            
+
             for (int i = 0; i < count; i++)
             {
                 IAudioInfluencer influencer = hits[i].collider.gameObject.GetComponentInParent<IAudioInfluencer>();

--- a/Assets/MRTK/SDK/Features/Audio/Influencers/AudioLoFiEffect.cs
+++ b/Assets/MRTK/SDK/Features/Audio/Influencers/AudioLoFiEffect.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
         public AudioLoFiSourceQuality SourceQuality
         {
             get { return sourceQuality; }
-            set { sourceQuality = value;  }
+            set { sourceQuality = value; }
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.Audio
             /// </summary>
             /// <returns>True if equivalent, false otherwise.</returns>
             public override bool Equals(object obj)
-            {               
+            {
                 if (obj == null)
                 {
                     return false;

--- a/Assets/MRTK/SDK/Features/Input/Events/ManipulationEventData.cs
+++ b/Assets/MRTK/SDK/Features/Input/Events/ManipulationEventData.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Whether the Manipulation is a NearInteration or not.
         /// </summary>
-        public bool IsNearInteraction {get; set; }
+        public bool IsNearInteraction { get; set; }
 
         /// <summary>
         /// Center of the <see cref="ObjectManipulator"/>'s Pointer in world space

--- a/Assets/MRTK/SDK/Features/Input/Handlers/BaseInputHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/BaseInputHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         protected virtual void Update()
         {
-            if(isFocusRequiredRuntime != isFocusRequired)
+            if (isFocusRequiredRuntime != isFocusRequired)
             {
                 isFocusRequiredRuntime = isFocusRequired;
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Constraints/RotationAxisConstraint.cs
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 eulers.z = 0;
             }
 
-            transform.Rotation = useLocalSpaceForConstraint 
+            transform.Rotation = useLocalSpaceForConstraint
                 ? worldPoseOnManipulationStart.Rotation * Quaternion.Euler(eulers)
                 : Quaternion.Euler(eulers) * worldPoseOnManipulationStart.Rotation;
         }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -203,13 +203,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region Obsolete
 
-        #pragma warning disable 0414
+#pragma warning disable 0414
         [SerializeField]
         [HideInInspector]
         [System.Obsolete("Use the Handedness property instead to get current handedness which is set by Controller attached")]
         [Tooltip("Use the Handedness property instead to get current handedness which is set by Controller attached")]
         private Handedness handedness = Handedness.Left;
-        #pragma warning restore 0414
+#pragma warning restore 0414
 
         #endregion
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -97,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return onSelected; }
             set { onSelected = value; }
         }
-        
+
         [SerializeField]
         [Tooltip("If true, the eye cursor (if enabled) will snap to the center of this object.")]
         private bool eyeCursorSnapToTargetCenter = false;
@@ -121,7 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Returns true if the user has been looking at the target for a certain amount of time specified by dwellTimeInSec.
         /// </summary>
         public bool IsDwelledOn { get; private set; } = false;
-        
+
         private DateTime lookAtStartTime;
 
         /// <summary>
@@ -137,9 +137,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The time stamp from the eye tracker has its own time frame, which makes it difficult to compare to local times. 
         /// </summary>
-        private static DateTime lastEyeSignalUpdateTimeLocal = DateTime.MinValue; 
+        private static DateTime lastEyeSignalUpdateTimeLocal = DateTime.MinValue;
 
-        public static GameObject LookedAtTarget { get;  private set; }
+        public static GameObject LookedAtTarget { get; private set; }
         public static EyeTrackingTarget LookedAtEyeTarget { get; private set; }
         public static Vector3 LookedAtPoint { get; private set; }
 
@@ -156,13 +156,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             var eyeGazeProvider = CoreServices.InputSystem?.EyeGazeProvider;
             // Try to manually poll the eye tracking data
-            if (eyeGazeProvider != null 
+            if (eyeGazeProvider != null
                 && eyeGazeProvider.IsEyeTrackingEnabledAndValid)
             {
                 UpdateHitTarget();
 
                 bool isLookedAtNow = (LookedAtTarget == this.gameObject);
-                                
+
                 if (IsLookedAt && (!isLookedAtNow))
                 {
                     // Stopped looking at the target
@@ -235,12 +235,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
             }
         }
-        
+
         protected void OnEyeFocusStart()
         {
             lookAtStartTime = DateTime.UtcNow;
             IsLookedAt = true;
-            OnLookAtStart.Invoke();            
+            OnLookAtStart.Invoke();
         }
 
         protected void OnEyeFocusStay()
@@ -263,7 +263,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             IsDwelledOn = false;
             IsLookedAt = false;
-            OnLookAway.Invoke();            
+            OnLookAway.Invoke();
         }
 
         #endregion 
@@ -282,7 +282,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 OnSelected.Invoke();
             }
         }
-        
+
         void IMixedRealitySpeechHandler.OnSpeechKeywordRecognized(SpeechEventData eventData)
         {
             if ((IsLookedAt) && (this.gameObject == LookedAtTarget))

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get => hostTransform;
             set => hostTransform = value;
         }
-        
+
         [SerializeField]
         [Tooltip("Can manipulation be done only with one hand, only with two hands, or with both?")]
         private HandMovementType manipulationType = HandMovementType.OneAndTwoHanded;
@@ -128,7 +128,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get => releaseBehavior;
             set => releaseBehavior = value;
         }
-        
+
         [SerializeField]
         [Tooltip("Constrain rotation along an axis")]
         private RotationConstraintType constraintOnRotation = RotationConstraintType.None;
@@ -171,7 +171,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get => constraintOnMovement;
             set => constraintOnMovement = value;
         }
-        
+
         [SerializeField]
         [Tooltip("Check to enable frame-rate independent smoothing. ")]
         private bool smoothingActive = true;
@@ -561,7 +561,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         #endregion Public Methods
-            
+
         #region Hand Event Handlers
 
         /// <inheritdoc />

--- a/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationMoveLogic.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/Manipulation/ManipulationMoveLogic.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Physics
             pointerRefDistance = GetDistanceToBody(pointerCentroidPose);
 
             pointerPosIndependentOfHead = pointerRefDistance != 0;
-            
+
             Quaternion worldToPointerRotation = Quaternion.Inverse(pointerCentroidPose.Rotation);
             pointerLocalGrabPoint = worldToPointerRotation * (grabCentroid - pointerCentroidPose.Position);
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/MinMaxScaleConstraint.cs
@@ -19,10 +19,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         [SerializeField]
         [Tooltip("Minimum scaling allowed")]
-        private  float scaleMinimum = 0.2f;
+        private float scaleMinimum = 0.2f;
 
         private Vector3 minimumScale;
-        
+
         /// <summary>
         /// Minimum scaling allowed
         /// </summary>
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private float scaleMaximum = 2f;
 
         private Vector3 maximumScale;
-        
+
         /// <summary>
         /// Maximum scaling allowed
         /// </summary>
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [Tooltip("Min/max scaling relative to initial scale if true")]
         private bool relativeToInitialState = true;
-        
+
         /// <summary>
         /// Min/max scaling relative to initial scale if true
         /// </summary>
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion Public Methods
 
         #region Private Methods
-        
+
         private void SetScaleLimits()
         {
             if (relativeToInitialState)

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             set => hostTransform = value;
         }
-        
+
         [SerializeField]
         [EnumFlags]
         [Tooltip("Can manipulation be done only with one hand, only with two hands, or with both?")]
@@ -152,7 +152,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get => releaseBehavior;
             set => releaseBehavior = value;
         }
-        
+
         [SerializeField]
         [Tooltip("Check to enable frame-rate independent smoothing.")]
         private bool smoothingActive = true;
@@ -266,7 +266,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion
 
         #region Private Properties
-        
+
         private ManipulationMoveLogic moveLogic;
         private TwoHandScaleLogic scaleLogic;
         private TwoHandRotateLogic rotateLogic;
@@ -432,7 +432,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <inheritdoc />
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
-            if (eventData.used || 
+            if (eventData.used ||
                 (!allowFarManipulation && eventData.Pointer as IMixedRealityNearPointer == null))
             {
                 return;
@@ -478,7 +478,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         public void OnPointerDragged(MixedRealityPointerEventData eventData)
-        {                    
+        {
             // Call manipulation updated handlers
             if (IsOneHandedManipulationEnabled)
             {
@@ -588,7 +588,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             MixedRealityPose pointerPose = new MixedRealityPose(pointer.Position, pointer.Rotation);
             MixedRealityPose hostPose = new MixedRealityPose(HostTransform.position, HostTransform.rotation);
-            moveLogic.Setup(pointerPose, pointerData.GrabPoint, hostPose, HostTransform.localScale);            
+            moveLogic.Setup(pointerPose, pointerData.GrabPoint, hostPose, HostTransform.localScale);
         }
 
         private void HandleOneHandMoveUpdated()
@@ -640,7 +640,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 wasKinematic = rigidBody.isKinematic;
                 rigidBody.isKinematic = false;
             }
-            
+
             constraints.Initialize(new MixedRealityPose(HostTransform.position, HostTransform.rotation));
         }
 
@@ -658,9 +658,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     PointerCentroid = pointerGrabPoint,
                     PointerVelocity = pointerVelocity,
                     PointerAngularVelocity = pointerAnglularVelocity
-                }); 
+                });
             }
-            
+
             ReleaseRigidBody(pointerVelocity, pointerAnglularVelocity);
         }
 

--- a/Assets/MRTK/SDK/Features/Input/Handlers/SpeechInputHandler.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/SpeechInputHandler.cs
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public void RemoveResponse(string keyword, UnityAction action)
         {
             string lowerKeyword = keyword.ToLower();
-            if(responses.ContainsKey(lowerKeyword))
+            if (responses.ContainsKey(lowerKeyword))
             {
                 responses[lowerKeyword].RemoveListener(action);
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableAudioReceiver.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private void PlayAudio(Interactable source)
         {
             AudioSource audioSource = source.GetComponent<AudioSource>();
-            if(audioSource == null)
+            if (audioSource == null)
             {
                 audioSource = source.gameObject.AddComponent<AudioSource>();
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnClickReceiver.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Creates receiver for raising OnClick events
         /// </summary>
-        public InteractableOnClickReceiver(UnityEvent ev): base(ev, "OnClick") { }
+        public InteractableOnClickReceiver(UnityEvent ev) : base(ev, "OnClick") { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnGrabReceiver.cs
@@ -33,7 +33,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Creates a receiver that raises grab start and end events.
         /// </summary>
-        public InteractableOnGrabReceiver() : this( new UnityEvent()) { }
+        public InteractableOnGrabReceiver() : this(new UnityEvent()) { }
 
         /// <inheritdoc />
         public override void OnUpdate(InteractableStates state, Interactable source)

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnHoldReceiver.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Creates receiver that raises OnHold events
         /// </summary>
-        public InteractableOnHoldReceiver(UnityEvent ev): base(ev, "OnHold") { }
+        public InteractableOnHoldReceiver(UnityEvent ev) : base(ev, "OnHold") { }
 
         /// <summary>
         /// Creates receiver that raises OnHold events
@@ -46,7 +46,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 hasDown = true;
                 clickTimer = 0;
             }
-            else if(state.GetState(InteractableStates.InteractableStateEnum.Pressed).Value < 1)
+            else if (state.GetState(InteractableStates.InteractableStateEnum.Pressed).Value < 1)
             {
                 hasDown = false;
             }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Events/InteractableOnPressReceiver.cs
@@ -44,8 +44,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Specify whether press event is for near or far interaction
         /// </summary>
-        [InspectorField(Label = "Interaction Filter", 
-            Tooltip = "Specify whether press event is for near or far interaction", 
+        [InspectorField(Label = "Interaction Filter",
+            Tooltip = "Specify whether press event is for near or far interaction",
             Type = InspectorField.FieldTypes.DropdownInt, Options = new string[] { "Near and Far", "Near Only", "Far Only" })]
         public int InteractionFilter = (int)InteractionType.NearAndFar;
 

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -806,7 +806,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
                 else
                 {
-                    Debug.LogWarning($"Empty event receiver found on {gameObject.name}, you may want to re-create this asset." );
+                    Debug.LogWarning($"Empty event receiver found on {gameObject.name}, you may want to re-create this asset.");
                 }
             }
         }
@@ -835,7 +835,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private void SetupThemes()
         {
-            allThemeDimensionPairs.Clear();   
+            allThemeDimensionPairs.Clear();
             // Profiles are one per GameObject/ThemeContainer
             // ThemeContainers are one per dimension
             // ThemeDefinitions are one per desired effect (i.e theme)
@@ -1447,7 +1447,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     focusingPointers.Add(eventData.Pointer);
                 }
             }
-            else if (eventData.OldFocusedObject != null 
+            else if (eventData.OldFocusedObject != null
                 && eventData.OldFocusedObject.transform.IsChildOf(gameObject.transform))
             {
                 focusingPointers.Remove(eventData.Pointer);

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/InteractableToggleCollection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public Interactable[] ToggleList
         {
             get => toggleList;
-            set 
+            set
             {
                 if (value != null && toggleList != value)
                 {
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public int CurrentIndex
         {
             get => currentIndex;
-            set => SetSelection(value, true, true);    
+            set => SetSelection(value, true, true);
         }
 
         [Tooltip("This event is triggered when any of the toggles in the ToggleList are selected")]
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     AddSelectionListeners();
 
                     SetSelection(CurrentIndex, true, true);
-                }  
+                }
             }
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSize.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Layout/ButtonBackgroundSize.cs
@@ -78,7 +78,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             BasePixelScale = scale;
         }
-        
+
         /// <summary>
         /// Set the size
         /// </summary>

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Simulation/InteractablePointerSimulator.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Simulation/InteractablePointerSimulator.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// A way to test button state feedback while in the editor
     /// </summary>
-    
+
     [AddComponentMenu("Scripts/MRTK/SDK/InteractablePointerSimulator")]
     public class InteractablePointerSimulator : MonoBehaviour
     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/AppBar/AppBar.cs
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             get => backgroundBar;
             set => backgroundBar = value;
         }
-        
+
         [Header("States")]
 
         [Tooltip("The AppBar's display type; default is Manipulation")]

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -2248,7 +2248,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         }
                     }
                 }
-                
+
                 // Get the max radius possible of our current bounds and extent the range to include proximity scaled objects. This is done by adjusting the original bounds to include the ObjectMediumProximity range in x, y and z axis
                 float maxRadius = currentBoundsExtents.sqrMagnitude + (3 * handleMediumProximity * handleMediumProximity);
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonConfigHelper.cs
@@ -159,7 +159,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField, Tooltip("Optional texture used for texture icon. This will be set by configuration actions.")]
         private Texture iconQuadTexture = null;
         // Disable 'assigned but never used' errors to avoid errors related to editor-only fields.
-        #pragma warning disable CS0414
+#pragma warning disable CS0414
         [SerializeField, Tooltip("The default material used by quad button icons. Used to detect legacy custom buttons.")]
         private Material defaultButtonQuadMaterial = null;
 
@@ -168,7 +168,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private ButtonIconSet iconSet = null;
         [SerializeField, Tooltip("The default icon set.")]
         private ButtonIconSet defaultIconSet = null;
-        #pragma warning restore CS0414
+#pragma warning restore CS0414
 
         private MaterialPropertyBlock iconTexturePropertyBlock;
 
@@ -433,7 +433,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private static readonly string generatedIconSetName = "CustomIconSet";
         private static readonly string customIconSetsFolderName = "CustomIconSets";
         private static readonly string customIconSetCreatedMessage = "A new icon set has been created to hold your button's custom icons. This icon set will be used by your button's ButtonConfigHelper component. It has been saved to:\n\n{0}";
-        
+
         /// <summary>
         /// Returns true if the button is using a custom icon material.
         /// </summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/GridObjectCollection.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// How the columns are aligned in the grid
         /// </summary>
-        public LayoutHorizontalAlignment ColumnAlignment 
+        public LayoutHorizontalAlignment ColumnAlignment
         {
             get { return columnAlignment; }
             set { columnAlignment = value; }
@@ -369,7 +369,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             float startOffsetY = (yMax * 0.5f) * CellHeight;
             if (anchor == LayoutAnchor.UpperLeft || anchor == LayoutAnchor.UpperCenter || anchor == LayoutAnchor.UpperRight)
             {
-                startOffsetY = anchorAlongAxis ? 0.5f * CellHeight: 0;
+                startOffsetY = anchorAlongAxis ? 0.5f * CellHeight : 0;
             }
             else if (anchor == LayoutAnchor.BottomLeft || anchor == LayoutAnchor.BottomCenter || anchor == LayoutAnchor.BottomRight)
             {
@@ -392,7 +392,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                                     alignmentOffsetX = 0;
                                     break;
                                 case LayoutHorizontalAlignment.Center:
-                                    alignmentOffsetX = CellWidth *((xMax - (NodeList.Count % xMax)) % xMax) * 0.5f;
+                                    alignmentOffsetX = CellWidth * ((xMax - (NodeList.Count % xMax)) % xMax) * 0.5f;
                                     break;
                                 case LayoutHorizontalAlignment.Right:
                                     alignmentOffsetX = CellWidth * ((xMax - (NodeList.Count % xMax)) % xMax);
@@ -438,7 +438,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                                                  (startOffsetY - (y * CellHeight) - HalfCell.y) + NodeList[cellCounter].Offset.y + alignmentOffsetY,
                                                  0.0f);
                         }
-                    cellCounter++;
+                        cellCounter++;
                     }
                 }
             }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/TileGridObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/TileGridObjectCollection.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// structure elements of a grid layout
         /// </summary>
-        public enum GridDivisions { Rows, Columns};
+        public enum GridDivisions { Rows, Columns };
 
         /// <summary>
         /// How many columns should the grid have
@@ -115,11 +115,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             int row = Columns > 0 ? Mathf.FloorToInt(index / Columns) : index;
 
             Vector3 size = Vector3.Scale(TileSize + Gutters, LayoutDireciton);
-            
+
             float xPos = size.x * column;
             float yPos = size.y * row;
             float zPos = DepthCalculatedBy == GridDivisions.Rows ? size.z * row : size.z * column;
-            
+
             return new Vector3(xPos, yPos, zPos);
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -132,7 +132,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             get { return cursorAngularSize; }
             set { cursorAngularSize = value; }
         }
-        
+
         [SerializeField, FormerlySerializedAs("cursorAngularScale")]
         [Tooltip("The angular scale of cursor in relation to Main Camera, assuming a mesh with bounds of Vector3(1,1,1)")]
         private float cursorAngularSize = 50.0f;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Override base behavior to align the cursor with the finger, else perform normal cursor transformations.
         /// </summary>
-        protected override void UpdateCursorTransform() 
+        protected override void UpdateCursorTransform()
         {
             IMixedRealityNearPointer nearPointer = (IMixedRealityNearPointer)Pointer;
 
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     indexKnucklePosition = transform.position;
                 }
-                
+
                 if (!nearPointer.IsInteractionEnabled)
                 {
                     // If the pointer is disabled, make sure to turn the ring cursor off

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/ObjectCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/ObjectCursor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         protected override void OnEnable()
         {
-            if(ParentTransform == null)
+            if (ParentTransform == null)
             {
                 ParentTransform = transform;
             }
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             if (state != CursorStateEnum.Contextual)
             {
                 // Hide all children first
-                for(int i = 0; i < ParentTransform.childCount; i++)
+                for (int i = 0; i < ParentTransform.childCount; i++)
                 {
                     ParentTransform.GetChild(i).gameObject.SetActive(false);
                 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -72,18 +72,18 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public virtual void SetCursor(GameObject newCursor = null)
         {
             using (SetCursorPerfMarker.Auto())
-            { 
+            {
                 if (cursorInstance != null)
                 {
                     DestroyCursorInstance();
                     cursorInstance = newCursor;
                 }
 
-            if (cursorInstance == null && cursorPrefab != null)
-            {
-                cursorInstance = Instantiate(cursorPrefab, transform);
-                isCursorInstantiatedFromPrefab = true;
-            }
+                if (cursorInstance == null && cursorPrefab != null)
+                {
+                    cursorInstance = Instantiate(cursorPrefab, transform);
+                    isCursorInstantiatedFromPrefab = true;
+                }
 
                 if (cursorInstance != null)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseMousePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/BaseMousePointer.cs
@@ -147,7 +147,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public override void OnInputUp(InputEventData eventData)
         {
             using (OnInputUpPerfMarker.Auto())
-            { 
+            {
                 if (!cursorWasDisabledOnDown)
                 {
                     base.OnInputUp(eventData);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPrimaryPointerSelector.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/DefaultPrimaryPointerSelector.cs
@@ -102,7 +102,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData) { }
 
-        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData) {}
+        void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData) { }
 
         #endregion IMixedRealityPointerHandler
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/GGVPointer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// <inheritdoc />
         public bool IsInteractionEnabled => IsActive;
-        
+
         /// <inheritdoc />
         public bool IsActive { get; set; }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/PokePointer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             "touchable but cannot see it. Visual FOV is defined by cone centered about display center, " +
             "radius equal to half display height.")]
         private bool ignoreCollidersNotInFOV = true;
-       
+
         /// <summary>
         /// Whether to ignore colliders that may be near the pointer, but not actually in the visual FOV.
         /// This can prevent accidental touches, and will allow hand rays to turn on when you may be near 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [Tooltip("Maximum push distance. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.")]
         private float maxPushDistance = 0.2f;
-        
+
         /// <summary>
         /// Maximum push distance. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.
         /// </summary>
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [FormerlySerializedAs("minPressDepth")]
         [Tooltip("Distance the button must be pushed until it is considered pressed. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.")]
         private float pressDistance = 0.02f;
-        
+
         /// <summary>
         /// Distance the button must be pushed until it is considered pressed. Distance is relative to the pivot of either the moving visuals if there's any or the button itself.
         /// </summary>
@@ -95,7 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [FormerlySerializedAs("withdrawActivationAmount")]
         [Tooltip("Withdraw amount needed to transition from Pressed to Released.")]
         private float releaseDistanceDelta = 0.01f;
-        
+
         /// <summary>
         ///  Withdraw amount needed to transition from Pressed to Released.
         /// </summary>
@@ -112,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [Tooltip("Button will send the release event on touch end after successful press even if release plane hasn't been passed.")]
         private bool releaseOnTouchEnd = true;
-        
+
         /// <summary>
         ///  Button will send the release event on touch end after successful press even if release plane hasn't been passed.
         /// </summary>
@@ -121,7 +121,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [Tooltip("Ensures that the button can only be pushed from the front. Touching the button from the back or side is prevented.")]
         private bool enforceFrontPush = true;
-        
+
         /// <summary>
         /// Ensures that the button can only be pushed from the front. Touching the button from the back or side is prevented.
         /// </summary>
@@ -203,14 +203,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 {
                     return nearInteractionTouchable.transform.TransformDirection(nearInteractionTouchable.LocalPressDirection);
                 }
-                
+
                 return transform.forward;
             }
         }
 
         private Transform PushSpaceSourceTransform
         {
-            get => movingButtonVisuals != null ? movingButtonVisuals.transform : transform; 
+            get => movingButtonVisuals != null ? movingButtonVisuals.transform : transform;
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Multiply world scale positions by this value to convert to local space
         /// </summary>
         private float WorldToLocalScale => transform.InverseTransformVector(WorldSpacePressDirection).magnitude;
-        
+
         /// <summary>
         /// Initial offset from moving visuals to button
         /// </summary>

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButtonHoloLens2.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             while (blendTime > 0.0f)
             {
-                float t =  1.0f - (blendTime / time);
+                float t = 1.0f - (blendTime / time);
                 UpdateHightlightPlateVisuals(fadeIn ? t : 1.0f - t);
                 blendTime -= Time.deltaTime;
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorLoadingBar.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/ProgressIndicators/ProgressIndicatorLoadingBar.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("Whether to display the percentage as text in addition to the loading bar.")]
         [SerializeField]
         private bool displayPercentage = true;
-        
+
         private float smoothProgress = 0f;
         private float lastSmoothProgress = -1;
         private ProgressIndicatorState state = ProgressIndicatorState.Closed;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -11,7 +11,7 @@ using UnityEngine.Serialization;
 namespace Microsoft.MixedReality.Toolkit.UI
 {
     [AddComponentMenu("Scripts/MRTK/SDK/HandInteractionPanZoom")]
-    public class HandInteractionPanZoom : 
+    public class HandInteractionPanZoom :
         BaseFocusHandler, IMixedRealityTouchHandler, IMixedRealityPointerHandler, IMixedRealitySourceStateHandler
     {
         /// <summary>
@@ -104,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// Returns the current pan delta (pan value - previous pan value)
         /// in UV coordinates (0 being no pan, 1, being pan of the entire ) 
         /// </summary>
-        public Vector2  CurrentPanDelta
+        public Vector2 CurrentPanDelta
         {
             get { return totalUVOffset; }
         }
@@ -218,13 +218,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #region Private Methods
         private bool TryGetMRControllerRayPoint(HandPanData data, out Vector3 rayPoint)
         {
-           
+
             if (data.currentPointer != null && data.currentController != null && data.currentController.IsPositionAvailable)
             {
                 rayPoint = data.touchingInitialPt + (SnapFingerToQuad(data.currentPointer.Position) - data.initialProjectedOffset);
                 return true;
             }
-          
+
             rayPoint = Vector3.zero;
             return false;
         }
@@ -268,11 +268,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
         private bool TryGetHandRayPoint(IMixedRealityController controller, out Vector3 handRayPoint)
         {
-           if (controller != null &&
-                controller.InputSource != null &&
-                controller.InputSource.Pointers != null &&
-                controller.InputSource.Pointers.Length > 0 &&
-                controller.InputSource.Pointers[0].Result != null)
+            if (controller != null &&
+                 controller.InputSource != null &&
+                 controller.InputSource.Pointers != null &&
+                 controller.InputSource.Pointers.Length > 0 &&
+                 controller.InputSource.Pointers[0].Result != null)
             {
                 handRayPoint = controller.InputSource.Pointers[0].Result.Details.Point;
                 return true;
@@ -305,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             currentMaterial = this.gameObject.GetComponent<Renderer>().material;
             proximityLightCenterColorID = Shader.PropertyToID("_ProximityLightCenterColorOverride");
             bool materialValid = currentMaterial != null && currentMaterial.HasProperty(proximityLightCenterColorID);
-            defaultProximityLightCenterColor = materialValid ? 
+            defaultProximityLightCenterColor = materialValid ?
                 currentMaterial.GetColor(proximityLightCenterColorID) :
                 new Color(0.0f, 0.0f, 0.0f, 0.0f);
 
@@ -655,7 +655,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     {
                         data.touchingRayOffset = handRayPt - SnapFingerToQuad(touchPosition);
                     }
-                }              
+                }
             }
 
             // Store value in case of MRController
@@ -697,7 +697,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             var hand = controller as IMixedRealityHand;
             if (hand != null)
-            { 
+            {
                 if (hand.TryGetJoint(joint, out MixedRealityPose pose))
                 {
                     position = pose.Position;
@@ -761,7 +761,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
 
         #region BaseFocusHandler Methods
-        
+
         /// <inheritdoc />
         public override void OnFocusEnter(FocusEventData eventData) { }
 
@@ -800,13 +800,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {
             oldIsTargetPositionLockedOnFocusLock = eventData.Pointer.IsTargetPositionLockedOnFocusLock;
-            if (! (eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
+            if (!(eventData.Pointer is IMixedRealityNearPointer) && eventData.Pointer.Controller.IsRotationAvailable)
             {
                 eventData.Pointer.IsTargetPositionLockedOnFocusLock = false;
             }
             SetAffordancesActive(false);
             EndTouch(eventData.SourceId);
-            SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer,  false);
+            SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer, false);
             eventData.Use();
         }
         public void OnPointerUp(MixedRealityPointerEventData eventData)
@@ -814,7 +814,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
             EndTouch(eventData.SourceId);
             eventData.Use();
-        }    
+        }
         #endregion IMixedRealityInputHandler Methods
 
         #region IMixedRealitySourceStateHandler Methods
@@ -826,7 +826,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         #endregion IMixedRealitySourceStateHandler Methods
 
         #region Unused Methods
-        public void OnSourceDetected(SourceStateEventData eventData) { }   
+        public void OnSourceDetected(SourceStateEventData eventData) { }
         public void OnPointerDragged(MixedRealityPointerEventData eventData) { }
         public void OnPointerClicked(MixedRealityPointerEventData eventData) { }
         #endregion Unused Methods

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Sliders/PinchSlider.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Sliders/PinchSlider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         [Header("Slider Axis Visuals")]
-    
+
         [Tooltip("The gameObject that contains the trackVisuals. This will get rotated to match the slider axis")]
         [SerializeField]
         private GameObject trackVisuals = null;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Sliders/SliderSounds.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Sliders/SliderSounds.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region Private members
         private PinchSlider slider;
-        
+
         // Play sound when passing through slider notches
         private float accumulatedDeltaSliderValue = 0;
         private float lastSoundPlayTime;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTip.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTip.cs
@@ -296,10 +296,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             get
             {
-                return ResolveTipState(masterTipState, groupTipState, tipState, HasFocus);              
+                return ResolveTipState(masterTipState, groupTipState, tipState, HasFocus);
             }
         }
-        
+
         public static bool ResolveTipState(DisplayMode masterTipState, DisplayMode groupTipState, DisplayMode tipState, bool hasFocus)
         {
             switch (masterTipState)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundBlob.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipBackgroundBlob.cs
@@ -34,7 +34,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion Transform Targets
 
-                /// <summary>
+        /// <summary>
         /// Determines whether background of Tooltip is visible.
         /// </summary>
         public bool IsVisible

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipConnector.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Tooltips/ToolTipConnector.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             {
                 return;
             }
-            
+
             switch (connectorFollowType)
             {
                 case ConnectorFollowType.AnchorOnly:

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/ThemeEaseSettings.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/ThemeEaseSettings.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     /// <summary>
     /// Ease settings and functionality for themes
     /// </summary>
-    
+
     [System.Serializable]
     public class ThemeEaseSettings
     {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/BaseStateModel.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/BaseStateModel.cs
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     bitCount += bit;
                 }
             }
-            
+
             return bitCount;
         }
     }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/States.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/States/States.cs
@@ -23,7 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public List<State> StateList
         {
-            get {return stateList;}
+            get { return stateList; }
             set { stateList = value; }
         }
 
@@ -106,8 +106,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <returns>true if internal list of state values and class configuration matches other, false otherwise</returns>
         public bool Equals(States other)
         {
-            if (this.StateList.Count != other.StateList.Count 
-                || this.StateModelType != other.StateModelType 
+            if (this.StateList.Count != other.StateList.Count
+                || this.StateModelType != other.StateModelType
                 || this.DefaultIndex != other.DefaultIndex)
             {
                 return false;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableColorTheme.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableColorTheme.cs
@@ -30,7 +30,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public InteractableColorTheme()
         {
-            Types = new Type[] { typeof(Renderer), typeof(TextMesh), typeof(Text), typeof(TextMeshPro), typeof(TextMeshProUGUI), typeof(Graphic)};
+            Types = new Type[] { typeof(Renderer), typeof(TextMesh), typeof(Text), typeof(TextMeshPro), typeof(TextMeshProUGUI), typeof(Graphic) };
             Name = "Color Theme";
         }
 
@@ -335,6 +335,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 host.GetComponent<TextMesh>() != null ||
                 host.GetComponent<Text>() != null);
         }
-        
+
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableGrabScaleTheme.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableGrabScaleTheme.cs
@@ -180,7 +180,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         #region Obsolete
-        
+
         [System.Obsolete("startScaleValue is no longer supported. Use originalLocalScale instead.")]
         protected ThemePropertyValue startScaleValue = new ThemePropertyValue();
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableShaderTheme.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/InteractableShaderTheme.cs
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         ShaderPropertyName = DefaultShaderProperty,
                     },
                 },
-                CustomProperties =  new List<ThemeProperty>(),
+                CustomProperties = new List<ThemeProperty>(),
             };
         }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/ScaleOffsetColorTheme.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/ThemeEngines/ScaleOffsetColorTheme.cs
@@ -77,7 +77,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             hostTransform.localPosition = originalPosition;
             hostTransform.localScale = originalScale;
-            
+
             base.Reset();
         }
 

--- a/Assets/MRTK/SDK/Features/Utilities/InputRayUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/InputRayUtils.cs
@@ -34,12 +34,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IMixedRealityEyeGazeProvider eyeGazeProvider = CoreServices.InputSystem?.EyeGazeProvider;
             if ((eyeGazeProvider == null) ||
                 !eyeGazeProvider.IsEyeTrackingDataValid)
-            { 
-                return false; 
+            {
+                return false;
             }
-          
+
             ray = eyeGazeProvider.LatestEyeGaze;
-            
+
             return true;
         }
 

--- a/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/PointerUtils.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <param name="inputType">Input type of pointer</param>
         /// <param name="endPoint">Output point position</param>
         /// <returns>True if pointer found, false otherwise. If not found, endPoint is set to zero</returns>
-        public static bool TryGetPointerEndpoint<T>(Handedness handedness, InputSourceType inputType, out Vector3 endPoint) where T: IMixedRealityPointer
+        public static bool TryGetPointerEndpoint<T>(Handedness handedness, InputSourceType inputType, out Vector3 endPoint) where T : IMixedRealityPointer
         {
             foreach (var pointer in GetPointers<IMixedRealityPointer>(handedness, inputType))
             {

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/ControllerFinder.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/ControllerFinder.cs
@@ -109,8 +109,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         /// <param name="newController">The new controller to be tracked.</param>
         protected virtual void AddControllerTransform(IMixedRealityController newController)
         {
-            if (newController == null || 
-                newController.Visualizer == null || 
+            if (newController == null ||
+                newController.Visualizer == null ||
                 newController.Visualizer.GameObjectProxy == null ||
                 newController.Visualizer.GameObjectProxy.transform == null)
             {

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -253,19 +253,19 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
                 float distanceToHandPlane;
 
                 // If we can generate the handplane/are able to set an activation point on it, and then are able to raycast against it
-                if (TryGenerateHandPlaneAndActivationPoint(jointedHand, out handPlane, out activationPoint) && 
+                if (TryGenerateHandPlaneAndActivationPoint(jointedHand, out handPlane, out activationPoint) &&
                     handPlane.Raycast(gazeRay, out distanceToHandPlane))
                 {
-                        // Now that we know the dist to the plane, create a vector at that point
-                        Vector3 gazePosOnPlane = gazeRay.origin + gazeRay.direction.normalized * distanceToHandPlane;
-                        Vector3 planePos = handPlane.ClosestPointOnPlane(gazePosOnPlane);
-                        float gazePosDistToActivationPosition = (activationPoint - planePos).sqrMagnitude;
-                        float gazeActivationThreshold = usedEyeGaze ? eyeGazeProximityThreshold : headGazeProximityThreshold; 
-                        gazeActivationAlreadyTriggered = (gazePosDistToActivationPosition < gazeActivationThreshold);
+                    // Now that we know the dist to the plane, create a vector at that point
+                    Vector3 gazePosOnPlane = gazeRay.origin + gazeRay.direction.normalized * distanceToHandPlane;
+                    Vector3 planePos = handPlane.ClosestPointOnPlane(gazePosOnPlane);
+                    float gazePosDistToActivationPosition = (activationPoint - planePos).sqrMagnitude;
+                    float gazeActivationThreshold = usedEyeGaze ? eyeGazeProximityThreshold : headGazeProximityThreshold;
+                    gazeActivationAlreadyTriggered = (gazePosDistToActivationPosition < gazeActivationThreshold);
 
-                        return gazeActivationAlreadyTriggered;
-                    }
+                    return gazeActivationAlreadyTriggered;
                 }
+            }
 
             return false;
         }

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/Orbital.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/Orbital.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             get { return tetherAngleSteps; }
             set
             {
-                tetherAngleSteps =  Mathf.Clamp(value, 2, 24);
+                tetherAngleSteps = Mathf.Clamp(value, 2, 24);
             }
         }
 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -238,7 +238,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             get => preferredTrackedHandedness;
             set
             {
-                if ((value.IsLeft() || value.IsRight()) 
+                if ((value.IsLeft() || value.IsRight())
                     && preferredTrackedHandedness != value)
                 {
                     preferredTrackedHandedness = value;
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         private float lastUpdateTime;
 
-        private IMixedRealityHandJointService HandJointService 
+        private IMixedRealityHandJointService HandJointService
             => handJointService ?? CoreServices.GetInputSystemDataProvider<IMixedRealityHandJointService>();
 
         private IMixedRealityHandJointService handJointService = null;
@@ -470,7 +470,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 return true;
             }
-            
+
             // If we are attached to a pointer (i.e controller ray), 
             // check if pointer's controller is still be tracked
             if (TrackedTargetType == TrackedObjectType.ControllerRay &&
@@ -478,7 +478,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 return true;
             }
-            
+
             // If we were tracking a particular hand, check that our transform is still valid
             // The HandJointService does not destroy it's own hand joint tracked GameObjects even when a hand is no longer tracked
             // Those HandJointService's GameObjects though are the parents of our tracked transform and thus will not be null/destroyed

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SurfaceMagnetism.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             /// Blend between tracked transform and the surface normal orientation
             /// </summary>
             Blended = 3,
-            
+
             /// <summary>
             /// Face toward this object's position
             /// </summary>
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         #endregion
 
         #region SurfaceMagnetism Parameters
-        
+
         [SerializeField]
         [Tooltip("Array of LayerMask to execute from highest to lowest priority. First layermask to provide a raycast hit will be used by component")]
         private LayerMask[] magneticSurfaces = { UnityEngine.Physics.DefaultRaycastLayers };

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
@@ -44,7 +44,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         public float DefaultPlacementDistance
         {
             get => defaultPlacementDistance;
-            set => defaultPlacementDistance = value;    
+            set => defaultPlacementDistance = value;
         }
 
         [SerializeField]
@@ -203,12 +203,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
             if (AutoStart)
             {
-                StartPlacement();  
+                StartPlacement();
             }
             else
             {
                 SolverHandler.UpdateSolvers = false;
-            } 
+            }
         }
 
         private void OnDisable()
@@ -293,7 +293,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             CurrentRay.UpdateRayStep(ref origin, ref endpoint);
 
             // Check if the current ray hits a magnetic surface
-            DidHitSurface = MixedRealityRaycaster.RaycastSimplePhysicsStep(CurrentRay, MaxRaycastDistance, MagneticSurfaces, false, out CurrentHit);  
+            DidHitSurface = MixedRealityRaycaster.RaycastSimplePhysicsStep(CurrentRay, MaxRaycastDistance, MagneticSurfaces, false, out CurrentHit);
         }
 
         /// <summary>
@@ -305,7 +305,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             if (DidHitSurface)
             {
                 // Take the current hit point and add an offset relative to the surface to avoid half of the object in the surface
-                GoalPosition = CurrentHit.point;  
+                GoalPosition = CurrentHit.point;
                 AddOffset(CurrentHit.normal * SurfaceNormalOffset);
 
 #if UNITY_EDITOR
@@ -326,7 +326,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         {
             Vector3 direction = CurrentRay.Direction;
             Vector3 surfaceNormal = CurrentHit.normal;
-            
+
             if (KeepOrientationVertical)
             {
                 direction.y = 0;
@@ -338,7 +338,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 GoalRotation = Quaternion.LookRotation(-surfaceNormal, Vector3.up);
             }
-            else 
+            else
             {
                 GoalRotation = Quaternion.LookRotation(direction, Vector3.up);
             }

--- a/Assets/MRTK/SDK/Inspectors/Dwell/DwellHandlerInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/Dwell/DwellHandlerInspector.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Dwell.Editor
             }
             EditorGUI.indentLevel--;
 
-            EditorGUILayout.PropertyField(this.serializedObject.FindProperty("DwellIntended"),  true);
+            EditorGUILayout.PropertyField(this.serializedObject.FindProperty("DwellIntended"), true);
             EditorGUILayout.PropertyField(this.serializedObject.FindProperty("DwellStarted"), true);
             EditorGUILayout.PropertyField(this.serializedObject.FindProperty("DwellCompleted"), true);
             EditorGUILayout.PropertyField(this.serializedObject.FindProperty("DwellCanceled"), true);

--- a/Assets/MRTK/SDK/Inspectors/Experimental/FollowSolver/FollowInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/Experimental/FollowSolver/FollowInspector.cs
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
         private SerializedProperty pivotAxis;
         private SerializedProperty reorientWhenOutsideParameters;
         private SerializedProperty orientToControllerDeadzoneDegrees;
-        
+
         // Distance
         private SerializedProperty ignoreDistanceClamp;
         private SerializedProperty minDistance;
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
             base.OnInspectorGUI();
 
             serializedObject.Update();
-            
+
             GUIStyle style = EditorStyles.foldout;
             FontStyle previousStyle = style.fontStyle;
             style.fontStyle = FontStyle.Bold;
@@ -166,7 +166,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Editor
                     }
                 }
                 else
-                {                    
+                {
                     EditorGUILayout.HelpBox("Disable \"Ignore Angle Clamp\" to show options", MessageType.Info);
                 }
             }

--- a/Assets/MRTK/SDK/Inspectors/Input/Handlers/ControllerPoseSynchronizerInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/Input/Handlers/ControllerPoseSynchronizerInspector.cs
@@ -49,9 +49,9 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
                 }
             }
 
-            if (!synchronizationSettingsFoldout) 
-            { 
-                return; 
+            if (!synchronizationSettingsFoldout)
+            {
+                return;
             }
 
             using (new EditorGUI.IndentLevelScope())

--- a/Assets/MRTK/SDK/Inspectors/UX/Collections/BaseCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Collections/BaseCollectionInspector.cs
@@ -6,7 +6,7 @@ using UnityEditor;
 
 namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 {
-    [CustomEditor( typeof(BaseObjectCollection), true )]
+    [CustomEditor(typeof(BaseObjectCollection), true)]
     public class BaseCollectionInspector : UnityEditor.Editor
     {
         private SerializedProperty ignoreInactiveTransforms;

--- a/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Collections/GridObjectCollectionInspector.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
 
 
-            LayoutOrder layoutTypeIndex = (LayoutOrder) layout.enumValueIndex;
+            LayoutOrder layoutTypeIndex = (LayoutOrder)layout.enumValueIndex;
             if (layoutTypeIndex == LayoutOrder.ColumnThenRow)
             {
                 EditorGUILayout.HelpBox("ColumnThenRow will lay out content first horizontally (by column), then vertically (by row). NumColumns specifies number of columns per row.", MessageType.Info);
@@ -79,7 +79,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 EditorGUILayout.PropertyField(cellHeight);
             }
 
-            ObjectOrientationSurfaceType surfaceTypeIndex = (ObjectOrientationSurfaceType) surfaceType.enumValueIndex;
+            ObjectOrientationSurfaceType surfaceTypeIndex = (ObjectOrientationSurfaceType)surfaceType.enumValueIndex;
             if (surfaceTypeIndex == ObjectOrientationSurfaceType.Plane)
             {
                 EditorGUILayout.PropertyField(distance, new GUIContent("Distance from parent", "Distance from parent object's origin"));

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/InteractableInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/InteractableInspector.cs
@@ -331,9 +331,9 @@ namespace Microsoft.MixedReality.Toolkit.UI.Editor
                 using (new EditorGUI.PropertyScope(position, selectionModeLabel, dimensions))
                 {
                     // Show enum popup for selection mode, hide option to select SelectionModes.Invalid
-                    selectionMode = (SelectionModes)EditorGUI.EnumPopup(position, selectionModeLabel, 
-                        Interactable.ConvertToSelectionMode(dimensions.intValue), 
-                        (value) => { return (SelectionModes)value != SelectionModes.Invalid; } );
+                    selectionMode = (SelectionModes)EditorGUI.EnumPopup(position, selectionModeLabel,
+                        Interactable.ConvertToSelectionMode(dimensions.intValue),
+                        (value) => { return (SelectionModes)value != SelectionModes.Invalid; });
 
                     switch (selectionMode)
                     {

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/InteractableReceiverListInspector.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     [CustomEditor(typeof(InteractableReceiverList))]
     public class InteractableReceiverListInspector : UnityEditor.Editor
     {
-        private static readonly GUIContent InteractableLabel = new GUIContent("Interactable","The Interactable that will be monitored");
+        private static readonly GUIContent InteractableLabel = new GUIContent("Interactable", "The Interactable that will be monitored");
         private static readonly GUIContent SearchScopeLabel = new GUIContent("Search Scope", "Where to look for an Interactable if one is not assigned");
 
         public override void OnInspectorGUI()
@@ -20,7 +20,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             SerializedProperty events = serializedObject.FindProperty("Events");
 
-            if(events.arraySize < 1)
+            if (events.arraySize < 1)
             {
                 AddEvent(0);
             }

--- a/Assets/MRTK/SDK/Inspectors/UX/Pointers/BaseControllerPointerInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Pointers/BaseControllerPointerInspector.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Editor
         protected override void OnEnable()
         {
             base.OnEnable();
-            
+
             cursorPrefab = serializedObject.FindProperty("cursorPrefab");
             disableCursorOnStart = serializedObject.FindProperty("disableCursorOnStart");
             setCursorVisibilityOnSourceDetected = serializedObject.FindProperty("setCursorVisibilityOnSourceDetected");

--- a/Assets/MRTK/SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Tooltips/ToolTipConnectorInspector.cs
@@ -40,7 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
             editorSettingsFoldout = SessionState.GetBool(EditorSettingsFoldoutKey, editorSettingsFoldout);
 
             connector = (ToolTipConnector)target;
-         
+
             serializedObject.ApplyModifiedProperties();
         }
 
@@ -262,7 +262,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                             {
                                 manualPivotDirection = serializedObject.FindProperty("manualPivotDirection");
                                 manualPivotDirection.vector3Value = (newPivotPosition - targetPosition).normalized;
-                                
+
                                 serializedObject.ApplyModifiedProperties();
                             }
                             break;

--- a/Assets/MRTK/SDK/Inspectors/UX/Tooltips/ToolTipInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Tooltips/ToolTipInspector.cs
@@ -155,7 +155,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
 
             if (basicSettingsFoldout)
             {
-                EditorGUI.indentLevel++; 
+                EditorGUI.indentLevel++;
 
                 EditorGUILayout.PropertyField(showBackground);
                 EditorGUILayout.PropertyField(showConnector);
@@ -221,7 +221,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         {
             if (DrawAttachPoints)
             {
-                Handles.color = Color.Lerp (Color.clear, Color.red, 0.5f);
+                Handles.color = Color.Lerp(Color.clear, Color.red, 0.5f);
                 float scale = toolTip.ContentScale * 0.01f;
 
                 ToolTipUtility.GetAttachPointPositions(ref localAttachPointPositions, toolTip.LocalContentSize);

--- a/Assets/MRTK/SDK/Inspectors/Utilities/Solvers/SolverHandlerInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/Utilities/Solvers/SolverHandlerInspector.cs
@@ -53,8 +53,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
 
             if (!SolverHandler.IsValidTrackedObjectType(solverHandler.TrackedTargetType))
             {
-                InspectorUIUtility.DrawWarning(" Current Tracked Target Type value of \"" 
-                    + Enum.GetName(typeof(TrackedObjectType), solverHandler.TrackedTargetType) 
+                InspectorUIUtility.DrawWarning(" Current Tracked Target Type value of \""
+                    + Enum.GetName(typeof(TrackedObjectType), solverHandler.TrackedTargetType)
                     + "\" is obsolete. Select MotionController or HandJoint values instead");
             }
 

--- a/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
+++ b/Assets/MRTK/Services/BoundarySystem/XR2018/MixedRealityBoundarySystem.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Boundary
         /// <param name="scale">The application's configured <see cref="Utilities.ExperienceScale"/>.</param>
         public MixedRealityBoundarySystem(
             MixedRealityBoundaryVisualizationProfile profile,
-            ExperienceScale scale) : base(profile, scale) { }        
+            ExperienceScale scale) : base(profile, scale) { }
 
         #region IMixedRealityService Implementation
 

--- a/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/Assets/MRTK/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -107,10 +107,10 @@ namespace Microsoft.MixedReality.Toolkit.CameraSystem
                 {
                     MixedRealityCameraSettingsConfiguration configuration = profile.SettingsConfigurations[i];
 
-                    if (configuration.ComponentType?.Type == null) 
-                    { 
+                    if (configuration.ComponentType?.Type == null)
+                    {
                         // Incomplete configuration, do not try to register until a type is set in the profile.
-                        continue; 
+                        continue;
                     }
 
                     object[] args = { this, configuration.ComponentName, configuration.Priority, configuration.SettingsProfile };

--- a/Assets/MRTK/Services/InputAnimation/InputAnimationSerializationUtils.cs
+++ b/Assets/MRTK/Services/InputAnimation/InputAnimationSerializationUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// Generate a file name for export.
         /// </summary>
-        public static string GetOutputFilename(string baseName="InputAnimation", bool appendTimestamp=true)
+        public static string GetOutputFilename(string baseName = "InputAnimation", bool appendTimestamp = true)
         {
             string filename;
             if (appendTimestamp)

--- a/Assets/MRTK/Services/InputAnimation/InputRecordingService.cs
+++ b/Assets/MRTK/Services/InputAnimation/InputRecordingService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IMixedRealityInputSystem inputSystem,
             string name = null,
             uint priority = DefaultPriority,
-            BaseMixedRealityProfile profile = null) : this( inputSystem, name, priority, profile)
+            BaseMixedRealityProfile profile = null) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }

--- a/Assets/MRTK/Services/InputSimulation/BaseInputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/BaseInputSimulationService.cs
@@ -123,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             System.Type controllerType = simulationMode == HandSimulationMode.Gestures ? typeof(SimulatedGestureHand) : typeof(SimulatedArticulatedHand);
-            
+
             if (controller == null || !controller.Enabled)
             {
                 // Controller failed to be setup correctly.

--- a/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
@@ -133,9 +133,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             EditorGUILayout.Space();
 
-// XXX Reloading the scene is currently not supported,
-// due to the life cycle of the MRTK "instance" object (see see #4530).
-// Enable the button below once scene reloading is supported!
+            // XXX Reloading the scene is currently not supported,
+            // due to the life cycle of the MRTK "instance" object (see see #4530).
+            // Enable the button below once scene reloading is supported!
 #if false
             using (new GUIEnabledWrapper(Application.isPlaying))
             {

--- a/Assets/MRTK/Services/InputSimulation/IInputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/IInputSimulationService.cs
@@ -4,7 +4,7 @@
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
-{ 
+{
     public interface IInputSimulationService : IMixedRealityInputDeviceManager
     {
         /// <summary>

--- a/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
+++ b/Assets/MRTK/Services/InputSimulation/InputSimulationService.cs
@@ -176,7 +176,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IMixedRealityInputSystem inputSystem,
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : this(inputSystem, name, priority, profile) 
+            BaseMixedRealityProfile profile) : this(inputSystem, name, priority, profile)
         {
             Registrar = registrar;
         }
@@ -469,7 +469,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 // Viewport delta x and y can be computed from screen x/y.
                 // Note that the conversion functions do not change Z, it is expected to always be in world space units.
                 Vector3 viewportDelta = CameraCache.Main.ScreenToViewportPoint(screenDelta);
-                
+
                 // Compute viewport-scale z delta
                 viewportDelta.z = WorldToViewport(worldDepthDelta).x;
 

--- a/Assets/MRTK/Services/InputSimulation/KeyBinding.cs
+++ b/Assets/MRTK/Services/InputSimulation/KeyBinding.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 int index = 0;
                 Action<KeyType, int> AddEnumValue = (bindingType, code) =>
                 {
-                    var kb = new KeyBinding() { bindingType=bindingType, code=code };
+                    var kb = new KeyBinding() { bindingType = bindingType, code = code };
                     names.Add(kb.ToString());
                     EnumToKeyBindingMap[index] = Tuple.Create(bindingType, code);
                     KeyBindingToEnumMap[Tuple.Create(bindingType, code)] = index;

--- a/Assets/MRTK/Services/InputSimulation/MixedRealityInputSimulationProfile.cs
+++ b/Assets/MRTK/Services/InputSimulation/MixedRealityInputSimulationProfile.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public float MouseRotationSensitivity => mouseRotationSensitivity;
         [SerializeField]
         [Tooltip("Mouse Movement X-axis")]
-        private string mouseX = "Mouse X"; 
+        private string mouseX = "Mouse X";
         /// <summary>
         /// Mouse Movement X-axis
         /// </summary>

--- a/Assets/MRTK/Services/InputSimulation/MouseRotationProvider.cs
+++ b/Assets/MRTK/Services/InputSimulation/MouseRotationProvider.cs
@@ -144,9 +144,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     UnityEngine.Cursor.visible = wasCursorVisible;
                 }
 
-    #if UNITY_EDITOR
+#if UNITY_EDITOR
                 UnityEditor.EditorGUIUtility.SetWantsMouseJumping(wantsJumping ? 1 : 0);
-    #endif
+#endif
             }
         }
     }

--- a/Assets/MRTK/Services/InputSimulation/SimulatedArticulatedHandPoses.cs
+++ b/Assets/MRTK/Services/InputSimulation/SimulatedArticulatedHandPoses.cs
@@ -953,7 +953,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
           ]
         }";
-        
+
         #endregion
 
         #region ArticulatedHandPose_Open JSON
@@ -1395,7 +1395,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
           ]
         }";
-        
+
         #endregion
 
         #region ArticulatedHandPose_OpenSteadyGrabPoint JSON
@@ -1837,7 +1837,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
           ]
         }";
-        
+
         #endregion
 
         #region ArticulatedHandPose_Pinch JSON
@@ -2726,7 +2726,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         #region ArticulatedHandPose_Poke JSON
 
-        private const string ArticulatedHandPose_Poke= @"
+        private const string ArticulatedHandPose_Poke = @"
         {
           ""items"": [
             {

--- a/Assets/MRTK/Services/InputSimulation/SimulatedGestureHand.cs
+++ b/Assets/MRTK/Services/InputSimulation/SimulatedGestureHand.cs
@@ -41,9 +41,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// Constructor.
         /// </summary>
         public SimulatedGestureHand(
-            TrackingState trackingState, 
-            Handedness controllerHandedness, 
-            IMixedRealityInputSource inputSource = null, 
+            TrackingState trackingState,
+            Handedness controllerHandedness,
+            IMixedRealityInputSource inputSource = null,
             MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {

--- a/Assets/MRTK/Services/InputSimulation/SimulatedHandDataProvider.cs
+++ b/Assets/MRTK/Services/InputSimulation/SimulatedHandDataProvider.cs
@@ -89,8 +89,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
             else
             {
                 ViewportPosition.x += mouseDelta.viewportDelta.x;
-				ViewportPosition.y += mouseDelta.viewportDelta.y;
-				viewportPositionZTarget += mouseDelta.viewportDelta.z;
+                ViewportPosition.y += mouseDelta.viewportDelta.y;
+                viewportPositionZTarget += mouseDelta.viewportDelta.z;
             }
 
             JitterOffset = UnityEngine.Random.insideUnitSphere * noiseAmount;
@@ -308,7 +308,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     isSimulatingRight = false;
                 }
-                if(isSimulatingGaze)
+                if (isSimulatingGaze)
                     lastSimulationGaze = time;
             }
 

--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -17,8 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     /// <remarks>There are convenience properties for getting only Gaze Pointer if needed.</remarks>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Overview.html")]
-    public class FocusProvider : BaseCoreSystem, 
-        IMixedRealityFocusProvider, 
+    public class FocusProvider : BaseCoreSystem,
+        IMixedRealityFocusProvider,
         IPointerPreferences
     {
         /// <summary>
@@ -241,7 +241,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 raycastHit = hit;
                 graphicsRaycastResult = default(RaycastResult);
 
-                hitObject = focusIndividualCompoundCollider? hit.collider.gameObject : hit.transform.gameObject;
+                hitObject = focusIndividualCompoundCollider ? hit.collider.gameObject : hit.transform.gameObject;
                 hitPointOnObject = hit.point;
                 hitNormalOnObject = hit.normal;
 
@@ -1588,7 +1588,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
 
             return GetPointerBehavior(
-                pointer.GetType(), 
+                pointer.GetType(),
                 pointer.Controller.ControllerHandedness,
                 pointer.InputSourceParent.SourceType);
         }
@@ -1676,7 +1676,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 return PointerBehavior.Default;
             }
             public void SetBehaviorForHandedness(
-                Handedness h, 
+                Handedness h,
                 PointerBehavior b)
             {
                 if ((h & Handedness.Right) != 0)

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -279,7 +279,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
             /// <inheritdoc />
             public override Quaternion Rotation => gazeTransform.rotation;
-            
+
             /// <inheritdoc />
             public override void Reset()
             {

--- a/Assets/MRTK/Services/InputSystem/InputSystemGlobalListener.cs
+++ b/Assets/MRTK/Services/InputSystem/InputSystemGlobalListener.cs
@@ -22,9 +22,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             if (CoreServices.InputSystem != null && !lateInitialize)
             {
-            #pragma warning disable 0618
+#pragma warning disable 0618
                 CoreServices.InputSystem.Register(gameObject);
-            #pragma warning restore 0618
+#pragma warning restore 0618
             }
         }
 
@@ -41,17 +41,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 lateInitialize = false;
-            #pragma warning disable 0618
+#pragma warning disable 0618
                 CoreServices.InputSystem.Register(gameObject);
-            #pragma warning restore 0618
+#pragma warning restore 0618
             }
         }
 
         protected virtual void OnDisable()
         {
-        #pragma warning disable 0618
+#pragma warning disable 0618
             CoreServices.InputSystem?.Unregister(gameObject);
-        #pragma warning restore 0618
+#pragma warning restore 0618
         }
 
         /// <summary>

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputSystem.cs
@@ -840,8 +840,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (RaiseSourceDetectedPerfMarker.Auto())
             {
-                if (DetectedInputSources.Contains(source)) 
-                { 
+                if (DetectedInputSources.Contains(source))
+                {
                     Debug.LogWarning($"[MRTK Issue] {source.SourceName} has already been registered with the Input Manager!");
                     return;
                 }
@@ -877,8 +877,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             using (RaiseSourceLostPerfMarker.Auto())
             {
-                if (!DetectedInputSources.Contains(source)) 
-                { 
+                if (!DetectedInputSources.Contains(source))
+                {
                     Debug.LogWarning($"[MRTK Issue] {source.SourceName} was never registered with the Input Manager!");
                     return;
                 }

--- a/Assets/MRTK/Services/InputSystem/Utilities/CanvasUtility.cs
+++ b/Assets/MRTK/Services/InputSystem/Utilities/CanvasUtility.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Utilities
     public class CanvasUtility : MonoBehaviour, IMixedRealityPointerHandler
     {
         private bool oldIsTargetPositionLockedOnFocusLock = false;
-        public void OnPointerClicked(MixedRealityPointerEventData eventData) {}
+        public void OnPointerClicked(MixedRealityPointerEventData eventData) { }
 
         public void OnPointerDown(MixedRealityPointerEventData eventData)
         {

--- a/Assets/MRTK/Services/InputSystem/Utilities/ScaleMeshEffect.cs
+++ b/Assets/MRTK/Services/InputSystem/Utilities/ScaleMeshEffect.cs
@@ -50,7 +50,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.Utilities
             var canvas = GetComponentInParent<Canvas>();
 
             // Pack the z scale into x and a flag indicating this value comes from a ScaleMeshEffect into y into UV channel 3.
-            var depth = new Vector2((canvas ? (1.0f / canvas.transform.lossyScale.z) : 1.0f) * rectTransform.localScale.z, 
+            var depth = new Vector2((canvas ? (1.0f / canvas.transform.lossyScale.z) : 1.0f) * rectTransform.localScale.z,
                                     -1.0f);
 
             var vertex = new UIVertex();

--- a/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -881,7 +881,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 try
                 {
                     foreach (string sceneName in sceneNames)
-                    {  
+                    {
                         // Announce scenes individually regardless of type
                         OnWillUnloadScene?.Invoke(sceneName);
                     }

--- a/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
+++ b/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
@@ -315,12 +315,12 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             updatingSettingsOnEditorChanged = false;
         }
-        
+
         /// <summary>
         /// Checks whether any of the save dates on our lighting scenes are later than the save date of our cached lighting data.
         /// </summary>
         private void EditorCheckIfCachedLightingOutOfDate()
-        {            
+        {
             DateTime cachedLightingTimestamp = profile.GetEarliestLightingCacheTimestamp();
             bool outOfDate = false;
 
@@ -654,7 +654,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                     }
 
                     EditorGUIUtility.PingObject(rootObjectsToMove.FirstOrDefault());
-                } 
+                }
                 catch (Exception)
                 {
                     // This can happen if the move object operation fails. No big deal, we'll try again next time.
@@ -688,7 +688,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
             {
                 if (EditorSceneUtils.AddSceneToBuildSettings(
                     contentScene,
-                    cachedBuildScenes, 
+                    cachedBuildScenes,
                     EditorSceneUtils.BuildIndexTarget.None))
                 {
                     cachedBuildScenes = EditorBuildSettings.scenes;
@@ -700,7 +700,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 foreach (SceneInfo lightingScene in profile.LightingScenes)
                 {   // Make sure ALL lighting scenes are added to build settings
                     if (EditorSceneUtils.AddSceneToBuildSettings(
-                        lightingScene, 
+                        lightingScene,
                         cachedBuildScenes,
                         EditorSceneUtils.BuildIndexTarget.Last))
                     {
@@ -742,7 +742,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                 allScenes.Add(profile.ManagerScene);
             }
 
-            if(EditorSceneUtils.CheckBuildSettingsForDuplicates(allScenes, duplicates))
+            if (EditorSceneUtils.CheckBuildSettingsForDuplicates(allScenes, duplicates))
             {
                 // If it's already open, don't display
                 if (!ResolveDuplicateScenesWindow.IsOpen)

--- a/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
+++ b/Assets/MRTK/Services/SpatialAwarenessSystem/MixedRealitySpatialAwarenessSystem.cs
@@ -13,8 +13,8 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
     /// </summary>
     [HelpURL("https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/SpatialAwareness/SpatialAwarenessGettingStarted.html")]
     public class MixedRealitySpatialAwarenessSystem :
-        BaseDataProviderAccessCoreSystem, 
-        IMixedRealitySpatialAwarenessSystem, 
+        BaseDataProviderAccessCoreSystem,
+        IMixedRealitySpatialAwarenessSystem,
         IMixedRealityCapabilityCheck
     {
         /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.Toolkit.SpatialAwareness
         /// <inheritdoc />
         public bool CheckCapability(MixedRealityCapability capability)
         {
-            foreach(var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
+            foreach (var observer in GetDataProviders<IMixedRealitySpatialAwarenessObserver>())
             {
                 IMixedRealityCapabilityCheck capabilityChecker = observer as IMixedRealityCapabilityCheck;
 

--- a/Assets/MRTK/Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Boundary
         /// </remarks>
         private static void AssertWithinTolerance(double expected, double actual)
         {
-            Assert.IsTrue(Math.Abs((expected - actual)/expected) < TolerancePercent);
+            Assert.IsTrue(Math.Abs((expected - actual) / expected) < TolerancePercent);
         }
     }
 }

--- a/Assets/MRTK/Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Physics/Utilities/InterpolationUtilitiesTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Physics
             Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 6.0f /*dTime*/),
                 Is.EqualTo(new Vector3(137.5f, 237.5f, 337.5f)));
 
-            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 20.0f /*dTime*/), 
+            Assert.That(InterpolationUtilities.ExpDecay(from, to, 2.0f /*hLife*/, 20.0f /*dTime*/),
                 Is.EqualTo(new Vector3(149.90234f, 249.90234f, 349.90234f)));
         }
 

--- a/Assets/MRTK/Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Physics/Utilities/InterpolatorTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Physics
         {
             Vector3 from = new Vector3(10, 10, 10);
             Vector3 to = new Vector3(100, 100, 100);
-            
+
             // Regardless of the time delta, a zero speed will always snap to the final location.
             Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 0.0f /*deltaTime*/, 0.0f /*speed*/), Is.EqualTo(to));
             Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 100.0f /*deltaTime*/, 0.0f /*speed*/), Is.EqualTo(to));
@@ -36,12 +36,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Physics
             Vector3 to = new Vector3(100, 100, 100);
 
             Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 1.0f /*deltaTime*/, 0.5f /*speed*/),
-                Is.EqualTo(new Vector3(50, 50 , 50)));
+                Is.EqualTo(new Vector3(50, 50, 50)));
 
             Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 2.0f /*deltaTime*/, 0.5f /*speed*/),
                 Is.EqualTo(new Vector3(100, 100, 100)));
 
-            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 3.0f /*deltaTime*/, 0.5f /*speed*/), 
+            Assert.That(Interpolator.NonLinearInterpolateTo(from, to, 3.0f /*deltaTime*/, 0.5f /*speed*/),
                 Is.EqualTo(new Vector3(100, 100, 100)));
         }
     }

--- a/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Experimental/BoundsControlTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
     /// Tests for edit mode behavior of bounds control
     /// </summary>
     public class BoundsControlTests
-    {       
+    {
         [Test]
         /// <summary>
         /// Tests configuring every property of bounds control in edit mode
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Experimental
             scaleConfig.HandleMaterial = testMaterial;
             scaleConfig.HandleGrabbedMaterial = testMaterial;
             scaleConfig.HandlePrefab = testCube;
-            scaleConfig.HandleSize = 0.05f ;
+            scaleConfig.HandleSize = 0.05f;
             scaleConfig.ColliderPadding = Vector3.one;
             scaleConfig.DrawTetherWhenManipulating = false;
             scaleConfig.HandlesIgnoreCollider = collider;

--- a/Assets/MRTK/Tests/EditModeTests/InputSystem/InteractionDefinitionTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/InputSystem/InteractionDefinitionTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
                 }
             }
         }
-            
+
         private static void TestVector2Internal(bool invertXAxis, bool invertYAxis, Vector2 vectorValue)
         {
             string msg = string.Format("invertXAxis: {0}, invertYAxis: {1}, vectorValue: {2}", invertXAxis, invertYAxis, vectorValue);

--- a/Assets/MRTK/Tests/EditModeTests/InputSystem/TestPointer.cs
+++ b/Assets/MRTK/Tests/EditModeTests/InputSystem/TestPointer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.InputSystem
         public int GetHashCode(object obj)
         {
             var pointer = obj as TestPointer;
-            return (int) pointer.PointerId;
+            return (int)pointer.PointerId;
         }
 
         /// <inheritdoc />

--- a/Assets/MRTK/Tests/EditModeTests/Services/TestExtensionService2.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Services/TestExtensionService2.cs
@@ -7,8 +7,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
     internal class TestExtensionService2 : BaseTestExtensionService, ITestExtensionService2
     {
         public TestExtensionService2(
-            string name, 
-            uint priority, 
+            string name,
+            uint priority,
             BaseMixedRealityProfile profile) : base(name, priority, profile) { }
     }
 }

--- a/Assets/MRTK/Tests/EditModeTests/Services/TestExtensionService3.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Services/TestExtensionService3.cs
@@ -9,6 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Services
         public TestExtensionService3(
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : base( name, priority, profile) { }
+            BaseMixedRealityProfile profile) : base(name, priority, profile) { }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseCursorTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             PlayModeTestUtilities.Setup();
             TestUtilities.PlayspaceToOriginLookingForward();
-            
+
             // Target frame rate is set to 50 to match the physics
             // tick rate. The rest of the test code needs to wait on a frame to have
             // passed, and this is a rough way of ensuring that each WaitForFixedUpdate()
@@ -65,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private void VerifyCursorStateFromPointers(IEnumerable<IMixedRealityPointer> pointers, CursorStateEnum state)
         {
             Assert.NotZero(pointers.ToReadOnlyCollection().Count);
-            foreach(var pointer in pointers)
+            foreach (var pointer in pointers)
             {
                 VerifyCursorState(pointer.BaseCursor, state);
             }

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale, originalEdgeHandlerScale, "The edge handler changed mistakingly");
             TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale.normalized, originalCornerHandlerScale.normalized, "The corner handler scale has changed");
-            Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale.x/originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
+            Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale.x / originalCornerHandlerScale.x, bbox.MediumScale, 0.1f, "The corner handler did not grow when a pointer was near it");
 
             // Move the hand to a handler on the edge
             yield return rightHand.MoveTo(edgeHandlerPosition, numSteps);
@@ -165,7 +165,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale, originalCornerHandlerScale, "The corner handler changed mistakingly");
             TestUtilities.AssertAboutEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.normalized, originalEdgeHandlerScale.normalized, "The edge handler scale has changed");
-            Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.x/originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
+            Assert.AreApproximatelyEqual(bbox.transform.Find("rigRoot/midpoint_0/Sphere").transform.localScale.x / originalEdgeHandlerScale.x, bbox.MediumScale, 0.1f, "The edge handler did not grow when a pointer was near it");
 
             GameObject.Destroy(bbox.gameObject);
             // Wait for a frame to give Unity a change to actually destroy the object
@@ -279,7 +279,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             CameraCache.Main.transform.LookAt(bbox.ScaleCorners[3].transform);
 
-            var startHandPos = CameraCache.Main.transform.TransformPoint(new Vector3( 0.1f, 0f, 1.5f));
+            var startHandPos = CameraCache.Main.transform.TransformPoint(new Vector3(0.1f, 0f, 1.5f));
             TestHand rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(startHandPos);
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);

--- a/Assets/MRTK/Tests/PlayModeTests/Components/TestInputGlobalListener.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Components/TestInputGlobalListener.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     // For InputSystemGlobalListener
 #pragma warning disable 0618
     [AddComponentMenu("Scripts/MRTK/Tests/TestInputGlobalListener")]
-    internal class TestInputGlobalListener: InputSystemGlobalListener, IMixedRealityPointerHandler, IMixedRealitySpeechHandler
+    internal class TestInputGlobalListener : InputSystemGlobalListener, IMixedRealityPointerHandler, IMixedRealitySpeechHandler
     {
         // Parameters, which are set by child classes
         protected bool useObjectBasedRegistration = false;
@@ -65,7 +65,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             {
                 base.OnDisable();
             }
-            else if(CoreServices.InputSystem != null)
+            else if (CoreServices.InputSystem != null)
             {
                 if (registerSpeechOnly)
                 {

--- a/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ConstraintTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return new WaitForFixedUpdate();
             yield return null;
-            
+
             const int numHandSteps = 1;
 
             // Hand pointing at middle of cube
@@ -646,7 +646,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return null;
 
             const int numHandSteps = 10;
-            
+
             TestHand leftHand = new TestHand(Handedness.Left);
             TestHand rightHand = new TestHand(Handedness.Right);
             yield return leftHand.Show(new Vector3(-0.05f, -0.1f, 0.45f));
@@ -685,7 +685,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator CombinedConstraintFarNear()
         {
             TestUtilities.PlayspaceToOriginLookingForward();
-            
+
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one * 0.2f;
             Vector3 originalPosition = Vector3.forward;
@@ -760,7 +760,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator ConstrainRotationFaceUser()
         {
             TestUtilities.PlayspaceToOriginLookingForward();
-            
+
             var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.localScale = Vector3.one * 0.2f;
             testObject.transform.position = Vector3.forward;

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             cube.transform.localScale = boundsControlStartScale;
             BoundsControl boundsControl = cube.AddComponent<BoundsControl>();
             TestUtilities.PlayspaceToOriginLookingForward();
-            boundsControl.Active = true; 
+            boundsControl.Active = true;
 
             return boundsControl;
         }
@@ -716,7 +716,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
             Assert.IsTrue(boundsControl.Active, "control should be active");
             Assert.IsFalse(boundsControl.WireframeOnly, "wireframeonly should be disabled");
-            
+
             yield return hand.MoveTo(pointOnCube);
             Assert.IsTrue(boundsControl.Active, "control should be active");
             Assert.IsTrue(boundsControl.WireframeOnly, "wireframeonly should be enabled");
@@ -901,7 +901,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             var defaultPadding = boundsControl.BoxPadding;
             var targetBoundsOriginal = boundsControl.TargetBounds; // this has the default padding already applied
             var targetBoundsSize = targetBoundsOriginal.size;
-            Vector3 targetBoundsScaleInv = new Vector3(1.0f/ targetBoundsOriginal.transform.lossyScale.x, 1.0f / targetBoundsOriginal.transform.lossyScale.y, 1.0f / targetBoundsOriginal.transform.lossyScale.z);
+            Vector3 targetBoundsScaleInv = new Vector3(1.0f / targetBoundsOriginal.transform.lossyScale.x, 1.0f / targetBoundsOriginal.transform.lossyScale.y, 1.0f / targetBoundsOriginal.transform.lossyScale.z);
 
             // set padding
             boundsControl.BoxPadding = Vector3.one * 0.5f;
@@ -996,7 +996,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         /// </summary>
         [UnityTest]
         public IEnumerator LinksRadiusTest()
-        { 
+        {
             var boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
 
@@ -1330,7 +1330,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             // check if new mesh filter was applied
             Assert.IsTrue(cornerMeshFilter.mesh.name.StartsWith(sharedMeshFilter.mesh.name), "sphere scale handle wasn't applied");
-            yield return null; 
+            yield return null;
         }
 
         /// <summary>
@@ -1360,7 +1360,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         private IEnumerator HandleMaterialTest(string handleVisualName, HandlesBaseConfiguration handleConfig, BoundsControl boundsControl)
-        { 
+        {
             // fetch rigroot, corner visual and rotation handle config
             GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
@@ -1450,7 +1450,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         {
             var boundsControl = InstantiateSceneAndDefaultBoundsControl();
             yield return VerifyInitialBoundsCorrect(boundsControl);
-            yield return HandleColliderPaddingTest("corner_3","corner_3/visualsScale/visuals", boundsControl.ScaleHandlesConfig, boundsControl);
+            yield return HandleColliderPaddingTest("corner_3", "corner_3/visualsScale/visuals", boundsControl.ScaleHandlesConfig, boundsControl);
         }
 
         /// <summary>
@@ -1467,7 +1467,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         private IEnumerator HandleColliderPaddingTest(string handleName, string handleVisualName, HandlesBaseConfiguration handleConfig, BoundsControl boundsControl)
-        { 
+        {
             // fetch rigroot, corner visual and rotation handle config
             GameObject rigRoot = boundsControl.transform.Find("rigRoot").gameObject;
             Assert.IsNotNull(rigRoot, "rigRoot couldn't be found");
@@ -1500,7 +1500,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
             // now adjust collider bounds and try grabbing the handle again
-            handleConfig.ColliderPadding = handleConfig.ColliderPadding  + newColliderPadding;
+            handleConfig.ColliderPadding = handleConfig.ColliderPadding + newColliderPadding;
             yield return new WaitForFixedUpdate();
             Assert.IsNotNull(rigRoot, "rigRoot got destroyed while configuring bounds control during runtime");
             Assert.IsNotNull(cornerVisual, "corner visual got destroyed when setting material");

--- a/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/FocusProviderTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Grab pointer is near grabbable
             Assert.IsTrue(grabPointer.IsNearObject, "Grab pointer should be near a grabbable");
-          
+
             // Head cursor invisible when grab pointer is near grabbable
             Assert.IsFalse(CoreServices.InputSystem.GazeProvider.GazeCursor.IsVisible, "Eye gaze cursor should not be visible");
 

--- a/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GltfTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
     {
         private const string AvocadoCustomAttrGuid = "fea29429b97dbb14b97820f56c74060a";
         private const string CubeCustomAttrGuid = "f0bb9fb635c69be4e8526b0fb6b48f39";
-        
+
         private AsyncCoroutineRunner asyncCoroutineRunner;
         [SetUp]
         public void Setup()
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             PlayModeTestUtilities.TearDown();
             GameObject.Destroy(asyncCoroutineRunner.gameObject);
         }
-        
+
         private IEnumerator WaitForTask(Task task)
         {
             while (!task.IsCompleted) { yield return null; }
@@ -100,7 +100,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int temperature = gltfObject.accessors[temperatureIdx].count;
             Assert.AreEqual(100, temperature);
         }
-        
+
         [UnityTest]
         public IEnumerator TestGltfCustomAttributesData()
         {
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
         #endregion
-        
+
     }
 }
 #endif

--- a/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/GridObjectCollectionTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             grid.CellWidth = 0.15f;
             grid.CellHeight = 0.15f;
 
-            for(int i = 0; i < 3; i++)
+            for (int i = 0; i < 3; i++)
             {
                 var child = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 child.transform.parent = go.transform;
@@ -93,18 +93,18 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Testing non-axis aligned anchors
             grid.AnchorAlongAxis = false;
             expectedIdx = 0;
-            foreach(LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
+            foreach (LayoutAnchor et in Enum.GetValues(typeof(LayoutAnchor)))
             {
                 grid.Anchor = et;
                 grid.UpdateCollection();
-                foreach(Transform childTransform in go.transform)
+                foreach (Transform childTransform in go.transform)
                 {
                     var expected = freeAnchorTestExpected[expectedIdx];
                     var actual = childTransform.transform.localPosition;
                     TestUtilities.AssertAboutEqual(
-                        actual, 
-                        expected, 
-                        "Child object not in expected position, layout " + et, 
+                        actual,
+                        expected,
+                        "Child object not in expected position, layout " + et,
                         0.01f);
                     expectedIdx++;
                 }
@@ -112,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
             yield return null;
         }
-        
+
         /// <summary>
         /// Tests that grid lays out object correctly for all different alignment options
         /// </summary>
@@ -270,9 +270,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             new Vector3(-0.075f, -0.150f, 0.75f), // Middle Vertical 1
             new Vector3(0.075f, -0.150f, 0.75f), // Top Vertical 2
         };
-    #endregion
-    
-    #endregion
+        #endregion
+
+        #endregion
     }
 }
 #endif

--- a/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputEventSystemTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 "Input event system doesn't contain expected event handler types.");
 
             CollectionAssert.AreEquivalent(
-                new HandleList { new Handle (handlerBasedListener, true) },
+                new HandleList { new Handle(handlerBasedListener, true) },
                 inputSystem.EventHandlersByType[typeof(IMixedRealitySpeechHandler)],
                 "Input event system doesn't contain expected IMixedRealitySpeechHandler handlers.");
 
@@ -205,30 +205,30 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             inputSystem.RaisePointerClicked(inputSystem.GazeProvider.GazePointer, MixedRealityInputAction.None, 1);
 
             Assert.AreEqual(objectBasedListener.pointerClickedCount, 1, "Pointer clicked event is not received by old API handler.");
-            Assert.Zero(objectBasedListener.pointerDownCount,           "Pointer down event is received by old API handler.");
-            Assert.Zero(objectBasedListener.pointerUpCount,             "Pointer up event is received by old API handler.");
-            Assert.Zero(objectBasedListener.pointerDraggedCount,        "Pointer dragged event is received by old API handler.");
-            Assert.Zero(objectBasedListener.speechCommandsReceived.Count(),                "Speech event is received by old API handler.");
+            Assert.Zero(objectBasedListener.pointerDownCount, "Pointer down event is received by old API handler.");
+            Assert.Zero(objectBasedListener.pointerUpCount, "Pointer up event is received by old API handler.");
+            Assert.Zero(objectBasedListener.pointerDraggedCount, "Pointer dragged event is received by old API handler.");
+            Assert.Zero(objectBasedListener.speechCommandsReceived.Count(), "Speech event is received by old API handler.");
 
             // Wrong behavior, preserved for backward compatibility
             Assert.AreEqual(handlerBasedListener.pointerClickedCount, 1, "Pointer clicked event is not received by new API handler.");
-            Assert.Zero(handlerBasedListener.pointerDownCount,           "Pointer down event is received by new  API handler.");
-            Assert.Zero(handlerBasedListener.pointerUpCount,             "Pointer up event is received by new API handler.");
-            Assert.Zero(handlerBasedListener.pointerDraggedCount,        "Pointer dragged event is received by new API handler.");
-            Assert.Zero(handlerBasedListener.speechCommandsReceived.Count(),                "Speech event is received by new API handler.");
+            Assert.Zero(handlerBasedListener.pointerDownCount, "Pointer down event is received by new  API handler.");
+            Assert.Zero(handlerBasedListener.pointerUpCount, "Pointer up event is received by new API handler.");
+            Assert.Zero(handlerBasedListener.pointerDraggedCount, "Pointer dragged event is received by new API handler.");
+            Assert.Zero(handlerBasedListener.speechCommandsReceived.Count(), "Speech event is received by new API handler.");
 
             Assert.AreEqual(handlerBasedListener1.pointerClickedCount, 1, "Pointer clicked event is not received by all-handlers component.");
-            Assert.Zero(handlerBasedListener1.pointerDownCount,           "Pointer down event is received by all-handlers component.");
-            Assert.Zero(handlerBasedListener1.pointerUpCount,             "Pointer up event is received by all-handlers component.");
-            Assert.Zero(handlerBasedListener1.pointerDraggedCount,        "Pointer dragged event is received by all-handlers component.");
-            Assert.Zero(handlerBasedListener1.speechCommandsReceived.Count(),                "Speech event is received by all-handlers component.");
+            Assert.Zero(handlerBasedListener1.pointerDownCount, "Pointer down event is received by all-handlers component.");
+            Assert.Zero(handlerBasedListener1.pointerUpCount, "Pointer up event is received by all-handlers component.");
+            Assert.Zero(handlerBasedListener1.pointerDraggedCount, "Pointer dragged event is received by all-handlers component.");
+            Assert.Zero(handlerBasedListener1.speechCommandsReceived.Count(), "Speech event is received by all-handlers component.");
 
             // No pointer clicked event:
-            Assert.Zero(handlerBasedListener2.pointerClickedCount,        "Pointer clicked event is received by speech-handler component.");
-            Assert.Zero(handlerBasedListener2.pointerDownCount,           "Pointer down event is received by speech-handler component.");
-            Assert.Zero(handlerBasedListener2.pointerUpCount,             "Pointer up event is received by speech-handler component.");
-            Assert.Zero(handlerBasedListener2.pointerDraggedCount,        "Pointer dragged event is received by speech-handler component.");
-            Assert.Zero(handlerBasedListener2.speechCommandsReceived.Count(),                "Speech event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.pointerClickedCount, "Pointer clicked event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.pointerDownCount, "Pointer down event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.pointerUpCount, "Pointer up event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.pointerDraggedCount, "Pointer dragged event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.speechCommandsReceived.Count(), "Speech event is received by speech-handler component.");
 
             Object.Destroy(object1);
             Object.Destroy(object2);
@@ -266,27 +266,27 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
 
             Assert.Zero(objectBasedListener.pointerClickedCount, "Pointer clicked event is received by old API handler.");
-            Assert.Zero(objectBasedListener.pointerDownCount,    "Pointer down event is received by old API handler.");
-            Assert.Zero(objectBasedListener.pointerUpCount,      "Pointer up event is received by old API handler.");
+            Assert.Zero(objectBasedListener.pointerDownCount, "Pointer down event is received by old API handler.");
+            Assert.Zero(objectBasedListener.pointerUpCount, "Pointer up event is received by old API handler.");
             Assert.Zero(objectBasedListener.pointerDraggedCount, "Pointer dragged event is received by old API handler.");
             Assert.True(objectBasedListener.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly by old API handler.");
 
             Assert.Zero(handlerBasedListener.pointerClickedCount, "Pointer clicked event is received by new API handler.");
-            Assert.Zero(handlerBasedListener.pointerDownCount,    "Pointer down event is received by new  API handler.");
-            Assert.Zero(handlerBasedListener.pointerUpCount,      "Pointer up event is received by new API handler.");
+            Assert.Zero(handlerBasedListener.pointerDownCount, "Pointer down event is received by new  API handler.");
+            Assert.Zero(handlerBasedListener.pointerUpCount, "Pointer up event is received by new API handler.");
             Assert.Zero(handlerBasedListener.pointerDraggedCount, "Pointer dragged event is received by new API handler.");
             Assert.True(handlerBasedListener.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly by new API handler.");
 
             Assert.Zero(handlerBasedListener1.pointerClickedCount, "Pointer clicked event is received by all-handlers component.");
-            Assert.Zero(handlerBasedListener1.pointerDownCount,    "Pointer down event is received by all-handlers component.");
-            Assert.Zero(handlerBasedListener1.pointerUpCount,      "Pointer up event is received by all-handlers component.");
+            Assert.Zero(handlerBasedListener1.pointerDownCount, "Pointer down event is received by all-handlers component.");
+            Assert.Zero(handlerBasedListener1.pointerUpCount, "Pointer up event is received by all-handlers component.");
             Assert.Zero(handlerBasedListener1.pointerDraggedCount, "Pointer dragged event is received by all-handlers component.");
             Assert.True(handlerBasedListener1.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly by all-handlers component");
 
             // No pointer clicked event:
             Assert.Zero(handlerBasedListener2.pointerClickedCount, "Pointer clicked event is received by speech-handler component.");
-            Assert.Zero(handlerBasedListener2.pointerDownCount,    "Pointer down event is received by speech-handler component.");
-            Assert.Zero(handlerBasedListener2.pointerUpCount,      "Pointer up event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.pointerDownCount, "Pointer down event is received by speech-handler component.");
+            Assert.Zero(handlerBasedListener2.pointerUpCount, "Pointer up event is received by speech-handler component.");
             Assert.Zero(handlerBasedListener2.pointerDraggedCount, "Pointer dragged event is received by speech-handler component.");
             Assert.True(handlerBasedListener2.speechCommandsReceived.SequenceEqual(commandList.Select(x => x.Keyword)), "Speech events were not received correctly by speech-handler component.");
 

--- a/Assets/MRTK/Tests/PlayModeTests/InputRayUtilsTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputRayUtilsTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             TestContext.Out.WriteLine($"origin: {ray.origin}");
             Assert.True(ray.origin == Vector3.zero);
             TestContext.Out.WriteLine($"direction: {ray.direction}");
-            Assert.True(ray.direction == new Vector3(0.0f, 0.0f, -1.0f)); 
+            Assert.True(ray.direction == new Vector3(0.0f, 0.0f, -1.0f));
         }
 
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/InputSystem/DisableEnableInputSystemTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
         {
             PlayModeTestUtilities.TearDown();
         }
-        
+
         [UnityTest]
         public IEnumerator DisableEnableInputSystem()
         {

--- a/Assets/MRTK/Tests/PlayModeTests/LoadingIndicatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/LoadingIndicatorTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingObject.prefab
         private const string progressIndicatorRotatingObjectPrefabGuid = "274fde8ad8cd85a4a88acb4c2c892028";
         private static readonly string progressIndicatorRotatingObjectPrefabPath = AssetDatabase.GUIDToAssetPath(progressIndicatorRotatingObjectPrefabGuid);
-        
+
         // SDK/Features/UX/Prefabs/ProgressIndicators/ProgressIndicatorRotatingOrbs.prefab
         private const string progressIndicatorRotatingOrbsPrefabGuid = "65fa42bb01c733c42b05a4e91628f494";
         private static readonly string progressIndicatorRotatingOrbsPrefabPath = AssetDatabase.GUIDToAssetPath(progressIndicatorRotatingOrbsPrefabGuid);

--- a/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ManipulationHandlerTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // This particular test is sensitive to the number of steps that a hand is moving,
             // so it's set to 30 to override the default amount.
             int numSteps = 30;
-            
+
             Vector3 handOffset = new Vector3(0, 0, 0.1f);
             Vector3 initialHandPosition = new Vector3(0, 0, 0.5f);
             Vector3 rightPosition = new Vector3(1f, 0f, 1f);
@@ -418,7 +418,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Hand pointing at middle of cube
             Vector3 initialHandPosition = new Vector3(0.044f, -0.1f, 0.45f);
-            TestHand hand = new TestHand(Handedness.Right);     
+            TestHand hand = new TestHand(Handedness.Right);
 
             // do this test for every one hand rotation mode
             foreach (ManipulationHandler.RotateInOneHandType type in Enum.GetValues(typeof(ManipulationHandler.RotateInOneHandType)))
@@ -437,7 +437,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
                 yield return hand.Show(initialHandPosition);
                 yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
-               
+
                 yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
                 // save relative pos grab point to object - for far interaction we need to check the grab point where the pointer ray hits the manipulated object
@@ -700,7 +700,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                     p.LookAt(rotatedFwd);
                 });
                 yield return null;
-                
+
                 Vector3 newHandPosition = Quaternion.AngleAxis(testRotation, Vector3.up) * rightHandFarPos;
                 yield return rightHand.MoveTo(newHandPosition, numSteps);
                 RecordTransform(testObject.transform, "one hand rotate far");
@@ -803,7 +803,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator ManipulationHandlerMinMaxScale()
         {
-            float initialScale =  0.2f;
+            float initialScale = 0.2f;
             float minScale = 0.5f;
             float maxScale = 2f;
 
@@ -886,11 +886,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var manipHandler = testObject.AddComponent<ManipulationHandler>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            
+
             Vector3 originalHandPosition = new Vector3(0, 0, 0.5f);
             TestHand hand = new TestHand(Handedness.Right);
             const int numHandSteps = 1;
-            
+
             // Grab cube
             yield return hand.Show(originalHandPosition);
 
@@ -946,12 +946,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var manipHandler = testObject.AddComponent<ManipulationHandler>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            
+
             TestHand hand = new TestHand(Handedness.Right);
             const int numHandSteps = 1;
-            
+
             float expectedDist = Vector3.Distance(testObject.transform.position, CameraCache.Main.transform.position);
-            
+
             yield return hand.Show(CameraCache.Main.transform.position);
             yield return null;
 
@@ -1124,7 +1124,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int manipulationEndedCount = 0;
             manipHandler.OnManipulationStarted.AddListener((med) => manipulationStartedCount++);
             manipHandler.OnManipulationEnded.AddListener((med) => manipulationEndedCount++);
-            
+
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);
 
@@ -1151,7 +1151,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(1, manipulationStartedCount);
             Assert.AreEqual(1, manipulationEndedCount);
         }
-        
+
         /// <summary>
         /// Test that OnManipulationStarted and OnManipulationEnded events call as expected
         /// for Two Handed Only.

--- a/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/NearInteractionTouchableTests.cs
@@ -190,14 +190,14 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return testHand.MoveTo(objectPosition);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(1, catcher.EventsCompleted);
-                yield return testHand.MoveTo(backPosition);              
+                yield return testHand.MoveTo(backPosition);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
                 Assert.Greater(catcher.DragEventCount, 1);
                 int dragEventCount = catcher.DragEventCount;
 
                 // No touch when moving at behind the plane
-                yield return testHand.MoveTo(rightPosition);              
+                yield return testHand.MoveTo(rightPosition);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
                 Assert.AreEqual(dragEventCount, catcher.DragEventCount, "No drag events should fire when poke pointer moving behind plane");
@@ -247,12 +247,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 yield return testHand.MoveTo(objectPosition);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(1, catcher.EventsCompleted);
-                yield return testHand.MoveTo(backPosition);              
+                yield return testHand.MoveTo(backPosition);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
 
                 // No touch when moving at behind the plane
-                yield return testHand.MoveTo(rightPosition);              
+                yield return testHand.MoveTo(rightPosition);
                 Assert.AreEqual(2, catcher.EventsStarted);
                 Assert.AreEqual(2, catcher.EventsCompleted);
 
@@ -276,7 +276,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator NearInteractionTouchableVolumeVariant()
         {
             var touchable = CreateTouchable<NearInteractionTouchableVolume>(Vector3.one);
-            
+
             yield return new WaitForFixedUpdate();
             yield return null;
 

--- a/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ObjectManipulatorTests.cs
@@ -360,7 +360,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Hand pointing at middle of cube
             Vector3 initialHandPosition = new Vector3(0.044f, -0.1f, 0.45f);
-            TestHand hand = new TestHand(Handedness.Right);  
+            TestHand hand = new TestHand(Handedness.Right);
 
             // do this test for every one hand rotation mode
             foreach (ObjectManipulator.RotateInOneHandType type in Enum.GetValues(typeof(ObjectManipulator.RotateInOneHandType)))
@@ -436,17 +436,17 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             // set up cube with manipulation handler
             GameObject parentObject = new GameObject("Test Object Parent");
-            
+
             // In case of error, this object won't be cleaned up, so clean up at the end of the test
             cleanupAction.Add(() => { if (parentObject != null) UnityEngine.Object.Destroy(parentObject); });
-            
+
             GameObject testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
             testObject.transform.parent = parentObject.transform;
 
             // Rotate the parent object, as we differ when constraining on local vs world
             Quaternion initialQuaternion = Quaternion.Euler(30f, 30f, 30f);
             parentObject.transform.rotation = initialQuaternion;
-            
+
             testObject.transform.localScale = Vector3.one * 0.2f;
             Vector3 initialObjectPosition = new Vector3(0f, 0f, 1f);
             testObject.transform.position = initialObjectPosition;
@@ -562,7 +562,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
             yield return hand.Hide();
-            
+
             UnityEngine.Object.Destroy(parentObject);
         }
 
@@ -639,7 +639,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                     p.LookAt(rotatedFwd);
                 });
                 yield return null;
-                
+
                 Vector3 newHandPosition = Quaternion.AngleAxis(testRotation, Vector3.up) * rightHandFarPos;
                 yield return rightHand.MoveTo(newHandPosition);
                 RecordTransform(testObject.transform, "one hand rotate far");
@@ -760,7 +760,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var manipHandler = testObject.AddComponent<ObjectManipulator>();
             manipHandler.HostTransform = testObject.transform;
             manipHandler.SmoothingActive = false;
-            
+
             Vector3 originalHandPosition = new Vector3(0, 0, 0.5f);
             TestHand hand = new TestHand(Handedness.Right);
             const int numHandSteps = 1;
@@ -968,8 +968,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             TestUtilities.AssertAboutEqual(originalObjectPos, testObject.transform.position, "Object moved after it was disabled");
         }
-		
-		/// <summary>
+
+        /// <summary>
         /// Test that OnManipulationStarted and OnManipulationEnded events call as expected
         /// for various One Handed Only.
         /// </summary>
@@ -993,7 +993,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int manipulationEndedCount = 0;
             manipHandler.OnManipulationStarted.AddListener((med) => manipulationStartedCount++);
             manipHandler.OnManipulationEnded.AddListener((med) => manipulationEndedCount++);
-            
+
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);
 
@@ -1020,8 +1020,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(1, manipulationStartedCount);
             Assert.AreEqual(1, manipulationEndedCount);
         }
-		
-		/// <summary>
+
+        /// <summary>
         /// Test that OnManipulationStarted and OnManipulationEnded events call as expected
         /// for Two Handed Only.
         /// </summary>
@@ -1045,7 +1045,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int manipulationEndedCount = 0;
             manipHandler.OnManipulationStarted.AddListener((med) => manipulationStartedCount++);
             manipHandler.OnManipulationEnded.AddListener((med) => manipulationEndedCount++);
-            
+
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);
 
@@ -1072,8 +1072,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.AreEqual(1, manipulationStartedCount);
             Assert.AreEqual(1, manipulationEndedCount);
         }
-		
-		/// <summary>
+
+        /// <summary>
         /// Test that OnManipulationStarted and OnManipulationEnded events call as expected
         /// for One Handed and Two Handed.
         /// </summary>
@@ -1097,7 +1097,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             int manipulationEndedCount = 0;
             manipHandler.OnManipulationStarted.AddListener((med) => manipulationStartedCount++);
             manipHandler.OnManipulationEnded.AddListener((med) => manipulationEndedCount++);
-            
+
             TestHand rightHand = new TestHand(Handedness.Right);
             TestHand leftHand = new TestHand(Handedness.Left);
 
@@ -1165,7 +1165,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var backgroundmaterial = new Material(StandardShaderUtility.MrtkStandardShader);
             backgroundmaterial.color = Color.green;
             backgroundObject.GetComponent<MeshRenderer>().material = backgroundmaterial;
-            
+
             const int numHandSteps = 10;
             TestHand hand = new TestHand(Handedness.Right);
             yield return hand.Show(new Vector3(0.1f, -0.1f, 0.5f));

--- a/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerProfileTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string eyeTrackingConfigurationProfileGuid = "6615cacb3eaaa044f99b917186093aeb";
 
         private static readonly string eyeTrackingConfigurationProfilePath = AssetDatabase.GUIDToAssetPath(eyeTrackingConfigurationProfileGuid);
-        
+
         [SetUp]
         public void Setup()
         {
@@ -26,7 +26,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             PlayModeTestUtilities.TearDown();
         }
-        
+
         // <summary>
         /// Verifies if eye tracking configuration is correctly applied at gaze provider initialization.
         /// </summary>
@@ -43,6 +43,6 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             MixedRealityToolkit.Instance.ResetConfiguration(profile);
 
             Assert.IsTrue(eyeGazeProvider.IsEyeTrackingEnabled, "Use eye tracking should be set to true");
-        }       
+        }
     }
 }

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             testObjects.handler.TrackedTargetType = TrackedObjectType.HandJoint;
             testObjects.handler.TrackedHandness = Handedness.Both;
 
-            var handConstraintSolver = (HandConstraintPalmUp) testObjects.solver;
+            var handConstraintSolver = (HandConstraintPalmUp)testObjects.solver;
             handConstraintSolver.FollowHandUntilFacingCamera = true;
             handConstraintSolver.UseGazeActivation = false;
 
@@ -327,7 +327,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Place hand 1 meter in front of user, 50 cm below eye level
             var handTestPos = cameraTransform.position + cameraTransform.forward - (Vector3.up * 0.5f);
-            
+
             var cameraLookVector = (handTestPos - cameraTransform.position).normalized;
 
             // Generate hand rotation with hand palm facing camera
@@ -358,7 +358,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return new WaitForSeconds(SolverUpdateWaitTime);
         }
-        
+
         /// <summary>
         /// Test the HandConstraintPalm up to make sure the activation methods work as intended for the Ulnar safe zone
         /// </summary>
@@ -450,21 +450,21 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return leftHand.SetRotation(handRotation);
 
-            TestHand rightHand = new TestHand(Handedness.Right);            
+            TestHand rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(new Vector3(0, 0, 0.5f));
             yield return null;
 
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
             yield return rightHand.Move(testObjects.target.transform.position);
             yield return null;
-            
+
             yield return rightHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             yield return new WaitForFixedUpdate();
             yield return null;
 
 
             var delta = new Vector3(0.5f, 0.5f, 0f);
-            yield return rightHand.Move(delta);            
+            yield return rightHand.Move(delta);
 
             // Grab the menu position to compare it later on
             Vector3 menuPosition = testObjects.target.transform.position;
@@ -481,7 +481,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Before the right hand opens, make sure that the transform of the attached menu is farther than it would if attached
             Assert.IsTrue((testObjects.target.transform.position - movedLeftHand).sqrMagnitude > .1f);
-            
+
             // Then move the left hand back to the point of activation
             yield return leftHand.Move(handTestPos);
             yield return leftHand.SetRotation(handRotation);
@@ -516,7 +516,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var leftHand = new TestHand(Handedness.Left);
             yield return leftHand.Show(handPosition);
             yield return leftHand.SetRotation(handRotation);
-            
+
             yield return WaitForFrames(2);
             var hand = PlayModeTestUtilities.GetInputSimulationService().GetHandDevice(Handedness.Left);
             Assert.IsNotNull(hand);
@@ -713,7 +713,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
             tapToPlaceObj.target.transform.position = Vector3.forward;
             TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
-            
+
             // Start Placing the object immediately
             tapToPlace.AutoStart = true;
 
@@ -823,7 +823,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             const float ANGLE_THRESHOLD = 30.0f;
 
             var directionTarget = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
-            directionTarget.transform.position = 10.0f * Vector3.right; 
+            directionTarget.transform.position = 10.0f * Vector3.right;
 
             // Instantiate our test gameobject with solver.
             var testObjects = InstantiateTestSolver<DirectionalIndicator>();
@@ -961,7 +961,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return new WaitForFixedUpdate();
             yield return null;
-            
+
             Assert.AreEqual(targetTransform.rotation, Quaternion.identity, "Target rotated before we moved beyond the deadzone");
 
             MixedRealityPlayspace.PerformTransformation(p => p.RotateAround(Vector3.zero, Vector3.up, 45));
@@ -1015,7 +1015,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return new WaitForFixedUpdate();
             yield return null;
-            
+
             Assert.LessOrEqual(Mathf.Abs(xAngle()), maxXAngle, "Follow exceeded the max horizontal angular bounds");
             Assert.LessOrEqual(Mathf.Abs(yAngle()), maxYAngle, "Follow exceeded the max vertical angular bounds");
 
@@ -1026,7 +1026,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.LessOrEqual(Mathf.Abs(xAngle()), maxXAngle, "Follow exceeded the max horizontal angular bounds");
             Assert.LessOrEqual(Mathf.Abs(yAngle()), maxYAngle, "Follow exceeded the max vertical angular bounds");
-            
+
             // Test x axis rotation
             MixedRealityPlayspace.PerformTransformation(p => p.Rotate(Vector3.right, 45));
             yield return new WaitForFixedUpdate();
@@ -1099,7 +1099,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         private IEnumerator TestHandSolver(SetupData testData, InputSimulationService inputSimulationService, Vector3 handPos, Handedness hand)
         {
-            Assert.IsTrue(testData.handler.TrackedTargetType == TrackedObjectType.ControllerRay 
+            Assert.IsTrue(testData.handler.TrackedTargetType == TrackedObjectType.ControllerRay
                 || testData.handler.TrackedTargetType == TrackedObjectType.HandJoint, "TestHandSolver supports on ControllerRay and HandJoint tracked target types");
 
             yield return PlayModeTestUtilities.ShowHand(hand, inputSimulationService, Utilities.ArticulatedHandPose.GestureId.Open, handPos);
@@ -1123,7 +1123,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             Assert.AreEqual(testData.handler.CurrentTrackedHandedness, hand);
             Assert.IsNotNull(expectedTransform);
-            
+
             // SolverHandler creates a dummy GameObject to provide a transform for tracking so it can be managed (allocated/deleted)
             // Look at the parent to compare transform equality for what we should be tracking against
             Assert.AreEqual(testData.handler.TransformTarget.parent, expectedTransform);
@@ -1133,7 +1133,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return WaitForFrames(2);
         }
 
-        private SetupData InstantiateTestSolver<T>() where T: Solver
+        private SetupData InstantiateTestSolver<T>() where T : Solver
         {
             var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.name = typeof(T).Name;
@@ -1144,7 +1144,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             SolverHandler handler = cube.GetComponent<SolverHandler>();
             Assert.IsNotNull(handler, "GetComponent<SolverHandler>() returned null");
 
-           var setupData =  new SetupData()
+            var setupData = new SetupData()
             {
                 handler = handler,
                 solver = solver,
@@ -1190,7 +1190,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             testObjects.handler.TrackedTargetType = TrackedObjectType.HandJoint;
             testObjects.handler.TrackedHandness = Handedness.Both;
 
-            var handConstraintSolver = (HandConstraintPalmUp) testObjects.solver;
+            var handConstraintSolver = (HandConstraintPalmUp)testObjects.solver;
             handConstraintSolver.FollowHandUntilFacingCamera = true;
             handConstraintSolver.UseGazeActivation = true;
 
@@ -1237,8 +1237,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <returns>The Vector3 representing where the hand should be positioned to during the test to trigger the activation</returns>
         private Vector3 DetermineHandOriginPositionOffset(HandConstraint.SolverSafeZone safeZone, Handedness targetHandedness)
         {
-            switch(safeZone)
-            {   
+            switch (safeZone)
+            {
                 case HandConstraint.SolverSafeZone.RadialSide:
                     if (targetHandedness == Handedness.Left)
                     {
@@ -1268,7 +1268,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             }
         }
 
-#endregion
+        #endregion
     }
 }
 #endif

--- a/Assets/MRTK/Tests/PlayModeTests/SpeechTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpeechTests.cs
@@ -55,10 +55,10 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             // Toggle the profiler visualization off.
             var gazeInputSource = CoreServices.InputSystem.DetectedInputSources.Where(x => x.SourceName.Equals("Gaze")).First();
             CoreServices.InputSystem.RaiseSpeechCommandRecognized(
-                gazeInputSource, 
-                RecognitionConfidenceLevel.High, 
-                new TimeSpan(), 
-                DateTime.Now, 
+                gazeInputSource,
+                RecognitionConfidenceLevel.High,
+                new TimeSpan(),
+                DateTime.Now,
                 new SpeechCommands("toggle profiler", KeyCode.Alpha9, MixedRealityInputAction.None));
             // It may take a few frames before the event is handled and the system responds to the state change.
             for (int i = 0; i < frameDelay; i++) { yield return null; }

--- a/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SpherePointerTests.cs
@@ -52,11 +52,11 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var grabbable = cube.AddComponent<NearInteractionGrabbable>();
             Assert.IsNotNull(grabbable);
-            
+
             float overlapCenterZ = centerZ;
             overlapRect = GameObject.CreatePrimitive(PrimitiveType.Cube);
             overlapRect.transform.localPosition = new Vector3(0, 0, overlapCenterZ);
-            overlapRect.transform.localScale = new Vector3(1.5f,1.5f,1f) * scale;
+            overlapRect.transform.localScale = new Vector3(1.5f, 1.5f, 1f) * scale;
             overlapRect.SetActive(false);
 
             var overlapCollider = overlapRect.GetComponentInChildren<Collider>();

--- a/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/UserInputSimulationTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             cube.transform.localScale = new Vector3(.2f, .2f, .2f);
 
             interactable = cube.AddComponent<Interactable>();
-            
+
             KeyInputSystem.StartKeyInputStimulation();
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Input
             KeyInputSystem.StopKeyInputSimulation();
             PlayModeTestUtilities.TearDown();
         }
-        
+
         [UnityTest]
         public IEnumerator InputSimulationHandsFreeInteraction()
         {

--- a/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/VisualThemeTests.cs
@@ -307,12 +307,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             };
 
             yield return TestTheme<ScaleOffsetColorTheme, MeshRenderer>(defaultStateValues,
-                (host, theme) => 
+                (host, theme) =>
                 {
                     Assert.AreEqual(Vector3.one, host.transform.localScale);
                     Assert.AreEqual(Vector3.zero, host.transform.position);
                 },
-                (theme) => 
+                (theme) =>
                 {
                     Assert.AreEqual(state0, theme.Host.transform.localScale);
                     Assert.AreEqual(state0Offset, theme.Host.transform.position);
@@ -376,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return TestTheme<InteractableColorChildrenTheme, AudioSource>(parent,
                 defaultStateValues,
-                (host, theme) => 
+                (host, theme) =>
                 {
                     foreach (Transform child in host.transform)
                     {
@@ -445,7 +445,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             };
 
             yield return TestTheme<InteractableStringTheme, Text>(defaultStateValues,
-                (host,theme) => { Assert.AreEqual(string.Empty, host.GetComponent<Text>().text); },
+                (host, theme) => { Assert.AreEqual(string.Empty, host.GetComponent<Text>().text); },
                 (theme) => { Assert.AreEqual(State0, theme.Host.GetComponent<Text>().text); },
                 (theme) => { Assert.AreEqual(State1, theme.Host.GetComponent<Text>().text); });
 

--- a/Assets/MRTK/Tests/TestUtilities/TestHand.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestHand.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         {
             Vector3 oldPosition = position;
             position = newPosition;
-            for (var iter = PlayModeTestUtilities.MoveHand(oldPosition, newPosition, gestureId, handedness, simulationService, numSteps); iter.MoveNext(); )
+            for (var iter = PlayModeTestUtilities.MoveHand(oldPosition, newPosition, gestureId, handedness, simulationService, numSteps); iter.MoveNext();)
             {
                 yield return iter.Current;
             }
@@ -106,7 +106,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// </param>
         public IEnumerator Move(Vector3 delta, int numSteps = PlayModeTestUtilities.HandMoveStepsSentinelValue)
         {
-            for (var iter = MoveTo(position + delta, PlayModeTestUtilities.CalculateNumSteps(numSteps)); iter.MoveNext(); )
+            for (var iter = MoveTo(position + delta, PlayModeTestUtilities.CalculateNumSteps(numSteps)); iter.MoveNext();)
             {
                 yield return iter.Current;
             }
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         public IEnumerator SetGesture(ArticulatedHandPose.GestureId newGestureId, bool waitForFixedUpdate = true)
         {
             gestureId = newGestureId;
-            for (var iter = PlayModeTestUtilities.MoveHand(position, position, gestureId, handedness, simulationService, 1); iter.MoveNext(); )
+            for (var iter = PlayModeTestUtilities.MoveHand(position, position, gestureId, handedness, simulationService, 1); iter.MoveNext();)
             {
                 yield return iter.Current;
             }
@@ -170,15 +170,15 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <param name="numSteps">Number of steps of the hand movement</param>
         public IEnumerator GrabAndThrowAt(Vector3 positionToRelease, bool waitForFinalFixedUpdate, int numSteps = 30)
         {
-            for (var iter = SetGesture(ArticulatedHandPose.GestureId.Pinch); iter.MoveNext(); )
+            for (var iter = SetGesture(ArticulatedHandPose.GestureId.Pinch); iter.MoveNext();)
             {
                 yield return iter.Current;
             }
-            for (var iter = MoveTo(positionToRelease, numSteps); iter.MoveNext(); )
+            for (var iter = MoveTo(positionToRelease, numSteps); iter.MoveNext();)
             {
                 yield return iter.Current;
             }
-            for (var iter = SetGesture(ArticulatedHandPose.GestureId.Open, waitForFinalFixedUpdate); iter.MoveNext(); )
+            for (var iter = SetGesture(ArticulatedHandPose.GestureId.Open, waitForFinalFixedUpdate); iter.MoveNext();)
             {
                 yield return iter.Current;
             }

--- a/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
+++ b/Assets/MRTK/Tests/TestUtilities/TestUtilities.cs
@@ -248,7 +248,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
                 Debug.Log("Couldn't find test icon.");
                 return;
             }
-            
+
             IEnumerable<string> testDirectories = MixedRealityToolkitFiles.GetDirectories(MixedRealityToolkitModuleType.Tests);
 
             foreach (string directory in testDirectories)

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -57,9 +57,9 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private static readonly string[] TARGET_DEVICE_OPTIONS = { "Any Device", "PC", "Mobile", "HoloLens" };
 
-        private static readonly string[] ARCHITECTURE_OPTIONS = { 
-            "x86", 
-            "x64", 
+        private static readonly string[] ARCHITECTURE_OPTIONS = {
+            "x86",
+            "x64",
             "ARM",
             #if UNITY_2019_1_OR_NEWER
             "ARM64"
@@ -70,7 +70,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private static readonly string[] PLATFORM_TOOLSET_NAMES = { "Solution", "v141", "v142" };
 
-        private static readonly string[] LocalRemoteOptions = { "Local", "Remote"};
+        private static readonly string[] LocalRemoteOptions = { "Local", "Remote" };
 
         private static readonly List<string> Builds = new List<string>(0);
 
@@ -872,7 +872,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                                     {
                                         EditorApplication.delayCall += () =>
                                         {
-                                            ExecuteAction((DeviceInfo connection) 
+                                            ExecuteAction((DeviceInfo connection)
                                                 => InstallAppOnDeviceAsync(fullBuildLocation, connection));
                                         };
                                     }
@@ -881,7 +881,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                                     {
                                         EditorApplication.delayCall += () =>
                                         {
-                                            ExecuteAction((DeviceInfo connection) 
+                                            ExecuteAction((DeviceInfo connection)
                                                 => UninstallAppOnDeviceAsync(connection));
                                         };
                                     }
@@ -1061,7 +1061,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                         foreach (var address in adapter.IpAddresses)
                         {
                             string ipAddress = address.IpAddress;
-                            if (IsValidIpAddress(ipAddress) 
+                            if (IsValidIpAddress(ipAddress)
                                 && !portalConnections.Connections.Any(connection => connection.IP == ipAddress))
                             {
                                 Debug.Log($"Adding new IP {ipAddress} for local hololens {machineName.ComputerName} to remote connection list");
@@ -1162,7 +1162,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 {
                     string fullBuildLocation = CalcMostRecentBuild();
 
-                    await ExecuteActionAsync((DeviceInfo connection) 
+                    await ExecuteActionAsync((DeviceInfo connection)
                         => InstallAppOnDeviceAsync(fullBuildLocation, connection));
                 }
             }
@@ -1290,7 +1290,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 ipAddr = portSegments[0];
             }
 
-            return ipAddr.Split('.').Length == 4 && !ipAddr.Contains(EMPTY_IP_ADDRESS) && 
+            return ipAddr.Split('.').Length == 4 && !ipAddr.Contains(EMPTY_IP_ADDRESS) &&
                 (IPAddress.TryParse(ipAddr, out IPAddress address) || ipAddr.Contains(DeviceInfo.LocalMachine));
         }
 

--- a/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
+++ b/Assets/MRTK/Tools/DependencyWindow/DependencyWindow.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 excludeUnityScenes = EditorGUILayout.Toggle("Exclude Unity Scenes", excludeUnityScenes);
 
                 string tooltip = "Although certain asset types may not be directly referenced by other assets as tracked via Unity meta files, these assets may be utilized and/or necessary to a project in other ways.\n\nThus, this list of asset extensions are ignored and always excluded in the list below.\n\n";
-                foreach(string extension in assetsWhichCanBeUnreferenced)
+                foreach (string extension in assetsWhichCanBeUnreferenced)
                 {
                     tooltip += extension + "\n";
                 }

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -432,7 +432,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 {
                     AssetDatabase.CreateFolder("Assets", DefaultGeneratedFolderName);
                 }
-                
+
                 AssetDatabase.CreateFolder(generatedFolder, DefaultExtensionsFolderName);
                 AssetDatabase.Refresh();
 
@@ -463,7 +463,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             {
                 errors.Add("Name must end with 'Service' suffix.");
             }
-            
+
             if (!CSharpCodeProvider.CreateProvider("C#").IsValidIdentifier(ServiceName))
             {
                 errors.Add("Name must not contain illegal characters.");

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceWizard.cs
@@ -341,7 +341,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             if (!registered)
             {
                 EditorGUILayout.LabelField("Would you like to register this service in your current MixedRealityToolkit profile?", EditorStyles.miniLabel);
-                
+
                 // Check to see whether it's possible to register the profile
                 bool canRegisterProfile = true;
                 if (MixedRealityToolkit.Instance == null || !MixedRealityToolkit.Instance.HasActiveProfile)

--- a/Assets/MRTK/Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/AssemblyDefinitionInfo.cs
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         /// Gets whether this is marked as a TestAssembly.
         /// </summary>
         public bool TestAssembly { get; private set; }
-        
+
         /// <summary>
         /// Gets whether this is a default assembly definition like Assembly-CSharp
         /// </summary>

--- a/Assets/MRTK/Tools/MSBuild/Scripts/TargetFramework.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/TargetFramework.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
         Net20,
         Net46
     }
-    
+
     /// <summary>
     /// Helper extensions for the <see cref="TargetFramework"/> enum.
     /// </summary>

--- a/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
+++ b/Assets/MRTK/Tools/MigrationWindow/MigrationWindow.cs
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             migrationHandlerTypeNames = migrationTypeNamesList.ToArray();
 
             selectedMigrationHandlerIndex = 0;
-            
+
             failIcon = (Texture)AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(failIconGUID), typeof(Texture));
             passIcon = (Texture)AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(passIconGUID), typeof(Texture));
             lightTabIcon = (Texture)AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(lightTabIconGUID), typeof(Texture));
@@ -284,14 +284,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                             }
                         }
                     }
-                    
+
                     else if (migrationTool.MigrationState == MigrationTool.MigrationToolState.PostMigration && !String.IsNullOrEmpty(migrationLog))
                     {
                         using (var logScrollView = new EditorGUILayout.ScrollViewScope(logScrollPosition))
                         {
                             logScrollPosition = logScrollView.scrollPosition;
                             GUILayout.TextArea(migrationLog);
-                        }                    
+                        }
                     }
                 }
             }

--- a/Assets/MRTK/Tools/TextureCombinerWindow/TextureCombinerWindow.cs
+++ b/Assets/MRTK/Tools/TextureCombinerWindow/TextureCombinerWindow.cs
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             }
             else
             {
-                smoothnessMap = ((int)standardMaterial.GetFloat("_SmoothnessTextureChannel") == 0) ? (Texture2D)standardMaterial.GetTexture("_SpecGlossMap") : 
+                smoothnessMap = ((int)standardMaterial.GetFloat("_SmoothnessTextureChannel") == 0) ? (Texture2D)standardMaterial.GetTexture("_SpecGlossMap") :
                                                                                                      (Texture2D)standardMaterial.GetTexture("_MainTex");
                 smoothnessMapChannel = smoothnessMap != null ? Channel.Alpha : smoothnessMapChannel;
             }
@@ -211,7 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
                 }
             }
         }
-        
+
         private bool CanSave()
         {
             return metallicMap != null || occlusionMap != null || emissionMap != null || smoothnessMap != null ||
@@ -222,8 +222,8 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         {
             if (material != null)
             {
-                if (material.shader.name == StandardShaderName || 
-                    material.shader.name == StandardRoughnessShaderName || 
+                if (material.shader.name == StandardShaderName ||
+                    material.shader.name == StandardRoughnessShaderName ||
                     material.shader.name == StandardSpecularShaderName)
                 {
                     return true;


### PR DESCRIPTION
There are a ton of small nits and formatting issues that have been introduced over the ages in our code (and still sneak in) which can be difficult to catch via manual code review.

I'm going to update some of our tooling/docs to point to https://github.com/dotnet/format, which can be used to format c# code to a reasonable set of defaults, such that we can spend time less on manually watching nits (i.e. space between if( -> if ( ), and more on the actual content.

This is after a baseline run on the MRTK codebase - a lot of dead whitespace is removed, formatting is fixed in some cases where the indentation is way off, and extra whitespace has been removed between some locations.

Note that the intention is not to make this formatting required - there is always value in being able to structure things manually in a certain way when there is value there. However, I would love to get to a state where we can use git hooks to autoformat for engineers who don't want to worry about this stuff.