### PR TITLE
Split out WMR hand definition and WMR hand mesh provider

### DIFF
--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs
@@ -1,0 +1,197 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Input;
+using Microsoft.MixedReality.Toolkit.Utilities;
+using System;
+
+#if WINDOWS_UWP
+using System.Threading.Tasks;
+using Unity.Profiling;
+using UnityEngine;
+using Windows.Perception.People;
+using Windows.UI.Input.Spatial;
+#endif // WINDOWS_UWP
+
+namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
+{
+    /// <summary>
+    /// Defines the additional data, like hand mesh, that an articulated hand on HoloLens 2 can provide.
+    /// </summary>
+    /// <remarks>This class is deprecated. Use WindowsMixedRealityHandMeshProvider instead.</remarks>
+    [Obsolete("This class is deprecated. Use WindowsMixedRealityHandMeshProvider instead.")]
+    public class WindowsMixedRealityArticulatedHandDefinition : ArticulatedHandDefinition
+    {
+        [Obsolete("This class is deprecated. Use WindowsMixedRealityHandMeshProvider instead.")]
+        public WindowsMixedRealityArticulatedHandDefinition(IMixedRealityInputSource source, Handedness handedness) : base(source, handedness) { }
+
+#if WINDOWS_UWP
+        private HandMeshObserver handMeshObserver = null;
+
+        private ushort[] handMeshTriangleIndices = null;
+        private HandMeshVertex[] vertexAndNormals = null;
+
+        private Vector3[] handMeshVerticesUnity = null;
+        private Vector3[] handMeshNormalsUnity = null;
+        private int[] handMeshTriangleIndicesUnity = null;
+        private Vector2[] handMeshUVsUnity = null;
+
+        private bool hasRequestedHandMeshObserver = false;
+
+        private async void SetHandMeshObserver(SpatialInteractionSourceState sourceState)
+        {
+            handMeshObserver = await sourceState.Source.TryCreateHandMeshObserverAsync();
+        }
+
+        private void InitializeUVs(Vector3[] neutralPoseVertices)
+        {
+            if (neutralPoseVertices.Length == 0)
+            {
+                Debug.LogError("Loaded 0 verts for neutralPoseVertices");
+            }
+
+            float minY = neutralPoseVertices[0].y;
+            float maxY = minY;
+
+            for (int ix = 1; ix < neutralPoseVertices.Length; ix++)
+            {
+                Vector3 p = neutralPoseVertices[ix];
+
+                if (p.y < minY)
+                {
+                    minY = p.y;
+                }
+                else if (p.y > maxY)
+                {
+                    maxY = p.y;
+                }
+            }
+
+            float scale = 1.0f / (maxY - minY);
+
+            handMeshUVsUnity = new Vector2[neutralPoseVertices.Length];
+
+            for (int ix = 0; ix < neutralPoseVertices.Length; ix++)
+            {
+                Vector3 p = neutralPoseVertices[ix];
+
+                handMeshUVsUnity[ix] = new Vector2(p.x * scale + 0.5f, (p.y - minY) * scale);
+            }
+        }
+
+        private static readonly ProfilerMarker UpdateHandMeshPerfMarker = new ProfilerMarker("[MRTK] WindowsMixedRealityArticulatedHandDefinition.UpdateHandMesh");
+
+        /// <summary>
+        /// Updates the current hand mesh based on the passed in state of the hand.
+        /// </summary>
+        /// <param name="sourceState">The current hand state.</param>
+        [Obsolete("This class is deprecated. Use WindowsMixedRealityHandMeshProvider.UpdateHandMesh instead.")]
+        public void UpdateHandMesh(SpatialInteractionSourceState sourceState)
+        {
+            using (UpdateHandMeshPerfMarker.Auto())
+            {
+                MixedRealityHandTrackingProfile handTrackingProfile = null;
+                MixedRealityInputSystemProfile inputSystemProfile = CoreServices.InputSystem?.InputSystemProfile;
+                if (inputSystemProfile != null)
+                {
+                    handTrackingProfile = inputSystemProfile.HandTrackingProfile;
+                }
+
+                if (handTrackingProfile == null || !handTrackingProfile.EnableHandMeshVisualization)
+                {
+                    // If hand mesh visualization is disabled make sure to destroy our hand mesh observer if it has already been created
+                    if (handMeshObserver != null)
+                    {
+                        // Notify that hand mesh has been updated (cleared)
+                        HandMeshInfo handMeshInfo = new HandMeshInfo();
+                        CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                        hasRequestedHandMeshObserver = false;
+                        handMeshObserver = null;
+                    }
+                    return;
+                }
+
+                HandPose handPose = sourceState.TryGetHandPose();
+
+                // Accessing the hand mesh data involves copying quite a bit of data, so only do it if application requests it.
+                if (handMeshObserver == null && !hasRequestedHandMeshObserver)
+                {
+                    SetHandMeshObserver(sourceState);
+                    hasRequestedHandMeshObserver = true;
+                }
+
+                if (handMeshObserver != null && handPose != null)
+                {
+                    if (handMeshTriangleIndices == null)
+                    {
+                        handMeshTriangleIndices = new ushort[handMeshObserver.TriangleIndexCount];
+                        handMeshTriangleIndicesUnity = new int[handMeshObserver.TriangleIndexCount];
+                        handMeshObserver.GetTriangleIndices(handMeshTriangleIndices);
+
+                        Array.Copy(handMeshTriangleIndices, handMeshTriangleIndicesUnity, (int)handMeshObserver.TriangleIndexCount);
+
+                        // Compute neutral pose
+                        Vector3[] neutralPoseVertices = new Vector3[handMeshObserver.VertexCount];
+                        HandPose neutralPose = handMeshObserver.NeutralPose;
+                        var neutralVertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
+                        HandMeshVertexState handMeshVertexState = handMeshObserver.GetVertexStateForPose(neutralPose);
+                        handMeshVertexState.GetVertices(neutralVertexAndNormals);
+
+                        Parallel.For(0, handMeshObserver.VertexCount, i =>
+                        {
+                            neutralVertexAndNormals[i].Position.ConvertToUnityVector3(ref neutralPoseVertices[i]);
+                        });
+
+                        // Compute UV mapping
+                        InitializeUVs(neutralPoseVertices);
+                    }
+
+                    if (vertexAndNormals == null)
+                    {
+                        vertexAndNormals = new HandMeshVertex[handMeshObserver.VertexCount];
+                        handMeshVerticesUnity = new Vector3[handMeshObserver.VertexCount];
+                        handMeshNormalsUnity = new Vector3[handMeshObserver.VertexCount];
+                    }
+
+                    if (vertexAndNormals != null && handMeshTriangleIndices != null)
+                    {
+                        var handMeshVertexState = handMeshObserver.GetVertexStateForPose(handPose);
+                        handMeshVertexState.GetVertices(vertexAndNormals);
+
+                        var meshTransform = handMeshVertexState.CoordinateSystem.TryGetTransformTo(WindowsMixedRealityUtilities.SpatialCoordinateSystem);
+                        if (meshTransform.HasValue)
+                        {
+                            System.Numerics.Matrix4x4.Decompose(meshTransform.Value,
+                                out System.Numerics.Vector3 scale,
+                                out System.Numerics.Quaternion rotation,
+                                out System.Numerics.Vector3 translation);
+
+                            Parallel.For(0, handMeshObserver.VertexCount, i =>
+                            {
+                                vertexAndNormals[i].Position.ConvertToUnityVector3(ref handMeshVerticesUnity[i]);
+                                vertexAndNormals[i].Normal.ConvertToUnityVector3(ref handMeshNormalsUnity[i]);
+                            });
+
+                            /// Hands should follow the Playspace to accommodate teleporting, so fold in the Playspace transform.
+                            Vector3 positionUnity = MixedRealityPlayspace.TransformPoint(translation.ToUnityVector3());
+                            Quaternion rotationUnity = MixedRealityPlayspace.Rotation * rotation.ToUnityQuaternion(); 
+
+                            HandMeshInfo handMeshInfo = new HandMeshInfo
+                            {
+                                vertices = handMeshVerticesUnity,
+                                normals = handMeshNormalsUnity,
+                                triangles = handMeshTriangleIndicesUnity,
+                                uvs = handMeshUVsUnity,
+                                position = positionUnity,
+                                rotation = rotationUnity
+                            };
+
+                            CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                        }
+                    }
+                }
+            }
+        }
+#endif // WINDOWS_UWP
+    }
+}

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs.meta
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityArticulatedHandDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ed31dfb20949274d9033b9ca0a7bb3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs
@@ -3,12 +3,12 @@
 
 using Microsoft.MixedReality.Toolkit.Input;
 using Microsoft.MixedReality.Toolkit.Utilities;
+
+#if WINDOWS_UWP
 using System;
 using System.Threading.Tasks;
 using Unity.Profiling;
 using UnityEngine;
-
-#if WINDOWS_UWP
 using Windows.Perception.People;
 using Windows.UI.Input.Spatial;
 #endif // WINDOWS_UWP
@@ -16,11 +16,15 @@ using Windows.UI.Input.Spatial;
 namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
 {
     /// <summary>
-    /// Defines the additional data, like hand mesh, that an articulated hand on HoloLens 2 can provide.
+    /// Queries the hand mesh data that an articulated hand on HoloLens 2 can provide.
     /// </summary>
-    public class WindowsMixedRealityArticulatedHandDefinition : ArticulatedHandDefinition
+    public class WindowsMixedRealityHandMeshProvider
     {
-        public WindowsMixedRealityArticulatedHandDefinition(IMixedRealityInputSource source, Handedness handedness) : base(source, handedness) { }
+        public WindowsMixedRealityHandMeshProvider(IMixedRealityController controller) => this.controller = controller;
+
+        private readonly IMixedRealityController controller;
+        private IMixedRealityInputSource InputSource => controller.InputSource;
+        private Handedness Handedness => controller.ControllerHandedness;
 
 #if WINDOWS_UWP
         private HandMeshObserver handMeshObserver = null;
@@ -100,7 +104,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                     {
                         // Notify that hand mesh has been updated (cleared)
                         HandMeshInfo handMeshInfo = new HandMeshInfo();
-                        CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                        CoreServices.InputSystem?.RaiseHandMeshUpdated(InputSource, Handedness, handMeshInfo);
                         hasRequestedHandMeshObserver = false;
                         handMeshObserver = null;
                     }
@@ -182,7 +186,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality
                                 rotation = rotationUnity
                             };
 
-                            CoreServices.InputSystem?.RaiseHandMeshUpdated(inputSource, handedness, handMeshInfo);
+                            CoreServices.InputSystem?.RaiseHandMeshUpdated(InputSource, Handedness, handMeshInfo);
                         }
                     }
                 }

--- a/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs.meta
+++ b/Assets/MRTK/Providers/WindowsMixedReality/Shared/WindowsMixedRealityHandMeshProvider.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2ed31dfb20949274d9033b9ca0a7bb3d
+guid: e81d6dc376fdd8349b0576d112375ef8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XR2018/Controllers/WindowsMixedRealityArticulatedHand.cs
@@ -40,7 +40,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public WindowsMixedRealityArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
                 : base(trackingState, controllerHandedness, inputSource, interactions)
         {
-            handDefinition = new WindowsMixedRealityArticulatedHandDefinition(inputSource, controllerHandedness);
+            handDefinition = new ArticulatedHandDefinition(inputSource, controllerHandedness);
+            handMeshProvider = new WindowsMixedRealityHandMeshProvider(this);
             articulatedHandApiAvailable = WindowsApiChecker.IsMethodAvailable(
                 "Windows.UI.Input.Spatial",
                 "SpatialInteractionSourceState",
@@ -54,7 +55,8 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
         public override MixedRealityInteractionMapping[] DefaultInteractions => handDefinition?.DefaultInteractions;
 
         private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
-        private readonly WindowsMixedRealityArticulatedHandDefinition handDefinition;
+        private readonly ArticulatedHandDefinition handDefinition;
+        private readonly WindowsMixedRealityHandMeshProvider handMeshProvider;
         private readonly bool articulatedHandApiAvailable = false;
 
         #region IMixedRealityHand Implementation
@@ -143,7 +145,7 @@ namespace Microsoft.MixedReality.Toolkit.WindowsMixedReality.Input
                     if (sourceState.Source.Id.Equals(interactionSourceState.source.id))
                     {
 #if WINDOWS_UWP
-                        handDefinition?.UpdateHandMesh(sourceState);
+                        handMeshProvider?.UpdateHandMesh(sourceState);
 #endif // WINDOWS_UWP
 
                         HandPose handPose = sourceState.TryGetHandPose();

--- a/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
+++ b/Assets/MRTK/Providers/WindowsMixedReality/XRSDK/Controllers/WindowsMixedRealityXRSDKArticulatedHand.cs
@@ -33,14 +33,16 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
         public WindowsMixedRealityXRSDKArticulatedHand(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions)
         {
-            handDefinition = new WindowsMixedRealityArticulatedHandDefinition(inputSource, controllerHandedness);
+            handDefinition = new ArticulatedHandDefinition(inputSource, controllerHandedness);
+            handMeshProvider = new WindowsMixedRealityHandMeshProvider(this);
         }
 
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultInteractions => handDefinition?.DefaultInteractions;
 
         private readonly Dictionary<TrackedHandJoint, MixedRealityPose> unityJointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
-        private readonly WindowsMixedRealityArticulatedHandDefinition handDefinition;
+        private readonly ArticulatedHandDefinition handDefinition;
+        private readonly WindowsMixedRealityHandMeshProvider handMeshProvider;
 
         private static readonly HandFinger[] handFingers = Enum.GetValues(typeof(HandFinger)) as HandFinger[];
         private readonly List<Bone> fingerBones = new List<Bone>();
@@ -108,7 +110,7 @@ namespace Microsoft.MixedReality.Toolkit.XRSDK.WindowsMixedReality
                 {
                     if (sourceState.Source.Handedness.ToMRTKHandedness() == ControllerHandedness)
                     {
-                        handDefinition?.UpdateHandMesh(sourceState);
+                        handMeshProvider?.UpdateHandMesh(sourceState);
                         break;
                     }
                 }


### PR DESCRIPTION
## Overview

To reduce the amount of platform-specific code stored in a strict inheritance chain, I've split out the mesh code from the controller definition concept. Now, WMR articulated hands can use the base definition, while still defining their own way of providing the hand mesh (in this case, directly from the Windows APIs. In the future, other hand definitions may grab this from XR plug-in extensions).