### PR TITLE
Ensure that the MixedRealityInputModule.OnPointerUp does not throw a KeyNotFoundException

### DIFF
--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
@@ -309,7 +309,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             // OnPointerUp can be raised during an OnSourceLost. If the pointer has already been removed
             // from the pointerDataToUpdate Dictionary and added to the pointerDataToRemove list, then
             // that pointer's state update can be ignored.
-            Debug.Assert(pointerDataToUpdate.ContainsKey(pointerId) || IsPointerIdInRemovedList());
+            Debug.Assert(pointerDataToUpdate.ContainsKey(pointerId) || IsPointerIdInRemovedList(pointerId));
             if (pointerDataToUpdate.TryGetValue(pointerId, out PointerData pointerData))
             {
                 pointerData.nextPressState = PointerEventData.FramePressState.Released;
@@ -329,7 +329,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
         }
 
-        private bool IsPointerIdInRemovedList()
+        private bool IsPointerIdInRemovedList(int pointerId)
         {
             for (int i = 0; i < pointerDataToRemove.Count; i++)
             {

--- a/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
+++ b/Assets/MRTK/Services/InputSystem/MixedRealityInputModule.cs
@@ -314,19 +314,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 pointerData.nextPressState = PointerEventData.FramePressState.Released;
             }
-
-            bool IsPointerIdInRemovedList()
-            {
-                for (int i = 0; i < pointerDataToRemove.Count; i++)
-                {
-                    if (pointerDataToRemove[i].pointer.PointerId == pointerId)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
         }
 
         void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
@@ -340,6 +327,19 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
         {
+        }
+
+        private bool IsPointerIdInRemovedList()
+        {
+            for (int i = 0; i < pointerDataToRemove.Count; i++)
+            {
+                if (pointerDataToRemove[i].pointer.PointerId == pointerId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         #endregion


### PR DESCRIPTION
## Overview
From https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7989, if OnPointerUp happens during an OnSourceLost, and if the BaseControllerPointer handles the OnSourceLost after MixedRealityInputModule, then OnPointerUp here can throw a KeyNotFoundException.  MixedRealityInputModule should be resilient to the effects other handlers of OnSourceLost, and not throw an exception if the pointer has already been removed.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7989.
