### PR TITLE
Add a .unitypackage for MRTK's TestUtilities

### DIFF
--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -7,6 +7,30 @@
 
 ### What's new
 
+**TestUtilities package**
+
+There is now a package (Microsoft.MixedReality.Toolkit.Unity.TestUtilities.2.5.0.unitypackage) that contains the
+PlayMode and TestMode test infrastructure that the MRTK uses to create end-to-end tests. This infrastructure has
+been extremely handy for the MRTK team itself, and we're excited to have consumers use this to add test coverage
+to their own projects.
+
+The following code shows how to create a test hand, show it at a certain location, move it around, and then
+pinch and open.
+
+```csharp
+TestHand leftHand = new TestHand(Handedness.Left);
+yield return leftHand.Show(new Vector3(-0.1f, -0.1f, 0.5f));
+yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+yield return leftHand.Move(new Vector3(0.2f, 0.2f, 0));
+yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
+```
+
+For instructions on how to write a test using these TestUtilities, see this section on
+[writing tests](Contributing/UnitTests.html#writing-tests)
+
+For examples of existing tests that use this infrastructure, see MRTK's [PlayModeTests]
+(https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Tests/PlayModeTests)
+
 **Enable MSBuild for Unity removed from the configuration dialog**
 
 To prevent the MRTK configuration dialog from repeatedly displaying when `Enable MSBuild for Unity` is unchecked, it has been moved to the `Mixed Reality Toolkit' menu as shown in the following image.

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -28,8 +28,7 @@ yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
 For instructions on how to write a test using these TestUtilities, see this section on
 [writing tests](Contributing/UnitTests.html#writing-tests)
 
-For examples of existing tests that use this infrastructure, see MRTK's [PlayModeTests]
-(https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Tests/PlayModeTests)
+For examples of existing tests that use this infrastructure, see MRTK's [PlayModeTests](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Tests/PlayModeTests)
 
 **Enable MSBuild for Unity removed from the configuration dialog**
 

--- a/Documentation/ReleaseNotes.md
+++ b/Documentation/ReleaseNotes.md
@@ -26,7 +26,7 @@ yield return leftHand.SetGesture(ArticulatedHandPose.GestureId.Open);
 ```
 
 For instructions on how to write a test using these TestUtilities, see this section on
-[writing tests](Contributing/UnitTests.html#writing-tests)
+[writing tests](Contributing/UnitTests.md#writing-tests)
 
 For examples of existing tests that use this infrastructure, see MRTK's [PlayModeTests](https://github.com/microsoft/MixedRealityToolkit-Unity/tree/mrtk_development/Assets/MRTK/Tests/PlayModeTests)
 

--- a/scripts/packaging/unitypackage.ps1
+++ b/scripts/packaging/unitypackage.ps1
@@ -92,6 +92,9 @@ $packages = @{
     "Tools" = @(
         "Assets\MRTK\Tools"
     );
+    "TestUtilities" = @(
+        "Assets\MRTK\Tests\TestUtilities"
+    );
 }
 
 function GetPackageVersion() {


### PR DESCRIPTION
The TestUtility refactor that @CDiaz-MS did a while back added some cool NuGet package for the MRTK test infrastructure. This has been used internally by a few teams to build out their test infra, and up until now we haven't had a .unitypackage equivalent.

This PR publishes the core set of test infrastructure that the MRTK itself uses to write integration tests, things like:

1. Show hand there.
2. Pinch
3. Move hand over there.
4. Release

This lets you write automated tests that interact with things in your scene, so that instead of having to do manual test passes, you can have automated (i.e. CI-time) coverage of core/common things. The tests that we've written have helped us avoid regressions in components and to prove functionality, and it's like that consumers will also be able to benefit from this.

Note that there is an initial investment to writing any set of tests, but the payoff is usually worth it (it has been worth it for us)