### PR TITLE
Make the RemoveController API public so that applications can work around stale sources when the app is paused

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -726,7 +726,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// Remove the selected controller from the Active Store
         /// </summary>
         /// <param name="interactionSourceState">Source State provided by the SDK to remove</param>
-        public void RemoveController(InteractionSource interactionSource)
+        private void RemoveController(InteractionSource interactionSource)
         {
             var controller = GetOrAddController(interactionSource, false);
 
@@ -746,6 +746,12 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
             }
 
             activeControllers.Remove(interactionSource.id);
+        }
+
+        [Obsolete("This function exists to workaround a bug in Unity and will be removed in an upcoming release. For more details, see https://github.com/microsoft/MixedRealityToolkit-Unity/pull/8101")]
+        public void RemoveControllerForSuspendWorkaround(InteractionSource interactionSource)
+        {
+            RemoveController(interactionSource);
         }
 
         #endregion Controller Utilities

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealityDeviceManager.cs
@@ -726,7 +726,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         /// Remove the selected controller from the Active Store
         /// </summary>
         /// <param name="interactionSourceState">Source State provided by the SDK to remove</param>
-        private void RemoveController(InteractionSource interactionSource)
+        public void RemoveController(InteractionSource interactionSource)
         {
             var controller = GetOrAddController(interactionSource, false);
 


### PR DESCRIPTION
## Overview
When Unity is paused and then resumed, the InteractionManager gets in a bad state, and some InteractionSources never have their SourceLost event raised even if the sources are no longer relevant. This change is making the RemoveController API public so that applications like Remote Assist can work around this problem while waiting for a proper fix from Unity.

Here's the additional code we plan to add to our application as part of this workaround:

```
public class StaleInteractionSourceMonitor : MonoBehaviour
{
    private static readonly TimeSpan staleSourceWaitTime = TimeSpan.FromMilliseconds(500);
    private CancellationTokenSource cancelInteractionSourceCleanup;

    private void OnApplicationPause(bool pause)
    {
        this.cancelInteractionSourceCleanup?.Cancel();

        if (!pause)
        {
            this.cancelInteractionSourceCleanup = new CancellationTokenSource();
            CheckForStaleSourcesAsync(this.cancelInteractionSourceCleanup.Token);
        }
    }

    private static HashSet<InteractionSource> GetCurrentSources()
    {
        var interactionSources = new HashSet<InteractionSource>();
        foreach (var interactionSourceState in InteractionManager.GetCurrentReading())
        {
            interactionSources.Add(interactionSourceState.source);
        }

        return interactionSources;
    }

    private async void CheckForStaleSourcesAsync(CancellationToken cancellationToken)
    {
        HashSet<InteractionSource> potentiallyStaleSources = GetCurrentSources();
        Action<InteractionSourceLostEventArgs> sourceLost = e =>
        {
            potentiallyStaleSources.Remove(e.state.source);
        };

        InteractionManager.InteractionSourceLost += sourceLost;
        await Task.Delay(staleSourceWaitTime, cancellationToken);
        InteractionManager.InteractionSourceLost -= sourceLost;

        if (cancellationToken.IsCancellationRequested)
        {
            return;
        }

        HashSet<InteractionSource> stillRelevantSources = GetCurrentSources();

        var deviceManager = CoreServices.GetInputSystemDataProvider<WindowsMixedRealityDeviceManager>();
        if (deviceManager != null)
        {
            foreach (InteractionSource staleSource in potentiallyStaleSources)
            {
                if (!stillRelevantSources.Contains(staleSource))
                {
                    Debug.Log($"Removing a stale source {staleSource.id}");
                    deviceManager.RemoveController(staleSource);
                }
                else
                {
                    Debug.Log("$Potentially stale source was still relevant, keeping it");
                }
            }
        }
        else
        {
            Debug.LogError("Failed to get the WindowsMixedRealityDeviceManager");
        }
    }
}
```