### PR TITLE
Add input simulation to XRSDK profile

### DIFF
--- a/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKInputSystemProfile.asset
+++ b/Assets/MRTK/Providers/XRSDK/Profiles/DefaultXRSDKInputSystemProfile.asset
@@ -28,6 +28,13 @@ MonoBehaviour:
     priority: 0
     runtimePlatform: 33
     deviceManagerProfile: {fileID: 0}
+  - componentType:
+      reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation
+    componentName: Input Simulation Service
+    priority: 0
+    runtimePlatform: 208
+    deviceManagerProfile: {fileID: 11400000, guid: 41478039094d47641bf4e09c20e61a5a,
+      type: 2}
   focusProviderType:
     reference: Microsoft.MixedReality.Toolkit.Input.FocusProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
   raycastProviderType:


### PR DESCRIPTION
## Overview

Adds the input simulation service to the XR SDK profile, so people can use it in-editor like they're used to.