### PR TITLE
Clean up some "unused" warnings

### DIFF
--- a/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeSaccadeProvider.cs
+++ b/Assets/MRTK/Core/Interfaces/InputSystem/IMixedRealityEyeSaccadeProvider.cs
@@ -6,22 +6,22 @@ using System;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Provides eye tracking information.
+    /// Provides eye tracking saccade events.
     /// </summary>
     public interface IMixedRealityEyeSaccadeProvider : IMixedRealityDataProvider
     {
         /// <summary>
-        /// Triggered when user is saccading across the view (jumping quickly with their eye gaze above a certain threshold in visual angles). 
+        /// Triggered when user is saccading across the view (jumping quickly with their eye gaze above a certain threshold in visual angles).
         /// </summary>
         event Action OnSaccade;
 
         /// <summary>
-        /// Triggered when user is saccading horizontally across the view (jumping quickly with their eye gaze above a certain threshold in visual angles). 
+        /// Triggered when user is saccading horizontally across the view (jumping quickly with their eye gaze above a certain threshold in visual angles).
         /// </summary>
         event Action OnSaccadeX;
 
         /// <summary>
-        /// Triggered when user is saccading vertically across the view (jumping quickly with their eye gaze above a certain threshold in visual angles). 
+        /// Triggered when user is saccading vertically across the view (jumping quickly with their eye gaze above a certain threshold in visual angles).
         /// </summary>
         event Action OnSaccadeY;
     }

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/BaseWindowsMixedRealityCameraSettings.cs
@@ -49,10 +49,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 
         private WindowsMixedRealityCameraSettingsProfile Profile => ConfigurationProfile as WindowsMixedRealityCameraSettingsProfile;
 
+#if WINDOWS_UWP
         private static readonly bool isTryGetViewConfigurationSupported = Windows.Utilities.WindowsApiChecker.IsMethodAvailable(
             "Windows.Graphics.Holographic",
             "HolographicDisplay",
             "TryGetViewConfiguration");
+#endif // WINDOWS_UWP
 
         private WindowsMixedRealityReprojectionUpdater reprojectionUpdater = null;
 

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandRecorder.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandRecorder.cs
@@ -71,21 +71,17 @@ namespace Microsoft.MixedReality.Toolkit.Input
             StoreRecordedHandPose(pose.ToJson(), filename);
         }
 
-#if WINDOWS_UWP
         private static void StoreRecordedHandPose(string data, string filename)
         {
+#if WINDOWS_UWP
             string path = Path.Combine(Application.persistentDataPath, filename);
             using (TextWriter writer = File.CreateText(path))
             {
                 writer.Write(data);
             }
-        }
 #else
-        private static void StoreRecordedHandPose(string data, string filename)
-        {
-            Debug.Log(data);
-        }
+            Debug.Log($"{filename}: {data}");
 #endif
+        }
     }
-
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -78,6 +78,10 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 
         public IMixedRealityEyeSaccadeProvider SaccadeProvider => this;
 
+        public event Action OnSaccade;
+        public event Action OnSaccadeX;
+        public event Action OnSaccadeY;
+        private readonly bool eyesApiAvailable = false;
         private readonly float smoothFactorNormalized = 0.96f;
         private readonly float saccadeThreshInDegree = 2.5f; // In degrees (not radians)
 
@@ -86,11 +90,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         private int confidenceOfSaccadeThreshold = 6; // TODO(https://github.com/Microsoft/MixedRealityToolkit-Unity/issues/3767): This value should be adjusted based on the FPS of the ET system
         private Ray saccade_initialGazePoint;
         private readonly List<Ray> saccade_newGazeCluster = new List<Ray>();
-
-        public event Action OnSaccade;
-        public event Action OnSaccadeX;
-        public event Action OnSaccadeY;
-        private readonly bool eyesApiAvailable = false;
 
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         private static bool askedForETAccessAlready = false; // To make sure that this is only triggered once.
@@ -117,9 +116,9 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public override void Initialize()
         {
 #if UNITY_EDITOR && UNITY_WSA && UNITY_2019_3_OR_NEWER
-            Toolkit.Utilities.Editor.UWPCapabilityUtility.RequireCapability(
+            Utilities.Editor.UWPCapabilityUtility.RequireCapability(
                     UnityEditor.PlayerSettings.WSACapability.GazeInput,
-                    this.GetType());
+                    GetType());
 #endif // UNITY_EDITOR && UNITY_WSA && UNITY_2019_3_OR_NEWER
 
             if (Application.isPlaying && eyesApiAvailable)
@@ -131,14 +130,30 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
         }
 
+        private void ReadProfile()
+        {
+            if (ConfigurationProfile == null)
+            {
+                Debug.LogError("Windows Mixed Reality Eye Tracking Provider requires a configuration profile to run properly.");
+                return;
+            }
+
+            MixedRealityEyeTrackingProfile profile = ConfigurationProfile as MixedRealityEyeTrackingProfile;
+            if (profile == null)
+            {
+                Debug.LogError("Windows Mixed Reality Eye Tracking Provider's configuration profile must be a MixedRealityEyeTrackingProfile.");
+                return;
+            }
+
+            SmoothEyeTracking = profile.SmoothEyeTracking;
+        }
+
 #if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         private static readonly ProfilerMarker UpdatePerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityEyeGazeDataProvider.Update");
-#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
 
         /// <inheritdoc />
         public override void Update()
         {
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
             using (UpdatePerfMarker.Auto())
             {
                 if (WindowsMixedRealityUtilities.SpatialCoordinateSystem == null || !eyesApiAvailable)
@@ -168,28 +183,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     }
                 }
             }
-#endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 
-        private void ReadProfile()
-        {
-            if (ConfigurationProfile == null)
-            {
-                Debug.LogError("Windows Mixed Reality Eye Tracking Provider requires a configuration profile to run properly.");
-                return;
-            }
-
-            MixedRealityEyeTrackingProfile profile = ConfigurationProfile as MixedRealityEyeTrackingProfile;
-            if (profile == null)
-            {
-                Debug.LogError("Windows Mixed Reality Eye Tracking Provider's configuration profile must be a MixedRealityEyeTrackingProfile.");
-                return;
-            }
-
-            SmoothEyeTracking = profile.SmoothEyeTracking;
-        }
-
-#if (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         /// <summary>
         /// Triggers a prompt to let the user decide whether to permit using eye tracking 
         /// </summary>
@@ -258,9 +253,6 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                 {
                     isSaccading = true;
                 }
-
-                Vector3 v1 = oldGaze.Value.origin + oldGaze.Value.direction;
-                Vector3 v2 = newGaze.Value.origin + newGaze.Value.direction;
 
                 // Saccade-dependent local smoothing
                 if (isSaccading)

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityEyeGazeDataProvider.cs
@@ -74,13 +74,21 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
 #endif // (UNITY_WSA && DOTNETWINRT_PRESENT) || WINDOWS_UWP
         }
 
+        /// <inheritdoc />
         public bool SmoothEyeTracking { get; set; } = false;
 
+        /// <inheritdoc />
         public IMixedRealityEyeSaccadeProvider SaccadeProvider => this;
 
+        /// <inheritdoc />
         public event Action OnSaccade;
+
+        /// <inheritdoc />
         public event Action OnSaccadeX;
+
+        /// <inheritdoc />
         public event Action OnSaccadeY;
+
         private readonly bool eyesApiAvailable = false;
         private readonly float smoothFactorNormalized = 0.96f;
         private readonly float saccadeThreshInDegree = 2.5f; // In degrees (not radians)


### PR DESCRIPTION
## Overview

Cleans up a couple examples of fields or methods not being properly scoped by `#if` blocks and appearing as "unused" in certain build configurations.

Also improved some docs in the files I was updating.