### PR TITLE
Update Unity versions for public CI / PR validation

### DIFF
--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2019.4.1f1
+    - Unity2019.4.8f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
@@ -26,7 +26,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.23f1
+    - Unity2018.4.26f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-daily.yml
+++ b/pipelines/ci-daily.yml
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2019.2.0f1
+    - Unity2019.4.1f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:
@@ -26,7 +26,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.6f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.23f1
+    - Unity2018.4.26f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci-packaging.yml
+++ b/pipelines/ci-packaging.yml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.6f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.23f1
+    - Unity2018.4.26f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/ci.yaml
+++ b/pipelines/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.6f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -1,7 +1,7 @@
 variables:
   # Unity version on AIPMR build agents
-  Unity2018Version: Unity2018.4.23f1
-  Unity2019Version: Unity2019.4.1f1
+  Unity2018Version: Unity2018.4.26f1
+  Unity2019Version: Unity2019.4.8f1
   # Unity version on internal build agents (release builds)
   Unity2018VersionInternal: Unity2018.4.12f1
   Unity2019VersionInternal: Unity2019.2.0f1

--- a/pipelines/config/settings.yml
+++ b/pipelines/config/settings.yml
@@ -1,7 +1,7 @@
 variables:
   # Unity version on AIPMR build agents
-  Unity2018Version: Unity2018.4.6f1
-  Unity2019Version: Unity2019.2.0f1
+  Unity2018Version: Unity2018.4.23f1
+  Unity2019Version: Unity2019.4.1f1
   # Unity version on internal build agents (release builds)
   Unity2018VersionInternal: Unity2018.4.12f1
   Unity2019VersionInternal: Unity2019.2.0f1

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.23f1
+    - Unity2018.4.26f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:

--- a/pipelines/pr.yaml
+++ b/pipelines/pr.yaml
@@ -9,7 +9,7 @@ jobs:
   pool:
     name: On-Prem Unity
     demands:
-    - Unity2018.4.6f1
+    - Unity2018.4.23f1
     - COG-UnityCache-WUS2-01
     - SDK_18362 -equals TRUE
   steps:


### PR DESCRIPTION
## Overview

A CI machine was updated with these latest Unity versions, so this PR intends to test out the installs / new machine.
We may want to hold off merging until additional machines are updated, or else we'll be stuck with a single machine for both CI and PR validation.