### PR TITLE
Update some textures to load by GUID

### DIFF
--- a/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityInspectorUtility.cs
+++ b/Assets/MRTK/Core/Inspectors/Utilities/MixedRealityInspectorUtility.cs
@@ -48,9 +48,14 @@ namespace Microsoft.MixedReality.Toolkit.Utilities.Editor
         public const float DottedLineScreenSpace = 4.65f;
         public const string DefaultConfigProfileName = "DefaultMixedRealityToolkitConfigurationProfile";
 
-        public static readonly Texture2D LogoLightTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath("StandardAssets/Textures/MRTK_Logo_Black.png"), typeof(Texture2D));
+        // StandardAssets/Textures/MRTK_Logo_Black.png
+        private const string LogoLightThemeGuid = "c2c00ef21cc44bcfa09695879e0ebecd";
+        // StandardAssets/Textures/MRTK_Logo_White.png
+        private const string LogoDarkThemeGuid = "84643a20fa6b4fa7969ef84ad2e40992";
 
-        public static readonly Texture2D LogoDarkTheme = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath("StandardAssets/Textures/MRTK_Logo_White.png"), typeof(Texture2D));
+        public static readonly Texture2D LogoLightTheme = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(LogoLightThemeGuid));
+
+        public static readonly Texture2D LogoDarkTheme = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(LogoDarkThemeGuid));
 
         private const string CloneProfileHelpLabel = "Currently viewing a MRTK default profile. It is recommended to clone defaults and modify a custom profile.";
         private const string CloneProfileHelpLockedLabel = "Clone this default profile to edit properties below";

--- a/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
@@ -460,20 +460,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void LoadIcons()
         {
-            LoadTexture(ref iconPlay, "MRTK_TimelinePlay.png");
-            LoadTexture(ref iconRecord, "MRTK_TimelineRecord.png");
-            LoadTexture(ref iconRecordActive, "MRTK_TimelineRecordActive.png");
-            LoadTexture(ref iconStepFwd, "MRTK_TimelineStepFwd.png");
-            LoadTexture(ref iconJumpFwd, "MRTK_TimelineJumpFwd.png");
-            LoadTexture(ref iconJumpBack, "MRTK_TimelineJumpBack.png");
+            // MRTK_TimelinePlay.png
+            LoadTexture(ref iconPlay, "474f3f21b48daea4f8617806305769ff");
+            // MRTK_TimelineRecord.png
+            LoadTexture(ref iconRecord, "c079cf55f13c1dc4db7d09053a51a40d");
+            // MRTK_TimelineRecordActive.png
+            LoadTexture(ref iconRecordActive, "6752387ee2181ee4fbef5cc74691b6ac");
+            // MRTK_TimelineStepFwd.png
+            LoadTexture(ref iconStepFwd, "230b98155638e544892c123d8d674737");
+            // MRTK_TimelineJumpFwd.png
+            LoadTexture(ref iconJumpFwd, "3afb597cbd6ec44439ea7b8ce92d957a");
+            // MRTK_TimelineJumpBack.png
+            LoadTexture(ref iconJumpBack, "a5d8e80a54741dc459e4f116e1d477f2");
         }
 
-        private static void LoadTexture(ref Texture2D tex, string filename)
+        private static void LoadTexture(ref Texture2D tex, string fileGuid)
         {
-            const string assetPath = "StandardAssets/Textures";
             if (tex == null)
             {
-                tex = (Texture2D)AssetDatabase.LoadAssetAtPath(MixedRealityToolkitFiles.MapRelativeFilePath(Path.Combine(assetPath, filename)), typeof(Texture2D));
+                tex = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(fileGuid));
             }
         }
     }


### PR DESCRIPTION
## Overview

In support of #8058, this PR updates a few cases where textures attempt to load by path, and it's assumed the path is in `Assets`. Though, when consuming MRTK via UPM, those paths don't resolve correctly.

Using Unity's APIs and consistent GUID references allows these textures to be loaded regardless of where the file is located.