### PR TITLE
Update WMR Plugin version to 1.0.21

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.xr.arfoundation": "1.5.0-preview.6",
     "com.unity.xr.arkit": "2.1.2",
     "com.unity.xr.openvr.standalone": "1.0.5",
-    "com.unity.xr.windowsmr.metro": "1.0.19",
+    "com.unity.xr.windowsmr.metro": "1.0.21",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",


### PR DESCRIPTION
## Overview

1.0.21 updated the remoting plugins to 2.1.3, which [fixes some stability bugs that some devs were hitting](https://docs.microsoft.com/en-us/windows/mixed-reality/holographic-remoting-version-history). A selection of changes between the previous version and this one:

> 1. Starting with version 2.1.3 HolographicSpace.CameraAdded is synchronized with pose data coming from the Holographic Remoting Player and users can expect that when a camera is added there is also a valid HolographicCameraPose available for that camera on the the next frame.
> 1. Added support for HolographicCameraRenderingParameters.CommitDirect3D11DepthBuffer.