### PR TITLE
Updated BoundsControl rotation calculations + lerp/smoothing

### DIFF
--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1004,8 +1004,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     Vector3 initDir = Vector3.ProjectOnPlane(initialGrabPoint - transform.position, currentRotationAxis).normalized;
                     Vector3 currentDir = Vector3.ProjectOnPlane(currentGrabPoint - transform.position, currentRotationAxis).normalized;
-                    Quaternion q = Quaternion.FromToRotation(initDir, currentDir);
-                    Target.transform.rotation = SmoothTo(Target.transform.rotation, q * initialRotationOnGrabStart, rotateLerpTime);
+                    Quaternion goal = Quaternion.FromToRotation(initDir, currentDir) * initialRotationOnGrabStart;
+                    Target.transform.rotation = smoothingActive ? Smoothing.SmoothTo(Target.transform.rotation, goal, rotateLerpTime, Time.deltaTime) : goal;
                 }
                 else if (transformType == HandleType.Scale)
                 {
@@ -1026,22 +1026,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                     }
 
                     var newPosition = initialPositionOnGrabStart * scaleFactor + (1 - scaleFactor) * oppositeCorner;
-                    Target.transform.localScale = SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime);
-                    Target.transform.position = SmoothTo(Target.transform.position, newPosition, scaleLerpTime);
+                    Target.transform.localScale = smoothingActive ? Smoothing.SmoothTo(Target.transform.localScale, clampedTransform.Scale, scaleLerpTime, Time.deltaTime) : clampedTransform.Scale;
+                    Target.transform.position = smoothingActive ? Smoothing.SmoothTo(Target.transform.position, newPosition, scaleLerpTime, Time.deltaTime) : newPosition;
                 }
             }
         }
-
-        private Vector3 SmoothTo(Vector3 source, Vector3 goal, float lerpTime)
-        {
-            return Vector3.Lerp(source, goal, (!smoothingActive || lerpTime == 0f) ? 1f : 1f - Mathf.Pow(lerpTime, Time.deltaTime));
-        }
-
-        private Quaternion SmoothTo(Quaternion source, Quaternion goal, float slerpTime)
-        {
-            return Quaternion.Slerp(source, goal, (!smoothingActive || slerpTime == 0f) ? 1f : 1f - Mathf.Pow(slerpTime, Time.deltaTime));
-        }
-
+        
         private void OnTargetBoundsChanged()
         {
             DetermineTargetBounds();

--- a/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
+++ b/Assets/MRTK/SDK/Experimental/Features/UX/BoundsControl/BoundsControl.cs
@@ -1004,8 +1004,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI.BoundsControl
                 {
                     Vector3 initDir = Vector3.ProjectOnPlane(initialGrabPoint - transform.position, currentRotationAxis).normalized;
                     Vector3 currentDir = Vector3.ProjectOnPlane(currentGrabPoint - transform.position, currentRotationAxis).normalized;
-                    Debug.DrawLine(transform.position, initDir);
-                    Debug.DrawLine(transform.position, currentDir);
                     Quaternion q = Quaternion.FromToRotation(initDir, currentDir);
                     Target.transform.rotation = SmoothTo(Target.transform.rotation, q * initialRotationOnGrabStart, rotateLerpTime);
                 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/ObjectManipulator.cs
@@ -679,9 +679,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (rigidBody == null)
             {
-                HostTransform.position = SmoothTo(HostTransform.position, targetTransform.Position, moveLerpTime);
-                HostTransform.rotation = SmoothTo(HostTransform.rotation, targetTransform.Rotation, rotateLerpTime);
-                HostTransform.localScale = SmoothTo(HostTransform.localScale, targetTransform.Scale, scaleLerpTime);
+                HostTransform.position = smoothingActive ? Smoothing.SmoothTo(HostTransform.position, targetTransform.Position, moveLerpTime, Time.deltaTime) : targetTransform.Position;
+                HostTransform.rotation = smoothingActive ? Smoothing.SmoothTo(HostTransform.rotation, targetTransform.Rotation, rotateLerpTime, Time.deltaTime) : targetTransform.Rotation;
+                HostTransform.localScale = smoothingActive ? Smoothing.SmoothTo(HostTransform.localScale, targetTransform.Scale, scaleLerpTime, Time.deltaTime) : targetTransform.Scale;
             }
             else
             {
@@ -696,18 +696,8 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     rigidBody.angularVelocity = ((1f - Mathf.Pow(rotateLerpTime, Time.deltaTime)) / Time.deltaTime) * (axis.normalized * angle * Mathf.Deg2Rad);
                 }
 
-                HostTransform.localScale = SmoothTo(HostTransform.localScale, targetTransform.Scale, scaleLerpTime);
+                HostTransform.localScale = smoothingActive ? Smoothing.SmoothTo(HostTransform.localScale, targetTransform.Scale, scaleLerpTime, Time.deltaTime) : targetTransform.Scale;
             }
-        }
-
-        private Vector3 SmoothTo(Vector3 source, Vector3 goal, float lerpTime)
-        {
-            return Vector3.Lerp(source, goal, (!smoothingActive || lerpTime == 0f) ? 1f : 1f - Mathf.Pow(lerpTime, Time.deltaTime));
-        }
-
-        private Quaternion SmoothTo(Quaternion source, Quaternion goal, float slerpTime)
-        {
-            return Quaternion.Slerp(source, goal, (!smoothingActive || slerpTime == 0f) ? 1f : 1f - Mathf.Pow(slerpTime, Time.deltaTime));
         }
 
         private Vector3[] GetHandPositionArray()

--- a/Assets/MRTK/SDK/Features/Utilities/Smoothing.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Smoothing.cs
@@ -9,7 +9,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
     /// <summary>
     /// Provides several utility functions for smoothing and lerping.
     /// </summary>
-    public class Smoothing {
+    internal class Smoothing {
 
         /// <summary>
         /// Smooths from source to goal, provided lerptime and a deltaTime.
@@ -19,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="lerpTime">Smoothing/lerp amount. Smoothing of 0 means no smoothing, and max value means no change at all.</param>
         /// <param name="deltaTime">Delta time. Usually would be set to Time.deltaTime</param>
         /// <returns>Smoothed value</returns>
-        public static Vector3 SmoothTo(Vector3 source, Vector3 goal, float lerpTime, float deltaTime)
+        internal static Vector3 SmoothTo(Vector3 source, Vector3 goal, float lerpTime, float deltaTime)
         {
             return Vector3.Lerp(source, goal, (lerpTime == 0f) ? 1f : 1f - Mathf.Pow(lerpTime, deltaTime));
         }
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.Toolkit.Utilities
         /// <param name="slerpTime">Smoothing/lerp amount. Smoothing of 0 means no smoothing, and max value means no change at all.</param>
         /// <param name="deltaTime">Delta time. Usually would be set to Time.deltaTime</param>
         /// <returns>Smoothed value</returns>
-        public static Quaternion SmoothTo(Quaternion source, Quaternion goal, float slerpTime, float deltaTime)
+        internal static Quaternion SmoothTo(Quaternion source, Quaternion goal, float slerpTime, float deltaTime)
         {
             return Quaternion.Slerp(source, goal, (slerpTime == 0f) ? 1f : 1f - Mathf.Pow(slerpTime, deltaTime));
         }

--- a/Assets/MRTK/SDK/Features/Utilities/Smoothing.cs
+++ b/Assets/MRTK/SDK/Features/Utilities/Smoothing.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.Utilities
+{
+    /// <summary>
+    /// Provides several utility functions for smoothing and lerping.
+    /// </summary>
+    public class Smoothing {
+
+        /// <summary>
+        /// Smooths from source to goal, provided lerptime and a deltaTime.
+        /// </summary>
+        /// <param name="source">Current value</param>
+        /// <param name="goal">"goal" value which will be lerped to</param>
+        /// <param name="lerpTime">Smoothing/lerp amount. Smoothing of 0 means no smoothing, and max value means no change at all.</param>
+        /// <param name="deltaTime">Delta time. Usually would be set to Time.deltaTime</param>
+        /// <returns>Smoothed value</returns>
+        public static Vector3 SmoothTo(Vector3 source, Vector3 goal, float lerpTime, float deltaTime)
+        {
+            return Vector3.Lerp(source, goal, (lerpTime == 0f) ? 1f : 1f - Mathf.Pow(lerpTime, deltaTime));
+        }
+
+        /// <summary>
+        /// Smooths from source to goal, provided slerptime and a deltaTime.
+        /// </summary>
+        /// <param name="source">Current value</param>
+        /// <param name="goal">"goal" value which will be lerped to</param>
+        /// <param name="slerpTime">Smoothing/lerp amount. Smoothing of 0 means no smoothing, and max value means no change at all.</param>
+        /// <param name="deltaTime">Delta time. Usually would be set to Time.deltaTime</param>
+        /// <returns>Smoothed value</returns>
+        public static Quaternion SmoothTo(Quaternion source, Quaternion goal, float slerpTime, float deltaTime)
+        {
+            return Quaternion.Slerp(source, goal, (slerpTime == 0f) ? 1f : 1f - Mathf.Pow(slerpTime, deltaTime));
+        }
+    }
+}

--- a/Assets/MRTK/SDK/Features/Utilities/Smoothing.cs.meta
+++ b/Assets/MRTK/SDK/Features/Utilities/Smoothing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 914489b781a98f348a3f97f4419bfe8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/Experimental/BoundsControlTests.cs
@@ -241,6 +241,57 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
         }
 
         /// <summary>
+        /// Test bounds control rotation via far interaction, while moving extremely slowly.
+        /// Rotation amount should be coherent even with extremely small per-frame motion
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotateVerySlowlyViaFarInteraction()
+        {
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
+            Vector3 rightFrontRotationHandlePoint = new Vector3(0.121f, -0.127f, 0.499f); // position of hand for far interacting with front right rotation sphere 
+            Vector3 endRotation = new Vector3(-0.18f, -0.109f, 0.504f); // end position for far interaction scaling
+
+            TestHand hand = new TestHand(Handedness.Left);
+            yield return hand.Show(pointOnCube); // Initially make sure that hand ray is pointed on cube surface so we won't go behind the cube with our ray
+            // grab front right rotation point
+            yield return hand.MoveTo(rightFrontRotationHandlePoint);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            // First, we make a series of very very tiny movements, as if the user
+            // is making very precise adjustments to the rotation. If the rotation is
+            // being calculated per-frame instead of per-manipulation-event, this should
+            // induce drift/error.
+            for (int i = 0; i < 50; i++)
+            {
+                yield return hand.MoveTo(Vector3.Lerp(rightFrontRotationHandlePoint, endRotation, (1/1000.0f) * i));
+            }
+
+            // Move the rest of the way very quickly.
+            yield return hand.MoveTo(endRotation);
+
+            // make sure rotation is as expected and no other transform values have been modified through this
+            Vector3 expectedPosition = new Vector3(0f, 0f, 1.5f);
+            Vector3 expectedSize = Vector3.one * 0.5f;
+            float angle;
+            Vector3 axis = new Vector3();
+            boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
+            float expectedAngle = 85f;
+            float angleDiff = Mathf.Abs(expectedAngle - angle);
+            Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
+            TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
+            Assert.IsTrue(angleDiff <= 1f, "cube didn't rotate as expected");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube moved while rotating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while rotating");
+
+            GameObject.Destroy(boundsControl.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+        }
+
+        /// <summary>
         /// Test bounds control rotation via near interaction
         /// Verifies gameobject has rotation in one axis only applied and no other transform changes happen during interaction
         /// </summary>
@@ -274,6 +325,58 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Experimental
             Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
             TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
             Assert.IsTrue(angleDiff <= 1f, "cube didn't rotate as expected");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube moved while rotating");
+            TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while rotating");
+
+            GameObject.Destroy(boundsControl.gameObject);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+        }
+
+        /// <summary>
+        /// Test bounds control rotation via near interaction, while moving extremely slowly.
+        /// Rotation amount should be coherent even with extremely small per-frame motion
+        /// </summary>
+        [UnityTest]
+        public IEnumerator RotateVerySlowlyViaNearInteraction()
+        {
+            BoundsControl boundsControl = InstantiateSceneAndDefaultBoundsControl();
+            yield return VerifyInitialBoundsCorrect(boundsControl);
+
+            Vector3 pointOnCube = new Vector3(-0.033f, -0.129f, 0.499f); // position where hand ray points on center of the test cube
+            Vector3 rightFrontRotationHandlePoint = new Vector3(0.248f, 0.001f, 1.226f); // position of hand for far interacting with front right rotation sphere 
+            Vector3 endRotation = new Vector3(-0.284f, -0.001f, 1.23f); // end position for far interaction scaling
+
+            TestHand hand = new TestHand(Handedness.Left);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.OpenSteadyGrabPoint);
+            yield return hand.Show(pointOnCube);
+            // grab front right rotation point
+            yield return hand.MoveTo(rightFrontRotationHandlePoint);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            
+            // First, we make a series of very very tiny movements, as if the user
+            // is making very precise adjustments to the rotation. If the rotation is
+            // being calculated per-frame instead of per-manipulation-event, this should
+            // induce drift/error.
+            for (int i = 0; i < 50; i++)
+            {
+                yield return hand.MoveTo(Vector3.Lerp(rightFrontRotationHandlePoint, endRotation, (1/1000.0f) * i));
+            }
+
+            // Move the rest of the way very quickly.
+            yield return hand.MoveTo(endRotation);
+
+            // make sure rotation is as expected and no other transform values have been modified through this
+            Vector3 expectedPosition = new Vector3(0f, 0f, 1.5f);
+            Vector3 expectedSize = Vector3.one * 0.5f;
+            float angle;
+            Vector3 axis = new Vector3();
+            boundsControl.transform.rotation.ToAngleAxis(out angle, out axis);
+            float expectedAngle = 90f;
+            float angleDiff = Mathf.Abs(expectedAngle - angle);
+            Vector3 expectedAxis = new Vector3(0f, 1f, 0f);
+            TestUtilities.AssertAboutEqual(axis, expectedAxis, "Rotated around wrong axis");
+            Assert.IsTrue(angleDiff <= 1f, $"cube didn't rotate as expected, actual angle: {angle}");
             TestUtilities.AssertAboutEqual(boundsControl.transform.position, expectedPosition, "cube moved while rotating");
             TestUtilities.AssertAboutEqual(boundsControl.transform.localScale, expectedSize, "cube scaled while rotating");
 


### PR DESCRIPTION
## Overview

Updates the rotation calculation method in `BoundsControl` to use an init-rotation method, instead of the per-frame method that was being used before.

- Before: a single-frame delta would be obtained from the controller/pointer position, and this single-frame delta would be applied to the object each frame, many times.
- Now: In the same way that the scale handles are calculated, an initial rotation is first calculated, and then a **_full_** delta is calculated, from the init rotation all the way to the current intended rotation. The object's rotation is then set according to this delta.

**Motivation for this change: ** the per-frame method actually induces a significant amount of error during rotations. Due to inherent jitter and imprecision in how the hand/pointer positions are reported, it is actually possible to move your hand very slowly while rotating a `BoundsControl` and end up with _zero rotation actually effected upon the object._ By calculating the rotation by comparing the current rotation/pointer position to the initial rotation, and performing an absolute rotation assignment, this error is not present.

You might also notice that the rotation vectors are now calculated in relation to `transform.position` instead of `rigRoot.transform.position`. This is to resolve erroneous and undesirable behavior when rotating `BoundsControls` with large off-axis displacements; as the `BoundsControl` is actually rotated _around_ `transform.position`, and not the `rigRoot`'s position, this could cause strange behaviors. 

In addition, `BoundsControl` is upgraded to use the same input smoothing system that `ObjectManipulator` currently uses. The code included for this is taken directly from `ObjectManipulator`. The `smoothingActive` property is set to false by default for compatibility with existing unit tests.

## Changes
- Rotation is now calculated per-manipulation, not per-frame, resulting in enhanced accuracy and precision (and resolving drift issues)
- Rotation is now calculated in relation to `transform.position` instead of `rigRoot.position`, resulting in more coherent hand/ray interactions
- Configurable lerp/smoothing is now available in `BoundsControl`, implemented identically to `ObjectManipulator`

## Verification
- All existing `BoundsControl` manipulation-based tests pass.
- `ObjectManipulator` does not test smoothing; if we add unit tests to verify smoothing for `BoundsControl`, the same tests should also be devised for `ObjectManipulator`
