### PR TITLE
Fix some AddComponentMenu paths

### DIFF
--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboard.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/MixedRealityKeyboard.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// UWP keyboard from showing up again after it is closed.
     /// Unity bug tracking the issue https://fogbugz.unity3d.com/default.asp?1137074_rttdnt8t1lccmtd3
     /// </summary>
-    [AddComponentMenu("Scripts/MRTK/Experimental/MixedRealityKeyboard")]
+    [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/MixedRealityKeyboard")]
     public class MixedRealityKeyboard : MixedRealityKeyboardBase
     {
         /// <summary>

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/TMP_KeyboardInputField.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// A component that can be added to TMP_InputField to make them work with Windows Mixed Reality's system keyboard
     /// </summary>
     [RequireComponent(typeof(TMP_InputField))]
-    [AddComponentMenu("Scripts/MRTK/Experimental/MixedRealityKeyboard")]
+    [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/TMP_KeyboardInputField")]
     public class TMP_KeyboardInputField : KeyboardInputFieldBase<TMP_InputField>
     {
         public override string Text { get => inputField.text; protected set => inputField.text = value; }

--- a/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
+++ b/Assets/MRTK/SDK/Experimental/MixedRealityKeyboard/UI_KeyboardInputField.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// A component that can be added to InputField to make them work with Windows Mixed Reality's system keyboard
     /// </summary>
     [RequireComponent(typeof(InputField))]
-    [AddComponentMenu("Scripts/MRTK/Experimental/MixedRealityKeyboard")]
+    [AddComponentMenu("Scripts/MRTK/Experimental/Keyboard/UI_KeyboardInputField")]
     public class UI_KeyboardInputField : KeyboardInputFieldBase<InputField>
     {
         public override string Text { get => inputField.text; protected set => inputField.text = value; }

--- a/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/UICollection.cs
+++ b/Assets/MRTK/SDK/Experimental/NonNativeKeyboard/Scripts/UICollection.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// To use this component attach it to a UI element (a GameObject with a
     /// RectTransform component) such as an Image or Panel.
     /// </summary>
-    [AddComponentMenu("MRTK/Experimental/UICollection")]
+    [AddComponentMenu("Scripts/MRTK/Experimental/UICollection")]
     [RequireComponent(typeof(RectTransform))]
     [ExecuteInEditMode]
     public class UICollection : MonoBehaviour


### PR DESCRIPTION
## Overview

Three components used identical `MixedRealityKeyboard` paths, and one was missing the `Scripts` entry in the path.