### PR TITLE
Update the upgrade instructions to heavily encourage use of the migration window.

### DIFF
--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -40,8 +40,8 @@ To get started with the Mixed Reality Toolkit, you will need:
 1. Under Assets, download:
     * **Microsoft.MixedRealityToolkit.Unity.Foundation.unitypackage**
     * (**_Optional_**) Microsoft.MixedRealityToolkit.Unity.Extensions.unitypackage
-    * (**_Optional_**) Microsoft.MixedRealityToolkit.Unity.Tools.unitypackage
     * (**_Optional_**) Microsoft.MixedRealityToolkit.Unity.Examples.unitypackage
+    * (**_Required for version-to-version upgrades, Optional otherwise_**) Microsoft.MixedRealityToolkit.Unity.Tools.unitypackage
 
 For information on package contents, see [MRTK Package Contents](MRTK_PackageContents.md).
 
@@ -53,7 +53,7 @@ The Mixed Reality Toolkit is also available for download on NuGet.org; for detai
 1. Import the **Microsoft.MixedRealityToolkit.Unity.Foundation.unitypackage** you downloaded by going into "Asset -> Import Package -> Custom Package", select the .unitypackage file, ensure all items to import are checked, and then select "Import".
 1. (**_Optional_**) Import the **Microsoft.MixedRealityToolkit.Unity.Extensions.unitypackage** following the same steps as the foundation package. The extensions package provides a set of useful optional components for the MRTK.
 1. (**_Optional_**) Import the **Microsoft.MixedRealityToolkit.Unity.Examples.unitypackage** following the same steps as above. The examples package is optional and contains useful demonstration scenes for current MRTK features. **Note that the Examples package requires the Extensions package.**
-1. (**_Optional_**) Import the **Microsoft.MixedRealityToolkit.Unity.Tools.unitypackage** following the same steps as the foundation package. The tools package is optional and contains useful tools, such as the ExtensionServiceCreator, that enhance the MRTK developer experience.
+1. (**_Required for version-to-version upgrades, Optional otherwise_**) Import the **Microsoft.MixedRealityToolkit.Unity.Tools.unitypackage** following the same steps as the foundation package. The tools package is optional and contains useful tools, such as the ExtensionServiceCreator, that enhance the MRTK developer experience.
 
 > [!Note]
 > Android and iOS development require additional package installations. For more information, see [How to configure MRTK for iOS and Android](CrossPlatform/UsingARFoundation.md).

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -39,6 +39,26 @@ A [Leap Motion Controller](https://www.ultraleap.com/product/leap-motion-control
 
 ![LeapMotionIntroGif](Images/CrossPlatform/LeapMotion/LeapMotionSideBySide2.gif)
 
+**Migration window**
+
+![Migration window](Images/MigrationWindow/MRTK_Migration_Window.png)
+
+MRTK now comes with a migration tool that will help you upgrade deprecated components to their newer
+versions and to keep existing code working even as MRTK makes breaking changes.
+
+**It is generally recommended to run the migration tool after pulling a new version of MRTK** to
+ensure that as much of your project will be auto-adjusted to the latest MRTK code.
+
+The [migration window](Tools/MigrationWindow.md) can be found in 'Mixed Reality Toolkit > Utilities >
+Migration Window'. It it part of the **Tools** package.
+
+It currently supports:
+
+- Upgrading ManipulationHandler and BoundingBox to their newer versions ObjectManipulator and BoundsControl.
+- Updating custom button icons to work correctly with the new Button Config Helper.
+
+Note that BoundsControl is still in experimental phase and therefore API or properties might still change in the next version.
+
 **MRTK folder layout changes**
 
 This version of MRTK modifies the layout of the MRTK folder structure. This change encapsulates all MRTK code into a single folder hierarchy and reduces the total path length of all MRTK files.
@@ -169,13 +189,6 @@ Users can take advantage of the new [migration window](Tools/MigrationWindow.md)
 **Bounds control improvements**
 
 We extensively increased test coverage for bounds control this version and addressed one of the biggest pain points of users of bounding box: bounds control will now no longer recreate its visuals on configuration changes. Also it now supports reconfiguring any property during runtime. Also the properties DrawTetherWhenManipulating and HandlesIgnoreCollider are now configurable per handle type. 
-
-**Migration window**
-
-![Migration window](Images/MigrationWindow/MRTK_Migration_Window.png)
-
-MRTK now comes with a migration tool that will help you upgrade deprecated components to their newer versions. The [migration window](Tools/MigrationWindow.md) can be found in 'Mixed Reality Toolkit > Utilities > Migration Window'. It currently supports upgrading ManipulationHandler and BoundingBox to their newer versions ObjectManipulator and BoundsControl. 
-Note that BoundsControl is still in experimental phase and therefore API or properties might still change in the next version.
 
 ### Breaking changes in 2.4.0
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -16,7 +16,7 @@ The 2.4.0 release has some changes that may impact application projects. Breakin
 
 *Starting with 2.4.0, it is strongly recommended to run the [migration tool](Tools/MigrationWindow.md)
 after getting the MRTK update** to auto-fix and upgrade from deprecated components and adjust to
-breaking changes.
+breaking changes. The migration tool is part of the **Tools** package.
 
 ### Unity asset (.unitypackage) files
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -14,10 +14,15 @@ The 2.4.0 release has some changes that may impact application projects. Breakin
 > [!NOTE]
 > At this time, it is not supported to switch between using .unitypackage files and NuGet.
 
+*Starting with 2.4.0, it is strongly recommended to run the [migration tool](Tools/MigrationWindow.md)
+after getting the MRTK update** to auto-fix and upgrade from deprecated components and adjust to
+breaking changes.
+
 ### Unity asset (.unitypackage) files
 
 For the smoothest upgrade path, please use the following steps.
 
+1. Save a copy of your current project, in case you hit any snags at any point in the upgrade steps.
 1. Close Unity
 1. Inside the *Assets* folder, delete most of the **MixedRealityToolkit** folders, along with their .meta files (the project may not have all listed folders)
     - MixedRealityToolkit
@@ -38,7 +43,7 @@ For the smoothest upgrade path, please use the following steps.
 1. Re-open the project in Unity
 1. Import the new unity packages
     - Foundation - _Import this package first_
-    - (Optional) Tools
+    - Tools
     - (Optional) Extensions
     > [!NOTE]
     > If additional extensions had been installed, they may need to be re-imported.
@@ -50,6 +55,7 @@ For the smoothest upgrade path, please use the following steps.
     - Select **MixedRealityToolkit -> Add to Scene and Configure**
     - Select **MixedRealityToolkit -> Utilities -> Update -> Controller Mapping Profiles** (only needs to be done once)
             - This will update any custom controller mapping profiles with updated axes and data, while leaving your custom-assigned input actions intact
+1. Run the [migration tool](Tools/MigrationWindow.md) and run the tool on the *Full Project* to ensure that all of your code is updated to the latest.
 
 ### NuGet packages
 


### PR DESCRIPTION
With some of the latest changes to 2.4.0 (i.e. button config helper, BoundsControl/ObjectManipulator), running the migration tool is extremely helpful in ensuring that upgraded projects can get into a good state.

In general, we want to push consumers to use this tooling to help auto-fix as much of their projects as is possible - as we make version to version changes, there's always some inevitable probability around breaking changes (even if the changes are relatively small), but having these changes be auto-fixed is way nicer than having to stumble through weird behaviors (or worse, deploying to device and realizing that something is off, and then trying to walk back from that).

As we add more handlers to this migration tooling, getting consumers in this habit will help ensure that good state of their projects as they do upgrade to upgrade.