### PR TITLE
Update the release notes to point to where to download the MRTK bits.

### DIFF
--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -23,6 +23,15 @@ The following software is required.
 - [Windows 10 SDK](https://developer.microsoft.com/windows/downloads/windows-10-sdk) 18362 or later (installed by the Visual Studio Installer)
 - [Unity](https://unity3d.com/get-unity/download) 2018.4 LTS or 2019 (2019.3 recommended)
 
+**Download**
+
+[Microsoft.MixedReality.Toolkit.Unity.Foundation.2.4.0.unitypackage](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/download/v2.4.0/Microsoft.MixedReality.Toolkit.Unity.Foundation.2.4.0.unitypackage)
+[Microsoft.MixedReality.Toolkit.Unity.Extensions.2.4.0.unitypackage](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/download/v2.4.0/Microsoft.MixedReality.Toolkit.Unity.Extensions.2.4.0.unitypackage)
+[Microsoft.MixedReality.Toolkit.Unity.Examples.2.4.0.unitypackage](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/download/v2.4.0/Microsoft.MixedReality.Toolkit.Unity.Examples.2.4.0.unitypackage)
+[Microsoft.MixedReality.Toolkit.Unity.Tools.2.4.0.unitypackage](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/download/v2.4.0/Microsoft.MixedReality.Toolkit.Unity.Tools.2.4.0.unitypackage)
+
+Other files can be found on the [GitHub release page](https://github.com/microsoft/MixedRealityToolkit-Unity/releases/tag/v2.4.0)
+
 **NuGet requirements**
 
 If importing the [Mixed Reality Toolkit NuGet packages](MRTKNuGetPackage.md), the following software is recommended.


### PR DESCRIPTION
Adding a direct download link from the release notes, so that you don't have to navigate some other structure in order to find the MRTK download bits.

I opted to only link to the .unitypackages because those are the core bits needed to start building.