### PR TITLE
BoundsExtensions compute bounds relative to another transform

### DIFF
--- a/Assets/MRTK/Core/Extensions/BoundsExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/BoundsExtensions.cs
@@ -427,6 +427,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="target">gameObject that boundingBox bounds.</param>
         /// <param name="boundsPoints">array reference that gets filled with points</param>
         /// <param name="ignoreLayers">layerMask to simplify search</param>
+        /// <param name="relativeTo">compute bounds relative to this transform</param>
         public static void GetColliderBoundsPoints(GameObject target, List<Vector3> boundsPoints, LayerMask ignoreLayers, Transform relativeTo = null)
         {
             Collider[] colliders = target.GetComponentsInChildren<Collider>();

--- a/Assets/MRTK/Core/Extensions/BoundsExtensions.cs
+++ b/Assets/MRTK/Core/Extensions/BoundsExtensions.cs
@@ -427,14 +427,26 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="target">gameObject that boundingBox bounds.</param>
         /// <param name="boundsPoints">array reference that gets filled with points</param>
         /// <param name="ignoreLayers">layerMask to simplify search</param>
-        public static void GetColliderBoundsPoints(GameObject target, List<Vector3> boundsPoints, LayerMask ignoreLayers)
+        public static void GetColliderBoundsPoints(GameObject target, List<Vector3> boundsPoints, LayerMask ignoreLayers, Transform relativeTo = null)
         {
             Collider[] colliders = target.GetComponentsInChildren<Collider>();
             for (int i = 0; i < colliders.Length; i++)
             {
-                GetColliderBoundsPoints(colliders[i], boundsPoints, ignoreLayers);
+                GetColliderBoundsPoints(colliders[i], boundsPoints, ignoreLayers, relativeTo);
             }
         }
+
+        private static void InverseTransformPoints(ref Vector3[] positions, Transform relativeTo)	 
+        {	 	 
+            if (relativeTo)	 	 
+            {	 	 
+                for (var i = 0; i < positions.Length; ++i)	 	 
+                {	 	 
+                    positions[i] = relativeTo.InverseTransformPoint(positions[i]);	 	 
+                }	 	 
+            }	 	 
+        }
+
 
         /// <summary>
         /// Method to get bounds from a single Collider
@@ -442,7 +454,7 @@ namespace Microsoft.MixedReality.Toolkit
         /// <param name="collider">Target collider</param>
         /// <param name="boundsPoints">array reference that gets filled with points</param>
         /// <param name="ignoreLayers">layerMask to simplify search</param>
-        public static void GetColliderBoundsPoints(Collider collider, List<Vector3> boundsPoints, LayerMask ignoreLayers)
+        public static void GetColliderBoundsPoints(Collider collider, List<Vector3> boundsPoints, LayerMask ignoreLayers, Transform relativeTo = null)
         {
             if (ignoreLayers == (1 << collider.gameObject.layer | ignoreLayers)) { return; }
 
@@ -451,6 +463,7 @@ namespace Microsoft.MixedReality.Toolkit
                 SphereCollider sc = collider as SphereCollider;
                 Bounds sphereBounds = new Bounds(sc.center, Vector3.one * sc.radius * 2);
                 sphereBounds.GetFacePositions(sc.transform, ref corners);
+                InverseTransformPoints(ref corners, relativeTo);
                 boundsPoints.AddRange(corners);
             }
             else if (collider is BoxCollider)
@@ -458,6 +471,7 @@ namespace Microsoft.MixedReality.Toolkit
                 BoxCollider bc = collider as BoxCollider;
                 Bounds boxBounds = new Bounds(bc.center, bc.size);
                 boxBounds.GetCornerPositions(bc.transform, ref corners);
+                InverseTransformPoints(ref corners, relativeTo);
                 boundsPoints.AddRange(corners);
 
             }
@@ -466,6 +480,7 @@ namespace Microsoft.MixedReality.Toolkit
                 MeshCollider mc = collider as MeshCollider;
                 Bounds meshBounds = mc.sharedMesh.bounds;
                 meshBounds.GetCornerPositions(mc.transform, ref corners);
+                InverseTransformPoints(ref corners, relativeTo);
                 boundsPoints.AddRange(corners);
             }
             else if (collider is CapsuleCollider)
@@ -487,6 +502,7 @@ namespace Microsoft.MixedReality.Toolkit
                         break;
                 }
                 capsuleBounds.GetFacePositions(cc.transform, ref corners);
+                InverseTransformPoints(ref corners, relativeTo);
                 boundsPoints.AddRange(corners);
             }
         }

--- a/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using NUnit.Framework;
+using System.Collections.Generic;
+using UnityEngine;
+using Microsoft.MixedReality.Toolkit;
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.MixedReality.Toolkit.OpenVR.Headers;
+
+namespace Microsoft.MixedReality.Toolkit.Tests.EditMode.Extensions
+{
+    public class BoundsExtensionsTests
+    {
+        List<Vector3> boundsPoints = new List<Vector3>();
+        GameObject cube;
+        Vector3[] expectedPoints;
+        string path;
+
+        [SetUp]
+        public void SetUp()
+        {
+            cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = Vector3.zero;
+            cube.transform.rotation = Quaternion.identity;
+            boundsPoints.Clear();
+            var timestr = DateTime.UtcNow.ToString("yyMMdd-HHmmss");
+            path = Path.Combine(Application.persistentDataPath, $"BoundsExtensionsTests-{timestr}.txt");
+        }
+
+        private void WriteBoundsPointsToFile()
+        {
+            using (var writer = new StreamWriter(path, true))
+            {
+                writer.WriteLine();
+                writer.WriteLine("expectedPoints = new Vector3[] {");
+                boundsPoints.ForEach((pt) => writer.WriteLine($"\tnew Vector3({pt.x}f, {pt.y}f, {pt.z}f),"));
+                writer.WriteLine("};");
+            }
+        }
+
+        [Test]
+        public void GetColliderBoundsPoints()
+        {
+            // SetUp
+            expectedPoints = new Vector3[] {
+                new Vector3(-0.5f, -0.5f, -0.5f),
+                new Vector3(-0.5f, -0.5f, 0.5f),
+                new Vector3(-0.5f, 0.5f, -0.5f),
+                new Vector3(-0.5f, 0.5f, 0.5f),
+                new Vector3(0.5f, -0.5f, -0.5f),
+                new Vector3(0.5f, -0.5f, 0.5f),
+                new Vector3(0.5f, 0.5f, -0.5f),
+                new Vector3(0.5f, 0.5f, 0.5f),
+            };
+
+            BoundsExtensions.GetColliderBoundsPoints(cube, boundsPoints, 0);
+
+            Assert.AreEqual(expectedPoints, boundsPoints.ToArray());
+
+            boundsPoints.Clear();
+            cube.transform.localScale = Vector3.one * 2f;
+            BoundsExtensions.GetColliderBoundsPoints(cube, boundsPoints, 0);
+            expectedPoints = new Vector3[] {
+                new Vector3(-1f, -1f, -1f),
+                new Vector3(-1f, -1f, 1f),
+                new Vector3(-1f, 1f, -1f),
+                new Vector3(-1f, 1f, 1f),
+                new Vector3(1f, -1f, -1f),
+                new Vector3(1f, -1f, 1f),
+                new Vector3(1f, 1f, -1f),
+                new Vector3(1f, 1f, 1f),
+            };
+            Assert.AreEqual(expectedPoints, boundsPoints.ToArray());
+
+            boundsPoints.Clear();
+            cube.transform.localScale = new Vector3(10, 1, 1);
+            BoundsExtensions.GetColliderBoundsPoints(cube, boundsPoints, 0);
+
+            expectedPoints = new Vector3[] {
+                new Vector3(-5f, -0.5f, -0.5f),
+                new Vector3(-5f, -0.5f, 0.5f),
+                new Vector3(-5f, 0.5f, -0.5f),
+                new Vector3(-5f, 0.5f, 0.5f),
+                new Vector3(5f, -0.5f, -0.5f),
+                new Vector3(5f, -0.5f, 0.5f),
+                new Vector3(5f, 0.5f, -0.5f),
+                new Vector3(5f, 0.5f, 0.5f),
+            };
+
+            Assert.AreEqual(expectedPoints, boundsPoints.ToArray());
+        }
+
+        [Test]
+        public void GetColliderBoundsPointsRelativeTo()
+        {
+            var relativeTo = new GameObject();
+            relativeTo.transform.position = Vector3.forward;
+            relativeTo.transform.rotation = Quaternion.identity;
+
+            BoundsExtensions.GetColliderBoundsPoints(cube, boundsPoints, 0, relativeTo.transform);
+            expectedPoints = new Vector3[] {
+                new Vector3(-0.5f, -0.5f, -1.5f),
+                new Vector3(-0.5f, -0.5f, -0.5f),
+                new Vector3(-0.5f, 0.5f, -1.5f),
+                new Vector3(-0.5f, 0.5f, -0.5f),
+                new Vector3(0.5f, -0.5f, -1.5f),
+                new Vector3(0.5f, -0.5f, -0.5f),
+                new Vector3(0.5f, 0.5f, -1.5f),
+                new Vector3(0.5f, 0.5f, -0.5f),
+            };
+            Assert.AreEqual(expectedPoints, boundsPoints.ToArray());
+
+            boundsPoints.Clear();
+            relativeTo.transform.localScale = 0.5f * Vector3.one;
+            BoundsExtensions.GetColliderBoundsPoints(cube, boundsPoints, 0, relativeTo.transform);
+            expectedPoints = new Vector3[] {
+                new Vector3(-1f, -1f, -3f),
+                new Vector3(-1f, -1f, -1f),
+                new Vector3(-1f, 1f, -3f),
+                new Vector3(-1f, 1f, -1f),
+                new Vector3(1f, -1f, -3f),
+                new Vector3(1f, -1f, -1f),
+                new Vector3(1f, 1f, -3f),
+                new Vector3(1f, 1f, -1f),
+            };
+            Assert.AreEqual(expectedPoints, boundsPoints.ToArray());
+        }
+    }
+}

--- a/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs.meta
+++ b/Assets/MRTK/Tests/EditModeTests/Core/Extensions/BoundsExtensionsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c968b81d5375cb642983439d57c38fa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
Add optional parameter to BoundsExtensions.ComputeBoundsPoints to compute bounds relative to another transform.

Also create a new test file for BoundsExtensions, and add two small tests to BoundsExtensions, including one to verify this change.

## Changes
- Fixes: #8089 
