### PR TITLE
Scroll Graduation 

### DIFF
--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Prefabs/ScrollingOC_Objects_Plated32x32.prefab
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Prefabs/ScrollingOC_Objects_Plated32x32.prefab
@@ -271,12 +271,12 @@ MonoBehaviour:
   canScroll: 1
   setUpAtRuntime: 1
   viewableArea: 2
-  handDeltaMagThreshold: 0.4
+  handDeltaMagThreshold: 0.02
   dragTimeThreshold: 0.75
   useNearScrollBoundary: 0
   scrollDirection: 0
   useOnPreRender: 0
-  velocityMultiplier: 0.8
+  velocityMultiplier: 0.008
   velocityDampen: 0.9
   typeOfVelocity: 0
   paginationCurve:

--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Prefabs/ScrollingOC_PressableBtn_32x96.prefab
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Prefabs/ScrollingOC_PressableBtn_32x96.prefab
@@ -212,12 +212,12 @@ MonoBehaviour:
   canScroll: 1
   setUpAtRuntime: 1
   viewableArea: 5
-  handDeltaMagThreshold: 0.4
+  handDeltaMagThreshold: 0.02
   dragTimeThreshold: 0.75
   useNearScrollBoundary: 0
   scrollDirection: 0
   useOnPreRender: 0
-  velocityMultiplier: 0.8
+  velocityMultiplier: 0.008
   velocityDampen: 0.9
   typeOfVelocity: 0
   paginationCurve:

--- a/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
+++ b/Assets/MRTK/Examples/Experimental/ScrollingObjectCollection/Scripts/ScrollableListPopulator.cs
@@ -112,13 +112,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Examples
                 scrollCollection = newScroll.AddComponent<ScrollingObjectCollection>();
 
                 // Prevent the scrolling collection from running until we're done dynamically populating it.
-                scrollCollection.SetUpAtRuntime = false;
+                scrollCollection.SetupAtRuntime = false;
                 scrollCollection.CellHeight = 0.032f;
                 scrollCollection.CellWidth = 0.032f;
                 scrollCollection.Tiers = 3;
                 scrollCollection.ViewableArea = 5;
                 scrollCollection.DragTimeThreshold = 0.75f;
-                scrollCollection.HandDeltaMagThreshold = 0.8f;
+                scrollCollection.HandDeltaMagThreshold = 0.02f;
                 scrollCollection.TypeOfVelocity = ScrollingObjectCollection.VelocityType.FalloffPerItem;
             }
 

--- a/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
+++ b/Assets/MRTK/SDK/Experimental/Inspectors/ScrollingObjectCollection/ScrollingObjectCollectionInspector.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
         private SerializedProperty tiers;
         private SerializedProperty useCameraPreRender;
 
-        private SerializedProperty setUpAtRuntime;
+        private SerializedProperty setupAtRuntime;
         private SerializedProperty occlusionPositionPadding;
         private SerializedProperty occlusionScalePadding;
         private SerializedProperty dragTimeThreshold;
@@ -68,7 +68,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             scrollDirection = serializedObject.FindProperty("scrollDirection");
             useNearScrollBoundary = serializedObject.FindProperty("useNearScrollBoundary");
             viewableArea = serializedObject.FindProperty("viewableArea");
-            setUpAtRuntime = serializedObject.FindProperty("setUpAtRuntime");
+            setupAtRuntime = serializedObject.FindProperty("setupAtRuntime");
             useCameraPreRender = serializedObject.FindProperty("useOnPreRender");
 
             occlusionPositionPadding = serializedObject.FindProperty("occlusionPositionPadding");
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.Inspectors
             {
                 EditorGUILayout.PropertyField(canScroll);
                 EditorGUILayout.PropertyField(scrollDirection);
-                EditorGUILayout.PropertyField(setUpAtRuntime);
+                EditorGUILayout.PropertyField(setupAtRuntime);
                 EditorGUILayout.PropertyField(useCameraPreRender);
                 EditorGUILayout.Space();
             }

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -373,7 +373,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         public UnityEvent ListMomentumEnded = new UnityEvent();
 
         /// <summary>
-        /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity
+        /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.
         /// </summary>
         [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
         public UnityEvent ListMomentumBegin = new UnityEvent();

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -5,6 +5,7 @@ using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -17,10 +18,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ScrollingObjectCollection")]
     public class ScrollingObjectCollection : BaseObjectCollection,
-        IMixedRealityInputHandler,
-        IMixedRealityInputHandler<Vector2>,
-        IMixedRealityInputHandler<Vector3>,
-        IMixedRealityInputHandler<MixedRealityPose>,
         IMixedRealityPointerHandler,
         IMixedRealitySourceStateHandler,
         IMixedRealityTouchHandler
@@ -62,15 +59,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         [SerializeField]
         [Tooltip("Automatically set up scroller at runtime.")]
-        private bool setUpAtRuntime = true;
+        private bool setupAtRuntime = true;
 
         /// <summary>
         /// Automatically set up scroller at runtime.
         /// </summary>
-        public bool SetUpAtRuntime
+        public bool SetupAtRuntime
         {
-            get { return setUpAtRuntime; }
-            set { setUpAtRuntime = value; }
+            get { return setupAtRuntime; }
+            set { setupAtRuntime = value; }
         }
 
         [SerializeField]
@@ -88,8 +85,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         [SerializeField]
         [Tooltip("The distance the user's pointer can make before its considered a drag.")]
-        [Range(0.0f, 2.0f)]
-        private float handDeltaMagThreshold = 0.4f;
+        [Range(0.0f, 0.2f)]
+        private float handDeltaMagThreshold = 0.02f;
 
         /// <summary>
         /// The distance the user's pointer can make before its considered a drag.
@@ -183,8 +180,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         [SerializeField]
         [Tooltip("Amount of (extra) velocity to be applied to scroller")]
-        [Range(0.0f, 2.0f)]
-        private float velocityMultiplier = 0.8f;
+        [Range(0.0f, 0.02f)]
+        private float velocityMultiplier = 0.008f;
 
         /// <summary>
         /// Amount of (extra) velocity to be applied to scroller.
@@ -268,7 +265,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         [Tooltip("Whether items that are partially clipped are disabled for input hit testing")]
         [SerializeField]
         private bool disableClippedItems = true;
-        public bool DisableClippedItems {
+        public bool DisableClippedItems
+        {
             get => disableClippedItems;
             set => disableClippedItems = value;
         }
@@ -416,6 +414,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         // Maximum amount the scroller can travel (horizontally) - this will always be zero. Here for readability
         private readonly float maxX = 0.0f;
 
+        // Depth of scrolling background box collider
+        private float scrollingBackgroundDepth = 0.001f;
+
         // Minimum amount the scroller can travel (horizontally)
         private float minX
         {
@@ -444,7 +445,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         // Take the previous view and then subtract the column remainder and we add the viewable area as a multiplier (minus 1 since the index is zero based).
-        // The first item not viewable in the list
+        // The first item not visible in the list
         private int numItemsPostView
         {
             get
@@ -460,6 +461,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
             }
         }
+
+        // Allows scroll when interacting with empty spaces
+        private BoxCollider scrollingBackground;
+
+        private bool isRegisteredForGlobalPointerEvents = false;
+
+        /// <summary>
+        /// The local position of the moving scroll container. Can be used to represent the container drag displacement
+        /// </summary>
+        public Vector3 ScrollContainerPosition => scrollContainer.transform.localPosition;
 
         // The empty game object that contains our nodes and be scrolled
         [SerializeField]
@@ -496,8 +507,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         #region scroll state variables
 
-        // Tracks whether an item in the list is being interacted with
-        private bool isEngaged = false;
+        /// <summary>
+        /// Tracks whether an item in the list or scroll is being interacted with
+        /// </summary>
+        public bool IsEngaged { get; private set; } = false;
 
         // Tracks whether a movement action resulted in dragging the list  
         private bool isDragging = false;
@@ -592,8 +605,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         public override void UpdateCollection()
         {
             // Generate our scroll specific objects
-            SetUpScrollContainer();
-            SetUpClippingPrimitive();
+            SetupScrollContainer();
+            SetupClippingPrimitive();
 
             // ensure IgnoreInactiveTransforms is set to false, otherwise the node prune will remove any hidden items in the list.g
             IgnoreInactiveTransforms = false;
@@ -642,7 +655,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             for (int i = 0; i < scrollContainer.transform.childCount; i++)
             {
                 Transform child = scrollContainer.transform.GetChild(i);
-                
+
                 if (ContainsNode(child, out int nodeIndex) && NodeList[nodeIndex].GetType() != typeof(ScrollingObjectCollectionNode))
                 {
                     // This node is in the list, but of the wrong type
@@ -668,7 +681,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             OnCollectionUpdated?.Invoke(this);
         }
 
-        private void SetUpScrollContainer()
+        private void SetupScrollContainer()
         {
             // ScrollContainer empty game object null check - ensure its set up properly
             if (scrollContainer == null)
@@ -692,7 +705,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        private void SetUpClippingPrimitive()
+        private void SetupClippingPrimitive()
         {
             // ClippingObject empty game object null check - ensure its set up properly
             if (clippingObject == null)
@@ -736,6 +749,40 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     cameraMethods = CameraCache.Main.gameObject.EnsureComponent<CameraEventRouter>();
                     cameraMethods.OnCameraPreRender += OnCameraPreRender;
                 }
+            }
+        }
+
+        // Setting up a collider and a near interaction touchable to allow interaction with empty spaces like corners or in between children items
+        private void SetupScrollingBackground()
+        {
+            if (scrollingBackground == null)
+            {
+                scrollingBackground = GetComponent<BoxCollider>();
+                if (scrollingBackground == null)
+                {
+                    scrollingBackground = gameObject.AddComponent<BoxCollider>();
+                }
+
+                if (scrollDirection == ScrollDirectionType.UpAndDown)
+                {
+                    scrollingBackground.size = new Vector3(CellWidth * Tiers, CellHeight * ViewableArea, scrollingBackgroundDepth);
+                }
+                else
+                {
+                    scrollingBackground.size = new Vector3(CellWidth * ViewableArea, CellHeight * Tiers, scrollingBackgroundDepth);
+                }
+
+                Vector3 position;
+                position.x = scrollingBackground.size.x / 2;
+                position.y = -scrollingBackground.size.y / 2;
+                position.z = 0.01f;
+                scrollingBackground.center = position;
+
+                var touchable = gameObject.AddComponent<NearInteractionTouchable>();
+                Vector2 size = new Vector2(
+                            Math.Abs(Vector3.Dot(scrollingBackground.size, touchable.LocalRight)),
+                            Math.Abs(Vector3.Dot(scrollingBackground.size, touchable.LocalUp)));
+                touchable.SetBounds(size);
             }
         }
 
@@ -886,19 +933,11 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnEnable()
         {
-            if (CoreServices.InputSystem != null)
-            {
-                // Register for event propagation on trickle down phase in order to handle events before children
-                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<Vector2>>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<Vector3>>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<MixedRealityPose>>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);               
+            CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
+            CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityPointerHandler>(this, PropagationPhase.TrickleDown);
 
-                // Register for global input events
-                CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
-                CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
-            }
+            // Register for global input events
+            CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
 
             if (useOnPreRender)
             {
@@ -919,10 +958,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void Start()
         {
-            if (setUpAtRuntime)
+            if (setupAtRuntime)
             {
                 UpdateCollection();
             }
+
+            SetupScrollingBackground();
         }
 
         private void Update()
@@ -940,10 +981,15 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
 
             // The scroller has detected input and has a valid pointer
-            if (isEngaged && TryGetPointerPositionOnPlane(out Vector3 currentPointerPos))
+            if (IsEngaged && TryGetPointerPositionOnPlane(out Vector3 currentPointerPos))
             {
                 Vector3 handDelta = initialPointerPos - currentPointerPos;
                 handDelta = transform.InverseTransformDirection(handDelta);
+
+                if (isDragging && currentPointer != null) // Changing lock after drag started frame to allow for focus provider to move pointer focus to scroll background before locking
+                {
+                    currentPointer.IsFocusLocked = true;
+                }
 
                 // Lets see if this is gonna be a click or a drag
                 // Check the scroller's length state to prevent resetting calculation
@@ -953,12 +999,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     float absAxisHandDelta = (scrollDirection == ScrollDirectionType.UpAndDown) ? Mathf.Abs(handDelta.y) : Mathf.Abs(handDelta.x);
 
                     // Catch an intentional finger in scroller to stop momentum, this isn't a drag its definitely a stop
-                    if (absAxisHandDelta > (handDeltaMagThreshold * 0.1f) || TimeTest(initialPressTime, Time.time, dragTimeThreshold))
+                    if (absAxisHandDelta > handDeltaMagThreshold)
                     {
                         scrollVelocity = 0.0f;
                         avgVelocity = 0.0f;
 
                         isDragging = true;
+                        handDelta = Vector3.zero;
+
                         ListMomentumBegin.Invoke();
                         velocityState = VelocityState.None;
 
@@ -1048,18 +1096,16 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnDisable()
         {
-            if (CoreServices.InputSystem != null)
-            {
-                // Unregister for event propagation on trickle down phase
-                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<Vector2>>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<Vector3>>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<MixedRealityPose>>(this, PropagationPhase.TrickleDown);
-                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
+            CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
+            CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityPointerHandler>(this, PropagationPhase.TrickleDown);
 
-                // Unregister global input events
-                CoreServices.InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+            // Unregister global input events
+            CoreServices.InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+
+            if (isRegisteredForGlobalPointerEvents)
+            {
                 CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
+                isRegisteredForGlobalPointerEvents = false;
             }
 
             if (useOnPreRender && cameraMethods != null)
@@ -1425,8 +1471,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             TryGetPointerPositionOnPlane(out Vector3 newPos);
 
             scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
-                             ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
-                             : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
+                             ? (newPos.y - lastPointerPos.y) / Time.deltaTime * velocityMultiplier
+                             : (newPos.x - lastPointerPos.x) / Time.deltaTime * velocityMultiplier;
 
             // And filter it...
             avgVelocity = (avgVelocity * (1.0f - velocityFilterWeight)) + (scrollVelocity * velocityFilterWeight);
@@ -1663,7 +1709,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         i < prevItems - Tiers || i > postItems + Tiers;
 
                     // Disable colliders on items that will be scrolling in and out of view
-                    if (disableNode)
+                    // During drag all visible children should also has its colliders disabled 
+                    if (disableNode || isDragging)
                     {
                         foreach (Collider c in node.Colliders)
                         {
@@ -1751,12 +1798,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             TouchEnded?.Invoke(initialFocusedObject);
 
             // Release the pointer
+            if (currentPointer != null) currentPointer.IsFocusLocked = false;
             currentPointer = null;
             initialFocusedObject = null;
 
             // Clear our states
             isTouched = false;
-            isEngaged = false;
+            IsEngaged = false;
             isDragging = false;
         }
 
@@ -1969,22 +2017,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <summary>
-        /// Simple time threshold check
-        /// </summary>
-        /// <param name="initTime">Initial time</param>
-        /// <param name="currTime">Current time</param>
-        /// <param name="pressMargin">Time threshold</param>
-        /// <returns>true if amount of time surpasses <paramref name="pressMargin"/></returns>
-        public static bool TimeTest(float initTime, float currTime, float pressMargin)
-        {
-            if (currTime - initTime > pressMargin)
-            {
-                return true;
-            }
-            return false;
-        }
-
-        /// <summary>
         /// Finds the object-aligned size of a <see href="https://docs.unity3d.com/ScriptReference/Transform.html">Transform</see>.
         /// </summary>
         /// <param name="obj">Transform representing the object to get offset from</param>
@@ -2079,7 +2111,13 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 return;
             }
 
-            if (!isTouched && isEngaged && animateScroller == null)
+            if (IsEngaged && isRegisteredForGlobalPointerEvents)
+            {
+                CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
+                isRegisteredForGlobalPointerEvents = false;
+            }
+
+            if (!isTouched && IsEngaged && animateScroller == null)
             {
                 if (isDragging)
                 {
@@ -2102,11 +2140,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             currentPointer = eventData.Pointer;
             oldIsTargetPositionLockedOnFocusLock = currentPointer.IsTargetPositionLockedOnFocusLock;
 
-            // Quick check for the global listener to bail if the object is not in the list
-            if (currentPointer?.Result?.CurrentPointerTarget == null
-                || !ContainsNode(currentPointer.Result.CurrentPointerTarget.transform) || initialFocusedObject != null)
+            if (initialFocusedObject != null)
             {
                 return;
+            }
+
+            // Registering for global to listen for pointerups if focused child is disabled after dragged out of view
+            // Temporary workaround. Trying to fix bad performance of pointer and node focus checks when subscribing globally on the on enable callback
+            if (!isRegisteredForGlobalPointerEvents)
+            {
+                CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
+                isRegisteredForGlobalPointerEvents = true;
             }
 
             if (!(currentPointer is IMixedRealityNearPointer) && currentPointer.Controller.IsRotationAvailable)
@@ -2118,6 +2162,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             pointerHitDistance = currentPointer.Result.Details.RayDistance;
 
             initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
+            currentPointer.IsFocusLocked = false; // Unwanted focus locked on children items
 
             // Reset the scroll state
             scrollVelocity = 0.0f;
@@ -2129,7 +2174,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 velocityState = VelocityState.None;
 
                 isTouched = false;
-                isEngaged = true;
+                IsEngaged = true;
                 isDragging = false;
 
                 TouchStarted?.Invoke(initialFocusedObject);
@@ -2143,7 +2188,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         /// <inheritdoc/>
-        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData){}
+        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData) { }
 
         #endregion IMixedRealityPointerHandler implementation
 
@@ -2164,7 +2209,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                 StopAllCoroutines();
                 animateScroller = null;
 
-                if (!isTouched && !isEngaged)
+                if (!isTouched && !IsEngaged)
                 {
                     initialPointerPos = currentPointer.Position;
                     initialPressTime = Time.time;
@@ -2172,7 +2217,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     initialScrollerPos = scrollContainer.transform.localPosition;
 
                     isTouched = true;
-                    isEngaged = true;
+                    IsEngaged = true;
                     isDragging = false;
 
                     TouchStarted?.Invoke(initialFocusedObject);
@@ -2192,7 +2237,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData)
         {
-            if (isDragging)
+            IMixedRealityPointer pointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
+
+            if (pointer == currentPointer && isDragging)
             {
                 eventData.Use();
             }
@@ -2207,12 +2254,17 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         void IMixedRealitySourceStateHandler.OnSourceLost(SourceStateEventData eventData)
         {
             // We'll consider this a drag release
-            if (isEngaged && animateScroller == null && currentPointer != null && currentPointer.InputSourceParent.SourceId == eventData.SourceId)
+            if (IsEngaged && animateScroller == null && currentPointer != null && currentPointer.InputSourceParent.SourceId == eventData.SourceId)
             {
                 if (isTouched || isDragging)
                 {
                     // Its a drag release
                     initialScrollerPos = workingScrollerPos;
+                }
+
+                if (isRegisteredForGlobalPointerEvents)
+                {
+                    CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
                 }
 
                 ResetState();
@@ -2222,53 +2274,5 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         }
 
         #endregion IMixedRealitySourceStateHandler implementation
-
-        #region IMixedRealityInputHandler implementation
-
-        /// <inheritdoc/>
-        void IMixedRealityInputHandler.OnInputUp(InputEventData eventData)
-        {
-            if (isDragging)
-            {
-                eventData.Use();
-            }
-        }
-
-        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
-        {
-            if(isDragging)
-            {
-                eventData.StopPropagation();
-            }
-        }
-
-        /// <inheritdoc/>
-        public void OnInputChanged(InputEventData<Vector2> eventData)
-        {
-            if (isDragging)
-            {
-                eventData.Use();
-            }
-        }
-
-        /// <inheritdoc/>
-        public void OnInputChanged(InputEventData<Vector3> eventData)
-        {
-            if (isDragging)
-            {
-                eventData.Use();
-            }
-        }
-
-        /// <inheritdoc/>
-        public void OnInputChanged(InputEventData<MixedRealityPose> eventData)
-        {
-            if (isDragging)
-            {
-                eventData.Use();
-            }
-        }
-
-        #endregion IMixedRealityInputHandler implementation
     }
 }

--- a/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
+++ b/Assets/MRTK/SDK/Experimental/ScrollingObjectCollection/ScrollingObjectCollection.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Physics;
-using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
 using System.Collections;
@@ -17,7 +16,14 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
     /// A set of child objects organized in a series of Rows/Columns that can scroll in either the X or Y direction.
     /// </summary>
     [AddComponentMenu("Scripts/MRTK/SDK/ScrollingObjectCollection")]
-    public class ScrollingObjectCollection : BaseObjectCollection, IMixedRealityPointerHandler, IMixedRealityTouchHandler, IMixedRealitySourceStateHandler, IMixedRealityInputHandler
+    public class ScrollingObjectCollection : BaseObjectCollection,
+        IMixedRealityInputHandler,
+        IMixedRealityInputHandler<Vector2>,
+        IMixedRealityInputHandler<Vector3>,
+        IMixedRealityInputHandler<MixedRealityPose>,
+        IMixedRealityPointerHandler,
+        IMixedRealitySourceStateHandler,
+        IMixedRealityTouchHandler
     {
         /// <summary>
         /// How velocity is applied to a <see cref="ScrollingObjectCollection"/> when a scroll is released.
@@ -367,6 +373,12 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         public UnityEvent ListMomentumEnded = new UnityEvent();
 
         /// <summary>
+        /// Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity
+        /// </summary>
+        [Tooltip("Event that is fired on the target object when the ScrollingObjectCollection is starting motion with velocity.")]
+        public UnityEvent ListMomentumBegin = new UnityEvent();
+
+        /// <summary>
         /// First item (visible) in the <see cref="ViewableArea"/>. 
         /// </summary>
         public int FirstItemInViewIndex
@@ -516,9 +528,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
         // The ray length of original pointer down
         private float pointerHitDistance;
 
-        // This flag is set by PointerUp to prevent InputUp from continuing to propagate. e.g. Interactables
-        private bool shouldSwallowEvents = false;
-
         #endregion scroll state variables
 
         #region drag position calculation variables
@@ -642,7 +651,7 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
                 if (!ContainsNode(child) && (child.gameObject.activeSelf || !IgnoreInactiveTransforms))
                 {
-                    NodeList.Add( new ScrollingObjectCollectionNode { Name = child.name, Transform = child, Colliders = child.GetComponentsInChildren<Collider>() });
+                    NodeList.Add(new ScrollingObjectCollectionNode { Name = child.name, Transform = child, Colliders = child.GetComponentsInChildren<Collider>() });
                 }
             }
 
@@ -877,13 +886,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnEnable()
         {
-            // Register for global input events
             if (CoreServices.InputSystem != null)
             {
-                CoreServices.InputSystem.RegisterHandler<IMixedRealityInputHandler>(this);
-                CoreServices.InputSystem.RegisterHandler<IMixedRealityTouchHandler>(this);
-                CoreServices.InputSystem.RegisterHandler<IMixedRealityPointerHandler>(this);
-                CoreServices.InputSystem.RegisterHandler<IMixedRealitySourceStateHandler>(this);
+                // Register for event propagation on trickle down phase in order to handle events before children
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<Vector2>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<Vector3>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityInputHandler<MixedRealityPose>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.RegisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);               
+
+                // Register for global input events
+                CoreServices.InputSystem?.RegisterHandler<IMixedRealitySourceStateHandler>(this);
+                CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
             }
 
             if (useOnPreRender)
@@ -945,14 +959,8 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                         avgVelocity = 0.0f;
 
                         isDragging = true;
+                        ListMomentumBegin.Invoke();
                         velocityState = VelocityState.None;
-
-                        // Now that we're dragging, reset the interacted with interactable if it exists
-                        Interactable ixable = initialFocusedObject.GetComponent<Interactable>();
-                        if (ixable != null)
-                        {
-                           ixable.ResetInputTrackingStates();
-                        }
 
                         // Reset initialHandPos to prevent the scroller from jumping
                         initialScrollerPos = workingScrollerPos = scrollContainer.transform.localPosition;
@@ -1040,13 +1048,18 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
 
         private void OnDisable()
         {
-            // Unregister global input events
             if (CoreServices.InputSystem != null)
             {
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealityInputHandler>(this);
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealityTouchHandler>(this);
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealityPointerHandler>(this);
-                CoreServices.InputSystem.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+                // Unregister for event propagation on trickle down phase
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<Vector2>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<Vector3>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityInputHandler<MixedRealityPose>>(this, PropagationPhase.TrickleDown);
+                CoreServices.InputPropagationSystem?.UnregisterPropagationHandler<IMixedRealityTouchHandler>(this, PropagationPhase.TrickleDown);
+
+                // Unregister global input events
+                CoreServices.InputSystem?.UnregisterHandler<IMixedRealitySourceStateHandler>(this);
+                CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
             }
 
             if (useOnPreRender && cameraMethods != null)
@@ -1411,9 +1424,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // Update simple velocity
             TryGetPointerPositionOnPlane(out Vector3 newPos);
 
-                scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
-                                 ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
-                                 : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
+            scrollVelocity = (scrollDirection == ScrollDirectionType.UpAndDown)
+                             ? (newPos.y - lastPointerPos.y) / Time.deltaTime * (velocityMultiplier * 0.01f)
+                             : (newPos.x - lastPointerPos.x) / Time.deltaTime * (velocityMultiplier * 0.01f);
 
             // And filter it...
             avgVelocity = (avgVelocity * (1.0f - velocityFilterWeight)) + (scrollVelocity * velocityFilterWeight);
@@ -2067,11 +2080,10 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
 
             if (!isTouched && isEngaged && animateScroller == null)
-            {   
+            {
                 if (isDragging)
                 {
                     eventData.Use();
-                    shouldSwallowEvents = true;
                     // Its a drag release
                     initialScrollerPos = workingScrollerPos;
                     velocityState = VelocityState.Calculating;
@@ -2130,6 +2142,9 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             // We ignore this event and calculate click in the Update() loop;
         }
 
+        /// <inheritdoc/>
+        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData){}
+
         #endregion IMixedRealityPointerHandler implementation
 
         #region IMixedRealityTouchHandler implementation
@@ -2146,13 +2161,6 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             currentPointer = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
             if (currentPointer != null)
             {
-                // Quick check for the global listener to bail if the object is not in the list
-                if (currentPointer.Result?.CurrentPointerTarget == null ||
-                    !ContainsNode(currentPointer.Result?.CurrentPointerTarget.transform))
-                {
-                    return;
-                }
-
                 StopAllCoroutines();
                 animateScroller = null;
 
@@ -2162,53 +2170,31 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
                     initialPressTime = Time.time;
                     initialFocusedObject = currentPointer.Result?.CurrentPointerTarget;
                     initialScrollerPos = scrollContainer.transform.localPosition;
-                    shouldSwallowEvents = true;
 
                     isTouched = true;
                     isEngaged = true;
                     isDragging = false;
 
                     TouchStarted?.Invoke(initialFocusedObject);
-
                 }
             }
-
         }
 
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            // Quick check for the global listener to bail if the object is not in the list
-            if (currentPointer != null && currentPointer.Result?.CurrentPointerTarget != null 
-                && ContainsNode(currentPointer.Result.CurrentPointerTarget.transform))
+            if (isDragging)
             {
-                if (isDragging)
-                {
-                    eventData.Use();
-                }
-                return;
+                eventData.Use();
             }
         }
 
         /// <inheritdoc/>
         void IMixedRealityTouchHandler.OnTouchUpdated(HandTrackingInputEventData eventData)
         {
-            IMixedRealityPointer p = PointerUtils.GetPointer<PokePointer>(eventData.Handedness);
-
-            if (p != null)
+            if (isDragging)
             {
-                // Quick check for the global listener to bail if the object is not in the list
-                if (currentPointer == null || 
-                    currentPointer.Result?.CurrentPointerTarget == null ||
-                    !ContainsNode(p.Result.CurrentPointerTarget.transform) || initialFocusedObject != p.Result.CurrentPointerTarget)
-                {
-                    return;
-                }
-
-                if (p == currentPointer && isDragging)
-                {
-                    eventData.Use();
-                }
+                eventData.Use();
             }
         }
 
@@ -2235,20 +2221,54 @@ namespace Microsoft.MixedReality.Toolkit.Experimental.UI
             }
         }
 
-        void IMixedRealityPointerHandler.OnPointerDragged(MixedRealityPointerEventData eventData) { }
+        #endregion IMixedRealitySourceStateHandler implementation
 
+        #region IMixedRealityInputHandler implementation
+
+        /// <inheritdoc/>
         void IMixedRealityInputHandler.OnInputUp(InputEventData eventData)
         {
-            if (shouldSwallowEvents)
+            if (isDragging)
             {
-                // Prevents the handled event from PointerUp to continue propagating
                 eventData.Use();
-                shouldSwallowEvents = false;
             }
         }
 
-        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData) { }
+        void IMixedRealityInputHandler.OnInputDown(InputEventData eventData)
+        {
+            if(isDragging)
+            {
+                eventData.StopPropagation();
+            }
+        }
 
-        #endregion IMixedRealitySourceStateHandler implementation
+        /// <inheritdoc/>
+        public void OnInputChanged(InputEventData<Vector2> eventData)
+        {
+            if (isDragging)
+            {
+                eventData.Use();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnInputChanged(InputEventData<Vector3> eventData)
+        {
+            if (isDragging)
+            {
+                eventData.Use();
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnInputChanged(InputEventData<MixedRealityPose> eventData)
+        {
+            if (isDragging)
+            {
+                eventData.Use();
+            }
+        }
+
+        #endregion IMixedRealityInputHandler implementation
     }
 }

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -397,7 +397,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                     }
                     else
                     {
-                        rollOffTimer = rollOffTime;
+                        rollOffTimer = RollOffTime;
                     }
 
                     SetState(InteractableStates.InteractableStateEnum.Focus, value);
@@ -564,9 +564,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
         // directly manipulate a theme value, skip blending
         protected bool forceUpdate = false;
 
-        // allows for switching colliders without firing a lose focus immediately
-        // for advanced controls like drop-downs
-        protected float rollOffTime = 0.25f;
+        /// <summary>
+        /// Allows for switching colliders without firing a lose focus immediately for advanced controls like drop-downs
+        /// </summary>
+        public float RollOffTime { get; protected set; } = 0.25f;
         protected float rollOffTimer = 0.25f;
 
         protected List<IInteractableHandler> handlers = new List<IInteractableHandler>();
@@ -679,11 +680,11 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         private void InternalUpdate()
         {
-            if (rollOffTimer < rollOffTime && HasPress)
+            if (rollOffTimer < RollOffTime && HasPress)
             {
                 rollOffTimer += Time.deltaTime;
 
-                if (rollOffTimer >= rollOffTime)
+                if (rollOffTimer >= RollOffTime)
                 {
                     HasPress = false;
                     HasGesture = false;
@@ -1362,12 +1363,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToMoveEvent(eventData))
             {
-                if (eventData.used)
-                {
-                    ResetInputTrackingStates();
-                    return;
-                }
-
                 if (dragStartPosition == null)
                 {
                     dragStartPosition = inputPosition;
@@ -1552,7 +1547,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            if (!IsEnabled || eventData.used)
+            if (!IsEnabled)
             {
                 return;
             }
@@ -1564,7 +1559,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            if (!IsEnabled || eventData.used)
+            if (!IsEnabled)
             {
                 return;
             }
@@ -1574,14 +1569,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             eventData.Use();
         }
 
-        public void OnTouchUpdated(HandTrackingInputEventData eventData)
-        {
-            if (IsEnabled && eventData.used && ShouldListenToMoveEvent(eventData))
-            {
-                ResetInputTrackingStates();
-                return;
-            }
-        }
+        public void OnTouchUpdated(HandTrackingInputEventData eventData) { }
 
         #endregion TouchHandlers
 
@@ -1597,12 +1585,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToUpDownEvent(eventData))
             {
-                if (eventData.used)
-                {
-                    ResetInputTrackingStates();
-                    return;
-                }
-
                 SetInputUp();
                 if (IsInputFromNearInteraction(eventData))
                 {
@@ -1624,12 +1606,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToUpDownEvent(eventData))
             {
-                if (eventData.used)
-                {
-                    ResetInputTrackingStates();
-                    return;
-                }
-
                 pressingInputSources.Add(eventData.InputSource);
                 SetInputDown();
                 HasGrab = IsInputFromNearInteraction(eventData);

--- a/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
+++ b/Assets/MRTK/SDK/Features/UX/Interactable/Scripts/Interactable.cs
@@ -1362,6 +1362,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToMoveEvent(eventData))
             {
+                if (eventData.used)
+                {
+                    ResetInputTrackingStates();
+                    return;
+                }
+
                 if (dragStartPosition == null)
                 {
                     dragStartPosition = inputPosition;
@@ -1546,7 +1552,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            if (!IsEnabled)
+            if (!IsEnabled || eventData.used)
             {
                 return;
             }
@@ -1558,7 +1564,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         public void OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            if (!IsEnabled)
+            if (!IsEnabled || eventData.used)
             {
                 return;
             }
@@ -1568,7 +1574,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
             eventData.Use();
         }
 
-        public void OnTouchUpdated(HandTrackingInputEventData eventData) { }
+        public void OnTouchUpdated(HandTrackingInputEventData eventData)
+        {
+            if (IsEnabled && eventData.used && ShouldListenToMoveEvent(eventData))
+            {
+                ResetInputTrackingStates();
+                return;
+            }
+        }
 
         #endregion TouchHandlers
 
@@ -1584,6 +1597,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToUpDownEvent(eventData))
             {
+                if (eventData.used)
+                {
+                    ResetInputTrackingStates();
+                    return;
+                }
+
                 SetInputUp();
                 if (IsInputFromNearInteraction(eventData))
                 {
@@ -1605,6 +1624,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             if (ShouldListenToUpDownEvent(eventData))
             {
+                if (eventData.used)
+                {
+                    ResetInputTrackingStates();
+                    return;
+                }
+
                 pressingInputSources.Add(eventData.InputSource);
                 SetInputDown();
                 HasGrab = IsInputFromNearInteraction(eventData);

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -304,14 +304,6 @@ namespace Microsoft.MixedReality.Toolkit.UI
             UpdatePressedState(currentPushDistance);
         }
 
-        private void ResetInteraction()
-        {
-            touchPoints.Clear();
-            currentInputSources.Clear();
-            IsTouching = false;
-            IsPressing = false;
-        }
-
         private void RetractButton()
         {
             float retractDistance = currentPushDistance - startPushDistance;
@@ -376,7 +368,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         void IMixedRealityTouchHandler.OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            if (touchPoints.ContainsKey(eventData.Controller) || eventData.used)
+            if (touchPoints.ContainsKey(eventData.Controller))
             {
                 return;
             }
@@ -403,26 +395,13 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (touchPoints.ContainsKey(eventData.Controller))
             {
-                if (eventData.used)
-                {
-                    ResetInteraction();
-                }
-                else
-                {
-                    touchPoints[eventData.Controller] = eventData.InputData;
-                }
+                touchPoints[eventData.Controller] = eventData.InputData;
+                eventData.Use();
             }
-            eventData.Use();
-            return;
         }
 
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
-            if(eventData.used)
-            {
-                return;
-            }
-
             if (touchPoints.ContainsKey(eventData.Controller))
             {
                 // When focus is lost, before removing controller, update the respective touch point to give a last chance for checking if pressed occurred 

--- a/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
+++ b/Assets/MRTK/SDK/Features/UX/Scripts/PressableButtons/PressableButton.cs
@@ -304,6 +304,14 @@ namespace Microsoft.MixedReality.Toolkit.UI
             UpdatePressedState(currentPushDistance);
         }
 
+        private void ResetInteraction()
+        {
+            touchPoints.Clear();
+            currentInputSources.Clear();
+            IsTouching = false;
+            IsPressing = false;
+        }
+
         private void RetractButton()
         {
             float retractDistance = currentPushDistance - startPushDistance;
@@ -368,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
         void IMixedRealityTouchHandler.OnTouchStarted(HandTrackingInputEventData eventData)
         {
-            if (touchPoints.ContainsKey(eventData.Controller))
+            if (touchPoints.ContainsKey(eventData.Controller) || eventData.used)
             {
                 return;
             }
@@ -395,13 +403,26 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (touchPoints.ContainsKey(eventData.Controller))
             {
-                touchPoints[eventData.Controller] = eventData.InputData;
-                eventData.Use();
+                if (eventData.used)
+                {
+                    ResetInteraction();
+                }
+                else
+                {
+                    touchPoints[eventData.Controller] = eventData.InputData;
+                }
             }
+            eventData.Use();
+            return;
         }
 
         void IMixedRealityTouchHandler.OnTouchCompleted(HandTrackingInputEventData eventData)
         {
+            if(eventData.used)
+            {
+                return;
+            }
+
             if (touchPoints.ContainsKey(eventData.Controller))
             {
                 // When focus is lost, before removing controller, update the respective touch point to give a last chance for checking if pressed occurred 

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.MixedReality.Toolkit.Experimental.UI;
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.UI;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using NUnit.Framework;
+using System.Collections;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Microsoft.MixedReality.Toolkit.Tests
+{
+    public class ScrollViewTests : BasePlayModeTests
+    {
+        #region Tests
+
+        /// <summary>
+        /// Tests if interaction with a pressable button is reset after scroll drag is engaged
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollEngageResetsNearInteractionwithChildren()
+        {
+            // Setting up scroll view object with two pressable button children
+            GameObject scrollObject = new GameObject();
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.parent = scrollObject.transform;
+
+            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button3.transform.parent = scrollObject.transform;
+
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.Tiers = 1;
+            scrollView.ViewableArea = 2;
+            scrollView.HandDeltaMagThreshold = scrollView.CellHeight * 0.2f;
+            scrollView.UpdateCollection();
+
+            scrollObject.transform.position = Vector3.forward;
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            PressableButton buttonComponent = button1.GetComponentInChildren<PressableButton>();
+
+            Assert.IsNotNull(buttonComponent);
+
+            bool buttonTouchBegin = false;
+            buttonComponent.TouchBegin.AddListener(() =>
+            {
+                buttonTouchBegin = true;
+            });
+
+            bool buttonTouchEnd = false;
+            buttonComponent.TouchEnd.AddListener(() =>
+            {
+                buttonTouchEnd = true;
+            });
+
+            bool buttonPressBegin = false;
+            buttonComponent.ButtonPressed.AddListener(() =>
+            {
+                buttonPressBegin = true;
+            });
+
+            bool buttonPressCompleted = false;
+            buttonComponent.ButtonReleased.AddListener(() =>
+            {
+                buttonPressCompleted = true;
+            });
+
+            bool scrollDragBegin = false;
+            scrollView.ListMomentumBegin.AddListener(() =>
+            {
+                scrollDragBegin = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 buttonPos = buttonComponent.transform.position;
+            Vector3 startHandPos = buttonPos + new Vector3(0, 0, buttonComponent.StartPushDistance - offset); // Just before touch
+            Vector3 onPressPos = buttonPos + new Vector3(0, 0, buttonComponent.PressDistance + offset); // Past press plane         
+            Vector3 onScrollEngagedPos = onPressPos + new Vector3(0, -(scrollView.HandDeltaMagThreshold + offset), 0); // Engaging in scroll drag
+
+            // If scroll drag not yet engaged then child button interaction should behave normally
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(startHandPos);
+            yield return hand.MoveTo(onPressPos);
+            yield return hand.MoveTo(startHandPos);
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.IsTrue(buttonTouchBegin, "Button touch begin did not trigger.");
+            Assert.IsTrue(buttonPressBegin, "Button press begin did not trigger.");
+            Assert.IsTrue(buttonPressCompleted, "Button press release did not trigger.");
+
+            yield return hand.Hide();
+
+            Assert.IsTrue(buttonTouchEnd, "Button touch end did not trigger.");
+
+            // Reset values
+            buttonTouchBegin = false;
+            buttonTouchEnd = false;
+            buttonPressBegin = false;
+            buttonPressCompleted = false;
+            scrollDragBegin = false;
+
+            // Scroll drag engage should halt interaction with any child button            
+            yield return hand.Show(startHandPos);
+            yield return hand.MoveTo(onPressPos);
+            
+            Assert.IsTrue(buttonTouchBegin, "Button touch begin did not trigger.");
+            Assert.IsTrue(buttonPressBegin, "Button press begin did not trigger.");
+
+            yield return hand.MoveTo(onScrollEngagedPos);
+
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin dit not trigger.");
+            Assert.IsTrue(buttonTouchEnd, "Button touch end did not trigger.");
+            Assert.IsFalse(buttonPressCompleted, "Button press release did not trigger.");
+
+            yield return hand.Hide();
+        }
+
+        /// <summary>
+        /// Tests if interaction triggered by far pointer on interactable object is reset after scroll is engaged
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ScrollEngageResetsFarInteractionwithChildren()
+        {          
+            // Setting up scroll view object with two pressable button children
+            GameObject scrollObject = new GameObject();
+            float scale = 10f;
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.localScale *= scale;
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.localScale *= scale;
+            button2.transform.parent = scrollObject.transform;
+
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
+            scrollView.Tiers = 1;
+            scrollView.ViewableArea = 1;
+            scrollView.HandDeltaMagThreshold = scrollView.CellHeight * 0.2f;
+            scrollView.UpdateCollection();
+
+            scrollObject.transform.position = Vector3.forward;
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            Interactable interactableComponent1 = button1.GetComponent<Interactable>();
+
+            Assert.IsNotNull(interactableComponent1);
+
+            bool scrollDragBegin = false;
+            scrollView.ListMomentumBegin.AddListener(() =>
+            {
+                scrollDragBegin = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 buttonPos = interactableComponent1.transform.position;
+            Vector3 startHandPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
+            Vector3 onScrollEngagedPos = startHandPos + new Vector3(0, -(scrollView.HandDeltaMagThreshold + offset), 0); // Engaging in scroll drag
+
+            // If scroll drag not yet engaged child button interaction should behave normally
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(startHandPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
+            Assert.IsTrue(interactableComponent1.HasPress, "Interactable did not get press from far interaction.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered");
+            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
+            Assert.IsFalse(interactableComponent1.HasPress, "Interactable still have press from far interaction.");
+
+            // Scroll drag engage should halt interaction with any child button 
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
+            Assert.IsTrue(interactableComponent1.HasPress, "Interactable did not get press from far interaction.");
+
+            yield return hand.MoveTo(onScrollEngagedPos);
+
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin was not triggered");
+            Assert.IsFalse(interactableComponent1.HasFocus, "Interactable still have far pointer focus.");
+            Assert.IsFalse(interactableComponent1.HasPress, "Interactable still have press from far interaction.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.Hide();
+        }
+
+        #endregion Tests
+
+        #region Utilities
+
+        private GameObject InstantiatePrefab(string path)
+        {
+            Object buttonPrefab = AssetDatabase.LoadAssetAtPath(path, typeof(Object));
+            GameObject button = Object.Instantiate(buttonPrefab) as GameObject;
+
+            return button;
+        }
+
+        #endregion Utilities
+    }
+}

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs
@@ -18,12 +18,13 @@ namespace Microsoft.MixedReality.Toolkit.Tests
         #region Tests
 
         /// <summary>
-        /// Tests if interaction with a pressable button is reset after scroll drag is engaged
+        /// Tests if near interaction with a pressable button item is reset after the user engages in a scroll drag.
+        /// User should be able to interact with other buttons right after scroll engage is finished.
         /// </summary>
         [UnityTest]
-        public IEnumerator ScrollEngageResetsNearInteractionwithChildren()
+        public IEnumerator ScrollEngageResetsNearInteractionWithChildren()
         {
-            // Setting up scroll view object with two pressable button children
+            // Setting up three pressable buttons as scroll items
             GameObject scrollObject = new GameObject();
 
             GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
@@ -35,44 +36,71 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
             button3.transform.parent = scrollObject.transform;
 
+            // Setting up a vertical 2x1 scroll view. The first two items are visible
             var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
             scrollView.Tiers = 1;
             scrollView.ViewableArea = 2;
-            scrollView.HandDeltaMagThreshold = scrollView.CellHeight * 0.2f;
             scrollView.UpdateCollection();
-
+            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
             scrollObject.transform.position = Vector3.forward;
+
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            PressableButton buttonComponent = button1.GetComponentInChildren<PressableButton>();
+            PressableButton button1Component = button1.GetComponentInChildren<PressableButton>();
+            PressableButton button2Component = button2.GetComponentInChildren<PressableButton>();
 
-            Assert.IsNotNull(buttonComponent);
+            Assert.IsNotNull(button1Component);
+            Assert.IsNotNull(button2Component);
 
-            bool buttonTouchBegin = false;
-            buttonComponent.TouchBegin.AddListener(() =>
+            bool button1TouchBegin = false;
+            button1Component.TouchBegin.AddListener(() =>
             {
-                buttonTouchBegin = true;
+                button1TouchBegin = true;
             });
 
-            bool buttonTouchEnd = false;
-            buttonComponent.TouchEnd.AddListener(() =>
+            bool button1TouchEnd = false;
+            button1Component.TouchEnd.AddListener(() =>
             {
-                buttonTouchEnd = true;
+                button1TouchEnd = true;
             });
 
-            bool buttonPressBegin = false;
-            buttonComponent.ButtonPressed.AddListener(() =>
+            bool button1PressBegin = false;
+            button1Component.ButtonPressed.AddListener(() =>
             {
-                buttonPressBegin = true;
+                button1PressBegin = true;
             });
 
-            bool buttonPressCompleted = false;
-            buttonComponent.ButtonReleased.AddListener(() =>
+            bool button1PressCompleted = false;
+            button1Component.ButtonReleased.AddListener(() =>
             {
-                buttonPressCompleted = true;
+                button1PressCompleted = true;
+            });
+
+            bool button2TouchBegin = false;
+            button2Component.TouchBegin.AddListener(() =>
+            {
+                button2TouchBegin = true;
+            });
+
+            bool button2TouchEnd = false;
+            button2Component.TouchEnd.AddListener(() =>
+            {
+                button2TouchEnd = true;
+            });
+
+            bool button2PressBegin = false;
+            button2Component.ButtonPressed.AddListener(() =>
+            {
+                button2PressBegin = true;
+            });
+
+            bool button2PressCompleted = false;
+            button2Component.ButtonReleased.AddListener(() =>
+            {
+                button2PressCompleted = true;
             });
 
             bool scrollDragBegin = false;
@@ -83,56 +111,68 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Hand positions
             float offset = 0.001f;
-            Vector3 buttonPos = buttonComponent.transform.position;
-            Vector3 startHandPos = buttonPos + new Vector3(0, 0, buttonComponent.StartPushDistance - offset); // Just before touch
-            Vector3 onPressPos = buttonPos + new Vector3(0, 0, buttonComponent.PressDistance + offset); // Past press plane         
-            Vector3 onScrollEngagedPos = onPressPos + new Vector3(0, -(scrollView.HandDeltaMagThreshold + offset), 0); // Engaging in scroll drag
+            Vector3 initialPos = Vector3.zero;
+            Vector3 preButtonTouchPos = button1Component.transform.position + new Vector3(0, 0, button1Component.StartPushDistance - offset);
+            Vector3 postButtonPressPos = button1Component.transform.position + new Vector3(0, 0, button1Component.PressDistance + offset);     
+            Vector3 scrollEngagedPos = postButtonPressPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset);
 
-            // If scroll drag not yet engaged then child button interaction should behave normally
+            // Interaction with child button should behave normally if scroll drag not yet engaged
             TestHand hand = new TestHand(Handedness.Right);
-            yield return hand.Show(startHandPos);
-            yield return hand.MoveTo(onPressPos);
-            yield return hand.MoveTo(startHandPos);
+            yield return hand.Show(initialPos);
+            yield return hand.MoveTo(preButtonTouchPos);
+            yield return hand.MoveTo(postButtonPressPos);
+            yield return hand.MoveTo(initialPos);
 
             Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
-            Assert.IsTrue(buttonTouchBegin, "Button touch begin did not trigger.");
-            Assert.IsTrue(buttonPressBegin, "Button press begin did not trigger.");
-            Assert.IsTrue(buttonPressCompleted, "Button press release did not trigger.");
+            Assert.IsTrue(button1TouchBegin, "Button1 touch begin did not trigger.");
+            Assert.IsTrue(button1PressBegin, "Button1 press begin did not trigger.");
+            Assert.IsTrue(button1PressCompleted, "Button1 press release did not trigger.");
+            Assert.IsTrue(button1TouchEnd, "Button1 touch end did not trigger.");
 
-            yield return hand.Hide();
-
-            Assert.IsTrue(buttonTouchEnd, "Button touch end did not trigger.");
-
-            // Reset values
-            buttonTouchBegin = false;
-            buttonTouchEnd = false;
-            buttonPressBegin = false;
-            buttonPressCompleted = false;
             scrollDragBegin = false;
+            button1TouchBegin = false;
+            button1PressBegin = false;
+            button1PressCompleted = false;
+            button1TouchEnd = false;
 
-            // Scroll drag engage should halt interaction with any child button            
-            yield return hand.Show(startHandPos);
-            yield return hand.MoveTo(onPressPos);
+            // Scroll drag engage should halt interaction with child button                
+            yield return hand.MoveTo(preButtonTouchPos);
+            yield return hand.MoveTo(postButtonPressPos);
             
-            Assert.IsTrue(buttonTouchBegin, "Button touch begin did not trigger.");
-            Assert.IsTrue(buttonPressBegin, "Button press begin did not trigger.");
+            Assert.IsTrue(button1TouchBegin, "Button1 touch begin did not trigger.");
+            Assert.IsTrue(button1PressBegin, "Button1 press begin did not trigger.");
 
-            yield return hand.MoveTo(onScrollEngagedPos);
+            yield return hand.MoveTo(scrollEngagedPos);
 
-            Assert.IsTrue(scrollDragBegin, "Scroll drag begin dit not trigger.");
-            Assert.IsTrue(buttonTouchEnd, "Button touch end did not trigger.");
-            Assert.IsFalse(buttonPressCompleted, "Button press release did not trigger.");
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin did not trigger.");
+            Assert.IsTrue(button1TouchEnd, "Button1 touch end did not trigger.");
+            Assert.IsTrue(button1PressCompleted, "Button1 press release did not trigger.");
+
+            yield return hand.MoveTo(initialPos);
+
+            Assert.IsFalse(scrollView.IsEngaged);
+
+            // Interaction with other children buttons should behave normally after scroll drag engage is finished
+            yield return hand.MoveTo(preButtonTouchPos);
+            yield return hand.MoveTo(postButtonPressPos);
+            yield return hand.MoveTo(initialPos);
+
+            Assert.IsTrue(button2TouchBegin, "Button2 touch begin did not trigger.");
+            Assert.IsTrue(button2PressBegin, "Button2 press begin did not trigger.");
+            Assert.IsTrue(button2PressCompleted, "Button2 press release did not trigger.");
+            Assert.IsTrue(button2TouchEnd, "Button2 touch end did not trigger.");
 
             yield return hand.Hide();
         }
 
         /// <summary>
-        /// Tests if interaction triggered by far pointer on interactable object is reset after scroll is engaged
+        /// Tests if far interaction with a pressable button item is reset after the user engages in a scroll drag.
+        /// User should be able to interact with other buttons right after scroll engage is finished.
         /// </summary>
         [UnityTest]
-        public IEnumerator ScrollEngageResetsFarInteractionwithChildren()
-        {          
-            // Setting up scroll view object with two pressable button children
+        public IEnumerator ScrollEngageResetsFarInteractionWithChildren()
+        {
+            // Setting up two pressable buttons as scroll items
             GameObject scrollObject = new GameObject();
             float scale = 10f;
 
@@ -144,21 +184,24 @@ namespace Microsoft.MixedReality.Toolkit.Tests
             button2.transform.localScale *= scale;
             button2.transform.parent = scrollObject.transform;
 
+            // Setting up a vertical 1x1 scroll view 
             var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
             scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
             scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
             scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
             scrollView.Tiers = 1;
             scrollView.ViewableArea = 1;
-            scrollView.HandDeltaMagThreshold = scrollView.CellHeight * 0.2f;
             scrollView.UpdateCollection();
-
+            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
             scrollObject.transform.position = Vector3.forward;
+
             TestUtilities.PlayspaceToOriginLookingForward();
 
-            Interactable interactableComponent1 = button1.GetComponent<Interactable>();
+            Interactable interactable1 = button1.GetComponent<Interactable>();
+            Interactable interactable2 = button2.GetComponent<Interactable>();
 
-            Assert.IsNotNull(interactableComponent1);
+            Assert.IsNotNull(interactable1);
+            Assert.IsNotNull(interactable2);
 
             bool scrollDragBegin = false;
             scrollView.ListMomentumBegin.AddListener(() =>
@@ -168,39 +211,175 @@ namespace Microsoft.MixedReality.Toolkit.Tests
 
             // Hand positions
             float offset = 0.001f;
-            Vector3 buttonPos = interactableComponent1.transform.position;
-            Vector3 startHandPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
-            Vector3 onScrollEngagedPos = startHandPos + new Vector3(0, -(scrollView.HandDeltaMagThreshold + offset), 0); // Engaging in scroll drag
+            Vector3 initialPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
+            Vector3 scrollEngagedPos = initialPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight  + offset);
 
-            // If scroll drag not yet engaged child button interaction should behave normally
+            // Interaction with child button should behave normally if scroll drag not yet engaged
             TestHand hand = new TestHand(Handedness.Right);
-            yield return hand.Show(startHandPos);
+            yield return hand.Show(initialPos);
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
 
             Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
-            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
-            Assert.IsTrue(interactableComponent1.HasPress, "Interactable did not get press from far interaction.");
+            Assert.IsTrue(interactable1.HasFocus, "Interactable1 does not have far pointer focus.");
+            Assert.IsTrue(interactable1.HasPress, "Interactable1 did not get press from far interaction.");
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
 
             Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered");
-            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
-            Assert.IsFalse(interactableComponent1.HasPress, "Interactable still have press from far interaction.");
+            Assert.IsTrue(interactable1.HasFocus, "Interactable1 does not have far pointer focus.");
+            Assert.IsFalse(interactable1.HasPress, "Interactable1 still have press from far interaction.");
 
-            // Scroll drag engage should halt interaction with any child button 
+            // Scroll drag engage should halt interaction with child button 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
             
             Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
-            Assert.IsTrue(interactableComponent1.HasFocus, "Interactable does not have far pointer focus.");
-            Assert.IsTrue(interactableComponent1.HasPress, "Interactable did not get press from far interaction.");
+            Assert.IsTrue(interactable1.HasFocus, "Interactable1 does not have far pointer focus.");
+            Assert.IsTrue(interactable1.HasPress, "Interactable1 did not get press from far interaction.");
 
-            yield return hand.MoveTo(onScrollEngagedPos);
+            yield return hand.MoveTo(scrollEngagedPos);            
+            yield return new WaitForSeconds(interactable1.RollOffTime); // Wait for interactable has press roll off
 
             Assert.IsTrue(scrollDragBegin, "Scroll drag begin was not triggered");
-            Assert.IsFalse(interactableComponent1.HasFocus, "Interactable still have far pointer focus.");
-            Assert.IsFalse(interactableComponent1.HasPress, "Interactable still have press from far interaction.");
+            Assert.IsFalse(interactable1.HasFocus, "Interactable1 still have far pointer focus.");
+            Assert.IsFalse(interactable1.HasPress, "Interactable1 still have press from far interaction.");
 
             yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+
+            Assert.IsFalse(scrollView.IsEngaged);
+
+            // Interaction with other children buttons should behave normally after scroll drag engage is finished
+            yield return hand.MoveTo(initialPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+
+            Assert.IsTrue(interactable2.HasFocus, "Interactable2 does not have far pointer focus.");
+            Assert.IsTrue(interactable2.HasPress, "Interactable2 did not get press from far interaction.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);
+            yield return hand.Hide();
+        }
+
+        /// <summary>
+        /// Tests if interaction with a pressable button child triggers an undesired jump or scroll drag.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator NoJumpsWhenInteractingWithChildren()
+        {
+            // Setting up three pressable buttons as scroll items
+            GameObject scrollObject = new GameObject();
+            float scale = 10f;
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.localScale *= scale;
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.localScale *= scale;
+            button2.transform.parent = scrollObject.transform;
+
+            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button3.transform.localScale *= scale;
+            button3.transform.parent = scrollObject.transform;
+
+            // Setting up a vertical 2x1 scroll view
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x * scale;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y * scale;
+            scrollView.Tiers = 1;
+            scrollView.ViewableArea = 2;
+            scrollView.UpdateCollection();
+            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
+            scrollObject.transform.position = new Vector3(0, scrollView.CellHeight, 1.0f);
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            bool scrollDragBegin = false;
+            scrollView.ListMomentumBegin.AddListener(() =>
+            {
+                scrollDragBegin = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 initialPos = new Vector3(0.13f, -0.17f, 0.5f); // Far pointer focus is on button       
+            Vector3 scrollEngagedPos = initialPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset);
+
+            // Interaction with child button should behave normally if scroll drag not yet engaged
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialPos);
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Pinch);
+            yield return new WaitForSeconds(1.0f); // Waiting for possible timed drag trigger
+
+            Assert.IsFalse(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.AreEqual(scrollView.ScrollContainerPosition.y, 0, "Scroll container has moved.");
+
+            yield return hand.SetGesture(ArticulatedHandPose.GestureId.Open);           
+            yield return hand.Hide();
+        }
+
+        /// <summary>
+        /// Tests scroll drag engage by interacting with the background empty space of a scroll view 
+        /// </summary>
+        [UnityTest]
+        public IEnumerator InteractionWithBackgroundEmptySpace()
+        {
+            // Setting up three pressable buttons as scroll items
+            GameObject scrollObject = new GameObject();
+
+            GameObject button1 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button1.transform.parent = scrollObject.transform;
+
+            GameObject button2 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button2.transform.parent = scrollObject.transform;
+
+            GameObject button3 = InstantiatePrefab(TestButtonUtilities.PressableHoloLens2PrefabPath);
+            button3.transform.parent = scrollObject.transform;
+
+            // Setting up a vertical 2x1 scroll view where second row has one button and one empty slot
+            var scrollView = scrollObject.AddComponent<ScrollingObjectCollection>();
+            scrollView.ScrollDirection = ScrollingObjectCollection.ScrollDirectionType.UpAndDown;
+            scrollView.CellWidth = button1.GetComponent<NearInteractionTouchable>().Bounds.x;
+            scrollView.CellHeight = button1.GetComponent<NearInteractionTouchable>().Bounds.y;
+            scrollView.Tiers = 2;
+            scrollView.ViewableArea = 1;
+            scrollView.UpdateCollection();
+            scrollView.TypeOfVelocity = ScrollingObjectCollection.VelocityType.NoVelocitySnapToItem;
+            scrollObject.transform.position = Vector3.forward;
+
+            TestUtilities.PlayspaceToOriginLookingForward();
+
+            bool scrollDragBegin = false;
+            scrollView.ListMomentumBegin.AddListener(() =>
+            {
+                scrollDragBegin = true;
+            });
+
+            // Hand positions
+            float offset = 0.001f;
+            Vector3 initialPos = Vector3.zero;
+            Vector3 scrollTouchPos = button2.transform.position + Vector3.forward * 0.015f; // Touching scroll second colum slot        
+            Vector3 scrollEngagedUpPos = scrollTouchPos + Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset); // Scrolls up one row
+            Vector3 scrollEngagedDownPos = scrollTouchPos - Vector3.up * (scrollView.HandDeltaMagThreshold + scrollView.CellHeight + offset); // Scrolls down one row
+
+            // Scrolls up from button to reveal second row with empty slot 
+            TestHand hand = new TestHand(Handedness.Right);
+            yield return hand.Show(initialPos);
+            yield return hand.MoveTo(scrollTouchPos);
+            yield return hand.MoveTo(scrollEngagedUpPos);
+            yield return hand.MoveTo(initialPos);
+
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.AreEqual(scrollView.ScrollContainerPosition.y, scrollView.CellHeight, 0.001, "Scroll container has not moved to second row.");
+
+            // Reset drag and scrolls down from empty space
+            scrollDragBegin = false;
+
+            yield return hand.MoveTo(scrollTouchPos);
+            yield return hand.MoveTo(scrollEngagedDownPos);
+
+            Assert.IsTrue(scrollDragBegin, "Scroll drag begin was triggered.");
+            Assert.AreEqual(scrollView.ScrollContainerPosition.y, 0, 0.001, "Scroll container has not moved to first row.");
+
             yield return hand.Hide();
         }
 

--- a/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs.meta
+++ b/Assets/MRTK/Tests/PlayModeTests/ScrollViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 521754bf45dc6e149978d1e7b7a907e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
This PR is part of Scroll View graduation and addresses the following issues / fixes:

 #7444, #7445, #7447 .
- **Issue:** When user engage in a scroll drag, pointer, touch, and input event data have eventData.used set to true on Scroll Object Collection. MixedRealityInputSystem halts event dispatch if event data is used by global listener, so children buttons cannot proper receive OnTouchCompleted events. 
- **Fix:** using propagation event routing, events dispatch is not stopped when eventdata.used == true. Tests added.
![scroll_reset_before](https://user-images.githubusercontent.com/16922045/85422373-6fcd2700-b56d-11ea-9bb4-9d19e5ce62fd.gif)

 #7446 .
- **Issue:** Scroll engage should trigger children interaction reset
- **Fix:** Instead of directly accessing children code, focus on children is unlocked and moved to a scroll background collider setup on runtime. Tests added.

 #8068 .
- **Issue:** Scroll View should allow for engage with empty background areas
- **Fix:** the scroll view now has a near touchable setup during runtime to receive focus and enable catch of events from empty areas without the need for global event subscription. Tests added.
 ![scroll_empty_before](https://user-images.githubusercontent.com/16922045/85419058-81143480-b569-11ea-98da-9bd60d0a4582.gif) 

#7448 .
- **Issue:** Sometimes Scroll position jumps when interacting with children.
- **Fix:** Removed timed check for detection of drag and zeroed hand delta when drag scroll starts. Tests added.
![scroll_jump_before](https://user-images.githubusercontent.com/16922045/85420673-6cd13700-b56b-11ea-8aac-6fb795391e95.gif)

## Other changes

- **Pointer event handler workaround** - 
ScrollObjectCollection was subscribing as a global listener for pointer events. During pointer event handling a check for event target in the list of scroll children was also required. To improve performance a proposed workaround makes global registration only temporary in between a pointer down and a pointer up. Other solution ideas are welcome.

- Deleted input handler implementation as no need to talk directly with interactable.cs children
- pointer handler interface only receives propagation events, but register for global when drag starts
- Changed velocityMultiplier and handDeltaMagThreshould to incorporate magic numbers
- Changed velocityMultiplier and handDeltaMagThreshould default values on demo scenes and prefabs
- Exposed ScrollObjectCollection isEngaged for tests

This PR is based on the Event Propagation feature branch.

- Fixes #7444
- Fixes #7445 
- Fixes #7446 
- Fixes #8068 
- Fixes #7447
- Fixes #7448 
  
