### PR TITLE
Removes the memory alloc of FocusProvider::GetPointers

### DIFF
--- a/Assets/MRTK/Services/InputSystem/FocusProvider.cs
+++ b/Assets/MRTK/Services/InputSystem/FocusProvider.cs
@@ -883,17 +883,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <inheritdoc />
         public IEnumerable<T> GetPointers<T>() where T : class, IMixedRealityPointer
         {
-            List<T> typePointers = new List<T>();
             foreach (var pointer in pointers.Values)
             {
                 T typePointer = pointer.Pointer as T;
                 if (typePointer != null)
                 {
-                    typePointers.Add(typePointer);
+                    yield return typePointer;
                 }
             }
-
-            return typePointers;
         }
 
         public void SubscribeToPrimaryPointerChanged(PrimaryPointerChangedHandler handler, bool invokeHandlerWithCurrentPointer)


### PR DESCRIPTION
## Overview
GetPointers currently returns an IEnumerable backed by a List, which allocs memory for each call to it. While we could have 'saved' on this by caching a result for a particular type T on a per-Update loop basis, this would also end up making things more complex than necessary (i.e. saving cached state, clearing it, making it possible for us to hit bugs there).

Since the function is already an IEnumerable, we can just use yield return typePointer to avoid allocing a return structure (thanks @Alexees for the solution here)

We use this in a bunch of non-test and test locations, so this is verified just with existing tests that pass.

## Changes
- Fixes: https://github.com/microsoft/MixedRealityToolkit-Unity/issues/8109

