### PR TITLE
Bounds override fix

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -471,7 +471,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             // Record what the initial size of the bounds override
             // was when we constructed the rig, so we can restore
             // it after we destructively edit the size with the
-            // BoxPadding (#7997)
+            // BoxPadding (https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7997)
             if (boundsOverride != null)
             {
                 initialBoundsOverrideSize = boundsOverride.size;

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -374,6 +374,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
         // Used to determine if boundsOverride size has changed.
         private Bounds prevBoundsOverride = new Bounds();
 
+        // Used to record the initial size of the bounds override, if it exists.
+        // Necessary because BoxPadding will destructively edit the size of the
+        // override BoxCollider, and repeated calls to BoxPadding will result
+        // in the override bounds growing continually larger/smaller.
+        private Vector3? initialBoundsOverrideSize = null;
+
         // True if this game object is a child of the Target one
         private bool isChildOfTarget = false;
         private static readonly string rigRootName = "rigRoot";
@@ -460,6 +466,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             if (!IsInitialized)
             {
                 return;
+            }
+
+            // Record what the initial size of the bounds override
+            // was when we constructed the rig, so we can restore
+            // it after we destructively edit the size with the
+            // BoxPadding (#7997)
+            if (boundsOverride != null)
+            {
+                initialBoundsOverrideSize = boundsOverride.size;
             }
 
             DestroyRig();
@@ -873,7 +888,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
             }
             else
             {
-                boundsOverride.size -= boxPadding;
+                // If we have previously logged an initial bounds size,
+                // reset the boundsOverride BoxCollider to the initial size.
+                // This is because the CalculateBoxPadding
+                if (initialBoundsOverrideSize.HasValue)
+                {
+                    boundsOverride.size = initialBoundsOverrideSize.Value;
+                }
 
                 if (TargetBounds != null)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1202,6 +1202,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         public void CreateRig()
         {
+            // Record what the initial size of the bounds override
+            // was when we constructed the rig, so we can restore
+            // it after we destructively edit the size with the
+            // BoxPadding (#7997)
+            if (boundsOverride != null){
+                initialBoundsOverrideSize = boundsOverride.size;
+            }
             DestroyRig();
             SetMaterials();
             InitializeRigRoot();
@@ -1226,14 +1233,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void OnEnable()
         {
-            // Record what the initial size of the bounds override
-            // was when we constructed the rig, so we can restore
-            // it after we destructively edit the size with the
-            // BoxPadding (#7997)
-            if (boundsOverride != null){
-                initialBoundsOverrideSize = boundsOverride.size;
-            }
-
             CreateRig();
             CaptureInitialState();
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;
@@ -1206,7 +1206,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // was when we constructed the rig, so we can restore
             // it after we destructively edit the size with the
             // BoxPadding (#7997)
-            if (boundsOverride != null){
+            if (boundsOverride != null)
+            {
                 initialBoundsOverrideSize = boundsOverride.size;
             }
             DestroyRig();
@@ -1333,7 +1334,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // If we have previously logged an initial bounds size,
                 // reset the boundsOverride BoxCollider to the initial size.
                 // This is because the CalculateBoxPadding
-                if (initialBoundsOverrideSize.HasValue){
+                if (initialBoundsOverrideSize.HasValue)
+                {
                     boundsOverride.size = initialBoundsOverrideSize.Value;
                 }
 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1091,6 +1091,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
         // Used to determine if boundsOverride size has changed.
         private Bounds prevBoundsOverride = new Bounds();
 
+        // Used to record the initial size of the bounds override, if it exists.
+        // Necessary because BoxPadding will destructively edit the size of the
+        // override BoxCollider, and repeated calls to BoxPadding will result
+        // in the override bounds growing continually larger/smaller.
+        private Vector3? initialBoundsOverrideSize = null;
+
         // True if this game object is a child of the Target one
         private bool isChildOfTarget = false;
         private static readonly string rigRootName = "rigRoot";
@@ -1220,6 +1226,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void OnEnable()
         {
+            // Record what the initial size of the bounds override
+            // was when we constructed the rig, so we can restore
+            // it after we destructively edit the size with the
+            // BoxPadding (#7997)
+            if(boundsOverride != null){
+                initialBoundsOverrideSize = boundsOverride.size;
+            }
+
             CreateRig();
             CaptureInitialState();
 
@@ -1317,7 +1331,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
             else
             {
-                boundsOverride.size -= boxPadding;
+                // If we have previously logged an initial bounds size,
+                // reset the boundsOverride BoxCollider to the initial size.
+                // This is because the CalculateBoxPadding
+                if(initialBoundsOverrideSize.HasValue){
+                    boundsOverride.size = initialBoundsOverrideSize.Value;
+                }
 
                 if (TargetBounds != null)
                 {

--- a/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -1230,7 +1230,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             // was when we constructed the rig, so we can restore
             // it after we destructively edit the size with the
             // BoxPadding (#7997)
-            if(boundsOverride != null){
+            if (boundsOverride != null){
                 initialBoundsOverrideSize = boundsOverride.size;
             }
 
@@ -1334,7 +1334,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 // If we have previously logged an initial bounds size,
                 // reset the boundsOverride BoxCollider to the initial size.
                 // This is because the CalculateBoxPadding
-                if(initialBoundsOverrideSize.HasValue){
+                if (initialBoundsOverrideSize.HasValue){
                     boundsOverride.size = initialBoundsOverrideSize.Value;
                 }
 

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -111,6 +111,72 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         }
 
         /// <summary>
+        /// Test that if we toggle the bounding box's active status,
+        /// that the size of the boundsOverride is consistent, even
+        /// when BoxPadding is set.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator BBoxOverridePaddingReset()
+        {
+            var bbox = InstantiateSceneAndDefaultBbox();
+            yield return null;
+            bbox.BoundingBoxActivation = BoundingBox.BoundingBoxActivationType.ActivateOnStart;
+            bbox.HideElementsInInspector = false;
+
+            // Set the bounding box to have a large padding.
+            bbox.BoxPadding = Vector3.one;
+            yield return null;
+
+            var newObject = new GameObject();
+            var bc = newObject.AddComponent<BoxCollider>();
+            bc.center = new Vector3(1, 2, 3);
+            var backupSize = bc.size = new Vector3(1, 2, 3);
+            bbox.BoundsOverride = bc;
+            yield return null;
+
+            // Toggles the bounding box and verifies
+            // integrity of the measurements.
+            VerifyBoundingBox();
+
+            // Change the center and size of the boundsOverride
+            // in the middle of execution, to ensure
+            // these changes will be correctly reflected
+            // in the BoundingBox after toggling.
+            bc.center = new Vector3(0.1776f, 0.42f, 0.0f);
+            backupSize = bc.size = new Vector3(0.1776f, 0.42f, 1.0f);
+            bbox.BoundsOverride = bc;
+            yield return null;
+
+            // Toggles the bounding box and verifies
+            // integrity of the measurements.
+            VerifyBoundingBox();
+
+            // Private helper function to prevent code copypasta.
+            IEnumerator VerifyBoundingBox() {
+                // Toggle the bounding box active status to check that the boundsOverride
+                // will persist, and will not be destructively resized 
+                bbox.gameObject.SetActive(false);
+                yield return null;
+                Debug.Log($"bc.size = {bc.size}");
+                bbox.gameObject.SetActive(true);
+                yield return null;
+                Debug.Log($"bc.size = {bc.size}");
+
+                Bounds b = GetBoundingBoxRigBounds(bbox);
+
+                var expectedSize = backupSize + Vector3.Scale(bbox.BoxPadding, newObject.transform.lossyScale);
+                Debug.Assert(b.center == bc.center, $"bounds center should be {bc.center} but they are {b.center}");
+                Debug.Assert(b.size == expectedSize, $"bounds size should be {expectedSize} but they are {b.size}");
+                Debug.Assert(bc.size == expectedSize, $"boundsOverride's size was corrupted.");
+            }
+
+            GameObject.Destroy(bbox.gameObject);
+            GameObject.Destroy(newObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+        }
+
+        /// <summary>
         /// Tests to see that the handlers grow in size when a pointer is near them
         /// </summary>
         [UnityTest]

--- a/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/BoundingBoxTests.cs
@@ -10,14 +10,14 @@
 // issue will likely persist for 2018, this issue is worked around by wrapping all
 // play mode tests in this check.
 
-using Microsoft.MixedReality.Toolkit.UI;
-using NUnit.Framework;
 using System.Collections;
+using System.Linq;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Microsoft.MixedReality.Toolkit.Input;
-using Microsoft.MixedReality.Toolkit.Utilities;
-using System.Linq;
 using Assert = UnityEngine.Assertions.Assert;
 
 namespace Microsoft.MixedReality.Toolkit.Tests
@@ -152,7 +152,8 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             VerifyBoundingBox();
 
             // Private helper function to prevent code copypasta.
-            IEnumerator VerifyBoundingBox() {
+            IEnumerator VerifyBoundingBox()
+            {
                 // Toggle the bounding box active status to check that the boundsOverride
                 // will persist, and will not be destructively resized 
                 bbox.gameObject.SetActive(false);


### PR DESCRIPTION
## Overview
In `BoundingBox`, you can set a `boundsOverride` collider which essentially provides a "proxy object" to provide the bounds to the `BoundingBox`. There is an optional `boxPadding` that can be applied to this collider, to space out the `BoundingBox` around the object.

Unfortunately, this padding is achieved by destructively resizing the provided `boundsOverride` `BoxCollider`.

In the existing code, there is a line that is intended to compensate for this destructive resizing operation; in `DestroyRig` the code resizes the `boundsOverride` in the _negative_ direction of the padding, effectively cancelling out the previous padding operation.

However, `DestroyRig` is actually called first when we are creating the rig (it's actually included inside `CreateRig`, ironically!), in addition to being called when we destroy the rig; it seems as though the original author of the code believed that `DestroyRig` was only called when the rig was being torn down (honest assumption, and shouldn't cause issues most of the time!)

This has the ill effect, however, of resizing the `boundsOverride` one too many times when you repeatedly set the `BoundingBox` to be Active/Inactive. If you continue activating/deactivating the `BoundingBox` gameobject, the bounds will continue to grow/shrink to a very large (and incorrect) size!

This PR fixes this behavior in the following way: instead of applying negative padding to "cancel out" the resizing operation, it simply resets the `boundsOverride` to whatever size it had when the `BoundingBox` was enabled, and when `CreateRig()` was called.

This resolves #7997 :)

## Changes
- Resolves #7997 by preventing unwanted `boundsOverride` resizing behavior when toggling the status of the root `BoundingBox` object.
- Adds a `Vector3? initialBoundsOverrideSize` which is used to record the size of the `boundsOverride` when the rig is constructed.
- Adds code in `DestroyRig` to reset the `boundsOverride` size to the recorded `initialBoundsOverrideSize` when destroying/tearing down the rig.
- Adds unit test that covers the issue reported in #7997.

## Verification
- An additional test has been added to verify that changing `boundsOverride` size and toggling the active status of the `BoundingBox` does not destructively modify the `boundsOverride` size.
