### PR TITLE
Re-enable source debugging for the nuget packages

### DIFF
--- a/Assets/MRTK/Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MRTK/Examples/MixedReality.Toolkit.Examples.nuspec
@@ -29,6 +29,6 @@
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.*" target="Plugins\" />
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Demos.*" target="Plugins\" />
     <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\..\Assets\MRTK\Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Examples" /> -->
+    <file src="..\..\..\Assets\MRTK\Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Examples" />
   </files>
 </package>

--- a/Assets/MRTK/Examples/MixedReality.Toolkit.Examples.nuspec
+++ b/Assets/MRTK/Examples/MixedReality.Toolkit.Examples.nuspec
@@ -28,7 +28,6 @@
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Examples.*" target="Plugins\" />
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Demos.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
     <file src="..\..\..\Assets\MRTK\Examples\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Examples" />
   </files>
 </package>

--- a/Assets/MRTK/Extensions/MixedReality.Toolkit.Extensions.nuspec
+++ b/Assets/MRTK/Extensions/MixedReality.Toolkit.Extensions.nuspec
@@ -27,6 +27,6 @@
     <file src="..\..\MRTK\Core\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Extensions.targets" />
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Extensions.*" target="Plugins\" />
-    <!-- <file src="..\..\..\Assets\MRTK\Extensions\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Extensions" /> -->
+    <file src="..\..\..\Assets\MRTK\Extensions\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Extensions" />
   </files>
 </package>

--- a/Assets/MRTK/Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
+++ b/Assets/MRTK/Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
@@ -27,7 +27,6 @@
     <file src="..\..\..\MRTK\Core\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Providers.UnityAR.targets" />
 
     <file src="..\..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
     <file src="..\..\..\..\Assets\MRTK\Providers\UnityAR\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Providers\UnityAR" />
   </files>
 </package>

--- a/Assets/MRTK/Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
+++ b/Assets/MRTK/Providers/UnityAR/MixedReality.Toolkit.Providers.UnityAR.nuspec
@@ -28,6 +28,6 @@
 
     <file src="..\..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR.*" target="Plugins\" />
     <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\..\..\Assets\MRTK\Providers\UnityAR\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Providers\UnityAR" /> -->
+    <file src="..\..\..\..\Assets\MRTK\Providers\UnityAR\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Providers\UnityAR" />
   </files>
 </package>

--- a/Assets/MRTK/Tests/MixedReality.Toolkit.Tests.nuspec
+++ b/Assets/MRTK/Tests/MixedReality.Toolkit.Tests.nuspec
@@ -29,7 +29,6 @@
     <file src="..\..\MRTK\Core\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tests.targets" />
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.*" exclude="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.Utilities*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
     <file src="..\..\..\Assets\MRTK\Tests\**\*.cs" exclude="..\..\..\Assets\MRTK\Tests\TestUtilities\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tests" />
   </files>
 </package>

--- a/Assets/MRTK/Tests/MixedReality.Toolkit.Tests.nuspec
+++ b/Assets/MRTK/Tests/MixedReality.Toolkit.Tests.nuspec
@@ -30,6 +30,6 @@
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.*" exclude="..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.Utilities*" target="Plugins\" />
     <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\..\Assets\MRTK\Tests\**\*.cs" exclude="..\..\..\Assets\MRTK\Tests\TestUtilities\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tests" /> -->
+    <file src="..\..\..\Assets\MRTK\Tests\**\*.cs" exclude="..\..\..\Assets\MRTK\Tests\TestUtilities\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tests" />
   </files>
 </package>

--- a/Assets/MRTK/Tests/TestUtilities/MixedReality.Toolkit.Tests.Utilities.nuspec
+++ b/Assets/MRTK/Tests/TestUtilities/MixedReality.Toolkit.Tests.Utilities.nuspec
@@ -28,6 +28,6 @@
     <file src="..\..\..\MRTK\Core\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tests.Utilities.targets" />
 
     <file src="..\..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tests.Utilities*" target="Plugins\" />
-    <!-- <file src="..\..\..\..\Assets\MRTK\Tests\TestUtilities\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tests\TestUtilities" /> -->
+    <file src="..\..\..\..\Assets\MRTK\Tests\TestUtilities\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tests\TestUtilities" />
   </files>
 </package>

--- a/Assets/MRTK/Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MRTK/Tools/MixedReality.Toolkit.Tools.nuspec
@@ -28,6 +28,6 @@
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tools.*" target="Plugins\" />
     <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\..\Assets\MRTK\Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tools" /> -->
+    <file src="..\..\..\Assets\MRTK\Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tools" />
   </files>
 </package>

--- a/Assets/MRTK/Tools/MixedReality.Toolkit.Tools.nuspec
+++ b/Assets/MRTK/Tools/MixedReality.Toolkit.Tools.nuspec
@@ -27,7 +27,6 @@
     <file src="..\..\MRTK\Core\MixedReality.Toolkit.targets" target="build\Microsoft.MixedReality.Toolkit.Tools.targets" />
 
     <file src="..\..\..\Plugins\**\Microsoft.MixedReality.Toolkit.Tools.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
     <file src="..\..\..\Assets\MRTK\Tools\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Tools" />
   </files>
 </package>

--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -34,24 +34,20 @@
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.dll*" target="Plugins\" />
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.pdb*" target="Plugins\" />
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Gltf.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\Assets\MixedRealityToolkit\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Core" /> -->
+    <file src="..\..\Assets\MixedRealityToolkit\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Core" />
 
     <!-- Assemblies and Sources that are built from the Providers folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.*" exclude="..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR*;..\Plugins\**\Microsoft.MixedReality.Toolkit.Providers.UnityAR\**\*.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\Assets\MRTK\Providers\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Providers" /> -->
+    <file src="..\..\Assets\MRTK\Providers\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Providers" />
 
     <!-- Assemblies and Sources that are built from the SDK folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.SDK.*" target="Plugins\" />
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.SDK.Inspectors.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\Assets\MRTK\SDK\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\SDK" /> -->
+    <file src="..\..\Assets\MRTK\SDK\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\SDK" />
 
     <!-- Assemblies and Sources that are built from the Services folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.*" target="Plugins\" />
-    <!-- The following line is commented out because of a path length issue -->
-    <!-- <file src="..\..\Assets\MRTK\Services\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Services" /> -->
+    <file src="..\..\Assets\MRTK\Services\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Services" />
     
     <!-- 
       link.xml is copied to the root location, so that it can catch IL2CPP


### PR DESCRIPTION
This change reverts https://github.com/microsoft/MixedRealityToolkit-Unity/pull/6618 to enable source debugging of NuGet packages.

Note that this makes any generated nuget packages not work with Nuget4Unity (which we haven't supported from 2.4 and on). This primarily affects anyone who has stood up their own internal build/nuget pipeline to build their own packages. For those folks you'd have to strip out the sources (i.e. revert this revert)

Ideally we would actually use a different mechanism for source debugging (i.e. maybe something like https://devblogs.microsoft.com/nuget/introducing-source-code-link-for-nuget-packages/), but this is a cheap way of unblocking other work.