### PR TITLE
Move initialization to later (when solvers have been initialized)

### DIFF
--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboardPreview/MixedRealityKeyboardPreview.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboardPreview/MixedRealityKeyboardPreview.cs
@@ -127,6 +127,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         private void OnEnable()
         {
             StartCoroutine(BlinkCaret());
+        }
+
+        private void Start()
+        {
             ApplyShellSolverParameters();
         }
 


### PR DESCRIPTION
Per the conversation in #7926, moving the initialization in the mixed reality keyboard preview code to Start(), where the solver handler / solver system would have been initialized by.

Fixes #7926 