### PR TITLE
Turn off head gaze override by default

### DIFF
--- a/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
+++ b/Assets/MRTK/Core/Definitions/InputSystem/MixedRealityPointerProfile.cs
@@ -73,7 +73,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("If true, platform-specific head gaze override is used, when available. Otherwise, the center of the camera frame is used by default.")]
-        private bool useHeadGazeOverride = true;
+        private bool useHeadGazeOverride = false;
 
         /// <summary>
         /// If true, platform-specific head gaze override is used, when available. Otherwise, the center of the camera frame is used by default.

--- a/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
+++ b/Assets/MRTK/Examples/Demos/EyeTracking/General/Profiles/EyeTrackingDemoPointerProfile.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  useHeadGazeOverride: 1
+  useHeadGazeOverride: 0
   isEyeTrackingEnabled: 1
   pointerOptions:
   - controllerType: 256

--- a/Assets/MRTK/Examples/Demos/Input/Scenes/DisablePointers/DisablePointersExamplePointerProfile.asset
+++ b/Assets/MRTK/Examples/Demos/Input/Scenes/DisablePointers/DisablePointersExamplePointerProfile.asset
@@ -28,7 +28,7 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  useHeadGazeOverride: 1
+  useHeadGazeOverride: 0
   isEyeTrackingEnabled: 0
   pointerOptions:
   - controllerType: 1071

--- a/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubPointerProfile.asset
+++ b/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubPointerProfile.asset
@@ -28,7 +28,7 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  useHeadGazeOverride: 1
+  useHeadGazeOverride: 0
   isEyeTrackingEnabled: 0
   pointerOptions:
   - controllerType: 1071

--- a/Assets/MRTK/Examples/Experimental/NonNativeKeyboard/Profiles/NonNativeKeyboardMixedRealityInputPointerProfile.asset
+++ b/Assets/MRTK/Examples/Experimental/NonNativeKeyboard/Profiles/NonNativeKeyboardMixedRealityInputPointerProfile.asset
@@ -28,7 +28,7 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  useHeadGazeOverride: 1
+  useHeadGazeOverride: 0
   isEyeTrackingEnabled: 0
   pointerOptions:
   - controllerType: 1071

--- a/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
+++ b/Assets/MRTK/SDK/Profiles/DefaultMixedRealityInputPointerProfile.asset
@@ -28,7 +28,7 @@ MonoBehaviour:
     type: 3}
   gazeProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
-  useHeadGazeOverride: 1
+  useHeadGazeOverride: 0
   isEyeTrackingEnabled: 0
   pointerOptions:
   - controllerType: 1071


### PR DESCRIPTION
## Overview

As the platform feature begins roll-out, it'd be best to allow this feature to be opt-in until broad deployment of the feature is achieved.

Request from the platform team.