### PR TITLE
Changes Controller Axis to valid axis

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/SpherePointer.cs
@@ -274,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 axis = transform.forward;
-                return false;
+                return true;
             }
         }
 


### PR DESCRIPTION
## Overview
The GrabPointer was not grabbing, because its TryGetNearGraspAxis returned bool was false, even though its forward Vector3 is to be considered valid.

## Changes
- Fixes: #7961 .