### PR TITLE
Modify how spatial mesh updates are handled

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/WindowsMixedRealitySpatialMeshObserver.cs
@@ -677,13 +677,18 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.SpatialAwareness
                 bool sendUpdatedEvent = false;
                 if (meshes.ContainsKey(cookedData.id.handle))
                 {
-                    // Reclaim the old mesh object for future use.
-                    ReclaimMeshObject(meshes[cookedData.id.handle]);
-                    meshes.Remove(cookedData.id.handle);
+                    SpatialAwarenessMeshObject toRemove = meshes[cookedData.id.handle];
 
+                    meshes[cookedData.id.handle] = meshObject;
                     sendUpdatedEvent = true;
+
+                    // Reclaim the old mesh object for future use.
+                    ReclaimMeshObject(toRemove);
                 }
-                meshes.Add(cookedData.id.handle, meshObject);
+                else
+                {
+                    meshes.Add(cookedData.id.handle, meshObject);
+                }
 
                 meshObject.GameObject.transform.parent = (ObservedObjectParent.transform != null) ? ObservedObjectParent.transform : null;
 


### PR DESCRIPTION
This change modifies how spatial mesh updates are handled. Instead of removing then re-adding to the collection, this change updates the mesh data in place and then reclaims the previous object.

Fixes: #8097