### PR TITLE
Update InputSimulationWindow to show pause button

### DIFF
--- a/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.MixedReality.Toolkit.Utilities;
-using Microsoft.MixedReality.Toolkit.Utilities.Editor;
-using UnityEngine;
-using UnityEditor;
 using System;
 using System.IO;
+using UnityEditor;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
@@ -15,7 +14,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
     /// </summary>
     public class InputSimulationWindow : EditorWindow
     {
-        private InputAnimation animation
+        private InputAnimation Animation
         {
             get { return PlaybackService?.Animation; }
             set { if (PlaybackService != null) PlaybackService.Animation = value; }
@@ -77,15 +76,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             Playback,
         }
 
-        private ToolMode mode = ToolMode.Record;
-        public ToolMode Mode
-        {
-            get { return mode; }
-            private set
-            {
-                mode = value;
-            }
-        }
+        public ToolMode Mode { get; private set; } = ToolMode.Record;
 
         /// Icon textures
         private Texture2D iconPlay = null;
@@ -121,7 +112,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
             string[] modeStrings = Enum.GetNames(typeof(ToolMode));
             Mode = (ToolMode)GUILayout.SelectionGrid((int)Mode, modeStrings, modeStrings.Length);
 
-            switch (mode)
+            switch (Mode)
             {
                 case ToolMode.Record:
                     DrawRecordingGUI();
@@ -341,7 +332,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 }
 
                 float time = PlaybackService.LocalTime;
-                float duration = (animation != null ? animation.Duration : 0.0f);
+                float duration = (Animation != null ? Animation.Duration : 0.0f);
                 float newTimeField = EditorGUILayout.FloatField("Current time", time);
                 float newTimeSlider = GUILayout.HorizontalSlider(time, 0.0f, duration);
 
@@ -391,10 +382,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
             {
                 GUILayout.Label("Animation Info:", EditorStyles.boldLabel);
 
-                if (animation != null)
+                if (Animation != null)
                 {
                     GUILayout.Label($"File Path: {loadedFilePath}");
-                    GUILayout.Label($"Duration: {animation.Duration} seconds");
+                    GUILayout.Label($"Duration: {Animation.Duration} seconds");
                 }
                 else
                 {

--- a/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
+++ b/Assets/MRTK/Services/InputSimulation/Editor/InputSimulationWindow.cs
@@ -80,6 +80,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         /// Icon textures
         private Texture2D iconPlay = null;
+        private Texture2D iconPause = null;
         private Texture2D iconRecord = null;
         private Texture2D iconRecordActive = null;
         private Texture2D iconStepFwd = null;
@@ -324,7 +325,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                 {
                     jumpBack = GUILayout.Button(new GUIContent(iconJumpBack, "Jump to the start of the input animation"), "Button");
                     var playButtonContent = wasPlaying
-                        ? new GUIContent(iconPlay, "Stop playing input animation")
+                        ? new GUIContent(iconPause, "Stop playing input animation")
                         : new GUIContent(iconPlay, "Play back input animation");
                     play = GUILayout.Toggle(wasPlaying, playButtonContent, "Button");
                     stepFwd = GUILayout.Button(new GUIContent(iconStepFwd, "Step forward one frame"), "Button");
@@ -453,6 +454,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             // MRTK_TimelinePlay.png
             LoadTexture(ref iconPlay, "474f3f21b48daea4f8617806305769ff");
+            // MRTK_TimelinePause.png
+            LoadTexture(ref iconPause, "1bfd4df7e86b18640b9fa1af5713bfb9");
             // MRTK_TimelineRecord.png
             LoadTexture(ref iconRecord, "c079cf55f13c1dc4db7d09053a51a40d");
             // MRTK_TimelineRecordActive.png


### PR DESCRIPTION
## Overview

Currently, the button stays with the "play" icon even while playing:

![image](https://user-images.githubusercontent.com/3580640/85076634-5dba4580-b175-11ea-8392-437034f4c255.png)

the repo's icon set contains a pause button, so I updated the script to load it and display it when relevant:

![image](https://user-images.githubusercontent.com/3580640/85076672-70cd1580-b175-11ea-94d7-d2e5346d5656.png)

Also, formatting.