### PR TITLE
Spell check pass on code comments and docs for 2.4

### DIFF
--- a/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/UnityObjectExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.MixedReality.Toolkit
         }
 
         /// <summary>
-        /// Destroys a Unity object appropriately depending if running in in edit or play mode.
+        /// Destroys a Unity object appropriately depending if running in edit or play mode.
         /// </summary>
         /// <param name="obj">Unity object to destroy</param>
         /// <param name="t">Time in seconds at which to destroy the object, if applicable.</param>

--- a/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Core/Providers/Hands/ArticulatedHandDefinition.cs
@@ -52,7 +52,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    Debug.LogError("EnterPinchDistance must be be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
+                    Debug.LogError("EnterPinchDistance must be between 0.015 and 0.1, please change Enter Pinch Distance in the Leap Motion Device Manager Profile");
                 }   
             }
         }
@@ -75,7 +75,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    Debug.LogError("ExitPinchDistance must be be between 0.015 and 0.1, please change Exit Pinch Distance in the Leap Motion Device Manager Profile");
+                    Debug.LogError("ExitPinchDistance must be between 0.015 and 0.1, please change Exit Pinch Distance in the Leap Motion Device Manager Profile");
                 }
             }
         }

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         }
 
         /// <summary>
-        /// Gets the build configuraition type as a WSABuildType enum
+        /// Gets the build configuration type as a WSABuildType enum
         /// </summary>
         public static WSABuildType BuildConfigType
         {

--- a/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
+++ b/Assets/MRTK/Core/Utilities/Editor/SpatializerUtilities.cs
@@ -58,7 +58,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
                 return false;
             }
 
-            // A spatializer is correctly confiugured.
+            // A spatializer is correctly configured.
             return true;
         }
 

--- a/Assets/MRTK/Core/Utilities/Gltf/Serialization/GltfUtility.cs
+++ b/Assets/MRTK/Core/Utilities/Gltf/Serialization/GltfUtility.cs
@@ -415,7 +415,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Gltf.Serialization
         /// <summary>
         /// Takes a json object string with key value pairs, and returns a json string
         /// in the format of `{"items": [{"key": $key_name, "value": $value}]}`.
-        /// This format can be handled by JsonUtility and support an aribtrary number
+        /// This format can be handled by JsonUtility and support an arbitrary number
         /// of key/value pairs
         /// </summary>
         /// <param name="json">JSON string in the format `{"key": $value}`</param>

--- a/Assets/MRTK/Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
+++ b/Assets/MRTK/Core/Utilities/Lines/DataProviders/BaseMixedRealityLineDataProvider.cs
@@ -214,11 +214,11 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         [SerializeField]
-        [Tooltip("Curve that defines distoration strength over distance, only used when DistortionMode = NormalizedLength")]
+        [Tooltip("Curve that defines distortion strength over distance, only used when DistortionMode = NormalizedLength")]
         private AnimationCurve distortionStrength = AnimationCurve.Linear(0f, 1f, 1f, 1f);
 
         /// <summary>
-        /// Curve that defines distoration strength over distance, only used when DistortionMode = NormalizedLength
+        /// Curve that defines distortion strength over distance, only used when DistortionMode = NormalizedLength
         /// </summary>
         public AnimationCurve DistortionStrength
         {
@@ -227,12 +227,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         }
 
         [Range(0f, 1f)]
-        [Tooltip("Float value that defines distoration strength uniformly over distance, only used when DistortionMode = Uniform")]
+        [Tooltip("Float value that defines distortion strength uniformly over distance, only used when DistortionMode = Uniform")]
         [SerializeField]
         private float uniformDistortionStrength = 1f;
 
         /// <summary>
-        /// Float value that defines distoration strength uniformly over distance, only used when DistortionMode = Uniform
+        /// Float value that defines distortion strength uniformly over distance, only used when DistortionMode = Uniform
         /// </summary>
         public float UniformDistortionStrength
         {

--- a/Assets/MRTK/Examples/Demos/UX/Collections/Scripts/GridObjectLayoutControl.cs
+++ b/Assets/MRTK/Examples/Demos/UX/Collections/Scripts/GridObjectLayoutControl.cs
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.Toolkit.Examples.Demos
         /// Use this to run mock tests in grid object collection tests
         /// and print the resulting positions of child objects to a file.
         /// Used to get expected values for GridObjectCollectionTests.
-        /// When you run the comand, look in the Debug log for where the file is output,
+        /// When you run the command, look in the Debug log for where the file is output,
         /// it will be of form "printgrid-yyMMdd-HHmmss.txt"
         /// </summary>
         public void RunTest()

--- a/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
+++ b/Assets/MRTK/Extensions/HandPhysicsService/HandPhysicsService.cs
@@ -239,7 +239,7 @@ namespace Microsoft.MixedReality.Toolkit.Extensions.HandPhysics
 
             if (currentGameObject.GetComponent<Collider>() == null)
             {
-                Debug.LogError("The HandPhysicsService assumes the FingerTipKinematicBodyPrefab has a Collder component.");
+                Debug.LogError("The HandPhysicsService assumes the FingerTipKinematicBodyPrefab has a Collider component.");
                 UnityEngine.Object.Destroy(currentGameObject);
                 return false;
             }

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionArticulatedHand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
 
         internal ArticulatedHandDefinition handDefinition;
 
-        // Set the interations for each hand to the Default interactions of the hand definition
+        // Set the interactions for each hand to the Default interactions of the hand definition
         public override MixedRealityInteractionMapping[] DefaultInteractions => handDefinition?.DefaultInteractions;
 
         private static readonly ProfilerMarker UpdateStatePerfMarker = new ProfilerMarker("[MRTK] LeapMotionArticulatedHand.UpdateState");

--- a/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
+++ b/Assets/MRTK/Providers/LeapMotion/LeapMotionDeviceManagerProfile.cs
@@ -26,9 +26,9 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
         public LeapControllerOrientation LeapControllerOrientation => leapControllerOrientation;
 
         [SerializeField]
-        [Tooltip("Adds an offset to the game object with LeapServiceProvider attached.  This offset is only applied if the leapControllerOrientation" +
+        [Tooltip("Adds an offset to the game object with LeapServiceProvider attached.  This offset is only applied if the leapControllerOrientation " +
         "is LeapControllerOrientation.Desk and is necessary for the hand to appear in front of the main camera. If the leap controller is on the " +
-        "desk, the LeapServiceProvider is added to the scene instead of the LeapXRServiceProvider. The anchor point for the hands is the position of the" + 
+        "desk, the LeapServiceProvider is added to the scene instead of the LeapXRServiceProvider. The anchor point for the hands is the position of the " + 
         "game object with the LeapServiceProvider attached.")]
         private Vector3 leapControllerOffset = new Vector3(0, -0.2f, 0.2f);
 
@@ -61,12 +61,12 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion.Input
 
         [SerializeField]
         [Tooltip("The minimum distance between the index finger tip and the thumb tip required to exit the pinch/air tap gesture to deselect.  The distance between the thumb and  " +
-            "the index tip must be greater than than the ExitPinchDistance to raise the OnInputUp event")]
+            "the index tip must be greater than the ExitPinchDistance to raise the OnInputUp event")]
         private float exitPinchDistance = 0.05f;
 
         /// <summary>
         /// The minimum distance between the index finger tip and the thumb tip required to exit the pinch/air tap gesture to deselect.  The distance between the thumb and 
-        /// the index tip must be greater than than the ExitPinchDistance to raise the OnInputUp event
+        /// the index tip must be greater than the ExitPinchDistance to raise the OnInputUp event
         /// </summary>
         public float ExitPinchDistance
         {        

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Buttons/ButtonIconSet.cs
@@ -714,7 +714,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                             }
                             else
                             {
-                                EditorGUILayout.HelpBox("No icons added yet. Click avaialable icons to add.", MessageType.Info);
+                                EditorGUILayout.HelpBox("No icons added yet. Click available icons to add.", MessageType.Info);
                             }
 
                             if (removeIndex >= 0)

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Collections/BaseObjectCollection.cs
@@ -135,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <summary>
         /// Check if a node exists in the NodeList.
         /// </summary>
-        /// <param name="node">The Transfrom belonging to the <see cref="ObjectCollectionNode"/></param>
+        /// <param name="node">The Transform belonging to the <see cref="ObjectCollectionNode"/></param>
         /// <returns>true when <paramref name="node"/> belongs to an element of the list.</returns>
         protected bool ContainsNode(Transform node)
         {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Cursors/FingerCursor.cs
@@ -228,7 +228,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Vector3 tipPosition = fingerPosition + tipNormal * skinSurfaceOffset;
             Vector3 tipOffset = tipPosition - fingerPosition;
 
-            // Check how perpindicular the finger normal is to the surface, so that the cursor will
+            // Check how perpendicular the finger normal is to the surface, so that the cursor will
             // not translate to the finger pad if the user is poking with a horizontal finger
             float fingerSurfaceDot = Vector3.Dot(tipNormal, -surfaceNormal);
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Pointers/ShellHandRayPointer.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// Implementation for default hand ray pointers shipped with MRTK. Primariliy used with hands and motion controllers
+    /// Implementation for default hand ray pointers shipped with MRTK. Primarily used with hands and motion controllers
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ShellHandRayPointer")]
     public class ShellHandRayPointer : LinePointer

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Sliders/PinchSlider.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Sliders/PinchSlider.cs
@@ -140,7 +140,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private SliderAxis? previousSliderAxis = null;
         /// <summary>
-        /// Property accessor for previousSliderAxis that is used also to initiallize the property with the current value in case of null value.
+        /// Property accessor for previousSliderAxis that is used also to initialize the property with the current value in case of null value.
         /// </summary>
         private SliderAxis PreviousSliderAxis
         {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PointerBehaviorControls.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Utilities/PointerBehaviorControls.cs
@@ -157,7 +157,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         /// <summary>
         /// Sets pointer behavior to mimic HoloLens 1 interactions, useful
-        /// for using Hololens 1 interactions on HoloLens 2.
+        /// for using HoloLens 1 interactions on HoloLens 2.
         /// PokePointer will be off
         /// GrabPointer will be off
         /// HandRayPointer will be off

--- a/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/ThemeProperty.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/VisualThemes/Core/ThemeProperty.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
     public class ThemeProperty
     {
         /// <summary>
-        /// Dispalyed as Label in Inspector
+        /// Displayed as Label in Inspector
         /// </summary>
         public string Name;
 

--- a/Assets/MRTK/SDK/Features/Utilities/Migration/Tools/MigrationTool.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Migration/Tools/MigrationTool.cs
@@ -318,7 +318,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
             }
             catch (Exception)
             {
-                Debug.LogError("Selected MigrationHandler implementation could not be instanciated.");
+                Debug.LogError("Selected MigrationHandler implementation could not be instantiated.");
                 return false;
             }
             return true;

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/HandConstraintPalmUp.cs
@@ -281,14 +281,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         }
 
         /// <summary>
-        /// This function attenpts to generate a hand plane based on the wrist, index knuckle and pinky knuckle joints present in the hand.
+        /// This function attempts to generate a hand plane based on the wrist, index knuckle and pinky knuckle joints present in the hand.
         /// On a success, it then calls GenerateActivationPoint to try to generate a hand-based activation point that the user
         /// needs to gaze at to activate the constrained object.
         /// On a failure, it assigns them to be default values and then returns false
         /// </summary>
         /// <param name="jointedHand">Hand reference to the user's hand that is used to generate the hand plane and activation point</param>
         /// <param name="handPlane">Out Plane that represents the hand and is raycasted against to determine whether the users gaze is close to the activation point or not</param>
-        /// <param name="activationPoint">Out Vector3 that represents the point on the hand-based plane to determine whther the menu activates or not</param>
+        /// <param name="activationPoint">Out Vector3 that represents the point on the hand-based plane to determine whether the menu activates or not</param>
         /// <returns>True if the function can properly generate an activation point using the hand-based plane</returns>
         private bool TryGenerateHandPlaneAndActivationPoint(IMixedRealityHand jointedHand, out Plane handPlane, out Vector3 activationPoint)
         {

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/SolverHandler.cs
@@ -390,7 +390,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
                     if (controllerRay == null)
                     {
-                        // If no pointer found, try again on the the opposite hand
+                        // If no pointer found, try again on the opposite hand
                         currentTrackedHandedness = currentTrackedHandedness.GetOppositeHandedness();
                         controllerRay = PointerUtils.GetPointer<LinePointer>(currentTrackedHandedness);
                     }

--- a/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             EditorGUILayout.Space();
 
 // XXX Reloading the scene is currently not supported,
-// due to the life cycle of the MRTK "instance" object (see see #4530).
+// due to the life cycle of the MRTK "instance" object (see #4530).
 // Enable the button below once scene reloading is supported!
 #if false
             using (new GUIEnabledWrapper(Application.isPlaying))

--- a/Assets/MRTK/Services/InputSystem/GazeProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/GazeProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private const float MovementThreshold = 0.01f;
 
         /// <summary>
-        /// Used on Gaze Pointer initialization. To make the object lock/not lock when focus locked durign runtime, use the IsTargetPositionLockedOnFocusLock 
+        /// Used on Gaze Pointer initialization. To make the object lock/not lock when focus locked during runtime, use the IsTargetPositionLockedOnFocusLock 
         /// attribute of <see cref="GazePointer.IsTargetPositionLockedOnFocusLock"/>
         /// </summary>
         [SerializeField]

--- a/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystem.cs
+++ b/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystem.cs
@@ -940,7 +940,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
                             break;
 
                         default:
-                            // Don't announce other types of scenes invidually
+                            // Don't announce other types of scenes individually
                             break;
                     }
                 }

--- a/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
+++ b/Assets/MRTK/Services/SceneSystem/MixedRealitySceneSystemEditorOperations.cs
@@ -470,7 +470,7 @@ namespace Microsoft.MixedReality.Toolkit.SceneSystem
 
             if (EditorSceneUtils.LoadScene(profile.ManagerScene, true, out Scene scene))
             {
-                // If we're managing scene heirarchy, move this to the front
+                // If we're managing scene hierarchy, move this to the front
                 if (profile.EditorEnforceSceneOrder)
                 {
                     Scene currentFirstScene = EditorSceneManager.GetSceneAt(0);

--- a/Assets/MRTK/Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/BoundarySystem/InscribedRectangleTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Boundary
         public void TestDegenerateSailboat()
         {
             // A set of edges that represents the fancy art above. Note that in this test case
-            // the width/height is a bit lengtened to really ensure that the top rectangle is
+            // the width/height is a bit lengthened to really ensure that the top rectangle is
             // much bigger.
             Edge[] edges = new Edge[]
             {
@@ -112,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Boundary
         }
 
         /// <summary>
-        /// Asserts that the expected and actual values are within 'tolernace' percent.
+        /// Asserts that the expected and actual values are within 'tolerance' percent.
         /// </summary>
         /// <remarks>
         /// Assumes that expected isn't zero (none of our test cases should lead to an empty sized

--- a/Assets/MRTK/Tests/PlayModeTests/BaseEventSystemTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BaseEventSystemTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             yield return null;
 
-            // Emits a single event and validates the the pointer click and diagnostic handler are both called.
+            // Emits a single event and validates that the pointer click and diagnostic handler are both called.
             inputSystem.RaisePointerClicked(inputSystem.GazeProvider.GazePointer, MixedRealityInputAction.None, 1);
             Assert.AreEqual(1, inputListener.pointerClickedCount);
             Assert.AreEqual(1, diagnosticsListener.eventCount);

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             var inputSimulationService = PlayModeTestUtilities.GetInputSimulationService();
 
-            // Definining the edge and corner handlers that will be used
+            // Defining the edge and corner handlers that will be used
             Debug.Log(bbox.transform.Find("rigRoot/midpoint_0").GetChild(0));
             var originalCornerHandlerScale = bbox.transform.Find("rigRoot/corner_0/visualsScale/visuals").transform.localScale;
             var cornerHandlerPosition = bbox.transform.Find("rigRoot/corner_0").transform.position;

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -254,7 +254,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
-        /// Test bounds control rotation via hololens 1 interaction / GGV
+        /// Test bounds control rotation via HoloLens 1 interaction / GGV
         /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
         /// </summary>
         [UnityTest]
@@ -538,7 +538,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             yield return hand.MoveTo(frontRightCornerPos);
             yield return null;
 
-            // we're in poximity scaling range - check if proximity scaling wasn't applied
+            // we're in proximity scaling range - check if proximity scaling wasn't applied
             Assert.AreEqual(proximityScaledVisual.localScale, defaultHandleSize, "Handle was scaled even though proximity effect wasn't active");
 
             //// reset hand
@@ -819,7 +819,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Assert.IsTrue(rotationHandleAxisY.gameObject.activeSelf, "rotation handle y not active");
             Assert.IsFalse(rotationHandleAxisZ.gameObject.activeSelf, "rotation handle z not hidden");
 
-            // make sure handles are disabled and enabled when bounds control is deactived / activated
+            // make sure handles are disabled and enabled when bounds control is deactivated / activated
             boundsControl.Active = false;
             Assert.IsNotNull(rigRoot, "rigRoot was destroyed on disabling bounds control");
             Assert.IsFalse(scaleHandle.gameObject.activeSelf, "scale handle not disabled");
@@ -1211,7 +1211,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         /// <summary>
         /// Test for verifying changing the handle prefabs during runtime 
-        /// and making sure the the entire rig won't be recreated
+        /// and making sure the entire rig won't be recreated
         /// </summary>
         [UnityTest]
         public IEnumerator RotationHandlePrefabTest()
@@ -1258,7 +1258,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
 
         /// <summary>
         /// Test for verifying changing the handle prefabs during runtime 
-        /// in regular and flatten mode and making sure the the entire rig won't be recreated
+        /// in regular and flatten mode and making sure the entire rig won't be recreated
         /// </summary>
         [UnityTest]
         public IEnumerator ScaleHandlePrefabTest()

--- a/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/PointerTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             hitObject.transform.position = new Vector3(0.0f, -0.8f, 2.0f);
             yield return PlayModeTestUtilities.WaitForInputSystemUpdate();
 
-            // Confirm the teleport poitner is collding with the cube which is in front but down
+            // Confirm the teleport pointer is colliding with the cube which is in front but down
             Assert.IsTrue(hitObject == curvePointer.Result.CurrentPointerTarget);
             Assert.IsNull(linePointer.Result.CurrentPointerTarget);
 

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -812,7 +812,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Experimental
 
         /// <summary>
-        /// Tests that the DirectionalIndicator can be instatiated through code.
+        /// Tests that the DirectionalIndicator can be instantiated through code.
         /// </summary>
         [UnityTest]
         public IEnumerator TestDirectionalIndicator()
@@ -1222,7 +1222,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return hand.Move(delta, 5);
             yield return null;
 
-            // Ensure Activation occured by making sure the testObjects position isn't still Vector3.zero
+            // Ensure Activation occurred by making sure the testObjects position isn't still Vector3.zero
             Assert.AreNotEqual(testObjects.target.transform.position, Vector3.zero);
 
             yield return hand.Hide();

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -521,7 +521,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
                 // Platform Toolset
                 int currentPlatformToolsetIndex = Array.IndexOf(PLATFORM_TOOLSET_VALUES, UwpBuildDeployPreferences.PlatformToolset);
-                int newPlatformToolsetIndex = EditorGUILayout.Popup("Plaform Toolset", currentPlatformToolsetIndex, PLATFORM_TOOLSET_NAMES, GUILayout.Width(HALF_WIDTH));
+                int newPlatformToolsetIndex = EditorGUILayout.Popup("Platform Toolset", currentPlatformToolsetIndex, PLATFORM_TOOLSET_NAMES, GUILayout.Width(HALF_WIDTH));
 
                 // Force rebuild
                 bool forceRebuildAppx = EditorGUILayout.ToggleLeft("Force Rebuild", UwpBuildDeployPreferences.ForceRebuild);
@@ -675,7 +675,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     {
                         using (new EditorGUI.DisabledGroupScope(!AreCredentialsValid(localConnection)))
                         {
-                            if (GUILayout.Button("Discover Hololens Wifi IP", GUILayout.Width(HALF_WIDTH)))
+                            if (GUILayout.Button("Discover HoloLens WiFi IP", GUILayout.Width(HALF_WIDTH)))
                             {
                                 EditorApplication.delayCall += () =>
                                 {
@@ -1064,7 +1064,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                             if (IsValidIpAddress(ipAddress) 
                                 && !portalConnections.Connections.Any(connection => connection.IP == ipAddress))
                             {
-                                Debug.Log($"Adding new IP {ipAddress} for local hololens {machineName.ComputerName} to remote connection list");
+                                Debug.Log($"Adding new IP {ipAddress} for local HoloLens {machineName.ComputerName} to remote connection list");
 
                                 AddRemoteConnection(new DeviceInfo(ipAddress,
                                     localConnection.User,
@@ -1077,7 +1077,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                     }
                 }
 
-                Debug.Log($"No new or valid Wifi IP Addresses found for local hololens {machineName.ComputerName}");
+                Debug.Log($"No new or valid WiFi IP Addresses found for local HoloLens {machineName.ComputerName}");
             }
         }
 

--- a/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
+++ b/Assets/MRTK/Tools/ExtensionServiceCreator/ExtensionServiceCreator.cs
@@ -542,7 +542,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         }
 
         /// <summary>
-        /// Start the creation process for all revelant extension service files based on current creator property settings
+        /// Start the creation process for all relevant extension service files based on current creator property settings
         /// </summary>
         public async Task BeginAssetCreationProcess()
         {

--- a/Assets/MRTK/Tools/MSBuild/Scripts/CSProjectInfo.cs
+++ b/Assets/MRTK/Tools/MSBuild/Scripts/CSProjectInfo.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.Toolkit.MSBuild
     }
 
     /// <summary>
-    /// A class representing a CSProject to be outputed.
+    /// A class representing a CSProject to be outputted.
     /// </summary>
     public class CSProjectInfo : ReferenceItemInfo
     {


### PR DESCRIPTION
## Overview

Follow up to https://github.com/microsoft/MixedRealityToolkit-Unity/pull/7973, spell checking our code comments and summaries.
Used [this VS spell checker extension](https://marketplace.visualstudio.com/items?itemName=EWoodruff.VisualStudioSpellCheckerVS2017andLater).