### PR TITLE
Several fixes and improvements to EyeTrackingTarget

### DIFF
--- a/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -99,6 +99,24 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
 
         [SerializeField]
+        private UnityEvent onTapDown = new UnityEvent();
+
+        public UnityEvent OnTapDown
+        {
+            get { return onTapDown; }
+            set { onTapDown = value; }
+        }
+
+        [SerializeField]
+        private UnityEvent onTapUp = new UnityEvent();
+
+        public UnityEvent OnTapUp
+        {
+            get { return onTapUp; }
+            set { onTapUp = value; }
+        }
+
+        [SerializeField]
         [Tooltip("If true, the eye cursor (if enabled) will snap to the center of this object.")]
         private bool eyeCursorSnapToTargetCenter = false;
 
@@ -139,9 +157,15 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// </summary>
         private static DateTime lastEyeSignalUpdateTimeLocal = DateTime.MinValue;
 
+        private DateTime lastTimeClicked;
+        private float minTimeoutBetweenClicksInMs = 20f;
+
+
         public static GameObject LookedAtTarget { get; private set; }
         public static EyeTrackingTarget LookedAtEyeTarget { get; private set; }
         public static Vector3 LookedAtPoint { get; private set; }
+
+        public static GameObject SelectedTarget { get; set; }
 
         #region Focus handling
         protected override void Start()
@@ -154,10 +178,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void Update()
         {
-            var eyeGazeProvider = CoreServices.InputSystem?.EyeGazeProvider;
             // Try to manually poll the eye tracking data
-            if (eyeGazeProvider != null
-                && eyeGazeProvider.IsEyeTrackingEnabledAndValid)
+            if ((CoreServices.InputSystem != null) && (CoreServices.InputSystem.EyeGazeProvider != null) &&
+                CoreServices.InputSystem.EyeGazeProvider.IsEyeTrackingEnabled &&
+                CoreServices.InputSystem.EyeGazeProvider.IsEyeTrackingDataValid)
             {
                 UpdateHitTarget();
 
@@ -187,14 +211,12 @@ namespace Microsoft.MixedReality.Toolkit.Input
             OnEyeFocusStop();
         }
 
-        /// <inheritdoc />
         protected override void RegisterHandlers()
         {
             CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
             CoreServices.InputSystem?.RegisterHandler<IMixedRealitySpeechHandler>(this);
         }
 
-        /// <inheritdoc />
         protected override void UnregisterHandlers()
         {
             CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
@@ -203,17 +225,16 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         private void UpdateHitTarget()
         {
-            var eyeGazeProvider = CoreServices.InputSystem?.EyeGazeProvider;
-            if (eyeGazeProvider != null)
+            if (lastEyeSignalUpdateTimeFromET != CoreServices.InputSystem?.EyeGazeProvider?.Timestamp)
             {
-                if (lastEyeSignalUpdateTimeFromET != eyeGazeProvider.Timestamp)
+                if ((CoreServices.InputSystem != null) && (CoreServices.InputSystem.EyeGazeProvider != null))
                 {
-                    lastEyeSignalUpdateTimeFromET = eyeGazeProvider.Timestamp;
+                    lastEyeSignalUpdateTimeFromET = (CoreServices.InputSystem?.EyeGazeProvider?.Timestamp).Value;
                     lastEyeSignalUpdateTimeLocal = DateTime.UtcNow;
 
                     // ToDo: Handle raycasting layers
-                    RaycastHit hitInfo = default(RaycastHit);
-                    Ray lookRay = new Ray(eyeGazeProvider.GazeOrigin, eyeGazeProvider.GazeDirection.normalized);
+                    RaycastHit hitInfo;
+                    Ray lookRay = new Ray(CoreServices.InputSystem.EyeGazeProvider.GazeOrigin, CoreServices.InputSystem.EyeGazeProvider.GazeDirection.normalized);
                     bool isHit = UnityEngine.Physics.Raycast(lookRay, out hitInfo);
 
                     if (isHit)
@@ -228,11 +249,11 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         LookedAtEyeTarget = null;
                     }
                 }
-                else if ((DateTime.UtcNow - lastEyeSignalUpdateTimeLocal).TotalMilliseconds > EyeTrackingTimeoutInMilliseconds)
-                {
-                    LookedAtTarget = null;
-                    LookedAtEyeTarget = null;
-                }
+            }
+            else if ((DateTime.UtcNow - lastEyeSignalUpdateTimeLocal).TotalMilliseconds > EyeTrackingTimeoutInMilliseconds)
+            {
+                LookedAtTarget = null;
+                LookedAtEyeTarget = null;
             }
         }
 
@@ -277,8 +298,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
 
         void IMixedRealityPointerHandler.OnPointerClicked(MixedRealityPointerEventData eventData)
         {
-            if ((eventData.MixedRealityInputAction == selectAction) && IsLookedAt)
+            if ((eventData.MixedRealityInputAction == selectAction) && IsLookedAt && ((DateTime.UtcNow - lastTimeClicked).TotalMilliseconds > minTimeoutBetweenClicksInMs))
             {
+                lastTimeClicked = DateTime.UtcNow;
+                EyeTrackingTarget.SelectedTarget = this.gameObject;
                 OnSelected.Invoke();
             }
         }
@@ -293,6 +316,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     {
                         if (eventData.MixedRealityInputAction == voiceSelect[i])
                         {
+                            EyeTrackingTarget.SelectedTarget = this.gameObject;
                             OnSelected.Invoke();
                         }
                     }
@@ -300,5 +324,21 @@ namespace Microsoft.MixedReality.Toolkit.Input
             }
         }
         #endregion
+
+        public void RaiseSelectEventManually()
+        {
+            EyeTrackingTarget.SelectedTarget = this.gameObject;
+            OnSelected.Invoke();
+        }
+
+        public void RaiseEventManually_TapDown()
+        {
+            OnTapDown.Invoke();
+        }
+
+        public void RaiseEventManually_TapUp()
+        {
+            OnTapUp.Invoke();
+        }
     }
 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -101,6 +101,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         private UnityEvent onTapDown = new UnityEvent();
 
+        /// <summary>
+        /// Event is triggered when the RaiseEventManually_TapDown is called.
+        /// </summary>
         public UnityEvent OnTapDown
         {
             get { return onTapDown; }
@@ -110,6 +113,9 @@ namespace Microsoft.MixedReality.Toolkit.Input
         [SerializeField]
         private UnityEvent onTapUp = new UnityEvent();
 
+        /// <summary>
+        /// Event is triggered when the RaiseEventManually_TapUp is called.
+        /// </summary>
         public UnityEvent OnTapUp
         {
             get { return onTapUp; }
@@ -160,11 +166,24 @@ namespace Microsoft.MixedReality.Toolkit.Input
         private DateTime lastTimeClicked;
         private float minTimeoutBetweenClicksInMs = 20f;
 
-
+        /// <summary>
+        /// GameObject eye gaze is currently targeting, updated once per frame.
+        /// null if no object with colllider is currently being looked at.
+        /// </summary>
         public static GameObject LookedAtTarget { get; private set; }
+
+        /// <summary>
+        /// EyeTrackingTarget eye gaze is currently looking at.
+        /// null if currently gazed at object has no EyeTrackingTarget, or if
+        /// no object with collider is being looked at.
+        /// </summary>
         public static EyeTrackingTarget LookedAtEyeTarget { get; private set; }
         public static Vector3 LookedAtPoint { get; private set; }
 
+        /// <summary>
+        /// Most recently selected target, selected either using pointer
+        /// or voice.
+        /// </summary>
         public static GameObject SelectedTarget { get; set; }
 
         #region Focus handling
@@ -211,12 +230,14 @@ namespace Microsoft.MixedReality.Toolkit.Input
             OnEyeFocusStop();
         }
 
+        /// <inheritdoc/>
         protected override void RegisterHandlers()
         {
             CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
             CoreServices.InputSystem?.RegisterHandler<IMixedRealitySpeechHandler>(this);
         }
-
+        
+        /// <inheritdoc/>
         protected override void UnregisterHandlers()
         {
             CoreServices.InputSystem?.UnregisterHandler<IMixedRealityPointerHandler>(this);
@@ -233,9 +254,10 @@ namespace Microsoft.MixedReality.Toolkit.Input
                     lastEyeSignalUpdateTimeLocal = DateTime.UtcNow;
 
                     // ToDo: Handle raycasting layers
-                    RaycastHit hitInfo;
-                    Ray lookRay = new Ray(CoreServices.InputSystem.EyeGazeProvider.GazeOrigin, CoreServices.InputSystem.EyeGazeProvider.GazeDirection.normalized);
-                    bool isHit = UnityEngine.Physics.Raycast(lookRay, out hitInfo);
+                    var lookRay = new Ray(
+                        CoreServices.InputSystem.EyeGazeProvider.GazeOrigin,
+                        CoreServices.InputSystem.EyeGazeProvider.GazeDirection.normalized);
+                    bool isHit = UnityEngine.Physics.Raycast(lookRay, out RaycastHit hitInfo);
 
                     if (isHit)
                     {
@@ -325,6 +347,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         }
         #endregion
 
+        #region Methods to Invoke Events Manually
         public void RaiseSelectEventManually()
         {
             EyeTrackingTarget.SelectedTarget = this.gameObject;
@@ -340,5 +363,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
         {
             OnTapUp.Invoke();
         }
+        #endregion
     }
 }

--- a/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -236,7 +236,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             CoreServices.InputSystem?.RegisterHandler<IMixedRealityPointerHandler>(this);
             CoreServices.InputSystem?.RegisterHandler<IMixedRealitySpeechHandler>(this);
         }
-        
         /// <inheritdoc/>
         protected override void UnregisterHandlers()
         {

--- a/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
+++ b/Assets/MRTK/SDK/Features/Input/Handlers/EyeTrackingTarget.cs
@@ -353,16 +353,6 @@ namespace Microsoft.MixedReality.Toolkit.Input
             EyeTrackingTarget.SelectedTarget = this.gameObject;
             OnSelected.Invoke();
         }
-
-        public void RaiseEventManually_TapDown()
-        {
-            OnTapDown.Invoke();
-        }
-
-        public void RaiseEventManually_TapUp()
-        {
-            OnTapUp.Invoke();
-        }
         #endregion
     }
 }


### PR DESCRIPTION
## Changes
- Fixes: #8138
- Expose static variables to easily see which object eyes are currently gazing at, which item was last selected.
- Ensure mulitple click events are not raised from the same hand.
- Add methods for manually invoking OnTapDown and OnTapUp events

## Verification
> This optional section is a place where you can detail the specific type of verification 
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
