### PR TITLE
Update the build tools to support VS2019's .vcxproj extension

### DIFF
--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -24,6 +24,11 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         public static bool IsBuilding { get; private set; } = false;
 
         /// <summary>
+        /// The list of filename extensions that are valid VCProjects.
+        /// </summary>
+        private static readonly string[] VcProjExtensions = { "vcsproj", "vcxproj" };
+
+        /// <summary>
         /// Build the UWP appx bundle for this project.  Requires that <see cref="UwpPlayerBuildTools.BuildPlayer(string,bool,CancellationToken)"/> has already be run or a user has
         /// previously built the Unity Player with the WSA Player as the Build Target.
         /// </summary>
@@ -229,15 +234,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             // For ARM64 builds we need to add ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch
             // to vcxproj file in order to ensure that the build passes
-
-            string projectName = PlayerSettings.productName;
-            string projectFilePath = Path.Combine(Path.GetFullPath(buildInfo.OutputDirectory), projectName, $"{projectName}.vcsproj");
-
-            if (!File.Exists(projectFilePath))
-            {
-                Debug.LogError($"Cannot find project file: {projectFilePath}");
-                return false;
-            }
+            string projectFilePath = GetProjectFilePath(buildInfo);
 
             var rootNode = XElement.Load(projectFilePath);
             var defaultNamespace = rootNode.GetDefaultNamespace();
@@ -263,6 +260,28 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             rootNode.Save(projectFilePath);
 
             return true;
+        }
+
+        /// <summary>
+        /// Given the project name and build path, resolves the valid VcProject file (i.e. .vcsproj, vcxproj)
+        /// </summary>
+        /// <returns>A valid path if the project file exists, null otherwise</returns>
+        private static string GetProjectFilePath(IBuildInfo buildInfo)
+        {
+            string projectName = PlayerSettings.productName;
+            foreach (string extension in VcProjExtensions)
+            {
+                string projectFilePath = Path.Combine(Path.GetFullPath(buildInfo.OutputDirectory), projectName, $"{projectName}.{extension}");
+                if (File.Exists(projectFilePath))
+                {
+                    return projectFilePath;
+                }
+            }
+
+            string projectDirectory = Path.Combine(Path.GetFullPath(buildInfo.OutputDirectory), projectName);
+            string combinedExtensions = String.Join("|", VcProjExtensions);
+            Debug.LogError($"Cannot find project file {projectDirectory} given names {projectName}.{combinedExtensions}");
+            return null;
         }
 
         private static bool UpdateAppxManifest(IBuildInfo buildInfo)

--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpAppxBuildTools.cs
@@ -235,6 +235,10 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             // For ARM64 builds we need to add ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch
             // to vcxproj file in order to ensure that the build passes
             string projectFilePath = GetProjectFilePath(buildInfo);
+            if (projectFilePath == null)
+            {
+                return false;
+            }
 
             var rootNode = XElement.Load(projectFilePath);
             var defaultNamespace = rootNode.GetDefaultNamespace();


### PR DESCRIPTION
We currently have a 2019 CI daily build which is busted for a few reasons (one of which being that we don't have VS2019 on that hosted agent, which is something I'm following up on separately).

Another issue in the code itself is that we look for only a single extension (.vcsproj) instead of both .vcsproj and .vcxproj (vcxproj being the VS2019 extension).

This is one of the (probably many) fixes needed to prep for the 2019 PR pipeline