### PR TITLE
Update in param to ref param in BaseInputDeviceManager

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -216,7 +216,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         if (requestedPointer == null)
                         {
                             // We couldn't obtain a pointer from our cache, resort to creating a new one
-                            requestedPointer = CreatePointer(in option);
+                            requestedPointer = CreatePointer(ref option);
                         }
 
                         if (requestedPointer != null)
@@ -292,7 +292,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <remarks>
         /// PointerOption is passed by ref to reduce copy overhead of struct
         /// </remarks>
-        private IMixedRealityPointer CreatePointer(in PointerOption option)
+        private IMixedRealityPointer CreatePointer(ref PointerOption option)
         {
             using (CreatePointerPerfMarker.Auto())
             {


### PR DESCRIPTION
## Overview

In doing some research around the perf implications of structs and how MRTK uses them, I came across the fact that passing a struct as an `in` parameter doesn't always reduce the number of copies, but potentially increases them. Instead of copying at the time the struct is passed in, the method ends up copying ANY time a non-readonly property or method is called on the struct.

From https://devblogs.microsoft.com/premier-developer/the-in-modifier-and-the-readonly-structs-in-c/ (emphasis mine):

>To make sure that the parameter’s value stays the same the compiler **make a defensive copy of the parameter every time a method/property is used**.
>
>It means that you should never pass a non-readonly struct as in parameter. It almost always will make the performance worse. Yes, **the argument passing is cheaper, but once the parameter is used, the defensive copy will nullify the benefits or will make the performance worse**. It could make sense if the struct is a C-like struct with a bunch of public fields and everyone in the team is aware that changing fields to properties would have a drastic performance impact on the application. But in this case, I would **suggest passing the struct by reference instead**.

[An example using SharpLab.io](https://sharplab.io/#v2:D4AQzABAzgLgTgVwMYwgNQKYoPZwEwCwAUAN7EQUTgQBmANtgIaoAeA3OZdfU6gJ4cilCJwrcGzCABkMAOwDmMABYBlAI4JGcDABMIAXgB8EABQsIAKggsAlBADUpvpYh8bggL7Fi1EHggAwhBkQlyQPJIAsgCMJto06FgwuP4Abox0CBh2IcLCIADsEOmZGAB0MgrK6praeo4lWRVyiqoaWrqCwl6hFKJU4RKokXgmAJayiTj4xRlZOf35RY3lla01HfWzpc1VbbWd/T3C/eK8ECMmmNNpc9nBi1zLd7vr7XUO201r1e+HvRAeh4gA=) to show how the compiler sees these parameter modifiers. Specifically notice the additional copies in the `in` version that aren't present in either the `ref` or non-modified version.

Note that in our case, we were only calling one property on the struct in the most common case anyway (except for the case where `IMixedRealityPointer` was missing, which shouldn't be a common one), so the `in` param was behaving essentially identically to the original, unmodified version. Updating this to `ref` should see any perf benefits that were expected in the original change.