### PR TITLE
Update Build and Deploy documentation with steps for Unity 2019.3

### DIFF
--- a/Documentation/BuildAndDeploy.md
+++ b/Documentation/BuildAndDeploy.md
@@ -6,11 +6,6 @@ To run an app on device as a standalone app (for HoloLens, Android, iOS, etc.), 
 
 Instructions on how to build and deploy for HoloLens 1 and HoloLens 2 (UWP) can be found at [building your application to device](https://docs.microsoft.com/windows/mixed-reality/mrlearning-base-ch1#build-your-application-to-your-device).
 
->[!IMPORTANT]
-> If using Unity 2019.3.x, select **ARM64** and not **ARM** as the build architecture in Visual Studio. With the default Unity settings in Unity 2019.3.x, a Unity app will not deploy to a HoloLens if ARM is selected due to a Unity bug. This can be tracked on [Unity's issue tracker](https://issuetracker.unity3d.com/issues/enabling-graphics-jobs-in-2019-dot-3-x-results-in-a-crash-or-nothing-rendering-on-hololens-2).
->
-> If the ARM architecture is required, navigate to **Edit > Project Settings, Player**, and under the **Other Settings** menu disable **Graphics Jobs**. Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is recommended.
-
 **Tip:** When building for WMR, HoloLens 1, or HoloLens 2, it is recommended that the build settings "Target SDK Version"
 and "Minimum Platform Version" look like they do in the picture below:
 
@@ -22,6 +17,27 @@ be changed inside the Visual Studio solution).
 Make sure that the "Target SDK Version" dropdown includes the option "10.0.18362.0" - if this is missing,
 [the latest Windows SDK](https://developer.microsoft.com/windows/downloads/windows-10-sdk) needs to be installed.
 
+
+### Unity 2019.3 and HoloLens
+
+If a HoloLens app appears as a 2D panel on device, make sure the following settings have been configured in Unity 2019.3.x before deploying your UWP app:
+
+If using the legacy XR:
+1. Navigate to Edit > Project Settings, Player 
+1. Under **XR Settings** in the UWP tab, make sure **Virtual Reality Supported** is enabled and the **Windows Mixed Reality** SDK has been added to SDKs.
+1. Build and deploy in Visual Studio
+
+If using the XR-Plugin:
+
+1. Follow the steps found in [Getting Started with XRSDK](GettingStartedWithMRTKAndXRSDK.md)
+1. Make sure the configuration profile is the **DefaultXRSDKConfigurationProfile** 
+1. Navigate to **Edit > Project Settings, XR-Plugin Management** and make sure **Windows Mixed Reality** is enabled.
+1. Build and deploy in Visual Studio
+
+>[!IMPORTANT]
+> If using Unity 2019.3.x, select **ARM64** and not **ARM** as the build architecture in Visual Studio. With the default Unity settings in Unity 2019.3.x, a Unity app will not deploy to a HoloLens if ARM is selected due to a Unity bug. This can be tracked on [Unity's issue tracker](https://issuetracker.unity3d.com/issues/enabling-graphics-jobs-in-2019-dot-3-x-results-in-a-crash-or-nothing-rendering-on-hololens-2).
+>
+> If the ARM architecture is required, navigate to **Edit > Project Settings, Player**, and under the **Other Settings** menu disable **Graphics Jobs**. Disabling **Graphics Jobs** will allow the app to deploy using the ARM build architecture for Unity 2019.3.x, but ARM64 is recommended.
 
 ## Building and deploying MRTK to a Windows Mixed Reality Headset
 


### PR DESCRIPTION
## Overview

Unity 2019.3 by default does not have the Windows Mixed Reality SDK added in the Player settings. If you switch to UWP and build, you will end up with your HL2 app as a 2D panel on device without these extra steps.

Added a Unity 2019.3 and HoloLens section with steps for legacy XR and the XR-plugin. Also moved the warning about ARM64 to this new section.

## Changes
- Fixes: #7957 
