### PR TITLE
Optional Forces for ObjectManipulator

### DIFF
--- a/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/UX/ObjectManipulator/ObjectManipulatorInspector.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
         private SerializedProperty hostTransform;
         private SerializedProperty manipulationType;
         private SerializedProperty allowFarManipulation;
+        private SerializedProperty useForcesForNearManipulation;
 
         private SerializedProperty oneHandRotationModeNear;
         private SerializedProperty oneHandRotationModeFar;
@@ -54,6 +55,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             hostTransform = serializedObject.FindProperty("hostTransform");
             manipulationType = serializedObject.FindProperty("manipulationType");
             allowFarManipulation = serializedObject.FindProperty("allowFarManipulation");
+            useForcesForNearManipulation = serializedObject.FindProperty("useForcesForNearManipulation");
 
             // One handed
             oneHandRotationModeNear = serializedObject.FindProperty("oneHandRotationModeNear");
@@ -83,6 +85,7 @@ namespace Microsoft.MixedReality.Toolkit.Editor
             EditorGUILayout.PropertyField(hostTransform);
             EditorGUILayout.PropertyField(manipulationType);
             EditorGUILayout.PropertyField(allowFarManipulation);
+            EditorGUILayout.PropertyField(useForcesForNearManipulation);
 
             var handedness = (ManipulationHandFlags)manipulationType.intValue;
 


### PR DESCRIPTION
## Overview

When ObjectManipulator is used on an object with a RigidBody, using forces for near manipulation is now optional and defaults to off. This makes near manipulation of these kinds of objects feel much more responsive.

See issue #8051 for more background.


## Changes
- Fixes: #8051 


## Verification
Please help verify that existing samples continue to work. Especially the hands interaction sample. 