### PR TITLE
Update mappings for generic XR SDK controller

### DIFF
--- a/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneSystemProfile.asset
+++ b/Assets/MRTK/Examples/Experimental/ExamplesHub/Profiles/MRTKExamplesHubSceneSystemProfile.asset
@@ -39,8 +39,8 @@ MonoBehaviour:
     Asset: {fileID: 102900000, guid: 63a00118e809c754f9c7911bb85d635f, type: 3}
   - Name: HandInteractionExamples
     Path: Assets/MRTK/Examples/Demos/HandTracking/Scenes/HandInteractionExamples.unity
-    Included: 0
-    BuildIndex: -1
+    Included: 1
+    BuildIndex: 0
     Tag: Untagged
     Asset: {fileID: 102900000, guid: 3dd4a396b5225f8469b9a1eb608bfa57, type: 3}
   - Name: ClippingExamples

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/BaseWindowsMixedRealityXRSDKSource.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/BaseWindowsMixedRealityXRSDKSource.cs
@@ -8,10 +8,6 @@ using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.XR;
 
-#if WMR_ENABLED
-using Unity.XR.WindowsMR;
-#endif // WMR_ENABLED
-
 namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 {
     /// <summary>
@@ -25,7 +21,6 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         protected BaseWindowsMixedRealityXRSDKSource(TrackingState trackingState, Handedness sourceHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, sourceHandedness, inputSource, interactions) { }
 
-#if WMR_ENABLED
         private Vector3 currentPointerPosition = Vector3.zero;
         private Quaternion currentPointerRotation = Quaternion.identity;
         private MixedRealityPose currentPointerPose = MixedRealityPose.ZeroIdentity;
@@ -47,12 +42,12 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 switch (interactionMapping.InputType)
                 {
                     case DeviceInputType.SpatialPointer:
-                        if (inputDevice.TryGetFeatureValue(WindowsMRUsages.PointerPosition, out currentPointerPosition))
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerPosition, out currentPointerPosition))
                         {
                             currentPointerPose.Position = MixedRealityPlayspace.TransformPoint(currentPointerPosition);
                         }
 
-                        if (inputDevice.TryGetFeatureValue(WindowsMRUsages.PointerRotation, out currentPointerRotation))
+                        if (inputDevice.TryGetFeatureValue(CustomUsages.PointerRotation, out currentPointerRotation))
                         {
                             currentPointerPose.Rotation = MixedRealityPlayspace.Rotation * currentPointerRotation;
                         }
@@ -71,6 +66,5 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 }
             }
         }
-#endif // WMR_ENABLED
     }
 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKMotionController.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
 {
@@ -37,5 +40,96 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
             new MixedRealityInteractionMapping(10, "Thumbstick Position", AxisType.DualAxis, DeviceInputType.ThumbStick),
             new MixedRealityInteractionMapping(11, "Thumbstick Press", AxisType.Digital, DeviceInputType.ThumbStickPress),
         };
+
+        private static readonly ProfilerMarker UpdateButtonDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityXRSDKMotionController.UpdateButtonData");
+
+        /// <inheritdoc />
+        protected override void UpdateButtonData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
+        {
+            using (UpdateButtonDataPerfMarker.Auto())
+            {
+                Debug.Assert(interactionMapping.AxisType == AxisType.Digital);
+
+                InputFeatureUsage<bool> buttonUsage;
+
+                // These mappings are flipped from the base class,
+                // where thumbstick is primary and touchpad is secondary.
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.TouchpadTouch:
+                        buttonUsage = CommonUsages.primary2DAxisTouch;
+                        break;
+                    case DeviceInputType.TouchpadPress:
+                        buttonUsage = CommonUsages.primary2DAxisClick;
+                        break;
+                    case DeviceInputType.ThumbStickPress:
+                        buttonUsage = CommonUsages.secondary2DAxisClick;
+                        break;
+                    default:
+                        base.UpdateButtonData(interactionMapping, inputDevice);
+                        return;
+                }
+
+                if (inputDevice.TryGetFeatureValue(buttonUsage, out bool buttonPressed))
+                {
+                    interactionMapping.BoolData = buttonPressed;
+                }
+
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    if (interactionMapping.BoolData)
+                    {
+                        CoreServices.InputSystem?.RaiseOnInputDown(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    }
+                    else
+                    {
+                        CoreServices.InputSystem?.RaiseOnInputUp(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction);
+                    }
+                }
+            }
+        }
+
+        private static readonly ProfilerMarker UpdateDualAxisDataPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityXRSDKMotionController.UpdateDualAxisData");
+
+        /// <inheritdoc />
+        protected override void UpdateDualAxisData(MixedRealityInteractionMapping interactionMapping, InputDevice inputDevice)
+        {
+            using (UpdateDualAxisDataPerfMarker.Auto())
+            {
+                Debug.Assert(interactionMapping.AxisType == AxisType.DualAxis);
+
+                InputFeatureUsage<Vector2> axisUsage;
+
+                // These mappings are flipped from the base class,
+                // where thumbstick is primary and touchpad is secondary.
+                switch (interactionMapping.InputType)
+                {
+                    case DeviceInputType.ThumbStick:
+                        axisUsage = CommonUsages.secondary2DAxis;
+                        break;
+                    case DeviceInputType.Touchpad:
+                        axisUsage = CommonUsages.primary2DAxis;
+                        break;
+                    default:
+                        base.UpdateDualAxisData(interactionMapping, inputDevice);
+                        return;
+                }
+
+                if (inputDevice.TryGetFeatureValue(axisUsage, out Vector2 axisData))
+                {
+                    // Update the interaction data source
+                    interactionMapping.Vector2Data = axisData;
+                }
+
+                // If our value changed raise it.
+                if (interactionMapping.Changed)
+                {
+                    // Raise input system event if it's enabled
+                    CoreServices.InputSystem?.RaisePositionInputChanged(InputSource, ControllerHandedness, interactionMapping.MixedRealityInputAction, interactionMapping.Vector2Data);
+                }
+            }
+        }
     }
 }

--- a/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
+++ b/Assets/MRTK/Providers/XRSDK/Controllers/GenericXRSDKController.cs
@@ -156,16 +156,19 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                             buttonUsage = CommonUsages.triggerButton;
                             break;
                         case DeviceInputType.TouchpadTouch:
-                            buttonUsage = CommonUsages.primary2DAxisTouch;
+                            buttonUsage = CommonUsages.secondary2DAxisTouch;
                             break;
                         case DeviceInputType.TouchpadPress:
-                            buttonUsage = CommonUsages.primary2DAxisClick;
+                            buttonUsage = CommonUsages.secondary2DAxisClick;
                             break;
                         case DeviceInputType.Menu:
                             buttonUsage = CommonUsages.menuButton;
                             break;
+                        case DeviceInputType.ThumbStickTouch:
+                            buttonUsage = CommonUsages.primary2DAxisTouch;
+                            break;
                         case DeviceInputType.ThumbStickPress:
-                            buttonUsage = CommonUsages.secondary2DAxisClick;
+                            buttonUsage = CommonUsages.primary2DAxisClick;
                             break;
                         default:
                             return;
@@ -271,10 +274,10 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
                 switch (interactionMapping.InputType)
                 {
                     case DeviceInputType.ThumbStick:
-                        axisUsage = CommonUsages.secondary2DAxis;
+                        axisUsage = CommonUsages.primary2DAxis;
                         break;
                     case DeviceInputType.Touchpad:
-                        axisUsage = CommonUsages.primary2DAxis;
+                        axisUsage = CommonUsages.secondary2DAxis;
                         break;
                     default:
                         return;

--- a/Assets/MRTK/Providers/XRSDK/CustomUsages.cs
+++ b/Assets/MRTK/Providers/XRSDK/CustomUsages.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace Microsoft.MixedReality.Toolkit.XRSDK.Input
+{
+    /// <summary>
+    /// Additional usages to Unity's CommonUsages.
+    /// </summary>
+    /// <remarks>These might be plugin-specific, shared across several plug-ins, or custom-defined for new input sources.</remarks>
+    public static class CustomUsages
+    {
+        /// <summary>
+        /// Represents the origin of the pointing ray of an input source.
+        /// </summary>
+        public static readonly InputFeatureUsage<Vector3> PointerPosition = new InputFeatureUsage<Vector3>("PointerPosition");
+
+        /// <summary>
+        /// Represents the orientation of the pointing ray of an input source.
+        /// </summary>
+        public static readonly InputFeatureUsage<Quaternion> PointerRotation = new InputFeatureUsage<Quaternion>("PointerRotation");
+    }
+}

--- a/Assets/MRTK/Providers/XRSDK/CustomUsages.cs.meta
+++ b/Assets/MRTK/Providers/XRSDK/CustomUsages.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cca057097a14af4db13623d39b6bcf5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

1. Flips the generic handling of thumbstick / touchpad as primary / secondary axes to a more common case.
    1. Overrides this flip in the WMR motion controller class correspondingly
1. Re-serializes a scene profile to match the repo's build state
1. Refactors out a WindowsMRUsage into an MRTK-defined `CustomUsage`, as the `pointerPosition` and `pointerRotation` features are shared across several packages.