### PR TITLE
Added alerts and documentation to for button migration

### DIFF
--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -92,6 +92,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                             if (!EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window"))
                             {
                                 EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use this button", "OK");
+                            }
                         }
 
                         InspectorUIUtility.RenderDocumentationButton(upgradeDocUrl);

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -91,7 +91,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                         {
                             if (!EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window"))
                             {
-                                EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use this button", "OK");
+                                EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use the Migration Tool", "OK");
                             }
                         }
 

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
         private const string generatedIconSetName = "CustomIconSet";
         private const string customIconSetsFolderName = "CustomIconSets";
         private const string customIconUpgradeMessage = "This button appears to have a custom icon material. This is no longer required for custom icons.\n\n" +
-            "We recommend upgrading the buttons in your project using the Migration Tool.";
+            "We recommend upgrading the buttons in your project by installing the Microsoft.MixedRealityToolkit.Unity.Tools package and using the Migration Tool.";
         private const string missingIconWarningMessage = "The icon used by this button's custom material was not found in the icon set.";
         private const string customIconSetCreatedMessage = "A new icon set has been created to hold your button's custom icons. It has been saved to:\n\n{0}";
         private const string upgradeDocUrl = "https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_Button.html#how-to-change-the-icon-and-text";
@@ -89,7 +89,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                     {
                         if (GUILayout.Button("Use migration tool to upgrade buttons"))
                         {
-                            EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window");
+                            if(!EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window"))
+                                EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use this button", "OK");
                         }
 
                         InspectorUIUtility.RenderDocumentationButton(upgradeDocUrl);

--- a/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
+++ b/Assets/MRTK/SDK/Inspectors/UX/Interactable/ButtonConfigHelperInspector.cs
@@ -89,7 +89,8 @@ namespace Microsoft.MixedReality.Toolkit.Inspectors
                     {
                         if (GUILayout.Button("Use migration tool to upgrade buttons"))
                         {
-                            if(!EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window"))
+                            if (!EditorApplication.ExecuteMenuItem("Mixed Reality Toolkit/Utilities/Migration Window"))
+                            {
                                 EditorUtility.DisplayDialog("Package Required", "You need to install the MRTK tools (Microsoft.MixedRealityToolkit.Unity.Tools) package to use this button", "OK");
                         }
 

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -134,6 +134,8 @@ In MRTK 2.4 and beyond, we recommend custom icon textures be moved into an IconS
 To upgrade the assets on all buttons in a project to the new recommended format, use the ButtonConfigHelperMigrationHandler. 
 (Mixed Reality Toolkit -> Utilities -> Migration Window -> Migration Handler Selection -> Microsoft.MixedReality.Toolkit.Utilities.ButtonConfigHelperMigrationHandler)
 
+Importing the Microsoft.MixedRealityToolkit.Unity.Tools package required to upgrade the buttons.
+
 ![Upgrade window dialogue](https://user-images.githubusercontent.com/39840334/82096923-bd28bf80-96b6-11ea-93a9-ceafcb822242.png)
 
 If an icon is not found in the default icon set during migration, a custom icon set will be created in MixedRealityToolkit.Generated/CustomIconSets. A dialog will indicate that this has taken place.


### PR DESCRIPTION
## Overview
Addresses errors and lack of clarity when trying to use the button upgrade migration tool without the tools package

## Changes
- Fixes: #7950


## Verification
> Change the material on a button's icon to an invalid one, prompting the upgrade tool, and then verified that the alert showed up properly when the menu item wasn't present