### PR TITLE
Fix CI: remove link.xml* from the foundation nuspec, it is auto generated

### DIFF
--- a/Assets/MixedReality.Toolkit.Foundation.nuspec
+++ b/Assets/MixedReality.Toolkit.Foundation.nuspec
@@ -48,12 +48,5 @@
     <!-- Assemblies and Sources that are built from the Services folder -->
     <file src="..\Plugins\**\Microsoft.MixedReality.Toolkit.Services.*" target="Plugins\" />
     <file src="..\..\Assets\MRTK\Services\**\*.cs" target="contentFiles\any\any\.PkgSrc\MRTK\Services" />
-    
-    <!-- 
-      link.xml is copied to the root location, so that it can catch IL2CPP
-      bytecode stripping issues for all scripts included in this package.
-    -->
-    <file src="link.xml" target="" />
-    <file src="link.xml.meta" target="" />
   </files>
 </package>


### PR DESCRIPTION
This change fixes CI by removing link.xml and link.xml.meta from MixedReality.Toolkit.Foundation.nuspec