### PR TITLE
Fix controller mapping profile rendering in Unity 2019.3

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -37,11 +37,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
           };
 
         /// <summary>
-        /// Default style for large button
+        /// Default style for controller mapping buttons
         /// </summary>
         public static readonly GUIStyle ControllerButtonStyle = new GUIStyle("LargeButton")
         {
             imagePosition = ImagePosition.ImageAbove,
+            fixedHeight = 128,
             fontStyle = FontStyle.Bold,
             stretchHeight = true,
             stretchWidth = true,


### PR DESCRIPTION
## Overview

Button rendering in the controller mapping profile is currently broken in Unity 2019:

![image](https://user-images.githubusercontent.com/3580640/83574232-e84a4600-a4e1-11ea-908c-417290379d78.png)

This PR adds an explicit height value to the `GUIStyle`, which matches the hardcoded height of the button already:

https://github.com/microsoft/MixedRealityToolkit-Unity/blob/6df48e126d779da4d82662b1bb16fb963f2986d0/Assets/MRTK/Core/Inspectors/Profiles/MixedRealityControllerMappingProfileInspector.cs#L299

![image](https://user-images.githubusercontent.com/3580640/83574058-783bc000-a4e1-11ea-9219-9da2a39d0fd7.png)
