### PR TITLE
Use discard in MRTK access, add missing readonly modifier, add "hand tracking" devices to XR SDK

### DIFF
--- a/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
+++ b/Assets/MRTK/Core/Providers/BaseInputDeviceManager.cs
@@ -73,8 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             IMixedRealityInputSystem inputSystem,
             string name,
             uint priority,
-            BaseMixedRealityProfile profile) : base(inputSystem, name, priority, profile)
-        { }
+            BaseMixedRealityProfile profile) : base(inputSystem, name, priority, profile) { }
 
         #region Private members
 
@@ -117,7 +116,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
 
-        private static ProfilerMarker RequestPointersPerfMarker = new ProfilerMarker("[MRTK] BaseInputDeviceManager.RequestPointers");
+        private static readonly ProfilerMarker RequestPointersPerfMarker = new ProfilerMarker("[MRTK] BaseInputDeviceManager.RequestPointers");
 
         // Active pointers associated with the config index they were spawned from
         private readonly Dictionary<IMixedRealityPointer, uint> activePointersToConfig

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -600,7 +600,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public static bool ConfirmInitialized()
         {
-            // Assigning the Instance to access is used Implicitly.
+            // Calling the Instance property performs important initialization work.
             _ = Instance;
             return IsInitialized;
         }

--- a/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
+++ b/Assets/MRTK/Core/Services/MixedRealityToolkit.cs
@@ -600,9 +600,8 @@ namespace Microsoft.MixedReality.Toolkit
         /// </summary>
         public static bool ConfirmInitialized()
         {
-            // ReSharper disable once UnusedVariable
             // Assigning the Instance to access is used Implicitly.
-            MixedRealityToolkit access = Instance;
+            _ = Instance;
             return IsInitialized;
         }
 

--- a/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
+++ b/Assets/MRTK/Providers/XRSDK/XRSDKDeviceManager.cs
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                     return;
                 }
 
-                InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.Controller, inputDevices);
+                InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.HandTracking, inputDevices);
                 foreach (InputDevice device in inputDevices)
                 {
                     if (device.isValid)
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                     controllingHand = Handedness.None;
                 }
 
-                var currentControllerType = GetCurrentControllerType(inputDevice);
+                SupportedControllerType currentControllerType = GetCurrentControllerType(inputDevice);
                 Type controllerType = GetControllerType(currentControllerType);
                 InputSourceType inputSourceType = GetInputSourceType(currentControllerType);
 


### PR DESCRIPTION
## Overview

This PR:

1. Updates one of the profiler markers to be `static readonly`, which matches the rest of the markers.
1. Updates the MRTK instance access to be discarded, which matches the way we do this for the playspace:
    https://github.com/microsoft/MixedRealityToolkit-Unity/blob/375f306d0af44e26335297b2fc988f4d612bf787/Assets/MRTK/Core/Services/MixedRealityToolkit.cs#L485-L486
1. Adds `HandTracking` devices to the list of devices we care about from XR SDK. This is because the WMR-plugin currently marks hands as both `HandTracking` and `Controller`, but other don't and it may not in the future if they standardize.