### PR TITLE
Swap GUIDs in MixedRealityKeyboard files

### DIFF
--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboard.cs.meta
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboard.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4889bdd8237266a46acf2a42b20c359d
+guid: bd7587e3eacaf31439947b67a41e58a8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs.meta
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboardBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bd7587e3eacaf31439947b67a41e58a8
+guid: 4889bdd8237266a46acf2a42b20c359d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Overview
Swap the GUIDs in the MixedRealityKeyboard.cs.meta and MixedRealityKeyboardBase.cs.meta files to resolve the invalid script for the MixedRealityKeyboard component after an upgrade from 2.3 to 2.4.

## Changes
- Fixes: #7972 

## Verification
Confirmed fix by:
1. Importing 2.3 foundation package
2. Created new scene and added MRTK
3. Created empty game object with the MixedRealityKeyboard component attached
4. Closed Unity and followed upgrade steps
5. Imported foundation Unity package that was generated based on this branch
6. Confirmed the script was valid on the game object with the MixedRealityKeyboard component attached 
