### PR TITLE
Spell check and markdown formatting pass on .md files for 2.4

### DIFF
--- a/Documentation/Architecture/SystemsExtensionsProviders.md
+++ b/Documentation/Architecture/SystemsExtensionsProviders.md
@@ -36,7 +36,7 @@ Data providers are components that, per their name, provide data to a Mixed Real
 they implement the [`IMixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityDataProvider) interface.
 
 > [!NOTE]
-> Not all services will require data providers. Of the MixedRealityToolkit's systems, the Input and Spatial Awareness systems are the
+> Not all services will require data providers. Of the Mixed Reality Toolkit's systems, the Input and Spatial Awareness systems are the
 only services to utilize data providers.
 
 To be accessible to the specific MRTK service, data providers are registered in the service's configuration profile.

--- a/Documentation/BuildAndDeploy.md
+++ b/Documentation/BuildAndDeploy.md
@@ -17,20 +17,20 @@ be changed inside the Visual Studio solution).
 Make sure that the "Target SDK Version" dropdown includes the option "10.0.18362.0" - if this is missing,
 [the latest Windows SDK](https://developer.microsoft.com/windows/downloads/windows-10-sdk) needs to be installed.
 
-
 ### Unity 2019.3 and HoloLens
 
 If a HoloLens app appears as a 2D panel on device, make sure the following settings have been configured in Unity 2019.3.x before deploying your UWP app:
 
 If using the legacy XR:
-1. Navigate to Edit > Project Settings, Player 
+
+1. Navigate to Edit > Project Settings, Player
 1. Under **XR Settings** in the UWP tab, make sure **Virtual Reality Supported** is enabled and the **Windows Mixed Reality** SDK has been added to SDKs.
 1. Build and deploy in Visual Studio
 
 If using the XR-Plugin:
 
 1. Follow the steps found in [Getting Started with XRSDK](GettingStartedWithMRTKAndXRSDK.md)
-1. Make sure the configuration profile is the **DefaultXRSDKConfigurationProfile** 
+1. Make sure the configuration profile is the **DefaultXRSDKConfigurationProfile**
 1. Navigate to **Edit > Project Settings, XR-Plugin Management** and make sure **Windows Mixed Reality** is enabled.
 1. Build and deploy in Visual Studio
 
@@ -46,7 +46,7 @@ The Windows Mixed Reality (WMR) headset can be used for Universal Windows Platfo
 > [!NOTE]
 > Unity's XR SDK also supports native WMR in Standalone builds, but does not require SteamVR or WMR plugin. These steps are required for Unity's legacy XR.
 
-1. Install [Steam](https://store.steampowered.com/about/) 
+1. Install [Steam](https://store.steampowered.com/about/)
 1. Install [SteamVR](https://store.steampowered.com/app/250820/SteamVR/)
 1. Install the [WMR Plugin](https://store.steampowered.com/app/719950/Windows_Mixed_Reality_for_SteamVR/)
 
@@ -58,13 +58,12 @@ The Windows Mixed Reality (WMR) headset can be used for Universal Windows Platfo
 
     ![WMR Plugin Search](Images/BuildDeploy/WMR/SteamSearchWMRPlugin.png)
 
-
 1. Select **Launch** for the Windows Mixed Reality for SteamVR Plugin.
 
     ![WMR Plugin](Images/BuildDeploy/WMR/WMRPlugin.png)
 
-    -  SteamVR and the WMR plugin will launch and a new tracking status window for the WMR headset will appear.
-    - For more information visit the [Windows Mixed Reality Steam Documentation](https://support.microsoft.com/en-us/help/4053622/windows-10-play-steamvr-games-in-windows-mixed-reality)
+    - SteamVR and the WMR plugin will launch and a new tracking status window for the WMR headset will appear.
+    - For more information visit the [Windows Mixed Reality Steam Documentation](https://support.microsoft.com/help/4053622/windows-10-play-steamvr-games-in-windows-mixed-reality)
 
         ![WMR Launch Appearance](Images/BuildDeploy/WMR/WMRPluginActive.png)
 
@@ -78,13 +77,12 @@ The Windows Mixed Reality (WMR) headset can be used for Universal Windows Platfo
 
     ![Build Settings for Standalone](Images/BuildDeploy/WMR/BuildSettingsStandaloneUnity.png)
 
-
 1. A new Unity executable will be created, to launch your app select the Unity executable in File Explorer.
 
     ![File Explorer Unity](Images/BuildDeploy/WMR/FileExplorerUnityExe.png)
 
-
 ## See also
+
 - [Android and iOS Support](CrossPlatform/UsingARFoundation.md)
 - [Leap Motion Support](CrossPlatform/LeapMotionMRTK.md)
 - [Detecting Platform Capabilities](DetectingPlatformCapabilities.md)

--- a/Documentation/CrossPlatform/LeapMotionMRTK.md
+++ b/Documentation/CrossPlatform/LeapMotionMRTK.md
@@ -1,4 +1,4 @@
-# How to Configure Leap Motion by Ultraleap Hand Tracking in MRTK 
+# How to Configure Leap Motion by Ultraleap Hand Tracking in MRTK
 
 A [Leap Motion Controller](https://www.ultraleap.com/product/leap-motion-controller/) is required to use this data provider.
 
@@ -7,6 +7,7 @@ The Leap Motion Data Provider enables articulated hand tracking for VR and could
 ![LeapMotionIntroGif](../Images/CrossPlatform/LeapMotion/LeapHandsGif3.gif)
 
 ## Using Leap Motion by Ultraleap hand tracking in MRTK
+
 1. Prepare MRTK project for Leap Motion
 
     - **This step only applies for the Leap Motion Unity Core Assets version 4.4.0 and if the source of MRTK is cloned from the git repo, NOT from the Unity packages. This step is not required if the Core Assets from Leap Motion Unity Modules version 4.5.0 are used. If the MRTK source is going to be from the Unity packages, start at the next step**
@@ -25,14 +26,14 @@ The Leap Motion Data Provider enables articulated hand tracking for VR and could
     > On import of the Core Assets, test directories are removed and 10 assembly definitions are added to the project. Make sure Visual Studio is closed.
     - If using Unity 2018.4.x
         - After the Core Assets import, navigate to **Assets/LeapMotion/**, there should be a LeapMotion.asmdef file next to the Core directory.  If the asmdef file is not present, go to the [Leap Motion Common Errors](#leap-motion-has-not-integrated-with-mrtk). If the file is present, go to the next step.
-        
+
     - If using Unity 2019.3.x, go to the next step
 
 1. Adding the Leap Motion Data Provider
     - Create a new Unity scene
     - Add MRTK to the scene by navigating to **Mixed Reality Toolkit** > **Add to Scene and Configure**
     - Select the MixedRealityToolkit game object in the hierarchy and select **Copy and Customize** to clone the default mixed reality profile.
-    
+
     ![LeapMotionProfileClone](../Images/CrossPlatform/LeapMotion/LeapProfileClone.png)
 
     - Select the **Input** Configuration Profile
@@ -51,25 +52,23 @@ The Leap Motion Data Provider enables articulated hand tracking for VR and could
 
     ![LeapDataProviderPreClone](../Images/CrossPlatform/LeapMotion/LeapDeviceManagerProfileBeforeClone.png)
 
-
     - The Leap Motion Data Provider contains the `LeapControllerOrientation` property which is the location of the Leap Motion Controller. `LeapControllerOrientation.Headset` indicates the controller is mounted on a headset. `LeapControllerOrientation.Desk` indicates the controller is placed flat on desk. The default value is set to `LeapControllerOrientation.Headset`.  If the orientation is the desk, an extra property `LeapControllerOffset` will appear.  `LeapControllerOffset` is the anchor for the position of the desk leap hands.  The offset is calculated relative to the main camera position and the default value is (0,-0.2, 0.2) to make sure the hands appear in front and in view of the camera.
     - `EnterPinchDistance` and `ExitPinchDistance` are the distance thresholds for pinch/air tap gesture detection.  The pinch gesture is calculated by measuring the distance between the index finger tip and the thumb tip.  To raise an on input down event, the default `EnterPinchDistance` is set to 0.02.  To raise an on input up event (exiting the pinch), the default distance between the index finger tip and the thumb tip is 0.05.
 
-    `LeapControllerOrientation`: Headset (Default) |  `LeapControllerOrientation`: Desk 
+    `LeapControllerOrientation`: Headset (Default) |  `LeapControllerOrientation`: Desk
     :-------------------------:|:-------------------------:
     ![LeapHeadsetGif](../Images/CrossPlatform/LeapMotion/LeapHeadsetOrientationExampleMetacarpals.gif)  |  ![LeapDeskGif](../Images/CrossPlatform/LeapMotion/LeapDeskOrientationExampleMetacarpals.gif)
     ![LeapHeadsetInspector](../Images/CrossPlatform/LeapMotion/LeapDeviceManagerHeadset.png) |     ![LeapDeskInspector](../Images/CrossPlatform/LeapMotion/LeapDeviceManagerDesk.png)
 
-    
 1. Testing the Leap Motion Data Provider
     - After Leap Motion Data Provider has been added to the input system profile, press play, move your hand in front of the Leap Motion Controller and you should see the joint representation of the hand.
 
-1. Building your project 
+1. Building your project
     - Navigate to **File > Build Settings**
     - Only Standalone builds are supported if using the Leap Motion Data Provider.
     - For instructions on how to use a Windows Mixed Reality headset for Standalone builds, see [Build and Deploy](../BuildAndDeploy.md#building-and-deploying-mrtk-to-a-windows-mixed-reality-headset).
 
-## Getting the hand joints 
+## Getting the hand joints
 
 Getting joints using the Leap Motion Data Provider is identical to hand joint retrieval for an MRTK Articulated Hand.  For more information, see [Hand Tracking](../Input/HandTracking.md#polling-joint-pose-from-handjointutils).
 
@@ -77,7 +76,7 @@ With MRTK in a unity scene and the Leap Motion Data Provider added as an Input D
 
 This script is a simple example of how to retrieve the pose of the palm joint in a Leap Motion Hand.  A sphere follows the left Leap hand while a cube follows the right Leap hand.
 
-```
+```c#
 using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
@@ -98,7 +97,7 @@ public class LeapHandJoints : MonoBehaviour, IMixedRealityHandJointHandler
         leftHandSphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
         leftHandSphere.transform.localScale = Vector3.one * 0.03f;
 
-        // Create a cube to follow the right hand palm position 
+        // Create a cube to follow the right hand palm position
         rightHandCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
         rightHandCube.transform.localScale = Vector3.one * 0.03f;
     }
@@ -121,13 +120,12 @@ public class LeapHandJoints : MonoBehaviour, IMixedRealityHandJointHandler
 
 ## Unity editor workflow tip
 
-Using the Leap Motion Data Provider does not require a VR headset.  Changes to an MRTK app can be tested in the editor with the Leap hands without a headset. 
+Using the Leap Motion Data Provider does not require a VR headset.  Changes to an MRTK app can be tested in the editor with the Leap hands without a headset.
 
-The Leap Motion Hands will show up in the editor, without a VR headset plugged in.  If the `LeapControllerOrientation` is set to **Headset**, then the Leap Motion controller will need to be held up by one hand with the camera facing forward. 
+The Leap Motion Hands will show up in the editor, without a VR headset plugged in.  If the `LeapControllerOrientation` is set to **Headset**, then the Leap Motion controller will need to be held up by one hand with the camera facing forward.
 
 > [!NOTE]
 > If the camera is moved using WASD keys in the editor and the `LeapControllerOrientation` is **Headset**, the hands will not follow the camera. The hands will only follow camera movement if a VR headset is plugged in while the `LeapControllerOrientation` is set **Headset**.  The Leap hands will follow the camera movement in the editor if the `LeapControllerOrientation` is set to **Desk**.
-
 
 ## Removing Leap Motion from the Project
 
@@ -137,7 +135,7 @@ The Leap Motion Hands will show up in the editor, without a VR headset plugged i
     - Delete the **UnityProjectName/Library** directory
     - Delete the **UnityProjectName/Assets/LeapMotion** directory
     - Delete the **UnityProjectName/Assets/LeapMotion.meta** file
-- Reopen Unity
+1. Reopen Unity
 
 In Unity 2018.4, you might notice that errors still remain in the console after deleting the Library and the Leap Motion Core Assets.
 If errors are logged after reopening, restart Unity again.
@@ -164,13 +162,14 @@ Assets\LeapMotion\Core\Scripts\Attachments\AttachmentHands.cs(105,31): error CS0
 
 These errors appear if **Mixed Reality Toolkit > Utilities > Leap Motion > Configure CSC File for Leap Motion** was not selected BEFORE the Leap Motion Unity Core Assets import.
 
-####  Solution 
+#### Solution
 
 - Navigate to **Mixed Reality Toolkit > Utilities > Leap Motion > Configure CSC File for Leap Motion**, this will update the csc file to filter out Leap Motion warnings that are converted to errors in MRTK repo.
 - Close Unity
 - Reopen Unity
 
 ### Leap Motion has not integrated with MRTK
+
 This error can occur if the Unity version is 2018.4.x, the MRTK source is from the Unity packages and after the import of the Leap Motion Unity Core Assets.
 
 To test if MRTK recognizes the presence of the Leap Motion Unity Core Assets, open the LeapMotionHandTrackingExample scene located in MRTK/Examples/Demos/HandTracking/ and press play.  If the Leap Motion Unity Core Assets are recognized a green message on the informational panel in the scene will appear.  If the Leap Motion Unity Core Assets are not recognized a red message will appear.
@@ -178,20 +177,20 @@ To test if MRTK recognizes the presence of the Leap Motion Unity Core Assets, op
 If the Leap Motion Unity Core Assets are in your project and you see a red message on the informational panel, the project needs to be configured.
 
 #### Solution
+
 - Navigate to **Mixed Reality Toolkit > Utilities > Leap Motion > Configure Leap Motion**
-    - This will force Leap Motion integration if the configuration process was not started after the Leap Motion Unity Core Assets import.
-
-
+  - This will force Leap Motion integration if the configuration process was not started after the Leap Motion Unity Core Assets import.
 
 ### Copying assembly Multiplayer HLAPI failed
 
-On import of the Leap Motion Unity Core Assets this error might be logged: 
+On import of the Leap Motion Unity Core Assets this error might be logged:
 
 ```
 Copying assembly from 'Temp/com.unity.multiplayer-hlapi.Runtime.dll' to 'Library/ScriptAssemblies/com.unity.multiplayer-hlapi.Runtime.dll' failed
 ```
 
 #### Solution
+
 - A short term solution is to restart Unity. See [Issue 7761](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7761) for more information.
 
 ## Leap Motion Example Scene

--- a/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
+++ b/Documentation/EyeTracking/EyeTracking_IsUserCalibrated.md
@@ -16,7 +16,7 @@ This page covers the following:
 
 ### How to detect the eye calibration state
 
-Eye tracking configuration in MRTK is configured via the [`IMixedRealityEyeGazeProvider`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityEyeGazeProvider) interface. 
+Eye tracking configuration in MRTK is configured via the [`IMixedRealityEyeGazeProvider`](xref:Microsoft.MixedReality.Toolkit.Input.IMixedRealityEyeGazeProvider) interface.
 
 Using [CoreServices.InputSystem.EyeGazeProvider](EyeTracking_EyeGazeProvider.md) provides the default gaze provider implementation registered in the toolkit at runtime. `IMixedRealityEyeGazeProvider.IsEyeGazeValid` returns a `bool?` which is null if no information from the eye tracker is available yet.
 Once data has been received, it will either return true or false to indicate that the user's eye tracking calibration is valid or invalid.

--- a/Documentation/EyeTracking/EyeTracking_Main.md
+++ b/Documentation/EyeTracking/EyeTracking_Main.md
@@ -21,4 +21,4 @@ It is recommended to start by exploring some of the existing eye tracking sample
 - [MRTK Eye Tracking setup](EyeTracking_BasicSetup.md)
 - [MRTK Eye Tracking via Code](EyeTracking_EyeGazeProvider.md)
 - [MRTK Eye Tracking Calibration](EyeTracking_IsUserCalibrated.md)
-- [HoloLens 2 Eye Tracking Documentation](https://docs.microsoft.com/windows/mixed-reality/eye-tracking) 
+- [HoloLens 2 Eye Tracking Documentation](https://docs.microsoft.com/windows/mixed-reality/eye-tracking)

--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -99,6 +99,7 @@ To create a **HoloLens application**, switch to the Universal Windows Platform:
     Profiles configure the behavior of MRTK core components and are described in more detail in the [profiles](Profiles/Profiles.md) article.
 
     > [!NOTE]
+    >
     > * If you're using Unity's XR SDK in Unity 2019.3 or later, you should choose the "DefaultXRSDKConfigurationProfile". This profile is set up with MRTK's XR SDK systems and providers, where needed.  
     > * If you're getting started on the HoloLens or HoloLens 2, you should choose the "DefaultHoloLens1ConfigurationProfile" or DefaultHoloLens2ConfigurationProfile" instead.  
     > * See the [profiles](Profiles/Profiles.md#hololens-2-profile) for more information on the differences between DefaultMixedRealityToolkitConfigurationProfile and DefaultHoloLens2ConfigurationProfile.

--- a/Documentation/Input/CreateDataProvider.md
+++ b/Documentation/Input/CreateDataProvider.md
@@ -190,7 +190,7 @@ It is recommended to implement the pattern utilized by the MRTK when instrumenti
 
 > [!Note]
 > The name used to identify the profiler marker is arbitrary. The MRTK uses the following pattern.
-> 
+>
 > "[product] className.methodName - optional note"
 >
 > It is recommended that custom data providers follow a similar pattern to help simplify identification of specific components and methods when analyzing traces.

--- a/Documentation/InputSimulation/InputSimulationService.md
+++ b/Documentation/InputSimulation/InputSimulationService.md
@@ -98,7 +98,7 @@ Hands can be toggled on permanently in the [input simulation tools window](#inpu
 
 Mouse movement will move the hand in the view plane. Hands can be moved further or closer to the camera using the **mouse wheel**.
 
-To rotate hands using the mouse, hold both the **Left/Right Hand Control Key** (*Left Shift* or *Space*) *and* the **Hand Rotate Button** (default: *cntrl* button) and then move the mouse to rotate the hand. Hand rotation speed can be configured by changing the **Mouse Hand Rotation Speed** setting in the input simulation profile.
+To rotate hands using the mouse, hold both the **Left/Right Hand Control Key** (*Left Shift* or *Space*) *and* the **Hand Rotate Button** (default: *ctrl* button) and then move the mouse to rotate the hand. Hand rotation speed can be configured by changing the **Mouse Hand Rotation Speed** setting in the input simulation profile.
 
 All hand placement can also changed in the [input simulation tools window](#input-simulation-tools-window), including resetting hands to default.
 

--- a/Documentation/LargeProjects.md
+++ b/Documentation/LargeProjects.md
@@ -103,7 +103,7 @@ MSBuildForUnity.Common.props
 Dependencies*
 Nuget.config*
 
-# DotNetAdapater specific
+# DotNetAdapter specific
 # This section covers files that are deployed by the imported DotNetWinRT NuGet package
 # This is primarily used for Unity Editor to HoloLens 2 in-editor remoting 
 !/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj

--- a/Documentation/LargeProjects.md
+++ b/Documentation/LargeProjects.md
@@ -105,7 +105,7 @@ Nuget.config*
 
 # DotNetAdapter specific
 # This section covers files that are deployed by the imported DotNetWinRT NuGet package
-# This is primarily used for Unity Editor to HoloLens 2 in-editor remoting 
+# This is primarily used for Unity Editor to HoloLens 2 in-editor remoting
 !/Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/DotNetAdapter.csproj
 Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/.bin/
 Assets/MixedRealityToolkit.Providers/WindowsMixedReality/Shared/DotNetAdapter/.obj/

--- a/Documentation/MRTK_Configuration_Dialog.md
+++ b/Documentation/MRTK_Configuration_Dialog.md
@@ -29,7 +29,7 @@ Configures the Virtual Reality Supported and Virtual Reality SDK options in **Pl
 
 Configures the **Player Settings** > **XR Settings** > **Stereo Rendering Mode** to **Single Pass Instanced**.
 
-### Set default Spatial Awareness layer 
+### Set default Spatial Awareness layer
 
 Registers Spatial Awareness as layer 31 to enable easy and consistent configuration of raycast and physics options.
 
@@ -48,7 +48,7 @@ Microsoft provided spatializer that supports utilization of hardware acceleratio
 
 This spatializer is available via [NuGet](https://www.nuget.org/packages/Microsoft.SpatialAudio.Spatializer.Unity/) and [GitHub](https://github.com/microsoft/spatialaudio-unity).
 
-More details on Microsoft Spatializer can be found in the [Spatial Sound documentation](https://docs.microsoft.com/en-us/windows/mixed-reality/spatial-sound-in-unity).
+More details on Microsoft Spatializer can be found in the [Spatial Sound documentation](https://docs.microsoft.com/windows/mixed-reality/spatial-sound-in-unity).
 
 - MS HRTF Spatializer
 
@@ -58,7 +58,7 @@ Microsoft Windows spatializer that is provided by Unity as part of the Windows M
 
 A cross platform spatializer from Google that is provided by Unity.
 
-More information can be found on the [Resonance Audio documentation](https://resonance-audio.github.io/resonance-audio/develop/unity/getting-started) site. 
+More information can be found on the [Resonance Audio documentation](https://resonance-audio.github.io/resonance-audio/develop/unity/getting-started) site.
 
 ## Universal Windows Platform settings
 
@@ -76,7 +76,7 @@ Enables specific application capabilities for Universal Windows Platform applica
 
 - Microphone
 
-  Enables capturing sound via the microphone. 
+  Enables capturing sound via the microphone.
 
 - Internet Client
 

--- a/Documentation/MRTK_Configuration_Dialog.md
+++ b/Documentation/MRTK_Configuration_Dialog.md
@@ -15,7 +15,7 @@ All build targets share a collection of common options.
 
 ![Common Settings](Images/ConfigurationDialog/ConfigurationDialogCommonSettings.png)
 
-### Force text asset serilialization and Enable visible meta files
+### Force text asset serialization and Enable visible meta files
 
 These settings help simplify working with Unity projects and source control systems (ex: Git).
 
@@ -23,7 +23,7 @@ These settings help simplify working with Unity projects and source control syst
 
 **Unity 2018**
 
-Configures the Virutual Reality Supported and Virtual Reality SDK options in **Player Settings** > **XR Settings**.
+Configures the Virtual Reality Supported and Virtual Reality SDK options in **Player Settings** > **XR Settings**.
 
 ### Set Single Pass Instanced rendering path
 
@@ -72,7 +72,7 @@ MSBuild for Unity is a component that enables automatic restoring of specific Nu
 
 ### UWP Capabilities
 
-Enables specific application capabilites for Universal Windows Platform application. These capabilities enable the platform to inform and request permission to enable specific functionality.
+Enables specific application capabilities for Universal Windows Platform application. These capabilities enable the platform to inform and request permission to enable specific functionality.
 
 - Microphone
 
@@ -100,7 +100,7 @@ Configuration settings to support AR applications on Android powered devices.
 
 ### Disable Multi-Threaded Rendering
 
-Disbles **Player Settings** > **Other Settings** > **Multithreaded Rendering** as required by Android's AR support.
+Disables **Player Settings** > **Other Settings** > **Multithreaded Rendering** as required by Android's AR support.
 
 ### Set Minimum API Level
 
@@ -122,4 +122,4 @@ Sets the value of **Player Settings** > **Other Settings** > **Architecture** to
 
 ### Set Camera Usage Descriptions
 
-Sets the value of **Player Settings** > **Other Settings** > **Camera Usage Description** used to request permission to use the device's camnera.
+Sets the value of **Player Settings** > **Other Settings** > **Camera Usage Description** used to request permission to use the device's camera.

--- a/Documentation/MixedRealityConfigurationGuide.md
+++ b/Documentation/MixedRealityConfigurationGuide.md
@@ -15,7 +15,7 @@ The main configuration profile, which is attached to the *MixedRealityToolkit* G
 
 ![MRTK configuration profile](../Documentation/Images/MixedRealityToolkitConfigurationProfileScreens/MRTK_ActiveConfiguration.png)
 
-All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets/MRT/KSDK/Profiles.
+All the "default" profiles for the Mixed Reality Toolkit can be found in the SDK project in the folder Assets/MRTK/SDK/Profiles.
 
 > [!IMPORTANT]
 > DefaultHoloLens2ConfigurationProfile is optimized for HoloLens 2. See [Profiles](Profiles/Profiles.md) for the details.

--- a/Documentation/Performance/PerfGettingStarted.md
+++ b/Documentation/Performance/PerfGettingStarted.md
@@ -39,7 +39,7 @@ To maintain comfortable frame rates (typically 60 frames per second), applicatio
 [MRTK] className.methodName
 ```
 
-> [!Note] 
+> [!Note]
 > There may be additional data following the method name. This is used to identify conditionally executed, potentially expensive functionality that may be avoided by small changes to application code.
 
 ![Example Unity Profiler Hierarchy](../../Documentation/Images/Performance/UnityProfilerHierarchy.png)

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -178,7 +178,7 @@ HoloLens 2's shell-style button's size is 32x32mm. To customize the dimension, c
 2. **Quad** under BackPlate
 3. **Box Collider** on the root
 
-Then, click **Fix Bounds** button in the NearInteractionTouchble script which is in the root of the button. 
+Then, click **Fix Bounds** button in the NearInteractionTouchable script which is in the root of the button.
 
 Update the size of the FrontPlate
 ![Button](Images/Button/MRTK_Button_SizeCustomization1.png)

--- a/Documentation/README_Button.md
+++ b/Documentation/README_Button.md
@@ -36,13 +36,12 @@ The `Button` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/Button.prefab) is
 `PressableButtonHoloLens2` (Assets/MRTK/SDK/Features/UX/Interactable/Prefabs/PressableButtonHoloLens2.prefab) is HoloLens 2's shell style button that supports the precise movement of the button for the direct hand tracking input. It combines `Interactable` script with `PressableButton` script.
 
 For HoloLens 2, it is recommended to use buttons with an opaque backplate. Transparent buttons are not recommended because of these usability and stability issues:
+
 - Icon and text are difficult to read with the physical environment
 - It is hard to understand when the event triggers
 - Holograms that are displayed through a transparent plane can be unstable with HoloLens 2's Depth LSR stabilization
 
 ![Button](Images/Button/MRTK_Button_UsePlated.png)
-
-
 
 ## How to use pressable buttons
 
@@ -82,7 +81,6 @@ In HoloLens 2 shell-style button, there are many visual cues and affordances to 
 |:--- | :--- | :--- | :--- |
 | Proximity light | Focus highlight | Compressing cage | Pulse on trigger |
 
-
 The subtle pulse effect is triggered by the pressable button, which looks for *ProximityLight(s)* that live on the currently interacting pointer. If any proximity lights are found, the `ProximityLight.Pulse` method is called, which automatically animates shader parameters to display a pulse.
 
 ## Inspector properties
@@ -119,9 +117,10 @@ MRTK buttons use a `ButtonConfigHelper` component to assist you in changing the 
 
 ![Button](../Documentation/Images/Button/MRTK_Button_Config_Helper.png)
 
-### Creating and Modifying Icon Sets ###
+### Creating and Modifying Icon Sets
 
 An **Icon Set** is a shared set of icon assets used by the `ButtonConfigHelper` component. Three icon *styles* are supported.
+
 * **Quad** icons are rendered on a quad using a `MeshRenderer`. This is the default icon style.
 * **Sprite** icons are rendered using a `SpriteRenderer`. This is useful if you prefer to import your icons as a sprite sheet, or if you want your icon assets to be shared with Unity UI components. To use this style you will need to install the Sprite Editor package **(Windows -> Package Manager -> 2D Sprite)**
 * **Char** icons are rendered using a `TextMeshPro` component. This is useful if you prefer to use an icon font. To use the HoloLens icon font you will need to create a `TextMeshPro` font asset.
@@ -130,8 +129,8 @@ To change which style your button uses, expand the *Icons* dropdown in the Butto
 
 You can create a new button icon set with the asset menu: **Create > Mixed Reality Toolkit > Icon Set.** To add quad and sprite icons, simply drag them into their respective arrays. To add Char icons, you must first create and assign a font asset.
 
-In MRTK 2.4 and beyond, we recommend custom icon textures be moved into an IconSet. 
-To upgrade the assets on all buttons in a project to the new recommended format, use the ButtonConfigHelperMigrationHandler. 
+In MRTK 2.4 and beyond, we recommend custom icon textures be moved into an IconSet.
+To upgrade the assets on all buttons in a project to the new recommended format, use the ButtonConfigHelperMigrationHandler.
 (Mixed Reality Toolkit -> Utilities -> Migration Window -> Migration Handler Selection -> Microsoft.MixedReality.Toolkit.Utilities.ButtonConfigHelperMigrationHandler)
 
 Importing the Microsoft.MixedRealityToolkit.Unity.Tools package required to upgrade the buttons.
@@ -142,15 +141,16 @@ If an icon is not found in the default icon set during migration, a custom icon 
 
 ![Custom icon notification](https://user-images.githubusercontent.com/9789716/82093856-c57dfc00-96b0-11ea-83ab-4df57446d661.PNG)
 
-
-### Creating a HoloLens Icon Font Asset ###
+### Creating a HoloLens Icon Font Asset
 
 First, import the icon font into Unity. On Windows machines you can find the default HoloLens font in *Windows/Fonts/holomdl2.ttf.* Copy and paste this file into your Assets folder.
 
 Next, open the TextMeshPro Font Asset Creator via **Window > TextMeshPro > Font Asset Creator.** Here are the recommended settings for generating a HoloLens font atlas. To include all icons, paste the following Unicode range into the *Character Sequence* field:
+
 ```c#
 E700-E702,E706,E70D-E70E,E710-E714,E718,E71A,E71D-E71E,E720,E722,E728,E72A-E72E,E736,E738,E73F,E74A-E74B,E74D,E74F-E752,E760-E761,E765,E767-E769,E76B-E76C,E770,E772,E774,E777,E779-E77B,E782-E783,E785-E786,E799,E7A9-E7AB,E7AF-E7B1,E7B4,E7C8,E7E8-E7E9,E7FC,E80F,E821,E83F,E850-E859,E872-E874,E894-E895,E8A7,E8B2,E8B7,E8B9,E8D5,E8EC,E8FB,E909,E91B,E92C,E942,E95B,E992-E995,E9E9-E9EA,EA37,EA40,EA4A,EA55,EA96,EB51-EB52,EB65,EB9D-EBB5,EBCB-EBCC,EBCF-EBD3,EC03,EC19,EC3F,EC7A,EC8E-EC98,ECA2,ECD8-ECDA,ECE0,ECE7-ECEB,ED17,EE93,EFA9,F114-F120,F132,F181,F183-F186
 ```
+
 ![Button](../Documentation/Images/Button/MRTK_Font_Asset_Creation_1.png)
 
 Once the font asset is generated, save it to your project and assign it to your Icon Set's *Char Icon Font* field. The *Available Icons* dropdown will now be populated. To make an icon available for use by a button, click it. It will be added to the *Selected Icons* dropdown and will now show up in the `ButtonConfigHelper.` You can optionally give the icon a tag. This enables setting the icon at runtime.
@@ -160,7 +160,7 @@ Once the font asset is generated, save it to your project and assign it to your 
 ![Button](../Documentation/Images/Button/MRTK_Font_Asset_Creation_2.png)
 
 ```c#
-public void SetButtonToAdjust() 
+public void SetButtonToAdjust()
 {
     ButtonConfigHelper buttonConfigHelper = gameObject.GetComponent<ButtonConfigHelper>();
     buttonConfigHelper.SetCharIconByName("AppBarAdjust");
@@ -174,6 +174,7 @@ To use your Icon Set select a button, expand the Icons dropdown in the `ButtonCo
 ## How to change the size of a button
 
 HoloLens 2's shell-style button's size is 32x32mm. To customize the dimension, change the size of these objects in the button prefab:
+
 1. **FrontPlate**
 2. **Quad** under BackPlate
 3. **Box Collider** on the root

--- a/Documentation/README_HandMenu.md
+++ b/Documentation/README_HandMenu.md
@@ -5,33 +5,36 @@
 Hand menus allow users to quickly bring up hand-attached UI for frequently used functions. To prevent false activation while interacting with other objects, hand menu provides options such as 'Require Flat Hand' and 'Use Gaze Activation'. It is recommended to use these options to prevent unwanted activation.
 
 ## Hand menu examples
-**HandMenuExamples.unity** scene is under ``MRTK/Examples/Demos/HandTracking/Scenes`` folder. When it is running, the scene will only activate currently selected menu type. 
+
+**HandMenuExamples.unity** scene is under ``MRTK/Examples/Demos/HandTracking/Scenes`` folder. When it is running, the scene will only activate currently selected menu type.
 <br/><img src="Images/HandMenu/MRTK_HandMenu_ExampleScene.png" width="600px">
 
 You can find these hand menu prefabs under ``MRTK/Examples/Demos/HandTracking/Prefabs`` folder.
 
 ### HandMenu_Small_HideOnHandDrop and HandMenu_Medium_HideOnHandDrop
+
 These two examples simply activate and deactivate the MenuContent object to show and hide menu on **OnFirstHandDetected()** and **OnLastHandLost()** event.
 <br/><img src="Images/HandMenu/MRTK_HandMenu_Example1.png" width="600">
 <br/><img src="Images/HandMenu/MRTK_HandMenu_Example2.png" width="600">
 
 ### HandMenu_Large_WorldLock_On_GrabAndPull
+
 For more complex menus that require longer interaction time, it is recommended to world-lock the menu. In this example, the user can grab and pull to world-lock the menu, in addition to activating and deactivating the MenuContent on **OnFirstHandDetected()** and **OnLastHandLost()** events.
 <br/><img src="Images/HandMenu/MRTK_HandMenu_Example3.png" width="600">
 
-Backplate's `ManipulationHanlder` makes it grabbable and movable. **On Manipulation Started** event, **SolverHandler.UpdateSolvers** is deactivated to world-lock the menu. Additionally, it shows the **Close button** to allow the user to close the menu when the task is finished. **On Manipulation Ended** event, it calls **HandConstraintPalmUp.StartWorldLockReattachCheckCoroutine** to allow the user bring the menu back to hand by raising and looking at the palm.
+Backplate's `ManipulationHandler` makes it grabbable and movable. **On Manipulation Started** event, **SolverHandler.UpdateSolvers** is deactivated to world-lock the menu. Additionally, it shows the **Close button** to allow the user to close the menu when the task is finished. **On Manipulation Ended** event, it calls **HandConstraintPalmUp.StartWorldLockReattachCheckCoroutine** to allow the user bring the menu back to hand by raising and looking at the palm.
 <br/><img src="Images/HandMenu/MRTK_HandMenu_Example4.png" width="600">
 
 **Close** button reactivates **SolverHandler.UpdateSolvers** and hide the **MenuContent**.
 <br/><img src="Images/HandMenu/MRTK_HandMenu_Example5.png">
 
 ### HandMenu_Large_AutoWorldLock_On_HandDrop
-This example is similar to HandMenu_Large_WorldLock_On_GrabAndPull. The only difference is that the menu will be automatically world-locked on hand drop. This is done by simply not hiding the MenuContent on **OnLastHandLost()** event. Grab & pull behavior is same as HandMenu_Large_WorldLock_On_GrabAndPull example.
 
+This example is similar to HandMenu_Large_WorldLock_On_GrabAndPull. The only difference is that the menu will be automatically world-locked on hand drop. This is done by simply not hiding the MenuContent on **OnLastHandLost()** event. Grab & pull behavior is same as HandMenu_Large_WorldLock_On_GrabAndPull example.
 
 ## Scripts
 
-The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behavior provides a solver that constrains the tracked object to a region safe for hand constrained content (such as hand UI, menus, etc). Safe regions are considered areas that don't intersect with the hand. A derived class of [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) called [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is also included to demonstrate a common behavior of activating the solver tracked object when the palm is facing the user. 
+The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behavior provides a solver that constrains the tracked object to a region safe for hand constrained content (such as hand UI, menus, etc). Safe regions are considered areas that don't intersect with the hand. A derived class of [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) called [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is also included to demonstrate a common behavior of activating the solver tracked object when the palm is facing the user.
 
 Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) property for additional documentation. A few properties are defined in more detail below.
 
@@ -45,20 +48,18 @@ Please see the tool tips available for each [`HandConstraint`](xref:Microsoft.Mi
 
 * **Activation Events**: Currently the [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) triggers four activation events. These events can be used in many different combinations to create unique [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behaviors, please see the HandBasedMenuExample scene under `MRTK/Examples/Demos/HandTracking/Scenes/` for examples of these behaviors.
 
-    * *OnHandActivate*: triggers when a hand satisfies the IsHandActive method.
-    * *OnHandDeactivate*: triggers when the IsHandActive method is no longer satisfied.
-    * *OnFirstHandDetected*: occurs when the hand tracking state changes from no hands in view, to the first hand in view.
-    * *OnLastHandLost*: occurs when the hand tracking state changes from at least one hand in view, to no hands in view.
+  * *OnHandActivate*: triggers when a hand satisfies the IsHandActive method.
+  * *OnHandDeactivate*: triggers when the IsHandActive method is no longer satisfied.
+  * *OnFirstHandDetected*: occurs when the hand tracking state changes from no hands in view, to the first hand in view.
+  * *OnLastHandLost*: occurs when the hand tracking state changes from at least one hand in view, to no hands in view.
 
 * **Solver Activation/Deactivation Logic**: Currently the recommendation for activating and deactivating [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) logic is to do so through the use of the SolverHandler's UpdateSolver value, rather than by disabling/enabling the object. This can be seen in the example scene through the editor-based hooks triggered after the attached menu's ManipulationHandler "OnManipulationStarted/Ended" events.
 
-    * *Stopping the hand-constraint logic*: When trying to set the hand constrained object to stop (as well as not run the activation/deactivation logic), set UpdateSolver to False rather than disabling HandConstraintPalmUp. 
-         * If you want to enable the gaze-based (or even non-gaze-based) Reattach logic, this is then followed by calling the HandConstraintPalmUp.StartWorldLockReattachCheckCorotine() function. This will trigger a coroutine that then continues to check if the "IsValidController" criteria is met and will set UpdateSolver to True once it is (or the object is disabled) 
-    	
-	 * *Starting the hand-constraint logic*: When trying to set the hand constrained object to start following your hand again (based on whether it meets the activation criteria), set the SolverHandler's UpdateSolver to true. 
+  * *Stopping the hand-constraint logic*: When trying to set the hand constrained object to stop (as well as not run the activation/deactivation logic), set UpdateSolver to False rather than disabling HandConstraintPalmUp.
+    * If you want to enable the gaze-based (or even non-gaze-based) Reattach logic, this is then followed by calling the HandConstraintPalmUp.StartWorldLockReattachCheckCoroutine() function. This will trigger a coroutine that then continues to check if the "IsValidController" criteria is met and will set UpdateSolver to True once it is (or the object is disabled)
+  * *Starting the hand-constraint logic*: When trying to set the hand constrained object to start following your hand again (based on whether it meets the activation criteria), set the SolverHandler's UpdateSolver to true.
 
-
-* **Reattach Logic**: Currently the [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is able to automatically reattach the target object to the tracked point, regardless of whether the SolverHandler's UpdateSolver is True or not. This is done through calling the HandConstraintPalmUp's StartWorldLockReattachCheckCorotine() function, after it's been world-locked (which in this case, is effectively setting the SolverHandler's UpdateSolver to False). 
+* **Reattach Logic**: Currently the [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is able to automatically reattach the target object to the tracked point, regardless of whether the SolverHandler's UpdateSolver is True or not. This is done through calling the HandConstraintPalmUp's StartWorldLockReattachCheckCoroutine() function, after it's been world-locked (which in this case, is effectively setting the SolverHandler's UpdateSolver to False).
 
 ## See also
 

--- a/Documentation/README_Interactable.md
+++ b/Documentation/README_Interactable.md
@@ -100,7 +100,7 @@ Themes work a lot like materials. They are scriptable objects that contain a lis
 
 **Reset On Destroy**
 
-Visual themes modify various properties on a targeted GameObject, dependent on the class and type of theme engine selected. If *Reset On Destroy* is true when the Interactable component is destroyed, the component will reset all modified properties from active themes to their original values. Otherwise, when destroyed, the Interactable component will leave any modified properties as-is. In this latter case, the last state of values will persist unless altered by another external component. The default is false. 
+Visual themes modify various properties on a targeted GameObject, dependent on the class and type of theme engine selected. If *Reset On Destroy* is true when the Interactable component is destroyed, the component will reset all modified properties from active themes to their original values. Otherwise, when destroyed, the Interactable component will leave any modified properties as-is. In this latter case, the last state of values will persist unless altered by another external component. The default is false.
 
 <img src="../Documentation/Images/Interactable/Profiles_Themes.png" width="450">
 

--- a/Documentation/README_MRTKStandardShader.md
+++ b/Documentation/README_MRTKStandardShader.md
@@ -6,7 +6,7 @@ MRTK Standard shading system utilizes a single, flexible shader that can achieve
 
 ## Example scenes
 
-You can find the shader material examples in the **MaterialGallery** scene under 
+You can find the shader material examples in the **MaterialGallery** scene under
 `MRTK/Examples/Demos/StandardShader/Scenes/`. All materials in this scene are using the MRTK/Standard shader.
 
 ![Material Gallery](../Documentation/Images/MRTKStandardShader/MRTK_MaterialGallery.jpg)

--- a/Documentation/README_ObjectManipulator.md
+++ b/Documentation/README_ObjectManipulator.md
@@ -14,7 +14,7 @@ To make the object respond to near articulated hand input, add the `NearInteract
 
 Physics behaviour can be enabled for the object manipulator by adding a rigidbody component to the object. Physics behaviour enabled by adding this component is discussed in greater detail in [*Physics and collisions*](#physics-and-collisions).
 
-As well as this, manipulation can be constrained by adding [manipulation constraint components](#transform-constraints) to the object. These are special components that work with manipulation and change the manipulation behaviour in some way. 
+As well as this, manipulation can be constrained by adding [manipulation constraint components](#transform-constraints) to the object. These are special components that work with manipulation and change the manipulation behaviour in some way.
 
 ![Manipulation Handler](../Documentation/Images/ObjectManipulator/MRTK_ObjectManipulator_Howto.png)
 
@@ -49,6 +49,7 @@ Specifies how the object will behave when it is being grabbed with one hand near
 * *Rotate about grab point*: Rotate object with the hand about the grab point between the thumb and index finger. It should feel as if the object is being held by the hand.
 
 #### One hand rotation mode far
+
 Specifies how the object will behave when it is being grabbed with one hand at distance. These options only work for articulated hands.
 
 * *Rotate about object center*: Rotate object using rotation of the hand, but about the object center point. Useful for inspecting at a distance without the object center moving as the object rotates.
@@ -74,7 +75,7 @@ This button allows a constraint component to be added directly from the object m
 
 #### Go to component
 
-All constraints found on the object wil be listed here with a *Go to component* button. This button will cause the inspector to scroll to the selected constraint component so that it can be configured. 
+All constraints found on the object wil be listed here with a *Go to component* button. This button will cause the inspector to scroll to the selected constraint component so that it can be configured.
 
 ### Physics
 
@@ -88,15 +89,19 @@ Specify which physical properties a manipulated object should keep upon release.
 ### Smoothing
 
 #### Smoothing active
+
 Specifies whether smoothing is active.
 
 #### Move lerp time
+
 Amount of smoothing to apply to the movement. Smoothing of 0 means no smoothing. Max value means no change to value.
 
 #### Rotate lerp time
+
 Amount of smoothing to apply to the rotation. Smoothing of 0 means no smoothing. Max value means no change to value.
 
 #### Scale lerp time
+
 Amount of smoothing to apply to the scale. Smoothing of 0 means no smoothing. Max value means no change to value.
 
 ### Manipulation events
@@ -244,7 +249,9 @@ Physics behaviour can be enabled by adding a rigidbody component to the same obj
 When a rigidbody is added, collisions should work correctly.
 
 ### Without rigidbody
+
 <img src="../Documentation/Images/ObjectManipulator/MRTK_PhysicsManipulation_NoRigidbody.gif" width="500">
 
 ### With rigidbody
+
 <img src="../Documentation/Images/ObjectManipulator/MRTK_PhysicsManipulation_Rigidbody.gif" width="500">

--- a/Documentation/README_ProgressIndicator.md
+++ b/Documentation/README_ProgressIndicator.md
@@ -1,4 +1,5 @@
 # Progress Indicators
+
 ![Progress Indicators](../Documentation/Images/ProgressIndicator/MRTK_ProgressIndicator_Main.png)
 
 ## Example scene
@@ -22,9 +23,10 @@ private void Start()
 }
 ```
 
-The `IProgressIndicator.OpenAsnyc()` and `IProgressIndicator.CloseAsync()` methods return [Tasks](xref:System.Threading.Tasks.Task). We recommend awaiting these Tasks in an aync method.
+The `IProgressIndicator.OpenAsync()` and `IProgressIndicator.CloseAsync()` methods return [Tasks](xref:System.Threading.Tasks.Task). We recommend awaiting these Tasks in an async method.
 
 Set the indicator's `Progress` property to a value from 0-1 to update its displayed progress. Set its `Message` property to update its displayed message. Different implementations may display this content in different ways.
+
 ```c#
 private async void OpenProgressIndicator()
 {
@@ -55,11 +57,12 @@ State | Valid Operations
 `ProgressIndicatorState.Closed` | `OpenAsync()`
 
 `AwaitTransitionAsync()` can be used to be sure an indicator is fully opened or closed before using it.
+
 ```c#
 private async void ToggleIndicator(IProgressIndicator indicator)
 {
     await indicator.AwaitTransitionAsync();
-    
+
     switch (indicator.State)
     {
         case ProgressIndicatorState.Closed:

--- a/Documentation/README_Solver.md
+++ b/Documentation/README_Solver.md
@@ -37,10 +37,10 @@ The *Tracked Target Type* property of the [`SolverHandler`](xref:Microsoft.Mixed
 
 * *Head* : Point of reference is the transform of the main camera
 * *ControllerRay*: Point of reference is the [`LinePointer`](xref:Microsoft.MixedReality.Toolkit.Input.LinePointer) transform on a controller (i.e pointer origin on a motion controller or hand controller) pointing in the direction of the line ray
-    * Use the `TrackedHandedness` property to select the handedness preference (i.e Left, Right, Both)
+  * Use the `TrackedHandedness` property to select the handedness preference (i.e Left, Right, Both)
 * *HandJoint*: Point of reference is the transform of a specific hand joint
-    * Use the `TrackedHandedness` property to select the handedness preference (i.e Left, Right, Both)
-    * Use the  `TrackedHandJoint` property to determine the joint transform to utilize
+  * Use the `TrackedHandedness` property to select the handedness preference (i.e Left, Right, Both)
+  * Use the  `TrackedHandJoint` property to determine the joint transform to utilize
 * *CustomOverride*: Point of reference from the assigned `TransformOverride`
 
 > [!NOTE]
@@ -51,9 +51,9 @@ The *Tracked Target Type* property of the [`SolverHandler`](xref:Microsoft.Mixed
 
 > [!IMPORTANT]
 > Most solvers use the forward vector of the tracked transform target supplied by the `SolverHandler`. When using a *Hand Joint* tracked target type, the forward vector of the palm joint may point through the fingers and not through the palm. This depends on the platform supplying the hand joint data. For input simulation and Windows Mixed Reality, it is the *up vector* that points up through the palm (i.e green vector is up, blue vector is forward).
-> 
+>
 > ![Solver](Images/Solver/HandJoint_ForwardUpVectors.png)
-> 
+>
 > To overcome this, update the *Additional Rotation* property on the `SolverHandler` to **<90, 0, 0>**. This will ensure the forward vector supplied to solvers is pointing through the palm and outward away from the hand.
 >
 > ![Solver](Images/Solver/SolverHandler_AdditionalRotation.png)
@@ -174,7 +174,7 @@ Finally, surfaces farther than the `MaxRaycastDistance` property setting will be
 
 ![Hand Menu UX Example](Images/Solver/MRTK_UX_HandMenu.png)
 
-The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behavior provides a solver that constrains the tracked object to a region safe for hand constrained content (such as hand UI, menus, etc). Safe regions are considered areas that don't intersect with the hand. A derived class of [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) called [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is also included to demonstrate a common behavior of activating the solver tracked object when the palm is facing the user. 
+The [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) behavior provides a solver that constrains the tracked object to a region safe for hand constrained content (such as hand UI, menus, etc). Safe regions are considered areas that don't intersect with the hand. A derived class of [`HandConstraint`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraint) called [`HandConstraintPalmUp`](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.HandConstraintPalmUp) is also included to demonstrate a common behavior of activating the solver tracked object when the palm is facing the user.
 
 [Please see Hand Menu page](README_HandMenu.md) for the examples of using Hand Constraint solver to create hand menus.
 

--- a/Documentation/README_SystemKeyboard.md
+++ b/Documentation/README_SystemKeyboard.md
@@ -39,4 +39,5 @@ private void Update()
 You can see a simple example of how to bring up system keyboard in `MixedRealityKeyboard.cs` (Assets/MRTK/SDK/Experimental/Features/UX/MixedRealityKeyboard.cs)
 
 ## See Also
-- [Mixed Reality Keyboard Helper Classes](../Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/README_MixedRealityKeyboard.md) 
+
+- [Mixed Reality Keyboard Helper Classes](../Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/README_MixedRealityKeyboard.md)

--- a/Documentation/README_TapToPlace.md
+++ b/Documentation/README_TapToPlace.md
@@ -15,7 +15,7 @@ Tap to Place is a far interaction component that is used to place a game object 
 1. Attach [Tap to Place](xref:Microsoft.MixedReality.Toolkit.Utilities.Solvers.TapToPlace) to a game object with a collider
 
     ![TapToPlaceInspector](Images/Solver/TapToPlace/TapToPlaceInspector2.png)
-    
+
     - When the Tap to Place component is added, a Solver Handler will also be attached. Tap to Place derives from the [Solver](README_Solver.md) class which requires a Solver Handler. The position of a Tap to Place object is calculated relative to the `TrackedTargetType` within the Solver Handler. By default the Head is the `TrackedTargetType`, i.e. when the head moves, the object follows if it is selected.  The `TrackedTargetType` can also be set to Controller Ray which has the object follow the controller. The first group of properties in the Tap to Place inspector are the [Common Solver Properties](README_Solver.md#common-solver-properties).  
     > [!IMPORTANT]
     > Tap to Place is a stand alone Solver and cannot be chained with other Solvers. It cannot be chained because SolverHandler.UpdateSolvers is used to update the object's position while it is being placed.
@@ -31,26 +31,25 @@ Tap to Place is a far interaction component that is used to place a game object 
         - `On Placing Started`: This event is triggered once when the game object to place is selected.
         - `On Placing Stopped`: This event is triggered once when the game object to place is unselected, placed.
 
-1.  Testing Tap to Place behavior in editor
+1. Testing Tap to Place behavior in editor
     - Press play and hold the space bar to show an input simulation hand.
     - Move the hand until the cube is in focus and simulate a click with the input simulation hand by clicking with the left mouse.
         - If colliders are not present in the scene, the object will follow the `TrackedTargetType` at the defined `Default Placement Distance`.
     - The object will follow the movement of the `TrackedTargetType` after selection. To simulate head movement in editor, press the WASD keys. Change head rotation by clicking and holding the right mouse.
     - To stop placing the object, click again.  The object does not need to be in focus for the stop placement click. Focus is only required for the initial click that starts the placement process.
 
-    `TrackedTargetType`: Head (Default) |  `TrackedTargetType`: Controller Ray 
+    `TrackedTargetType`: Head (Default) |  `TrackedTargetType`: Controller Ray
     :-------------------------:|:-------------------------:
     ![TapToPlaceInputSimulationHead](Images/Solver/TapToPlace/TapToPlaceInputSimulationHead.gif)  |  ![TapToPlaceInputSimulationControllerRay](Images/Solver/TapToPlace/TapToPlaceInputSimulationControllerRay.gif)
 
+## Tap to Place Code Configurability
 
-## Tap to Place Code Configurability 
-
-Tap to Place object selection timing can also be controlled via `StartPlacement()` and `StopPlacement()` instead of requiring a click event. This capability is useful for writing tests and provides an alternative method to place an object in editor without using the MRTK Input System. 
+Tap to Place object selection timing can also be controlled via `StartPlacement()` and `StopPlacement()` instead of requiring a click event. This capability is useful for writing tests and provides an alternative method to place an object in editor without using the MRTK Input System.
 
 1. Create an empty game object
 1. Create and attach the following example script to the empty game object
 
-    ```
+    ```c#
     using UnityEngine;
     using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 
@@ -81,6 +80,7 @@ Tap to Place object selection timing can also be controlled via `StartPlacement(
         }
     }
     ```
+
 1. In play mode, press the *U key* to start placing the cube
 1. Press the *I key* to stop the placement
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -188,7 +188,7 @@ Users can take advantage of the new [migration window](Tools/MigrationWindow.md)
 
 **Bounds control improvements**
 
-We extensively increased test coverage for bounds control this version and addressed one of the biggest pain points of users of bounding box: bounds control will now no longer recreate its visuals on configuration changes. Also it now supports reconfiguring any property during runtime. Also the properties DrawTetherWhenManipulating and HandlesIgnoreCollider are now configurable per handle type. 
+We extensively increased test coverage for bounds control this version and addressed one of the biggest pain points of users of bounding box: bounds control will now no longer recreate its visuals on configuration changes. Also it now supports reconfiguring any property during runtime. Also the properties DrawTetherWhenManipulating and HandlesIgnoreCollider are now configurable per handle type.
 
 ### Breaking changes in 2.4.0
 
@@ -222,13 +222,13 @@ For more information on these changes and complete instructions for eye tracking
 
 ### Known issues in 2.4.0
 
-**MRTK Configurator dialog does not show 'Enable MSBuild for Unity' in Unity 2019.3** 
+**MRTK Configurator dialog does not show 'Enable MSBuild for Unity' in Unity 2019.3**
 
-An issue exists where enabling MSBuild for Unity in 2019.3 may result in an infinite loop restoring packages ([#7239](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7239)). 
+An issue exists where enabling MSBuild for Unity in 2019.3 may result in an infinite loop restoring packages ([#7239](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7239)).
 
 As a workaround, the Microsoft.Windows.DotNetWinRT package can be imported using [NuGet for Unity](https://github.com/GlitchEnzo/NuGetForUnity/releases/latest).
 
-**Duplicate Assembly Version and Multiple Precompiled Assemblies Unity 2018.4** 
+**Duplicate Assembly Version and Multiple Precompiled Assemblies Unity 2018.4**
 
 If the platform is switched from Standalone to UWP and then back to Standalone in Unity 2018.4, the following errors might be in the console:
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -131,7 +131,7 @@ Markers take the format of "[MRTK] ClassWithoutNamespace.Method".
 
 **WindowsApiChecker: IsMethodAvailable(), IsPropertyAvailable() and IsTypeAvailable()**
 
-This version of MRTK adds three new methods to the [`WindowsApiChecker`](xref:Microsoft.MixedReality.Toolkit.Windows.Utilities.WindowsApiChecker) class: `IsMethodAvailable`, `IsPropertyAvailable` and `IsTypeAvailable`. These methods allow for checking for feature support on Windows 10 and are prefered over using the `UniversalApiContractV#_IsAvailable` properties.
+This version of MRTK adds three new methods to the [`WindowsApiChecker`](xref:Microsoft.MixedReality.Toolkit.Windows.Utilities.WindowsApiChecker) class: `IsMethodAvailable`, `IsPropertyAvailable` and `IsTypeAvailable`. These methods allow for checking for feature support on Windows 10 and are preferred over using the `UniversalApiContractV#_IsAvailable` properties.
 
 **Helpers to get text input fields working with MixedRealityKeyboard for UnityUI, TextMeshPro (Experimental)**
 

--- a/Documentation/Rendering/ClippingPrimitive.md
+++ b/Documentation/Rendering/ClippingPrimitive.md
@@ -20,7 +20,7 @@ The **ClippingExamples** and **MaterialGallery** scenes demonstrate usage of the
 
 ## Advanced Usage
 
-By default only one [`ClippingPrimitive`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) can clip a [renderer](https://docs.unity3d.com/ScriptReference/Renderer.html) at a time. If your project requires more than one [`ClippingPrimitive`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) to influence a [renderer](https://docs.unity3d.com/ScriptReference/Renderer.html)  the sample code below demonstrates how to achive this.
+By default only one [`ClippingPrimitive`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) can clip a [renderer](https://docs.unity3d.com/ScriptReference/Renderer.html) at a time. If your project requires more than one [`ClippingPrimitive`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) to influence a [renderer](https://docs.unity3d.com/ScriptReference/Renderer.html)  the sample code below demonstrates how to achieve this.
 
 > [!NOTE]
 > Having multiple [`ClippingPrimitives`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) clip a [renderer](https://docs.unity3d.com/ScriptReference/Renderer.html) will increase pixel shader instructions and will impact performance. Please profile these changes within your project.
@@ -39,7 +39,7 @@ By default only one [`ClippingPrimitive`](xref:Microsoft.MixedReality.Toolkit.Ut
 #pragma multi_compile _ _CLIPPING_BOX
 ```
 > [!NOTE]
-> The above change will inccur additional shader compilation time.
+> The above change will incur additional shader compilation time.
 
 *How to have two of the same [`ClippingPrimitives`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingPrimitive) clip a render. For example two [`ClippingBoxes`](xref:Microsoft.MixedReality.Toolkit.Utilities.ClippingBox) at the same time:*
 

--- a/Documentation/Rendering/HoverLight.md
+++ b/Documentation/Rendering/HoverLight.md
@@ -14,12 +14,12 @@ Most scenes within the MRTK utilize a [`HoverLight`](xref:Microsoft.MixedReality
 
 ## Advanced Usage
 
-By default only two [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) can illuminate a [material](https://docs.unity3d.com/ScriptReference/Material.html) at a time. If your project requires more than two [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) to influence a [material](https://docs.unity3d.com/ScriptReference/Material.html) the sample code below demonstrates how to achive this.
+By default only two [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) can illuminate a [material](https://docs.unity3d.com/ScriptReference/Material.html) at a time. If your project requires more than two [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) to influence a [material](https://docs.unity3d.com/ScriptReference/Material.html) the sample code below demonstrates how to achieve this.
 
 > [!Note]
 > Having many [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) illuminate a [material](https://docs.unity3d.com/ScriptReference/Material.html) will increase pixel shader instructions and will impact performance. Please profile these changes within your project.
 
-*How to increase the number of avalible [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight)
+*How to increase the number of available [`HoverLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight)
  from two to four.*
 
 ```C#

--- a/Documentation/Rendering/HoverLight.md
+++ b/Documentation/Rendering/HoverLight.md
@@ -1,6 +1,6 @@
 # Hover Light
 
-A [`HoverLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) is a [Fluent Design System](https://www.microsoft.com/design/fluent/) paradigm that mimics a [point light](https://docs.unity3d.com/Manual/Lighting.html) hovering near the surface of an object. Often used for far away interactions, the application can control the properties of a Hover Light via the [`HoverLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) component. 
+A [`HoverLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) is a [Fluent Design System](https://www.microsoft.com/design/fluent/) paradigm that mimics a [point light](https://docs.unity3d.com/Manual/Lighting.html) hovering near the surface of an object. Often used for far away interactions, the application can control the properties of a Hover Light via the [`HoverLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) component.
 
 For a material to be influenced by a [`HoverLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight) the *Mixed Reality Toolkit/Standard* shader must be used and the *Hover Light* property must be enabled.
 
@@ -10,7 +10,6 @@ For a material to be influenced by a [`HoverLight`](xref:Microsoft.MixedReality.
 ## Examples
 
 Most scenes within the MRTK utilize a [`HoverLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.HoverLight). The most common use case can be found on the MRTK/SDK/Features/UX/Prefabs/Cursors/DefaultCursor.prefab
-
 
 ## Advanced Usage
 
@@ -41,10 +40,9 @@ private const int hoverLightCount = 4;
 ```
 
 > [!NOTE]
-> If Unity logs a warning simular to below then you must restart Unity before your changes will take effect.
-> ```
-> Property (_HoverLightData) exceeds previous array size (8 vs 4). Cap to previous >size.
-> ```
+> If Unity logs a warning similar to below then you must restart Unity before your changes will take effect.
+>
+> `Property (_HoverLightData) exceeds previous array size (8 vs 4). Cap to previous >size.`
 
 ## See also
 

--- a/Documentation/Rendering/ProximityLight.md
+++ b/Documentation/Rendering/ProximityLight.md
@@ -14,12 +14,12 @@ Most scenes within the MRTK utilize a [`ProximityLight`](xref:Microsoft.MixedRea
 
 ## Advanced Usage
 
-By default only two [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) can illuminate a [material](https://docs.unity3d.com/ScriptReference/Material.html) at a time. If your project requires more than two [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) to influence a [material](https://docs.unity3d.com/ScriptReference/Material.html) the sample code below demonstrates how to achive this.
+By default only two [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) can illuminate a [material](https://docs.unity3d.com/ScriptReference/Material.html) at a time. If your project requires more than two [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) to influence a [material](https://docs.unity3d.com/ScriptReference/Material.html) the sample code below demonstrates how to achieve this.
 
 > [!NOTE]
 > Having many [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) illuminate a [material](https://docs.unity3d.com/ScriptReference/Material.html) will increase pixel shader instructions and will impact performance. Please profile these changes within your project.
 
-*How to increase the number of avalible [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight)
+*How to increase the number of available [`ProximityLights`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight)
  from two to four.*
 
 ```C#

--- a/Documentation/Rendering/ProximityLight.md
+++ b/Documentation/Rendering/ProximityLight.md
@@ -1,6 +1,6 @@
 # Proximity Light
 
-A [`ProximityLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) is a [Fluent Design System](https://www.microsoft.com/design/fluent/) paradigm that mimics a "gradient inverse point light" hovering near the surface of an object. Often used for near interactions, the application can control the properties of a Proximity Light via the [`ProximityLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) component. 
+A [`ProximityLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) is a [Fluent Design System](https://www.microsoft.com/design/fluent/) paradigm that mimics a "gradient inverse point light" hovering near the surface of an object. Often used for near interactions, the application can control the properties of a Proximity Light via the [`ProximityLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) component.
 
 For a material to be influenced by a [`ProximityLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight) the *Mixed Reality Toolkit/Standard* shader must be used and the *Proximity Light* property must be enabled.
 
@@ -10,7 +10,6 @@ For a material to be influenced by a [`ProximityLight`](xref:Microsoft.MixedReal
 ## Examples
 
 Most scenes within the MRTK utilize a [`ProximityLight`](xref:Microsoft.MixedReality.Toolkit.Utilities.ProximityLight). The most common use case can be found on the MRTK/SDK/Features/UX/Prefabs/Cursors/FingerCursor.prefab
-
 
 ## Advanced Usage
 
@@ -41,11 +40,9 @@ private const int proximityLightCount = 4;
 ```
 
 > [!NOTE]
-> If Unity logs a warning simular to below then you must restart Unity before your changes will take effect.
+> If Unity logs a warning similar to below then you must restart Unity before your changes will take effect.
 >
->```
->Property (_ProximityLightData) exceeds previous array size (24 vs 12). Cap to previous size.
->```
+>`Property (_ProximityLightData) exceeds previous array size (24 vs 12). Cap to previous size.`
 
 ## See also
 

--- a/Documentation/SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.md
+++ b/Documentation/SpatialAwareness/ConfiguringSpatialAwarenessMeshObserver.md
@@ -101,7 +101,6 @@ Specifies how spatial meshes are to be displayed by the observer. Supported valu
 
 ![Select the Spatial Awareness System Implementation](../../Documentation/Images/SpatialAwareness/MRTK_SpatialAwareness_DisplayOptions.jpg)
 
-
 Spatial Observers can be [resumed/suspended at runtime via code.](UsageGuide.md#starting-and-stopping-mesh-observation)
 
 > [!WARNING]

--- a/Documentation/SpatialAwareness/CreateDataProvider.md
+++ b/Documentation/SpatialAwareness/CreateDataProvider.md
@@ -199,7 +199,7 @@ It is recommended to implement the pattern utilized by the MRTK when instrumenti
 
 > [!Note]
 > The name used to identify the profiler marker is arbitrary. The MRTK uses the following pattern.
-> 
+>
 > "[product] className.methodName - optional note"
 >
 > It is recommended that custom data providers follow a similar pattern to help simplify identification of specific components and methods when analyzing traces.

--- a/Documentation/Tools/HolographicRemoting.md
+++ b/Documentation/Tools/HolographicRemoting.md
@@ -23,7 +23,7 @@ configure the project using the following steps.
 1. Ensure that **Enable MSBuild for Unity** is selected
 1. Click **Apply**
 
-When using **Unity 2019.3** and later the **Enable MSBuild for Unity** is not available. please follow the below procedures to enable holographic remoting. 
+When using **Unity 2019.3** and later the **Enable MSBuild for Unity** is not available. please follow the below procedures to enable holographic remoting.
 
 1. Run the MRTK Configurator Utility (**Mixed Reality Toolkit > Utilities > Configure Unity Project**)
 1. Set the target platform in **File > Build Settings** to **Universal Windows Platform**
@@ -31,7 +31,7 @@ When using **Unity 2019.3** and later the **Enable MSBuild for Unity** is not av
 1. Open **Window > Package Manager**
     - Ensure that the **Windows XR Plugin** is not installed if the project isn't using [XR SDK](../GettingStartedWithMRTKAndXRSDK.md), as the legacy **Windows Mixed Reality** package will not function alongside it
 1. Open **Edit > Project Settings > Player**
-    
+
     ![Windows Mixed Reality SDK](../Images/Tools/Remoting/WindowsMixedRealitySDK.png)
 
 1. Ensure that **Virtual Reality Supported** is selected and that **Windows Mixed Reality** is added to the **Virtual Reality SDKs**
@@ -48,7 +48,7 @@ These issues are particularly relevant when running on **Unity 2019.3** or later
 
 > [!Note]
 > There is a known issue that prevents MSBuild for Unity from functioning properly on some versions of Unity 2019. To avoid this issue, the MRTK does not support MSBuild for Unity on Unity 2019.3.
-> 
+>
 > To acquire the required NuGet package when running on Unity 2019.3, please refer to the [manual installation instructions](#manual-dotnetadapter-installation).
 
 The best way to check is to open Window -> Package Manager and make sure MSBuild for Unity shows up in the packages list. If it's there, assume this step succeeded. If it's not there, try running Mixed Reality Toolkit -> Utilities -> Configure Unity and repeat the steps above for running the MRTK Configurator.

--- a/Documentation/Tools/MigrationWindow.md
+++ b/Documentation/Tools/MigrationWindow.md
@@ -1,18 +1,16 @@
 
 # Migration window
 
-As the MRTK undergoes changes, some components might get deprecated and replacements will get introduced. 
+As the MRTK undergoes changes, some components might get deprecated and replacements will get introduced.
 The migration window is a tool that helps users to automatically migrate a subset of those deprecated components to the new replacements.
 
 ![Migration window](../Images/MigrationWindow/MRTK_Migration_Window.png)
-
 
 ## Usage
 
 To open the window, select *Mixed Reality Toolkit* > *Utilities* > *Migration Window*. Once the migration window is open, the selection mode navigation tabs can be enabled by choosing the component specific implementation of the migration handler.  
 
 ![Migration selection modes](../Images/MigrationWindow/MRTK_Migration_Modes.png)
-
 
 ### Object mode
 
@@ -23,13 +21,11 @@ Once all the desired objects are in the list, pressing the *Migrate* button will
 
 ![Selection migration](../Images/MigrationWindow/MRTK_Object_Migration.png)
 
-
 ### Scene mode
 
 Allows user to drag and drop scene assets containing objects to be migrated.
 
 ![Selecting scenes for migration](../Images/MigrationWindow/MRTK_Scene_Selection.png)
-
 
 ### Project mode
 
@@ -42,4 +38,3 @@ Pressing the *Migrate* button will update the component targeted by the migratio
 - [Updating from earlier versions](../Updating.md)
 - [Microsoft Mixed Reality Toolkit releases](../ReleaseNotes.md)
 - [MRTK roadmap](../Contributing/Roadmap.md)
-

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -131,7 +131,7 @@ if (CoreServices.InputSystem.GazeProvider is GazeProvider gazeProvider)
 
 **WindowsApiChecker properties**
 
-The following WindowsApiChecker properties have been marked as obsolete. Please use `IsMethodAvilable`, `IsPropertyAvailable` or `IsTypeAvailable`.
+The following WindowsApiChecker properties have been marked as obsolete. Please use `IsMethodAvailable`, `IsPropertyAvailable` or `IsTypeAvailable`.
 
 - UniversalApiContractV8_IsAvailable
 - UniversalApiContractV7_IsAvailable
@@ -188,7 +188,7 @@ The lineRendererSelected and lineRendererNoTarget members of the ShellHandRayPoi
 
 Please replace lineRendererSelected with lineMaterialSelected and/or lineRendererNoTarget with lineMaterialNoTarget to resolve compile errors.
 
-**Spatial observer StarupBehavior**
+**Spatial observer StartupBehavior**
 
 Spatial observers built upon the `BaseSpatialObserver` class now honor the value of StartupBehavior when re-enabled ([#6919](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6919)).
 

--- a/Documentation/Updating.md
+++ b/Documentation/Updating.md
@@ -147,10 +147,10 @@ There are no plans to add properties to WindowsApiChecker for future API contrac
 The gltf mesh primitive attributes used to be settable, they are now read-only. Their values
 will be set once when deserialized.
 
-### Custom Button Icon Migration 
+### Custom Button Icon Migration
 
 Previously custom button icons required assigning a new material to the button's quad renderer. This is no longer necessary and we recommend moving custom icon textures into an IconSet. Existing custom materials and icons are preserved. However they will be less optimal until upgraded.
-To upgrade the assets on all buttons in the project to the new recommended format, use the ButtonConfigHelperMigrationHandler. 
+To upgrade the assets on all buttons in the project to the new recommended format, use the ButtonConfigHelperMigrationHandler.
 (Mixed Reality Toolkit -> Utilities -> Migration Window -> Migration Handler Selection -> Microsoft.MixedReality.Toolkit.Utilities.ButtonConfigHelperMigrationHandler)
 
 ![Upgrade window dialogue](https://user-images.githubusercontent.com/39840334/82096923-bd28bf80-96b6-11ea-93a9-ceafcb822242.png)
@@ -169,7 +169,7 @@ If an icon is not found in the default icon set during migration, a custom icon 
 
 The private ControllerPoseSynchronizer.handedness field has been marked as obsolete. This should have minimal impact on applications as the field is not visible outside of its class.
 
-The public ControllerPoseSynchronizer.Handedness property's setter has been removed ([#7012](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7012)). 
+The public ControllerPoseSynchronizer.Handedness property's setter has been removed ([#7012](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7012)).
 
 **MSBuild for Unity**
 

--- a/Documentation/VisualThemes.md
+++ b/Documentation/VisualThemes.md
@@ -128,7 +128,6 @@ For the given property, which can be identified by `ThemeStateProperty.Name`, re
 
 Returns a [`ThemeDefinition`](xref:Microsoft.MixedReality.Toolkit.UI.ThemeDefinition) object that defines the default properties and configuration needed for the custom theme
 
-
 `protected abstract void SetValue(ThemeStateProperty property, ThemePropertyValue value)`
 
 Protected variant of the public `SetValue()` definition, except provided ThemePropertyValue to set instead of directing to use index and/or percentage configuration.
@@ -158,7 +157,6 @@ If the custom Theme Engine can support targeting shader properties. It is recomm
 > - [`InteractableColorTheme`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableColorTheme)
 > - [`InteractableTextureTheme`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableTextureTheme)
 > - [`ScaleOffsetColorTheme`](xref:Microsoft.MixedReality.Toolkit.UI.ScaleOffsetColorTheme)
-
 
 [`InteractableThemeBase.Reset`](xref:Microsoft.MixedReality.Toolkit.UI.InteractableThemeBase.Reset)
 


### PR DESCRIPTION
## Overview

Ran a pass on our .md files for spelling and markdown formatting.
I use a combination of the VS Code extensions in [the Microsoft Docs Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack) for these checks.

Recommend reviewing [without whitespace changes](https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7973/files?diff=split&w=1).