### PR TITLE
Added a note about NuGet package support.

### DIFF
--- a/Documentation/GettingStartedWithTheMRTK.md
+++ b/Documentation/GettingStartedWithTheMRTK.md
@@ -46,6 +46,8 @@ To get started with the Mixed Reality Toolkit, you will need:
 For information on package contents, see [MRTK Package Contents](MRTK_PackageContents.md).
 
 The Mixed Reality Toolkit is also available for download on NuGet.org; for details see [MRTK NuGet Packages](MRTKNuGetPackage.md).
+>[!NOTE]
+> As of MRTK 2.4.0, NuGet packages are no longer supported.
 
 ### Import MRTK packages into your Unity project
 


### PR DESCRIPTION
## Overview
NuGet packages are no longer supported as of MRTK 2.4.0. This should be clear to users.

## Changes
- Fixes: Added a note to the NuGet Package comments of the Getting Started page to make it clear that NuGet packages are no longer supported as of MRTK 2.4.0.

