### PR TITLE
Fix SurfaceNormalOffset configurability + custom inspector for Tap to Place

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -37,16 +37,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
           };
 
         /// <summary>
-        /// Default style for foldouts with a bold medium font size
-        /// </summary>
-        public static readonly GUIStyle HeaderBoldFoldoutStyle =
-          new GUIStyle(EditorStyles.foldout)
-          {
-              fontStyle = FontStyle.Bold,
-              fontSize = InspectorUIUtility.HeaderFontSize,
-          };
-
-        /// <summary>
         /// Default style for controller mapping buttons
         /// </summary>
         public static readonly GUIStyle ControllerButtonStyle = new GUIStyle("LargeButton")

--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityStylesUtility.cs
@@ -37,6 +37,16 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
           };
 
         /// <summary>
+        /// Default style for foldouts with a bold medium font size
+        /// </summary>
+        public static readonly GUIStyle HeaderBoldFoldoutStyle =
+          new GUIStyle(EditorStyles.foldout)
+          {
+              fontStyle = FontStyle.Bold,
+              fontSize = InspectorUIUtility.HeaderFontSize,
+          };
+
+        /// <summary>
         /// Default style for controller mapping buttons
         /// </summary>
         public static readonly GUIStyle ControllerButtonStyle = new GUIStyle("LargeButton")

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
@@ -104,10 +104,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
         private void RenderAdvancedProperties()
         {
             // Render Advanced Settings
-            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Advanced Properties", AdvancedPropertiesFoldoutKey, MixedRealityStylesUtility.HeaderBoldFoldoutStyle, false))
+            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Advanced Properties", AdvancedPropertiesFoldoutKey, MixedRealityStylesUtility.TitleFoldoutStyle, false))
             {
                 using (new EditorGUI.IndentLevelScope())
                 {
+                    EditorGUILayout.Space();
+
                     EditorGUILayout.PropertyField(updateLinkedTransformProperty);
                     EditorGUILayout.PropertyField(moveLerpTimeProperty);
                     EditorGUILayout.PropertyField(rotateLerpTimeProperty);

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.﻿
+
+using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities.Editor.Solvers
+{
+    /// <summary>
+    /// Custom inspector for the Tap to Place component.
+    /// </summary>
+    [CustomEditor(typeof(TapToPlace))]
+    [CanEditMultipleObjects]
+    public class TapToPlaceInspector : UnityEditor.Editor
+    {
+        private TapToPlace instance;
+
+        // Tap to Place properties
+        private SerializedProperty autoStart;
+        private SerializedProperty defaultPlacementDistance;
+        private SerializedProperty maxRaycastDistance;
+        private SerializedProperty surfaceNormalOffset;
+        private SerializedProperty useDefaultSurfaceNormalOffset;
+        private SerializedProperty keepOrientationVertical;
+        private SerializedProperty rotateAccordingToSurface;
+        private SerializedProperty debugEnabled;
+        private SerializedProperty onPlacingStarted;
+        private SerializedProperty onPlacingStopped;
+
+        // Advanced properties
+        private SerializedProperty updateLinkedTransformProperty;
+        private SerializedProperty moveLerpTimeProperty;
+        private SerializedProperty rotateLerpTimeProperty;
+        private SerializedProperty scaleLerpTimeProperty;
+        private SerializedProperty maintainScaleProperty;
+        private SerializedProperty smoothingProperty;
+        private SerializedProperty lifetimeProperty;
+        private SerializedProperty magneticSurfaces;
+
+        private const string AdvancedPropertiesFoldoutKey = "TapToPlaceAdvancedProperties";
+
+        protected virtual void OnEnable()
+        {
+            instance = (TapToPlace)target;
+
+            // Main Tap to Place Properties
+            autoStart = serializedObject.FindProperty("autoStart");
+            defaultPlacementDistance = serializedObject.FindProperty("defaultPlacementDistance");
+            maxRaycastDistance = serializedObject.FindProperty("maxRaycastDistance");
+            useDefaultSurfaceNormalOffset = serializedObject.FindProperty("useDefaultSurfaceNormalOffset");
+            surfaceNormalOffset = serializedObject.FindProperty("surfaceNormalOffset");
+            keepOrientationVertical = serializedObject.FindProperty("keepOrientationVertical");
+            rotateAccordingToSurface = serializedObject.FindProperty("rotateAccordingToSurface");
+            debugEnabled = serializedObject.FindProperty("debugEnabled");
+            onPlacingStopped = serializedObject.FindProperty("onPlacingStopped");
+            onPlacingStarted = serializedObject.FindProperty("onPlacingStarted");
+
+            // Advanced Properties
+            updateLinkedTransformProperty = serializedObject.FindProperty("updateLinkedTransform");
+            moveLerpTimeProperty = serializedObject.FindProperty("moveLerpTime");
+            rotateLerpTimeProperty = serializedObject.FindProperty("rotateLerpTime");
+            scaleLerpTimeProperty = serializedObject.FindProperty("scaleLerpTime");
+            maintainScaleProperty = serializedObject.FindProperty("maintainScale");
+            smoothingProperty = serializedObject.FindProperty("smoothing");
+            lifetimeProperty = serializedObject.FindProperty("lifetime");
+            magneticSurfaces = serializedObject.FindProperty("magneticSurfaces");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            RenderCustomInspector();
+        }
+
+        // Render the custom inspector with the basic and advanced properties
+        private void RenderCustomInspector()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(autoStart);
+            EditorGUILayout.PropertyField(defaultPlacementDistance);
+            EditorGUILayout.PropertyField(maxRaycastDistance);
+            EditorGUILayout.PropertyField(useDefaultSurfaceNormalOffset);
+
+            // Only show the SurfaceNormalOffset Property if UseDefaultSurfaceNormalOffset is false
+            if (!instance.UseDefaultSurfaceNormalOffset)
+            {
+                EditorGUILayout.PropertyField(surfaceNormalOffset);
+            }
+
+            EditorGUILayout.PropertyField(keepOrientationVertical);
+            EditorGUILayout.PropertyField(rotateAccordingToSurface);
+            EditorGUILayout.PropertyField(debugEnabled);
+            EditorGUILayout.PropertyField(onPlacingStarted);
+            EditorGUILayout.PropertyField(onPlacingStopped);
+
+            // Render Advanced Properties Foldout
+            RenderAdvancedProperties();
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        // Render the Advanced Properties under an indented foldout titled Advanced Properties
+        private void RenderAdvancedProperties()
+        {
+            // Render Advanced Settings
+            if (InspectorUIUtility.DrawSectionFoldoutWithKey("Advanced Properties", AdvancedPropertiesFoldoutKey, MixedRealityStylesUtility.HeaderBoldFoldoutStyle, false))
+            {
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    EditorGUILayout.PropertyField(updateLinkedTransformProperty);
+                    EditorGUILayout.PropertyField(moveLerpTimeProperty);
+                    EditorGUILayout.PropertyField(rotateLerpTimeProperty);
+                    EditorGUILayout.PropertyField(scaleLerpTimeProperty);
+                    EditorGUILayout.PropertyField(maintainScaleProperty);
+                    EditorGUILayout.PropertyField(smoothingProperty);
+                    EditorGUILayout.PropertyField(lifetimeProperty);
+                    EditorGUILayout.PropertyField(magneticSurfaces, true);
+                }
+            }
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs.meta
+++ b/Assets/MRTK/SDK/Editor/Inspectors/Utilities/Solvers/TapToPlaceInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ba2edd116e977040bb94024240211d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Solvers/TapToPlace.cs
@@ -75,7 +75,42 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
         public float SurfaceNormalOffset
         {
             get => surfaceNormalOffset;
-            set => surfaceNormalOffset = value;
+            set
+            {
+                if (surfaceNormalOffset != value)
+                {
+                    // If the current surface normal offset is the defaultSurfaceNormalOffset set the UseDefaultSurfaceNormalOffset
+                    if (value == defaultSurfaceNormalOffset)
+                    {
+                        UseDefaultSurfaceNormalOffset = true;
+                    }
+                    else
+                    {
+                        UseDefaultSurfaceNormalOffset = false;
+                    }
+
+                    surfaceNormalOffset = value;
+                }
+            }
+        }
+
+        [SerializeField]
+        [Tooltip("If true, the default surface normal offset will be used instead of any value specified for the SurfaceNormalOffset property. If false, the " +
+                "SurfaceNormalOffset is used. The default surface normal offset is the Z extents of the bounds on the attached collider, this ensures the object being " +
+                "placed is aligned on a surface. This property is automatically set to false if the SurfaceNormalOffset property is set and is not " +
+                "the default value.")]
+        private bool useDefaultSurfaceNormalOffset = true;
+
+        /// <summary>
+        /// If true, the default surface normal offset will be used instead of any value specified for the SurfaceNormalOffset property.  
+        /// If false, the SurfaceNormalOffset is used. The default surface normal offset is the Z extents of the bounds on the attached collider, this 
+        /// ensures the object being placed is aligned on a surface. This property is automatically set to false if the SurfaceNormalOffset property is set and is not 
+        /// the default value.
+        /// </summary>
+        public bool UseDefaultSurfaceNormalOffset
+        {
+            get => useDefaultSurfaceNormalOffset;
+            set => useDefaultSurfaceNormalOffset = value;
         }
 
         [SerializeField]
@@ -167,6 +202,12 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
 
         protected internal bool IsColliderPresent => gameObject != null ? gameObject.GetComponent<Collider>() != null : false;
 
+        /// <summary>
+        /// The default value for SurfaceNormalOffset if UseDefaultSurfaceNormalOffset is true.  This value ensures an object
+        /// will be placed in alignment with a surface.
+        /// </summary>
+        private float defaultSurfaceNormalOffset => gameObject.GetComponent<Collider>().bounds.extents.z;
+
         private int ignoreRaycastLayer;
 
         /// <summary>
@@ -196,8 +237,6 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             // of (1, 1, 1) which always returns a 0.5 SurfaceNormalOffset.  Adding SyncTransforms updates the
             // size of the collider to match the game object before we calculate the SurfaceNormalOffset.
             UnityPhysics.SyncTransforms();
-
-            SurfaceNormalOffset = gameObject.GetComponent<Collider>().bounds.extents.z;
 
             ignoreRaycastLayer = LayerMask.NameToLayer("Ignore Raycast");
 
@@ -306,6 +345,13 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Solvers
             {
                 // Take the current hit point and add an offset relative to the surface to avoid half of the object in the surface
                 GoalPosition = CurrentHit.point;
+
+                // Allow switching between a specified SurfaceNormalOffset and the defaultSurfaceNormalOffset while the object is in the placing state
+                if (UseDefaultSurfaceNormalOffset && SurfaceNormalOffset != defaultSurfaceNormalOffset)
+                {
+                    SurfaceNormalOffset = defaultSurfaceNormalOffset;
+                }
+
                 AddOffset(CurrentHit.normal * SurfaceNormalOffset);
 
 #if UNITY_EDITOR

--- a/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/SolverTests.cs
@@ -807,6 +807,91 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             Assert.False(tapToPlace.IsBeingPlaced);
         }
 
+
+        /// <summary>
+        /// Tests the UseDefaultSurfaceNormalOffset property for Tap to Place while the object is in the placing state. If the 
+        /// UseDefaultSurfaceNormalOffset is true, the object should appear flat against a collider. If false, the object will
+        /// have an offset based on SurfaceNormalOffset.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestTapToPlaceSurfaceNormalOffsetSet()
+        {
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            // Create a scene with 2 cubes
+            GameObject colliderObj1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            colliderObj1.transform.localScale = new Vector3(0.3f, 0.3f, 0.05f);
+            colliderObj1.transform.position = new Vector3(0.3f, 0, 1.5f);
+
+            GameObject colliderObj2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            colliderObj2.transform.localScale = new Vector3(0.3f, 0.3f, 0.05f);
+            colliderObj2.transform.position = new Vector3(-0.3f, 0, 1.5f);
+
+            // Create a cube with Tap to Place attached
+            var tapToPlaceObj = InstantiateTestSolver<TapToPlace>();
+            tapToPlaceObj.target.transform.position = Vector3.forward * 2;
+            tapToPlaceObj.target.transform.localScale = Vector3.one * 0.2f;
+            TapToPlace tapToPlace = tapToPlaceObj.solver as TapToPlace;
+
+            // Switching the TrackedTargetType to Controller Ray
+            SolverHandler tapToPlaceSolverHandler = tapToPlaceObj.handler;
+            tapToPlaceSolverHandler.TrackedTargetType = TrackedObjectType.ControllerRay;
+
+            Vector3 handStartPosition = new Vector3(0, -0.15f, 0.5f);
+            var leftHand = new TestHand(Handedness.Left);
+            yield return leftHand.Show(handStartPosition);
+
+            tapToPlace.KeepOrientationVertical = true;
+            tapToPlace.RotateAccordingToSurface = true;
+
+            // Set UseDefaultSurfaceNormalOffset
+            tapToPlace.UseDefaultSurfaceNormalOffset = false;
+
+            // Make sure the SurfaceNormalOffset is not the default z extents of the bounds
+            Assert.AreNotEqual(tapToPlace.SurfaceNormalOffset, tapToPlaceObj.target.GetComponent<Collider>().bounds.extents.z);
+       
+            // Make sure the default SurfaceNormalOffset is 0 initially, 0 is the SurfaceNormalOffset default
+            Assert.AreEqual(tapToPlace.SurfaceNormalOffset, 0);
+
+            // Start the placement via code instead of click from the hand
+            tapToPlace.StartPlacement();
+            yield return null;
+
+            Assert.True(tapToPlace.IsBeingPlaced);
+
+            // Move hand, object should follow
+            yield return leftHand.Move(new Vector3(-0.15f, 0, 0), 30);
+
+            // Make sure the depth of the Tap to Place Object is very close to the depth of the wall because the SurfaceNormalOffset is 0
+            Assert.AreEqual(tapToPlaceObj.target.transform.position.z, colliderObj1.transform.position.z, 0.05f);
+
+            // Set the UseDefaultSurfaceNormalOffset to true while still in the placing state
+            tapToPlace.UseDefaultSurfaceNormalOffset = true;
+            yield return null;
+
+            // Make sure the SurfaceNormalOffset is the z extents of the bounds after UseDefaultSurfaceNormalOffset is set to true
+            Assert.AreEqual(tapToPlace.SurfaceNormalOffset, tapToPlaceObj.target.GetComponent<Collider>().bounds.extents.z);
+
+            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+            Assert.True(tapToPlaceObj.target.transform.position.z > colliderObj1.transform.position.z);
+            yield return leftHand.Move(new Vector3(0.15f, 0, 0), 30);
+
+            // Make sure the depth of the Tap to Place Object is less than the depth of the wall because UseDefaultSurfaceNormalOffset is true
+            Assert.True(tapToPlaceObj.target.transform.position.z < colliderObj1.transform.position.z);
+
+            // Set a new SurfaceNormalOffset
+            tapToPlace.SurfaceNormalOffset = 0.5f;
+            yield return null;
+
+            // Make sure UseDefaultSurfaceNormalOffset was automatically set to false if a new SurfaceNormalOffset is specified
+            Assert.False(tapToPlace.UseDefaultSurfaceNormalOffset);
+
+            // Stop the placement via code instead of click from the hand
+            tapToPlace.StopPlacement();
+
+            Assert.False(tapToPlace.IsBeingPlaced);
+        }
+
         #endregion
 
         #region Experimental


### PR DESCRIPTION
## Overview

Added `UseDefaultSurfaceNormalOffset` property to Tap to Place to enable developers to either set a new `SurfaceNormalOffset` value or use the default value. 

Created a custom inspector that only displays the `SurfaceNormalOffset` property if `UseDefaultSurfaceNormalOffset` is false, and grouped other advanced properties under a foldout.

Added TestTapToPlaceSurfaceNormalOffset test for the change.

## To Do

- [ ] Update documentation with new property

## New Tap to Place Inspector 
**SurfaceNormalOffset Visibility depending on UseDefaultSurfaceNormalOffset**

| `UseDefaultSurfaceNormalOffset` false| `UseDefaultSurfaceNormalOffset` true|
|--------|-------|
| ![image](https://user-images.githubusercontent.com/53493796/84715453-5ac91600-af25-11ea-81c9-08ffd392e583.png) | ![image](https://user-images.githubusercontent.com/53493796/84715482-6f0d1300-af25-11ea-9fe5-cb7a798b8556.png) |

**Advanced Properties Foldout:**
![image](https://user-images.githubusercontent.com/53493796/84715661-f9557700-af25-11ea-9207-c98b121dd003.png)
 

## Changes
- Fixes: #8053 
