### PR TITLE
Remove extra IMixedRealityInputSystem casts

### DIFF
--- a/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
+++ b/Assets/MRTK/Core/Providers/UnityInput/UnityJoystickManager.cs
@@ -88,13 +88,11 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         {
             base.Disable();
 
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
             foreach (var genericJoystick in ActiveControllers)
             {
                 if (genericJoystick.Value != null)
                 {
-                    inputSystem?.RaiseSourceLost(genericJoystick.Value.InputSource, genericJoystick.Value);
+                    Service?.RaiseSourceLost(genericJoystick.Value.InputSource, genericJoystick.Value);
                 }
             }
 
@@ -119,8 +117,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         {
             using (RefreshDevicesPerfMarker.Auto())
             {
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
                 var joystickNames = UInput.GetJoystickNames();
 
                 if (joystickNames.Length <= 0)
@@ -140,7 +136,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                             if (controller != null)
                             {
-                                inputSystem?.RaiseSourceLost(controller.InputSource, controller);
+                                Service?.RaiseSourceLost(controller.InputSource, controller);
                             }
 
                             RemoveController(lastDeviceList[i]);
@@ -161,7 +157,7 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
 
                         if (controller != null)
                         {
-                            inputSystem?.RaiseSourceDetected(controller.InputSource, controller);
+                            Service?.RaiseSourceDetected(controller.InputSource, controller);
                         }
                     }
                 }
@@ -181,8 +177,6 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
         {
             using (GetOrAddControllerPerfMarker.Auto())
             {
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
                 if (ActiveControllers.ContainsKey(joystickName))
                 {
                     var controller = ActiveControllers[joystickName];
@@ -204,8 +198,8 @@ namespace Microsoft.MixedReality.Toolkit.Input.UnityInput
                         break;
                 }
 
-                var inputSource = inputSystem?.RequestNewGenericInputSource($"{controllerType.Name} Controller", sourceType: InputSourceType.Controller);
-                var detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, Handedness.None, inputSource, null) as GenericJoystickController;
+                IMixedRealityInputSource inputSource = Service?.RequestNewGenericInputSource($"{controllerType.Name} Controller", sourceType: InputSourceType.Controller);
+                GenericJoystickController detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, Handedness.None, inputSource, null) as GenericJoystickController;
 
                 if (detectedController == null || !detectedController.Enabled)
                 {

--- a/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
+++ b/Assets/MRTK/Providers/OpenVR/OpenVRDeviceManager.cs
@@ -118,11 +118,9 @@ namespace Microsoft.MixedReality.Toolkit.OpenVR.Input
                         return null;
                 }
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-                var pointers = RequestPointers(currentControllerType, controllingHand);
-                var inputSource = inputSystem?.RequestNewGenericInputSource($"{currentControllerType} Controller {controllingHand}", pointers, InputSourceType.Controller);
-                var detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, controllingHand, inputSource, null) as GenericOpenVRController;
+                IMixedRealityPointer[] pointers = RequestPointers(currentControllerType, controllingHand);
+                IMixedRealityInputSource inputSource = Service?.RequestNewGenericInputSource($"{currentControllerType} Controller {controllingHand}", pointers, InputSourceType.Controller);
+                GenericOpenVRController detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, controllingHand, inputSource, null) as GenericOpenVRController;
 
                 if (detectedController == null || !detectedController.Enabled)
                 {

--- a/Assets/MRTK/Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
+++ b/Assets/MRTK/Providers/WindowsVoiceInput/WindowsDictationInputProvider.cs
@@ -86,9 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             using (StartRecordingAsyncPerfMarker.Auto())
             {
 #if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-                if (IsListening || isTransitioning || inputSystem == null || !Application.isPlaying)
+                if (IsListening || isTransitioning || Service == null || !Application.isPlaying)
                 {
                     Debug.LogWarning("Unable to start recording");
                     return;
@@ -106,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 if (listener != null)
                 {
                     hasListener = true;
-                    inputSystem.PushModalInputHandler(listener);
+                    Service.PushModalInputHandler(listener);
                 }
 
                 if (PhraseRecognitionSystem.Status == SpeechSystemStatus.Running)
@@ -131,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
                 if (dictationRecognizer.Status == SpeechSystemStatus.Failed)
                 {
-                    inputSystem.RaiseDictationError(inputSource, "Dictation recognizer failed to start!");
+                    Service.RaiseDictationError(inputSource, "Dictation recognizer failed to start!");
                     return;
                 }
 
@@ -162,11 +160,9 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 IsListening = false;
                 isTransitioning = true;
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
                 if (hasListener)
                 {
-                    inputSystem?.PopModalInputHandler();
+                    Service?.PopModalInputHandler();
                     hasListener = false;
                 }
 
@@ -253,15 +249,13 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         {
             if (!Application.isPlaying) { return; }
 
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-            if (inputSystem == null)
+            if (Service == null)
             {
                 Debug.LogError($"Unable to start {Name}. An Input System is required for this feature.");
                 return;
             }
 
-            inputSource = inputSystem.RequestNewGenericInputSource(Name, sourceType: InputSourceType.Voice);
+            inputSource = Service.RequestNewGenericInputSource(Name, sourceType: InputSourceType.Voice);
             dictationResult = string.Empty;
 
             if (dictationRecognizer == null && InputSystemProfile.SpeechCommandsProfile.SpeechRecognizerStartBehavior == AutoStartBehavior.AutoStart)
@@ -299,9 +293,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         {
             using (UpdatePerfMarker.Auto())
             {
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-                if (!Application.isPlaying || inputSystem == null || dictationRecognizer == null) { return; }
+                if (!Application.isPlaying || Service == null || dictationRecognizer == null) { return; }
 
                 if (!isTransitioning && IsListening && !Microphone.IsRecording(deviceName) && dictationRecognizer.Status == SpeechSystemStatus.Running)
                 {
@@ -312,7 +304,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 if (!hasFailed && dictationRecognizer.Status == SpeechSystemStatus.Failed)
                 {
                     hasFailed = true;
-                    inputSystem.RaiseDictationError(inputSource, "Dictation recognizer has failed!");
+                    Service.RaiseDictationError(inputSource, "Dictation recognizer has failed!");
                 }
             }
         }
@@ -353,8 +345,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 // We don't want to append to textSoFar yet, because the hypothesis may have changed on the next event.
                 dictationResult = $"{textSoFar} {text}...";
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-                inputSystem?.RaiseDictationHypothesis(inputSource, dictationResult);
+                Service?.RaiseDictationHypothesis(inputSource, dictationResult);
             }
         }
 
@@ -373,8 +364,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
 
                 dictationResult = textSoFar.ToString();
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-                inputSystem?.RaiseDictationResult(inputSource, dictationResult);
+                Service?.RaiseDictationResult(inputSource, dictationResult);
             }
         }
 
@@ -397,8 +387,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                     dictationResult = "Dictation has timed out. Please try again.";
                 }
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-                inputSystem?.RaiseDictationComplete(inputSource, dictationResult, dictationAudioClip);
+                Service?.RaiseDictationComplete(inputSource, dictationResult, dictationAudioClip);
                 textSoFar = null;
                 dictationResult = string.Empty;
             }
@@ -417,8 +406,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
             {
                 dictationResult = $"{error}\nHRESULT: {hresult}";
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-                inputSystem?.RaiseDictationError(inputSource, dictationResult);
+                Service?.RaiseDictationError(inputSource, dictationResult);
                 textSoFar = null;
                 dictationResult = string.Empty;
             }

--- a/Assets/MRTK/Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
+++ b/Assets/MRTK/Providers/WindowsVoiceInput/WindowsSpeechInputProvider.cs
@@ -148,9 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
                 return;
             }
 
-            IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
-            InputSource = inputSystem?.RequestNewGenericInputSource("Windows Speech Input Source", sourceType: InputSourceType.Voice);
+            InputSource = Service?.RequestNewGenericInputSource("Windows Speech Input Source", sourceType: InputSourceType.Voice);
 
             var newKeywords = new string[Commands.Length];
 
@@ -229,13 +227,11 @@ namespace Microsoft.MixedReality.Toolkit.Windows.Input
         {
             using (OnPhraseRecognizedPerfMarker.Auto())
             {
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
-
                 for (int i = 0; i < Commands?.Length; i++)
                 {
                     if (Commands[i].LocalizedKeyword == text)
                     {
-                        inputSystem?.RaiseSpeechCommandRecognized(InputSource, (RecognitionConfidenceLevel)confidence, phraseDuration, phraseStartTime, Commands[i]);
+                        Service?.RaiseSpeechCommandRecognized(InputSource, (RecognitionConfidenceLevel)confidence, phraseDuration, phraseStartTime, Commands[i]);
                         break;
                     }
                 }

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -141,9 +141,8 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                 Type controllerType = GetControllerType(currentControllerType);
                 InputSourceType inputSourceType = GetInputSourceType(currentControllerType);
 
-                IMixedRealityInputSystem inputSystem = Service as IMixedRealityInputSystem;
                 IMixedRealityPointer[] pointers = RequestPointers(currentControllerType, controllingHand);
-                IMixedRealityInputSource inputSource = inputSystem?.RequestNewGenericInputSource($"{currentControllerType} Controller {controllingHand}", pointers, inputSourceType);
+                IMixedRealityInputSource inputSource = Service?.RequestNewGenericInputSource($"{currentControllerType} Controller {controllingHand}", pointers, inputSourceType);
                 GenericXRSDKController detectedController = Activator.CreateInstance(controllerType, TrackingState.NotTracked, controllingHand, inputSource, null) as GenericXRSDKController;
 
                 if (detectedController == null || !detectedController.Enabled)


### PR DESCRIPTION
## Overview

https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6779 introduced the ability to specify a data provider's service type explicitly, but not all data providers were updated with this feature. This PR updates the rest to no longer cast their `Service` to the `IMixedRealityInputSystem` they already are.