### PR TITLE
Fixing slate zoom when slate is rotated around up vector

### DIFF
--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -5,7 +5,6 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.Serialization;
 
 namespace Microsoft.MixedReality.Toolkit.UI
@@ -38,6 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         }
 
         #region Serialized Fields
+
         [SerializeField]
         [FormerlySerializedAs("enabled")]
         private bool isEnabled = true;
@@ -45,36 +45,47 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// This Property sets and gets whether a the pan/zoom behavior is active.
         /// </summary>
         public bool Enabled { get => isEnabled; set => isEnabled = value; }
+
         [Header("Behavior")]
         [SerializeField]
         private bool enableZoom = false;
+
         [SerializeField]
         private bool lockHorizontal = false;
+
         [SerializeField]
         private bool lockVertical = false;
+
         [SerializeField]
         [Tooltip("If this is checked, Max Pan Horizontal and Max Pan Vertical are ignored.")]
         private bool unlimitedPan = true;
+
         [SerializeField]
         [Range(1.0f, 20.0f)]
         private float maxPanHorizontal = 2;
+
         [SerializeField]
         [Range(1.0f, 20.0f)]
         private float maxPanVertical = 2;
+
         [SerializeField]
         [Range(0.1f, 1.0f)]
         private float minScale = 0.2f;
+
         [SerializeField]
         [Range(1.0f, 10.0f)]
         private float maxScale = 1.5f;
+
         [SerializeField]
         [Range(0.0f, 0.99f)]
         [Tooltip("a value of 0 results in panning coming to a complete stop when released.")]
         private float momentumHorizontal = 0.9f;
+
         [SerializeField]
         [Tooltip("a value of 0 results in panning coming to a complete stop when released.")]
         [Range(0.0f, 0.99f)]
         private float momentumVertical = 0.9f;
+
         [SerializeField]
         [Range(0.0f, 99.0f)]
         private float panZoomSmoothing = 80.0f;
@@ -84,10 +95,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("If affordance geometry is desired to emphasize the touch points(leftPoint and rightPoint) and the center point between them (reticle), assign them here.")]
         [FormerlySerializedAs("reticle")]
         private GameObject centerPoint = null;
+
         [SerializeField]
         private GameObject leftPoint = null;
+
         [SerializeField]
         private GameObject rightPoint = null;
+
         [Tooltip("When the slate is touched, what color to change on the ProximityLight center color override to. (Assumes the target material uses a proximity light and proximity light color override)")]
         [SerializeField]
         private Color proximityLightCenterColor = new Color(0.25f, 0.25f, 0.25f, 0.0f);
@@ -95,6 +109,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [SerializeField]
         [Tooltip("Current scale value. 1 is the original 100%.")]
         private float currentScale;
+        /// <summary>
+        /// Current scale value. 1 is the original 100%.
+        /// </summary>
         public float CurrentScale
         {
             get { return currentScale; }
@@ -116,8 +133,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #endregion Serialized Fields
 
-
         #region Private Properties
+
         private Mesh mesh;
         private MeshFilter meshFilter;
         private BoxCollider boxCollider;
@@ -148,9 +165,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         private Color defaultProximityLightCenterColor;
         private List<Vector2> unTransformedUVs = new List<Vector2>();
         private Dictionary<uint, HandPanData> handDataMap = new Dictionary<uint, HandPanData>();
-        List<Vector2> uvs = new List<Vector2>();
-        List<Vector2> uvsOrig = new List<Vector2>();
+        private List<Vector2> uvs = new List<Vector2>();
+        private List<Vector2> uvsOrig = new List<Vector2>();
         private bool oldIsTargetPositionLockedOnFocusLock;
+
         #endregion Private Properties
 
         /// <summary>
@@ -164,21 +182,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
             initialTouchDistance = 0.0f;
         }
 
-
         #region MonoBehaviour Handlers
+
         private void Awake()
         {
             Initialize();
         }
+
         private void Update()
         {
-            if (isEnabled == true)
+            if (isEnabled)
             {
                 if (touchActive)
                 {
                     foreach (uint key in handDataMap.Keys)
                     {
-                        if (true == UpdateHandTouchingPoint(key))
+                        if (UpdateHandTouchingPoint(key))
                         {
                             MoveTouch(key);
                         }
@@ -190,7 +209,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 UpdateIdle();
                 UpdateUVMapping();
 
-                if (touchActive == false && affordancesVisible == true)
+                if (!touchActive && affordancesVisible)
                 {
                     SetAffordancesActive(false);
                 }
@@ -212,10 +231,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
         }
+
         #endregion MonoBehaviour Handlers
 
-
         #region Private Methods
+
         private bool TryGetMRControllerRayPoint(HandPanData data, out Vector3 rayPoint)
         {
 
@@ -233,13 +253,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             Vector3 tryHandPoint = Vector3.zero;
             bool tryGetSucceeded = false;
-            if (handDataMap.ContainsKey(sourceId) == true)
+            if (handDataMap.ContainsKey(sourceId))
             {
                 HandPanData data = handDataMap[sourceId];
 
-                if (data.IsActive == true)
+                if (data.IsActive)
                 {
-                    if (data.IsSourceNear == true)
+                    if (data.IsSourceNear)
                     {
                         tryGetSucceeded = TryGetHandPositionFromController(data.currentController, TrackedHandJoint.IndexTip, out tryHandPoint);
                     }
@@ -252,10 +272,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                         tryGetSucceeded = TryGetMRControllerRayPoint(data, out tryHandPoint);
                     }
 
-                    if (tryGetSucceeded == true)
+                    if (tryGetSucceeded)
                     {
                         tryHandPoint = SnapFingerToQuad(tryHandPoint);
-                        Vector3 unfilteredTouchPt = (data.IsSourceNear == true) ? tryHandPoint : tryHandPoint + data.touchingRayOffset;
+                        Vector3 unfilteredTouchPt = data.IsSourceNear ? tryHandPoint : tryHandPoint + data.touchingRayOffset;
                         runningAverageSmoothing = panZoomSmoothing * percentToDecimal;
                         unfilteredTouchPt *= (1.0f - runningAverageSmoothing);
                         data.touchingPointSmoothed = (data.touchingPointSmoothed * runningAverageSmoothing) + unfilteredTouchPt;
@@ -266,6 +286,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return true;
         }
+
         private bool TryGetHandRayPoint(IMixedRealityController controller, out Vector3 handRayPoint)
         {
             if (controller != null &&
@@ -281,6 +302,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             handRayPoint = Vector3.zero;
             return false;
         }
+
         private void Initialize()
         {
             SetAffordancesActive(false);
@@ -322,9 +344,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             mesh.GetUVs(0, unTransformedUVs);
         }
+
         private void UpdateIdle()
         {
-            if (touchActive == false)
+            if (!touchActive)
             {
                 if (Mathf.Abs(totalUVOffset.x) < 0.01f && Mathf.Abs(totalUVOffset.y) < 0.01f)
                 {
@@ -337,6 +360,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 }
             }
         }
+
         private void UpdateUVMapping()
         {
             Vector2 tiling = currentMaterial != null ? currentMaterial.mainTextureScale : new Vector2(1.0f, 1.0f);
@@ -404,9 +428,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             mesh.SetUVs(0, uvs);
         }
+
         private float GetUVScaleFromTouches()
         {
-            if (scaleActive == false || initialTouchDistance == 0)
+            if (!scaleActive || initialTouchDistance == 0)
             {
                 return 0.0f;
             }
@@ -414,6 +439,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             float uvScaleFromTouches = GetContactDistance() / initialTouchDistance;
             return uvScaleFromTouches;
         }
+
         private void UpdateTouchUVOffset(uint sourceId)
         {
             HandPanData data = handDataMap[sourceId];
@@ -421,9 +447,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
             data.uvOffset = currentQuadCoord - data.touchingQuadCoord;
             data.touchingQuadCoord = currentQuadCoord;
         }
+
         private Vector2 GetUvOffset()
         {
-            if (touchActive && AreSourcesCompatible() == true)
+            if (touchActive && AreSourcesCompatible())
             {
                 Vector2 offset = Vector2.zero;
                 foreach (uint key in handDataMap.Keys)
@@ -435,6 +462,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             return totalUVOffset;
         }
+
         private Vector3 GetContactCenter()
         {
             Vector3 center = Vector3.zero;
@@ -451,6 +479,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return center;
         }
+
         private void SetAffordancesActive(bool active)
         {
             affordancesVisible = active;
@@ -489,6 +518,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return handPoint;
         }
+
         private bool AreSourcesCompatible()
         {
             int score = 0;
@@ -498,6 +528,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             return (score == 0 || score == handDataMap.Keys.Count);
         }
+
         private bool AreSourcesNear()
         {
             foreach (uint key in handDataMap.Keys)
@@ -509,6 +540,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             return true;
         }
+
         private Vector3 GetTouchPoint()
         {
             if (touchActive)
@@ -523,10 +555,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             return Vector3.zero;
         }
+
         private Vector2 GetScaleUVCentroid()
         {
             return GetUVFromPoint(GetTouchPoint());
         }
+
         private Vector2 GetDisplayedUVCentroid(List<Vector2> uvs)
         {
             Vector2 centroid = Vector2.zero;
@@ -537,16 +571,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return centroid /= (float)uvs.Count;
         }
+
         private float GetContactDistance()
         {
-            if (scaleActive == false || handDataMap.Keys.Count < 2)
+            if (!scaleActive || handDataMap.Keys.Count < 2)
             {
                 return 0.0f;
             }
 
             int index = 0;
-            Vector2 a = Vector2.zero;
-            Vector2 b = Vector2.zero;
+            Vector3 a = Vector3.zero;
+            Vector3 b = Vector3.zero;
             foreach (uint key in handDataMap.Keys)
             {
                 if (index == 0)
@@ -563,14 +598,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return (b - a).magnitude;
         }
+
         private Vector2 GetQuadCoordFromPoint(Vector3 point)
         {
             Vector2 quadCoord = GetQuadCoord(point);
             quadCoord = new Vector2(lockHorizontal ? 0.0f : quadCoord.x, lockVertical ? 0.0f : quadCoord.y);
             return quadCoord;
         }
+
         private Vector2 GetUVFromQuadCoord(Vector2 coord)
         {
+            Vector2 uvCoord = Vector2.zero;
             Vector2[] uvs = mesh.uv;
             Vector2 upperLeft = uvs[3];
             Vector2 upperRight = uvs[1];
@@ -579,16 +617,22 @@ namespace Microsoft.MixedReality.Toolkit.UI
             float magVertical = (lowerLeft - upperLeft).magnitude;
             float magHorizontal = (upperRight - upperLeft).magnitude;
 
-            float v = Vector2.Dot(coord - upperLeft, (lowerLeft - upperLeft) / (magVertical * magVertical));
-            float h = Vector2.Dot(coord - upperLeft, (upperRight - upperLeft) / (magHorizontal * magHorizontal));
+            if (magVertical != 0.0f && magHorizontal != 0.0f)
+            {
+                // Get coord projection on uv coordinates then divide by length to get quad coord 0 to 1
+                uvCoord.x = Vector2.Dot(coord - upperLeft, upperRight - upperLeft) / (magHorizontal * magHorizontal);
+                uvCoord.y = Vector2.Dot(coord - upperLeft, lowerLeft - upperLeft) / (magVertical * magVertical);
+            }
 
-            return new Vector2(h, v);
+            return uvCoord;
         }
+
         private Vector2 GetUVFromPoint(Vector3 point)
         {
             Vector2 quadCoord = GetQuadCoordFromPoint(point);
             return GetUVFromQuadCoord(quadCoord);
         }
+
         private Vector2 GetQuadCoord(Vector3 point)
         {
             Vector2 quadCoord = Vector2.zero;
@@ -599,18 +643,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             float magVertical = (lowerLeft - upperLeft).magnitude;
             float magHorizontal = (upperRight - upperLeft).magnitude;
+
             if (magVertical != 0.0f && magHorizontal != 0.0f)
             {
-                Vector3 verticalEdgeNorm = (lowerLeft - upperLeft) / magVertical;
-                Vector3 horizontalEdgeNorm = (upperRight - upperLeft) / magHorizontal;
-                // Get dotproduct to determine distance ->then divide by length to get quad coord 0 to 1
-                float v = Vector3.Dot(point - upperLeft, verticalEdgeNorm) / magVertical;
-                float h = Vector3.Dot(point - upperLeft, horizontalEdgeNorm) / magHorizontal;
-                quadCoord = new Vector2(h, v);
+                // Get point projection on vertices coordinates then divide by length to get quad coord 0 to 1
+                quadCoord.x = Vector3.Dot(point - upperLeft, upperRight - upperLeft) / (magHorizontal * magHorizontal);
+                quadCoord.y = Vector3.Dot(point - upperLeft, lowerLeft - upperLeft) / (magVertical * magVertical);
             }
 
             return quadCoord;
         }
+
         private Vector3 SnapFingerToQuad(Vector3 pointToSnap)
         {
             Vector3 planePoint = this.transform.TransformPoint(mesh.vertices[0]);
@@ -618,7 +661,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             return Vector3.ProjectOnPlane(pointToSnap - planePoint, planeNormal) + planePoint;
         }
-
 
         private void SetHandDataFromController(IMixedRealityController controller, IMixedRealityPointer pointer, bool isNear)
         {
@@ -629,9 +671,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
             data.currentController = controller;
             data.currentPointer = pointer;
 
-            if (isNear == true)
+            if (isNear)
             {
-                if (TryGetHandPositionFromController(data.currentController, TrackedHandJoint.IndexTip, out Vector3 touchPosition) == true)
+                if (TryGetHandPositionFromController(data.currentController, TrackedHandJoint.IndexTip, out Vector3 touchPosition))
                 {
                     data.touchingInitialPt = SnapFingerToQuad(touchPosition);
                     data.touchingPointSmoothed = data.touchingInitialPt;
@@ -646,12 +688,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     data.touchingPoint = data.touchingInitialPt;
                     data.touchingPointSmoothed = data.touchingInitialPt;
                 }
-                else if (TryGetHandRayPoint(controller, out Vector3 handRayPt) == true)
+                else if (TryGetHandRayPoint(controller, out Vector3 handRayPt))
                 {
                     data.touchingInitialPt = SnapFingerToQuad(handRayPt);
                     data.touchingPoint = data.touchingInitialPt;
                     data.touchingPointSmoothed = data.touchingInitialPt;
-                    if (TryGetHandPositionFromController(data.currentController, TrackedHandJoint.Palm, out Vector3 touchPosition) == true)
+                    if (TryGetHandPositionFromController(data.currentController, TrackedHandJoint.Palm, out Vector3 touchPosition))
                     {
                         data.touchingRayOffset = handRayPt - SnapFingerToQuad(touchPosition);
                     }
@@ -708,57 +750,64 @@ namespace Microsoft.MixedReality.Toolkit.UI
             position = Vector3.zero;
             return false;
         }
+
         #endregion Private Methods
 
-
         #region Internal State Handlers
+
         private void StartTouch(uint sourceId)
         {
             UpdateTouchUVOffset(sourceId);
             RaisePanStarted(sourceId);
         }
+
         private void EndTouch(uint sourceId)
         {
-            if (handDataMap.ContainsKey(sourceId) == true)
+            if (handDataMap.ContainsKey(sourceId))
             {
                 handDataMap.Remove(sourceId);
                 RaisePanEnded(0);
             }
         }
+
         private void EndAllTouches()
         {
             handDataMap.Clear();
             RaisePanEnded(0);
         }
+
         private void MoveTouch(uint sourceId)
         {
             UpdateTouchUVOffset(sourceId);
             RaisePanning(sourceId);
         }
+
         #endregion Internal State Handlers
 
-
         #region Fire Events to Listening Objects
+
         private void RaisePanStarted(uint sourceId)
         {
             HandPanEventData eventData = new HandPanEventData();
             eventData.PanDelta = GetUvOffset();
             PanStarted?.Invoke(eventData);
         }
+
         private void RaisePanEnded(uint sourceId)
         {
             HandPanEventData eventData = new HandPanEventData();
             eventData.PanDelta = Vector2.zero;
             PanStopped?.Invoke(eventData);
         }
+
         private void RaisePanning(uint sourceId)
         {
             HandPanEventData eventData = new HandPanEventData();
             eventData.PanDelta = GetUvOffset();
             PanUpdated?.Invoke(eventData);
         }
-        #endregion Fire Events to Listening Objects
 
+        #endregion Fire Events to Listening Objects
 
         #region BaseFocusHandler Methods
 
@@ -770,8 +819,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             EndAllTouches();
         }
-        #endregion
 
+        #endregion
 
         #region IMixedRealityTouchHandler
         /// <summary>
@@ -784,16 +833,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
             SetHandDataFromController(eventData.Controller, null, true);
             eventData.Use();
         }
+
         public void OnTouchCompleted(HandTrackingInputEventData eventData)
         {
             EndTouch(eventData.SourceId);
             eventData.Use();
         }
+
         public void OnTouchUpdated(HandTrackingInputEventData eventData) { }
+
         #endregion IMixedRealityTouchHandler
 
-
         #region IMixedRealityInputHandler Methods
+
         /// <summary>
         /// The Input Event handlers receive Hand Ray events.
         /// </summary>
@@ -809,12 +861,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
             SetHandDataFromController(eventData.Pointer.Controller, eventData.Pointer, false);
             eventData.Use();
         }
+
         public void OnPointerUp(MixedRealityPointerEventData eventData)
         {
             eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
             EndTouch(eventData.SourceId);
             eventData.Use();
         }
+
         #endregion IMixedRealityInputHandler Methods
 
         #region IMixedRealitySourceStateHandler Methods
@@ -823,12 +877,17 @@ namespace Microsoft.MixedReality.Toolkit.UI
             EndTouch(eventData.SourceId);
             eventData.Use();
         }
+
         #endregion IMixedRealitySourceStateHandler Methods
 
         #region Unused Methods
+
         public void OnSourceDetected(SourceStateEventData eventData) { }
+
         public void OnPointerDragged(MixedRealityPointerEventData eventData) { }
+
         public void OnPointerClicked(MixedRealityPointerEventData eventData) { }
+
         #endregion Unused Methods
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -617,7 +618,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             float magVertical = (lowerLeft - upperLeft).magnitude;
             float magHorizontal = (upperRight - upperLeft).magnitude;
 
-            if (magVertical != 0.0f && magHorizontal != 0.0f)
+            if (!Mathf.Approximately(0, magVertical) && !Mathf.Approximately(0, magHorizontal))
             {
                 // Get coord projection on uv coordinates then divide by length to get quad coord 0 to 1
                 uvCoord.x = Vector2.Dot(coord - upperLeft, upperRight - upperLeft) / (magHorizontal * magHorizontal);
@@ -644,7 +645,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             float magVertical = (lowerLeft - upperLeft).magnitude;
             float magHorizontal = (upperRight - upperLeft).magnitude;
 
-            if (magVertical != 0.0f && magHorizontal != 0.0f)
+            if (!Mathf.Approximately(0, magVertical) && !Mathf.Approximately(0, magHorizontal))
             {
                 // Get point projection on vertices coordinates then divide by length to get quad coord 0 to 1
                 quadCoord.x = Vector3.Dot(point - upperLeft, upperRight - upperLeft) / (magHorizontal * magHorizontal);
@@ -763,7 +764,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void EndTouch(uint sourceId)
         {
-            if (handDataMap.ContainsKey(sourceId))
+                          if (handDataMap.ContainsKey(sourceId))
             {
                 handDataMap.Remove(sourceId);
                 RaisePanEnded(0);
@@ -864,7 +865,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnPointerUp(MixedRealityPointerEventData eventData)
         {
-            eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
+                                     eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
             EndTouch(eventData.SourceId);
             eventData.Use();
         }
@@ -882,7 +883,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region Unused Methods
 
-        public void OnSourceDetected(SourceStateEventData eventData) { }
+        public void OnSourceDetected(SourceStateEventData eventData) 
+        { 
+
+        }
 
         public void OnPointerDragged(MixedRealityPointerEventData eventData) { }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/Slate/HandInteractionPanZoom.cs
@@ -764,7 +764,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void EndTouch(uint sourceId)
         {
-                          if (handDataMap.ContainsKey(sourceId))
+            if (handDataMap.ContainsKey(sourceId))
             {
                 handDataMap.Remove(sourceId);
                 RaisePanEnded(0);
@@ -865,7 +865,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnPointerUp(MixedRealityPointerEventData eventData)
         {
-                                     eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
+            eventData.Pointer.IsTargetPositionLockedOnFocusLock = oldIsTargetPositionLockedOnFocusLock;
             EndTouch(eventData.SourceId);
             eventData.Use();
         }
@@ -883,10 +883,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         #region Unused Methods
 
-        public void OnSourceDetected(SourceStateEventData eventData) 
-        { 
-
-        }
+        public void OnSourceDetected(SourceStateEventData eventData) { }
 
         public void OnPointerDragged(MixedRealityPointerEventData eventData) { }
 

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator PrefabTouchScroll()
         {
-            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
+            InstantiateFromPrefab();
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator PrefabRayScroll()
         {
-            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
+            InstantiateFromPrefab();
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
@@ -101,7 +101,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator PrefabTouchZoom()
         {
-            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
+            InstantiateFromPrefab();
 
             TestHand handRight = new TestHand(Handedness.Right);
             yield return handRight.Show(Vector3.zero);
@@ -126,7 +126,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator PrefabGGVZoom()
         {
-            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
+            InstantiateFromPrefab();
 
             PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
@@ -150,7 +150,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
         /// <summary>
         /// Test zooming in using far and near interaction on a slate that is rotated 90 degrees around up vector.
-        /// This test garantees that the z component of the hand or controller position is being considered on the zooming logic.
+        /// This test guarantees that the z component of the hand or controller position is being considered on the zooming logic.
         /// </summary>
         [UnityTest]
         public IEnumerator ZoomRotatedSlate()
@@ -203,7 +203,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator PrefabGGVScroll()
         {
-            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
+            InstantiateFromPrefab();
             yield return RunGGVScrollTest(0.25f);
         }
 
@@ -213,7 +213,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         [UnityTest]
         public IEnumerator InstantiateGGVScroll()
         {
-            InstantiateFromCode(Vector3.forward);
+            InstantiateFromCode();
             yield return RunGGVScrollTest(0.08f);
         }
 
@@ -242,11 +242,12 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return handRight.Hide();
         }
 
-        private void InstantiateFromCode(Vector3 pos)
+        private void InstantiateFromCode(Vector3? position = null, Quaternion? rotation = null)
         {
             panObject = GameObject.CreatePrimitive(PrimitiveType.Quad);
             panObject.EnsureComponent<BoxCollider>();
-            panObject.transform.position = pos;
+            panObject.transform.position = position != null ? (Vector3)position : Vector3.forward;
+            panObject.transform.rotation = rotation != null ? (Quaternion)rotation : Quaternion.identity;
             panZoom = panObject.AddComponent<HandInteractionPanZoom>();
             panObject.AddComponent<NearInteractionTouchable>();
 
@@ -255,13 +256,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// <summary>
         /// Instantiates a slate from the default prefab at position and rotation
         /// </summary>
-        private void InstantiateFromPrefab(Vector3 position, Quaternion rotation)
+        private void InstantiateFromPrefab(Vector3? position = null, Quaternion? rotation = null)
         {
             UnityEngine.Object prefab = AssetDatabase.LoadAssetAtPath(slatePrefabAssetPath, typeof(UnityEngine.Object));
             panObject = UnityEngine.Object.Instantiate(prefab) as GameObject;
             Assert.IsNotNull(panObject);
-            panObject.transform.position = position;
-            panObject.transform.rotation = rotation;
+            panObject.transform.position = position != null ? (Vector3)position : Vector3.forward;
+            panObject.transform.rotation = rotation != null ? (Quaternion)rotation : Quaternion.identity;
             panZoom = panObject.GetComponentInChildren<HandInteractionPanZoom>();
             Assert.IsNotNull(panZoom);
         }

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         private const string slatePrefabAssetGuid = "937ce507dd7ee334ba569554e24adbdd";
         private static readonly string slatePrefabAssetPath = AssetDatabase.GUIDToAssetPath(slatePrefabAssetGuid);
 
-        GameObject panObject;
-        HandInteractionPanZoom panZoom;
+        private GameObject panObject;
+        private HandInteractionPanZoom panZoom;
 
         [SetUp]
         public void Setup()
@@ -51,9 +51,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Tests touch scrolling instantiated from prefab
         /// </summary>
         [UnityTest]
-        public IEnumerator Prefab_TouchScroll()
+        public IEnumerator PrefabTouchScroll()
         {
-            InstantiateFromPrefab(Vector3.forward);
+            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
@@ -70,9 +70,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test hand ray scroll instantiated from prefab
         /// </summary>
         [UnityTest]
-        public IEnumerator Prefab_RayScroll()
+        public IEnumerator PrefabRayScroll()
         {
-            InstantiateFromPrefab(Vector3.forward);
+            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
             Vector2 totalPanDelta = Vector2.zero;
             panZoom.PanUpdated.AddListener((hpd) => totalPanDelta += hpd.PanDelta);
 
@@ -99,9 +99,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test touch zooming instantiated from prefab
         /// </summary>
         [UnityTest]
-        public IEnumerator Prefab_TouchZoom()
+        public IEnumerator PrefabTouchZoom()
         {
-            InstantiateFromPrefab(Vector3.forward);
+            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
 
             TestHand handRight = new TestHand(Handedness.Right);
             yield return handRight.Show(Vector3.zero);
@@ -124,9 +124,9 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test ggv (gaze, gesture, and voice) zooming instantiated from prefab
         /// </summary>
         [UnityTest]
-        public IEnumerator Prefab_GGVZoom()
+        public IEnumerator PrefabGGVZoom()
         {
-            InstantiateFromPrefab(Vector3.forward);
+            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
 
             PlayModeTestUtilities.SetHandSimulationMode(HandSimulationMode.Gestures);
 
@@ -147,13 +147,63 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return handRight.Hide();
             yield return handLeft.Hide();
         }
+
+        // <summary>
+        /// Test zooming in using far and near interaction on a slate that is rotated 90 degrees around up vector.
+        /// This test garantees that the z component of the hand or controller position is being considered on the zooming logic.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ZoomRotatedSlate()
+        {
+            // Configuring camera and hands to interact with rotated slate
+            InstantiateFromPrefab(Vector3.right, Quaternion.LookRotation(Vector3.right));
+            MixedRealityPlayspace.PerformTransformation(p => p.Rotate(Vector3.up, 90));
+            yield return null;
+
+            // Right hand pinches slate
+            TestHand handRight = new TestHand(Handedness.Right);
+            yield return handRight.Show(panZoom.transform.position + Vector3.forward * -0.1f + Vector3.right * -0.3f);
+            yield return handRight.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // Left hand pinches slate
+            TestHand handLeft = new TestHand(Handedness.Left);
+            yield return handLeft.Show(panZoom.transform.position + Vector3.forward * 0.1f + Vector3.right * -0.3f);
+            yield return handLeft.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // Use both hands to zoom in
+            yield return handRight.Move(new Vector3(0f, 0f, -0.1f), 5);
+            yield return handLeft.Move(new Vector3(0f, 0f, 0.1f), 5);
+
+            Assert.AreEqual(0.6, panZoom.CurrentScale, 0.1, "Rotated slate did not zoom in using near interaction");
+
+            // Reset slate and hands configuration
+            panZoom.Reset();
+            yield return handRight.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return handLeft.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return null;
+
+            // Both hands touch slate
+            yield return handRight.MoveTo(panZoom.transform.position + Vector3.forward * -0.1f);
+            yield return handLeft.MoveTo(panZoom.transform.position + Vector3.forward * 0.1f);
+            yield return null;
+
+            // Use both hands to zoom in
+            yield return handRight.Move(new Vector3(0f, 0f, -0.1f), 5);
+            yield return handLeft.Move(new Vector3(0f, 0f, 0.1f), 5);
+
+            Assert.AreEqual(0.6, panZoom.CurrentScale, 0.1, "Rotated slate did not zoom in using far interaction");
+
+            yield return handRight.Hide();
+            yield return handLeft.Hide();
+        }
+
         /// <summary>
         /// Test ggv scroll instantiated from prefab
         /// </summary>
         [UnityTest]
-        public IEnumerator Prefab_GGVScroll()
+        public IEnumerator PrefabGGVScroll()
         {
-            InstantiateFromPrefab(Vector3.forward);
+            InstantiateFromPrefab(Vector3.forward, Quaternion.identity);
             yield return RunGGVScrollTest(0.25f);
         }
 
@@ -161,7 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         /// Test hand ray scroll instantiated from prefab
         /// </summary>
         [UnityTest]
-        public IEnumerator Instantiate_GGVScroll()
+        public IEnumerator InstantiateGGVScroll()
         {
             InstantiateFromCode(Vector3.forward);
             yield return RunGGVScrollTest(0.08f);
@@ -201,19 +251,20 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             panObject.AddComponent<NearInteractionTouchable>();
 
         }
+
         /// <summary>
-        /// Instantiates a slate from the default prefab at position, looking at the camera
+        /// Instantiates a slate from the default prefab at position and rotation
         /// </summary>
-        private void InstantiateFromPrefab(Vector3 position)
+        private void InstantiateFromPrefab(Vector3 position, Quaternion rotation)
         {
             UnityEngine.Object prefab = AssetDatabase.LoadAssetAtPath(slatePrefabAssetPath, typeof(UnityEngine.Object));
             panObject = UnityEngine.Object.Instantiate(prefab) as GameObject;
             Assert.IsNotNull(panObject);
             panObject.transform.position = position;
+            panObject.transform.rotation = rotation;
             panZoom = panObject.GetComponentInChildren<HandInteractionPanZoom>();
             Assert.IsNotNull(panZoom);
         }
-
     }
 }
 #endif

--- a/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SlateTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             yield return handLeft.Hide();
         }
 
-        // <summary>
+        /// <summary>
         /// Test zooming in using far and near interaction on a slate that is rotated 90 degrees around up vector.
         /// This test garantees that the z component of the hand or controller position is being considered on the zooming logic.
         /// </summary>


### PR DESCRIPTION
## Overview
Slate in HandInteractionExample is jumping in zoom levels when starting interaction with two hands. The issue is more visible when Slate is rotated in a way where hand click and drag only through z axis should trigger a slate zoom.

## Changes
Changed GetContactDistance() method from HandInteractionPanZoom.cs to account for global z component of hand / controler position.

- Fixes: #7788.

## Screenshots

Before:
![slate_zoom_before](https://user-images.githubusercontent.com/16922045/83654940-b2769180-a5b5-11ea-9ee7-ae75cbd12823.gif)

After:
![slate_zoom_after](https://user-images.githubusercontent.com/16922045/83654316-d7b6d000-a5b4-11ea-80a5-ff74238839bf.gif)

## Setup

- MRTK 2.4
- Unity 2018.4
- Hololens 2
