### PR TITLE
Add option to omit SSL Certificate Verification for Device Portal

### DIFF
--- a/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
+++ b/Assets/MRTK/Core/Utilities/BuildAndDeploy/UwpBuildDeployPreferences.cs
@@ -40,6 +40,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         private const string EDITOR_PREF_LOCAL_CONNECT_INFO = "BuildDeployWindow_LocalConnection";
         private const string EDITOR_PREF_FULL_REINSTALL = "BuildDeployWindow_FullReinstall";
         private const string EDITOR_PREF_USE_SSL = "BuildDeployWindow_UseSSL";
+        private const string EDITOR_PREF_VERIFY_SSL = "BuildDeployWindow_VerifySSL";
         private const string EDITOR_PREF_PROCESS_ALL = "BuildDeployWindow_ProcessAll";
         private const string EDITOR_PREF_GAZE_INPUT_CAPABILITY_ENABLED = "BuildDeployWindow_GazeInputCapabilityEnabled";
         private const string EDITOR_PREF_MULTICORE_APPX_BUILD_ENABLED = "BuildDeployWindow_MulticoreAppxBuildEnabled";
@@ -136,6 +137,15 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
         {
             get => EditorPreferences.Get(EDITOR_PREF_USE_SSL, false);
             set => EditorPreferences.Set(EDITOR_PREF_USE_SSL, value);
+        }
+
+        /// <summary>
+        /// Current setting to verify SSL certificates for connections to the device portal.
+        /// </summary>
+        public static bool VerifySSL
+        {
+            get => EditorPreferences.Get(EDITOR_PREF_VERIFY_SSL, true);
+            set => EditorPreferences.Set(EDITOR_PREF_VERIFY_SSL, value);
         }
 
         /// <summary>

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
@@ -17,11 +17,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// </summary>
     public static class Rest
     {
-        /// <summary>
-        /// Use SSL Connections when making rest calls.
-        /// </summary>
-        public static bool UseSSL { get; set; } = true;
-
         #region Authentication
 
         /// <summary>
@@ -57,8 +52,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="downloadHandler">Optional DownloadHandler for the request.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> GetAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, DownloadHandler downloadHandler = null, bool readResponseData = false)
+        public static async Task<Response> GetAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, DownloadHandler downloadHandler = null, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Get(query))
             {
@@ -67,7 +64,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                     webRequest.downloadHandler = downloadHandler;
                 }
 
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -82,12 +79,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> PostAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Post(query, null as string))
             {
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -99,12 +98,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, WWWForm formData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> PostAsync(string query, WWWForm formData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Post(query, formData))
             {
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -116,8 +117,10 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> PostAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Post(query, "POST"))
             {
@@ -126,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 webRequest.downloadHandler = new DownloadHandlerBuffer();
                 webRequest.SetRequestHeader("Content-Type", "application/json");
                 webRequest.SetRequestHeader("Accept", "application/json");
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -138,15 +141,17 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="bodyData">The raw data to post.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PostAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> PostAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Post(query, "POST"))
             {
                 webRequest.uploadHandler = new UploadHandlerRaw(bodyData);
                 webRequest.downloadHandler = new DownloadHandlerBuffer();
                 webRequest.SetRequestHeader("Content-Type", "application/octet-stream");
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -162,13 +167,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PutAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> PutAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Put(query, jsonData))
             {
                 webRequest.SetRequestHeader("Content-Type", "application/json");
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -180,13 +187,15 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> PutAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> PutAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Put(query, bodyData))
             {
                 webRequest.SetRequestHeader("Content-Type", "application/octet-stream");
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
@@ -201,18 +210,20 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="headers">Optional header information for the request.</param>
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
+        /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
         /// <returns>The response data.</returns>
-        public static async Task<Response> DeleteAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false)
+        public static async Task<Response> DeleteAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             using (var webRequest = UnityWebRequest.Delete(query))
             {
-                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData);
+                return await ProcessRequestAsync(webRequest, timeout, headers, readResponseData, certificateHandler, disposeCertificateHandlerOnDispose);
             }
         }
 
         #endregion DELETE
 
-        private static async Task<Response> ProcessRequestAsync(UnityWebRequest webRequest, int timeout, Dictionary<string, string> headers = null, bool readResponseData = false)
+        private static async Task<Response> ProcessRequestAsync(UnityWebRequest webRequest, int timeout, Dictionary<string, string> headers = null, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
             if (timeout > 0)
             {
@@ -239,6 +250,8 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
                 }
             }
 
+            webRequest.certificateHandler = certificateHandler;
+            webRequest.disposeCertificateHandlerOnDispose = disposeCertificateHandlerOnDispose;
             await webRequest.SendWebRequest();
 
 #if UNITY_2020_1_OR_NEWER

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="downloadHandler">Optional DownloadHandler for the request.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> GetAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, DownloadHandler downloadHandler = null, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
@@ -80,7 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> PostAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
@@ -99,7 +99,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> PostAsync(string query, WWWForm formData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
@@ -118,7 +118,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> PostAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {

--- a/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
+++ b/Assets/MRTK/Core/Utilities/WebRequestRest/Rest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> PostAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
@@ -168,7 +168,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> PutAsync(string query, string jsonData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
@@ -188,7 +188,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> PutAsync(string query, byte[] bodyData, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {
@@ -211,7 +211,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="timeout">Optional time in seconds before request expires.</param>
         /// <param name="readResponseData">Optional bool. If its true, response data will be read from web request download handler.</param>
         /// <param name="certificateHandler">Optional certificate handler for custom certificate verification</param>
-        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying <see cref="UnityWebRequest"/> is disposed.</param>
+        /// <param name="disposeCertificateHandlerOnDispose">Optional bool. If true and <paramref name="certificateHandler"/> is not null, <paramref name="certificateHandler"/> will be disposed, when the underlying UnityWebRequest is disposed.</param>
         /// <returns>The response data.</returns>
         public static async Task<Response> DeleteAsync(string query, Dictionary<string, string> headers = null, int timeout = -1, bool readResponseData = false, CertificateHandler certificateHandler = null, bool disposeCertificateHandlerOnDispose = true)
         {

--- a/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
+++ b/Assets/MRTK/Core/Utilities/WindowsDevicePortal/DevicePortal.cs
@@ -18,12 +18,44 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
     /// </summary>
     public static class DevicePortal
     {
+        /// <summary>
+        /// Use SSL Connections when making rest calls.
+        /// </summary>
+        public static bool UseSSL { get; set; } = true;
+
+        /// <summary>
+        /// Use SSL Certificate Verification when making SSL rest calls.
+        /// </summary>
+        public static bool VerifySSLCertificates { get; set; } = true;
+
         private enum AppInstallStatus
         {
             Invalid,
             Installing,
             InstallSuccess,
             InstallFail
+        }
+
+        /// <summary>
+        /// Custom certificate handler for device portal request.
+        /// The device portal on HoloLens uses a self-signed certificate, therefore SSL Unity WebRequest will fail.
+        /// As a fix we simply accept all certificates, including self-signed, without further checking, 
+        /// as they do not chain up to any Microsoft Root Certificate.
+        /// </summary>
+        private class BlankCertificateHandler : CertificateHandler
+        {
+            protected override bool ValidateCertificate(byte[] certificateData)
+            {
+                // Accept all the certificates!
+                return true;
+            }
+        }
+
+        private static readonly BlankCertificateHandler BlankCertificateHandlerInstance = new BlankCertificateHandler();
+
+        private static CertificateHandler DevicePortalCertificateHandler
+        {
+            get { return !VerifySSLCertificates ? BlankCertificateHandlerInstance : null; }
         }
 
         // Device Portal API Resources
@@ -65,7 +97,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetDeviceOsInfoQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -91,7 +123,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetMachineNameQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -117,7 +149,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetBatteryQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -143,7 +175,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(GetPowerStateQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -166,7 +198,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
             if (!isAuth) { return false; }
 
-            var response = await Rest.PostAsync(string.Format(RestartDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.PostAsync(string.Format(RestartDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (response.Successful)
             {
@@ -175,7 +207,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
                 while (!hasRestarted)
                 {
-                    response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+                    response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
                     if (!response.Successful)
                     {
@@ -212,7 +244,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
             if (!isAuth) { return false; }
 
-            var response = await Rest.PostAsync(string.Format(ShutdownDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.PostAsync(string.Format(ShutdownDeviceQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -258,7 +290,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 return false;
             }
 
-            var response = await Rest.GetAsync(string.Format(ProcessQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(string.Format(ProcessQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (response.Successful)
             {
@@ -313,7 +345,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             var isAuth = await EnsureAuthenticationAsync(targetDevice);
             if (!isAuth) { return null; }
 
-            var response = await Rest.GetAsync(string.Format(PackagesQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(string.Format(PackagesQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -409,7 +441,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             // Query
             string query = $"{string.Format(InstallQuery, FinalizeUrl(targetDevice.IP))}?package={UnityWebRequest.EscapeURL(fileName)}";
 
-            var response = await Rest.PostAsync(query, form, targetDevice.Authorization);
+            var response = await Rest.PostAsync(query, form, targetDevice.Authorization, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -445,7 +477,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
 
         private static async Task<AppInstallStatus> GetInstallStatusAsync(DeviceInfo targetDevice)
         {
-            var response = await Rest.GetAsync(string.Format(InstallStatusQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(string.Format(InstallStatusQuery, FinalizeUrl(targetDevice.IP)), targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (response.Successful)
             {
@@ -494,7 +526,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             Debug.Log($"Attempting to uninstall {packageName} on {targetDevice.ToString()}...");
 
             string query = $"{string.Format(InstallQuery, FinalizeUrl(targetDevice.IP))}?package={UnityWebRequest.EscapeURL(appInfo.PackageFullName)}";
-            var response = await Rest.DeleteAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.DeleteAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (response.Successful)
             {
@@ -537,7 +569,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             }
 
             string query = $"{string.Format(AppQuery, FinalizeUrl(targetDevice.IP))}?appid={UnityWebRequest.EscapeURL(appInfo.PackageRelativeId.EncodeTo64())}&package={UnityWebRequest.EscapeURL(appInfo.PackageFullName)}";
-            var response = await Rest.PostAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.PostAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -579,7 +611,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             }
 
             string query = $"{string.Format(AppQuery, FinalizeUrl(targetDevice.IP))}?package={UnityWebRequest.EscapeURL(appInfo.PackageFullName.EncodeTo64())}";
-            Response response = await Rest.DeleteAsync(query, targetDevice.Authorization, readResponseData: true);
+            Response response = await Rest.DeleteAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -621,7 +653,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             }
 
             string logFile = $"{Application.temporaryCachePath}/{targetDevice.MachineName}_{DateTime.Now.Year}{DateTime.Now.Month}{DateTime.Now.Day}{DateTime.Now.Hour}{DateTime.Now.Minute}{DateTime.Now.Second}_player.txt";
-            var response = await Rest.GetAsync(string.Format(FileQuery, FinalizeUrl(targetDevice.IP), appInfo.PackageFullName), targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(string.Format(FileQuery, FinalizeUrl(targetDevice.IP), appInfo.PackageFullName), targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -649,7 +681,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(IpConfigQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -676,7 +708,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(WiFiNetworkQuery, FinalizeUrl(targetDevice.IP), $"s?interface={interfaceInfo.GUID}");
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -708,7 +740,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
                 WiFiNetworkQuery,
                 FinalizeUrl(targetDevice.IP),
                 $"?interface={interfaceInfo.GUID}&ssid={wifiNetwork.SSID.EncodeTo64()}&op=connect&createprofile=yes&key={password}");
-            return await Rest.PostAsync(query, targetDevice.Authorization);
+            return await Rest.PostAsync(query, targetDevice.Authorization, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
         }
 
         /// <summary>
@@ -721,7 +753,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             if (!isAuth) { return null; }
 
             string query = string.Format(WiFiInterfacesQuery, FinalizeUrl(targetDevice.IP));
-            var response = await Rest.GetAsync(query, targetDevice.Authorization, readResponseData: true);
+            var response = await Rest.GetAsync(query, targetDevice.Authorization,  readResponseData: true, certificateHandler: DevicePortalCertificateHandler, disposeCertificateHandlerOnDispose: false);
 
             if (!response.Successful)
             {
@@ -745,12 +777,11 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
         /// <returns>The finalized URL with http/https prefix.</returns>
         public static string FinalizeUrl(string targetUrl)
         {
-            string ssl = Rest.UseSSL ? "s" : string.Empty;
+            string ssl = DevicePortal.UseSSL ? "s" : string.Empty;
 
             if (targetUrl.Contains(DeviceInfo.LocalMachine) || targetUrl.Contains(DeviceInfo.LocalIPAddress))
-            {
-                targetUrl = $"{DeviceInfo.LocalIPAddress}:10080";
-                ssl = string.Empty;
+            { 
+                targetUrl = UseSSL ? $"{DeviceInfo.LocalIPAddress}:10443" : $"{DeviceInfo.LocalIPAddress}:10080";
             }
 
             return $@"http{ssl}://{targetUrl}";
@@ -839,6 +870,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsDevicePortal
             UnityWebRequest webRequest = UnityWebRequest.Get(FinalizeUrl(targetDevice.IP));
 
             webRequest.timeout = 5;
+            webRequest.certificateHandler = DevicePortalCertificateHandler;
+            webRequest.disposeCertificateHandlerOnDispose = false;
             webRequest.SetRequestHeader("Authorization", targetDevice.Authorization["Authorization"]);
 
             await webRequest.SendWebRequest();

--- a/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
+++ b/Assets/MRTK/Tools/BuildWindow/BuildDeployWindow.cs
@@ -98,7 +98,9 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
 
         private readonly GUIContent VersionNumberLabel = new GUIContent("Version Number", "Major.Minor.Build.Revision\nNote: Revision should always be zero because it's reserved by Windows Store.");
 
-        private readonly GUIContent UseSSLLabel = new GUIContent("Use SSL?", "Use SLL to communicate with Device Portal");
+        private readonly GUIContent UseSSLLabel = new GUIContent("Use SSL?", "Use SSL to communicate with Device Portal");
+
+        private readonly GUIContent VerifySSLLabel = new GUIContent("Verify SSL Certificates?", "When using SSL for Device Portal communication, verfiy the SSL certificate against Root Certificates. For self-signed Device Portal certificates disabling this omits SSL rejection errors.");
 
         private readonly GUIContent TargetTypeLabel = new GUIContent("Target Type", "Target either local connection or a remote device");
 
@@ -285,7 +287,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             LoadWindowsSdkPaths();
             UpdateBuilds();
 
-            Rest.UseSSL = UwpBuildDeployPreferences.UseSSL;
+            DevicePortal.UseSSL = UwpBuildDeployPreferences.UseSSL;
 
             localConnection = JsonUtility.FromJson<DeviceInfo>(UwpBuildDeployPreferences.LocalConnectionInfo);
 
@@ -655,17 +657,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 {
                     RenderRemoteConnections();
 
-                    bool useSSL = UwpBuildDeployPreferences.UseSSL;
-                    bool newUseSSL = EditorGUILayout.ToggleLeft(UseSSLLabel, useSSL);
-                    if (newUseSSL != useSSL)
-                    {
-                        UwpBuildDeployPreferences.UseSSL = newUseSSL;
-                        Rest.UseSSL = newUseSSL;
-                    }
-                    else if (UwpBuildDeployPreferences.UseSSL != Rest.UseSSL)
-                    {
-                        Rest.UseSSL = UwpBuildDeployPreferences.UseSSL;
-                    }
+                    RenderSSLButtons();
                 }
                 else
                 {
@@ -684,6 +676,8 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                             }
                         }
                     }
+
+                    RenderSSLButtons();
                 }
 
                 EditorGUILayout.Space();
@@ -694,6 +688,38 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
             EditorGUILayout.Space();
 
             RenderBuildsList();
+        }
+
+        private void RenderSSLButtons()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                bool useSSL = UwpBuildDeployPreferences.UseSSL;
+                bool newUseSSL = EditorGUILayout.ToggleLeft(UseSSLLabel, useSSL);
+                if (newUseSSL != useSSL)
+                {
+                    UwpBuildDeployPreferences.UseSSL = newUseSSL;
+                    DevicePortal.UseSSL = newUseSSL;
+                }
+                else if (UwpBuildDeployPreferences.UseSSL != DevicePortal.UseSSL)
+                {
+                    DevicePortal.UseSSL = UwpBuildDeployPreferences.UseSSL;
+                }
+
+                bool verifySSL = UwpBuildDeployPreferences.VerifySSL;
+                bool newVerifySSL = EditorGUILayout.ToggleLeft(VerifySSLLabel, verifySSL);
+                if (newVerifySSL != verifySSL)
+                {
+                    UwpBuildDeployPreferences.VerifySSL = newVerifySSL;
+                    DevicePortal.VerifySSLCertificates = verifySSL;
+                }
+                else if (UwpBuildDeployPreferences.VerifySSL != DevicePortal.VerifySSLCertificates)
+                {
+                    DevicePortal.VerifySSLCertificates = UwpBuildDeployPreferences.VerifySSL;
+                }
+
+                GUILayout.FlexibleSpace();
+            }
         }
 
         private void RenderConnectionButtons()

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -9,4 +9,20 @@
 
 ### Breaking changes
 
+** Rest / Device Portal API**
+
+The `UseSSL` static property has been moved from `Rest` to `DevicePortal`.
+
+If you did this previously...
+
+```csharp
+Rest.UseSSL = true
+```
+
+Do this now...
+
+```csharp
+DevicePortal.UseSSL = true
+```
+
 ### Known issues


### PR DESCRIPTION
## Overview

On certain devices, i.e. HoloLens 2, the device portal seems to be forcing SSL and even redirecting HTTP to HTTPS. To omit SSL errors rejecting the self-signed device portal certificates when using the MRTK Build Window Deploy Options tab, an option is added to turn off the SSL Certificate Verification.

![image](https://user-images.githubusercontent.com/44086818/83771449-97258800-a682-11ea-95a7-edabec40a490.png)

This option is per default turned on, so to not alter the default behavior, as disabling SSL Verification may pose a security risk in some instances.

This change also displays the "Use SSL" checkbox for local USB connection, as HoloLens 2 uses a HTTPS connection at `https://127.0.0.1:10443/`.

## Changes
- Fixes: #6877

