### PR TITLE
Make sure to check that the AssemblyDefinition for LeapMotion exists before trying to use it

### DIFF
--- a/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
+++ b/Assets/MRTK/Providers/LeapMotion/Editor/ConfigurationChecker/LeapMotionConfigurationChecker.cs
@@ -103,6 +103,12 @@ namespace Microsoft.MixedReality.Toolkit.LeapMotion
         {
             FileInfo[] leapDataProviderAsmDefFile = FileUtilities.FindFilesInAssets("Microsoft.MixedReality.Toolkit.Providers.LeapMotion.asmdef");
 
+            // When MRTK is used through NuGet compiled assemblies, there will not be an asmdef file in the assets directory to configure.
+            if (leapDataProviderAsmDefFile.Length == 0)
+            {
+                return;
+            }
+
             AssemblyDefinition leapDataProviderAsmDef = AssemblyDefinition.Load(leapDataProviderAsmDefFile[0].FullName);
 
             List<string> references = leapDataProviderAsmDef.References.ToList();


### PR DESCRIPTION
When consuming MRTK through NuGet, the LeapMotionConfigurationChecker throw an IndexOutOfRangeException because the asmdef file does not exist. However, this is expected when using compiled NuGet binaries.

The fix here adds a length check, and does not continue configuration if the asmdef is not found in the assets directory.

## Changes
- Fixes: 8021